### PR TITLE
Fix DataStores to be not private anymore.

### DIFF
--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -7,7 +7,6 @@ const lruable = ['group', 'dm'];
 
 /**
  * Stores channels.
- * @private
  * @extends {DataStore}
  */
 class ChannelStore extends DataStore {

--- a/src/stores/ClientPresenceStore.js
+++ b/src/stores/ClientPresenceStore.js
@@ -7,7 +7,6 @@ const { TypeError } = require('../errors');
 /**
  * Stores the client presence and other presences.
  * @extends {PresenceStore}
- * @private
  */
 class ClientPresenceStore extends PresenceStore {
   constructor(...args) {

--- a/src/stores/EmojiStore.js
+++ b/src/stores/EmojiStore.js
@@ -6,7 +6,6 @@ const DataResolver = require('../util/DataResolver');
 
 /**
  * Stores emojis.
- * @private
  * @extends {DataStore}
  */
 class EmojiStore extends DataStore {

--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -7,7 +7,6 @@ const Permissions = require('../util/Permissions');
 
 /**
  * Stores guild channels.
- * @private
  * @extends {DataStore}
  */
 class GuildChannelStore extends DataStore {

--- a/src/stores/GuildEmojiStore.js
+++ b/src/stores/GuildEmojiStore.js
@@ -1,16 +1,16 @@
 const Collection = require('../util/Collection');
 const DataStore = require('./DataStore');
-const Emoji = require('../structures/Emoji');
+const GuildEmoji = require('../structures/GuildEmoji');
 const ReactionEmoji = require('../structures/ReactionEmoji');
 const DataResolver = require('../util/DataResolver');
 
 /**
- * Stores emojis.
+ * Stores guild emojis.
  * @extends {DataStore}
  */
-class EmojiStore extends DataStore {
+class GuildEmojiStore extends DataStore {
   constructor(guild, iterable) {
-    super(guild.client, iterable, Emoji);
+    super(guild.client, iterable, GuildEmoji);
     this.guild = guild;
   }
 
@@ -60,17 +60,17 @@ class EmojiStore extends DataStore {
   }
 
   /**
-   * Data that can be resolved into an Emoji object. This can be:
+   * Data that can be resolved into an GuildEmoji object. This can be:
    * * A custom emoji ID
-   * * An Emoji object
+   * * A GuildEmoji object
    * * A ReactionEmoji object
-   * @typedef {Snowflake|Emoji|ReactionEmoji} EmojiResolvable
+   * @typedef {Snowflake|GuildEmoji|ReactionEmoji} EmojiResolvable
    */
 
   /**
-   * Resolves a EmojiResolvable to a Emoji object.
+   * Resolves an EmojiResolvable to an Emoji object.
    * @param {EmojiResolvable} emoji The Emoji resolvable to identify
-   * @returns {?Emoji}
+   * @returns {?GuildEmoji}
    */
   resolve(emoji) {
     if (emoji instanceof ReactionEmoji) return super.resolve(emoji.id);
@@ -78,7 +78,7 @@ class EmojiStore extends DataStore {
   }
 
   /**
-   * Resolves a EmojiResolvable to a Emoji ID string.
+   * Resolves an EmojiResolvable to an Emoji ID string.
    * @param {EmojiResolvable} emoji The Emoji resolvable to identify
    * @returns {?Snowflake}
    */
@@ -110,4 +110,4 @@ class EmojiStore extends DataStore {
   }
 }
 
-module.exports = EmojiStore;
+module.exports = GuildEmojiStore;

--- a/src/stores/GuildStore.js
+++ b/src/stores/GuildStore.js
@@ -5,7 +5,6 @@ const Guild = require('../structures/Guild');
 
 /**
  * Stores guilds.
- * @private
  * @extends {DataStore}
  */
 class GuildStore extends DataStore {

--- a/src/stores/PresenceStore.js
+++ b/src/stores/PresenceStore.js
@@ -3,7 +3,6 @@ const { Presence } = require('../structures/Presence');
 
 /**
  * Stores presences.
- * @private
  * @extends {DataStore}
  */
 class PresenceStore extends DataStore {

--- a/src/stores/ReactionStore.js
+++ b/src/stores/ReactionStore.js
@@ -3,7 +3,6 @@ const MessageReaction = require('../structures/MessageReaction');
 
 /**
  * Stores reactions.
- * @private
  * @extends {DataStore}
  */
 class ReactionStore extends DataStore {

--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -5,7 +5,6 @@ const Permissions = require('../util/Permissions');
 
 /**
  * Stores roles.
- * @private
  * @extends {DataStore}
  */
 class RoleStore extends DataStore {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Some DataStore Classes with important functionality are private, that causes the docs to not show it via the Searchbar and this should be changed.
~~If requested i could also make the other Stores not private anymore to stay consistent.~~ [Done]

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
