### PR TITLE
feat(SnowflakeUtil): allow snowflakes to be generated dynamically

### DIFF
--- a/src/util/Snowflake.js
+++ b/src/util/Snowflake.js
@@ -27,12 +27,19 @@ class SnowflakeUtil {
   /**
    * Generates a Discord snowflake.
    * <info>This hardcodes the worker ID as 1 and the process ID as 0.</info>
+   * @param {number|Date} [timestamp=Date.now()] Timestamp or date of the snowflake to generate
    * @returns {Snowflake} The generated snowflake
    */
-  static generate() {
+  static generate(timestamp = Date.now()) {
+    if (timestamp instanceof Date) timestamp = timestamp.getTime();
+    if (typeof timestamp !== 'number' || isNaN(timestamp)) {
+      throw new TypeError(
+        `"timestamp" argument must be a number (received ${isNaN(timestamp) ? 'NaN' : typeof timestamp})`
+      );
+    }
     if (INCREMENT >= 4095) INCREMENT = 0;
     // eslint-disable-next-line max-len
-    const BINARY = `${(Date.now() - EPOCH).toString(2).padStart(42, '0')}0000100000${(INCREMENT++).toString(2).padStart(12, '0')}`;
+    const BINARY = `${(timestamp - EPOCH).toString(2).padStart(42, '0')}0000100000${(INCREMENT++).toString(2).padStart(12, '0')}`;
     return Util.binaryToID(BINARY);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This will allow to generate snowflakes with a specific timestamp component.
Throws an error if the provided timestamp is not a number or date.

Closes #2038; There hasn't been any sign of activity in the last three months.
**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
