### PR TITLE
[consistency] getters return null instead of undefined

### DIFF
--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -103,11 +103,11 @@ class GroupDMChannel extends Channel {
 
   /**
    * The owner of this Group DM
-   * @type {User}
+   * @type {?User}
    * @readonly
    */
   get owner() {
-    return this.client.users.get(this.ownerID);
+    return this.client.users.get(this.ownerID) || null;
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -301,11 +301,11 @@ class Guild extends Base {
 
   /**
    * The owner of the guild
-   * @type {GuildMember}
+   * @type {?GuildMember}
    * @readonly
    */
   get owner() {
-    return this.members.get(this.ownerID);
+    return this.members.get(this.ownerID) || null;
   }
 
   /**
@@ -411,11 +411,11 @@ class Guild extends Base {
 
   /**
    * The `@everyone` role of the guild
-   * @type {Role}
+   * @type {?Role}
    * @readonly
    */
   get defaultRole() {
-    return this.roles.get(this.id);
+    return this.roles.get(this.id) || null;
   }
 
   /**
@@ -424,7 +424,7 @@ class Guild extends Base {
    * @readonly
    */
   get me() {
-    return this.members.get(this.client.user.id);
+    return this.members.get(this.client.user.id) || null;
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -63,7 +63,7 @@ class GuildChannel extends Channel {
    * @readonly
    */
   get parent() {
-    return this.guild.channels.get(this.parentID);
+    return this.guild.channels.get(this.parentID) || null;
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -189,7 +189,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get voiceChannel() {
-    return this.guild.channels.get(this.voiceChannelID);
+    return this.guild.channels.get(this.voiceChannelID) || null;
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -186,7 +186,7 @@ class User extends Base {
    * @readonly
    */
   get dmChannel() {
-    return this.client.channels.filter(c => c.type === 'dm').find(c => c.recipient.id === this.id);
+    return this.client.channels.filter(c => c.type === 'dm').find(c => c.recipient.id === this.id) || null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Finds all locations where a getter may return undefined, and coerces the return value to null instead of undefined.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
