### PR TITLE
refactor: move Message#cleanContent function to Util

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -253,35 +253,7 @@ class Message extends Base {
    * @readonly
    */
   get cleanContent() {
-    return this.content
-      .replace(/@(everyone|here)/g, '@\u200b$1')
-      .replace(/<@!?[0-9]+>/g, input => {
-        const id = input.replace(/<|!|>|@/g, '');
-        if (this.channel.type === 'dm' || this.channel.type === 'group') {
-          return this.client.users.has(id) ? `@${this.client.users.get(id).username}` : input;
-        }
-
-        const member = this.channel.guild.members.get(id);
-        if (member) {
-          if (member.nickname) return `@${member.nickname}`;
-          return `@${member.user.username}`;
-        } else {
-          const user = this.client.users.get(id);
-          if (user) return `@${user.username}`;
-          return input;
-        }
-      })
-      .replace(/<#[0-9]+>/g, input => {
-        const channel = this.client.channels.get(input.replace(/<|#|>/g, ''));
-        if (channel) return `#${channel.name}`;
-        return input;
-      })
-      .replace(/<@&[0-9]+>/g, input => {
-        if (this.channel.type === 'dm' || this.channel.type === 'group') return input;
-        const role = this.guild.roles.get(input.replace(/<|@|>|&/g, ''));
-        if (role) return `@${role.name}`;
-        return input;
-      });
+    return Util.cleanContent(this.content, this);
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -394,29 +394,26 @@ class Util {
       .replace(/<@!?[0-9]+>/g, input => {
         const id = input.replace(/<|!|>|@/g, '');
         if (message.channel.type === 'dm' || message.channel.type === 'group') {
-          return message.client.users.has(id) ? `@${message.client.users.get(id).username}` : input;
+          const user = message.client.users.get(id);
+          return user ? `@${user.username}` : input;
         }
 
         const member = message.channel.guild.members.get(id);
         if (member) {
-          if (member.nickname) return `@${member.nickname}`;
-          return `@${member.user.username}`;
+          return member.displayName;
         } else {
           const user = message.client.users.get(id);
-          if (user) return `@${user.username}`;
-          return input;
+          return user ? `@${user.username}` : input;
         }
       })
       .replace(/<#[0-9]+>/g, input => {
         const channel = message.client.channels.get(input.replace(/<|#|>/g, ''));
-        if (channel) return `#${channel.name}`;
-        return input;
+        return channel ? `#${channel.name}` : input;
       })
       .replace(/<@&[0-9]+>/g, input => {
         if (message.channel.type === 'dm' || message.channel.type === 'group') return input;
         const role = message.guild.roles.get(input.replace(/<|@|>|&/g, ''));
-        if (role) return `@${role.name}`;
-        return input;
+        return role ? `@${role.name}` : input;
       });
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Moves the method that makes up `Message#cleanContent` to our `Util` class so that it can be used by external sources more easily.

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
