### PR TITLE
docs fix: RoleResolvable typedef missing and incorrecty documented methods

### DIFF
--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -18,6 +18,31 @@ class RoleStore extends DataStore {
   }
 
   /**
+   * Data that can be resolved to a Role object. This can be:
+   * * A Role
+   * * A Snowflake
+   * @typedef {Role|Snowflake} RoleResolvable
+   */
+
+  /**
+   * Resolves a RoleResolvable to a Role object.
+   * @method resolve
+   * @memberof RoleStore
+   * @instance
+   * @param {RoleResolvable} role The role resolvable to resolve
+   * @returns {?Role}
+   */
+
+  /**
+   * Resolves a RoleResolvable to a role ID string.
+   * @method resolveID
+   * @memberof RoleStore
+   * @instance
+   * @param {RoleResolvable} role The role resolvable to resolve
+   * @returns {?Snowflake}
+   */
+
+  /**
    * Creates a new role in the guild with given information.
    * <warn>The position will silently reset to 1 if an invalid one is provided, or none.</warn>
    * @param {Object} [options] Options
@@ -63,31 +88,7 @@ class RoleStore extends DataStore {
   get highest() {
     return this.reduce((prev, role) => role.comparePositionTo(prev) > 0 ? role : prev, this.first());
   }
-
-  /**
-   * Resolves a RoleResolvable to a Role object.
-   * @method resolve
-   * @memberof RoleStore
-   * @instance
-   * @param {RoleResolvable} role The role resolvable to resolve
-   * @returns {?Role}
-   */
-
-  /**
-   * Resolves a RoleResolvable to a role ID string.
-   * @method resolveID
-   * @memberof RoleStore
-   * @instance
-   * @param {RoleResolvable} role The role resolvable to resolve
-   * @returns {?Snowflake}
-   */
+ 
 }
-
-/**
- * Data that can be resolved to a Role object. This can be:
- * * A Role
- * * A Snowflake
- * @typedef {Role|Snowflake} RoleResolvable
- */
 
 module.exports = RoleStore;

--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -73,21 +73,21 @@ class RoleStore extends DataStore {
 
   /**
    * Resolves a RoleResolvable to a Role object.
-   * @method resolve
-   * @memberof RoleStore
-   * @instance
    * @param {RoleResolvable} role The role resolvable to resolve
    * @returns {?Role}
    */
+  resolve(role) {
+    return super.resolve(role);
+  }
 
   /**
    * Resolves a RoleResolvable to a role ID string.
-   * @method resolveID
-   * @memberof RoleStore
-   * @instance
    * @param {RoleResolvable} role The role resolvable to resolve
    * @returns {?Snowflake}
    */
+  resolveID(role) {
+    return super.resolveID(role);
+  }
 }
 
 module.exports = RoleStore;

--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -65,29 +65,29 @@ class RoleStore extends DataStore {
   }
 
   /**
-   * Data that can be resolved to a Role object. This can be:
-   * * A Role
-   * * A Snowflake
-   * @typedef {Role|Snowflake} RoleResolvable
-   */
-
-  /**
    * Resolves a RoleResolvable to a Role object.
+   * @method resolve
+   * @memberof RoleStore
+   * @instance
    * @param {RoleResolvable} role The role resolvable to resolve
    * @returns {?Role}
    */
-  resolve(role) {
-    return super.resolve(role);
-  }
 
   /**
    * Resolves a RoleResolvable to a role ID string.
+   * @method resolveID
+   * @memberof RoleStore
+   * @instance
    * @param {RoleResolvable} role The role resolvable to resolve
    * @returns {?Snowflake}
    */
-  resolveID(role) {
-    return super.resolveID(role);
-  }
 }
+
+/**
+ * Data that can be resolved to a Role object. This can be:
+ * * A Role
+ * * A Snowflake
+ * @typedef {Role|Snowflake} RoleResolvable
+ */
 
 module.exports = RoleStore;

--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -88,7 +88,6 @@ class RoleStore extends DataStore {
   get highest() {
     return this.reduce((prev, role) => role.comparePositionTo(prev) > 0 ? role : prev, this.first());
   }
- 
 }
 
 module.exports = RoleStore;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #2552. Also at the same time (somehow) addresses the current issues with the documentation for [RoleStore#resolveID](https://discord.js.org/#/docs/main/master/class/RoleStore?scrollTo=resolveID) and [RoleStore#resolve](https://discord.js.org/#/docs/main/master/class/RoleStore?scrollTo=resolve). ~~However, the solution seems to be a bit dirty, so I'm open to suggestions. I have tried things like `@override`, which did not seem to work (or perhaps I did it incorrectly).~~ ~~Dirtiness resolved thanks to @SpaceEEC suggestions.~~ jsdocs are dumb

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
