### PR TITLE
Added everyone role to GuildMemberRoleStore#_filtered

### DIFF
--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -20,7 +20,8 @@ class GuildMemberRoleStore extends Collection {
    * @private
    */
   get _filtered() {
-    return this.guild.roles.filter(role => this.member._roles.includes(role.id));
+    const everyone = this.guild.roles.get(this.guild.id);
+    return this.guild.roles.filter(role => this.member._roles.includes(role.id)).set(everyone.id, everyone);
   }
 
   /**

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -20,7 +20,7 @@ class GuildMemberRoleStore extends Collection {
    * @private
    */
   get _filtered() {
-    const everyone = this.guild.roles.get(this.guild.id);
+    const everyone = this.guild.defaultRole;
     return this.guild.roles.filter(role => this.member._roles.includes(role.id)).set(everyone.id, everyone);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a bug where the everyone role would not be added to `GuildMemberRoleStore#_filtered` getter, causing permissions to be inaccurate.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
