### PR TITLE
fix: Webhook#edit to resolve options.channel

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -1,5 +1,4 @@
 const DataResolver = require('../util/DataResolver');
-const { Channel } = require('./Channel');
 const { createMessage } = require('./shared');
 
 /**
@@ -201,7 +200,7 @@ class Webhook {
     if (avatar && (typeof avatar === 'string' && !avatar.startsWith('data:'))) {
       return DataResolver.resolveImage(avatar).then(image => this.edit({ name, avatar: image }, reason));
     }
-    if (channel) channel = channel instanceof Channel ? channel.id : channel;
+    if (channel) channel = this.client.channels.resolveID(channel);
     return this.client.api.webhooks(this.id, channel ? undefined : this.token).patch({
       data: { name, avatar, channel_id: channel },
       reason,


### PR DESCRIPTION
This is a fix to the issue that I was encountering when trying to do `Webhook.edit({ channel: TextChannel });`, which caused the error:
```
TypeError: Right-hand side of 'instanceof' is not an object
    at Webhook.edit (node_modules\discord.js\src\structures\Webhook.js:204:36)
```

**Please describe the changes this PR makes and why it should be merged:**
Fixes an error when trying to resolve the channel to edit.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
