### PR TITLE
Make `Webhook#token` not enumerable

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -27,9 +27,8 @@ class Webhook {
     /**
      * The token for the webhook
      * @type {string}
-     * @readonly
      */
-    Object.defineProperty(this, 'token', { value: data.token });
+    Object.defineProperty(this, 'token', { value: data.token, writable: true });
 
     /**
      * The avatar for the webhook

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -28,7 +28,7 @@ class Webhook {
      * The token for the webhook
      * @type {string}
      */
-    Object.defineProperty(this, 'token', { value: data.token, writable: true });
+    Object.defineProperty(this, 'token', { value: data.token, writable: true, configurable: true });
 
     /**
      * The avatar for the webhook

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -27,8 +27,9 @@ class Webhook {
     /**
      * The token for the webhook
      * @type {string}
+     * @readonly
      */
-    this.token = data.token;
+    Object.defineProperty(this, 'token', { value: data.token });
 
     /**
      * The avatar for the webhook


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

[`Client#token`](https://discord.js.org/#/docs/main/master/class/Client?scrollTo=token) is hidden with `Object.defineProperty` by making the property non-enumerable, however, [`Webhook#token`](https://discord.js.org/#/docs/main/master/class/Webhook?scrollTo=token) is not.

Other things to consider (but I need feedback from maintainers):

- ~~Make `Webhook#token` writable?~~
- Make `WebhookClient#token` non enumerable?

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
