### PR TITLE
Fix Incorrect NSFW Status on Channels

### DIFF
--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -35,7 +35,7 @@ class TextChannel extends GuildChannel {
      * @type {boolean}
      * @readonly
      */
-    this.nsfw = Boolean(data.nsfw);
+    this.nsfw = data.nsfw || this.name === 'nsfw' || this.name.startsWith('nsfw-');
 
     this.lastMessageID = data.last_message_id;
 

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -34,22 +34,12 @@ class TextChannel extends GuildChannel {
      * If the guild considers this channel NSFW
      * @type {boolean}
      * @readonly
-     * @private
      */
-    this._nsfw = Boolean(data.nsfw);
+    this.nsfw = data.nsfw || /^nsfw(-|$)/.test(this.name);
 
     this.lastMessageID = data.last_message_id;
 
     if (data.messages) for (const message of data.messages) this.messages.add(message);
-  }
-
-  /**
-   * If the Discord Client considers this channel NSFW
-   * @type {boolean}
-   * @readonly
-   */
-  get nsfw() {
-    return this._nsfw || /^nsfw(-|$)/.test(this.name);
   }
 
   /**

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -34,12 +34,22 @@ class TextChannel extends GuildChannel {
      * If the guild considers this channel NSFW
      * @type {boolean}
      * @readonly
+     * @private
      */
-    this.nsfw = data.nsfw || this.name === 'nsfw' || this.name.startsWith('nsfw-');
+    this._nsfw = Boolean(data.nsfw);
 
     this.lastMessageID = data.last_message_id;
 
     if (data.messages) for (const message of data.messages) this.messages.add(message);
+  }
+
+  /**
+   * If the Discord Client considers this channel NSFW
+   * @type {boolean}
+   * @readonly
+   */
+  get nsfw() {
+    return this._nsfw || /^nsfw(-|$)/.test(this.name);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
To fix #2498. According to the guys over at the Discord API server, this is the proper way to check a channel's NSFW state.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
