### PR TITLE
fix(GuildChannel#lockPermissions): Properties allow and deny always returning undefined

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -265,8 +265,8 @@ class GuildChannel extends Channel {
   lockPermissions() {
     if (!this.parent) return Promise.reject(new TypeError('Could not find a parent to this guild channel.'));
     const permissionOverwrites = this.parent.permissionOverwrites.map(overwrite => ({
-      deny: overwrite.deny.bitfield,
-      allow: overwrite.allow.bitfield,
+      deny: overwrite.denied.bitfield,
+      allow: overwrite.allowed.bitfield,
       id: overwrite.id,
       type: overwrite.type,
     }));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a bug where the intended permissions from the parent channel would not be applied to the channel's overwrites, due to the allow and deny bitfield always resolving to 0 by [resolvePermissions](https://github.com/discordjs/discord.js/blob/11.4-dev/src/structures/shared/resolvePermissions.js#L17-L18).

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
