### PR TITLE
Fix Messages un-deleting themselves

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -26,6 +26,12 @@ class Message extends Base {
      */
     this.channel = channel;
 
+    /**
+     * Whether this message has been deleted
+     * @type {boolean}
+     */
+    this.deleted = false;
+
     if (data) this._patch(data);
   }
 
@@ -157,12 +163,6 @@ class Message extends Base {
      * @private
      */
     this._edits = [];
-
-    /**
-     * Whether this message has been deleted
-     * @type {boolean}
-     */
-    this.deleted = false;
   }
 
   /**


### PR DESCRIPTION
when a _patch() is queued

**Please describe the changes this PR makes and why it should be merged:**
Sometimes a _patch() will happen after the messageDelete action, making the message think it's not deleted anymore. By moving the deleted property for the message to the constructor, it will no-longer undelete itself (state) anytime _patch() is called.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
