### PR TITLE
Docs: document ChannelData.parent and .permissionOverwrites, fix typedefs to not include Collection of ChannelCreationOverwrite 

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -714,17 +714,16 @@ class Guild {
     return this.edit({ explicitContentFilter }, reason);
   }
 
-  /* eslint-disable max-len */
   /**
    * Edits the setting of the default message notifications of the guild.
-   * @param {DefaultMessageNotifications|number} defaultMessageNotifications The new setting for the default message notifications
+   * @param {DefaultMessageNotifications|number} defaultMessageNotifications
+   * The new setting for the default message notifications
    * @param {string} [reason] Reason for changing the setting of the default message notifications
    * @returns {Promise<Guild>}
    */
   setDefaultMessageNotifications(defaultMessageNotifications, reason) {
     return this.edit({ defaultMessageNotifications }, reason);
   }
-  /* eslint-enable max-len */
 
   /**
    * Edit the name of the guild.
@@ -968,7 +967,7 @@ class Guild {
   }
 
   /**
-   * Can be used to overwrite permissions when creating a channel or replacing overwrites.
+   * Overwrites to use when creating a channel or replacing overwrites
    * @typedef {Object} ChannelCreationOverwrites
    * @property {PermissionResolvable} [allow] The permissions to allow
    * **(deprecated)**
@@ -976,14 +975,14 @@ class Guild {
    * @property {PermissionResolvable} [deny] The permissions to deny
    * **(deprecated)**
    * @property {PermissionResolvable} [denied] The permissions to deny
-   * @property {RoleResolvable|UserResolvable} id ID of the role or member this overwrite is for
+   * @property {GuildMemberResolvable|RoleResolvable} memberOrRole Member or role this overwrite is for
    */
 
   /**
    * Creates a new channel in the guild.
    * @param {string} name The name of the new channel
    * @param {string} [type='text'] The type of the new channel, either `text` or `voice` or `category`
-   * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>} [overwrites] Permission overwrites
+   * @param {ChannelCreationOverwrites[]|Collection<Snowflake, PermissionOverwrites>} [overwrites] Permission overwrites
    * @param {string} [reason] Reason for creating this channel
    * @returns {Promise<CategoryChannel|TextChannel|VoiceChannel>}
    * @example

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -284,6 +284,7 @@ class GuildChannel extends Channel {
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel
    * @property {string} [parent] The parent ID of the channel
+   * @property {Array<ChannelCreationOverwrites>} [permissionOverwrites] An array of overwrites to set for the channel
    */
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -274,6 +274,7 @@ class GuildChannel extends Channel {
     return this.edit({ permissionOverwrites });
   }
 
+  /* eslint-disable max-len */
   /**
    * The data for a guild channel.
    * @typedef {Object} ChannelData
@@ -284,7 +285,7 @@ class GuildChannel extends Channel {
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel
    * @property {string} [parent] The parent ID of the channel
-   * @property {Array<ChannelCreationOverwrites>} [permissionOverwrites] An array of overwrites to set for the channel
+   * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>|Collection<Snowflake, ChannelCreationOverwrites>} [options.overwrites] An array or collection of overwrites to set for the channel
    */
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -283,6 +283,7 @@ class GuildChannel extends Channel {
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel
+   * @property {string} [parent] The parent ID of the channel
    */
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -159,11 +159,11 @@ class GuildChannel extends Channel {
     };
   }
 
-  /* eslint-disable max-len */
   /**
    * Replaces the permission overwrites for a channel
    * @param {Object} [options] Options
-   * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>|Collection<Snowflake, ChannelCreationOverwrites>} [options.overwrites] Permission overwrites
+   * @param {ChannelCreationOverwrites[]|Collection<Snowflake, PermissionOverwrites>} [options.overwrites]
+   * Permission overwrites
    * @param {string} [options.reason] Reason for updating the channel overwrites
    * @returns {Promise<GuildChannel>}
    * @example
@@ -181,7 +181,6 @@ class GuildChannel extends Channel {
     return this.edit({ permissionOverwrites: overwrites, reason })
       .then(() => this);
   }
-  /* eslint-enable max-len */
 
   /**
    * An object mapping permission flags to `true` (enabled), `null` (unset) or `false` (disabled).
@@ -274,7 +273,6 @@ class GuildChannel extends Channel {
     return this.edit({ permissionOverwrites });
   }
 
-  /* eslint-disable max-len */
   /**
    * The data for a guild channel.
    * @typedef {Object} ChannelData
@@ -285,7 +283,8 @@ class GuildChannel extends Channel {
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel
    * @property {string} [parent] The parent ID of the channel
-   * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>|Collection<Snowflake, ChannelCreationOverwrites>} [overwrites] An array or collection of overwrites to set for the channel
+   * @param {ChannelCreationOverwrites[]|Collection<Snowflake, PermissionOverwrites>} [overwrites]
+   * Overwrites of the channel
    */
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -285,7 +285,7 @@ class GuildChannel extends Channel {
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel
    * @property {string} [parent] The parent ID of the channel
-   * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>|Collection<Snowflake, ChannelCreationOverwrites>} [options.overwrites] An array or collection of overwrites to set for the channel
+   * @param {Array<PermissionOverwrites|ChannelCreationOverwrites>|Collection<Snowflake, ChannelCreationOverwrites>} [overwrites] An array or collection of overwrites to set for the channel
    */
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -283,7 +283,7 @@ class GuildChannel extends Channel {
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel
    * @property {string} [parent] The parent ID of the channel
-   * @param {ChannelCreationOverwrites[]|Collection<Snowflake, PermissionOverwrites>} [overwrites]
+   * @property {ChannelCreationOverwrites[]|Collection<Snowflake, PermissionOverwrites>} [overwrites]
    * Overwrites of the channel
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Document missing properties ChannelData.parent and ChannelData.permissionOverwrites
<https://github.com/discordjs/discord.js/blob/stable/src/client/rest/RESTMethods.js#L324>
- Remove eslint disable/enable madness from defaultMessageNotification (not worth its own PR imo)
- Remove `PermissionOverwrites[]` where applicable

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.