### PR TITLE
docs/feat(WebsocketOptions): Parse ws options presence

### DIFF
--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -40,9 +40,8 @@ class ClientManager {
     this.client.token = token;
     const timeout = this.client.setTimeout(() => reject(new Error('WS_CONNECTION_TIMEOUT')), 1000 * 300);
     this.client.api.gateway.get().then(async res => {
-      const wsOptions = this.client.options.ws;
-      if (wsOptions != null && 'presence' in wsOptions) { // eslint-disable-line eqeqeq
-        this.client.options.ws.presence = await this.client.presences._parse(wsOptions.presence);
+      if (this.client.options.presence != null) { // eslint-disable-line eqeqeq
+        this.client.options.ws.presence = await this.client.presences._parse(this.client.options.presence);
       }
       const gateway = `${res.url}/`;
       this.client.emit(Events.DEBUG, `Using gateway ${gateway}`);

--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -39,7 +39,11 @@ class ClientManager {
     this.client.emit(Events.DEBUG, `Authenticated using token ${token}`);
     this.client.token = token;
     const timeout = this.client.setTimeout(() => reject(new Error('WS_CONNECTION_TIMEOUT')), 1000 * 300);
-    this.client.api.gateway.get().then(res => {
+    this.client.api.gateway.get().then(async res => {
+      const wsOptions = this.client.options.ws;
+      if (wsOptions != null && 'presence' in wsOptions) { // eslint-disable-line eqeqeq
+        this.client.options.ws.presence = await this.client.presences._parse(wsOptions.presence);
+      }
       const gateway = `${res.url}/`;
       this.client.emit(Events.DEBUG, `Using gateway ${gateway}`);
       this.client.ws.connect(gateway);

--- a/src/stores/ClientPresenceStore.js
+++ b/src/stores/ClientPresenceStore.js
@@ -19,7 +19,14 @@ class ClientPresenceStore extends PresenceStore {
     });
   }
 
-  async setClientPresence({ status, since, afk, activity }) { // eslint-disable-line complexity
+  async setClientPresence(presence) {
+    const packet = await this._parse(presence);
+    this.clientPresence.patch(packet);
+    this.client.ws.send({ op: OPCodes.STATUS_UPDATE, d: packet });
+    return this.clientPresence;
+  }
+
+  async _parse({ status, since, afk, activity }) { // eslint-disable-line complexity
     const applicationID = activity && (activity.application ? activity.application.id || activity.application : null);
     let assets = new Collection();
     if (activity) {
@@ -66,9 +73,7 @@ class ClientPresenceStore extends PresenceStore {
         packet.game.type : ActivityTypes.indexOf(packet.game.type);
     }
 
-    this.clientPresence.patch(packet);
-    this.client.ws.send({ op: OPCodes.STATUS_UPDATE, d: packet });
-    return this.clientPresence;
+    return packet;
   }
 }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -54,6 +54,7 @@ exports.DefaultOptions = {
    * @property {number} [large_threshold=250] Number of members in a guild to be considered large
    * @property {boolean} [compress=false] Whether to compress data sent on the connection
    * (defaults to `false` for browsers)
+   * @property {PresenceData} [presence] Presence data to use upon login
    */
   ws: {
     large_threshold: 250,

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -26,6 +26,7 @@ const browser = exports.browser = typeof window !== 'undefined';
  * corresponding websocket events
  * @property {number} [restTimeOffset=500] Extra time in millseconds to wait before continuing to make REST
  * requests (higher values will reduce rate-limiting errors on bad connections)
+ * @property {PresenceData} [presence] Presence data to use upon login
  * @property {WSEventType[]} [disabledEvents] An array of disabled websocket events. Events in this array will not be
  * processed, potentially resulting in performance improvements for larger bots. Only disable events you are
  * 100% certain you don't need, as many are important, but not obviously so. The safest one to disable with the
@@ -47,6 +48,7 @@ exports.DefaultOptions = {
   restWsBridgeTimeout: 5000,
   disabledEvents: [],
   restTimeOffset: 500,
+  presence: {},
 
   /**
    * WebSocket options (these are left as snake_case to match the API)
@@ -54,7 +56,6 @@ exports.DefaultOptions = {
    * @property {number} [large_threshold=250] Number of members in a guild to be considered large
    * @property {boolean} [compress=false] Whether to compress data sent on the connection
    * (defaults to `false` for browsers)
-   * @property {PresenceData} [presence] Presence data to use upon login
    */
   ws: {
     large_threshold: 250,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
You can give your client some presence data to use upon login via the client options, but it won't work if you try to use it the same way you would use `ClientUser#setPresence`; it'll only work if you send it the exact data the API expects (such as a `game` object instead of `activity`) . This PR normalizes that, as well as documents it in the `WebsocketOptions` typedef.

Example snippet:
```js
const { Client } = require('discord.js');

const client = new Client({
	presence: {
		status: 'dnd',
		activity: {
			name: 'YouTube',
			type: 'WATCHING',
		},
	},
});

client.login('pleasedonthackme');
```

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
