### PR TITLE
feat: allow multiple permission overwrites when editing channel

### DIFF
--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -1,9 +1,8 @@
-const Collection = require('../util/Collection');
 const Channel = require('../structures/Channel');
 const { ChannelTypes } = require('../util/Constants');
 const DataStore = require('./DataStore');
 const GuildChannel = require('../structures/GuildChannel');
-const Permissions = require('../util/Permissions');
+const resolvePermissions = require('../structures/shared/resolvePermissions');
 
 /**
  * Stores guild channels.
@@ -24,9 +23,9 @@ class GuildChannelStore extends DataStore {
 
   /**
    * Can be used to overwrite permissions when creating a channel.
-   * @typedef {Object} ChannelCreationOverwrites
-   * @property {PermissionResolvable[]|number} [allow] The permissions to allow
-   * @property {PermissionResolvable[]|number} [deny] The permissions to deny
+   * @typedef {Object} PermissionOverwriteOptions
+   * @property {PermissionResolvable[]|number} [allowed] The permissions to allow
+   * @property {PermissionResolvable[]|number} [denied] The permissions to deny
    * @property {RoleResolvable|UserResolvable} id ID of the role or member this overwrite is for
    */
 
@@ -39,7 +38,7 @@ class GuildChannelStore extends DataStore {
    * @param {number} [options.bitrate] Bitrate of the new channel in bits (only voice)
    * @param {number} [options.userLimit] Maximum amount of users allowed in the new channel (only voice)
    * @param {ChannelResolvable} [options.parent] Parent of the new channel
-   * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>} [options.overwrites] Permission overwrites
+   * @param {Array<PermissionOverwrites|PermissionOverwriteOptions>} [options.overwrites] Permission overwrites
    * @param {string} [options.reason] Reason for creating the channel
    * @returns {Promise<GuildChannel>}
    * @example
