### PR TITLE
Add new Permission PRIORITY_SPEAKER

### DIFF
--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -148,6 +148,7 @@ class Permissions {
  * * `MANAGE_GUILD` (edit the guild information, region, etc.)
  * * `ADD_REACTIONS` (add new reactions to messages)
  * * `VIEW_AUDIT_LOG`
+ * * `PRIORITY_SPEAKER`
  * * `VIEW_CHANNEL`
  * * `SEND_MESSAGES`
  * * `SEND_TTS_MESSAGES`
@@ -180,6 +181,7 @@ Permissions.FLAGS = {
   MANAGE_GUILD: 1 << 5,
   ADD_REACTIONS: 1 << 6,
   VIEW_AUDIT_LOG: 1 << 7,
+  PRIORITY_SPEAKER: 1 << 8,
 
   VIEW_CHANNEL: 1 << 10,
   SEND_MESSAGES: 1 << 11,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Discord added on Canary a new Feature called "PRIORITY SPEAKER" which added a new Permission to roles. see [this post](https://cdn.discordapp.com/attachments/125227483518861312/474517698118942741/unknown.png) from Discord Tester server.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
