### PR TITLE
Fix seek option

### DIFF
--- a/src/client/voice/player/BasePlayer.js
+++ b/src/client/voice/player/BasePlayer.js
@@ -45,7 +45,7 @@ class BasePlayer extends EventEmitter {
 
     const isStream = input instanceof ReadableStream;
 
-    const args = isStream ? FFMPEG_ARGUMENTS : ['-i', input, ...FFMPEG_ARGUMENTS];
+    const args = isStream ? FFMPEG_ARGUMENTS.slice() : ['-i', input, ...FFMPEG_ARGUMENTS];
     if (options.seek) args.push('-ss', String(options.seek));
 
     const ffmpeg = new prism.FFmpeg({ args });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Because `args` was not a copy of `FFMPEG_ARGIMENTS`, but a reference to it, pushing `-ss` argument pushed it to `FFMPEG_ARGUMENTS`, making it persistent.
So if you called `play` with `seek` option and then without it, `-ss` was still there.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
