### PR TITLE
Fix(GuildChannel#clone) options.parent not accepting (falsy) null.

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -414,18 +414,18 @@ class GuildChannel extends Channel {
    * @param {string} [options.reason] Reason for cloning this channel
    * @returns {Promise<GuildChannel>}
    */
-  clone({ name = this.name, withPermissions = true, withTopic = true, nsfw, parent, bitrate, userLimit, reason } = {}) {
-    const options = {
-      overwrites: withPermissions ? this.permissionOverwrites : [],
-      nsfw: typeof nsfw === 'undefined' ? this.nsfw : nsfw,
-      parent: parent || this.parent,
-      bitrate: bitrate || this.bitrate,
-      userLimit: userLimit || this.userLimit,
-      reason,
+  clone(options = {}) {
+    const createOptions = {
+      overwrites: options.overwrites ? this.permissionOverwrites : [],
+      nsfw: 'nsfw' in options ? options.nsfw : this.nsfw,
+      parent: 'parent' in options ? options.parent : this.parent,
+      bitrate: options.bitrate || this.bitrate,
+      userLimit: 'userLimit' in options ? options.userLimit : this.userLimit,
+      reason: options.reason,
       type: this.type,
     };
-    return this.guild.channels.create(name, options)
-      .then(channel => withTopic ? channel.setTopic(this.topic) : channel);
+    return this.guild.channels.create(options.name || this.name, createOptions)
+      .then(channel => options.withTopic ? channel.setTopic(this.topic) : channel);
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -415,16 +415,17 @@ class GuildChannel extends Channel {
    * @returns {Promise<GuildChannel>}
    */
   clone(options = {}) {
-    const createOptions = {
-      overwrites: options.overwrites ? this.permissionOverwrites : [],
-      nsfw: 'nsfw' in options ? options.nsfw : this.nsfw,
-      parent: 'parent' in options ? options.parent : this.parent,
-      bitrate: options.bitrate || this.bitrate,
-      userLimit: 'userLimit' in options ? options.userLimit : this.userLimit,
-      reason: options.reason,
-      type: this.type,
-    };
-    return this.guild.channels.create(options.name || this.name, createOptions)
+    Util.mergeDefault({
+      name: this.name,
+      withPermissions: true,
+      withTopic: true,
+      nsfw: this.nsfw,
+      parent: this.parent,
+      bitrate: this.bitrate,
+      userLimit: this.userLimit,
+      reason: null,
+    }, options);
+    return this.guild.channels.create(options.name, options)
       .then(channel => options.withTopic ? channel.setTopic(this.topic) : channel);
   }
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -415,9 +415,10 @@ class GuildChannel extends Channel {
    * @returns {Promise<GuildChannel>}
    */
   clone(options = {}) {
+    if (typeof options.withPermissions === 'undefined') options.withPermissions = true;
     Util.mergeDefault({
       name: this.name,
-      withPermissions: true,
+      overwrites: options.withPermissions ? this.permissionOverwrites : [],
       withTopic: true,
       nsfw: this.nsfw,
       parent: this.parent,
@@ -425,6 +426,7 @@ class GuildChannel extends Channel {
       userLimit: this.userLimit,
       reason: null,
     }, options);
+    options.type = this.type;
     return this.guild.channels.create(options.name, options)
       .then(channel => options.withTopic ? channel.setTopic(this.topic) : channel);
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The PR #2259 missed a little thing: if `options.parent` is given as `null` and the GuildChannel to clone has a parent, it'll default to it instead of being cloned as a channel with no parent, due to the usage of `||`.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
