### PR TITLE
Clear ratelimit timer when websocket is destroyed, fixes node process…

### DIFF
--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -251,6 +251,11 @@ class WebSocketConnection extends EventEmitter {
     this.ws = null;
     this.status = Status.DISCONNECTED;
     this.ratelimit.remaining = this.ratelimit.total;
+    if (this.ratelimit.resetTimer) {
+        this.client.clearTimeout(this.ratelimit.resetTimer);
+        this.ratelimit.resetTimer = null;
+    }
+
     return true;
   }
 

--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -252,8 +252,8 @@ class WebSocketConnection extends EventEmitter {
     this.status = Status.DISCONNECTED;
     this.ratelimit.remaining = this.ratelimit.total;
     if (this.ratelimit.resetTimer) {
-        this.client.clearTimeout(this.ratelimit.resetTimer);
-        this.ratelimit.resetTimer = null;
+      this.client.clearTimeout(this.ratelimit.resetTimer);
+      this.ratelimit.resetTimer = null;
     }
 
     return true;


### PR DESCRIPTION
… waiting 2 minutes for the timer to fire

**Please describe the changes this PR makes and why it should be merged:**
rate limit timer is not cleared

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
