### PR TITLE
feature: add GuildEmoji#fetchAuthor

### DIFF
--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -60,7 +60,7 @@ class GuildEmoji extends Emoji {
   get createdAt() {
     return new Date(this.createdTimestamp);
   }
-  
+
   /**
    * Fetches the author for this emoji
    * @returns {Promise<User>}

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -60,6 +60,15 @@ class GuildEmoji extends Emoji {
   get createdAt() {
     return new Date(this.createdTimestamp);
   }
+  
+  /**
+   * Fetches the author for this emoji
+   * @returns {Promise<User>}
+   */
+  fetchAuthor() {
+    return this.client.api.guilds(this.guild.id).emojis(this.id).get()
+      .then(emoji => this.client.users.add(emoji.user));
+  }
 
   /**
    * Data for editing an emoji.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Now that https://github.com/discordapp/discord-api-docs/issues/492 landed, you are able to fetch the author of an emoji.

Note: The user is not returned from the websocket on the `GUILD_EMOJIS_UPDATE` event. 

Now the question is, should the user get cached in the emoji? That can provide an interesting issue when the user doesn't fetch the author first. I feel like it's not needed, but I will still ask.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
