### PR TITLE
use new multiple issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Report incorrect or unexpected behavior of discord.js
+
+---
+
 <!--
 If you need help with discord.js installation or usage, please go to the discord.js Discord server instead:
   https://discord.gg/bRCvFy9

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Request a new feature that discord.js is missing
+
+---
+
+<!--
+If you need help with discord.js installation or usage, please go to the discord.js Discord server instead:
+  https://discord.gg/bRCvFy9
+This issue tracker is only for bug reports and enhancement suggestions. You won't receive any basic help here.
+-->
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
We get some feature requests that don't really fit with our existing issue template. This allows those feature requests to use a separate template. I'm open to suggestions on everything in here, especially with the feature request template (it's just the default one from GitHub, so there's probably some discord.js-specific information we should put in there).

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
