### PR TITLE
feat(Guild#defaultMessageNotifications)

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -184,9 +184,10 @@ class Guild extends Base {
 
     /**
      * The value set for a guild's default message notifications
-     * @type {DefaultMessageNotifications}
+     * @type {DefaultMessageNotifications|number}
      */
-    this.defaultMessageNotifications = DefaultMessageNotifications[data.default_message_notifications];
+    this.defaultMessageNotifications = DefaultMessageNotifications[data.default_message_notifications] ||
+      data.default_message_notifications;
 
     this.id = data.id;
     this.available = !data.unavailable;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -2,7 +2,7 @@ const Invite = require('./Invite');
 const GuildAuditLogs = require('./GuildAuditLogs');
 const Webhook = require('./Webhook');
 const VoiceRegion = require('./VoiceRegion');
-const { ChannelTypes, Events, browser } = require('../util/Constants');
+const { ChannelTypes, DefaultMessageNotifications, Events, browser } = require('../util/Constants');
 const Collection = require('../util/Collection');
 const Util = require('../util/Util');
 const DataResolver = require('../util/DataResolver');
@@ -183,11 +183,10 @@ class Guild extends Base {
     this.joinedTimestamp = data.joined_at ? new Date(data.joined_at).getTime() : this.joinedTimestamp;
 
     /**
-     * Whether members who have not explicitly set their notifications settings receive a notification
-     * for every message sent in this guild or not
-     * @type {boolean}
+     * The value set for a guild's default message notifications
+     * @type {DefaultMessageNotifications}
      */
-    this.defaultMessageNotifications = !data.default_message_notifications;
+    this.defaultMessageNotifications = DefaultMessageNotifications[data.default_message_notifications];
 
     this.id = data.id;
     this.available = !data.unavailable;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -182,6 +182,13 @@ class Guild extends Base {
      */
     this.joinedTimestamp = data.joined_at ? new Date(data.joined_at).getTime() : this.joinedTimestamp;
 
+    /**
+     * Whether members who have not explicitly set their notifications settings receive a notification
+     * for every message sent in this guild or not
+     * @type {boolean}
+     */
+    this.defaultMessageNotifications = !data.default_message_notifications;
+
     this.id = data.id;
     this.available = !data.unavailable;
     this.features = data.features || this.features || [];

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -725,6 +725,17 @@ exports.APIErrors = {
   REACTION_BLOCKED: 90001,
 };
 
+/**
+ * The value set for a guild's default message notifications, e.g. `ALL`. Here are the available types:
+ * * ALL
+ * * MENTIONS
+ * @typedef {string} DefaultMessageNotifications
+ */
+exports.DefaultMessageNotifications = [
+  'ALL',
+  'MENTIONS',
+];
+
 function keyMirror(arr) {
   let tmp = Object.create(null);
   for (const value of arr) tmp[value] = value;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The API sends the bot a property of `default_message_notifications` from both ws and rest. It is `0` when it mentions on all messages, and `1` when it mentions in only `@mentions`. This PR increases API coverage by supporting it.

~~**Note**: I have made that a boolean for user intuitiveness, when it's true, you get a notification in all messages, and when it's false, you only get them when you are mentioned.~~

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
