### PR TITLE
Docs small changes regarding permissions/overwrites

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -971,8 +971,10 @@ class Guild {
    * Can be used to overwrite permissions when creating a channel or replacing overwrites.
    * @typedef {Object} ChannelCreationOverwrites
    * @property {PermissionResolvable} [allow] The permissions to allow
+   * **(deprecated)**
    * @property {PermissionResolvable} [allowed] The permissions to allow
    * @property {PermissionResolvable} [deny] The permissions to deny
+   * **(deprecated)**
    * @property {PermissionResolvable} [denied] The permissions to deny
    * @property {RoleResolvable|UserResolvable} id ID of the role or member this overwrite is for
    */

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -143,7 +143,7 @@ class GuildChannel extends Channel {
   /**
    * Replaces the permission overwrites for a channel
    * @param {Object} [options] Options
-   * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>} [options.overwrites] Permission overwrites
+   * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>|Collection<Snowflake, ChannelCreationOverwrites>} [options.overwrites] Permission overwrites
    * @param {string} [options.reason] Reason for updating the channel overwrites
    * @returns {Promise<GuildChannel>}
    * @example

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -165,7 +165,7 @@ class GuildChannel extends Channel {
   /* eslint-enable max-len */
 
   /**
-   * An object mapping permission flags to `true` (enabled), `null` (default) or `false` (disabled).
+   * An object mapping permission flags to `true` (enabled), `null` (unset) or `false` (disabled).
    * ```js
    * {
    *  'SEND_MESSAGES': true,

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -163,10 +163,11 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * An object mapping permission flags to `true` (enabled), `false` (disabled), or `null` (not set).
+   * An object mapping permission flags to `true` (enabled), `null` (default) or `false` (disabled).
    * ```js
    * {
    *  'SEND_MESSAGES': true,
+   *  'EMBED_LINKS': null,
    *  'ATTACH_FILES': false,
    * }
    * ```

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -140,6 +140,7 @@ class GuildChannel extends Channel {
     };
   }
 
+  /* eslint-disable max-len */
   /**
    * Replaces the permission overwrites for a channel
    * @param {Object} [options] Options
@@ -161,6 +162,7 @@ class GuildChannel extends Channel {
     return this.edit({ permissionOverwrites: overwrites, reason })
       .then(() => this);
   }
+  /* eslint-enable max-len */
 
   /**
    * An object mapping permission flags to `true` (enabled), `null` (default) or `false` (disabled).

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -32,12 +32,14 @@ class PermissionOverwrites {
     /**
      * The permissions that are denied for the user or role as a bitfield.
      * @type {number}
+     * @deprecated
      */
     this.deny = data.deny;
 
     /**
      * The permissions that are allowed for the user or role as a bitfield.
      * @type {number}
+     * @deprecated
      */
     this.allow = data.allow;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Add Collection as parameter option to GuildChannel#replacePermissionOverwrites
- Add example for null to PermissionOverwriteOptions (akin to master PermissionOverwriteOption)
- Deprecated allow/deny in favor of allowed/denied

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
