### PR TITLE
Adds GuildChannel.manageable

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -546,8 +546,8 @@ class GuildChannel extends Channel {
  */
   get manageable() {
     if (this.client.user.id === this.guild.ownerID) return true;
-    if (this.permissionsFor(this.client.user).has([Permissions.FLAGS.MANAGE_CHANNELS, Permissions.FLAGS.VIEW_CHANNEL])) return true;
-    return false;
+    return this.permissionsFor(this.client.user).has([Permissions.FLAGS.MANAGE_CHANNELS,
+      Permissions.FLAGS.VIEW_CHANNEL]);
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -540,14 +540,13 @@ class GuildChannel extends Channel {
   }
 
   /**
- * Whether the channel is manageable in terms of role hierarchy by the client user
+ * Whether the channel is manageable by the client user
  * @type {boolean}
  * @readonly
  */
   get manageable() {
     if (this.client.user.id === this.guild.ownerID) return true;
-    if (this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS) &&
-    this.permissionsFor(this.client.user).has(Permissions.FLAGS.VIEW_CHANNEL)) return true;
+    if (this.permissionsFor(this.client.user).has([Permissions.FLAGS.MANAGE_CHANNELS, Permissions.FLAGS.VIEW_CHANNEL])) return true;
     return false;
   }
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -540,6 +540,18 @@ class GuildChannel extends Channel {
   }
 
   /**
+ * Whether the channel is manageable in terms of role hierarchy by the client user
+ * @type {boolean}
+ * @readonly
+ */
+  get manageable() {
+    if (this.client.user.id === this.guild.ownerID) return true;
+    if (this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS) &&
+    this.permissionsFor(this.client.user).has(Permissions.FLAGS.VIEW_CHANNEL)) return true;
+    return false;
+  }
+
+  /**
    * Deletes this channel.
    * @param {string} [reason] Reason for deleting this channel
    * @returns {Promise<GuildChannel>}

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -540,10 +540,10 @@ class GuildChannel extends Channel {
   }
 
   /**
- * Whether the channel is manageable by the client user
- * @type {boolean}
- * @readonly
- */
+   * Whether the channel is manageable by the client user
+   * @type {boolean}
+   * @readonly
+   */
   get manageable() {
     if (this.client.user.id === this.guild.ownerID) return true;
     const permissions = this.permissionsFor(this.client.user);

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -546,8 +546,8 @@ class GuildChannel extends Channel {
  */
   get manageable() {
     if (this.client.user.id === this.guild.ownerID) return true;
-    return this.permissionsFor(this.client.user).has([Permissions.FLAGS.MANAGE_CHANNELS,
-      Permissions.FLAGS.VIEW_CHANNEL]);
+    const permissions = this.permissionsFor(this.client.user);
+    return permissions && permissions.has([Permissions.FLAGS.MANAGE_CHANNELS, Permissions.FLAGS.VIEW_CHANNEL]);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

GuildMembers have a `manageable` property to check if a bot has permission to manage them, it would great if Channels (specifically GuildChannels) could get the same kind of property. With this property we can easily check if we can i.e. change the channel name or its permissions before actually initiating that action. It appears that the bot requires both `VIEW_CHANNEL` and `MANAGE_CHANNELS` permissions to do it so I have implemented as in this PR.

Test output:
```
$ npm run lint && npm run docs:test

> discord.js@12.0.0-dev lint E:\UserFiles\DevProjects\djs
> eslint src *.js


E:\UserFiles\DevProjects\djs\src\client\Client.js
  450:19  warning  Method '_validateOptions' has a complexity of 21  complexity

E:\UserFiles\DevProjects\djs\src\structures\Guild.js
  1010:1  warning  Unexpected 'todo' comment  no-warning-comments

✖ 2 problems (0 errors, 2 warnings)


> discord.js@12.0.0-dev docs:test E:\UserFiles\DevProjects\djs
> docgen --source src --custom docs/index.yml

Parsing JSDocs in source files...
Loading custom docs files...
6 custom docs files in 3 categories loaded.
1678 JSDoc items parsed.
Serializing documentation with format version 19...
- "messages" (src\structures\interfaces\TextBasedChannel.js:17) has no accessible parent.
- "lastMessageID" (src\structures\interfaces\TextBasedChannel.js:23) has no accessible parent.
- "makeDiscordjsError" (src\errors\DJSError.js:11) has no accessible parent.
- "message" (src\errors\DJSError.js:35) has no accessible parent.
- "register" (src\errors\DJSError.js:50) has no accessible parent.
Done!
Done in 9.86s.
```

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
