### PR TITLE
Remove duplicate send checks

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -195,7 +195,7 @@ class APIMessage {
 
     const apiMessages = [];
 
-    for (let i = 0; i < this.data.length; i++) {
+    for (let i = 0; i < this.data.content.length; i++) {
       let data;
       let opt;
 

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -111,16 +111,6 @@ class APIMessage {
   }
 
   /**
-   * Resolves both data and files.
-   * @returns {APIMessage}
-   */
-  async resolve() {
-    this.resolveData();
-    await this.resolveFiles();
-    return this;
-  }
-
-  /**
    * Resolves data.
    * @returns {APIMessage}
    */
@@ -210,13 +200,11 @@ class APIMessage {
       let opt;
 
       if (i === this.data.content.length - 1) {
-        const changes = { content: this.data.content[i] };
-        data = { ...this.data, ...changes };
-        opt = { ...this.options, ...changes };
+        data = { ...this.data, content: this.data.content[i] };
+        opt = { ...this.options, content: this.data.content[i] };
       } else {
-        const changes = { content: this.data.content[i], embed: undefined, embeds: undefined };
-        data = { ...this.data, ...changes };
-        opt = { ...this.options, ...changes, files: undefined };
+        data = { content: this.data.content[i], tts: this.data.tts };
+        opt = { content: this.data.content[i], tts: this.data.tts };
       }
 
       const apiMessage = new APIMessage(this.target, opt);

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -359,7 +359,7 @@ class Message extends Base {
 
   /**
    * Edits the content of the message.
-   * @param {StringResolvable} [content=''] The new content for the message
+   * @param {StringResolvable|APIMessage} [content=''] The new content for the message
    * @param {MessageEditOptions|MessageEmbed} [options] The options to provide
    * @returns {Promise<Message>}
    * @example
@@ -369,7 +369,9 @@ class Message extends Base {
    *   .catch(console.error);
    */
   edit(content, options) {
-    const data = APIMessage.create(this, content, options).resolveData();
+    const { data } = content instanceof APIMessage ?
+      content.resolveData() :
+      APIMessage.create(this, content, options).resolveData();
     return this.client.api.channels[this.channel.id].messages[this.id]
       .patch({ data })
       .then(d => {

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -460,7 +460,7 @@ class Message extends Base {
 
   /**
    * Replies to the message.
-   * @param {StringResolvable} [content=''] The content for the message
+   * @param {StringResolvable|APIMessage} [content=''] The content for the message
    * @param {MessageOptions|MessageAdditions} [options={}] The options to provide
    * @returns {Promise<Message|Message[]>}
    * @example
@@ -470,7 +470,10 @@ class Message extends Base {
    *   .catch(console.error);
    */
   reply(content, options) {
-    return this.channel.send(APIMessage.transformOptions(content, options, { reply: this.member || this.author }));
+    return this.channel.send(content instanceof APIMessage ?
+      content :
+      APIMessage.transformOptions(content, options, { reply: this.member || this.author })
+    );
   }
 
   /**

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -84,7 +84,7 @@ class Webhook {
 
   /**
    * Sends a message with this webhook.
-   * @param {StringResolvable} [content=''] The content to send
+   * @param {StringResolvable|APIMessage} [content=''] The content to send
    * @param {WebhookMessageOptions|MessageAdditions} [options={}] The options to provide
    * @returns {Promise<Message|Object>}
    * @example

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -126,27 +126,18 @@ class Webhook {
    *   .catch(console.error);
    */
   async send(content, options) {
-    const apiMessage = APIMessage.create(this, content, options);
-    const data = apiMessage.resolveData();
-    if (data.content instanceof Array) {
-      const messages = [];
-      for (let i = 0; i < data.content.length; i++) {
-        let opt;
-        if (i === data.content.length - 1) {
-          opt = { embeds: data.embeds, files: apiMessage.options.files };
-        } else {
-          opt = {};
-        }
+    let apiMessage;
 
-        Object.assign(opt, { avatarURL: data.avatar_url, content: data.content[i], username: data.username });
-        // eslint-disable-next-line no-await-in-loop
-        const message = await this.send(data.content[i], opt);
-        messages.push(message);
+    if (content instanceof apiMessage) {
+      apiMessage = content.resolveData();
+    } else {
+      apiMessage = APIMessage.create(this, content, options).resolveData();
+      if (apiMessage.data.content instanceof Array) {
+        return Promise.all(apiMessage.split().map(this.send.bind(this)));
       }
-      return messages;
     }
 
-    const files = await apiMessage.resolveFiles();
+    const { data, files } = await apiMessage.resolveFiles();
     return this.client.api.webhooks(this.id, this.token).post({
       data, files,
       query: { wait: true },

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -66,7 +66,7 @@ class TextBasedChannel {
 
   /**
    * Sends a message to this channel.
-   * @param {StringResolvable} [content=''] The content to send
+   * @param {StringResolvable|APIMessage} [content=''] The content to send
    * @param {MessageOptions|MessageAdditions} [options={}] The options to provide
    * @returns {Promise<Message|Message[]>}
    * @example
@@ -110,30 +110,23 @@ class TextBasedChannel {
   async send(content, options) {
     const User = require('../User');
     const GuildMember = require('../GuildMember');
+
     if (this instanceof User || this instanceof GuildMember) {
       return this.createDM().then(dm => dm.send(content, options));
     }
 
-    const apiMessage = APIMessage.create(this, content, options);
-    const data = apiMessage.resolveData();
-    if (data.content instanceof Array) {
-      const messages = [];
-      for (let i = 0; i < data.content.length; i++) {
-        let opt;
-        if (i === data.content.length - 1) {
-          opt = { tts: data.tts, embed: data.embed, files: apiMessage.options.files };
-        } else {
-          opt = { tts: data.tts };
-        }
+    let apiMessage;
 
-        // eslint-disable-next-line no-await-in-loop
-        const message = await this.send(data.content[i], opt);
-        messages.push(message);
+    if (content instanceof apiMessage) {
+      apiMessage = content.resolveData();
+    } else {
+      apiMessage = APIMessage.create(this, content, options).resolveData();
+      if (apiMessage.data.content instanceof Array) {
+        return Promise.all(apiMessage.split().map(this.send.bind(this)));
       }
-      return messages;
     }
 
-    const files = await apiMessage.resolveFiles();
+    const { data, files } = await apiMessage.resolveFiles();
     return this.client.api.channels[this.id].messages.post({ data, files })
       .then(d => this.client.actions.MessageCreate.handle(d).message);
   }

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -117,7 +117,7 @@ class TextBasedChannel {
 
     let apiMessage;
 
-    if (content instanceof apiMessage) {
+    if (content instanceof APIMessage) {
       apiMessage = content.resolveData();
     } else {
       apiMessage = APIMessage.create(this, content, options).resolveData();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -68,6 +68,7 @@ declare module 'discord.js' {
 		public resolve(): Promise<this>;
 		public resolveData(): this;
 		public resolveFiles(): Promise<this>;
+		public split(): APIMessage[];
 	}
 
 	export class Base {
@@ -666,13 +667,13 @@ declare module 'discord.js' {
 		public createReactionCollector(filter: CollectorFilter, options?: ReactionCollectorOptions): ReactionCollector;
 		public delete(options?: { timeout?: number, reason?: string }): Promise<Message>;
 		public edit(content: StringResolvable, options?: MessageEditOptions | MessageEmbed): Promise<Message>;
-		public edit(options: MessageEditOptions | MessageEmbed): Promise<Message>;
+		public edit(options: MessageEditOptions | MessageEmbed | APIMessage): Promise<Message>;
 		public equals(message: Message, rawData: object): boolean;
 		public fetchWebhook(): Promise<Webhook>;
 		public pin(): Promise<Message>;
 		public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
 		public reply(content?: StringResolvable, options?: MessageOptions | MessageAdditions): Promise<Message | Message[]>;
-		public reply(options?: MessageOptions | MessageAdditions): Promise<Message | Message[]>;
+		public reply(options?: MessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
 		public toJSON(): object;
 		public toString(): string;
 		public unpin(): Promise<Message>;
@@ -1393,7 +1394,7 @@ declare module 'discord.js' {
 		lastMessageChannelID: Snowflake;
 		readonly lastMessage: Message;
 		send(content?: StringResolvable, options?: MessageOptions | MessageAdditions): Promise<Message | Message[]>;
-		send(options?: MessageOptions | MessageAdditions): Promise<Message | Message[]>;
+		send(options?: MessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
 	};
 
 	type TextBasedChannelFields = {
@@ -1415,7 +1416,7 @@ declare module 'discord.js' {
 		delete(reason?: string): Promise<void>;
 		edit(options: WebhookEditData): Promise<Webhook>;
 		send(content?: StringResolvable, options?: WebhookMessageOptions | MessageAdditions): Promise<Message | Message[]>;
-		send(options?: WebhookMessageOptions | MessageAdditions): Promise<Message | Message[]>;
+		send(options?: WebhookMessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
 		sendSlackMessage(body: object): Promise<Message|object>;
 	};
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -42,8 +42,10 @@ declare module 'discord.js' {
 
 	export class APIMessage {
 		constructor(target: MessageTarget, options: MessageOptions | WebhookMessageOptions);
+		public data?: object;
 		public readonly isUser: boolean;
 		public readonly isWebhook: boolean;
+		public files?: object[];
 		public options: MessageOptions | WebhookMessageOptions;
 		public target: MessageTarget;
 
@@ -63,8 +65,9 @@ declare module 'discord.js' {
 		): MessageOptions | WebhookMessageOptions;
 
 		public makeContent(): string | string[];
-		public resolveData(): object;
-		public resolveFiles(): Promise<object[]>;
+		public resolve(): Promise<this>;
+		public resolveData(): this;
+		public resolveFiles(): Promise<this>;
 	}
 
 	export class Base {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pr is a follow-on pr to #2774 to avoid duplicating send checks with split messages. This pr accomplishes this, by caching and lazy resolving the data and files, allowing send/edit to take an APIMessage directly, without redoing any of the resolutions.

This adds APIMessage#split() which returns an array of APIMessages, that way the same split behavior can be reused in both Webhook#send() and TextBasedChannel#send(), and additionally can be reused in frameworks for split message Command Editing.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
