### PR TITLE
feat(login): allow logging in with presence data

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -271,7 +271,12 @@ class Client extends BaseClient {
    *      type: 'WATCHING',
    *    },
    *  },
-   * });
+   * })
+   *   .then(data => {
+   *     console.log('Token:', data.token);
+   *     console.log('Login options:', data.options);
+   *   })
+   *   .catch(console.error);
    */
   login(token = this.token, options = {}) {
     return new Promise((resolve, reject) => {

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -239,21 +239,45 @@ class Client extends BaseClient {
   }
 
   /**
+   * Options that can be passed when logging in.
+   * @typedef {Object} LoginOptions
+   * @property {PresenceData} presence Presence data to log in with
+   */
+
+  /**
+   * The data used when logging in.
+   * @typedef {Object} LoginData
+   * @property {string} token The token of the account used
+   * @property {LoginOptions} options The login options of the account used
+   */
+
+  /**
    * Logs the client in, establishing a websocket connection to Discord.
    * <info>Both bot and regular user accounts are supported, but it is highly recommended to use a bot account whenever
    * possible. User accounts are subject to harsher ratelimits and other restrictions that don't apply to bot accounts.
    * Bot accounts also have access to many features that user accounts cannot utilise. User accounts that are found to
    * be abusing/overusing the API will be banned, locking you out of Discord entirely.</info>
    * @param {string} token Token of the account to log in with
-   * @returns {Promise<string>} Token of the account used
+   * @param {LoginOptions} [options={}] Options to log in with
+   * @returns {Promise<LoginData>} Token and login options used to log in
    * @example
    * client.login('my token');
+   * @example
+   * client.login('my token', {
+   *  presence: {
+   *    status: 'dnd',
+   *    activity: {
+   *      name: 'YouTube',
+   *      type: 'WATCHING',
+   *    },
+   *  },
+   * });
    */
-  login(token = this.token) {
+  login(token = this.token, options = {}) {
     return new Promise((resolve, reject) => {
       if (!token || typeof token !== 'string') throw new Error('TOKEN_INVALID');
       token = token.replace(/^Bot\s*/i, '');
-      this.manager.connectToWebSocket(token, resolve, reject);
+      this.manager.connectToWebSocket(token, options, resolve, reject);
     }).catch(e => {
       this.destroy();
       return Promise.reject(e);

--- a/src/stores/ClientPresenceStore.js
+++ b/src/stores/ClientPresenceStore.js
@@ -19,7 +19,14 @@ class ClientPresenceStore extends PresenceStore {
     });
   }
 
-  async setClientPresence({ status, since, afk, activity }) { // eslint-disable-line complexity
+  async setClientPresence(presence) {
+    const packet = await this._parse(presence);
+    this.clientPresence.patch(packet);
+    this.client.ws.send({ op: OPCodes.STATUS_UPDATE, d: packet });
+    return this.clientPresence;
+  }
+
+  async _parse({ status, since, afk, activity }) { // eslint-disable-line complexity
     const applicationID = activity && (activity.application ? activity.application.id || activity.application : null);
     let assets = new Collection();
     if (activity) {
@@ -66,9 +73,7 @@ class ClientPresenceStore extends PresenceStore {
         packet.game.type : ActivityTypes.indexOf(packet.game.type);
     }
 
-    this.clientPresence.patch(packet);
-    this.client.ws.send({ op: OPCodes.STATUS_UPDATE, d: packet });
-    return this.clientPresence;
+    return packet;
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There's currently no support for setting a presence upon login, which the Discord API does support (see: [this gateway identifying snippet](https://discordapp.com/developers/docs/topics/gateway#identifying)). This PR adds a 2nd parameter to `Client#login` and acts in the same manner as `ClientUser#setPresence`. This will keep users from making an extra API call inside their `ready` event just to set their initial status/activity, as so many of us do.

Example snippet:
```js
client.login(token, {
    presence: {
        status: 'dnd',
        activity: {
            name: 'YouTube',
            type: 'WATCHING',
        },
    },
});
```

There were some things I wasn't very sure of (e.g. `Client#login`'s return value and the code inside `identifyNew()`), so if anyone has any suggestions on betters way to go about those, I'll gladly comply.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
