### PR TITLE
fix: revert #2768

### DIFF
--- a/src/client/rest/RESTManager.js
+++ b/src/client/rest/RESTManager.js
@@ -28,6 +28,7 @@ class RESTManager {
         request: apiRequest,
         resolve,
         reject,
+        retries: 0,
       });
     });
   }

--- a/src/client/rest/RESTManager.js
+++ b/src/client/rest/RESTManager.js
@@ -23,25 +23,11 @@ class RESTManager {
   }
 
   push(handler, apiRequest) {
-    // Preserve async stack
-    let stackTrace = null;
-    if (Error.captureStackTrace) {
-      stackTrace = {};
-      Error.captureStackTrace(stackTrace, this.makeRequest);
-    }
-
     return new Promise((resolve, reject) => {
       handler.push({
         request: apiRequest,
         resolve,
-        reject: error => {
-          if (stackTrace && (error instanceof Error)) {
-            stackTrace.name = error.name;
-            stackTrace.message = error.message;
-            error.stack = stackTrace.stack;
-          }
-          reject(error);
-        },
+        reject,
       });
     });
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I have opened up a PR for this because I would like for us to consider possible alternatives for this issue.
Here is the issue at hand: 
![Screenshot](https://cdn.discordapp.com/attachments/222079895583457280/492799803793866762/unknown.png)
I have managed to reproduce it with the following code sample:
```js
const djs = require('discord.js');
const { pichu } = require('./settings');
process
    .on('unhandledRejection', console.error)
    .on('uncaughtException', console.error);

new djs.Client()
    .on('ready', () => {
        console.log('ready');
    })
    .on('message', mes => {
        if (mes.author.id === '84484653687267328' && mes.content === 'ping') mes.reply('pong');
    })
    .login(pichu);
```
This was done by denying the bot's `SEND_MESSAGE` permissions, and simply triggering the API call. The issue was reproduced every single time with no exceptions whatsoever.
I have had issues reproducing this on my local machine, but I've had no problems reproducing it on my VPS, which runs on Ubuntu 16.04.4 LTS, and Node v10.9.0. I am opening up a PR to 11.4-dev because I have not managed to reproduce it myself in the master branch, but I am aware that this issue is also caused by a [similar commit](https://github.com/discordjs/discord.js/commit/3f81b613d83140cdf3d99b93ea74d83c52846b2c) to that branch.

- UPDATE -
To add, I have added a `.catch(e => console.error('caught perm error', e));`, and I managed to acquire this output:
![Screenshot2](https://cdn.discordapp.com/attachments/222079895583457280/492805545988849667/unknown.png)

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
