### PR TITLE
perf(Collection): Performance improvements

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -39,7 +39,8 @@ class Collection extends Map {
   /**
    * Creates an ordered array of the values of this collection, and caches it internally. The array will only be
    * reconstructed if an item is added to or removed from the collection, or if you change the length of the array
-   * itself. If you don't want this caching behaviour, use `[...collection.values()]` or `Array.from(collection.values())` instead.
+   * itself. If you don't want this caching behaviour, use `[...collection.values()]` or
+   * `Array.from(collection.values())` instead.
    * @returns {Array}
    */
   array() {
@@ -50,7 +51,8 @@ class Collection extends Map {
   /**
    * Creates an ordered array of the keys of this collection, and caches it internally. The array will only be
    * reconstructed if an item is added to or removed from the collection, or if you change the length of the array
-   * itself. If you don't want this caching behaviour, use `[...collection.keys()]` or `Array.from(collection.keys())` instead.
+   * itself. If you don't want this caching behaviour, use `[...collection.keys()]` or
+   * `Array.from(collection.keys())` instead.
    * @returns {Array}
    */
   keyArray() {

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -39,22 +39,22 @@ class Collection extends Map {
   /**
    * Creates an ordered array of the values of this collection, and caches it internally. The array will only be
    * reconstructed if an item is added to or removed from the collection, or if you change the length of the array
-   * itself. If you don't want this caching behaviour, use `Array.from(collection.values())` instead.
+   * itself. If you don't want this caching behaviour, use `[...collection.values()]` or `Array.from(collection.values())` instead.
    * @returns {Array}
    */
   array() {
-    if (!this._array || this._array.length !== this.size) this._array = Array.from(this.values());
+    if (!this._array || this._array.length !== this.size) this._array = [...this.values()];
     return this._array;
   }
 
   /**
    * Creates an ordered array of the keys of this collection, and caches it internally. The array will only be
    * reconstructed if an item is added to or removed from the collection, or if you change the length of the array
-   * itself. If you don't want this caching behaviour, use `Array.from(collection.keys())` instead.
+   * itself. If you don't want this caching behaviour, use `[...collection.keys()]` or `Array.from(collection.keys())` instead.
    * @returns {Array}
    */
   keyArray() {
-    if (!this._keyArray || this._keyArray.length !== this.size) this._keyArray = Array.from(this.keys());
+    if (!this._keyArray || this._keyArray.length !== this.size) this._keyArray = [...this.keys()];
     return this._keyArray;
   }
 
@@ -421,7 +421,7 @@ class Collection extends Map {
    * @returns {Collection}
    */
   sort(compareFunction = (x, y) => +(x > y) || +(x === y) - 1) {
-    return new Collection(Array.from(this.entries()).sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));
+    return new Collection([...this.entries()].sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR aims for performance improvements in the Collection -> Array conversion. In a [jsperf](https://jsperf.com/iterator-vs-array-from/1), I have achieved a 44% performance improvement by changing `Array.from(iterator)` to `[...iterator]`, using for this test, a simple iterator. Screenshot of test:

![image](https://user-images.githubusercontent.com/24852502/36230908-54a83898-11dc-11e8-84dd-f364d712c0b1.png)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
