### PR TITLE
Update GuildChannel.js

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -320,7 +320,7 @@ class GuildChannel extends Channel {
     }
     return this.client.api.channels(this.id).patch({
       data: {
-        name: (data.name || this.name).trim(),
+        name: String(data.name || this.name).trim(),
         topic: data.topic,
         nsfw: data.nsfw,
         bitrate: data.bitrate || this.bitrate,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When setting a channel name to a non-string value, this error is thrown: 
`TypeError: (data.name || channel.name).trim is not a function`.
This PR fixes this issue by stringifying the name.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
