### PR TITLE
[docs] Minor text fixes: GroupDMChannel

### DIFF
--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -178,7 +178,7 @@ class GroupDMChannel extends Channel {
   }
 
   /**
-   * Adds an user to this Group DM.
+   * Adds a user to this Group DM.
    * @param {Object} options Options for this method
    * @param {UserResolvable} options.user User to add to this Group DM
    * @param {string} [options.accessToken] Access token to use to add the user to this Group DM
@@ -196,7 +196,7 @@ class GroupDMChannel extends Channel {
   }
 
   /**
-   * Removes an user from this Group DM.
+   * Removes a user from this Group DM.
    * @param {UserResolvable} user User to remove
    * @returns {Promise<GroupDMChannel>}
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes two slightly incorrect lines of text in [`GroupDMChannel#removeUser()`](https://discord.js.org/#/docs/main/master/class/GroupDMChannel?scrollTo=removeUser) and in [`GroupDMChannel#addUser()`](https://discord.js.org/#/docs/main/master/class/GroupDMChannel?scrollTo=addUser), which I believe appear as descriptions in the Discord.js docs.

The English language can be a little weird sometimes, so although "user" starts with a vowel, "a" is still used, rather than "an".

This PR contributes to ensuring grammatical consistency throughout, and makes the respective descriptions slightly more readable.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
