### PR TITLE
Fix(Guild#equals) Array b being modified by the equality comparison

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -931,10 +931,10 @@ class Guild extends Base {
       this.memberCount === guild.memberCount &&
       this.large === guild.large &&
       this.icon === guild.icon &&
-      Util.arraysEqual(this.features, guild.features) &&
       this.ownerID === guild.ownerID &&
       this.verificationLevel === guild.verificationLevel &&
-      this.embedEnabled === guild.embedEnabled;
+      this.embedEnabled === guild.embedEnabled &&
+      Util.arraysEqual(this.features, guild.features.slice());
 
     if (equal) {
       if (this.embedChannel) {

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -934,7 +934,10 @@ class Guild extends Base {
       this.ownerID === guild.ownerID &&
       this.verificationLevel === guild.verificationLevel &&
       this.embedEnabled === guild.embedEnabled &&
-      Util.arraysEqual(this.features, guild.features);
+      (this.features === guild.features || (
+        this.features.length === guild.features.length &&
+        this.features.every((feat, i) => feat === guild.features[i]))
+      );
 
     if (equal) {
       if (this.embedChannel) {

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -934,7 +934,7 @@ class Guild extends Base {
       this.ownerID === guild.ownerID &&
       this.verificationLevel === guild.verificationLevel &&
       this.embedEnabled === guild.embedEnabled &&
-      Util.arraysEqual(this.features, guild.features.slice());
+      Util.arraysEqual(this.features, guild.features);
 
     if (equal) {
       if (this.embedChannel) {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -129,12 +129,15 @@ class Util {
     if (a === b) return true;
     if (a.length !== b.length) return false;
 
+    // Clone the array b before starting to modify it
+    const clone = b.slice();
+
     for (const item of a) {
-      const ind = b.indexOf(item);
-      if (ind !== -1) b.splice(ind, 1);
+      const ind = clone.indexOf(item);
+      if (ind !== -1) clone.splice(ind, 1);
     }
 
-    return b.length === 0;
+    return clone.length === 0;
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -119,9 +119,9 @@ class Util {
   }
 
   /**
-   * Checks whether the arrays are equal, also removes duplicated entries from b.
-   * @param {Array<*>} a Array which will not be modified.
-   * @param {Array<*>} b Array to remove duplicated entries from.
+   * Checks whether the arrays are equal.
+   * @param {Array<*>} a The first array to compare.
+   * @param {Array<*>} b The second array to compare.
    * @returns {boolean} Whether the arrays are equal.
    * @private
    */

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -119,28 +119,6 @@ class Util {
   }
 
   /**
-   * Checks whether the arrays are equal.
-   * @param {Array<*>} a The first array to compare.
-   * @param {Array<*>} b The second array to compare.
-   * @returns {boolean} Whether the arrays are equal.
-   * @private
-   */
-  static arraysEqual(a, b) {
-    if (a === b) return true;
-    if (a.length !== b.length) return false;
-
-    // Clone the array b before starting to modify it
-    const clone = b.slice();
-
-    for (const item of a) {
-      const ind = clone.indexOf(item);
-      if (ind !== -1) clone.splice(ind, 1);
-    }
-
-    return clone.length === 0;
-  }
-
-  /**
    * Shallow-copies an object with its class/prototype intact.
    * @param {Object} obj Object to clone
    * @returns {Object}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

~~If you were to compare 2 guilds with the same features using `Guild#equals`, the second would lose all its features from the cache since [`Util.arraysEqual`](https://discord.js.org/#/docs/main/master/class/Util?scrollTo=s-arraysEqual) modifies the second array, removing all the values from the first. This PR clones the array from the given guild in said method using `Array#slice()`'s method.~~

~~[`Util.arraysEqual`](https://discord.js.org/#/docs/main/master/class/Util?scrollTo=s-arraysEqual) is not supposed to modify the array b but instead make a clone of it.~~

[`Util.arraysEqual`](https://discord.js.org/#/docs/main/master/class/Util?scrollTo=s-arraysEqual) has been removed as it was only used in `Guild#equals` in favor of a better and more performant method. This was a bug affecting to `Guild#equals` (only place it is used) where using said method with two guilds that share common values in `Guild#features`, the guild B would get the items shared from guild A removed.~~

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
