### PR TITLE
Adds client#formattedUptime

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -206,7 +206,7 @@ class Client extends BaseClient {
     const days = `${d === 0 ? '' : d} ${d === 1 ? 'day,' : d === 0 ? '' : 'days,'}`;
     const hours = `${h === 0 ? '' : h} ${h === 1 ? 'hour,' : h === 0 ? '' : 'hours,'}`;
     const minutes = `${m === 0 ? '' : m} ${m === 1 ? 'minute and' : m === 0 ? '' : 'minutes and'}`;
-    const seconds = `${s === 0 ? '' : s} ${s === 1 ? 'second' : s === 0 ? '' : 'seconds'}`;
+    const seconds = `${s} ${s === 1 ? 'second' : 'seconds'}`;
     return `${days} ${hours} ${minutes} ${seconds}`.trim();
   }
 

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -188,6 +188,29 @@ class Client extends BaseClient {
   }
 
   /**
+   * How long it has been since the client hast entered the `READY` state, but in a readable format
+   * @type {string}
+   * @readonly
+   */
+
+  get formattedUptime() {
+    const ms = this.uptime;
+    let d, h, m, s;
+    s = Math.floor(ms / 1000);
+    m = Math.floor(s / 60);
+    s %= 60;
+    h = Math.floor(m / 60);
+    m %= 60;
+    d = Math.floor(h / 24);
+    h %= 24;
+    const days = `${d === 0 ? '' : d} ${d === 1 ? 'day,' : d === 0 ? '' : 'days,'}`;
+    const hours = `${h === 0 ? '' : h} ${h === 1 ? 'hour,' : h === 0 ? '' : 'hours,'}`;
+    const minutes = `${m === 0 ? '' : m} ${m === 1 ? 'minute and' : m === 0 ? '' : 'minutes and'}`;
+    const seconds = `${s === 0 ? '' : s} ${s === 1 ? 'second' : s === 0 ? '' : 'seconds'}`;
+    return `${days} ${hours} ${minutes} ${seconds}`.trim();
+  }
+
+  /**
    * Average heartbeat ping of the websocket, obtained by averaging the {@link Client#pings} property
    * @type {number}
    * @readonly


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**


**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

This allows a user to be able to see how long the client has been logged in for, in a cleaner format rather than using external modules to parse the milliseconds into a readable format. So if client.uptime was 390000, client.formattedUptime would be: `6 minutes and 30 seconds`