### PR TITLE
fix(Collection): use `new this.constructor` instead of `new Collection`

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -220,7 +220,7 @@ class Collection extends Map {
    */
   filter(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
-    const results = new Collection();
+    const results = new this.constructor();
     for (const [key, val] of this) {
       if (fn(val, key, this)) results.set(key, val);
     }
@@ -237,7 +237,7 @@ class Collection extends Map {
    */
   partition(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
-    const results = [new Collection(), new Collection()];
+    const results = [new this.constructor(), new this.constructor()];
     for (const [key, val] of this) {
       if (fn(val, key, this)) {
         results[0].set(key, val);
@@ -404,7 +404,7 @@ class Collection extends Map {
    * @example collection.sort((userA, userB) => userA.createdTimestamp - userB.createdTimestamp);
    */
   sort(compareFunction = (x, y) => +(x > y) || +(x === y) - 1) {
-    return new Collection([...this.entries()].sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));
+    return new this.constructor([...this.entries()].sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));
   }
 
   toJSON() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Using `new Collection()` within the Collection class causes unexpected behavior when extending it.
Example:

```js
class SuperCollection extends Collection {
  hasItems () { return this.size > 0 }
}

const sc = new SuperCollection([[1, 'one'], [2, 'two']])
sc.hasItems() // => true

const filtered = sc.filter(item => item === 'one') // returns a Collection, not a SuperCollection
filtered.hasItems() // error
```

This PR makes sure to use the same constructor when filtering, cloning etc.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
