### PR TITLE
fix(Collection): use Symbol.species for creating derived collections

### DIFF
--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -46,6 +46,10 @@ class DataStore extends Collection {
     if (typeof idOrInstance === 'string') return idOrInstance;
     return null;
   }
+
+  static get [Symbol.species]() {
+    return Collection;
+  }
 }
 
 module.exports = DataStore;

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -220,7 +220,7 @@ class Collection extends Map {
    */
   filter(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
-    const results = new Collection();
+    const results = new this.constructor[Symbol.species]();
     for (const [key, val] of this) {
       if (fn(val, key, this)) results.set(key, val);
     }
@@ -237,7 +237,7 @@ class Collection extends Map {
    */
   partition(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
-    const results = [new Collection(), new Collection()];
+    const results = [new this.constructor[Symbol.species](), new this.constructor[Symbol.species]()];
     for (const [key, val] of this) {
       if (fn(val, key, this)) {
         results[0].set(key, val);
@@ -348,7 +348,7 @@ class Collection extends Map {
    * @example const newColl = someColl.clone();
    */
   clone() {
-    return new this.constructor(this);
+    return new this.constructor[Symbol.species](this);
   }
 
   /**
@@ -404,7 +404,8 @@ class Collection extends Map {
    * @example collection.sort((userA, userB) => userA.createdTimestamp - userB.createdTimestamp);
    */
   sort(compareFunction = (x, y) => +(x > y) || +(x === y) - 1) {
-    return new Collection([...this.entries()].sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));
+    return new this.constructor[Symbol.species]([...this.entries()]
+      .sort((a, b) => compareFunction(a[1], b[1], a[0], b[0])));
   }
 
   toJSON() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixing collection extensions again. DataStore's should return Collections when derived.

See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/species.

With this changes:
```js
dataStore.filter(() => true) // returns Collection
superCollection.filter(() => true) // returns SuperCollection
```


**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
