### PR TITLE
fix: Better global ratelimit management

### DIFF
--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -9,7 +9,6 @@ class RESTManager {
   constructor(client, tokenPrefix = 'Bot') {
     this.client = client;
     this.handlers = new Collection();
-    this.globallyRateLimited = false;
     this.tokenPrefix = tokenPrefix;
     this.versioned = true;
     this.globalTimeout = null;
@@ -18,6 +17,10 @@ class RESTManager {
         this.handlers.sweep(handler => handler._inactive);
       }, client.options.restSweepInterval * 1000);
     }
+  }
+
+  get globallyRateLimited() {
+    return Boolean(this.globalTimeout);
   }
 
   get api() {

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -19,10 +19,6 @@ class RESTManager {
     }
   }
 
-  get globallyRateLimited() {
-    return Boolean(this.globalTimeout);
-  }
-
   get api() {
     return routeBuilder(this);
   }

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -127,10 +127,10 @@ class RequestHandler {
         // Set the manager's global timeout as the promise for other requests to "wait"
         this.manager.globalTimeout = Util.delayFor(this.retryAfter);
 
-        // Wait for the global timeout to resolve before continue and set globally ratelimited to false
+        // Wait for the global timeout to resolve before continue
         await this.manager.globalTimeout;
 
-        // Clean up global ratelimit
+        // Clean up global timeout
         this.manager.globalTimeout = null;
       }
     }

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -43,7 +43,7 @@ class RequestHandler {
   }
 
   get limited() {
-    return (this.manager.globallyRateLimited || this.remaining <= 0) && Date.now() < this.reset;
+    return (this.manager.globalTimeout || this.remaining <= 0) && Date.now() < this.reset;
   }
 
   get _inactive() {
@@ -85,7 +85,7 @@ class RequestHandler {
         });
       }
 
-      if (this.manager.globallyRateLimited) {
+      if (this.manager.globalTimeout) {
         await this.manager.globalTimeout;
       } else {
         // Wait for the timeout to expire in order to avoid an actual 429

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -124,9 +124,6 @@ class RequestHandler {
 
       // Handle global ratelimit
       if (res.headers.get('x-ratelimit-global')) {
-        // Set a global rate limit for all of the handlers instead of each one individually
-        this.manager.globallyRateLimited = true;
-
         // Set the manager's global timeout as the promise for other requests to "wait"
         this.manager.globalTimeout = Util.delayFor(this.retryAfter);
 
@@ -135,7 +132,6 @@ class RequestHandler {
 
         // Clean up global ratelimit
         this.manager.globalTimeout = null;
-        this.manager.globallyRateLimited = false;
       }
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

fixes https://github.com/discordjs/discord.js/issues/2785 (I will give it some time for the developers to try if this PR fixes their issue completely).

tl;dr: A global timeout would only switch one `RequestHandler#busy` to false: the one after the request that got the `x-ratelimit-global` header, making the other RequestHandlers hang on forever. In this change, `RESTManager#globalTimeout` is not longer a `Timeout` but the promise from `Util.delayFor(this.retryAfter)`. 

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
