### PR TITLE
docs: add video to MessageAttachment properties

### DIFF
--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -99,13 +99,13 @@ class MessageAttachment {
     this.proxyURL = data.proxy_url;
 
     /**
-     * The height of this attachment (if an image)
+     * The height of this attachment (if an image or video)
      * @type {?number}
      */
     this.height = data.height;
 
     /**
-     * The width of this attachment (if an image)
+     * The width of this attachment (if an image or video)
      * @type {?number}
      */
     this.width = data.width;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In case of a video attachment the MessageAttachment object still has a height and width property.
This PR changes the corresponding line in the documentation to account for that possibility

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
