### PR TITLE
[internal-sharding] Fix WebSocketShard's docs parent

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -8,6 +8,9 @@ try {
   zlib = require('pako');
 }
 
+/**
+ * Represents a Shard's Websocket connection.
+ */
 class WebSocketShard extends EventEmitter {
   constructor(manager, id) {
     super();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes WebSocketShard not showing up in docs.

```
- "manager" (member of "WebSocketShard", src/client/websocket/WebSocketShard.js:19) has no accessible parent.
- "id" (member of "WebSocketShard", src/client/websocket/WebSocketShard.js:25) has no accessible parent.
... ect
```

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
