### PR TITLE
feat(GuildChannel): add fetchInvites method

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -431,6 +431,21 @@ class GuildChannel extends Channel {
   }
 
   /**
+   * Fetches a collection of invites to this guild channel.
+   * Resolves with a collection mapping invites by their codes.
+   * @returns {Promise<Collection<string, Invite>>}
+   */
+  async fetchInvites() {
+    const inviteItems = await this.client.api.guilds(this.id).invites.get();
+    const invites = new Collection();
+    for (const inviteItem of inviteItems) {
+      const invite = new Invite(this.client, inviteItem);
+      invites.set(invite.code, invite);
+    }
+    return invites;
+  }
+
+  /**
    * Clones this channel.
    * @param {Object} [options] The options
    * @param {string} [options.name=this.name] Optional name for the new channel, otherwise it has the name

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -436,7 +436,7 @@ class GuildChannel extends Channel {
    * @returns {Promise<Collection<string, Invite>>}
    */
   async fetchInvites() {
-    const inviteItems = await this.client.api.guilds(this.id).invites.get();
+    const inviteItems = await this.client.api.channels(this.id).invites.get();
     const invites = new Collection();
     for (const inviteItem of inviteItems) {
       const invite = new Invite(this.client, inviteItem);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds support for the "Get Channel Invites" endpoint. ([api-docs](https://discordapp.com/developers/docs/resources/channel#get-channel-invites))

Adding a `GuildChannel#fetchInvites` method, which is "only" requires the MANAGE_CHANNEL permission, as opposed to `Guild#fetchInvites`, which requires the MANAGE_GUILD permission.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
