### PR TITLE
backport: Handle async stacks correctly

### DIFF
--- a/src/client/rest/RESTManager.js
+++ b/src/client/rest/RESTManager.js
@@ -23,11 +23,25 @@ class RESTManager {
   }
 
   push(handler, apiRequest) {
+    // Preserve async stack
+    let stackTrace = null;
+    if (Error.captureStackTrace) {
+      stackTrace = {};
+      Error.captureStackTrace(stackTrace, this.makeRequest);
+    }
+
     return new Promise((resolve, reject) => {
       handler.push({
         request: apiRequest,
         resolve,
-        reject,
+        reject: error => {
+          if (stackTrace && (error instanceof Error)) {
+            stackTrace.name = error.name;
+            stackTrace.message = error.message;
+            error.stack = stackTrace.stack;
+          }
+          reject(error);
+        },
       });
     });
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Backports https://github.com/discordjs/discord.js/pull/2744 to 11.4-dev, changing the stack of all errors thrown from the API.

**Before:**

```
DiscordAPIError: Unknown Message
    at item.request.gen.end (/*/node_modules/discord.js/src/client/rest/RequestHandlers/Sequential.js:79:15)
    at then (/*/node_modules/snekfetch/src/index.js:215:21)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

**After:**

```
DiscordAPIError: Unknown Message
    at RESTMethods.deleteMessage (/*/node_modules/discord.js/src/client/rest/RESTMethods.js:152:22)
    at Message.delete (/*/node_modules/discord.js/src/structures/Message.js:477:39)
    at Client.client.on (/*/index.js:8:17)
    at Client.emit (events.js:182:13)
    at MessageCreateHandler.handle (/*/node_modules/discord.js/src/client/websocket/packets/handlers/MessageCreate.js:9:34)
    at WebSocketPacketManager.handle (/*/node_modules/discord.js/src/client/websocket/packets/WebSocketPacketManager.js:103:65)
    at WebSocketConnection.onPacket (/*/node_modules/discord.js/src/client/websocket/WebSocketConnection.js:333:35)
    at WebSocketConnection.onMessage (/*/node_modules/discord.js/src/client/websocket/WebSocketConnection.js:296:17)
    at WebSocket.onMessage (/*/node_modules/ws/lib/event-target.js:120:16)
    at WebSocket.emit (events.js:182:13)
```

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
