### PR TITLE
Fix Destructuring Errors in Util

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -141,7 +141,7 @@ class Util {
    * @private
    */
   static convertToBuffer(ab) {
-    if (typeof ab === 'string') ab = this.str2ab(ab);
+    if (typeof ab === 'string') ab = Util.str2ab(ab);
     return Buffer.from(ab);
   }
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -127,7 +127,7 @@ class Util {
       if (!has(given, key) || given[key] === undefined) {
         given[key] = def[key];
       } else if (given[key] === Object(given[key])) {
-        given[key] = this.mergeDefault(def[key], given[key]);
+        given[key] = Util.mergeDefault(def[key], given[key]);
       }
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since the context of a static function is the same as referencing the class variable, there's no reason to use `this` inside of it. This also makes it so that you can destructure them from the Util class and they will still work as intended. Mostly a developer standpoint here since the methods are private and would really only be used by someone who knows what they are doing.

I don't think this follows any of the versioning guidelines below.. so just going to leave these blank

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
