### PR TITLE
feat(ShardClientUtil#broadcastEval): allow promise resolve

### DIFF
--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -119,7 +119,7 @@ class ShardClientUtil {
    * @param {*} message Message received
    * @private
    */
-  _handleMessage(message) {
+  async _handleMessage(message) {
     if (!message) return;
     if (message._fetchProp) {
       const props = message._fetchProp.split('.');
@@ -128,7 +128,7 @@ class ShardClientUtil {
       this._respond('fetchProp', { _fetchProp: message._fetchProp, _result: value });
     } else if (message._eval) {
       try {
-        this._respond('eval', { _eval: message._eval, _result: this.client._eval(message._eval) });
+        this._respond('eval', { _eval: message._eval, _result: await this.client._eval(message._eval) });
       } catch (err) {
         this._respond('eval', { _eval: message._eval, _error: Util.makePlainError(err) });
       }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allow returning of promises via the `broadcastEval()` method. One good use-case:
```js
client.shard.broadcastEval(`this.channels.get('id').send('test').then(m => m.id)`);
```
This would not be possible otherwise- the developer would have to resort to other methods, such as using the api without the library convenience methods.
If there's anything I missed, do let me know, I'm fairly confident this is enough (I have had this on my production bot for over a year).

Requesting review from @Gawdl3y.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
