### PR TITLE
feat: Add special iterator support for Collections

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -425,6 +425,10 @@ class Collection extends Map {
   sort(compareFunction = (x, y) => +(x > y) || +(x === y) - 1) {
     return new Collection([...this.entries()].sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));
   }
+
+  *[Symbol.iterator]() {
+    for (const value of this.values()) yield value;
+  }
 }
 
 module.exports = Collection;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes what Collections return when placed in a for loop. (`for const guild of client.guilds` as an example)

Now, this has been done, for two reasons:
1. We can now remove all instances of `client.store.values()` in discord.js, and making the code cleaner (imo) while it working the same way
2. Allow users to easily run a for loop on their collections SHOULD they choose to (yes Collection#array is easy, yes `[...collection.values()]` is easy, and yes there are probably 3 other ways to do it, but this makes it easier for the loop to be useful in certain cases, without having the user to add `.values()` OR extend Collections)

Point 1 brings me to the next question: should I go through all for loops in discord.js and remove the `.values()` parts of them, to use this """ new """ iterator or should they stay the same?

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
