### PR TITLE
Fixed JSDoc information (Guild => owner)

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -291,7 +291,7 @@ class Guild {
 
   /**
    * The owner of the guild
-   * @type {GuildMember}
+   * @type {?GuildMember}
    * @readonly
    */
   get owner() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Modified `{GuildMember}` to `{?GuildMember}` so users will know, on the documentation, that the `owner` property **may be** undefined in some specific cases.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
