### PR TITLE
fix: Check if WebSocket exists on the window object

### DIFF
--- a/src/WebSocket.js
+++ b/src/WebSocket.js
@@ -5,8 +5,9 @@ try {
   if (!erlpack.pack) erlpack = null;
 } catch (err) {} // eslint-disable-line no-empty
 
-if (browser) {
-  exports.WebSocket = window.WebSocket; // eslint-disable-line no-undef
+/* eslint-disable no-undef */
+if (browser && window.WebSocket) {
+  exports.WebSocket = window.WebSocket;
 } else {
   try {
     exports.WebSocket = require('uws');
@@ -14,6 +15,7 @@ if (browser) {
     exports.WebSocket = require('ws');
   }
 }
+/* eslint-enable no-undef */
 
 exports.encoding = erlpack ? 'etf' : 'json';
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In certain environments (*cough* vscode), the window object can be overwritten. That typically results in a `TypeError: Cannot read property 'CONNECTING' of undefined`.

This PR adds a check if WebSocket is available on the window property, since you can have a window object that isn't "global" (aka window == global)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
