### PR TITLE
fix: Handle async stacks correctly

### DIFF
--- a/src/rest/APIRouter.js
+++ b/src/rest/APIRouter.js
@@ -22,9 +22,11 @@ function buildRoute(manager) {
             return r;
           }).join('/'),
         }, options)).catch(error => {
-          stackTrace.name = error.name;
-          stackTrace.message = error.message;
-          error.stack = stackTrace.stack;
+          if (error instanceof Error) {
+            stackTrace.name = error.name;
+            stackTrace.message = error.message;
+            error.stack = stackTrace.stack;
+          }
           throw error;
         });
       }

--- a/src/rest/APIRouter.js
+++ b/src/rest/APIRouter.js
@@ -22,8 +22,9 @@ function buildRoute(manager) {
             return r;
           }).join('/'),
         }, options)).catch(error => {
+          stackTrace.name = error.name;
           stackTrace.message = error.message;
-          error.stack = `${error.constructor.name}:${stackTrace.stack.substring(6)}`;
+          error.stack = stackTrace.stack;
           throw error;
         });
       }

--- a/src/rest/APIRouter.js
+++ b/src/rest/APIRouter.js
@@ -12,8 +12,11 @@ function buildRoute(manager) {
       if (reflectors.includes(name)) return () => route.join('/');
       if (methods.includes(name)) {
         // Preserve async stack
-        const stackTrace = {};
-        Error.captureStackTrace(stackTrace, this.get);
+        let stackTrace = null;
+        if (Error.captureStackTrace) {
+          stackTrace = {};
+          Error.captureStackTrace(stackTrace, this.get);
+        }
 
         return options => manager.request(name, route.join('/'), Object.assign({
           versioned: manager.versioned,
@@ -22,7 +25,7 @@ function buildRoute(manager) {
             return r;
           }).join('/'),
         }, options)).catch(error => {
-          if (error instanceof Error) {
+          if (stackTrace && (error instanceof Error)) {
             stackTrace.name = error.name;
             stackTrace.message = error.message;
             error.stack = stackTrace.stack;

--- a/src/rest/APIRouter.js
+++ b/src/rest/APIRouter.js
@@ -11,13 +11,21 @@ function buildRoute(manager) {
     get(target, name) {
       if (reflectors.includes(name)) return () => route.join('/');
       if (methods.includes(name)) {
+        // Preserve async stack
+        const stackTrace = {};
+        Error.captureStackTrace(stackTrace, this.get);
+
         return options => manager.request(name, route.join('/'), Object.assign({
           versioned: manager.versioned,
           route: route.map((r, i) => {
             if (/\d{16,19}/g.test(r)) return /channels|guilds/.test(route[i - 1]) ? r : ':id';
             return r;
           }).join('/'),
-        }, options));
+        }, options)).catch(error => {
+          stackTrace.message = error.message;
+          error.stack = `${error.constructor.name}:${stackTrace.stack.substring(6)}`;
+          throw error;
+        });
       }
       route.push(name);
       return new Proxy(noop, handler);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes https://github.com/discordjs/discord.js/issues/2496

This fix modifies the error stacks from REST from this:

```
DiscordAPIError: Unknown Message
    at parseResponse.then.data (/*/node_modules/discord.js/src/rest/handlers/RequestHandler.js:110:15)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

To this:

```
DiscordAPIError: Unknown Message
    at KlasaMessage.delete (/*/node_modules/discord.js/src/structures/Message.js:453:9)
    at eval (eval at eval (/*/node_modules/klasa/src/commands/Admin/eval.js:49:13), <anonymous>:2:11)
    at module.exports.eval (/*/node_modules/klasa/src/commands/Admin/eval.js:49:13)
    at module.exports.run (/*/node_modules/klasa/src/commands/Admin/eval.js:18:54)
    at module.exports.runCommand (/*/node_modules/klasa/src/monitors/commandHandler.js:90:106)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

Which fixes completely the issue linked above, and allows developers to debug and fix their issues quicker.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
