### PR TITLE
fix(client#voiceConnections): Incorrect docs description

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -212,7 +212,7 @@ class Client extends EventEmitter {
   }
 
   /**
-   * All active voice connections that have been established, mapped by channel ID
+   * All active voice connections that have been established, mapped by guild ID
    * @type {Collection<Snowflake, VoiceConnection>}
    * @readonly
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a stable documentation error describing `client#voiceConnections` as a collection of voice channels mapped by voice channel ID while it's actually mapped by guild ID now.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
