### PR TITLE
fix: Allow roles to have their color reset

### DIFF
--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -179,7 +179,7 @@ class Role extends Base {
     return this.client.api.guilds[this.guild.id].roles[this.id].patch({
       data: {
         name: data.name || this.name,
-        color: Util.resolveColor(data.color || this.color),
+        color: data.color !== null ? Util.resolveColor(data.color || this.color) : null,
         hoist: typeof data.hoist !== 'undefined' ? data.hoist : this.hoist,
         permissions: data.permissions,
         mentionable: typeof data.mentionable !== 'undefined' ? data.mentionable : this.mentionable,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR allows roles to finally be able to loose their colors by passing `null` in either setColor or edit({ color: null })

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
