### PR TITLE
fix(MessageReaction): only delete reaction if cache and count is empty

### DIFF
--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -71,7 +71,7 @@ class MessageReaction {
     this.users.delete(user.id);
     if (!this.me || user.id !== this.message.client.user.id) this.count--;
     if (user.id === this.message.client.user.id) this.me = false;
-    if (this.count <= 0) {
+    if (this.count <= 0 && this.users.size === 0) {
       this.message.reactions.remove(this.emoji.id || this.emoji.name);
     }
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
For cases where the bot removes another user's reaction when there are 2 remaining reactions in a `ReactionUserStore`, the bot would remove that, correctly, but then, the gateway event received would decrement the count once more in `MessageReaction#_remove`, causing it to delete the entire reaction. This is the only way I can think to combat that issue, since there is no guarantee of the `count` ever being synchronized with the cached information, nor can I see a guarantee to keep it that way, as the count gets out of sync regardless.
Feel free to suggest something better, if anything comes up!
fixes #2653 

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
