### PR TITLE
refactor: role stores

### DIFF
--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -14,7 +14,7 @@ class GuildEmojiRoleStore {
 
   /**
    * The filtered collection of roles of the guild emoji
-   * @type {Collection<SnowFlake, Role>}
+   * @type {Collection<Snowflake, Role>}
    * @private
    */
   get _filtered() {
@@ -100,24 +100,6 @@ class GuildEmojiRoleStore {
   valueOf() {
     return this._filtered;
   }
-
-  /**
-   * Resolves a RoleResolvable to a Role object.
-   * @method resolve
-   * @memberof GuildEmojiRoleStore
-   * @instance
-   * @param {RoleResolvable} role The role resolvable to resolve
-   * @returns {?Role}
-   */
-
-  /**
-   * Resolves a RoleResolvable to a role ID string.
-   * @method resolveID
-   * @memberof GuildEmojiRoleStore
-   * @instance
-   * @param {RoleResolvable} role The role resolvable to resolve
-   * @returns {?Snowflake}
-   */
 }
 
 Util.mixin(GuildEmojiRoleStore, ['set']);

--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -14,6 +14,7 @@ class GuildEmojiRoleStore {
 
   /**
    * The filtered collection of roles of the guild emoji
+   * @type {RoleStore<SnowFlake, Role>}
    * @private
    */
   get _filtered() {

--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -9,12 +9,12 @@ class GuildEmojiRoleStore {
   constructor(emoji) {
     this.emoji = emoji;
     this.guild = emoji.guild;
-    this.client = emoji.client;
+    Object.defineProperty(this, 'client', { value: emoji.client });
   }
 
   /**
    * The filtered collection of roles of the guild emoji
-   * @type {RoleStore<SnowFlake, Role>}
+   * @type {Collection<SnowFlake, Role>}
    * @private
    */
   get _filtered() {
@@ -29,14 +29,14 @@ class GuildEmojiRoleStore {
   add(roleOrRoles) {
     if (roleOrRoles instanceof Collection) return this.add(roleOrRoles.keyArray());
     if (!(roleOrRoles instanceof Array)) return this.add([roleOrRoles]);
-
     roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
 
     if (roleOrRoles.includes(null)) {
       return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
         'Array or Collection of Roles or Snowflakes', true));
     }
-    const newRoles = [...new Set(roleOrRoles.concat(this.keys()))];
+
+    const newRoles = [...new Set(roleOrRoles.concat(...this.values()))];
     return this.set(newRoles);
   }
 
@@ -48,13 +48,13 @@ class GuildEmojiRoleStore {
   remove(roleOrRoles) {
     if (roleOrRoles instanceof Collection) return this.remove(roleOrRoles.keyArray());
     if (!(roleOrRoles instanceof Array)) return this.remove([roleOrRoles]);
-
     roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
 
     if (roleOrRoles.includes(null)) {
       return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
         'Array or Collection of Roles or Snowflakes', true));
     }
+
     const newRoles = this.keyArray().filter(role => !roleOrRoles.includes(role));
     return this.set(newRoles);
   }
@@ -80,7 +80,7 @@ class GuildEmojiRoleStore {
 
   clone() {
     const clone = new this.constructor(this.emoji);
-    clone._patch(this.keyArray());
+    clone._patch(this.keyArray().slice());
     return clone;
   }
 

--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -5,8 +5,9 @@ const { TypeError } = require('../errors');
 /**
  * Stores emoji roles
  */
-class GuildEmojiRoleStore {
+class GuildEmojiRoleStore extends Collection {
   constructor(emoji) {
+    super();
     this.emoji = emoji;
     this.guild = emoji.guild;
     Object.defineProperty(this, 'client', { value: emoji.client });

--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -4,6 +4,7 @@ const { TypeError } = require('../errors');
 
 /**
  * Stores emoji roles
+ * @extends {Collection}
  */
 class GuildEmojiRoleStore extends Collection {
   constructor(emoji) {

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -14,7 +14,7 @@ class GuildMemberRoleStore {
 
   /**
    * The filtered collection of roles of the member
-   * @type {Collection<SnowFlake, Role>}
+   * @type {Collection<Snowflake, Role>}
    * @private
    */
   get _filtered() {
@@ -76,7 +76,10 @@ class GuildMemberRoleStore {
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put();
-      return this.member._clone()._patch([...this.keys(), roleOrRoles.id]);
+
+      const clone = this.member._clone();
+      clone._patch({ roles: [...this.keys(), roleOrRoles.id] });
+      return clone;
     }
   }
 
@@ -104,7 +107,10 @@ class GuildMemberRoleStore {
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].remove();
-      return this.member._clone()._patch([...this.keys(), roleOrRoles.id]);
+
+      const clone = this.member._clone();
+      clone._patch({ roles: [...this.keys(), roleOrRoles.id] });
+      return clone;
     }
   }
 

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -77,7 +77,7 @@ class GuildMemberRoleStore extends Collection {
           'Array or Collection of Roles or Snowflakes', true));
       }
 
-      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put();
+      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put({ reason });
 
       const clone = this.member._clone();
       clone._patch({ roles: [...this.keys(), roleOrRoles.id] });
@@ -108,7 +108,7 @@ class GuildMemberRoleStore extends Collection {
           'Array or Collection of Roles or Snowflakes', true));
       }
 
-      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].remove();
+      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].remove({ reason });
 
       const clone = this.member._clone();
       clone._patch({ roles: [...this.keys(), roleOrRoles.id] });

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -4,6 +4,7 @@ const { TypeError } = require('../errors');
 
 /**
  * Stores member roles
+ * @extends {Collection}
  */
 class GuildMemberRoleStore extends Collection {
   constructor(member) {

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -5,8 +5,9 @@ const { TypeError } = require('../errors');
 /**
  * Stores member roles
  */
-class GuildMemberRoleStore {
+class GuildMemberRoleStore extends Collection {
   constructor(member) {
+    super();
     this.member = member;
     this.guild = member.guild;
     Object.defineProperty(this, 'client', { value: member.client });

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -76,7 +76,7 @@ class GuildMemberRoleStore {
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put();
-      return this.member;
+      return this.member._clone()._patch([...this.keys(), roleOrRoles.id]);
     }
   }
 
@@ -104,7 +104,7 @@ class GuildMemberRoleStore {
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].remove();
-      return this.member;
+      return this.member._clone()._patch([...this.keys(), roleOrRoles.id]);
     }
   }
 

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -128,7 +128,7 @@ class GuildMemberRoleStore {
 
   clone() {
     const clone = new this.constructor(this.member);
-    clone._patch(this.filtered.keyArray());
+    clone._patch(this.keyArray());
     return clone;
   }
 

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -14,6 +14,7 @@ class GuildMemberRoleStore {
 
   /**
    * The filtered collection of roles of the member
+   * @type {RoleStore<SnowFlake, Role>}
    * @private
    */
   get _filtered() {

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -9,12 +9,12 @@ class GuildMemberRoleStore {
   constructor(member) {
     this.member = member;
     this.guild = member.guild;
-    this.client = member.client;
+    Object.defineProperty(this, 'client', { value: member.client });
   }
 
   /**
    * The filtered collection of roles of the member
-   * @type {RoleStore<SnowFlake, Role>}
+   * @type {Collection<SnowFlake, Role>}
    * @private
    */
   get _filtered() {
@@ -65,13 +65,16 @@ class GuildMemberRoleStore {
         return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
           'Array or Collection of Roles or Snowflakes', true));
       }
-      const newRoles = [...new Set(roleOrRoles.concat(...this.keys()))];
+
+      const newRoles = [...new Set(roleOrRoles.concat(...this.values()))];
       return this.set(newRoles, reason);
     } else {
-      if (this.guild.roles.resolve(roleOrRoles) === null) {
+      roleOrRoles = this.guild.roles.resolve(roleOrRoles);
+      if (roleOrRoles === null) {
         return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
           'Array or Collection of Roles or Snowflakes', true));
       }
+
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put();
       return this.member;
     }
@@ -90,13 +93,16 @@ class GuildMemberRoleStore {
         return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
           'Array or Collection of Roles or Snowflakes', true));
       }
+
       const newRoles = this.guild.roles.filter(role => !roleOrRoles.includes(role.id));
       return this.set(newRoles, reason);
     } else {
-      if (this.guild.roles.resolve(roleOrRoles) === null) {
+      roleOrRoles = this.guild.roles.resolve(roleOrRoles);
+      if (roleOrRoles === null) {
         return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
           'Array or Collection of Roles or Snowflakes', true));
       }
+
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].remove();
       return this.member;
     }

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -16,7 +16,7 @@ class GuildEmoji extends Emoji {
      */
     this.guild = guild;
 
-    this._roles = null;
+    this._roles = [];
     this._patch(data);
   }
 

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -16,12 +16,7 @@ class GuildEmoji extends Emoji {
      */
     this.guild = guild;
 
-    /**
-     * A collection of roles this emoji is active for (empty if all), mapped by role ID
-     * @type {GuildEmojiRoleStore<Snowflake, Role>}
-     */
-    this.roles = new GuildEmojiRoleStore(this);
-
+    this._roles = null;
     this._patch(data);
   }
 
@@ -47,6 +42,14 @@ class GuildEmoji extends Emoji {
     const clone = super._clone();
     clone.roles = this.roles.clone();
     return clone;
+  }
+
+  /**
+   * A collection of roles this emoji is active for (empty if all), mapped by role ID
+   * @type {GuildEmojiRoleStore<Snowflake, Role>}
+   */
+  get roles() {
+    return new GuildEmojiRoleStore(this);
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -39,7 +39,7 @@ class GuildMember extends Base {
      */
     this.lastMessageChannelID = null;
 
-    this._roles = null;
+    this._roles = [];
     if (data) this._patch(data);
   }
 
@@ -71,12 +71,12 @@ class GuildMember extends Base {
 
   _clone() {
     const clone = super._clone();
-    clone._roles = this._roles;
+    clone._roles = this._roles.slice();
     return clone;
   }
 
   /**
-   * A list of roles that are applied to this GuildMember, mapped by the role ID
+   * A collection of roles that are applied to this GuildMember, mapped by the role ID
    * @type {GuildMemberRoleStore<Snowflake, Role>}
    * @readonly
    */

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -65,7 +65,7 @@ class GuildMember extends Base {
      */
     if (data.joined_at) this.joinedTimestamp = new Date(data.joined_at).getTime();
 
-    this.user = this.guild.client.users.add(data.user);
+    if (data.user) this.user = this.guild.client.users.add(data.user);
     if (data.roles) this.roles._patch(data.roles);
   }
 

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -28,15 +28,6 @@ class GuildMember extends Base {
     this.user = {};
 
     /**
-     * A list of roles that are applied to this GuildMember, mapped by the role ID
-     * @type {GuildMemberRoleStore<Snowflake, Role>}
-     */
-
-    this.roles = new GuildMemberRoleStore(this);
-
-    if (data) this._patch(data);
-
-    /**
      * The ID of the last message sent by the member in their guild, if one was sent
      * @type {?Snowflake}
      */
@@ -47,6 +38,9 @@ class GuildMember extends Base {
      * @type {?Snowflake}
      */
     this.lastMessageChannelID = null;
+
+    this._roles = null;
+    if (data) this._patch(data);
   }
 
   _patch(data) {
@@ -77,8 +71,17 @@ class GuildMember extends Base {
 
   _clone() {
     const clone = super._clone();
-    clone.roles = this.roles.clone();
+    clone._roles = this._roles;
     return clone;
+  }
+
+  /**
+   * A list of roles that are applied to this GuildMember, mapped by the role ID
+   * @type {GuildMemberRoleStore<Snowflake, Role>}
+   * @readonly
+   */
+  get roles() {
+    return new GuildMemberRoleStore(this);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since we added stores to roles there was significant overhead and duplication in terms of memory usage, so this aims to reduce that by making roles just a filtered result of `Guild#roles`.
We're also missing specific implementations for adding or removing a single role on a `GuildMember`, so this takes care of that as well.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
