### PR TITLE
Convert lastMessage to getters

### DIFF
--- a/src/client/actions/MessageCreate.js
+++ b/src/client/actions/MessageCreate.js
@@ -12,14 +12,13 @@ class MessageCreateAction extends Action {
       const user = message.author;
       const member = channel.guild ? channel.guild.member(user) : null;
       channel.lastMessageID = data.id;
-      channel.lastMessage = message;
       if (user) {
         user.lastMessageID = data.id;
-        user.lastMessage = message;
+        user.lastMessageChannelID = channel.id;
       }
       if (member) {
         member.lastMessageID = data.id;
-        member.lastMessage = message;
+        member.lastMessageChannelID = channel.id;
       }
 
       client.emit(Events.MESSAGE_CREATE, message);

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -44,6 +44,7 @@ class DMChannel extends Channel {
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
+  get lastMessage() {}
   send() {}
   search() {}
   startTyping() {}

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -220,6 +220,7 @@ class GroupDMChannel extends Channel {
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
+  get lastMessage() {}
   send() {}
   search() {}
   startTyping() {}

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -43,10 +43,10 @@ class GuildMember extends Base {
     this.lastMessageID = null;
 
     /**
-     * The Message object of the last message sent by the member in their guild, if one was sent
-     * @type {?Message}
+     * The ID of the channel for the last message sent by the member in their guild, if one was sent
+     * @type {?Snowflake}
      */
-    this.lastMessage = null;
+    this.lastMessageChannelID = null;
   }
 
   _patch(data) {
@@ -79,6 +79,17 @@ class GuildMember extends Base {
     const clone = super._clone();
     clone.roles = this.roles.clone();
     return clone;
+  }
+
+  /**
+   * The Message object of the last message sent by the member in their guild, if one was sent
+   * @type {?Message}
+   * @readonly
+   */
+  get lastMessage() {
+    const channel = this.guild.channels.get(this.lastMessageChannelID);
+    if (!channel) return undefined;
+    return channel.messages.get(this.lastMessageChannelID);
   }
 
   get voiceState() {

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -89,7 +89,7 @@ class GuildMember extends Base {
   get lastMessage() {
     const channel = this.guild.channels.get(this.lastMessageChannelID);
     if (!channel) return undefined;
-    return channel.messages.get(this.lastMessageChannelID);
+    return channel.messages.get(this.lastMessageID);
   }
 
   get voiceState() {

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -88,8 +88,7 @@ class GuildMember extends Base {
    */
   get lastMessage() {
     const channel = this.guild.channels.get(this.lastMessageChannelID);
-    if (!channel) return undefined;
-    return channel.messages.get(this.lastMessageID);
+    return (channel && channel.messages.get(this.lastMessageID)) || null;
   }
 
   get voiceState() {

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -96,6 +96,7 @@ class TextChannel extends GuildChannel {
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
+  get lastMessage() {}
   send() {}
   search() {}
   startTyping() {}

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -59,10 +59,10 @@ class User extends Base {
     this.lastMessageID = null;
 
     /**
-     * The Message object of the last message sent by the user, if one was sent
-     * @type {?Message}
+     * The ID of the channel for the last message sent by the user, if one was sent
+     * @type {?Snowflake}
      */
-    this.lastMessage = null;
+    this.lastMessageChannelID = null;
   }
 
   /**
@@ -81,6 +81,17 @@ class User extends Base {
    */
   get createdAt() {
     return new Date(this.createdTimestamp);
+  }
+
+  /**
+   * The Message object of the last message sent by the user, if one was sent
+   * @type {?Message}
+   * @readonly
+   */
+  get lastMessage() {
+    const channel = this.client.channels.get(this.lastMessageChannelID);
+    if (!channel) return undefined;
+    return channel.messages.get(this.lastMessageChannelID);
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -91,7 +91,7 @@ class User extends Base {
   get lastMessage() {
     const channel = this.client.channels.get(this.lastMessageChannelID);
     if (!channel) return undefined;
-    return channel.messages.get(this.lastMessageChannelID);
+    return channel.messages.get(this.lastMessageID);
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -90,8 +90,7 @@ class User extends Base {
    */
   get lastMessage() {
     const channel = this.client.channels.get(this.lastMessageChannelID);
-    if (!channel) return undefined;
-    return channel.messages.get(this.lastMessageID);
+    return (channel && channel.messages.get(this.lastMessageID)) || null;
   }
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -21,12 +21,15 @@ class TextBasedChannel {
      * @type {?Snowflake}
      */
     this.lastMessageID = null;
+  }
 
-    /**
-     * The Message object of the last message in the channel, if one was sent
-     * @type {?Message}
-     */
-    this.lastMessage = null;
+  /**
+   * The Message object of the last message in the channel, if one was sent
+   * @type {?Message}
+   * @readonly
+   */
+  get lastMessage() {
+    return this.messages.get(this.lastMessageID);
   }
 
   /**
@@ -334,6 +337,7 @@ class TextBasedChannel {
     if (full) {
       props.push(
         'acknowledge',
+        'lastMessage',
         'search',
         'bulkDelete',
         'startTyping',

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -29,7 +29,7 @@ class TextBasedChannel {
    * @readonly
    */
   get lastMessage() {
-    return this.messages.get(this.lastMessageID);
+    return this.messages.get(this.lastMessageID) || null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Converts user/member/channel#lastMessage to be getters for the following reasons:
- Allows all messages to be properly swept completely from memory in all cases, when using messageSweeping.
- Fixes a memory leak: Bot leaves a guild, and no-longer shares a guild with some users from that guild. However, that user who nolonger shares any guilds with the bot has a lastMessage property (reference currently) which has the entire guild/roles/members/channels/unswept messages from those channels as references on that message. This prevents the referenced guilds/roles/channels/messages from ever being garbage collected, unless all users from the left guilds sends a message the bot can see in another guild (not likely to happen, so left guilds and their contents build up in memory over time in production bots).

This adds lastMessageChannelID to users/members, for the purpose of the getter; and to allow fetching of said messages, given the messages have been swept by the dev's use of messageSweeping.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
