### PR TITLE
[docs] Added a note in userUpdate event

### DIFF
--- a/src/client/websocket/packets/handlers/PresenceUpdate.js
+++ b/src/client/websocket/packets/handlers/PresenceUpdate.js
@@ -60,6 +60,8 @@ class PresenceUpdateHandler extends AbstractHandler {
 
 /**
  * Emitted whenever a user's details (e.g. username) are changed.
+ * <info>Disabling {@link Client#presenceUpdate} will cause this event to only fire
+ * on {@link ClientUser} update.</info>
  * @event Client#userUpdate
  * @param {User} oldUser The user before the update
  * @param {User} newUser The user after the update


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

While the current description is written similarly to the description in the [API docs](https://discordapp.com/developers/docs/topics/gateway#user-update), this is a little misleading. The API sends the `USER_UPDATE` event payload on **client** user update, but ours listen to the `PRESENCE_UPDATE` event payload which allows us to listen on **all** user updates. Therefore, if you disabled the `PRESENCE_UPDATE` event via [ClientOptions](https://discord.js.org/#/docs/main/master/typedef/ClientOptions).disabledEvents, it would not emit user updates on all users but only in the client user.

This PR adds a note for the end developer so they are aware of this.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
