### PR TITLE
remove remaining apiRequestMethod property docs and typings

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -5,9 +5,6 @@ const browser = exports.browser = typeof window !== 'undefined';
 /**
  * Options for a client.
  * @typedef {Object} ClientOptions
- * all requests in the order they are triggered, whereas the burst handler runs multiple in parallel, and doesn't
- * provide the guarantee of any particular order. Burst mode is more likely to hit a 429 ratelimit error by its nature,
- * and is therefore slightly riskier to use.
  * @property {number} [shardId=0] ID of the shard to run
  * @property {number} [shardCount=0] Total number of shards
  * @property {number} [messageCacheMaxSize=200] Maximum number of messages to cache per channel

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1549,7 +1549,6 @@ declare module 'discord.js' {
 	};
 
 	type ClientOptions = {
-		apiRequestMethod?: 'sequential' | 'burst';
 		presence?: PresenceData;
 		shardId?: number;
 		shardCount?: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Typings as well as some additional lines of docs for the property were forgotten when it was removed in #2694.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
