### PR TITLE
make WebhookClient#token non-enumerable

### DIFF
--- a/src/client/WebhookClient.js
+++ b/src/client/WebhookClient.js
@@ -20,7 +20,7 @@ class WebhookClient extends BaseClient {
     super(options);
     Object.defineProperty(this, 'client', { value: this });
     this.id = id;
-    Object.defineProperty(this, 'token', { value: token, writable: true });
+    Object.defineProperty(this, 'token', { value: token, writable: true, configurable: true });
   }
 }
 

--- a/src/client/WebhookClient.js
+++ b/src/client/WebhookClient.js
@@ -20,7 +20,7 @@ class WebhookClient extends BaseClient {
     super(options);
     Object.defineProperty(this, 'client', { value: this });
     this.id = id;
-    this.token = token;
+    Object.defineProperty(this, 'token', { value: token, writable: true });
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds parity with Client by adding the barest protection against accidental exposure

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
