### PR TITLE
fix(GuildAuditLogs): default target to object with target_id

### DIFF
--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -148,6 +148,7 @@ class GuildAuditLogs {
    * * An emoji
    * * An invite
    * * A webhook
+   * * An object with an id key if target was deleted
    * * An object where the keys represent either the new value or the old value
    * @typedef {?Object|Guild|User|Role|GuildEmoji|Invite|Webhook} AuditLogEntryTarget
    */
@@ -355,7 +356,7 @@ class GuildAuditLogsEntry {
     } else if (targetType === Targets.MESSAGE) {
       this.target = guild.client.users.get(data.target_id);
     } else {
-      this.target = guild[`${targetType.toLowerCase()}s`].get(data.target_id);
+      this.target = guild[`${targetType.toLowerCase()}s`].get(data.target_id) || { id: data.target_id };
     }
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This will avoid `GuildAuditLogsEntry#target` being undefined by defaulting it to `{ id: data.target_id }`.
This occurs when the target (role / channel / etc) was deleted.

Fixes #2741

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
