### PR TITLE
Change default token

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -104,13 +104,13 @@ class Client extends BaseClient {
     this.presence = new ClientPresence(this);
 
     Object.defineProperty(this, 'token', { writable: true });
-    if (!browser && !this.token && 'CLIENT_TOKEN' in process.env) {
+    if (!browser && !this.token && 'DISCORD_TOKEN' in process.env) {
       /**
        * Authorization token for the logged in bot
        * <warn>This should be kept private at all times.</warn>
        * @type {?string}
        */
-      this.token = process.env.CLIENT_TOKEN;
+      this.token = process.env.DISCORD_TOKEN;
     } else {
       this.token = null;
     }

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -31,7 +31,7 @@ class ShardingManager extends EventEmitter {
       totalShards: 'auto',
       respawn: true,
       shardArgs: [],
-      token: process.env.CLIENT_TOKEN,
+      token: process.env.DISCORD_TOKEN,
     }, options);
 
     /**

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -31,7 +31,7 @@ class ShardingManager extends EventEmitter {
       totalShards: 'auto',
       respawn: true,
       shardArgs: [],
-      token: null,
+      token: process.env.CLIENT_TOKEN,
     }, options);
 
     /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Default `token` in ShardingManger to `process.env.CLIENT_TOKEN` like Client does.
https://github.com/discordjs/discord.js/blob/master/src/client/Client.js#L113
Not sure it's the best way to do it as it seems discord.js likes to use null as a default instead of undefined.
It doesn't break anything if it's not defined, Besides the token not being defined so the client won't login.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
