### PR TITLE
Remove GuildChannel fallback, and remove GuildChannel as extendable

### DIFF
--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -58,7 +58,7 @@ class ChannelStore extends DataStore {
     const channel = Channel.create(this.client, data, guild);
 
     if (!channel) {
-      this.client.emit(Events.DEBUG, `Failed to find guild for channel ${data.id} ${data.type}`);
+      this.client.emit(Events.DEBUG, `Failed to find guild, or unknown type for channel ${data.id} ${data.type}`);
       return null;
     }
 

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -93,12 +93,8 @@ class Channel extends Base {
             channel = new CategoryChannel(guild, data);
             break;
           }
-          default: {
-            const GuildChannel = Structures.get('GuildChannel');
-            channel = new GuildChannel(guild, data);
-          }
         }
-        guild.channels.set(channel.id, channel);
+        if (channel) guild.channels.set(channel.id, channel);
       }
     }
     return channel;

--- a/src/util/Structures.js
+++ b/src/util/Structures.js
@@ -67,7 +67,6 @@ const structures = {
   TextChannel: require('../structures/TextChannel'),
   VoiceChannel: require('../structures/VoiceChannel'),
   CategoryChannel: require('../structures/CategoryChannel'),
-  GuildChannel: require('../structures/GuildChannel'),
   GuildMember: require('../structures/GuildMember'),
   Guild: require('../structures/Guild'),
   Message: require('../structures/Message'),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
PR based on comments from Gawdl3y. Requesting review from @Gawdl3y.

Previously all known channel types are accounted for before defaulting to a generic GuildChannel if the channel type is unknown. If discord adds a channel type before the library properly handles it, this could lead to bugs of unknown impact (minor -> critical).

Because of this fallback, GuildChannel was added to the extendable-structures. (this also is not ideal since extensions to GuildChannel were not inherited by TextChannel or VoiceChannel) Now that the fallback is gone, we can cleanly remove it from the extendable structures.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
