### PR TITLE
fix: intervals and timeouts being overwritten

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -140,20 +140,6 @@ class Client extends BaseClient {
      */
     this.pings = [];
 
-    /**
-     * Timeouts set by {@link Client#setTimeout} that are still active
-     * @type {Set<Timeout>}
-     * @private
-     */
-    this._timeouts = new Set();
-
-    /**
-     * Intervals set by {@link Client#setInterval} that are still active
-     * @type {Set<Timeout>}
-     * @private
-     */
-    this._intervals = new Set();
-
     if (this.options.messageSweepInterval > 0) {
       this.setInterval(this.sweepMessages.bind(this), this.options.messageSweepInterval * 1000);
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes an issue with the process permanently hanging.

BaseClient (which Client extends) already defines the timeouts:

https://github.com/discordjs/discord.js/blob/0ad7c24aa394249a5213a8e11a826821d4b56266/src/client/BaseClient.js#L14-L26

On Client, a RESTManager was created using client.setInterval for the REST managers sweeper, however, the Sets were being overwritten, making it unaccesible from BaseClient#destroy, and thus, making the process hang forever.

tl:dr; When giving an unvalid token, this was instantiating BaseClient via super's call, then RESTManager (which creates an interval), and the sets were overwritten. On login, it attempts to login and fails, it automatically calls destroy, but the interval was unaccesible, causing the hang. This PR removes the overwrite in the Client, fixing this issue.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
