### PR TITLE
Fix permission checking for Administrator channel overwrites

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -290,7 +290,7 @@ class GuildChannel extends Channel {
   get members() {
     const members = new Collection();
     for (const member of this.guild.members.values()) {
-      if (this.permissionsFor(member).has('VIEW_CHANNEL')) {
+      if (this.permissionsFor(member).has('VIEW_CHANNEL', false)) {
         members.set(member.id, member);
       }
     }
@@ -537,7 +537,7 @@ class GuildChannel extends Channel {
    * @readonly
    */
   get deletable() {
-    return this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS);
+    return this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false);
   }
 
   /**
@@ -549,7 +549,7 @@ class GuildChannel extends Channel {
     if (this.client.user.id === this.guild.ownerID) return true;
     const permissions = this.permissionsFor(this.client.user);
     if (!permissions) return false;
-    return permissions.has([Permissions.FLAGS.MANAGE_CHANNELS, Permissions.FLAGS.VIEW_CHANNEL]);
+    return permissions.has([Permissions.FLAGS.MANAGE_CHANNELS, Permissions.FLAGS.VIEW_CHANNEL], false);
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -335,7 +335,7 @@ class Message extends Base {
    */
   get deletable() {
     return !this.deleted && (this.author.id === this.client.user.id || (this.guild &&
-      this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES)
+      this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)
     ));
   }
 
@@ -346,7 +346,7 @@ class Message extends Base {
    */
   get pinnable() {
     return !this.guild ||
-      this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES);
+      this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false);
   }
 
   /**

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -65,7 +65,7 @@ class VoiceChannel extends GuildChannel {
    * @readonly
    */
   get deletable() {
-    return super.deletable && this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT);
+    return super.deletable && this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false);
   }
 
   /**
@@ -75,8 +75,8 @@ class VoiceChannel extends GuildChannel {
    */
   get joinable() {
     if (browser) return false;
-    if (!this.permissionsFor(this.client.user).has('CONNECT')) return false;
-    if (this.full && !this.permissionsFor(this.client.user).has('MOVE_MEMBERS')) return false;
+    if (!this.permissionsFor(this.client.user).has('CONNECT', false)) return false;
+    if (this.full && !this.permissionsFor(this.client.user).has('MOVE_MEMBERS', false)) return false;
     return true;
   }
 
@@ -86,7 +86,7 @@ class VoiceChannel extends GuildChannel {
    * @readonly
    */
   get speakable() {
-    return this.permissionsFor(this.client.user).has('SPEAK');
+    return this.permissionsFor(this.client.user).has('SPEAK', false);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
ADMINISTRATOR has no meaning in a channel overwrite. permissionsFor already returns full permissions for guild owner and admin roles. Therefore, whenever using the returned Permissions from permissionsFor, you should never checkAdmin (which is default).

It has been stated that this is the [intended behavior](https://github.com/discordapp/discord-api-docs/issues/640) of the API by discord devs. Our permissionsFor also follows the [specified way](https://github.com/discordapp/discord-api-docs/blob/master/docs/topics/Permissions.md#permission-overwrites) of calculating permissions for a member in the context of a channel.

So the only answer is not checking Administrator in permissions returned from permissionsFor, as if any bot has set an Administrator overwrite in a given channel, it will return results not consistent with how discord actually works. (The api allows this, and returns the permissions over the websocket in future packets)

This could also be fixed indirectly by changing the default of checkAdmin to false, but that would be less obvious that you would generally want to pass true when checking Role permissions directly.

This is an edge case, but it is very problematic if encountered in the wild.

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
