### PR TITLE
Docs - Clarify messageReactionRemove user description

### DIFF
--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -31,7 +31,7 @@ class MessageReactionRemove extends Action {
  * Emitted whenever a reaction is removed from a message.
  * @event Client#messageReactionRemove
  * @param {MessageReaction} messageReaction The reaction object
- * @param {User} user The user whose reaction or reaction emoji was removed
+ * @param {User} user The user whose emoji or reaction emoji was removed
  */
 
 module.exports = MessageReactionRemove;

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -31,7 +31,7 @@ class MessageReactionRemove extends Action {
  * Emitted whenever a reaction is removed from a message.
  * @event Client#messageReactionRemove
  * @param {MessageReaction} messageReaction The reaction object
- * @param {User} user The user that originally reacted with the emoji or reaction emoji
+ * @param {User} user The user whose reaction or reaction emoji was removed
  */
 
 module.exports = MessageReactionRemove;

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -31,7 +31,7 @@ class MessageReactionRemove extends Action {
  * Emitted whenever a reaction is removed from a message.
  * @event Client#messageReactionRemove
  * @param {MessageReaction} messageReaction The reaction object
- * @param {User} user The user that removed the emoji or reaction emoji
+ * @param {User} user The user that originally reacted with the emoji or reaction emoji
  */
 
 module.exports = MessageReactionRemove;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The documentation states that the user parameter in the `messageReactionRemove` event is the user who removed the reaction. This is wrong; it is the user who initially reacted with the reaction. See [this conversation](https://discordapp.com/channels/222078108977594368/222078374472843266/467424090274267158) on the server.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
