### PR TITLE
Add Required And Implicit Permission Checks

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -292,7 +292,7 @@ class GuildMember extends Base {
    */
   hasPermission(permission, { checkAdmin = true, checkOwner = true } = {}) {
     if (checkOwner && this.user.id === this.guild.ownerID) return true;
-    return this.roles.some(r => r.permissions.has(permission, checkAdmin));
+    return this.roles.some(r => r.permissions.has(permission, { checkAdmin }));
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR is intended to fix a flaw in the Permission checker in d.js.

## Problem/Issue Solved
Currently, checking permission for a bot will return true no matter if the required permissions for that permission are denied or not. For example, if a user enables `SEND_MESSAGES` but denied `VIEW_CHANNEL` and I check permissions if my bot has the ability to send a message in the channel I get a response of `true`. This is an invalid response as my bot lacks the required permissions to send a message. There are various permissions that have **required** permissions that need to be checked before sending a response.

There is also implicit permissions, whereby a permission is automatically granted to a user by having another permission. For example, `MANAGE_ROLES`, automatically gives users the `MANAGE_CHANNELS` permission. Currently, if a user has MANAGE_ROLES but doesn't have MANAGE_CHANNELS this will return false as opposed to returning true.

## Result/Testing Changes
checkRequired = false With `SEND_MESSAGES` Denied
![image](https://user-images.githubusercontent.com/23035000/42066818-c69cd0ec-7b10-11e8-83aa-f5457faaf22a.png)

checkRequired = true With `SEND_MESSAGES` Denied
![image](https://user-images.githubusercontent.com/23035000/42066822-ccf67506-7b10-11e8-97ca-6ea230ebc4f0.png)

checkRequired = true With `SEND_MESSAGES` Neutral
![image](https://user-images.githubusercontent.com/23035000/42067311-8d0b7b00-7b13-11e8-9242-f3765a004e23.png)


## Possible Improvements
- I wanted to have the Permissions.REQUIRED_CHANNEL_PERMS and Permissions.IMPLICIT_PERMS in `util/Constants.js` however this caused a circular reference error where in order to have Permissions.Flags I had to require Permissions file inside Constants file and I needed to require Constants file inside Permissions file to get access to these exports in Constants.

If anyone can help provide an alternative solution, I would love to improve this.

- We can also separate this functionality to a separate function as suggested to me using hasRequired(). I personally believe it is better to have 1 function that can handle it all and easier to use for developers as opposed to several functions with very similar functionality. Nonetheless, whichever you feel is best I can change it to.

## Important Notes:

- As requested, I have changed the Permissions.has() to use an Object as its second parameter as opposed to three parameters. Please note that this will cause a **breaking** change to d.js.

- Although I believe this functionality should always check required permissions I have left this as an optional addition as opposed to completely changing the behavior. If other d.js developers feel that this is the right way to proceed I can change this to make `checkRequired = true` and make this the default behavior for d.js.

- It was discussed in depth of whether to edit the has() or to create getters for permissions like `channel.hasSendMessages` however, due to the amount of getters that would have to be created(17) I felt it was better to just add a few lines of code to 1 function instead of so many getters.

- I was only able to add the permissions that I am aware of that are required and are implicit. I have reached out to discord support to try and get a full list of these and I will update them when I get it. If anyone knows any other remaining permissions please let me know.

Thank you Hydrabolt and Space for the advice.

Huge thanks to @KingDGrizzle for all the help! <3

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
- [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
