### PR TITLE
Added docs for possible <MessageEmbed>.type's

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -23,7 +23,11 @@ class MessageEmbed {
 
   setup(data) {
     /**
-     * The type of this embed
+     * The type of this embed, either:
+     * * `image` - an image embed
+     * * `video` - a video embed
+     * * `link` - a link embed
+     * * `rich` - a rich embed
      * @type {string}
      */
     this.type = data.type;
@@ -47,7 +51,7 @@ class MessageEmbed {
     this.url = data.url;
 
     /**
-     * The color of the embed
+     * The color of this embed
      * @type {number}
      */
     this.color = data.color;


### PR DESCRIPTION
Added a list of the four <MessageEmbed>.type's an embed could have, similar to how <channel>.type got a list of possible values
I also changed "color of the embed" to "color of this embed" since everything else on this page uses "this" instead of "that", and that will make it more streamlined.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
