### PR TITLE
fix(MessageStore._fetchMany) Throw error if no perms to fetch messages or no results

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -68,6 +68,8 @@ const Messages = {
   IMAGE_SIZE: size => `Invalid image size: ${size}`,
 
   MESSAGE_MISSING: 'Message not found',
+  MESSAGES_MISSING_OR_NO_PERMISSIONS:
+    'No messages were returned or you are missing a permission required for fetching messages.',
   MESSAGE_BULK_DELETE_TYPE: 'The messages must be an Array, Collection, or number.',
   MESSAGE_NONCE_TYPE: 'Message nonce must fit in an unsigned 64-bit integer.',
 

--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -80,13 +80,15 @@ class MessageStore extends DataStore {
       .then(data => this.create(data));
   }
 
-  _fetchMany(options = {}) {
-    return this.client.api.channels[this.channel.id].messages.get({ query: options })
-      .then(data => {
-        const messages = new Collection();
-        for (const message of data) messages.set(message.id, this.create(message));
-        return messages;
-      });
+  async _fetchMany(options = {}) {
+    const data = await this.client.api.channels[this.channel.id].messages.get({ query: options });
+    if (!data.length) {
+      throw new Error('MESSAGES_MISSING_OR_NO_PERMISSIONS');
+    } else {
+      const messages = new Collection();
+      for (const message of data) messages.set(message.id, this.create(message));
+      return messages;
+    }
   }
 
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR makes it to where if no messages were returned from fetching multiple messages (missing permissions or no actual messages).

If there's any better way to do this, let me know. But I was unable to make it throw an error by revoking `READ_MESSAGE_HISTORY` (and yes I did make sure the bot didn't have admin)

EDIT: Discord docs clarified that if you're missing `READ_MESSAGE_HISTORY` permissions the API will return just an empty array. So, this is valid. Probably needs a better error code.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
