### PR TITLE
Fix incorrect positions when rawPosition is same

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -284,8 +284,8 @@ class Util {
   static discordSort(collection) {
     return collection.sort((a, b) =>
       a.rawPosition - b.rawPosition ||
-      parseInt(a.id.slice(0, -10)) - parseInt(b.id.slice(0, -10)) ||
-      parseInt(a.id.slice(10)) - parseInt(b.id.slice(10))
+      parseInt(b.id.slice(0, -10)) - parseInt(a.id.slice(0, -10)) ||
+      parseInt(b.id.slice(10)) - parseInt(a.id.slice(10))
     );
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The current implementation of `Util#discordSort()` puts objects with higher IDs before those with lower IDs if they share the same `rawPosition`, resulting in #2352. When two objects have the same `rawPosition`, the one created later (higher ID) should be put after the other. This fixes that issue.

Fixes #2352

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
