### PR TITLE
fix: use null for getter instead undefined

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -65,7 +65,7 @@ class GuildMember extends Base {
   get speaking() {
     return this.voiceChannel && this.voiceChannel.connection ?
       Boolean(this.voiceChannel.connection._speaking.get(this.id)) :
-      undefined;
+      null;
   }
 
   _patch(data) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
changes the return type for GuildMember#speaking when there is no VoiceChannel & Connection to null to stay consistent with other getters

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
