### PR TITLE
private_channels always returns an empty array on ready

### DIFF
--- a/src/client/websocket/packets/handlers/Ready.js
+++ b/src/client/websocket/packets/handlers/Ready.js
@@ -17,7 +17,6 @@ class ReadyHandler extends AbstractHandler {
     client.users.set(clientUser.id, clientUser);
 
     for (const guild of data.guilds) client.guilds.add(guild);
-    for (const privateDM of data.private_channels) client.channels.add(privateDM);
 
     const t = client.setTimeout(() => {
       client.ws.connection.triggerReady();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
According to the doc for Ready, private_channels is always an empty array - see [here](https://discordapp.com/developers/docs/topics/gateway#ready) and [here](https://discordapp.com/developers/docs/change-log#june-19-2018). No reason to do this as client.channels will never have anything added to it.

**edit:** answered by gus below, thank you!
~~I also had a question for line 19 - data.guilds comes back as an array of unavailable guilds:~~

![image](https://user-images.githubusercontent.com/17156890/44561363-b94e5000-a711-11e8-8154-e43a35744cf9.png)

~~The client.guilds is then populated by CREATE_GUILD events async, which get emitted pretty much immediately -- so is there actually any point in going through and calling guilds.add with the unavailable guilds on ready?~~

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
