### PR TITLE
fix: Messages being inserted in the wrong order

### DIFF
--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -86,7 +86,10 @@ class MessageStore extends DataStore {
   async _fetchMany(options = {}) {
     const data = await this.client.api.channels[this.channel.id].messages.get({ query: options });
     const messages = new Collection();
-    for (const message of data) messages.set(message.id, this.add(message));
+    
+    const parsed = data.reverse().map(m => this.add(m))
+    for (const message of parsed.reverse()) messages.set(message.id, message)
+    
     return messages;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**


Previously when you called `channel.messages.fetch()` and sent a message, the messages store would prune the last message sent (instead of the oldest)

**Current behavior:**

```ts
// Presuming max message cache of 4
const channel = client.channels.get('123')
(await channel.messages.fetch()).sort(sortByTimestamp).map(m => m.content) // ['1', '2', '3', '4']

// Send message '5' on Discord
channel.messages.map(m => m.content) // ['1', '2', '3', '5']
```

**New behavior:**

```ts
// Presuming max message cache of 4
const channel = client.channels.get('123')
(await channel.messages.fetch()).sort(sortByTimestamp).map(m => m.content) // ['1', '2', '3', '4']

// Send message '5' on Discord
channel.messages.map(m => m.content) // ['2', '3', '4', '5']
``` 


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
