### PR TITLE
add Collection as possible param to GuildChannel#overwritePermissions + wording port from 11.3-dev

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -180,7 +180,7 @@ class GuildChannel extends Channel {
   /**
    * Replaces the permission overwrites in this channel.
    * @param {Object} [options] Options
-   * @param {Array<PermissionOverwrites|PermissionOverwriteOptions>|Collection<Snowlfake, PermissionOverwriteOptions>} [options.overwrites] Permission overwrites
+   * @param {Array<PermissionOverwrites|PermissionOverwriteOptions>|Collection<Snowflake, PermissionOverwriteOptions>} [options.overwrites] Permission overwrites
    * @param {string} [options.reason] Reason for updating the channel overwrites
    * @returns {Promise<GuildChannel>}
    * @example

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -201,7 +201,7 @@ class GuildChannel extends Channel {
   /* eslint-disable max-len */
 
   /**
-   * An object mapping permission flags to `true` (enabled), `null` (default) or `false` (disabled).
+   * An object mapping permission flags to `true` (enabled), `null` (unset) or `false` (disabled).
    * ```js
    * {
    *  'SEND_MESSAGES': true,

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -198,7 +198,7 @@ class GuildChannel extends Channel {
     return this.edit({ permissionOverwrites: resolvePermissions.call(this, overwrites), reason })
       .then(() => this);
   }
-  /* eslint-disable max-len */
+  /* eslint-enable max-len */
 
   /**
    * An object mapping permission flags to `true` (enabled), `null` (unset) or `false` (disabled).

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -176,10 +176,11 @@ class GuildChannel extends Channel {
       .freeze();
   }
 
+  /* eslint-disable max-len */
   /**
    * Replaces the permission overwrites in this channel.
    * @param {Object} [options] Options
-   * @param {Array<PermissionOverwrites|PermissionOverwriteOptions>} [options.overwrites] Permission overwrites
+   * @param {Array<PermissionOverwrites|PermissionOverwriteOptions>|Collection<Snowlfake, PermissionOverwriteOptions>} [options.overwrites] Permission overwrites
    * @param {string} [options.reason] Reason for updating the channel overwrites
    * @returns {Promise<GuildChannel>}
    * @example
@@ -197,6 +198,7 @@ class GuildChannel extends Channel {
     return this.edit({ permissionOverwrites: resolvePermissions.call(this, overwrites), reason })
       .then(() => this);
   }
+  /* eslint-disable max-len */
 
   /**
    * An object mapping permission flags to `true` (enabled), `null` (default) or `false` (disabled).


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Add Collection as possible param to GuildChannel#overwritePermissions, works as flawlessly but is currently undocumented
- Change PermissionoverwriteOptions description default to unset in accordance to #2718 and Lewdcario

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
