### PR TITLE
fix: ratelimits

### DIFF
--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -12,7 +12,6 @@ class RESTManager {
     this.globallyRateLimited = false;
     this.tokenPrefix = tokenPrefix;
     this.versioned = true;
-    this.timeDifferences = [];
     if (client.options.restSweepInterval > 0) {
       client.setInterval(() => {
         this.handlers.sweep(handler => handler._inactive);
@@ -22,15 +21,6 @@ class RESTManager {
 
   get api() {
     return routeBuilder(this);
-  }
-
-  get timeDifference() {
-    return Math.round(this.timeDifferences.reduce((a, b) => a + b, 0) / this.timeDifferences.length);
-  }
-
-  set timeDifference(ms) {
-    this.timeDifferences.unshift(ms);
-    if (this.timeDifferences.length > 5) this.timeDifferences.length = 5;
   }
 
   getAuth() {

--- a/src/rest/handlers/RequestHandler.js
+++ b/src/rest/handlers/RequestHandler.js
@@ -23,7 +23,7 @@ class RequestHandler {
   }
 
   get _inactive() {
-    return this.queue.length === 0 && !this.limited && Date.now() > this.resetTime && this.busy !== true;
+    return this.queue.length === 0 && !this.limited && this.busy !== true;
   }
 
   /* eslint-disable prefer-promise-reject-errors */
@@ -32,7 +32,7 @@ class RequestHandler {
       const finish = timeout => {
         if (timeout || this.limited) {
           if (!timeout) {
-            timeout = this.resetTime - Date.now() + this.manager.timeDifference + this.client.options.restTimeOffset;
+            timeout = this.resetTime - Date.now() + this.client.options.restTimeOffset;
           }
           if (!this.manager.globalTimeout && this.manager.globallyRateLimited) {
             this.manager.globalTimeout = setTimeout(() => {
@@ -52,7 +52,6 @@ class RequestHandler {
              * @param {Object} rateLimitInfo Object containing the rate limit info
              * @param {number} rateLimitInfo.timeout Timeout in ms
              * @param {number} rateLimitInfo.limit Number of requests that can be made to this endpoint
-             * @param {number} rateLimitInfo.timeDifference Delta-T in ms between your system and Discord servers
              * @param {string} rateLimitInfo.method HTTP method used for request that triggered this event
              * @param {string} rateLimitInfo.path Path used for request that triggered this event
              * @param {string} rateLimitInfo.route Route used for request that triggered this event
@@ -60,7 +59,6 @@ class RequestHandler {
             this.client.emit(RATE_LIMIT, {
               timeout,
               limit: this.limit,
-              timeDifference: this.manager.timeDifference,
               method: item.request.method,
               path: item.request.path,
               route: item.request.route,
@@ -74,9 +72,9 @@ class RequestHandler {
         if (res && res.headers) {
           if (res.headers.get('x-ratelimit-global')) this.manager.globallyRateLimited = true;
           this.limit = Number(res.headers.get('x-ratelimit-limit') || Infinity);
-          this.resetTime = Number(res.headers.get('x-ratelimit-reset') || 0) * 1000;
+          // eslint-disable-next-line max-len
+          this.resetTime = (Number(res.headers.get('x-ratelimit-reset') || 0) * 1e3) - new Date(res.headers.get('date')).getTime() + Date.now();
           this.remaining = Number(res.headers.get('x-ratelimit-remaining') || 1);
-          this.manager.timeDifference = Date.now() - new Date(res.headers.get('date')).getTime();
         }
 
         if (res.ok) {

--- a/src/rest/handlers/RequestHandler.js
+++ b/src/rest/handlers/RequestHandler.js
@@ -72,9 +72,12 @@ class RequestHandler {
         if (res && res.headers) {
           if (res.headers.get('x-ratelimit-global')) this.manager.globallyRateLimited = true;
           this.limit = Number(res.headers.get('x-ratelimit-limit') || Infinity);
-          // eslint-disable-next-line max-len
-          this.resetTime = (Number(res.headers.get('x-ratelimit-reset') || 0) * 1e3) - new Date(res.headers.get('date')).getTime() + Date.now();
-          this.remaining = Number(res.headers.get('x-ratelimit-remaining') || 1);
+          const reset = res.headers.get('x-ratelimit-reset');
+          this.resetTime = reset !== null ?
+            (Number(reset) * 1e3) - new Date(res.headers.get('date') || Date.now()).getTime() + Date.now() :
+            Date.now();
+          const remaining = res.headers.get('x-ratelimit-remaining');
+          this.remaining = remaining !== null ? Number(remaining) : 1;
         }
 
         if (res.ok) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
**Fixes:**
- Adds Date header DeltaT calc back into ratelimits
- Fix x-ratelimit-reset is in seconds, not ms: ![img](https://puu.sh/AIXxY/9b3989b248.png)
- Fix remaining defaulting to 1, when 0 is remaining, as 0 is falsy

**Cleans Up:**
- removes legacy RESTManager#timeDifference code
- a duplicate check in `_inactive` that wasn't removed when the check was added to `limited`

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
