### PR TITLE
prevent max listener problems with collectors

### DIFF
--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -37,6 +37,7 @@ class MessageCollector extends Collector {
       for (const message of messages.values()) this.handleDispose(message);
     }).bind(this);
 
+    this.client.setMaxListeners(this.client.getMaxListeners() + 1);
     this.client.on(Events.MESSAGE_CREATE, this.handleCollect);
     this.client.on(Events.MESSAGE_DELETE, this.handleDispose);
     this.client.on(Events.MESSAGE_BULK_DELETE, bulkDeleteListener);
@@ -45,6 +46,7 @@ class MessageCollector extends Collector {
       this.client.removeListener(Events.MESSAGE_CREATE, this.handleCollect);
       this.client.removeListener(Events.MESSAGE_DELETE, this.handleDispose);
       this.client.removeListener(Events.MESSAGE_BULK_DELETE, bulkDeleteListener);
+      this.client.setMaxListeners(this.client.getMaxListeners() - 1);
     });
   }
 

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -42,6 +42,7 @@ class ReactionCollector extends Collector {
 
     this.empty = this.empty.bind(this);
 
+    this.client.setMaxListeners(this.client.getMaxListeners() + 1);
     this.client.on(Events.MESSAGE_REACTION_ADD, this.handleCollect);
     this.client.on(Events.MESSAGE_REACTION_REMOVE, this.handleDispose);
     this.client.on(Events.MESSAGE_REACTION_REMOVE_ALL, this.empty);
@@ -50,6 +51,7 @@ class ReactionCollector extends Collector {
       this.client.removeListener(Events.MESSAGE_REACTION_ADD, this.handleCollect);
       this.client.removeListener(Events.MESSAGE_REACTION_REMOVE, this.handleDispose);
       this.client.removeListener(Events.MESSAGE_REACTION_REMOVE_ALL, this.empty);
+      this.client.setMaxListeners(this.client.getMaxListeners() - 1);
     });
 
     this.on('collect', (reaction, user) => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since collectors implicitly add event listeners, they should also ensure that there are no issues with max listener counts.  I'm not pleased with how this is done, but I'm not sure how else to do it.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
