### PR TITLE
GuildEmoji: Move all role related functions to a separate store

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ module.exports = {
   ClientPresenceStore: require('./stores/ClientPresenceStore'),
   GuildChannelStore: require('./stores/GuildChannelStore'),
   GuildEmojiStore: require('./stores/GuildEmojiStore'),
+  GuildEmojiRoleStore: require('./stores/GuildEmojiRoleStore'),
   GuildMemberStore: require('./stores/GuildMemberStore'),
   GuildStore: require('./stores/GuildStore'),
   ReactionUserStore: require('./stores/ReactionUserStore'),

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -10,7 +10,7 @@ class DataStore extends Collection {
     super();
     if (!Structures) Structures = require('../util/Structures');
     Object.defineProperty(this, 'client', { value: client });
-    Object.defineProperty(this, 'holds', { value: Structures.get(holds.constructor.name) || holds });
+    Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) || holds });
     if (iterable) for (const item of iterable) this.add(item);
   }
 

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -10,7 +10,7 @@ class DataStore extends Collection {
     super();
     if (!Structures) Structures = require('../util/Structures');
     Object.defineProperty(this, 'client', { value: client });
-    Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) || holds });
+    Object.defineProperty(this, 'holds', { value: Structures.get(holds.constructor.name) || holds });
     if (iterable) for (const item of iterable) this.add(item);
   }
 

--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -1,5 +1,5 @@
 const DataStore = require('./DataStore');
-const GuildEmoji = require('../structures/GuildEmoji');
+let GuildEmoji;
 const Collection = require('../util/Collection');
 const { TypeError } = require('../errors');
 
@@ -9,6 +9,7 @@ const { TypeError } = require('../errors');
  */
 class GuildEmojiRoleStore extends DataStore {
   constructor(emoji) {
+    if (!GuildEmoji) GuildEmoji = require('../structures/GuildEmoji');
     super(emoji.client, null, GuildEmoji);
     this.emoji = emoji;
     this.guild = emoji.guild;

--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -24,6 +24,7 @@ class GuildEmojiRoleStore extends DataStore {
     if (!(roleOrRoles instanceof Array)) return this.add([roleOrRoles]);
 
     roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
+
     if (roleOrRoles.includes(null)) {
       return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
         'Array or Collection of Roles or Snowflakes', true));

--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -1,0 +1,110 @@
+const DataStore = require('./DataStore');
+const GuildEmoji = require('../structures/GuildEmoji');
+const Collection = require('../util/Collection');
+const { TypeError } = require('../errors');
+
+/**
+ * Stores emoji roles
+ * @extends {DataStore}
+ */
+class GuildEmojiRoleStore extends DataStore {
+  constructor(emoji) {
+    super(emoji.client, null, GuildEmoji);
+    this.emoji = emoji;
+    this.guild = emoji.guild;
+  }
+
+  /**
+   * Adds a role (or multiple roles) to the list of roles that can use this emoji.
+   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to add
+   * @returns {Promise<GuildEmoji>}
+   */
+  add(roleOrRoles) {
+    if (roleOrRoles instanceof Collection) return this.add(roleOrRoles.keyArray());
+    if (!(roleOrRoles instanceof Array)) return this.add([roleOrRoles]);
+
+    roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
+    if (roleOrRoles.includes(null)) {
+      return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+        'Array or Collection of Roles or Snowflakes', true));
+    } else {
+      for (const role of roleOrRoles) super.set(role.id, role);
+    }
+
+    return this.set(this);
+  }
+
+  /**
+   * Removes a role (or multiple roles) from the list of roles that can use this emoji.
+   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to remove
+   * @returns {Promise<GuildEmoji>}
+   */
+  remove(roleOrRoles) {
+    if (roleOrRoles instanceof Collection) return this.remove(roleOrRoles.keyArray());
+    if (!(roleOrRoles instanceof Array)) return this.remove([roleOrRoles]);
+
+    roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
+
+    if (roleOrRoles.includes(null)) {
+      return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+        'Array or Collection of Roles or Snowflakes', true));
+    } else {
+      for (const role of roleOrRoles) super.remove(role);
+    }
+
+    return this.set(this);
+  }
+
+  /**
+   * Sets the role(s) that can use this emoji.
+   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles The roles or role IDs to apply
+   * @returns {Promise<GuildEmoji>}
+   * @example
+   * // Set the emoji's roles to a single role
+   * guildEmoji.roles.set(['391156570408615936'])
+   *   .then(console.log)
+   *   .catch(console.error);
+   * @example
+   * // Remove all roles from an emoji
+   * guildEmoji.roles.set([])
+   *    .then(console.log)
+   *    .catch(console.error);
+   */
+  set(roles) {
+    return this.emoji.edit({ roles });
+  }
+
+  /**
+   * Patches the roles for this store
+   * @param {Snowflake[]} roles The new roles
+   * @private
+   */
+  _patch(roles) {
+    this.clear();
+
+    for (let role of roles) {
+      role = this.guild.roles.resolve(role);
+      if (role) super.set(role.id, role);
+    }
+  }
+
+  /**
+   * Resolves a RoleResolvable to a Role object.
+   * @method resolve
+   * @memberof GuildEmojiRoleStore
+   * @instance
+   * @param {RoleResolvable} role The role resolvable to resolve
+   * @returns {?Role}
+   */
+
+  /**
+   * Resolves a RoleResolvable to a role ID string.
+   * @method resolveID
+   * @memberof GuildEmojiRoleStore
+   * @instance
+   * @param {RoleResolvable} role The role resolvable to resolve
+   * @returns {?Snowflake}
+   */
+}
+
+module.exports = GuildEmojiRoleStore;

