### PR TITLE
feat(Collector): allow an async CollectorFilter fn

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -315,8 +315,8 @@ declare module 'discord.js' {
 		public readonly next: Promise<V>;
 		public options: CollectorOptions;
 		public checkEnd(): void;
-		public handleCollect(...args: any[]): void;
-		public handleDispose(...args: any[]): void;
+		public handleCollect(...args: any[]): Promise<void>;
+		public handleDispose(...args: any[]): Promise<void>;
 		public stop(reason?: string): void;
 		public toJSON(): object;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently the library does not natively allow an asynchronous function for a CollectorFilter.  When trying to allow an asynchronous function from a user endpoint, the users have to extend a Collector class, and override both the `handleDispose` and `handleCollect` methods with nearly the same code, which seems to be quite a hacky solution.  This PR allows support for an asynchronous CollectorFilter function.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
