### PR TITLE
Added support for `defaultMessageNotifications`

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -634,7 +634,7 @@ class Guild extends Base {
    * @property {Base64Resolvable} [icon] The icon of the guild
    * @property {GuildMemberResolvable} [owner] The owner of the guild
    * @property {Base64Resolvable} [splash] The splash screen of the guild
-   * @property {string|number} [defaultMessageNotifications] The default message notifications
+   * @property {DefaultMessageNotifications|number} [defaultMessageNotifications] The default message notifications
    */
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -634,7 +634,7 @@ class Guild extends Base {
    * @property {Base64Resolvable} [icon] The icon of the guild
    * @property {GuildMemberResolvable} [owner] The owner of the guild
    * @property {Base64Resolvable} [splash] The splash screen of the guild
-   * @property {boolean} [defaultMessageNotifications] The default message notifications
+   * @property {string|number} [defaultMessageNotifications] The default message notifications
    */
 
   /**
@@ -670,7 +670,9 @@ class Guild extends Base {
       _data.explicit_content_filter = Number(data.explicitContentFilter);
     }
     if (typeof data.defaultMessageNotifications !== 'undefined') {
-      _data.default_message_notifications = Number(data.defaultMessageNotifications);
+      _data.default_message_notifications = typeof data.defaultMessageNotifications === 'string' ?
+        DefaultMessageNotifications.indexOf(data.defaultMessageNotifications) :
+        Number(data.defaultMessageNotifications);
     }
     return this.client.api.guilds(this.id).patch({ data: _data, reason })
       .then(newData => this.client.actions.GuildUpdate.handle(newData).updated);

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -634,6 +634,7 @@ class Guild extends Base {
    * @property {Base64Resolvable} [icon] The icon of the guild
    * @property {GuildMemberResolvable} [owner] The owner of the guild
    * @property {Base64Resolvable} [splash] The splash screen of the guild
+   * @property {boolean} [defaultMessageNotifications] The default message notifications
    */
 
   /**
@@ -667,6 +668,9 @@ class Guild extends Base {
     if (data.splash) _data.splash = data.splash;
     if (typeof data.explicitContentFilter !== 'undefined') {
       _data.explicit_content_filter = Number(data.explicitContentFilter);
+    }
+    if (typeof data.defaultMessageNotifications !== 'undefined') {
+      _data.default_message_notifications = Number(data.defaultMessageNotifications);
     }
     return this.client.api.guilds(this.id).patch({ data: _data, reason })
       .then(newData => this.client.actions.GuildUpdate.handle(newData).updated);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

With https://github.com/discordjs/discord.js/pull/2538, `Guild#defaultMessageNotifications` was first introduced into the library, however, we could not edit it as `Guild#edit` was unedited. This PR adds the `defaultMessageNotifications` option into the `GuildEditData` typedef, and therefore, inside `Guild#edit`.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
