### PR TITLE
Round off Client#ping

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -179,7 +179,7 @@ class Client extends BaseClient {
    * @readonly
    */
   get ping() {
-    return this.pings.reduce((prev, p) => prev + p, 0) / this.pings.length;
+    return Math.round(this.pings.reduce((prev, p) => prev + p, 0) / this.pings.length);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If sum of pings is not divisible by 3, Client#ping returns decimal (e.g. 165.33333333333334)
But, many people do not need decimal places, so round off clien#ping instead of user

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
