### PR TITLE
Gateway: Fix guildBanAdd not emitting with uncached user

### DIFF
--- a/src/client/websocket/packets/handlers/GuildBanAdd.js
+++ b/src/client/websocket/packets/handlers/GuildBanAdd.js
@@ -8,7 +8,7 @@ class GuildBanAddHandler extends AbstractHandler {
     const client = this.packetManager.client;
     const data = packet.d;
     const guild = client.guilds.get(data.guild_id);
-    const user = client.users.get(data.user.id);
+    const user = client.users.add(data.user);
     if (guild && user) client.emit(Events.GUILD_BAN_ADD, guild, user);
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the guildBanAdd event not getting emitted when an uncached user gets banned.

Since the inner payload is a user object, this is easy to do.
Also fixes inconsistency with client/actions/GuildBanRemove (which was indeed using `client.users.add`)

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
