### PR TITLE
Add missing colors to doc

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -254,7 +254,6 @@ class Util {
    * - `ORANGE`
    * - `RED`
    * - `GREY`
-   * - `DARKER_GREY`
    * - `NAVY`
    * - `DARK_AQUA`
    * - `DARK_GREEN`
@@ -265,8 +264,10 @@ class Util {
    * - `DARK_ORANGE`
    * - `DARK_RED`
    * - `DARK_GREY`
+   * - `DARKER_GREY`
    * - `LIGHT_GREY`
    * - `DARK_NAVY`
+   * - `BLURPLE`
    * - `RANDOM`
    * @typedef {string|number|number[]} ColorResolvable
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The ColorResolvable documentation was missing `BLURPLE` so I added that to match what's actually available. (thought there were more differences but turns out it was just blurple missing ¯\\\_(ツ)\_/¯)

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
