### PR TITLE
docs: fix ClientUser#setActivity returns and example (11.3.2)

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -279,10 +279,10 @@ class ClientUser extends User {
    * @param {Object} [options] Options for setting the activity
    * @param {string} [options.url] Twitch stream URL
    * @param {ActivityType|number} [options.type] Type of the activity
-   * @returns {Promise<Presence>}
+   * @returns {Promise<ClientUser>}
    * @example
    * client.user.setActivity('YouTube', { type: 'WATCHING' })
-   *   .then(presence => console.log(`Activity set to ${presence.game ? presence.game.name : 'none'}`))
+   *   .then(user => console.log(`Activity set to ${user.presence.game.name}`))
    *   .catch(console.error);
    */
   setActivity(name, { url, type } = {}) {


### PR DESCRIPTION
Incorrect doc for stable branch, `ClientUser#setActivity` actually resolves with `ClientUser`.

Doesn't seems to be a issue in master, where it resolves `Presence`.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
