### PR TITLE
[On hold] Autofetch

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,3 @@
+{
+	"plugins": ["node_modules/jsdoc-strip-async-await"]
+}

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "types": "./typings/index.d.ts",
   "scripts": {
     "test": "npm run lint && npm run docs:test",
-    "docs": "docgen --source src --custom docs/index.yml --output docs/docs.json",
-    "docs:test": "docgen --source src --custom docs/index.yml",
+    "docs": "docgen --source src --custom docs/index.yml --output docs/docs.json --jsdoc jsdoc.json",
+    "docs:test": "docgen --source src --custom docs/index.yml --jsdoc jsdoc.json",
     "lint": "eslint src",
     "lint:fix": "eslint --fix src",
     "webpack": "parallel-webpack"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@types/node": "^8.0.0",
     "discord.js-docgen": "hydrabolt/discord.js-docgen",
     "eslint": "^4.0.0",
+    "jsdoc-strip-async-await": "^0.1.0",
     "parallel-webpack": "^2.0.0",
     "uglifyjs-webpack-plugin": "iCrawl/uglifyjs-webpack-plugin",
     "webpack": "^3.0.0"

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -564,6 +564,9 @@ class Client extends EventEmitter {
     if (!(options.disabledEvents instanceof Array)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'disabledEvents', 'an Array');
     }
+    if (!(options.autofetch instanceof Array)) {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'autofetch', 'an Array');
+    }
   }
 }
 

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -528,7 +528,7 @@ class Client extends EventEmitter {
    * @param {ClientOptions} [options=this.options] Options to validate
    * @private
    */
-  _validateOptions(options = this.options) {
+  _validateOptions(options = this.options) { // eslint-disable-line complexity
     if (typeof options.shardCount !== 'number' || isNaN(options.shardCount)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'shardCount', 'a number');
     }

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -19,8 +19,7 @@ class MessageReactionAdd extends Action {
     const message = channel.messages.get(data.message_id);
     if (!data.emoji) return false;
     if (!message) {
-      const { autofetch } = this.client.options;
-      if (autofetch && autofetch.includes(Constants.WSEvents.MESSAGE_REACTION_ADD)) {
+      if (this.client.options.autofetch.includes(Constants.WSEvents.MESSAGE_REACTION_ADD)) {
         // Check if message is fetchable
         if (!channel.permissionsFor(channel.guild.me).has('READ_MESSAGES')) return false;
 

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -9,7 +9,7 @@ const Constants = require('../../util/Constants');
 */
 
 class MessageReactionAdd extends Action {
-  handle(data) {
+  async handle(data) {
     const user = this.client.users.get(data.user_id);
     if (!user) return false;
     // Verify channel
@@ -24,10 +24,13 @@ class MessageReactionAdd extends Action {
         // Check if message is fetchable
         if (!channel.permissionsFor(channel.guild.me).has('READ_MESSAGES')) return false;
 
-        channel.fetchMessage(data.message_id).then(fetchedMessage => {
+        try {
+          const fetchedMessage = await channel.fetchMessage(data.message_id);
           const reaction = fetchedMessage._addReaction(data.emoji, user);
           this.client.emit(Constants.Events.MESSAGE_REACTION_ADD, reaction, user);
-        }).catch(() => this.client.emit('debug', 'Could not fetch message'));
+        } catch (e) {
+          this.client.emit('debug', 'Could not autofetch message');
+        }
       }
       return false;
     }

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -17,8 +17,20 @@ class MessageReactionRemove extends Action {
     if (!channel || channel.type === 'voice') return false;
     // Verify message
     const message = channel.messages.get(data.message_id);
-    if (!message) return false;
     if (!data.emoji) return false;
+    if (!message) {
+      const { autofetch } = this.client.options;
+      if (autofetch && autofetch.includes(Constants.WSEvents.MESSAGE_REACTION_REMOVE)) {
+        // Check if message is fetchable
+        if (!channel.permissionsFor(channel.guild.me).has('READ_MESSAGES')) return false;
+
+        channel.fetchMessage(data.message_id).then(fetchedMessage => {
+          const reaction = fetchedMessage._addReaction(data.emoji, user);
+          this.client.emit(Constants.Events.MESSAGE_REACTION_REMOVE, reaction, user);
+        }).catch(() => this.client.emit('debug', 'Could not fetch message'));
+      }
+      return false;
+    }
     // Verify reaction
     const reaction = message._removeReaction(data.emoji, user);
     if (reaction) this.client.emit(Constants.Events.MESSAGE_REACTION_REMOVE, reaction, user);

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -19,8 +19,7 @@ class MessageReactionRemove extends Action {
     const message = channel.messages.get(data.message_id);
     if (!data.emoji) return false;
     if (!message) {
-      const { autofetch } = this.client.options;
-      if (autofetch && autofetch.includes(Constants.WSEvents.MESSAGE_REACTION_REMOVE)) {
+      if (this.client.options.autofetch.includes(Constants.WSEvents.MESSAGE_REACTION_REMOVE)) {
         // Check if message is fetchable
         if (!channel.permissionsFor(channel.guild.me).has('READ_MESSAGES')) return false;
 

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -9,7 +9,7 @@ const Constants = require('../../util/Constants');
 */
 
 class MessageReactionRemove extends Action {
-  handle(data) {
+  async handle(data) {
     const user = this.client.users.get(data.user_id);
     if (!user) return false;
     // Verify channel
@@ -24,10 +24,13 @@ class MessageReactionRemove extends Action {
         // Check if message is fetchable
         if (!channel.permissionsFor(channel.guild.me).has('READ_MESSAGES')) return false;
 
-        channel.fetchMessage(data.message_id).then(fetchedMessage => {
+        try {
+          const fetchedMessage = await channel.fetchMessage(data.message_id);
           const reaction = fetchedMessage._addReaction(data.emoji, user);
           this.client.emit(Constants.Events.MESSAGE_REACTION_REMOVE, reaction, user);
-        }).catch(() => this.client.emit('debug', 'Could not fetch message'));
+        } catch (e) {
+          this.client.emit('debug', 'Could not autofetch message');
+        }
       }
       return false;
     }

--- a/src/client/actions/MessageUpdate.js
+++ b/src/client/actions/MessageUpdate.js
@@ -1,5 +1,6 @@
 const Action = require('./Action');
 const Constants = require('../../util/Constants');
+const Message = require('../../structures/Message');
 
 class MessageUpdateAction extends Action {
   handle(data) {
@@ -17,10 +18,21 @@ class MessageUpdateAction extends Action {
         };
       }
 
-      return {
-        old: message,
-        updated: message,
-      };
+      const { autofetch } = client.options;
+      if (autofetch && autofetch.includes(Constants.WSEvents.MESSAGE_UPDATE)) {
+        if (data.author) {
+          const newMessage = channel._cacheMessage(new Message(channel, data, client));
+          client.emit(Constants.Events.MESSAGE_UPDATE, null, newMessage);
+          return {
+            old: null,
+            updated: newMessage,
+          };
+        } else {
+          channel.fetchMessage(data.id).then(fetchedMessage => {
+            client.emit(Constants.Events.MESSAGE_UPDATE, null, fetchedMessage);
+          }).catch(() => this.client.emit('debug', 'Could not fetch message'));
+        }
+      }
     }
 
     return {

--- a/src/client/actions/MessageUpdate.js
+++ b/src/client/actions/MessageUpdate.js
@@ -18,8 +18,7 @@ class MessageUpdateAction extends Action {
         };
       }
 
-      const { autofetch } = client.options;
-      if (autofetch && autofetch.includes(Constants.WSEvents.MESSAGE_UPDATE)) {
+      if (this.client.options.autofetch.includes(Constants.WSEvents.MESSAGE_UPDATE)) {
         if (data.author) {
           const newMessage = channel._cacheMessage(new Message(channel, data, client));
           client.emit(Constants.Events.MESSAGE_UPDATE, null, newMessage);

--- a/src/client/actions/MessageUpdate.js
+++ b/src/client/actions/MessageUpdate.js
@@ -3,7 +3,7 @@ const Constants = require('../../util/Constants');
 const Message = require('../../structures/Message');
 
 class MessageUpdateAction extends Action {
-  handle(data) {
+  async handle(data) {
     const client = this.client;
 
     const channel = client.channels.get(data.channel_id);
@@ -28,9 +28,12 @@ class MessageUpdateAction extends Action {
             updated: newMessage,
           };
         } else {
-          channel.fetchMessage(data.id).then(fetchedMessage => {
+          try {
+            const fetchedMessage = await channel.fetchMessage(data.id);
             client.emit(Constants.Events.MESSAGE_UPDATE, null, fetchedMessage);
-          }).catch(() => this.client.emit('debug', 'Could not fetch message'));
+          } catch (e) {
+            this.client.emit('debug', 'Could not autofetch message');
+          }
         }
       }
     }

--- a/src/client/websocket/packets/handlers/MessageCreate.js
+++ b/src/client/websocket/packets/handlers/MessageCreate.js
@@ -7,8 +7,7 @@ class MessageCreateHandler extends AbstractHandler {
     const data = packet.d;
     const { message } = client.actions.MessageCreate.handle(data);
     if (message) {
-      const { autofetch } = client.options;
-      if (message.guild && autofetch && autofetch.includes(Constants.WSEvents.MESSAGE_CREATE)) {
+      if (message.guild && client.options.autofetch.includes(Constants.WSEvents.MESSAGE_CREATE)) {
         const fetchList = [];
         if (!message.member && !message.webhookID) fetchList.push(message.author.id);
 

--- a/src/client/websocket/packets/handlers/MessageCreate.js
+++ b/src/client/websocket/packets/handlers/MessageCreate.js
@@ -2,7 +2,7 @@ const AbstractHandler = require('./AbstractHandler');
 const Constants = require('../../../../util/Constants');
 
 class MessageCreateHandler extends AbstractHandler {
-  handle(packet) {
+  async handle(packet) {
     const client = this.packetManager.client;
     const data = packet.d;
     const { message } = client.actions.MessageCreate.handle(data);
@@ -17,10 +17,11 @@ class MessageCreateHandler extends AbstractHandler {
         });
 
         if (fetchList.length) {
-          // Emit create event regardless if members are fetched successfully
-          Promise.all(fetchList.map(user => message.guild.fetchMember(user)))
-          .then(() => client.emit(Constants.Events.MESSAGE_CREATE, message))
-          .catch(() => client.emit(Constants.Events.MESSAGE_CREATE, message));
+          try {
+            await Promise.all(fetchList.map(user => message.guild.fetchMember(user)));
+          } finally {
+            client.emit(Constants.Events.MESSAGE_CREATE, message);
+          }
           return;
         }
       }

--- a/src/client/websocket/packets/handlers/MessageCreate.js
+++ b/src/client/websocket/packets/handlers/MessageCreate.js
@@ -5,8 +5,27 @@ class MessageCreateHandler extends AbstractHandler {
   handle(packet) {
     const client = this.packetManager.client;
     const data = packet.d;
-    const response = client.actions.MessageCreate.handle(data);
-    if (response.message) client.emit(Constants.Events.MESSAGE_CREATE, response.message);
+    const { message } = client.actions.MessageCreate.handle(data);
+    if (message) {
+      const { autofetch } = client.options;
+      if (message.guild && autofetch && autofetch.includes(Constants.WSEvents.MESSAGE_CREATE)) {
+        const fetchList = [];
+        if (!message.member && !message.webhookID) fetchList.push(message.author.id);
+
+        data.mentions.forEach(user => {
+          if (!message.guild.members.get(user.id)) fetchList.push(user.id);
+        });
+
+        if (fetchList.length) {
+          // Emit create event regardless if members are fetched successfully
+          Promise.all(fetchList.map(user => message.guild.fetchMember(user)))
+          .then(() => client.emit(Constants.Events.MESSAGE_CREATE, message))
+          .catch(() => client.emit(Constants.Events.MESSAGE_CREATE, message));
+          return;
+        }
+      }
+      client.emit(Constants.Events.MESSAGE_CREATE, message);
+    }
   }
 }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -44,6 +44,7 @@ exports.DefaultOptions = {
   sync: false,
   restWsBridgeTimeout: 5000,
   disabledEvents: [],
+  autofetch: [],
   restTimeOffset: 500,
 
   /**


### PR DESCRIPTION
# Autofetch

Pull Request for #1376 

Autofetch is a new client setting that forces the lib to fetch  data if they were not originally cached. Usage is as follows: 
```js
const client = new Client({ autofetch: [
    'MESSAGE_CREATE',
    'MESSAGE_UPDATE',
    'MESSAGE_REACTION_ADD',
    'MESSAGE_REACTION_REMOVE',
] });
```
## Behaviour
- Check member cache for author and mentioned users. If members are not in cache, fetch guild members before emitting message event.
- Cache message and emit messageUpdate event instead of discarding update. `<message>.edits` will be empty because the old message was not cached.
- If the message that was reacted to was not previously in the cache, fetch the message and emit messageReactionAdd event instead of discarding the event.


If there are other events or properties that can be prefetched, let me know and I will include it. 

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
