### PR TITLE
Change 'the this' to 'this' in Role.comparePositionTo()

### DIFF
--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -132,8 +132,8 @@ class Role extends Base {
   /**
    * Compares this role's position to another role's.
    * @param {RoleResolvable} role Role to compare to this one
-   * @returns {number} Negative number if the this role's position is lower (other role's is higher),
-   * positive number if the this one is higher (other's is lower), 0 if equal
+   * @returns {number} Negative number if this role's position is lower (other role's is higher),
+   * positive number if this one is higher (other's is lower), 0 if equal
    */
   comparePositionTo(role) {
     role = this.guild.roles.resolve(role);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There are 2 typos in the description of the `comparePositionTo()` function. This removes the typos, with no code changes.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
