### PR TITLE
Collection debug methods, remove deleteAll

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -333,12 +333,29 @@ class Collection extends Map {
    * @returns {Collection}
    * @example
    * collection
-   *  .tap(user => console.log(user.username))
+   *  .each(user => console.log(user.username))
    *  .filter(user => user.bot)
-   *  .tap(user => console.log(user.username));
+   *  .each(user => console.log(user.username));
+   */
+  each(fn, thisArg) {
+    this.forEach(fn, thisArg);
+    return this;
+  }
+
+  /**
+   * Runs a function on the collection and returns the collection.
+   * @param {Function} fn Function to execute
+   * @param {*} [thisArg] Value to use as `this` when executing function
+   * @returns {Collection}
+   * @example
+   * collection
+   *  .tap(coll => coll.size)
+   *  .filter(user => user.bot)
+   *  .tap(coll => coll.size)
    */
   tap(fn, thisArg) {
-    this.forEach(fn, thisArg);
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+    fn(this);
     return this;
   }
 
@@ -363,18 +380,6 @@ class Collection extends Map {
       for (const [key, val] of coll) newColl.set(key, val);
     }
     return newColl;
-  }
-
-  /**
-   * Calls the `delete()` method on all items that have it.
-   * @returns {Promise[]}
-   */
-  deleteAll() {
-    const returns = [];
-    for (const item of this.values()) {
-      if (item.delete) returns.push(item.delete());
-    }
-    return returns;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Changes `tap` to be `fn(this)` and adds `each` for what `tap` was (naming was inconsistent with other places like Laravel)
- Removes `deleteAll` - it was inconsistent to the rest of the interface, even the docs were not guaranteed

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
