### PR TITLE
Switch snekfetch to superagent.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "pako": "^1.0.0",
     "prism-media": "^0.2.0",
-    "snekfetch": "^3.6.0",
+    "superagent": "^3.8.3",
     "tweetnacl": "^1.0.0",
     "ws": "^4.0.0"
   },

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -1,6 +1,9 @@
 const querystring = require('querystring');
 const superagent = require('superagent');
+const https = require('https');
 const { browser, UserAgent } = require('../util/Constants');
+
+if (https.Agent) var agent = new https.Agent({ keepAlive: true });
 
 class APIRequest {
   constructor(rest, method, path, options) {
@@ -18,7 +21,7 @@ class APIRequest {
     const API = this.options.versioned === false ? this.client.options.http.api :
       `${this.client.options.http.api}/v${this.client.options.http.version}`;
 
-    const request = superagent[this.method](`${API}${this.path}`);
+    const request = superagent[this.method](`${API}${this.path}`).agent(agent);
 
     if (this.options.auth !== false) request.set('Authorization', this.rest.getAuth());
     if (this.options.reason) request.set('X-Audit-Log-Reason', encodeURIComponent(this.options.reason));

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -27,7 +27,7 @@ class APIRequest {
 
     if (this.options.files) {
       for (const file of this.options.files) if (file && file.file) request.attach(file.name, file.file, file.name);
-      if (typeof this.options.data !== 'undefined') request.attach('payload_json', JSON.stringify(this.options.data));
+      if (typeof this.options.data !== 'undefined') request.field('payload_json', JSON.stringify(this.options.data));
     } else if (typeof this.options.data !== 'undefined') {
       request.send(this.options.data);
     }

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -1,9 +1,6 @@
 const querystring = require('querystring');
-const snekfetch = require('snekfetch');
-const https = require('https');
+const superagent = require('superagent');
 const { browser, UserAgent } = require('../util/Constants');
-
-if (https.Agent) var agent = new https.Agent({ keepAlive: true });
 
 class APIRequest {
   constructor(rest, method, path, options) {
@@ -21,7 +18,7 @@ class APIRequest {
     const API = this.options.versioned === false ? this.client.options.http.api :
       `${this.client.options.http.api}/v${this.client.options.http.version}`;
 
-    const request = snekfetch[this.method](`${API}${this.path}`, { agent });
+    const request = superagent[this.method](`${API}${this.path}`);
 
     if (this.options.auth !== false) request.set('Authorization', this.rest.getAuth());
     if (this.options.reason) request.set('X-Audit-Log-Reason', encodeURIComponent(this.options.reason));

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -21,8 +21,9 @@ class APIRequest {
     const API = this.options.versioned === false ? this.client.options.http.api :
       `${this.client.options.http.api}/v${this.client.options.http.version}`;
 
-    const request = superagent[this.method](`${API}${this.path}`).agent(agent);
+    const request = superagent[this.method](`${API}${this.path}`);
 
+    if (typeof agent !== 'undefined') request.agent(agent);
     if (this.options.auth !== false) request.set('Authorization', this.rest.getAuth());
     if (this.options.reason) request.set('X-Audit-Log-Reason', encodeURIComponent(this.options.reason));
     if (!browser) request.set('User-Agent', UserAgent);

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const snekfetch = require('snekfetch');
+const superagent = require('superagent');
 const Util = require('../util/Util');
 const { Error: DiscordError, TypeError } = require('../errors');
 const { browser } = require('../util/Constants');
@@ -88,7 +88,7 @@ class DataResolver {
 
     if (typeof resource === 'string') {
       if (/^https?:\/\//.test(resource)) {
-        return snekfetch.get(resource).then(res => res.body instanceof Buffer ? res.body : Buffer.from(res.text));
+        return superagent.get(resource).then(res => res.body instanceof Buffer ? res.body : Buffer.from(res.text));
       } else {
         return new Promise((resolve, reject) => {
           const file = browser ? resource : path.resolve(resource);

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -1,4 +1,4 @@
-const snekfetch = require('snekfetch');
+const superagent = require('superagent');
 const Collection = require('./Collection');
 const { Colors, DefaultOptions, Endpoints } = require('./Constants');
 const { Error: DiscordError, RangeError, TypeError } = require('../errors');
@@ -92,7 +92,7 @@ class Util {
   static fetchRecommendedShards(token, guildsPerShard = 1000) {
     return new Promise((resolve, reject) => {
       if (!token) throw new DiscordError('TOKEN_MISSING');
-      snekfetch.get(`${DefaultOptions.http.api}/v${DefaultOptions.http.version}${Endpoints.botGateway}`)
+      superagent.get(`${DefaultOptions.http.api}/v${DefaultOptions.http.version}${Endpoints.botGateway}`)
         .set('Authorization', `Bot ${token.replace(/^Bot\s*/i, '')}`)
         .end((err, res) => {
           if (err) reject(err);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
While node-fetch is another option, superagent was what we used before, has a close API to snekfetch (only required minor changes to work), and personal bias of course. snekfetch is good, but even Gus himself said we should switch away, and this is one of many ways to do so.

fixes #2581 
closes #2582 
closes #2583 
closes #2587 
closes #2589 
closes #a bigger door than gus'

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
