### PR TITLE
fix(Guild#deleteEmoji): Performing wrong checks

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1083,7 +1083,7 @@ class Guild {
    */
   deleteEmoji(emoji, reason) {
     if (typeof emoji === 'string') emoji = this.emojis.get(emoji);
-    if (!(emoji instanceof Emoji)) throw new TypeError('Emoji must be either an instance of Emoji or a string');
+    if (!(emoji instanceof Emoji)) throw new TypeError('Emoji must be either an instance of Emoji or an id');
     return this.client.rest.methods.deleteEmoji(emoji, reason);
   }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1083,7 +1083,7 @@ class Guild {
    */
   deleteEmoji(emoji, reason) {
     if (typeof emoji === 'string') emoji = this.emojis.get(emoji);
-    if (!(emoji instanceof Emoji)) throw new TypeError('Emoji must be either an instance of Emoji or an id');
+    if (!(emoji instanceof Emoji)) throw new TypeError('Emoji must be either an instance of Emoji or an ID');
     return this.client.rest.methods.deleteEmoji(emoji, reason);
   }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1082,7 +1082,8 @@ class Guild {
    * @returns {Promise}
    */
   deleteEmoji(emoji, reason) {
-    if (!(emoji instanceof Emoji)) emoji = this.emojis.get(emoji);
+    if (typeof emoji === 'string') emoji = this.emojis.get(emoji);
+    if (!(emoji instanceof Emoji)) throw new TypeError('Emoji must be either an instance of Emoji or a string');
     return this.client.rest.methods.deleteEmoji(emoji, reason);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR makes the checks in Guild#deleteEmoji more robust by requiring emoji to be an instance of Emoji before it's passed to RESTMethods, avoiding the following error:

```
TypeError: Cannot read property 'guild' of undefined
    at RESTMethods.deleteEmoji ([...]/discord.js/src/client/rest/RESTMethods.js:702:66)
    at Guild.deleteEmoji ([...]/discord.js/src/structures/Guild.js:1087:37)
    [...]
```

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
