### PR TITLE
feat: Add ESM exports

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,0 +1,84 @@
+import Discord from './index.js';
+
+// "Root" classes (starting points)
+export const { BaseClient } = Discord;
+export const { Client } = Discord;
+export const { Shard } = Discord;
+export const { ShardClientUtil } = Discord;
+export const { ShardingManager } = Discord;
+export const { WebhookClient } = Discord;
+
+// Utilities
+export const { Collection } = Discord;
+export const { Constants } = Discord;
+export const { DataResolver } = Discord;
+export const { DataStore } = Discord;
+export const { DiscordAPIError } = Discord;
+export const { Permissions } = Discord;
+export const { Snowflake } = Discord;
+export const { SnowflakeUtil } = Discord;
+export const { Structures } = Discord;
+export const { Util } = Discord;
+export const { util } = Discord;
+export const { version } = Discord;
+
+// Stores
+export const { ChannelStore } = Discord;
+export const { ClientPresenceStore } = Discord;
+export const { GuildChannelStore } = Discord;
+export const { GuildEmojiStore } = Discord;
+export const { GuildEmojiRoleStore } = Discord;
+export const { GuildMemberStore } = Discord;
+export const { GuildMemberRoleStore } = Discord;
+export const { GuildStore } = Discord;
+export const { ReactionUserStore } = Discord;
+export const { MessageStore } = Discord;
+export const { PresenceStore } = Discord;
+export const { RoleStore } = Discord;
+export const { UserStore } = Discord;
+
+// Shortcuts to Util methods
+export const { discordSort } = Discord;
+export const { escapeMarkdown } = Discord;
+export const { fetchRecommendedShards } = Discord;
+export const { resolveColor } = Discord;
+export const { resolveString } = Discord;
+export const { splitMessage } = Discord;
+
+// Structures
+export const { Base } = Discord;
+export const { Activity } = Discord;
+export const { CategoryChannel } = Discord;
+export const { Channel } = Discord;
+export const { ClientApplication } = Discord;
+export const { ClientUser } = Discord;
+export const { Collector } = Discord;
+export const { DMChannel } = Discord;
+export const { Emoji } = Discord;
+export const { GroupDMChannel } = Discord;
+export const { Guild } = Discord;
+export const { GuildAuditLogs } = Discord;
+export const { GuildChannel } = Discord;
+export const { GuildEmoji } = Discord;
+export const { GuildMember } = Discord;
+export const { Invite } = Discord;
+export const { Message } = Discord;
+export const { MessageAttachment } = Discord;
+export const { MessageCollector } = Discord;
+export const { MessageEmbed } = Discord;
+export const { MessageMentions } = Discord;
+export const { MessageReaction } = Discord;
+export const { PermissionOverwrites } = Discord;
+export const { Presence } = Discord;
+export const { ReactionCollector } = Discord;
+export const { ReactionEmoji } = Discord;
+export const { RichPresenceAssets } = Discord;
+export const { Role } = Discord;
+export const { TextChannel } = Discord;
+export const { User } = Discord;
+export const { UserConnection } = Discord;
+export const { VoiceChannel } = Discord;
+export const { VoiceRegion } = Discord;
+export const { Webhook } = Discord;
+
+export const { WebSocket } = Discord;

--- a/test/esm.mjs
+++ b/test/esm.mjs
@@ -1,0 +1,18 @@
+/* eslint no-console: 0 */
+
+/**
+ * This file tests ECMAScript Modules support in discord.js
+ * https://nodejs.org/dist/latest-v10.x/docs/api/esm.html
+ */
+import { Client } from '../';
+import { token } from './auth';
+
+const client = new Client();
+
+client.on('ready', () => {
+  console.log(`Ready with ${client.users.size} users!`);
+  console.log('Exiting proccess with code 0...');
+  process.exit(0);
+});
+
+client.login(token).then(console.log, console.error);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds exports for (experimental) [ECMAScript Modules](https://nodejs.org/dist/latest-v10.x/docs/api/esm.html) so we can destructure its exports.

Before this PR, we would need to do:

```javascript
import Discord from 'discord.js';
const client = new Discord.Client({});
```

But after this PR, we can normally destructure Client:

```javascript
import { Client } from 'discord.js';
const client = new Client({});
```

Additionally, I have added a new test (in `test/esm.mjs`, requires the `--experimental-modules` flag) to cover the new exports.

> **NOTE**: `discordjs.ClientUser` is a getter in `index.js` but I could not find the ESM's alternative.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
