### PR TITLE
fix(GuildAuditLogs): default to PartialGuildChannel if channel was deleted

### DIFF
--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -336,7 +336,7 @@ class GuildAuditLogsEntry {
         id: data.target_id,
         guild,
       });
-      changes.channel = guild.channels.get(changes.channel_id);
+      changes.channel = { id: changes.channel_id };
       this.target = new Invite(guild.client, changes);
     } else if (targetType === Targets.MESSAGE) {
       this.target = guild.client.users.get(data.target_id);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently when fetching audit logs containing an invite to a deleted channel will reject the promise with an error.
This will now create a PartialGuildChannel instead.
But since there is neither a type, nor a name available,
the type will always be `'text'` and the name `undefined`.

No idea if it's possible to work around that, changing the type signature of `Invite#channel` to `GuildChannel|PartialGuildChannel|Snowflake` is probably semver: major.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
