### PR TITLE
Add data object to Messages class

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -37,6 +37,12 @@ class Message extends Base {
 
   _patch(data) { // eslint-disable-line complexity
     /**
+     * The data of the message
+     * @type {object}
+     */
+    this.data = data;
+
+    /**
      * The ID of the message
      * @type {Snowflake}
      */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Although adding `data` as another field of `Message` uses more memory, it is valuable for more easily extending `Message` in TypeScript. 

For example, extending `Message` in TypeScript can be done with: 

```
class DogMessage extends Message {
  woof(): void {
    this.channel.send("Woof!")
  }
}

const client = new Client();

client.on("message", (message: Message) => {
  let dogMessage = new DogMessage(message.channel, message.data, message.client);
  dogMessage.woof()
});
```

This would require adding:
```
export class Message {
  ...
  public data: object;
  ...
}
```
to the typings file.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.