### PR TITLE
refactor: Move member role-related functions to a special store

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ module.exports = {
   EmojiStore: require('./stores/EmojiStore'),
   GuildChannelStore: require('./stores/GuildChannelStore'),
   GuildMemberStore: require('./stores/GuildMemberStore'),
+  GuildMemberRoleStore: require('./stores/GuildMemberRoleStore'),
   GuildStore: require('./stores/GuildStore'),
   ReactionUserStore: require('./stores/ReactionUserStore'),
   MessageStore: require('./stores/MessageStore'),

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -82,7 +82,7 @@ class GuildMemberRoleStore extends DataStore {
     if (this.resolve(roleOrRoles)) {
       roleOrRoles = this.resolve(roleOrRoles);
       if (!roleOrRoles) return Promise.reject(new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake'));
-      if (!this._roles.includes(roleOrRoles.id)) return Promise.resolve(this);
+      if (!this._roles.includes(roleOrRoles.id)) return Promise.resolve(this.member);
       return this.client.api.guilds(this.guild.id).members(this.member.id).roles(roleOrRoles.id)
         .delete({ reason })
         .then(() => {

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -22,7 +22,7 @@ class GuildMemberRoleStore extends DataStore {
    */
   add(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection) return this.add(roleOrRoles.keyArray(), reason);
-    if (!Array.isArray(roleOrRoles)) return this.add([roleOrRoles], reason);
+    if (!(roleOrRoles instanceof Array)) return this.add([roleOrRoles], reason);
 
     roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
 
@@ -64,7 +64,7 @@ class GuildMemberRoleStore extends DataStore {
    */
   remove(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection) return this.remove(roleOrRoles.keyArray(), reason);
-    if (!Array.isArray(roleOrRoles)) return this.remove([roleOrRoles], reason);
+    if (!(roleOrRoles instanceof Array)) return this.remove([roleOrRoles], reason);
 
     roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
 

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -66,13 +66,13 @@ class GuildMemberRoleStore extends DataStore {
     if (roleOrRoles instanceof Collection) return this.remove(roleOrRoles.keyArray(), reason);
     if (!Array.isArray(roleOrRoles)) return this.remove([roleOrRoles], reason);
 
-    roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
+    roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
 
     if (roleOrRoles.includes(null)) {
       return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
         'Array or Collection of Roles or Snowflakes', true));
     } else {
-      for (const role of roleOrRoles) super.remove(role.id);
+      for (const role of roleOrRoles) super.remove(role);
     }
 
     return this.set(this, reason);

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -22,7 +22,7 @@ class GuildMemberRoleStore extends DataStore {
    */
   add(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection) return this.add(roleOrRoles.keyArray(), reason);
-    if (!Array.isArray(roleOrRoles)) return this.add([roleOrRoles.id || roleOrRoles], reason);
+    if (!Array.isArray(roleOrRoles)) return this.add([roleOrRoles], reason);
 
     roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
 
@@ -64,7 +64,7 @@ class GuildMemberRoleStore extends DataStore {
    */
   remove(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection) return this.remove(roleOrRoles.keyArray(), reason);
-    if (!Array.isArray(roleOrRoles)) return this.remove([roleOrRoles.id || roleOrRoles], reason);
+    if (!Array.isArray(roleOrRoles)) return this.remove([roleOrRoles], reason);
 
     roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
 

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -15,23 +15,23 @@ class GuildMemberRoleStore extends DataStore {
   }
 
   /**
-	 * Function that does exactly the same as Map.set
-	 * but it is overwritten for this DataStore due to {@link GuildMemberRoleStore#set}
-	 * @private
-	 * @param {Snowflake} id The role ID
-	 * @param {Role} role The role object
-	 * @returns {GuildMemberRoleStore} The updated store
-	 */
+   * Function that does exactly the same as Map#set
+   * but it is overwritten for this DataStore due to {@link GuildMemberRoleStore#set}
+   * @private
+   * @param {Snowflake} id The role ID
+   * @param {Role} role The role object
+   * @returns {GuildMemberRoleStore} The updated store
+   */
   _set(id, role) {
     return super.set(id, role);
   }
 
   /**
-	 * Adds a role (or multiple roles) to the member
-	 * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to add
-	 * @param {string} [reason] Reason for adding the role(s)
-	 * @returns {Promise<GuildMember>}
-	 */
+   * Adds a role (or multiple roles) to the member
+   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to add
+   * @param {string} [reason] Reason for adding the role(s)
+   * @returns {Promise<GuildMember>}
+   */
   add(roleOrRoles, reason) {
     if (this.guild.roles.resolve(roleOrRoles)) {
       return this._addOne(roleOrRoles, reason);
@@ -41,12 +41,12 @@ class GuildMemberRoleStore extends DataStore {
   }
 
   /**
-	 * Adds a single role to the member
-	 * @param {RoleResolvable} role The role or role ID to add
-	 * @param {string} [reason] Reason for adding the role
-	 * @private
-	 * @returns {Promise<GuildMember>}
-	 */
+   * Adds a single role to the member
+   * @param {RoleResolvable} role The role or role ID to add
+   * @param {string} [reason] Reason for adding the role
+   * @private
+   * @returns {Promise<GuildMember>}
+   */
   _addOne(role, reason) {
     role = this.guild.roles.resolve(role);
     if (!role) return Promise.reject(new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake'));
@@ -64,7 +64,7 @@ class GuildMemberRoleStore extends DataStore {
    * Adds multiple roles to the member.
    * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles The roles or role IDs to add
    * @param {string} [reason] Reason for adding the roles
-	 * @private
+   * @private
    * @returns {Promise<GuildMember>}
    */
   _addMany(roles, reason) {
@@ -101,11 +101,11 @@ class GuildMemberRoleStore extends DataStore {
   }
 
   /**
-	 * Removes a role (or multiple roles) from the member
-	 * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to remove
-	 * @param {string} [reason] Reason for removing the role(s)
-	 * @returns {Promise<GuildMember>}
-	 */
+   * Removes a role (or multiple roles) from the member
+   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to remove
+   * @param {string} [reason] Reason for removing the role(s)
+   * @returns {Promise<GuildMember>}
+   */
   remove(roleOrRoles, reason) {
     if (this.guild.roles.resolve(roleOrRoles)) {
       return this._removeOne(roleOrRoles, reason);
@@ -118,7 +118,7 @@ class GuildMemberRoleStore extends DataStore {
    * Removes a single role from the member.
    * @param {RoleResolvable} role The role or ID of the role to remove
    * @param {string} [reason] Reason for removing the role
-	 * @private
+   * @private
    * @returns {Promise<GuildMember>}
    */
   _removeOne(role, reason) {
@@ -139,7 +139,7 @@ class GuildMemberRoleStore extends DataStore {
    * Removes multiple roles from the member.
    * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles The roles or role IDs to remove
    * @param {string} [reason] Reason for removing the roles
-	 * @private
+   * @private
    * @returns {Promise<GuildMember>}
    */
   _removeMany(roles, reason) {

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -15,7 +15,7 @@ class GuildMemberRoleStore extends DataStore {
   }
 
   /**
-   * Adds a role (or multiple roles) to the member
+   * Adds a role (or multiple roles) to the member.
    * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to add
    * @param {string} [reason] Reason for adding the role(s)
    * @returns {Promise<GuildMember>}
@@ -57,7 +57,7 @@ class GuildMemberRoleStore extends DataStore {
   }
 
   /**
-   * Removes a role (or multiple roles) from the member
+   * Removes a role (or multiple roles) from the member.
    * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to remove
    * @param {string} [reason] Reason for removing the role(s)
    * @returns {Promise<GuildMember>}

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -24,14 +24,15 @@ class GuildMemberRoleStore extends DataStore {
     if (roleOrRoles instanceof Collection) return this.add(roleOrRoles.keyArray(), reason);
     if (!Array.isArray(roleOrRoles)) return this.add([roleOrRoles.id || roleOrRoles], reason);
 
-    for (let role of roleOrRoles) {
-      role = this.guild.roles.resolve(role);
-      if (!role) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
-          'Array or Collection of Roles or Snowflakes', true));
-      }
-      super.set(role.id, role);
+    roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
+
+    if (roleOrRoles.includes(null)) {
+      return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+        'Array or Collection of Roles or Snowflakes', true));
+    } else {
+      for (const role of roleOrRoles) super.set(role.id, role);
     }
+
     return this.set(this, reason);
   }
 
@@ -65,13 +66,13 @@ class GuildMemberRoleStore extends DataStore {
     if (roleOrRoles instanceof Collection) return this.remove(roleOrRoles.keyArray(), reason);
     if (!Array.isArray(roleOrRoles)) return this.remove([roleOrRoles.id || roleOrRoles], reason);
 
-    for (let role of roleOrRoles) {
-      role = this.guild.roles.resolve(role);
-      if (!role) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
-          'Array or Collection of Roles or Snowflakes', true));
-      }
-      super.remove(role.id);
+    roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
+
+    if (roleOrRoles.includes(null)) {
+      return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+        'Array or Collection of Roles or Snowflakes', true));
+    } else {
+      for (const role of roleOrRoles) super.remove(role.id);
     }
 
     return this.set(this, reason);

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -34,7 +34,7 @@ class GuildMemberRoleStore extends DataStore {
     if (this.resolve(roleOrRoles)) {
       roleOrRoles = this.resolve(roleOrRoles);
       if (!roleOrRoles) return Promise.reject(new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake'));
-      if (this._roles.includes(roleOrRoles.id)) return Promise.resolve(this.member);
+      if (this.member._roles.includes(roleOrRoles.id)) return Promise.resolve(this.member);
       return this.client.api.guilds(this.guild.id).members(this.member.id).roles(roleOrRoles.id)
         .put({ reason })
         .then(() => {

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -33,7 +33,7 @@ class GuildMemberRoleStore extends DataStore {
    * @returns {Promise<GuildMember>}
    */
   add(roleOrRoles, reason) {
-    if (this.guild.roles.resolve(roleOrRoles)) {
+    if (this.resolve(roleOrRoles)) {
       return this._addOne(roleOrRoles, reason);
     } else {
       return this._addMany(roleOrRoles, reason);
@@ -48,7 +48,7 @@ class GuildMemberRoleStore extends DataStore {
    * @returns {Promise<GuildMember>}
    */
   _addOne(role, reason) {
-    role = this.guild.roles.resolve(role);
+    role = this.resolve(role);
     if (!role) return Promise.reject(new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake'));
     if (this.member._roles.includes(role.id)) return Promise.resolve(this.member);
     return this.client.api.guilds(this.guild.id).members(this.member.id).roles(role.id)
@@ -70,7 +70,7 @@ class GuildMemberRoleStore extends DataStore {
   _addMany(roles, reason) {
     let allRoles = this.member._roles.slice();
     for (let role of roles instanceof Collection ? roles.values() : roles) {
-      role = this.guild.roles.resolve(role);
+      role = this.resolve(role);
       if (!role) {
         return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
           'Array or Collection of Roles or Snowflakes', true));
@@ -107,7 +107,7 @@ class GuildMemberRoleStore extends DataStore {
    * @returns {Promise<GuildMember>}
    */
   remove(roleOrRoles, reason) {
-    if (this.guild.roles.resolve(roleOrRoles)) {
+    if (this.resolve(roleOrRoles)) {
       return this._removeOne(roleOrRoles, reason);
     } else {
       return this._removeMany(roleOrRoles, reason);
@@ -122,7 +122,7 @@ class GuildMemberRoleStore extends DataStore {
    * @returns {Promise<GuildMember>}
    */
   _removeOne(role, reason) {
-    role = this.guild.roles.resolve(role);
+    role = this.resolve(role);
     if (!role) return Promise.reject(new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake'));
     if (!this.member._roles.includes(role.id)) return Promise.resolve(this);
     return this.client.api.guilds(this.guild.id).members(this.member.id).roles(role.id)
@@ -145,7 +145,7 @@ class GuildMemberRoleStore extends DataStore {
   _removeMany(roles, reason) {
     const allRoles = this.member._roles.slice();
     for (let role of roles instanceof Collection ? roles.values() : roles) {
-      role = this.guild.roles.resolve(role);
+      role = this.resolve(role);
       if (!role) {
         return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
           'Array or Collection of Roles or Snowflakes', true));

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -1,0 +1,217 @@
+const DataStore = require('./DataStore');
+const Role = require('../structures/Role');
+const Collection = require('../util/Collection');
+const { TypeError } = require('../errors');
+
+/**
+ * Stores member roles
+ * @extends {DataStore}
+ */
+class GuildMemberRoleStore extends DataStore {
+  constructor(member) {
+    super(member.client, null, Role);
+    this.member = member;
+    this.guild = member.guild;
+  }
+
+  /**
+	 * Function that does exactly the same as Map.set
+	 * but it is overwritten for this DataStore due to {@link GuildMemberRoleStore#set}
+	 * @private
+	 * @param {Snowflake} id The role ID
+	 * @param {Role} role The role object
+	 * @returns {GuildMemberRoleStore} The updated store
+	 */
+  _set(id, role) {
+    return super.set(id, role);
+  }
+
+  /**
+	 * Adds a role (or multiple roles) to the member
+	 * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to add
+	 * @param {string} [reason] Reason for adding the role(s)
+	 * @returns {Promise<GuildMember>}
+	 */
+  add(roleOrRoles, reason) {
+    if (this.guild.roles.resolve(roleOrRoles)) {
+      return this._addOne(roleOrRoles, reason);
+    } else {
+      return this._addMany(roleOrRoles, reason);
+    }
+  }
+
+  /**
+	 * Adds a single role to the member
+	 * @param {RoleResolvable} role The role or role ID to add
+	 * @param {string} [reason] Reason for adding the role
+	 * @private
+	 * @returns {Promise<GuildMember>}
+	 */
+  _addOne(role, reason) {
+    role = this.guild.roles.resolve(role);
+    if (!role) return Promise.reject(new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake'));
+    if (this.member._roles.includes(role.id)) return Promise.resolve(this.member);
+    return this.client.api.guilds(this.guild.id).members(this.member.id).roles(role.id)
+      .put({ reason })
+      .then(() => {
+        const clone = this.member._clone();
+        if (!clone._roles.includes(role.id)) clone._roles.push(role.id);
+        return clone;
+      });
+  }
+
+  /**
+   * Adds multiple roles to the member.
+   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles The roles or role IDs to add
+   * @param {string} [reason] Reason for adding the roles
+	 * @private
+   * @returns {Promise<GuildMember>}
+   */
+  _addMany(roles, reason) {
+    let allRoles = this.member._roles.slice();
+    for (let role of roles instanceof Collection ? roles.values() : roles) {
+      role = this.guild.roles.resolve(role);
+      if (!role) {
+        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+          'Array or Collection of Roles or Snowflakes', true));
+      }
+      if (!allRoles.includes(role.id)) allRoles.push(role.id);
+    }
+    return this.member.edit({ roles: allRoles }, reason);
+  }
+
+  /**
+   * Sets the roles applied to the member.
+   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles The roles or role IDs to apply
+   * @param {string} [reason] Reason for applying the roles
+   * @returns {Promise<GuildMember>}
+   * @example
+   * // Set the member's roles to a single role
+   * guildMember.roles.set(['391156570408615936'])
+   *   .then(console.log)
+   *   .catch(console.error);
+   * @example
+   * // Remove all the roles from a member
+   * guildMember.roles.set([])
+   *   .then(member => console.log(`Member roles is now of ${member.roles.size} size`))
+   *   .catch(console.error);
+   */
+  set(roles, reason) {
+    return this.member.edit({ roles }, reason);
+  }
+
+  /**
+	 * Removes a role (or multiple roles) from the member
+	 * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to remove
+	 * @param {string} [reason] Reason for removing the role(s)
+	 * @returns {Promise<GuildMember>}
+	 */
+  remove(roleOrRoles, reason) {
+    if (this.guild.roles.resolve(roleOrRoles)) {
+      return this._removeOne(roleOrRoles, reason);
+    } else {
+      return this._removeMany(roleOrRoles, reason);
+    }
+  }
+
+  /**
+   * Removes a single role from the member.
+   * @param {RoleResolvable} role The role or ID of the role to remove
+   * @param {string} [reason] Reason for removing the role
+	 * @private
+   * @returns {Promise<GuildMember>}
+   */
+  _removeOne(role, reason) {
+    role = this.guild.roles.resolve(role);
+    if (!role) return Promise.reject(new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake'));
+    if (!this.member._roles.includes(role.id)) return Promise.resolve(this);
+    return this.client.api.guilds(this.guild.id).members(this.member.id).roles(role.id)
+      .delete({ reason })
+      .then(() => {
+        const clone = this.member._clone();
+        const index = clone._roles.indexOf(role.id);
+        if (~index) clone._roles.splice(index, 1);
+        return clone;
+      });
+  }
+
+  /**
+   * Removes multiple roles from the member.
+   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles The roles or role IDs to remove
+   * @param {string} [reason] Reason for removing the roles
+	 * @private
+   * @returns {Promise<GuildMember>}
+   */
+  _removeMany(roles, reason) {
+    const allRoles = this.member._roles.slice();
+    for (let role of roles instanceof Collection ? roles.values() : roles) {
+      role = this.guild.roles.resolve(role);
+      if (!role) {
+        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+          'Array or Collection of Roles or Snowflakes', true));
+      }
+      const index = allRoles.indexOf(role.id);
+      if (index >= 0) allRoles.splice(index, 1);
+    }
+    return this.member.edit({ roles: allRoles }, reason);
+  }
+
+  /**
+   * The role of the member used to hoist them in a separate category in the users list
+   * @type {?Role}
+   * @readonly
+   */
+  get hoistRole() {
+    const hoistedRoles = this.filter(role => role.hoist);
+    if (!hoistedRoles.size) return null;
+    return hoistedRoles.reduce((prev, role) => !prev || role.comparePositionTo(prev) > 0 ? role : prev);
+  }
+
+  /**
+   * The role of the member used to set their color
+   * @type {?Role}
+   * @readonly
+   */
+  get colorRole() {
+    const coloredRoles = this.filter(role => role.color);
+    if (!coloredRoles.size) return null;
+    return coloredRoles.reduce((prev, role) => !prev || role.comparePositionTo(prev) > 0 ? role : prev);
+  }
+
+  /**
+   * The role of the member with the highest position
+   * @type {Role}
+   * @readonly
+   */
+  get highestRole() {
+    return this.reduce((prev, role) => !prev || role.comparePositionTo(prev) > 0 ? role : prev);
+  }
+
+  resolve(idOrInstance) {
+    return this.guild.roles.resolve(idOrInstance);
+  }
+
+  resolveID(idOrInstance) {
+    return this.guild.roles.resolveID(idOrInstance);
+  }
+
+  /**
+   * Resolves a RoleResolvable to a Role object.
+   * @method resolve
+   * @memberof GuildMemberRoleStore
+   * @instance
+   * @param {RoleResolvable} role The role resolvable to resolve
+   * @returns {?Role}
+   */
+
+  /**
+   * Resolves a RoleResolvable to a role ID string.
+   * @method resolveID
+   * @memberof GuildMemberRoleStore
+   * @instance
+   * @param {RoleResolvable} role The role resolvable to resolve
+   * @returns {?Snowflake}
+   */
+}
+
+module.exports = GuildMemberRoleStore;

--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -32,6 +32,7 @@ class RoleStore extends DataStore {
    * @example
    * // Create a new role with data and a reason
    * guild.roles.create({
+   *   {
    *     name: 'Super Cool People',
    *     color: 'BLUE'
    *   },
@@ -62,22 +63,22 @@ class RoleStore extends DataStore {
    */
 
   /**
-    * Resolves a RoleResolvable to a Role object.
-    * @method resolve
-    * @memberof RoleStore
-    * @instance
-    * @param {RoleResolvable} role The role resolvable to resolve
-    * @returns {?Role}
-    */
+   * Resolves a RoleResolvable to a Role object.
+   * @method resolve
+   * @memberof RoleStore
+   * @instance
+   * @param {RoleResolvable} role The role resolvable to resolve
+   * @returns {?Role}
+   */
 
   /**
-    * Resolves a RoleResolvable to a role ID string.
-    * @method resolveID
-    * @memberof RoleStore
-    * @instance
-    * @param {RoleResolvable} role The role resolvable to resolve
-    * @returns {?Snowflake}
-    */
+   * Resolves a RoleResolvable to a role ID string.
+   * @method resolveID
+   * @memberof RoleStore
+   * @instance
+   * @param {RoleResolvable} role The role resolvable to resolve
+   * @returns {?Snowflake}
+   */
 }
 
 module.exports = RoleStore;

--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -32,11 +32,10 @@ class RoleStore extends DataStore {
    * @example
    * // Create a new role with data and a reason
    * guild.roles.create({
-   *   {
    *     name: 'Super Cool People',
    *     color: 'BLUE'
    *   },
-   *   reason: 'we needed a role for Super Cool People',
+   *   'we needed a role for Super Cool People',
    * })
    *   .then(console.log)
    *   .catch(console.error);

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -179,6 +179,18 @@ class Guild extends Base {
     this.available = !data.unavailable;
     this.features = data.features || this.features || [];
 
+    if (data.channels) {
+      this.channels.clear();
+      for (const rawChannel of data.channels) {
+        this.client.channels.add(rawChannel, this);
+      }
+    }
+
+    if (data.roles) {
+      this.roles.clear();
+      for (const role of data.roles) this.roles.add(role);
+    }
+
     if (data.members) {
       this.members.clear();
       for (const guildUser of data.members) this.members.add(guildUser);
@@ -190,18 +202,6 @@ class Guild extends Base {
        * @type {Snowflake}
        */
       this.ownerID = data.owner_id;
-    }
-
-    if (data.channels) {
-      this.channels.clear();
-      for (const rawChannel of data.channels) {
-        this.client.channels.add(rawChannel, this);
-      }
-    }
-
-    if (data.roles) {
-      this.roles.clear();
-      for (const role of data.roles) this.roles.add(role);
     }
 
     if (data.presences) {

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -140,17 +140,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get roles() {
-    const list = new GuildMemberRoleStore(this);
-
-    const everyoneRole = this.guild.roles.get(this.guild.id);
-    if (everyoneRole) list._set(everyoneRole.id, everyoneRole);
-
-    for (const roleID of this._roles) {
-      const role = this.guild.roles.resolve(roleID);
-      if (role) list._set(role.id, role);
-    }
-
-    return list;
+    return new GuildMemberRoleStore(this, this._roles);
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -145,7 +145,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get displayColor() {
-    const role = this.roles.colorRole;
+    const role = this.roles.color;
     return (role && role.color) || 0;
   }
 
@@ -155,7 +155,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get displayHexColor() {
-    const role = this.roles.colorRole;
+    const role = this.roles.color;
     return (role && role.hexColor) || '#000000';
   }
 

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -27,7 +27,12 @@ class GuildMember extends Base {
      */
     this.user = {};
 
-    this._roles = [];
+    /**
+     * A list of roles that are applied to this GuildMember, mapped by the role ID
+     * @type {GuildMemberRoleStore<Snowflake, Role>}
+     */
+
+    this.roles = new GuildMemberRoleStore(this);
 
     if (data) this._patch(data);
 
@@ -67,7 +72,7 @@ class GuildMember extends Base {
     if (data.joined_at) this.joinedTimestamp = new Date(data.joined_at).getTime();
 
     this.user = this.guild.client.users.add(data.user);
-    if (data.roles) this._roles = data.roles;
+    if (data.roles) this.roles._patch(data.roles);
   }
 
   get voiceState() {
@@ -132,15 +137,6 @@ class GuildMember extends Base {
    */
   get presence() {
     return this.frozenPresence || this.guild.presences.get(this.id) || new Presence(this.client);
-  }
-
-  /**
-   * A list of roles that are applied to this GuildMember, mapped by the role ID
-   * @type {GuildMemberRoleStore<Snowflake, Role>}
-   * @readonly
-   */
-  get roles() {
-    return new GuildMemberRoleStore(this, this._roles);
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -142,7 +142,6 @@ class GuildMember extends Base {
   get roles() {
     const list = new Collection();
     const everyoneRole = this.guild.roles.get(this.guild.id);
-
     if (everyoneRole) list.set(everyoneRole.id, everyoneRole);
 
     for (const roleID of this._roles) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR moves a few member role related functions to a new store, for consistency.

Also, should I rename the `GuildMemberRoleStore#highestRole`, `hoistRole` and `colorRole` to remove the role part? For some reason, it sounds better with and without. /shrug
Also, should I rename the store? It may be a little big too.. "big" for a name. But at the same time it represents exactly what it stores.

A list of what changed:
- `GuildMember#addRole` -> `GuildMemberRoleStore#add`
- `GuildMember#addRoles` -> `GuildMemberRoleStore#add` (it supports arrays OR one item only)
- `GuildMember#setRoles` -> `GuildMemberRoleStore#set`
- `GuildMember#removeRole` -> `GuildMemberRoleStore#remove`
- `GuildMember#removeRoles` -> `GuildMemberRoleStore#remove` (as `GuildMemberRoleStore#add`)
- Some minuscule doc fixes to `RoleStore` cause someone forgot a `{` in the move and messed up spacing

Fully documented everything, AND tested said documentation (localhost:666 FTW (that's my local instance of the D.js wiki site)). And also tested the code. Nothing broke.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
