### PR TITLE
Configure Bastion GitHub App

### DIFF
--- a/.github/bastion.yml
+++ b/.github/bastion.yml
@@ -1,0 +1,38 @@
+## Issue Welcome Comments ##
+
+# Comment to send on a user's first issue in the repository.
+firstIssueWelcomeComment: |
+  Thank you for opening this issue. Someone will soon be here to address this issue.
+  Since this is your first issue in this repository, please make sure follow the issue template and provide as much detail as possible.
+  
+  Note that the issue tracker is only for bug reports and enhancement suggestions. If this is a question, please ask it in the [Discord Server](https://discord.gg/bRCvFy9) instead of opening an issue – you will get redirected there anyway.
+  
+  Cheers,
+  Bastion
+
+# Comment to send on the user's forthcoming issues in the repository.
+issueWelcomeComment: |
+  Thank you for opening this issue. Someone will soon be here to address this issue.
+  
+  Note that the issue tracker is only for bug reports and enhancement suggestions. If this is a question, please ask it in the [Discord Server](https://discord.gg/bRCvFy9) instead of opening an issue – you will get redirected there anyway.
+  
+  Cheers,
+  Bastion
+
+
+## Pull Request Welcome Comments ##
+
+# Comment to send on a user's first pull request in the repository.
+firstPullRequestWelcomeComment: |
+  Thank you for opening this pull request. A maintainer will get by as soon as possible to review this pull request.
+  Since this is your first pull request in this repository, please make sure follow the pull request template and provide as much detail as possible.
+  
+  Cheers,
+  Bastion
+
+# Comment to send on the user's forthcoming pull requests in the repository.
+pullRequestWelcomeComment: |
+  Thank you for opening this pull request. A maintainer will get by as soon as possible to review this pull request.
+  
+  Cheers,
+  Bastion


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

With this PR I'm suggesting to install the [Bastion GitHub App](https://github.com/apps/bastion) for this org.
If you decide to install the app, this PR will configure Bastion for this repository, which will automate some tasks in this repository like sending welcoming comments in new issues and PRs directing users to the Discord.js Server if the issue is a support question.
And if any pull request's title suggests that the pull request is a work in progress (if the title contains the word WIP, work in progress, don't merge, or do not merge, etc), it will add a pending status to the pull request and block merging until the work in progress title is removed.
Note that the WIP status won't work for pull requests that's opened before Bastion was installed, so you need to update the PR title to trigger a PR update event to make it work for the PRs that're opened before this app was installed.

Please review the file `.github\bastion.yml` to customize the messages. If you don't want a specific message, you can remove that field, and Bastion won't respond for that event.

I thought this will be helpful for this org because I use this library for my Discord bot and I'm seeing users are posting support issues who are then redirected to Discord by maintainers. This will take the heavy lifting from the maintainers.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
