### PR TITLE
updated: new Buffer(size) API usage

### DIFF
--- a/src/client/voice/util/VolumeInterface.js
+++ b/src/client/voice/util/VolumeInterface.js
@@ -49,7 +49,7 @@ class VolumeInterface extends EventEmitter {
     volume = volume || this._volume;
     if (volume === 1) return buffer;
 
-    const out = new Buffer(buffer.length);
+    const out = Buffer.alloc(buffer.length);
     for (let i = 0; i < buffer.length; i += 2) {
       if (i >= buffer.length - 1) break;
       const uint = Math.min(32767, Math.max(-32767, Math.floor(volume * buffer.readInt16LE(i))));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

With Node.js 10, [`new Buffer(size);`](https://nodejs.org/dist/latest-v10.x/docs/api/buffer.html#buffer_new_buffer_size) has been deprecated in favor of [`Buffer.alloc(size);`](https://nodejs.org/dist/latest-v10.x/docs/api/buffer.html#buffer_class_method_buffer_alloc_size_fill_encoding) which is supported since Node.js v5.10.0. This PR changes the only occurrence of the former and replaces it with the latter.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
