### PR TITLE
Transition from Collection to Dictionary

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/hydrabolt/discord.js#readme",
   "runkitExampleFilename": "./docs/examples/ping.js",
   "dependencies": {
+    "@sugarcoated/fondant-dictionary": "^1.0.4",
     "pako": "^1.0.0",
     "prism-media": "^0.0.2",
     "snekfetch": "^3.5.0",

--- a/src/client/actions/MessageDeleteBulk.js
+++ b/src/client/actions/MessageDeleteBulk.js
@@ -1,6 +1,7 @@
 const Action = require('./Action');
-const Collection = require('../../util/Collection');
+const Dictionary = require('@sugarcoated/fondant-dictionary');
 const { Events } = require('../../util/Constants');
+const Message = require('../../structures/Message');
 
 class MessageDeleteBulkAction extends Action {
   handle(data) {
@@ -9,7 +10,7 @@ class MessageDeleteBulkAction extends Action {
 
     if (channel) {
       const ids = data.ids;
-      const messages = new Collection();
+      const messages = new Dictionary(Message);
       for (const id of ids) {
         const message = channel.messages.get(id);
         if (message) {
@@ -28,7 +29,7 @@ class MessageDeleteBulkAction extends Action {
 /**
  * Emitted whenever messages are deleted in bulk.
  * @event Client#messageDeleteBulk
- * @param {Collection<Snowflake, Message>} messages The deleted messages, mapped by their ID
+ * @param {Dictionary<Snowflake, Message>} messages The deleted messages, mapped by their ID
  */
 
 module.exports = MessageDeleteBulkAction;


### PR DESCRIPTION
Inspired by `Collection` (in utils), [I rewrote it into a library](https://github.com/Sugarcoated/Fondant/wiki/Collection) that I basically use in all of my projects, and regularly keep a suite of tests updated for. I also went on to write [a class called `Dictionary`](https://github.com/Sugarcoated/Fondant/wiki/Dictionary) that inherits from `Collection`, intending to restrict the contents to instances of a particular `class` -- even handling base JavaScript classes such as `String` and `Number` via casting.

Discord.js, for the most part, relies heavily on custom structures wrapped around the Discord API responses. Implementing `Dictionary` provides an alternate use case to `Collection`, and in the case of Discord.js, this means you can restrict/predict what type of set of items your functions are going to return, while using `Collection` when your sets of items are different `class`es from each other.

This would require a relatively simple implementation. `Collection` has all the methods used in the library, and implements further methods that users could use when dealing with their bots. However, there are two concerns with implementing this:

1. It can't be done all at once, there are at least 260 uses of the word `Collection` throughout the library.
2. I'm only just getting my head around how the library works, so I'm not always sure what is expected from a method.

I've provided an example in my commit for usage.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
