### PR TITLE
fix: ClientUser#presence#activity being null when set using client options

### DIFF
--- a/src/client/ClientManager.js
+++ b/src/client/ClientManager.js
@@ -41,7 +41,9 @@ class ClientManager {
     const timeout = this.client.setTimeout(() => reject(new Error('WS_CONNECTION_TIMEOUT')), 1000 * 300);
     this.client.api.gateway.get().then(async res => {
       if (this.client.options.presence != null) { // eslint-disable-line eqeqeq
-        this.client.options.ws.presence = await this.client.presences._parse(this.client.options.presence);
+        const presence = await this.client.presences._parse(this.client.options.presence);
+        this.client.options.ws.presence = presence;
+        this.client.presences.clientPresence.patch(presence);
       }
       const gateway = `${res.url}/`;
       this.client.emit(Events.DEBUG, `Using gateway ${gateway}`);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a bug where if you set the presence through client options, the ClientUser#presence#activity would be null.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
