### PR TITLE
Improved TextBasedChannel#send

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -107,8 +107,8 @@ class TextBasedChannel {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  send(content, options) { // eslint-disable-line complexity
-    if (!options && typeof content === 'object' && !(content instanceof Array)) {
+  send(content, options) {
+    if (content && content.constructor === Object && !options) {
       options = content;
       content = null;
     } else if (!options) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The current `TextBasedChannel#send` overload implementation is not only hard to read but also triggers false positives.

The current implementation is made in a way `TextBasedChannel#send` calls `Shared.sendMessage`, which calls `Shared.createMessage`, and in this line, the method calls `Util.resolveString`:

https://github.com/discordjs/discord.js/blob/7a3a4d1388c5f97d73a06021c1bd9167ea905656/src/structures/shared/CreateMessage.js#L47

Which calls this function:

https://github.com/discordjs/discord.js/blob/7a3a4d1388c5f97d73a06021c1bd9167ea905656/src/util/Util.js#L256-L260

However, with the false positives (e.g. `Date` instances or many other things that are typeof `object` and other things), but this method is meant to stringify non-object literals. The fastest and cleanest approach to check if an object is an object literal (what this method should take) is by checking if its constructor is `Object`.

Before this PR, the following code would always throw with "`DiscordAPIError: Cannot send an empty message`":

```javascript
message.channel.send(message.author.lastMessage.createdAt);
```

After this PR, the following code would send the stringified code, in my case, `Fri May 04 2018 11:02:39 GMT+0200 (Hora de verano romance)`, to the channel.

*And also removes the old eslint-disable-line comment from before the refactor.*

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
