### PR TITLE
fix what may or may not have been a typo of '+' to '<'

### DIFF
--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -284,7 +284,7 @@ class StreamDispatcher extends VolumeInterface {
     const data = this.streamingData;
     data.count++;
     data.sequence = data.sequence < 65535 ? data.sequence + 1 : 0;
-    data.timestamp = data.timestamp + 4294967295 ? data.timestamp + 960 : 0;
+    data.timestamp = ( (data.timestamp + 960) < 4294967295) ? data.timestamp + 960 : 0;
   }
 
   destroy(type, reason) {

--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -284,7 +284,7 @@ class StreamDispatcher extends VolumeInterface {
     const data = this.streamingData;
     data.count++;
     data.sequence = data.sequence < 65535 ? data.sequence + 1 : 0;
-    data.timestamp = ( (data.timestamp + 960) < 4294967295) ? data.timestamp + 960 : 0;
+    data.timestamp = ((data.timestamp + 960) < 4294967295) ? data.timestamp + 960 : 0;
   }
 
   destroy(type, reason) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Occasionally the timestamp of the data becomes extremely large due to this guard not doing its job because it was written wrongly. Basically the timestamp will explode in size.

This means that the timestamp + 960 becomes a number that is larger than UINT_MAX. This causes an error event to be emitted by the stream.

It may have been copypasta from a language that will simply overflow the number.

I understand that this section of the library is undergoing a rewrite from the changes occurring in master and it will likely no longer matter when the new code makes it into a release, but this bug has impacted the uptime of my bots that use it, so I am submitting this change in the interest of improving the stability of all clients which use this code in the interim.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
 - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
