### PR TITLE
docschange for GuildChannel#replacePermissionOverwrites

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -968,10 +968,12 @@ class Guild {
   }
 
   /**
-   * Can be used to overwrite permissions when creating a channel.
+   * Can be used to overwrite permissions when creating a channel or replacing overwrites.
    * @typedef {Object} ChannelCreationOverwrites
-   * @property {PermissionResolvable|number} [allow] The permissions to allow
-   * @property {PermissionResolvable|number} [deny] The permissions to deny
+   * @property {PermissionResolvable} [allow] The permissions to allow
+   * @property {PermissionResolvable} [allowed] The permissions to allow
+   * @property {PermissionResolvable} [deny] The permissions to deny
+   * @property {PermissionResolvable} [denied] The permissions to deny
    * @property {RoleResolvable|UserResolvable} id ID of the role or member this overwrite is for
    */
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -143,7 +143,7 @@ class GuildChannel extends Channel {
   /**
    * Replaces the permission overwrites for a channel
    * @param {Object} [options] Options
-   * @param {Array<PermissionOverwrites|PermissionOverwriteOptions>} [options.overwrites] Permission overwrites
+   * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>} [options.overwrites] Permission overwrites
    * @param {string} [options.reason] Reason for updating the channel overwrites
    * @returns {Promise<GuildChannel>}
    * @example


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Replaces accepted type for GuildChannel#replacePermissionOverwrites with ChannelCreationOverwrites and adds master properties denied and allowed to the same

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
