### PR TITLE
Fixed updateChannel being too protective

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -337,7 +337,7 @@ class RESTMethods {
     data.position = _data.position || channel.position;
     data.bitrate = _data.bitrate || (channel.bitrate ? channel.bitrate * 1000 : undefined);
     data.user_limit = typeof _data.userLimit !== 'undefined' ? _data.userLimit : channel.userLimit;
-    data.parent_id = _data.parent || (channel.parent ? channel.parent.id : undefined);
+    data.parent_id = _data.parent === null ? null : _data.parent || (channel.parent ? channel.parent.id : undefined);
     return this.rest.makeRequest('patch', Endpoints.Channel(channel), true, data, undefined, reason).then(newData =>
       this.client.actions.ChannelUpdate.handle(newData).updated
     );


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If I am not mistaken the only way atm to remove a channels parent atm is to do this to get the null value through the code.

channel.client.rest.methods.updateChannel({id:channel.id, name:channel.name,
            topic:channel.topic,position:channel.position,
            bitrate:channel.bitrate,userLimit:channel.userLimit,parent:{id:null}}, {});

This fixes the method allowing channel.setParent(null); to work

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
