### PR TITLE
Allow Users To Customize Their Folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ deploy/deploy_key.pub
 .vscode/
 docs/docs.json
 webpack/
+desktop.ini


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Desktop.ini files can be used to modify folders in Windows, such as setting the icons, folder-specific sorting settings, etc. Ignoring them will allow users to use custom icons and modify their folders their own way without accidentally committing it.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
