### PR TITLE
Fix(MessageEmbed): Update attachFiles method and Make this.files out of the data.files check

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -132,12 +132,13 @@ class MessageEmbed {
       proxyIconURL: data.footer.proxyIconURL || data.footer.proxy_icon_url,
     } : null;
 
+    /**
+     * The files of this embed
+     * @type {Array<FileOptions|string|MessageAttachment>}
+     */
+    this.files = [];
+
     if (data.files) {
-      /**
-       * The files of this embed
-       * @type {?Object}
-       * @property {Array<FileOptions|string|MessageAttachment>} files Files to attach
-       */
       this.files = data.files.map(file => {
         if (file instanceof MessageAttachment) {
           return typeof file.file === 'string' ? file.file : Util.cloneObject(file.file);
@@ -198,11 +199,9 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   attachFiles(files) {
+    files = files.map(file => file instanceof MessageAttachment ? file.file : file);
     if (this.files) this.files = this.files.concat(files);
     else this.files = files;
-    for (let file of files) {
-      if (file instanceof MessageAttachment) file = file.file;
-    }
     return this;
   }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -200,8 +200,7 @@ class MessageEmbed {
    */
   attachFiles(files) {
     files = files.map(file => file instanceof MessageAttachment ? file.file : file);
-    if (this.files) this.files = this.files.concat(files);
-    else this.files = files;
+    this.files = this.files.concat(files);
     return this;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In the attachFiles method before we return `this` there was a useless for..of doing nothing so that is removed in place of a map at the top of the function. For some reason, in the constructor `this.files` would get assigned only if data.files was present which is probably not the case for most people using the MessageEmbed helper, So I've moved that out of the if and improved the JSDoc as its an array, not an Object.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
