### PR TITLE
Document "end" and "finish" on StreamDispatcher.

### DIFF
--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -278,7 +278,7 @@ class StreamDispatcher extends Writable {
   get volume() {
     return this.streams.volume ? this.streams.volume.volume : 1;
   }
-  
+
   /**
    * Ends playback. Inherited from WriteableStream.
    */

--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -59,6 +59,10 @@ class StreamDispatcher extends Writable {
     this._pausedTime = 0;
     this.count = 0;
 
+    /**
+     * Emitted when the dispatcher ends. Previously known as the "end" event. Inherited from WriteableStream.
+     * @event StreamDispatcher#finish
+     */
     this.on('finish', () => {
       // Still emitting end for backwards compatibility, probably remove it in the future!
       this.emit('end');
@@ -273,6 +277,13 @@ class StreamDispatcher extends Writable {
   // Volume
   get volume() {
     return this.streams.volume ? this.streams.volume.volume : 1;
+  }
+  
+  /**
+   * Ends playback. Inherited from WriteableStream.
+   */
+  end() {
+    super.end();
   }
 
   setVolume(value) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Now before you go commenting like crazy "OH BUT IT'S EXTENDED" just hear me out. As much as I'd love to say that everyone will follow the inheritance and look up the WriteableStream from Node.js, I don't believe many will partially because it's not on the Discord.js site but the Node.js site and partially because most don't even care or bother to look at it. If we document it manually in Discord.js, it will stop users from going "how do I end a dispatcher" or "what's the new end event". Even though it's showed in the _example_, it's seemingly nowhere to be found in the documentation. This will also help confusion from previous versions of Discord.js.

**Semantic versioning classification:**
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
