### PR TITLE
docs: Added `url` to Invite's warning comment

### DIFF
--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -4,7 +4,8 @@ const Constants = require('../util/Constants');
 
 /**
  * Represents an invitation to a guild channel.
- * <warn>The only guaranteed properties are `code`, `guild` and `channel`. Other properties can be missing.</warn>
+ * <warn>The only guaranteed properties are `code`, `url`, `guild`, and `channel`.
+ * Other properties can be missing.</warn>
  */
 class Invite {
   constructor(client, data) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes https://github.com/discordjs/discord.js/issues/2769 by adding `url` to the list. And added the [serial comma](https://en.wikipedia.org/wiki/Serial_comma)

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
