### PR TITLE
misc(Guild,GuildMember): Update deprecations for latest master

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -970,11 +970,11 @@ class Guild {
    * Overwrites to use when creating a channel or replacing overwrites
    * @typedef {Object} ChannelCreationOverwrites
    * @property {PermissionResolvable} [allow] The permissions to allow
-   * **(deprecated)**
    * @property {PermissionResolvable} [allowed] The permissions to allow
-   * @property {PermissionResolvable} [deny] The permissions to deny
    * **(deprecated)**
+   * @property {PermissionResolvable} [deny] The permissions to deny
    * @property {PermissionResolvable} [denied] The permissions to deny
+   * **(deprecated)**
    * @property {GuildMemberResolvable|RoleResolvable} memberOrRole Member or role this overwrite is for
    */
 

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -605,5 +605,7 @@ TextBasedChannel.applyToClass(GuildMember);
 
 GuildMember.prototype.hasPermissions = util.deprecate(GuildMember.prototype.hasPermissions,
   'GuildMember#hasPermissions is deprecated - use GuildMember#hasPermission, it now takes an array');
+GuildMember.prototype.missingPermissions = util.deprecate(GuildMember.prototype.missingPermissions,
+  'GuildMember#missingPermissions is deprecated - use GuildMember#permissions.missing, it now takes an array');
 
 module.exports = GuildMember;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes the docs to approve `PermissionResolvable.{allow,deny}` again and deprecate `PermissionResolvable.{allowed,denied}`, plus deprecates `GuildMember#missingPermissions` to reflect the changes from https://github.com/discordjs/discord.js/pull/2765

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
