### PR TITLE
Reinstate the end method

### DIFF
--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -144,7 +144,7 @@ class StreamDispatcher extends Writable {
 
   /**
    * Stops the current stream permanently and emits a `finish` event.
-   * @param {string} reason The reason for ending this stream.
+   * @param {string} [reason='user'] The reason for ending this stream.
    */
   finish(reason = 'user') {
     super.end();

--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -143,6 +143,15 @@ class StreamDispatcher extends Writable {
   }
 
   /**
+   * Stops the current stream permanently and emits a `finish` event.
+   * @param {string} reason The reason for ending this stream.
+   */
+  finish(reason = 'user') {
+    super.end();
+    this.emit('finish', reason);
+  }
+
+  /**
    * The time (in milliseconds) that the dispatcher has actually been playing audio for
    * @type {number}
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR re-adds the `end` method but named as `finish` for consistency with the finish event. This is to bring back the reasons *so i can get my playlists working again* omegaLUL

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
