### PR TITLE
Add Collection#tap

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -372,7 +372,7 @@ class Collection extends Map {
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {Collection}
    * @example
-   * users
+   * collection
    *  .tap(user => console.log(user.username))
    *  .filter(user => user.bot)
    *  .tap(user => console.log(user.username));

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -373,11 +373,11 @@ class Collection extends Map {
    * @returns {Collection}
    * @example
    * collection
-   *  .inspect(user => console.log(user.username))
+   *  .tap(user => console.log(user.username))
    *  .filter(user => user.bot)
-   *  .inspect(user => console.log(user.username))
+   *  .tap(user => console.log(user.username));
    */
-  inspect(fn, thisArg) {
+  tap(fn, thisArg) {
     this.forEach(fn, thisArg);
     return this;
   }

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -375,7 +375,7 @@ class Collection extends Map {
    * collection
    *  .inspect(user => console.log(user.username))
    *  .filter(user => user.bot)
-   *  .inspect(u => console.log(user.username))
+   *  .inspect(user => console.log(user.username))
    */
   inspect(fn, thisArg) {
     this.forEach(fn, thisArg);

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -365,6 +365,24 @@ class Collection extends Map {
   }
 
   /**
+   * Identical to
+   * [Map.forEach()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach),
+   * but returns the collection instead of undefined.
+   * @param {Function} fn Function to execute for each element
+   * @param {*} [thisArg] Value to use as `this` when executing function
+   * @returns {Collection}
+   * @example
+   * collection
+   *  .inspect(user => console.log(user.username))
+   *  .filter(user => user.bot)
+   *  .inspect(u => console.log(user.username))
+   */
+  inspect(fn, thisArg) {
+    this.forEach(fn, thisArg);
+    return this;
+  }
+
+  /**
    * Creates an identical shallow copy of this collection.
    * @returns {Collection}
    * @example const newColl = someColl.clone();

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -372,7 +372,7 @@ class Collection extends Map {
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {Collection}
    * @example
-   * collection
+   * users
    *  .tap(user => console.log(user.username))
    *  .filter(user => user.bot)
    *  .tap(user => console.log(user.username));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds ~~`Collection#inspect`~~ `Collection#tap` which allows for easy debugging when chaining collection methods. 
Naming comes from ~~Rust~~ Laravel.

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
