### PR TITLE
docs: Added example for GuildChannel#clone()

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "erlpack": "discordapp/erlpack",
     "sodium": "^2.0.0",
     "libsodium-wrappers": "^0.7.0",
-    "uws": "^8.14.0",
+    "uws": "^9.14.0",
     "zlib-sync": "^0.1.0"
   },
   "devDependencies": {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -451,7 +451,6 @@ class GuildChannel extends Channel {
    *  withPermissions: true,
    *  withTopic: false,
    *  nsfw: false,
-   *  parent: this.parent,
    *  reason: 'Some reason'
    * })
    *  .then(() => console.log('Channel cloned!'))

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -444,7 +444,19 @@ class GuildChannel extends Channel {
    * @param {ChannelResolvable} [options.parent=this.parent] The parent of the new channel
    * @param {string} [options.reason] Reason for cloning this channel
    * @returns {Promise<GuildChannel>}
-   */
+   * @example 
+   * // Clone a channel
+   * channel.clone({
+   *  name: 'Some name',
+   *  withPermissions: true,
+   *  withTopic: false,
+   *  nsfw: false,
+   *  parent: this.parent,
+   *  reason: 'Some reason'
+   * })
+   *  .then(() => console.log('Channel cloned!))
+   *  .catch(console.error)
+  */
   clone(options = {}) {
     if (typeof options.withPermissions === 'undefined') options.withPermissions = true;
     Util.mergeDefault({

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -454,7 +454,7 @@ class GuildChannel extends Channel {
    *  parent: this.parent,
    *  reason: 'Some reason'
    * })
-   *  .then(() => console.log('Channel cloned!))
+   *  .then(() => console.log('Channel cloned!'))
    *  .catch(console.error)
   */
   clone(options = {}) {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -447,7 +447,7 @@ class GuildChannel extends Channel {
    * @example
    * // Clone a channel
    * channel.clone({
-   *  name: 'Some name',
+   *  name: 'Some-name',
    *  withPermissions: true,
    *  withTopic: false,
    *  nsfw: false,

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -431,6 +431,21 @@ class GuildChannel extends Channel {
   }
 
   /**
+   * Fetches a collection of invites to this guild channel.
+   * Resolves with a collection mapping invites by their codes.
+   * @returns {Promise<Collection<string, Invite>>}
+   */
+  async fetchInvites() {
+    const inviteItems = await this.client.api.channels(this.id).invites.get();
+    const invites = new Collection();
+    for (const inviteItem of inviteItems) {
+      const invite = new Invite(this.client, inviteItem);
+      invites.set(invite.code, invite);
+    }
+    return invites;
+  }
+
+  /**
    * Clones this channel.
    * @param {Object} [options] The options
    * @param {string} [options.name=this.name] Optional name for the new channel, otherwise it has the name

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -455,7 +455,7 @@ class GuildChannel extends Channel {
    *  reason: 'Some reason'
    * })
    *  .then(() => console.log('Channel cloned!'))
-   *  .catch(console.error)
+   *  .catch(console.error);
   */
   clone(options = {}) {
     if (typeof options.withPermissions === 'undefined') options.withPermissions = true;

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -444,7 +444,7 @@ class GuildChannel extends Channel {
    * @param {ChannelResolvable} [options.parent=this.parent] The parent of the new channel
    * @param {string} [options.reason] Reason for cloning this channel
    * @returns {Promise<GuildChannel>}
-   * @example 
+   * @example
    * // Clone a channel
    * channel.clone({
    *  name: 'Some name',

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -456,7 +456,7 @@ class GuildChannel extends Channel {
    * })
    *  .then(() => console.log('Channel cloned!'))
    *  .catch(console.error);
-  */
+   */
   clone(options = {}) {
     if (typeof options.withPermissions === 'undefined') options.withPermissions = true;
     Util.mergeDefault({


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds an example for GuildChannel#clone()

I think this is useful because this so far has not been documented and it would be useful for cloning channels in servers (idk what more to say)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.