### PR TITLE
MessageAttachment#{width,height}: use null when it's not present

### DIFF
--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -66,13 +66,13 @@ class MessageAttachment {
      * The height of this attachment (if an image or video)
      * @type {?number}
      */
-    this.height = data.height;
+    this.height = typeof data.height !== 'undefined' ? data.height : null;
 
     /**
      * The width of this attachment (if an image or video)
      * @type {?number}
      */
-    this.width = data.width;
+    this.width = typeof data.width !== 'undefined' ? data.width : null;
   }
 
   toJSON() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR attempts to make the library more consistent by making the nullable properties `height` and `width` return null instead of undefined when they're not present.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
