### PR TITLE
misc: Remove Clyde

### DIFF
--- a/src/client/websocket/packets/handlers/Ready.js
+++ b/src/client/websocket/packets/handlers/Ready.js
@@ -19,19 +19,6 @@ class ReadyHandler extends AbstractHandler {
     for (const guild of data.guilds) client.guilds.add(guild);
     for (const privateDM of data.private_channels) client.channels.add(privateDM);
 
-    if (!client.users.has('1')) {
-      client.users.add({
-        id: '1',
-        username: 'Clyde',
-        discriminator: '0000',
-        avatar: 'https://discordapp.com/assets/f78426a064bc9dd24847519259bc42af.png',
-        bot: true,
-        status: 'online',
-        activity: null,
-        verified: true,
-      });
-    }
-
     const t = client.setTimeout(() => {
       client.ws.connection.triggerReady();
     }, 1200 * data.guilds.length);

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -124,7 +124,6 @@ exports.Endpoints = {
       Asset: name => `${root}/assets/${name}`,
       DefaultAvatar: number => `${root}/embed/avatars/${number}.png`,
       Avatar: (userID, hash, format = 'default', size) => {
-        if (userID === '1') return hash;
         if (format === 'default') format = hash.startsWith('a_') ? 'gif' : 'webp';
         return makeImageUrl(`${root}/avatars/${userID}/${hash}`, { format, size });
       },


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This has been done [before](https://github.com/discordjs/discord.js/pull/2344) but got closed as everyone decided to meme the PR.

With the userbot support removal, Clyde can not longer peek in our clients, bots cannot get messages from other bots (or imaginary ones), including Clyde, thus in my opinion, we should be fine to clean up some unused memory.
![Image](https://join-the.gawesome.club/jkyhkor9b3dc56e.png)

Clyde can be considered an Easter Egg of the client, but it's actually just a phantom in the client that exists to help people out when they can't use emojis or they get kicked out of a DM call to save bandwidth.
The client doesn't know about Clyde unless you trigger one of his messages in the current instance of Discord.

I am looking forward for your feedback, please let me know if you aren't comfortable with this change and the reason for

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
