### PR TITLE
typings: Add HTTPError class definition

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -606,9 +606,9 @@ declare module 'discord.js' {
 
 	export class HTTPError extends Error {
 		constructor(message: string, name: string, code: number, method: string, path: string);
-		public name: string;
 		public code: number;
 		public method: string;
+		public name: string;
 		public path: string;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -604,6 +604,14 @@ declare module 'discord.js' {
 		public sync(): Promise<Integration>;
 	}
 
+	export class HTTPError extends Error {
+		constructor(message: string, name: string, code: number, method: string, path: string);
+		public name: string;
+		public code: number;
+		public method: string;
+		public path: string;
+	}
+
 	export class Invite extends Base {
 		constructor(client: Client, data: object);
 		public channel: GuildChannel | GroupDMChannel;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds the `HTTPError` class definition implemented from https://github.com/discordjs/discord.js/pull/2694

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
