### PR TITLE
Docs: correct Guild#memberCount to actual behaviour

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -107,7 +107,7 @@ class Guild extends Base {
     this.region = data.region;
 
     /**
-     * The full amount of members in this guild as of `READY`
+     * The full amount of members in this guild
      * @type {number}
      */
     this.memberCount = data.member_count || this.memberCount;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The docs currently state "The full amount of members in this guild __as of READY__" however the actual behaviour differs.
Guild#memberCount is updated on of GUILD_MEMBER_ADD and /_REMOVE respectively

Source: [GuildMemberAdd](https://github.com/discordjs/discord.js/blob/18646b72f902d79b73b8010013df2cb9141a2755/src/client/websocket/packets/handlers/GuildMemberAdd.js#L12) | [GuildMemberRemove](https://github.com/discordjs/discord.js/blob/18646b72f902d79b73b8010013df2cb9141a2755/src/client/actions/GuildMemberRemove.js#L11)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
