### PR TITLE
Add "deleted" property to multiple structures.

### DIFF
--- a/src/client/actions/ChannelDelete.js
+++ b/src/client/actions/ChannelDelete.js
@@ -13,6 +13,7 @@ class ChannelDeleteAction extends Action {
 
     if (channel) {
       client.channels.remove(channel.id);
+      channel.deleted = true;
       client.emit(Events.CHANNEL_DELETE, channel);
     }
 

--- a/src/client/actions/GuildDelete.js
+++ b/src/client/actions/GuildDelete.js
@@ -33,6 +33,7 @@ class GuildDeleteAction extends Action {
 
       // Delete guild
       client.guilds.remove(guild.id);
+      guild.deleted = true;
       client.emit(Events.GUILD_DELETE, guild);
       this.deleted.set(guild.id, guild);
       this.scheduleForDeletion(guild.id);

--- a/src/client/actions/GuildEmojiDelete.js
+++ b/src/client/actions/GuildEmojiDelete.js
@@ -4,6 +4,7 @@ const { Events } = require('../../util/Constants');
 class GuildEmojiDeleteAction extends Action {
   handle(emoji) {
     emoji.guild.emojis.remove(emoji.id);
+    emoji.deleted = true;
     this.client.emit(Events.GUILD_EMOJI_DELETE, emoji);
     return { emoji };
   }

--- a/src/client/actions/GuildMemberRemove.js
+++ b/src/client/actions/GuildMemberRemove.js
@@ -11,6 +11,7 @@ class GuildMemberRemoveAction extends Action {
       guild.memberCount--;
       if (member) {
         guild.voiceStates.delete(member.id);
+        member.deleted = true;
         guild.members.remove(member.id);
         if (client.status === Status.READY) client.emit(Events.GUILD_MEMBER_REMOVE, member);
       }

--- a/src/client/actions/GuildRoleDelete.js
+++ b/src/client/actions/GuildRoleDelete.js
@@ -11,6 +11,7 @@ class GuildRoleDeleteAction extends Action {
       role = guild.roles.get(data.role_id);
       if (role) {
         guild.roles.remove(data.role_id);
+        role.deleted = true;
         client.emit(Events.GUILD_ROLE_DELETE, role);
       }
     }

--- a/src/client/actions/MessageDelete.js
+++ b/src/client/actions/MessageDelete.js
@@ -11,6 +11,7 @@ class MessageDeleteAction extends Action {
       message = channel.messages.get(data.id);
       if (message) {
         channel.messages.delete(message.id);
+        message.deleted = true;
         client.emit(Events.MESSAGE_DELETE, message);
       }
     }

--- a/src/client/actions/MessageDeleteBulk.js
+++ b/src/client/actions/MessageDeleteBulk.js
@@ -13,6 +13,7 @@ class MessageDeleteBulkAction extends Action {
       for (const id of ids) {
         const message = channel.messages.get(id);
         if (message) {
+          message.deleted = true;
           messages.set(message.id, message);
           channel.messages.delete(id);
         }

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -23,7 +23,6 @@ class Channel extends Base {
      */
     this.type = type ? type.toLowerCase() : 'unknown';
 
-    
     /**
      * Whether the channel has been deleted
      * @type {boolean}

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -23,6 +23,13 @@ class Channel extends Base {
      */
     this.type = type ? type.toLowerCase() : 'unknown';
 
+    
+    /**
+     * Whether the channel has been deleted
+     * @type {boolean}
+     */
+    this.deleted = false;
+
     if (data) this._patch(data);
   }
 

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -24,6 +24,12 @@ class Emoji extends Base {
      * @type {?Snowflake}
      */
     this.id = emoji.id;
+
+    /**
+     * Whether this emoji has been deleted
+     * @type {boolean}
+     */
+    this.deleted = false;
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -50,6 +50,13 @@ class Guild extends Base {
      */
     this.presences = new PresenceStore(this.client);
 
+    
+    /**
+     * Whether the bot has been removed from the guild
+     * @type {boolean}
+     */
+    this.deleted = false;
+
     if (!data) return;
     if (data.unavailable) {
       /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -50,7 +50,6 @@ class Guild extends Base {
      */
     this.presences = new PresenceStore(this.client);
 
-    
     /**
      * Whether the bot has been removed from the guild
      * @type {boolean}

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -39,7 +39,6 @@ class GuildMember extends Base {
      */
     this.lastMessageChannelID = null;
 
-    
     /**
      * Whether the member has been removed from the guild
      * @type {boolean}

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -39,6 +39,13 @@ class GuildMember extends Base {
      */
     this.lastMessageChannelID = null;
 
+    
+    /**
+     * Whether the member has been removed from the guild
+     * @type {boolean}
+     */
+    this.deleted = false;
+
     this._roles = [];
     if (data) this._patch(data);
   }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -157,6 +157,12 @@ class Message extends Base {
      * @private
      */
     this._edits = [];
+
+    /**
+     * Whether this message has been deleted
+     * @type {boolean}
+     */
+    this.deleted = false;
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -347,9 +347,9 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
-    return this.author.id === this.client.user.id || (this.guild &&
+    return !this.deleted && (this.author.id === this.client.user.id || (this.guild &&
       this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES)
-    );
+    ));
   }
 
   /**

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -69,6 +69,12 @@ class Role extends Base {
      * @type {boolean}
      */
     this.mentionable = data.mentionable;
+
+    /**
+     * Whether the role has been deleted
+     * @type {boolean}
+     */
+    this.deleted = false;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #2489 

This PR adds a new property called "deleted" to multiple structures throughout discord.js. The property allows for an easy way to check if the specific structure is stale.

Affected Structures:
- Channel
- Emoji
- Guild
- GuildMember
- Message
- Role

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
