### PR TITLE
Add support for Guild#setDefaultMessageNotifications

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -688,6 +688,18 @@ class Guild extends Base {
     return this.edit({ explicitContentFilter }, reason);
   }
 
+  /* eslint-disable max-len */
+  /**
+   * Edits the setting of the default message notifications of the guild.
+   * @param {DefaultMessageNotifications|number} defaultMessageNotifications The new setting for the default message notifications
+   * @param {string} [reason] Reason for changing the setting of the default message notifications
+   * @returns {Promise<Guild>}
+   */
+  setDefaultMessageNotification(defaultMessageNotifications, reason) {
+    return this.edit({ defaultMessageNotifications }, reason);
+  }
+  /* eslint-enable max-len */
+
   /**
    * Edits the name of the guild.
    * @param {string} name The new name of the guild

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -695,7 +695,7 @@ class Guild extends Base {
    * @param {string} [reason] Reason for changing the setting of the default message notifications
    * @returns {Promise<Guild>}
    */
-  setDefaultMessageNotification(defaultMessageNotifications, reason) {
+  setDefaultMessageNotifications(defaultMessageNotifications, reason) {
     return this.edit({ defaultMessageNotifications }, reason);
   }
   /* eslint-enable max-len */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds the `Guild#setDefaultMessageNotifications` method, after
#2538 introduced `Guild#defaultMessageNotifications` and #2592 added support for it in `Guild#edit`


**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
