### PR TITLE
GuildEmoji.fetchAuthor() error handling

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -95,6 +95,8 @@ const Messages = {
 
   EMOJI_TYPE: 'Emoji must be a string or GuildEmoji/ReactionEmoji',
   EMOJI_MANAGED: 'Emoji is managed and has no Author.',
+  MISSING_MANAGE_EMOJIS_PERMISSION:
+    guild => `Client must have Manage Emoji permission in guild ${guild} to see emoji authors.`,
 
   REACTION_RESOLVE_USER: 'Couldn\'t resolve the user ID to remove from the reaction.',
 

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -90,6 +90,8 @@ class GuildEmoji extends Emoji {
   fetchAuthor() {
     if (this.managed) {
       return Promise.reject(new Error('EMOJI_MANAGED'));
+    } else if (!this.guild.me.permissions.has('MANAGE_EMOJIS')) {
+      return Promise.reject(new Error('MISSING_MANAGE_EMOJIS_PERMISSION', this.guild));
     }
     return this.client.api.guilds(this.guild.id).emojis(this.id).get()
       .then(emoji => this.client.users.add(emoji.user));

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -90,7 +90,7 @@ class GuildEmoji extends Emoji {
   fetchAuthor() {
     if (this.managed) {
       return Promise.reject(new Error('EMOJI_MANAGED'));
-    } else if (!this.guild.me.permissions.has('MANAGE_EMOJIS')) {
+    } else if (!this.guild.me.permissions.has(Permissions.FLAGS.MANAGE_EMOJIS)) {
       return Promise.reject(new Error('MISSING_MANAGE_EMOJIS_PERMISSION', this.guild));
     }
     return this.client.api.guilds(this.guild.id).emojis(this.id).get()

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -541,6 +541,7 @@ declare module 'discord.js' {
 		public delete(reason?: string): Promise<GuildEmoji>;
 		public edit(data: GuildEmojiEditData, reason?: string): Promise<GuildEmoji>;
 		public equals(other: GuildEmoji | object): boolean;
+		public fetchAuthor(): Promise<User>;
 		public setName(name: string, reason?: string): Promise<GuildEmoji>;
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently if you try to fetchAuthor on an emoji that belongs to a guild where the client doesn't have MANAGE_EMOJIS, it throws a wacky 'undefined has no id' error because the api doesn't return a user object in that case.  This PR adds a check for that before we make the request with matching error message.  I also added fetchAuthor to the typings since it wasn't there and that makes tsc mad.

Reference for needing MANAGE_EMOJIS to see user at all [here](https://github.com/discordapp/discord-api-docs/issues/593#issuecomment-386477863).

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
