### PR TITLE
Change ytdl example

### DIFF
--- a/src/client/voice/util/PlayInterface.js
+++ b/src/client/voice/util/PlayInterface.js
@@ -47,7 +47,7 @@ class PlayInterface {
    * connection.play('/home/hydrabolt/audio.mp3', { volume: 0.5 });
    * @example
    * // Play a ReadableStream
-   * connection.play(ytdl('https://www.youtube.com/watch?v=ZlAU_w7-Xp8', { filter: 'audioonly' }));
+   * connection.play(ytdl('https://www.youtube.com/watch?v=ZlAU_w7-Xp8', { quality: 'highestaudio' }));
    * @example
    * // Play a voice broadcast
    * const broadcast = client.createVoiceBroadcast();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
ytdl no longer recommends using filter: audioonly for reasons listed in [Issue 294](https://github.com/fent/node-ytdl-core/issues/294) as it can cause massive slowdowns in performance. As an alternative, using quality: highestaudio is recommended. This should be noted for new voice developers.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
