### PR TITLE
feature: add DiscordAPIError#method

### DIFF
--- a/src/rest/DiscordAPIError.js
+++ b/src/rest/DiscordAPIError.js
@@ -3,11 +3,17 @@
  * @extends Error
  */
 class DiscordAPIError extends Error {
-  constructor(path, error) {
+  constructor(path, error, method) {
     super();
     const flattened = this.constructor.flattenErrors(error.errors || error).join('\n');
     this.name = 'DiscordAPIError';
     this.message = error.message && flattened ? `${error.message}\n${flattened}` : error.message || flattened;
+
+    /**
+     * The HTTP method used for the request
+     * @type {string}
+     */
+    this.method = method;
 
     /**
      * The path of the request relative to the HTTP endpoint

--- a/src/rest/handlers/RequestHandler.js
+++ b/src/rest/handlers/RequestHandler.js
@@ -80,7 +80,8 @@ class RequestHandler {
             this.queue.unshift(item);
             finish(1e3 + this.client.options.restTimeOffset);
           } else {
-            item.reject(err.status >= 400 && err.status < 500 ? new DiscordAPIError(res.request.path, res.body) : err);
+            item.reject(err.status >= 400 && err.status < 500 ?
+              new DiscordAPIError(res.request.path, res.body, res.request.method) : err);
             finish();
           }
         } else {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

As mentioned in #2496, `DiscordAPIError` instances do not contain a property of method, this lack of information can affect error handling, specially when it comes to API errors from message edit or delete, which use the same endpoint (the former using the PATCH HTTP method, and the latter using the DELETE HTTP method).

To keep backwards compatibility, I added `method` as a third argument for the `DiscordAPIError` constructor.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
