### PR TITLE
backport: Sharding utility methods

### DIFF
--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -10,6 +10,9 @@ class ShardClientUtil {
   constructor(client) {
     this.client = client;
     process.on('message', this._handleMessage.bind(this));
+    client.on('ready', () => { process.send({ _ready: true }); });
+    client.on('disconnect', () => { process.send({ _disconnect: true }); });
+    client.on('reconnecting', () => { process.send({ _reconnecting: true }); });
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -202,6 +202,18 @@ class Util {
     }
     return array.indexOf(element);
   }
+
+  /**
+   * Creates a Promise that resolves after a specified duration.
+   * @param {number} ms How long to wait before resolving (in milliseconds)
+   * @returns {Promise<void>}
+   * @private
+   */
+  static delayFor(ms) {
+    return new Promise(resolve => {
+      setTimeout(resolve, ms);
+    });
+  }
 }
 
 module.exports = Util;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Backports a decent number of sharding-related commits, such as `Shard#kill`, `Shard#respawn`, the ability to pass `execArgv` into the Shard, and a few more.
Please suggest if there are any better ways to go about anything I've done. I've avoided a complete rewrite so as to keep it functioning as similarly to before as possible.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
