### PR TITLE
Check if process is defined instead of using window

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -1,6 +1,6 @@
 const Package = exports.Package = require('../../package.json');
 const { Error, RangeError } = require('../errors');
-const browser = exports.browser = typeof window !== 'undefined';
+const browser = exports.browser = typeof process === 'undefined';
 
 /**
  * Options for a client.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR allows for Discord.js to be ran on instances of Node.js that may be bundled with a web browser, for example, Electron, by checking if `process` is undefined instead of checking if `window` is defined.

This allows Discord.js to access voice channels while being ran in an Electon window, whilst still disallowing web browsers from accessing "special" features.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
