### PR TITLE
docs: Add links for the guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ client.login('token');
 ## Links
 * [Website](https://discord.js.org/) ([source](https://github.com/discordjs/website))
 * [Documentation](https://discord.js.org/#/docs)
+* [Guide](https://discordjs.guide/) ([source](https://github.com/discordjs/guide))
 * [Discord.js Discord server](https://discord.gg/bRCvFy9)
 * [Discord API Discord server](https://discord.gg/discord-api)
 * [GitHub](https://github.com/discordjs/discord.js)

--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -74,6 +74,7 @@ client.login('token');
 ## Links
 * [Website](https://discord.js.org/) ([source](https://github.com/discordjs/website))
 * [Documentation](https://discord.js.org/#/docs)
+* [Guide](https://discordjs.guide/) ([source](https://github.com/discordjs/guide))
 * [Discord.js Discord server](https://discord.gg/bRCvFy9)
 * [Discord API Discord server](https://discord.gg/discord-api)
 * [GitHub](https://github.com/discordjs/discord.js)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since [discordjs.guide](https://discordjs.guide/) became the official guide for d.js about 2 weeks ago, it only makes sense to add links for it on the readme/welcome page of the website.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
