### PR TITLE
feat(GuildEmoji#deletable)

### DIFF
--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -1,4 +1,5 @@
 const GuildEmojiRoleStore = require('../stores/GuildEmojiRoleStore');
+const Permissions = require('../util/Permissions');
 const Snowflake = require('../util/Snowflake');
 const Emoji = require('./Emoji');
 
@@ -45,8 +46,18 @@ class GuildEmoji extends Emoji {
   }
 
   /**
+   * Whether the emoji is deletable by the client user
+   * @type {boolean}
+   * @readonly
+   */
+  get deletable() {
+    return this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_EMOJIS);
+  }
+
+  /**
    * A collection of roles this emoji is active for (empty if all), mapped by role ID
    * @type {GuildEmojiRoleStore<Snowflake, Role>}
+   * @readonly
    */
   get roles() {
     return new GuildEmojiRoleStore(this);

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -51,7 +51,8 @@ class GuildEmoji extends Emoji {
    * @readonly
    */
   get deletable() {
-    return this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_EMOJIS);
+    return !this.managed &&
+      this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_EMOJIS);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds `GuildEmoji#deletable` for consistency with `GuildChannel#deletable` and `Message#deletable`. The permission required for this action is `MANAGE_EMOJIS` according to the [API docs](https://discordapp.com/developers/docs/resources/emoji#delete-guild-emoji).

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
