### PR TITLE
feat: add ClientOptions#retryLimit

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -436,6 +436,9 @@ class Client extends BaseClient {
     if (!(options.disabledEvents instanceof Array)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'disabledEvents', 'an Array');
     }
+    if (typeof options.retryLimit !== 'number' || isNaN(options.retryLimit)) {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'retryLimit', 'a number');
+    }
   }
 }
 

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -42,6 +42,7 @@ class RESTManager {
         request: apiRequest,
         resolve,
         reject,
+        retries: 0,
       }).catch(reject);
     });
   }

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -151,12 +151,11 @@ class RequestHandler {
       return this.run();
     } else if (res.status >= 500 && res.status < 600) {
       // Retry once for possible serverside issues
-      if (item.retried) {
+      if (item.retries++ === this.manager.client.options.retryLimit) {
         return reject(
           new HTTPError(res.statusText, res.constructor.name, res.status, item.request.method, request.route)
         );
       } else {
-        item.retried = true;
         this.queue.unshift(item);
         return this.run();
       }

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -150,12 +150,13 @@ class RequestHandler {
       await Util.delayFor(this.retryAfter);
       return this.run();
     } else if (res.status >= 500 && res.status < 600) {
-      // Retry once for possible serverside issues
-      if (item.retries++ === this.manager.client.options.retryLimit) {
+      // Retry the specified number of times for possible serverside issues
+      if (item.retries === this.manager.client.options.retryLimit) {
         return reject(
           new HTTPError(res.statusText, res.constructor.name, res.status, item.request.method, request.route)
         );
       } else {
+        item.retries++;
         this.queue.unshift(item);
         return this.run();
       }

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -26,7 +26,7 @@ const browser = exports.browser = typeof window !== 'undefined';
  * requests (higher values will reduce rate-limiting errors on bad connections)
  * @property {number} [restSweepInterval=60] How frequently to delete inactive request buckets, in seconds
  * (or 0 for never)
- * @property {number} [retryLimit=1] How many times to retry on 5XX errors
+ * @property {number} [retryLimit=1] How many times to retry on 5XX errors (Infinity for indefinite amount of retries)
  * @property {PresenceData} [presence] Presence data to use upon login
  * @property {WSEventType[]} [disabledEvents] An array of disabled websocket events. Events in this array will not be
  * processed, potentially resulting in performance improvements for larger bots. Only disable events you are

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -46,6 +46,7 @@ exports.DefaultOptions = {
   disableEveryone: false,
   restWsBridgeTimeout: 5000,
   disabledEvents: [],
+  retryLimit: 1,
   restTimeOffset: 500,
   restSweepInterval: 60,
   presence: {},

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -26,6 +26,7 @@ const browser = exports.browser = typeof window !== 'undefined';
  * requests (higher values will reduce rate-limiting errors on bad connections)
  * @property {number} [restSweepInterval=60] How frequently to delete inactive request buckets, in seconds
  * (or 0 for never)
+ * @property {number} [retryLimit=1] How many times to retry on 5XX errors
  * @property {PresenceData} [presence] Presence data to use upon login
  * @property {WSEventType[]} [disabledEvents] An array of disabled websocket events. Events in this array will not be
  * processed, potentially resulting in performance improvements for larger bots. Only disable events you are

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1559,7 +1559,8 @@ declare module 'discord.js' {
 		fetchAllMembers?: boolean;
 		disableEveryone?: boolean;
 		restWsBridgeTimeout?: number;
-		restTimeOffset?: number;
+    restTimeOffset?: number;
+    retryLimit?: number,
 		disabledEvents?: WSEventType[];
 		ws?: WebSocketOptions;
 		http?: HTTPOptions;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1559,8 +1559,8 @@ declare module 'discord.js' {
 		fetchAllMembers?: boolean;
 		disableEveryone?: boolean;
 		restWsBridgeTimeout?: number;
-    restTimeOffset?: number;
-    retryLimit?: number,
+		restTimeOffset?: number;
+		retryLimit?: number,
 		disabledEvents?: WSEventType[];
 		ws?: WebSocketOptions;
 		http?: HTTPOptions;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds the ability for users to toggle whether or not they want to retry (or however many times) in the event of outages, which come with their fair share of 5XX errors (yet sometimes still sending a successful response).
*I'd love to test this but I have no outage on me right now*

fixes https://github.com/discordjs/discord.js/issues/2655

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
