### PR TITLE
Fix(VoiceChannel): members returning collection of undefined.

### DIFF
--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -32,7 +32,7 @@ class VoiceChannel extends GuildChannel {
   get members() {
     return new Collection(this.guild.voiceStates
       .filter(state => state.channelID === this.id && state.member)
-      .map(state => state.member));
+      .map(state => [state.id, state.member]));
   }
 
   /**

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -30,9 +30,13 @@ class VoiceChannel extends GuildChannel {
    * @name VoiceChannel#members
    */
   get members() {
-    return new Collection(this.guild.voiceStates
-      .filter(state => state.channelID === this.id && state.member)
-      .map(state => [state.id, state.member]));
+    const coll = new Collection();
+    for (const state of this.guild.voiceStates.values()) {
+      if (state.channelID === this.id && state.member) {
+        coll.set(state.id, state.member);
+      }
+    }
+    return coll;
   }
 
   /**


### PR DESCRIPTION
Closes #2736

**Please describe the changes this PR makes and why it should be merged:**
Fixes the bug in VoiceChannel where `members` would return a Collection with `undefined, undefined` because of the map returning `[GuildMember]` and not `[[Snowflake, GuildMember]]`.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
