### PR TITLE
Make Util#splitMessage handle edge cases properly

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -22,17 +22,16 @@ class Util {
     if (text.length <= maxLength) return text;
     const splitText = text.split(char);
     if (splitText.length === 1) throw new RangeError('SPLIT_MAX_LEN');
-    const messages = [''];
-    let msg = 0;
-    for (let i = 0; i < splitText.length; i++) {
-      if (messages[msg].length + splitText[i].length + 1 > maxLength) {
-        messages[msg] += append;
-        messages.push(prepend);
-        msg++;
+    const messages = [];
+    let msg = '';
+    for (const chunk of splitText) {
+      if ((msg + char + chunk + append).length > maxLength) {
+        messages.push(msg + append);
+        msg = prepend;
       }
-      messages[msg] += (messages[msg].length > 0 && messages[msg] !== prepend ? char : '') + splitText[i];
+      msg += (msg.length > 0 && msg !== prepend ? char : '') + chunk;
     }
-    return messages.filter(m => m);
+    return messages.concat(msg).filter(m => m);
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -18,14 +18,14 @@ class Util {
    * @param {SplitOptions} [options] Options controlling the behaviour of the split
    * @returns {string|string[]}
    */
-  static splitMessage(text, { maxLength = 1950, char = '\n', prepend = '', append = '' } = {}) {
+  static splitMessage(text, { maxLength = 2000, char = '\n', prepend = '', append = '' } = {}) {
     if (text.length <= maxLength) return text;
     const splitText = text.split(char);
     if (splitText.length === 1) throw new RangeError('SPLIT_MAX_LEN');
     const messages = [];
     let msg = '';
     for (const chunk of splitText) {
-      if ((msg + char + chunk + append).length > maxLength) {
+      if (msg && (msg + char + chunk + append).length > maxLength) {
         messages.push(msg + append);
         msg = prepend;
       }

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -29,7 +29,7 @@ class Util {
         messages.push(msg + append);
         msg = prepend;
       }
-      msg += (msg.length > 0 && msg !== prepend ? char : '') + chunk;
+      msg += (msg && msg !== prepend ? char : '') + chunk;
     }
     return messages.concat(msg).filter(m => m);
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `splitMessage` method sometimes fails to deliver desired output because it does not take into account the length of the separator and that of the prefix and postfix (`prepend` and `append`).

**Examples**:
1.
```js
send(`${'a'.repeat(999)} | ${'b'.repeat(999)}`, { split: { maxLength: 2000, char: ' | ' } })
```
The separator is 3 characters long, the method only counts it as one making the message exceed 2k characters.

2.
```js
send(`${'a'.repeat(999)}\n${'b'.repeat(999)}\n${'c'.repeat(999)}`, { split: { maxLength: 2000, append: 'hello' } })
```
Expected to send 3 separate messages and postfix them properly, but instead it joins the first 2 parts (1998 chars) then adds the postfix (+5 chars), making it exceed 2k characters

3. 
```js
send(`${'a'.repeat(1999)}\n${'b'.repeat(1999)}`, { split: { prepend: 'c' } })
```
For some reason also prepends 'c' to the first message, which it shouldn't.
https://discord.js.org/#/docs/main/stable/typedef/SplitOptions


This PR fixes all the bugs described above.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
