### PR TITLE
docs: correct Guild#memberCount

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -106,7 +106,7 @@ class Guild {
     this.region = data.region;
 
     /**
-     * The full amount of members in this guild as of `READY`
+     * The full amount of members in this guild
      * @type {number}
      */
     this.memberCount = data.member_count || this.memberCount;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Correct Guild#memberCount to reflect actual behavior.   
The property is updated on the respective events leading to an always up-to-date number, not "as of READY" as the docs currently suggest.

The changed docs are already applied on master

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
