### PR TITLE
emit ReactionCollector#remove when reaction is removed by collected user

### DIFF
--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -105,7 +105,8 @@ class ReactionCollector extends Collector {
      * @param {MessageReaction} reaction The reaction that was removed
      * @param {User} user The user that removed the reaction
      */
-    if (this.collected.has(ReactionCollector.key(reaction))) {
+    if (this.collected.has(ReactionCollector.key(reaction)) &&
+        this.users.has(user.id)) {
       this.emit('remove', reaction, user);
     }
     return reaction.count ? null : ReactionCollector.key(reaction);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR aims to fix an issue where the `ReactionCollector#remove` is being emitted regardless of the `CollectorFilter` that was provided by the user. As far as I know, this event didn't exist in the stable release. I think this is the right solution but I'm open to feedback of course.

Fixes #2802.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
