### PR TITLE
docs: correct default value for SplitOptions.maxLength in Util#splitM…

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -73,7 +73,7 @@ class TextBasedChannel {
   /**
    * Options for splitting a message.
    * @typedef {Object} SplitOptions
-   * @property {number} [maxLength=1950] Maximum character length per message piece
+   * @property {number} [maxLength=2000] Maximum character length per message piece
    * @property {string} [char='\n'] Character to split the message with
    * @property {string} [prepend=''] Text to prepend to every piece except the first
    * @property {string} [append=''] Text to append to every piece except the last


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fixes #2705 

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