--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -1,5 +1,4 @@
 const DataStore = require('./DataStore');
-let GuildEmoji;
 const Collection = require('../util/Collection');
 const { TypeError } = require('../errors');
 
@@ -9,8 +8,7 @@ const { TypeError } = require('../errors');
  */
 class GuildEmojiRoleStore extends DataStore {
   constructor(emoji) {
-    if (!GuildEmoji) GuildEmoji = require('../structures/GuildEmoji');
-    super(emoji.client, null, GuildEmoji);
+    super(emoji.client, null, require('../structures/GuildEmoji'));
     this.emoji = emoji;
     this.guild = emoji.guild;
   }

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -120,13 +120,13 @@ class GuildEmoji extends Emoji {
         other.name === this.name &&
         other.managed === this.managed &&
         other.requiresColons === this.requiresColons &&
-        other._roles === this._roles
+        other.roles.every(role => this.roles.has(role.id))
       );
     } else {
       return (
         other.id === this.id &&
         other.name === this.name &&
-        other._roles === this._roles
+        other.roles.every(role => this.roles.has(role.id))
       );
     }
   }

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -35,7 +35,7 @@ class GuildEmoji extends Emoji {
      */
     this.managed = data.managed;
 
-    this._roles = data.roles;
+    if (data.roles) this.roles._patch(data.roles);
   }
 
   /**

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -126,7 +126,7 @@ class GuildEmoji extends Emoji {
       return (
         other.id === this.id &&
         other.name === this.name &&
-        other.roles.every(role => this.roles.has(role.id))
+        other.roles.every(role => this.roles.has(role))
       );
     }
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR moves all emoji role related functions to a new store, called `GuildEmojiRoleStore`.
Due to how Discord works, you need to reload your client if you have the role required to use the emoji.

A list of what changed:
- `GuildEmoji#addRestrictedRole` -> `GuildEmojiRoleStore#add`
- `GuildEmoji#addRestrictedRoles` -> `GuildEmojiRoleStore#add` (it supports arrays OR one item only)
- Added `GuildEmojiRoleStore#set`
- `GuildEmoji#removeRestrictedRole` -> `GuildEmojiRoleStore#remove`
- `GuildEmoji#removeRestrictedRoles` -> `GuildEmojiRoleStore#remove` (as `GuildEmojiRoleStore#add`)

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
