### PR TITLE
Small typo in documentation of Message.js

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -495,7 +495,7 @@ class Message extends Base {
    * @example
    * // Reply to a message
    * message.reply('Hey, I\'m a reply!')
-   *   .then(msg => console.log(`Sent a reply to ${msg.author.username}`))
+   *   .then(msg => console.log(`Sent a reply to ${message.author.username}`))
    *   .catch(console.error);
    */
   reply(content, options) {

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -495,7 +495,7 @@ class Message extends Base {
    * @example
    * // Reply to a message
    * message.reply('Hey, I\'m a reply!')
-   *   .then(msg => console.log(`Sent a reply to ${message.author.username}`))
+   *   .then(() => console.log(`Sent a reply to ${message.author.username}`))
    *   .catch(console.error);
    */
   reply(content, options) {


### PR DESCRIPTION
The current message.reply() example contains a small mistake. `msg.author` will always be the ClientUser, instead of the author of the message that got replied.


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
