### PR TITLE
Emit StreamDispatcher#volumeChange when the volume changes

### DIFF
--- a/src/client/voice/dispatcher/StreamDispatcher.js
+++ b/src/client/voice/dispatcher/StreamDispatcher.js
@@ -278,6 +278,13 @@ class StreamDispatcher extends Writable {
 
   setVolume(value) {
     if (!this.streams.volume) return false;
+    /**
+     * Emitted when the volume of this dispatcher changes.
+     * @event StreamDispatcher#volumeChange
+     * @param {number} oldVolume The old volume of this dispatcher
+     * @param {number} newVolume The new volume of this dispatcher
+     */
+    this.emit('volumeChange', this.volume, value);
     this.streams.volume.setVolume(value);
     return true;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`StreamDispatcher#volumeChange` was not emitted when the volume changes even though `StreamDispatcher` implements `VoiceInterface` that has `volumeChange` event.
It should be emitted I think.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
