### PR TITLE
Add fetches to ChannelStore and GuildStore

### DIFF
--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -108,9 +108,7 @@ class ChannelStore extends DataStore {
     const existing = this.get(id);
     if (existing) return Promise.resolve(existing);
 
-    return this.client.api.channels(id).get().then(data => {
-      return this.client.guilds.fetch(data.guild_id).then(guild => this.add(data, guild, cache));
-    });
+    return this.client.api.channels(id).get().then(data => this.client.guilds.fetch(data.guild_id).then(guild => this.add(data, guild, cache)));
   }
 }
 

--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -1,5 +1,6 @@
 const DataStore = require('./DataStore');
 const Channel = require('../structures/Channel');
+const Guild = require('../structures/Guild.js');
 const { Events } = require('../util/Constants');
 
 const kLru = Symbol('LRU');
@@ -96,6 +97,22 @@ class ChannelStore extends DataStore {
    * @param {ChannelResolvable} channel The channel resolvable to resolve
    * @returns {?Snowflake}
    */
+
+  /**
+    * Obtains a channel from Discord, or the channel cache if it's already available.
+    * <warn>This is only available when using a bot account.</warn>
+    * @param {Snowflake} id ID of the channel
+    * @param {boolean} [cache=true] Whether to cache the new channel object if it isn't already
+    * @returns {Promise<GuildChannel>}
+    */
+  fetch(id, cache = true) {
+    const existing = this.get(id);
+    if (existing) return Promise.resolve(existing);
+
+    return this.client.api.channels(id).get().then(data => {
+      return this.client.guilds.fetch(data.guild_id).then(guild => this.add(data, guild, cache));
+    });
+  }
 }
 
 module.exports = ChannelStore;

--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -108,7 +108,8 @@ class ChannelStore extends DataStore {
     const existing = this.get(id);
     if (existing) return Promise.resolve(existing);
 
-    return this.client.api.channels(id).get().then(data => this.client.guilds.fetch(data.guild_id).then(guild => this.add(data, guild, cache)));
+    return this.client.api.channels(id).get().then(
+      data => this.client.guilds.fetch(data.guild_id).then(guild => this.add(data, guild, cache)));
   }
 }
 

--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -102,7 +102,7 @@ class ChannelStore extends DataStore {
     * <warn>This is only available when using a bot account.</warn>
     * @param {Snowflake} id ID of the channel
     * @param {boolean} [cache=true] Whether to cache the new channel object if it isn't already
-    * @returns {Promise<GuildChannel>}
+    * @returns {Promise<Channel>}
     */
   fetch(id, cache = true) {
     const existing = this.get(id);

--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -1,6 +1,5 @@
 const DataStore = require('./DataStore');
 const Channel = require('../structures/Channel');
-const Guild = require('../structures/Guild.js');
 const { Events } = require('../util/Constants');
 
 const kLru = Symbol('LRU');

--- a/src/stores/GuildStore.js
+++ b/src/stores/GuildStore.js
@@ -80,13 +80,15 @@ class GuildStore extends DataStore {
     * <warn>This is only available when using a bot account.</warn>
     * @param {Snowflake} id ID of the guild
     * @param {boolean} [cache=true] Whether to cache the new guild object if it isn't already
-    * @returns {Promise<GuildChannel>}
+    * @returns {Promise<Guild>}
     */
   fetch(id, cache = true) {
     const existing = this.get(id);
     if (existing) return Promise.resolve(existing);
 
-    return this.client.api.guilds(id).get().then(data => this.add(data, cache));
+    return this.client.api.guilds(id).get().then(
+      data => this.client.api.guilds(id).channels.get().then(
+        cData => this.add(Object.assign({ channels: cData }, data), cache)));
   }
 }
 

--- a/src/stores/GuildStore.js
+++ b/src/stores/GuildStore.js
@@ -74,6 +74,20 @@ class GuildStore extends DataStore {
     return DataResolver.resolveImage(icon)
       .then(data => this.create(name, { region, icon: data || null }));
   }
+
+  /**
+    * Obtains a guild from Discord, or the guild cache if it's already available.
+    * <warn>This is only available when using a bot account.</warn>
+    * @param {Snowflake} id ID of the guild
+    * @param {boolean} [cache=true] Whether to cache the new guild object if it isn't already
+    * @returns {Promise<GuildChannel>}
+    */
+  fetch(id, cache = true) {
+    const existing = this.get(id);
+    if (existing) return Promise.resolve(existing);
+
+    return this.client.api.guilds(id).get().then(data => this.add(data, cache));
+  }
 }
 
 module.exports = GuildStore;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Due to sharding, it's extremely difficult to send a message to a channel in a different shard and get the message back in return. Heck, it doesn't even return the ID of the message. This makes it very difficult to interface between channels and guilds between shards. If we allow users to fetch guilds and channels, this means that it will be much easier to interface between shards allowing users to have easier cross-capabilities. For example, if a home guild is on Shard 0 but a person submitted feedback in Shard 1, and you want to edit or remove said feedback, it's extremely difficult to fetch the message AND edit it. Allowing us to fetch it makes it a huge deal easier.

Now you may bring up the point "this defeats the point of sharding" -- no, actually, it doesn't. It's the _user's_ choice to fetch the channel, and it will be cached for that shard as well. While that may seem like a bad thing, in reality instead of caching say 100 different guilds from another shard, you're caching one guild that may actually be used by said cache. This means the caching is still doing it's job -- making it faster to use and modify guild objects. If a user wants to send a message or use a channel in a guild form another shard, there's no need to use the (extremely annoying and hard to use) broadcastEval.

If there's anything that needs changing, please tell me. I prototyped on a bot in 10,000 servers and both fetches are currently working with all required information. Requesting a review from @hydrabolt.

**Example Usage**
```js
// You have a list of people's feedback in Shard 5, but you need to get this message event there.
// Assuming in async function
const chan = await client.channels.fetch("CHANNELIDINSHARD5WITHMYFEEDBACK");
const msg = chan.send(m.content); // The feedback
database.writeToDatabase({"mid": msg.id, "feedbackAuthor": m.author.id});
```
Now if a user wants to MODIFY their feedback:
```js
// Assuming in async fucntion
const chan = await client.channels.fetch("CHANNELIDINSHARD5WITHMYFEEDBACK");
const feedback = database.getFromDatabase({"feedbackAuthor": m.author.id});
const msg = await chan.messages.fetch(feedback.mid);
msg.edit(m.content); // Modify message with new feedback
```

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
