### PR TITLE
fix: do not cache webhook users

### DIFF
--- a/src/client/ClientDataManager.js
+++ b/src/client/ClientDataManager.js
@@ -39,10 +39,10 @@ class ClientDataManager {
     return guild;
   }
 
-  newUser(data) {
+  newUser(data, cache = true) {
     if (this.client.users.has(data.id)) return this.client.users.get(data.id);
     const user = new User(this.client, data);
-    this.client.users.set(user.id, user);
+    if (cache) this.client.users.set(user.id, user);
     return user;
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -55,7 +55,7 @@ class Message {
      * The author of the message
      * @type {User}
      */
-    this.author = this.client.dataManager.newUser(data.author);
+    this.author = this.client.dataManager.newUser(data.author, !data.webhook_id);
 
     /**
      * Represents the author of the message as a guild member


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This will make discord.js no longer cache webhook users.
Through this it's possible to access the actual used username and
avatar of webhook's messages as these can change every single message.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
