### PR TITLE
Restore Node v6 compatibility to 11.x

### DIFF
--- a/src/client/rest/RESTManager.js
+++ b/src/client/rest/RESTManager.js
@@ -16,7 +16,8 @@ class RESTManager {
   }
 
   destroy() {
-    for (const handler of Object.values(this.handlers)) {
+    for (const handlerKey of Object.keys(this.handlers)) {
+      const handler = this.handlers[handlerKey];
       if (handler.destroy) handler.destroy();
     }
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Object.values() is behind a flag in Node v6. This restores Node v6 compatibility.

Fixes #2486 

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
