### PR TITLE
fix: Util.basename being unreliable

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -2,7 +2,7 @@ const { Colors, DefaultOptions, Endpoints } = require('./Constants');
 const fetch = require('node-fetch');
 const { Error: DiscordError, RangeError, TypeError } = require('../errors');
 const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
-const splitPathRe = /^(\/?|)([\s\S]*?)((?:\.{1,2}|[^/]+?|)(\.[^./]*|))(?:[/]*)$/;
+const { parse } = require('path');
 
 /**
  * Contains various general-purpose utility methods. These functions are also available on the base `Discord` object.
@@ -330,9 +330,8 @@ class Util {
    * @private
    */
   static basename(path, ext) {
-    let f = splitPathRe.exec(path)[3];
-    if (ext && f.endsWith(ext)) f = f.slice(0, -ext.length);
-    return f;
+    let res = parse(path);
+    return ext && res.ext.startsWith(ext) ? res.name : res.base.split('?')[0];
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

fixes https://github.com/discordjs/discord.js/issues/2677

I have tried other options, such as `new URL()` for [WHATWG](https://whatwg.org/) parsing, but it only works for URLs and threw in local pathes, `path.basename` is unreliable (according to the devs' note), and path.parse seems to work well.

**Tested**: `Util.basename('https://cdn.discordapp.com/avatars/399849903406448640/eb5ade1bbbea079d82b099b618389a37.png?size=1024');` returns `eb5ade1bbbea079d82b099b618389a37.png`, and `basename('https://cdn.discordapp.com/avatars/399849903406448640/eb5ade1bbbea079d82b099b618389a37.png?size=1024', '.png')` returns `eb5ade1bbbea079d82b099b618389a37`.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
