### PR TITLE
fix(RESTMethods) Removing wrong listener

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -536,7 +536,7 @@ class RESTMethods {
 
       return this.rest.makeRequest('put', Endpoints.Member(member).Role(role.id), true, undefined, undefined, reason)
         .catch(err => {
-          this.client.removeListener(Constants.Events.GUILD_BAN_REMOVE, listener);
+          this.client.removeListener(Constants.Events.GUILD_MEMBER_UPDATE, listener);
           this.client.clearTimeout(timeout);
           reject(err);
         });
@@ -562,7 +562,7 @@ class RESTMethods {
 
       return this.rest.makeRequest('delete', Endpoints.Member(member).Role(role.id), true, undefined, undefined, reason)
         .catch(err => {
-          this.client.removeListener(Constants.Events.GUILD_BAN_REMOVE, listener);
+          this.client.removeListener(Constants.Events.GUILD_MEMBER_UPDATE, listener);
           this.client.clearTimeout(timeout);
           reject(err);
         });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`GuildMember#addRole` and `GuildMember#removeRole` call `RESTManager#addMemberRole` and `RESTManager#removeMemberRole`, each of which make make a temporary listener for the event `GUILD_MEMBER_UPDATE`. However, if the request failed, it'd try to remove the event from `GUILD_BAN_REMOVE`, which is incorrect, causing this issue to make more and more unused events.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