@@ -47,33 +46,19 @@ class GuildChannelStore extends DataStore {
    * guild.channels.create('new-general', { reason: 'Needed a cool new channel' })
    *   .then(console.log)
    *   .catch(console.error);
+   * @example
+   * // Create a new channel with overwrites
+   * guild.channels.create('new-voice', {
+   *   type: 'voice',
+   *   overwrites: [
+   *      {
+   *        id: message.author.id,
+   *        denied: ['VIEW_CHANNEL'],
+   *     },
+   *   ],
+   * })
    */
   create(name, { type, nsfw, bitrate, userLimit, parent, overwrites, reason } = {}) {
-    if (overwrites instanceof Collection || overwrites instanceof Array) {
-      overwrites = overwrites.map(overwrite => {
-        let allow = overwrite.allow || (overwrite.allowed ? overwrite.allowed.bitfield : 0);
-        let deny = overwrite.deny || (overwrite.denied ? overwrite.denied.bitfield : 0);
-        if (allow instanceof Array) allow = Permissions.resolve(allow);
-        if (deny instanceof Array) deny = Permissions.resolve(deny);
-
-        const role = this.guild.roles.resolve(overwrite.id);
-        if (role) {
-          overwrite.id = role.id;
-          overwrite.type = 'role';
-        } else {
-          overwrite.id = this.client.users.resolveID(overwrite.id);
-          overwrite.type = 'member';
-        }
-
-        return {
-          allow,
-          deny,
-          type: overwrite.type,
-          id: overwrite.id,
-        };
-      });
-    }
-
     if (parent) parent = this.client.channels.resolveID(parent);
     return this.client.api.guilds(this.guild.id).channels.post({
       data: {
@@ -83,7 +68,7 @@ class GuildChannelStore extends DataStore {
         bitrate,
         user_limit: userLimit,
         parent_id: parent,
-        permission_overwrites: overwrites,
+        permission_overwrites: resolvePermissions.call(this, overwrites),
       },
       reason,
     }).then(data => this.client.actions.ChannelCreate.handle(data).channel);

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -1,6 +1,7 @@
 const Channel = require('./Channel');
 const Role = require('./Role');
 const Invite = require('./Invite');
+const resolvePermissions = require('./shared/resolvePermissions');
 const PermissionOverwrites = require('./PermissionOverwrites');
 const Util = require('../util/Util');
 const Permissions = require('../util/Permissions');
@@ -177,6 +178,28 @@ class GuildChannel extends Channel {
   }
 
   /**
+   * Updates the permission overwrites for a channel
+   * @param {Object} [options] Options
+   * @param {Array<PermissionOverwrites|PermissionOverwriteOptions>} [options.overwrites] Permission overwrites
+   * @param {string} [options.reason] Reason for updating the channel overwrites
+   * @returns {Promise<GuildChannel>}
+   * @example
+   * channel.overwritePermissions({
+   * overwrites: [
+   *   {
+   *      id: message.author.id,
+   *      denied: ['VIEW_CHANNEL'],
+   *   },
+   * ],
+   *   reason: 'Needed to change permissions'
+   * });
+   */
+  overwritePermissions({ overwrites, reason } = {}) {
+    return this.edit({ permissionOverwrites: resolvePermissions.call(this, overwrites), reason })
+      .then(() => this);
+  }
+
+  /**
    * An object mapping permission flags to `true` (enabled), `null` (default) or `false` (disabled).
    * ```js
    * {
@@ -185,24 +208,24 @@ class GuildChannel extends Channel {
    *  'ATTACH_FILES': false,
    * }
    * ```
-   * @typedef {Object} PermissionOverwriteOptions
+   * @typedef {Object} PermissionOverwriteOption
    */
 
   /**
    * Overwrites the permissions for a user or role in this channel.
    * @param {RoleResolvable|UserResolvable} userOrRole The user or role to update
-   * @param {PermissionOverwriteOptions} options The options for the update
+   * @param {PermissionOverwriteOption} options The options for the update
    * @param {string} [reason] Reason for creating/editing this overwrite
    * @returns {Promise<GuildChannel>}
    * @example
    * // Overwrite permissions for a message author
-   * message.channel.overwritePermissions(message.author, {
+   * message.channel.updateOverwrite(message.author, {
    *   SEND_MESSAGES: false
    * })
-   *   .then(() => console.log('Done!'))
+   *   .then(channel => console.log(channel.permissionOverwrites.get(message.author.id)))
    *   .catch(console.error);
    */
-  overwritePermissions(userOrRole, options, reason) {
+  updateOverwrite(userOrRole, options, reason) {
     const allow = new Permissions(0);
     const deny = new Permissions(0);
     let type;

--- a/src/structures/shared/resolvePermissions.js
+++ b/src/structures/shared/resolvePermissions.js
@@ -1,0 +1,26 @@
+const Permissions = require('../../util/Permissions');
+const Collection = require('../../util/Collection');
+
+module.exports = function resolvePermissions(overwrites) {
+  if (overwrites instanceof Collection || overwrites instanceof Array) {
+    overwrites = overwrites.map(overwrite => {
+      const role = this.guild.roles.resolve(overwrite.id);
+      if (role) {
+        overwrite.id = role.id;
+        overwrite.type = 'role';
+      } else {
+        overwrite.id = this.client.users.resolveID(overwrite.id);
+        overwrite.type = 'member';
+      }
+
+      return {
+        allow: Permissions.resolve(overwrite.allowed || 0),
+        deny: Permissions.resolve(overwrite.denied || 0),
+        type: overwrite.type,
+        id: overwrite.id,
+      };
+    });
+  }
+
+  return overwrites;
+};

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -126,7 +126,8 @@ class Permissions {
    * @returns {number}
    */
   static resolve(permission) {
-    if (permission instanceof Permissions || (typeof permission === 'number' && permission >= 0)) return permission;
+    if (typeof permission === 'number' && permission >= 0) return permission;
+    if (permission instanceof Permissions) return permission.bitfield;
     if (permission instanceof Array) return permission.map(p => this.resolve(p)).reduce((prev, p) => prev | p, 0);
     if (typeof permission === 'string') return this.FLAGS[permission];
     throw new RangeError('PERMISSIONS_INVALID');

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -126,8 +126,7 @@ class Permissions {
    * @returns {number}
    */
   static resolve(permission) {
-    if (typeof permission === 'number' && permission >= 0) return permission;
-    if (permission instanceof Permissions) return permission.bitfield;
+    if (permission instanceof Permissions || (typeof permission === 'number' && permission >= 0)) return permission;
     if (permission instanceof Array) return permission.map(p => this.resolve(p)).reduce((prev, p) => prev | p, 0);
     if (typeof permission === 'string') return this.FLAGS[permission];
     throw new RangeError('PERMISSIONS_INVALID');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Thanks to @Tylertron1998 for noticing.
This PR replaces the original method, `GuildChannel#overwritePermissions`, to take multiple overwrites, similarly to creating a channel. In order to retain API coverage, I also made a new method, `GuildChannel#updateOverwrite`, to be what the original `GuildChannel#overwritePermissions` did.
Since there'd now be duplicate code, I refactored the main logic behind resolving permissions into a `shared` method.
Also added examples. Examples are nice.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
