### PR TITLE
docs(Client#channelPinsUpdate): clarify time param

### DIFF
--- a/src/client/websocket/packets/handlers/ChannelPinsUpdate.js
+++ b/src/client/websocket/packets/handlers/ChannelPinsUpdate.js
@@ -30,7 +30,8 @@ module.exports = ChannelPinsUpdate;
 /**
  * Emitted whenever the pins of a channel are updated. Due to the nature of the WebSocket event, not much information
  * can be provided easily here - you need to manually check the pins yourself.
+ * <warn>The `time` parameter will be a Unix Epoch Date object when there are no pins left.</warn>
  * @event Client#channelPinsUpdate
  * @param {DMChannel|GroupDMChannel|TextChannel} channel The channel that the pins update occured in
- * @param {Date} time The time of the pins update
+ * @param {Date} time The time when the last pinned message was pinned
  */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
According to the [API documentation](https://discordapp.com/developers/docs/topics/gateway#channel-pins-update), the field `last_pin_timestamp` is the time when the last pinned message was pinned, not "The time of the pins update".
This PR clarifies the misleading description and adds a warning because the `time` parameter will be a Unix Epoch Date object (due to constructing a Date object with null) when there are no pins left.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
