### PR TITLE
Add highest property to RoleStore

### DIFF
--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -56,6 +56,15 @@ class RoleStore extends DataStore {
   }
 
   /**
+   * The role with the highest position in the store
+   * @type {Role}
+   * @readonly
+   */
+  get highest() {
+    return this.reduce((prev, role) => !prev || role.comparePositionTo(prev) > 0 ? role : prev);
+  }
+
+  /**
    * Data that can be resolved to a Role object. This can be:
    * * A Role
    * * A Snowflake


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This commit adds a higest property to the RoleStore DataStore. This just makes it easier to get the highest role on a guild and makes the RoleStore class feel more like the GuildMemberRoleStore class. This PR should be merged because it adds a small utility method that would be helpful to have.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
