### PR TITLE
fix(Role): Update usages of highestRole#comparePositionTo to use GuildMemberRoleStore

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -222,7 +222,7 @@ class GuildMember extends Base {
   get manageable() {
     if (this.user.id === this.guild.ownerID) return false;
     if (this.user.id === this.client.user.id) return false;
-    return this.guild.me.highestRole.comparePositionTo(this.highestRole) > 0;
+    return this.guild.me.roles.highest.comparePositionTo(this.roles.highest) > 0;
   }
 
   /**

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -118,7 +118,7 @@ class Role extends Base {
     if (this.managed) return false;
     const clientMember = this.guild.member(this.client.user);
     if (!clientMember.permissions.has(Permissions.FLAGS.MANAGE_ROLES)) return false;
-    return clientMember.highestRole.comparePositionTo(this) > 0;
+    return clientMember.roles.highest.comparePositionTo(this) > 0;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Someone forgot to update the usages of `highestRole` in permission checking 👀 

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
