### PR TITLE
fix: reactions ratelimits

### DIFF
--- a/src/rest/APIRouter.js
+++ b/src/rest/APIRouter.js
@@ -22,6 +22,7 @@ function buildRoute(manager) {
           versioned: manager.versioned,
           route: route.map((r, i) => {
             if (/\d{16,19}/g.test(r)) return /channels|guilds/.test(route[i - 1]) ? r : ':id';
+            if (route[i - 1] === 'reactions') return ':reaction';
             return r;
           }).join('/'),
         }, options)).catch(error => {

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -131,7 +131,7 @@ class RequestHandler {
 
       // https://github.com/discordapp/discord-api-docs/issues/182
       if (item.request.route.includes('reactions')) {
-        this.reset = Date.now() + getAPIOffset(serverDate) + 250;
+        this.reset = new Date(serverDate).getTime() - getAPIOffset(serverDate) + 250;
       }
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
2 bugs:
1. Each reaction doesn't have their own rate-limit, reactions are rate-limited by channel_id major.
2. Hardcoded reaction rate-limit calculation was wrong

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
