### PR TITLE
backport(ClientOptions): add retryLimit

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -509,7 +509,7 @@ class Client extends EventEmitter {
    * @param {ClientOptions} [options=this.options] Options to validate
    * @private
    */
-  _validateOptions(options = this.options) {
+  _validateOptions(options = this.options) { // eslint-disable-line complexity
     if (typeof options.shardCount !== 'number' || isNaN(options.shardCount)) {
       throw new TypeError('The shardCount option must be a number.');
     }
@@ -540,6 +540,9 @@ class Client extends EventEmitter {
       throw new TypeError('The restWsBridgeTimeout option must be a number.');
     }
     if (!(options.disabledEvents instanceof Array)) throw new TypeError('The disabledEvents option must be an Array.');
+    if (typeof options.retryLimit !== 'number' || isNaN(options.retryLimit)) {
+      throw new TypeError('The retryLimit  options must be a number.');
+    }
   }
 }
 

--- a/src/client/rest/RESTManager.js
+++ b/src/client/rest/RESTManager.js
@@ -42,6 +42,7 @@ class RESTManager {
           }
           reject(error);
         },
+        retries: 0,
       });
     });
   }

--- a/src/client/rest/RequestHandlers/Sequential.js
+++ b/src/client/rest/RequestHandlers/Sequential.js
@@ -72,8 +72,14 @@ class SequentialRequestHandler extends RequestHandler {
             }, Number(res.headers['retry-after']) + this.client.options.restTimeOffset);
             if (res.headers['x-ratelimit-global']) this.globalLimit = true;
           } else if (err.status >= 500 && err.status < 600) {
-            this.queue.unshift(item);
-            this.client.setTimeout(resolve, 1e3 + this.client.options.restTimeOffset);
+            if (item.retries === this.client.options.retryLimit) {
+              item.reject(err);
+              resolve();
+            } else {
+              item.retries++;
+              this.queue.unshift(item);
+              this.client.setTimeout(resolve, 1e3 + this.client.options.restTimeOffset);
+            }
           } else {
             item.reject(err.status >= 400 && err.status < 500 ?
               new DiscordAPIError(res.request.path, res.body, res.request.method) : err);

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -24,6 +24,8 @@ exports.Package = require('../../package.json');
  * corresponding websocket events
  * @property {number} [restTimeOffset=500] Extra time in millseconds to wait before continuing to make REST
  * requests (higher values will reduce rate-limiting errors on bad connections)
+ * @property {number} [retryLimit=Infinity] How many times to retry on 5XX errors
+ * (Infinity for indefinite amount of retries)
  * @property {WSEventType[]} [disabledEvents] An array of disabled websocket events. Events in this array will not be
  * processed, potentially resulting in performance improvements for larger bots. Only disable events you are
  * 100% certain you don't need, as many are important, but not obviously so. The safest one to disable with the
@@ -42,6 +44,7 @@ exports.DefaultOptions = {
   disableEveryone: false,
   sync: false,
   restWsBridgeTimeout: 5000,
+  retryLimit: Infinity,
   disabledEvents: [],
   restTimeOffset: 500,
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1647,6 +1647,7 @@ declare module 'discord.js' {
 		sync?: boolean;
 		restWsBridgeTimeout?: number;
 		restTimeOffset?: number;
+		retryLimit?: number;
 		disabledEvents?: WSEventType[];
 		ws?: WebSocketOptions;
 		http?: HTTPOptions;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the ability to set a retry limit for 5xx http responses.
See #2805

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
