### PR TITLE
Remove unnecessary Collection methods and add Collection#partition

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -163,10 +163,12 @@ class Collection extends Map {
    * should use the `get` method. See
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get) for details.</warn>
    * @param {Function} fn The function to test with (should return boolean)
+   * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {*}
    * @example users.find(user => user.username === 'Bob');
    */
-  find(fn) {
+  find(fn, thisArg) {
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
     for (const [key, val] of this) {
       if (fn(val, key, this)) return val;
     }
@@ -179,12 +181,14 @@ class Collection extends Map {
    * [Array.findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex),
    * but returns the key rather than the positional index.
    * @param {Function} fn The function to test with (should return boolean)
+   * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {*}
    * @example
    * users.findKey(user => user.username === 'Bob');
    */
   /* eslint-enable max-len */
-  findKey(fn) {
+  findKey(fn, thisArg) {
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
     for (const [key, val] of this) {
       if (fn(val, key, this)) return key;
     }
@@ -196,11 +200,13 @@ class Collection extends Map {
    * [Array.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter),
    * but returns a Collection instead of an Array.
    * @param {Function} fn The function to test with (should return boolean)
+   * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {Collection}
    * @example
    * users.filter(user => user.username === 'Bob');
    */
-  filter(fn) {
+  filter(fn, thisArg) {
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
     const results = new Collection();
     for (const [key, val] of this) {
       if (fn(val, key, this)) results.set(key, val);
@@ -232,10 +238,12 @@ class Collection extends Map {
    * [Array.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map),
    * but returns a Collection instead of an Array.
    * @param {Function} fn Function that produces an element of the new collection, taking three arguments
+   * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {Collection}
    * @example users.map(user => user.tag);
    */
-  map(fn) {
+  map(fn, thisArg) {
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
     const results = new Collection();
     for (const [key, val] of this) results.set(key, fn(val, key, this));
     return results;
@@ -245,10 +253,12 @@ class Collection extends Map {
    * Checks if there exists an item that passes a test. Identical in behavior to
    * [Array.some()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some).
    * @param {Function} fn Function used to test (should return a boolean)
+   * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {boolean}
    * @example users.some(user => user.discriminator === '0000');
    */
-  some(fn) {
+  some(fn, thisArg) {
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
     for (const [key, val] of this) {
       if (fn(val, key, this)) return true;
     }
@@ -259,10 +269,12 @@ class Collection extends Map {
    * Checks if all items passes a test. Identical in behavior to
    * [Array.every()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every).
    * @param {Function} fn Function used to test (should return a boolean)
+   * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {boolean}
    * @example users.every(user => !user.bot);
    */
-  every(fn) {
+  every(fn, thisArg) {
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
     for (const [key, val] of this) {
       if (!fn(val, key, this)) return false;
     }

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -233,18 +233,18 @@ class Collection extends Map {
 
   /**
    * Maps each item to another value. Identical in behavior to
-   * [Array.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map),
-   * but returns a Collection instead of an Array.
-   * @param {Function} fn Function that produces an element of the new collection, taking three arguments
+   * [Array.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map).
+   * @param {Function} fn Function that produces an element of the new array, taking three arguments
    * @param {*} [thisArg] Value to use as `this` when executing function
-   * @returns {Collection}
+   * @returns {Array}
    * @example users.map(user => user.tag);
    */
   map(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
-    const results = new Collection();
-    for (const [key, val] of this) results.set(key, fn(val, key, this));
-    return results;
+    const arr = new Array(this.size);
+    let i = 0;
+    for (const [key, val] of this) arr[i++] = fn(val, key, this);
+    return arr;
   }
 
   /**

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -98,7 +98,7 @@ class Collection extends Map {
    * Obtains the last value(s) in this collection. This relies on {@link Collection#array}, and thus the caching
    * mechanism applies here as well.
    * @param {number} [amount] Amount of values to obtain from the end
-   * @returns {*|Array<*>} A single value if no amount is provided or an array of values, starting from the end if
+   * @returns {*|Array<*>} A single value if no amount is provided or an array of values, starting from the start if
    * amount is negative
    */
   last(amount) {
@@ -113,7 +113,7 @@ class Collection extends Map {
    * Obtains the last key(s) in this collection. This relies on {@link Collection#keyArray}, and thus the caching
    * mechanism applies here as well.
    * @param {number} [amount] Amount of keys to obtain from the end
-   * @returns {*|Array<*>} A single key if no amount is provided or an array of keys, starting from the end if
+   * @returns {*|Array<*>} A single key if no amount is provided or an array of keys, starting from the start if
    * amount is negative
    */
   lastKey(amount) {
@@ -125,7 +125,7 @@ class Collection extends Map {
   }
 
   /**
-   * Obtains random value(s) from this collection. This relies on {@link Collection#array}, and thus the caching
+   * Obtains unique random value(s) from this collection. This relies on {@link Collection#array}, and thus the caching
    * mechanism applies here as well.
    * @param {number} [amount] Amount of values to obtain randomly
    * @returns {*|Array<*>} A single value if no amount is provided or an array of values
@@ -141,7 +141,7 @@ class Collection extends Map {
   }
 
   /**
-   * Obtains random key(s) from this collection. This relies on {@link Collection#keyArray}, and thus the caching
+   * Obtains unique random key(s) from this collection. This relies on {@link Collection#keyArray}, and thus the caching
    * mechanism applies here as well.
    * @param {number} [amount] Amount of keys to obtain randomly
    * @returns {*|Array<*>} A single key if no amount is provided or an array

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -165,7 +165,7 @@ class Collection extends Map {
    * @param {Function} fn The function to test with (should return boolean)
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {*}
-   * @example users.find(user => user.username === 'Bob');
+   * @example collection.find(user => user.username === 'Bob');
    */
   find(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
@@ -183,7 +183,7 @@ class Collection extends Map {
    * @param {Function} fn The function to test with (should return boolean)
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {*}
-   * @example users.findKey(user => user.username === 'Bob');
+   * @example collection.findKey(user => user.username === 'Bob');
    */
   /* eslint-enable max-len */
   findKey(fn, thisArg) {
@@ -201,7 +201,7 @@ class Collection extends Map {
    * @param {Function} fn The function to test with (should return boolean)
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {Collection}
-   * @example users.filter(user => user.username === 'Bob');
+   * @example collection.filter(user => user.username === 'Bob');
    */
   filter(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
@@ -217,7 +217,7 @@ class Collection extends Map {
    * contains the items that passed and the second contains the items that failed.
    * @param {Function} fn Function used to test (should return a boolean)
    * @returns {Collection[]}
-   * @example const [small, big] = guilds.partition(guild => guild.memberCount > 250);
+   * @example const [big, small] = collection.partition(guild => guild.memberCount > 250);
    */
   partition(fn) {
     const results = [new Collection(), new Collection()];
@@ -237,7 +237,7 @@ class Collection extends Map {
    * @param {Function} fn Function that produces an element of the new array, taking three arguments
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {Array}
-   * @example users.map(user => user.tag);
+   * @example collection.map(user => user.tag);
    */
   map(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
@@ -253,7 +253,7 @@ class Collection extends Map {
    * @param {Function} fn Function used to test (should return a boolean)
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {boolean}
-   * @example users.some(user => user.discriminator === '0000');
+   * @example collection.some(user => user.discriminator === '0000');
    */
   some(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
@@ -269,7 +269,7 @@ class Collection extends Map {
    * @param {Function} fn Function used to test (should return a boolean)
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {boolean}
-   * @example users.every(user => !user.bot);
+   * @example collection.every(user => !user.bot);
    */
   every(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
@@ -286,7 +286,7 @@ class Collection extends Map {
    * and `collection`
    * @param {*} [initialValue] Starting value for the accumulator
    * @returns {*}
-   * @example guilds.reduce((acc, guild) => acc + guild.memberCount);
+   * @example collection.reduce((acc, guild) => acc + guild.memberCount, 0);
    */
   reduce(fn, initialValue) {
     let accumulator;
@@ -366,7 +366,7 @@ class Collection extends Map {
    * If omitted, the collection is sorted according to each character's Unicode code point value,
    * according to the string conversion of each element.
    * @returns {Collection}
-   * @example users.sort((a, b) => a.createdTimestamp - b.createdTimestamp);
+   * @example collection.sort((userA, userB) => userA.createdTimestamp - userB.createdTimestamp);
    */
   sort(compareFunction = (x, y) => +(x > y) || +(x === y) - 1) {
     return new Collection([...this.entries()].sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -183,8 +183,7 @@ class Collection extends Map {
    * @param {Function} fn The function to test with (should return boolean)
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {*}
-   * @example
-   * users.findKey(user => user.username === 'Bob');
+   * @example users.findKey(user => user.username === 'Bob');
    */
   /* eslint-enable max-len */
   findKey(fn, thisArg) {
@@ -202,8 +201,7 @@ class Collection extends Map {
    * @param {Function} fn The function to test with (should return boolean)
    * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {Collection}
-   * @example
-   * users.filter(user => user.username === 'Bob');
+   * @example users.filter(user => user.username === 'Bob');
    */
   filter(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -157,119 +157,55 @@ class Collection extends Map {
   }
 
   /**
-   * Searches for the existence of a single item where its specified property's value is identical to the given value
-   * (`item[prop] === value`), or the given function returns a truthy value.
-   * <warn>Do not use this to check for an item by its ID. Instead, use `collection.has(id)`. See
-   * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has) for details.</warn>
-   * @param {string|Function} propOrFn The property to test against, or the function to test with
-   * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
-   * @returns {boolean}
-   * @example
-   * if (users.exists('username', 'Bob')) {
-   *  console.log('user here!');
-   * }
-   * @example
-   * if (users.exists(user => user.username === 'Bob')) {
-   *  console.log('user here!');
-   * }
-   */
-  exists(propOrFn, value) {
-    return Boolean(this.find(propOrFn, value));
-  }
-
-  /**
-   * Searches for a single item where its specified property's value is identical to the given value
-   * (`item[prop] === value`), or the given function returns a truthy value. In the latter case, this behaves like
+   * Searches for a single item where the given function returns a truthy value. This behaves like
    * [Array.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find).
    * <warn>All collections used in Discord.js are mapped using their `id` property, and if you want to find by id you
    * should use the `get` method. See
    * [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get) for details.</warn>
-   * @param {string|Function} propOrFn The property to test against, or the function to test with
-   * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
+   * @param {Function} fn The function to test with (should return boolean)
    * @returns {*}
-   * @example
-   * users.find('username', 'Bob');
-   * @example
-   * users.find(user => user.username === 'Bob');
+   * @example users.find(user => user.username === 'Bob');
    */
-  find(propOrFn, value) {
-    if (typeof propOrFn === 'string') {
-      if (typeof value === 'undefined') throw new Error('Value must be specified.');
-      for (const item of this.values()) {
-        if (item[propOrFn] === value) return item;
-      }
-      return undefined;
-    } else if (typeof propOrFn === 'function') {
-      for (const [key, val] of this) {
-        if (propOrFn(val, key, this)) return val;
-      }
-      return undefined;
-    } else {
-      throw new Error('First argument must be a property string or a function.');
+  find(fn) {
+    for (const [key, val] of this) {
+      if (fn(val, key, this)) return val;
     }
+    return undefined;
   }
 
   /* eslint-disable max-len */
   /**
-   * Searches for the key of a single item where its specified property's value is identical to the given value
-   * (`item[prop] === value`), or the given function returns a truthy value. In the latter case, this behaves like
+   * Searches for the key of a single item where the given function returns a truthy value. This behaves like
    * [Array.findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex),
    * but returns the key rather than the positional index.
-   * @param {string|Function} propOrFn The property to test against, or the function to test with
-   * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
+   * @param {Function} fn The function to test with (should return boolean)
    * @returns {*}
-   * @example
-   * users.findKey('username', 'Bob');
    * @example
    * users.findKey(user => user.username === 'Bob');
    */
   /* eslint-enable max-len */
-  findKey(propOrFn, value) {
-    if (typeof propOrFn === 'string') {
-      if (typeof value === 'undefined') throw new Error('Value must be specified.');
-      for (const [key, val] of this) {
-        if (val[propOrFn] === value) return key;
-      }
-      return undefined;
-    } else if (typeof propOrFn === 'function') {
-      for (const [key, val] of this) {
-        if (propOrFn(val, key, this)) return key;
-      }
-      return undefined;
-    } else {
-      throw new Error('First argument must be a property string or a function.');
+  findKey(fn) {
+    for (const [key, val] of this) {
+      if (fn(val, key, this)) return key;
     }
+    return undefined;
   }
 
   /**
-   * Filters the collection for items where the specified property's value is identical to the given value
-   * (`item[prop] === value`), or the given function returns a truthy value. In the latter case, this is behaves like
+   * Filters the collection for items where the given function returns a truthy value. This behaves like
    * [Array.filter()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter),
    * but returns a Collection instead of an Array.
-   * @param {string|Function} propOrFn The property to test against, or the function to test with
-   * @param {*} [value] The expected value - only applicable and required if using a property for the first argument
+   * @param {Function} fn The function to test with (should return boolean)
    * @returns {Collection}
-   * @example
-   * users.filter('username', 'Bob');
    * @example
    * users.filter(user => user.username === 'Bob');
    */
-  filter(propOrFn, value) {
-    if (typeof propOrFn === 'string') {
-      const results = new Collection();
-      for (const [key, val] of this) {
-        if (val[propOrFn] === value) results.set(key, val);
-      }
-      return results;
-    } else if (typeof propOrFn === 'function') {
-      const results = new Collection();
-      for (const [key, val] of this) {
-        if (propOrFn(val, key, this)) results.set(key, val);
-      }
-      return results;
-    } else {
-      throw new Error('First argument must be a property string or a function.');
+  filter(fn) {
+    const results = new Collection();
+    for (const [key, val] of this) {
+      if (fn(val, key, this)) results.set(key, val);
     }
+    return results;
   }
 
   /**

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -201,7 +201,7 @@ class Collection extends Map {
    * @returns {number} The number of removed entries
    */
   sweep(fn, thisArg) {
-    if (thisArg) fn = fn.bind(thisArg);
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
     const previousSize = this.size;
     for (const [key, val] of this) {
       if (fn(val, key, this)) this.delete(key);
@@ -231,10 +231,12 @@ class Collection extends Map {
    * Partitions the collection into two collections where the first collection
    * contains the items that passed and the second contains the items that failed.
    * @param {Function} fn Function used to test (should return a boolean)
+   * @param {*} [thisArg] Value to use as `this` when executing function
    * @returns {Collection[]}
    * @example const [big, small] = collection.partition(guild => guild.memberCount > 250);
    */
-  partition(fn) {
+  partition(fn, thisArg) {
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
     const results = [new Collection(), new Collection()];
     for (const [key, val] of this) {
       if (fn(val, key, this)) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR reworks Collection a bit.
- Removed all methods `Collection#xxxArray` since the same can be done with `Array.from` or `Collection#array`.
- Removed the (prop, value) pattern you can use on `Collection#find`.
- Which also means `Collection#exists`  and `Collection#findAll` are removed.
- Added `Collection#partition`.
- Reworked some documentation and added more examples.

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
