### PR TITLE
fix message embed json serialization

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -305,9 +305,8 @@ class MessageEmbed {
   /**
    * Transforms the embed object to be processed.
    * @returns {Object} The raw data of this embed
-   * @private
    */
-  _apiTransform() {
+  toJSON() {
     return {
       title: this.title,
       type: 'rich',

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -302,10 +302,6 @@ class MessageEmbed {
     return this;
   }
 
-  toJSON() {
-    return Util.flatten(this, { hexColor: true });
-  }
-
   /**
    * Transforms the embed object to be processed.
    * @returns {Object} The raw data of this embed

--- a/src/structures/shared/CreateMessage.js
+++ b/src/structures/shared/CreateMessage.js
@@ -71,9 +71,9 @@ module.exports = async function createMessage(channel, options) {
     else options.files = options.embed.files;
   }
 
-  if (options.embed && webhook) options.embeds = [new Embed(options.embed)._apiTransform()];
-  else if (options.embed) options.embed = new Embed(options.embed)._apiTransform();
-  else if (options.embeds) options.embeds = options.embeds.map(e => new Embed(e)._apiTransform());
+  if (options.embed && webhook) options.embeds = [new Embed(options.embed)];
+  else if (options.embed) options.embed = new Embed(options.embed);
+  else if (options.embeds) options.embeds = options.embeds.map(e => new Embed(e));
 
   let files;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
remove the toJSON method on message embeds so the raw data is exposed for JSON serialization. this removes the hexColor property, but it probably should not have been there in the first place. fixes #2419

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
