### PR TITLE
backport: `WEBHOOKS_UPDATE` event

### DIFF
--- a/src/client/websocket/packets/WebSocketPacketManager.js
+++ b/src/client/websocket/packets/WebSocketPacketManager.js
@@ -53,6 +53,7 @@ class WebSocketPacketManager {
     this.register(Constants.WSEvents.MESSAGE_REACTION_ADD, require('./handlers/MessageReactionAdd'));
     this.register(Constants.WSEvents.MESSAGE_REACTION_REMOVE, require('./handlers/MessageReactionRemove'));
     this.register(Constants.WSEvents.MESSAGE_REACTION_REMOVE_ALL, require('./handlers/MessageReactionRemoveAll'));
+    this.register(Constants.WSEvents.WEBHOOKS_UPDATE, require('./handlers/WebhooksUpdate'));
   }
 
   get client() {

--- a/src/client/websocket/packets/handlers/WebhooksUpdate.js
+++ b/src/client/websocket/packets/handlers/WebhooksUpdate.js
@@ -1,0 +1,19 @@
+const AbstractHandler = require('./AbstractHandler');
+const { Events } = require('../../../../util/Constants');
+
+class WebhooksUpdate extends AbstractHandler {
+  handle(packet) {
+    const client = this.packetManager.client;
+    const data = packet.d;
+    const channel = client.channels.get(data.channel_id);
+    if (channel) client.emit(Events.WEBHOOKS_UPDATE, channel);
+  }
+}
+
+/**
+ * Emitted whenever a guild text channel has its webhooks changed.
+ * @event Client#webhookUpdate
+ * @param {TextChannel} channel The channel that had a webhook update
+ */
+
+module.exports = WebhooksUpdate;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -346,6 +346,7 @@ exports.Events = {
   VOICE_STATE_UPDATE: 'voiceStateUpdate',
   TYPING_START: 'typingStart',
   TYPING_STOP: 'typingStop',
+  WEBHOOKS_UPDATE: 'webhookUpdate',
   DISCONNECT: 'disconnect',
   RECONNECTING: 'reconnecting',
   ERROR: 'error',
@@ -414,6 +415,7 @@ exports.ActivityFlags = {
  * * VOICE_SERVER_UPDATE
  * * RELATIONSHIP_ADD
  * * RELATIONSHIP_REMOVE
+ * * WEBHOOKS_UPDATE
  * @typedef {string} WSEventType
  */
 exports.WSEvents = {
@@ -454,6 +456,7 @@ exports.WSEvents = {
   VOICE_SERVER_UPDATE: 'VOICE_SERVER_UPDATE',
   RELATIONSHIP_ADD: 'RELATIONSHIP_ADD',
   RELATIONSHIP_REMOVE: 'RELATIONSHIP_REMOVE',
+  WEBHOOKS_UPDATE: 'WEBHOOKS_UPDATE',
 };
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Backports https://github.com/discordjs/discord.js/pull/2762 to 11.4-dev.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
