### PR TITLE
Change to flat-square styled badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,7 @@
   </p>
   <br />
   <p>
-    <a href="https://discord.gg/bRCvFy9"><img src="https://discordapp.com/api/guilds/222078108977594368/embed.png" alt="Discord server" /></a>
-    <a href="https://www.npmjs.com/package/discord.js"><img src="https://img.shields.io/npm/v/discord.js.svg?maxAge=3600" alt="NPM version" /></a>
-    <a href="https://www.npmjs.com/package/discord.js"><img src="https://img.shields.io/npm/dt/discord.js.svg?maxAge=3600" alt="NPM downloads" /></a>
-    <a href="https://travis-ci.org/discordjs/discord.js"><img src="https://travis-ci.org/discordjs/discord.js.svg" alt="Build status" /></a>
-    <a href="https://david-dm.org/discordjs/discord.js"><img src="https://img.shields.io/david/discordjs/discord.js.svg?maxAge=3600" alt="Dependencies" /></a>
-    <a href="https://www.patreon.com/discordjs"><img src="https://img.shields.io/badge/donate-patreon-F96854.svg" alt="Patreon" /></a>
+    <a href="https://discord.gg/bRCvFy9"><img src="https://img.shields.io/discord/222078108977594368.svg?style=flat-square" alt="Discord server" /></a><a href="https://www.npmjs.com/package/discord.js"><img src="https://img.shields.io/npm/v/discord.js.svg?style=flat-square&maxAge=3600" alt="NPM version" /></a><a href="https://www.npmjs.com/package/discord.js"><img src="https://img.shields.io/npm/dt/discord.js.svg?style=flat-square&maxAge=3600" alt="NPM downloads" /></a><a href="https://travis-ci.org/discordjs/discord.js"><img src="https://img.shields.io/travis/discordjs/discord.js.svg?style=flat-square" alt="Build status" /></a><a href="https://david-dm.org/discordjs/discord.js"><img src="https://img.shields.io/david/discordjs/discord.js.svg?style=flat-square" alt="Dependencies" /></a><a href="https://www.patreon.com/discordjs"><img src="https://img.shields.io/badge/donate-patreon-F96854.svg?style=flat-square" alt="Patreon" /></a>
   </p>
   <p>
     <a href="https://nodei.co/npm/discord.js/"><img src="https://nodei.co/npm/discord.js.png?downloads=true&stars=true" alt="npm installnfo" /></a>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Flat-Square styled badges look significantly better and more modern than the previous style known as "flat" by shieldsIO standards, especially once you chain them together by removing whitespaces. Imo it looks best when using the ShieldsIO badge for Discord instead of the discord embed badge, but the final decision is on you guys. The following two show how it would look with both of these 2 options

Preview in PR message:

<div align="center">
  <a href="https://discord.gg/bRCvFy9"><img src="https://img.shields.io/discord/222078108977594368.svg?style=flat-square" alt="Discord server" /></a><a href="https://www.npmjs.com/package/discord.js"><img src="https://img.shields.io/npm/v/discord.js.svg?style=flat-square&maxAge=3600" alt="NPM version" /></a><a href="https://www.npmjs.com/package/discord.js"><img src="https://img.shields.io/npm/dt/discord.js.svg?style=flat-square&maxAge=3600" alt="NPM downloads" /></a><a href="https://travis-ci.org/discordjs/discord.js"><img src="https://img.shields.io/travis/discordjs/discord.js.svg?style=flat-square" alt="Build status" /></a><a href="https://david-dm.org/discordjs/discord.js"><img src="https://img.shields.io/david/discordjs/discord.js.svg?style=flat-square" alt="Dependencies" /></a><a href="https://www.patreon.com/discordjs"><img src="https://img.shields.io/badge/donate-patreon-F96854.svg?style=flat-square" alt="Patreon" /></a>
</div>

When sticking to the discord embed badge:

<div align="center">
  <a href="https://discord.gg/bRCvFy9"><img src="https://discordapp.com/api/guilds/222078108977594368/embed.png" alt="Discord server" /></a><a href="https://www.npmjs.com/package/discord.js"><img src="https://img.shields.io/npm/v/discord.js.svg?style=flat-square&maxAge=3600" alt="NPM version" /></a><a href="https://www.npmjs.com/package/discord.js"><img src="https://img.shields.io/npm/dt/discord.js.svg?style=flat-square&maxAge=3600" alt="NPM downloads" /></a><a href="https://travis-ci.org/discordjs/discord.js"><img src="https://img.shields.io/travis/discordjs/discord.js.svg?style=flat-square" alt="Build status" /></a><a href="https://david-dm.org/discordjs/discord.js"><img src="https://img.shields.io/david/discordjs/discord.js.svg?style=flat-square" alt="Dependencies" /></a><a href="https://www.patreon.com/discordjs"><img src="https://img.shields.io/badge/donate-patreon-F96854.svg?style=flat-square" alt="Patreon" /></a>
</div>

***

Another option for style which you see sometimes is `for-the-badge`. Personally I think that wouldn't really suit the "profesionalism" of a package such as DiscordJS but if you guys like it more that's possible too. Note that due to the fatness of these boxes swapping out the old discord badge from above would totally not blend well. This is what it would look like:

<div align="center">
<a href="https://discord.gg/bRCvFy9"><img src="https://img.shields.io/discord/222078108977594368.svg?style=for-the-badge" alt="Discord server" /></a><a href="https://www.npmjs.com/package/discord.js"><img src="https://img.shields.io/npm/v/discord.js.svg?style=for-the-badge&maxAge=3600" alt="NPM version" /></a><a href="https://www.npmjs.com/package/discord.js"><img src="https://img.shields.io/npm/dt/discord.js.svg?style=for-the-badge&maxAge=3600" alt="NPM downloads" /></a><a href="https://travis-ci.org/discordjs/discord.js"><img src="https://img.shields.io/travis/discordjs/discord.js.svg?style=for-the-badge" alt="Build status" /></a><a href="https://david-dm.org/discordjs/discord.js"><img src="https://img.shields.io/david/discordjs/discord.js.svg?style=for-the-badge" alt="Dependencies" /></a><a href="https://www.patreon.com/discordjs"><img src="https://img.shields.io/badge/donate-patreon-F96854.svg?style=for-the-badge" alt="Patreon" /></a>
</div>

***

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
