### PR TITLE
[On hold] fix: Add catch callback to item.request.make() in RequestHandler

### DIFF
--- a/src/rest/handlers/RequestHandler.js
+++ b/src/rest/handlers/RequestHandler.js
@@ -111,6 +111,13 @@ class RequestHandler {
           }, item.reject);
           finish();
         }
+      }).catch(error => {
+        // This library isn't transparent, in certain cases, it may reject with a FetchError:
+        // https://github.com/bitinn/node-fetch/blob/master/ERROR-HANDLING.md
+        item.reject(error.code && error.code >= 400 && error.code < 500 ?
+          new DiscordAPIError(item.request.route, error, item.request.method) :
+          error);
+        return finish();
       });
     });
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Unlike the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), node-fetch includes a [FetchError](https://github.com/bitinn/node-fetch/blob/master/README.md#class-fetcherror) class, which is thrown when an operational error happens during the fetching process.

The following url specifies how to handle errors in node-fetch:

https://github.com/bitinn/node-fetch/blob/master/ERROR-HANDLING.md

This PR also fixes uncaught errors, specially when the Discord API isn't fully operative, by handling the missing part of the request's error handling.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
