### PR TITLE
backport(TextBasedChannel): add lastPinTimestamp and lastPinAt

### DIFF
--- a/src/client/websocket/packets/handlers/ChannelPinsUpdate.js
+++ b/src/client/websocket/packets/handlers/ChannelPinsUpdate.js
@@ -16,16 +16,22 @@ class ChannelPinsUpdate extends AbstractHandler {
     const data = packet.d;
     const channel = client.channels.get(data.channel_id);
     const time = new Date(data.last_pin_timestamp);
-    if (channel && time) client.emit(Constants.Events.CHANNEL_PINS_UPDATE, channel, time);
+    if (channel && time) {
+      // Discord sends null for last_pin_timestamp if the last pinned message was removed
+      channel.lastPinTimestamp = time.getTime() || null;
+
+      client.emit(Constants.Events.CHANNEL_PINS_UPDATE, channel, time);
+    }
   }
 }
 
 /**
  * Emitted whenever the pins of a channel are updated. Due to the nature of the WebSocket event, not much information
  * can be provided easily here - you need to manually check the pins yourself.
+ * <warn>The `time` parameter will be a Unix Epoch Date object when there are no pins left.</warn>
  * @event Client#channelPinsUpdate
  * @param {Channel} channel The channel that the pins update occured in
- * @param {Date} time The time of the pins update
+ * @param {Date} time The time when the last pinned message was pinned
  */
 
 module.exports = ChannelPinsUpdate;

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -29,6 +29,12 @@ class DMChannel extends Channel {
      * @type {?Snowflake}
      */
     this.lastMessageID = data.last_message_id;
+
+    /**
+     * The timestamp when the last pinned message was pinned, if there was one
+     * @type {?number}
+     */
+    this.lastPinTimestamp = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
   }
 
   /**
@@ -42,6 +48,7 @@ class DMChannel extends Channel {
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
+  get lastPinAt() {}
   send() {}
   sendMessage() {}
   sendEmbed() {}

--- a/src/structures/GroupDMChannel.js
+++ b/src/structures/GroupDMChannel.js
@@ -99,6 +99,12 @@ class GroupDMChannel extends Channel {
      * @type {?Snowflake}
      */
     this.lastMessageID = data.last_message_id;
+
+    /**
+     * The timestamp when the last pinned message was pinned, if there was one
+     * @type {?number}
+     */
+    this.lastPinTimestamp = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
   }
 
   /**
@@ -212,6 +218,7 @@ class GroupDMChannel extends Channel {
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
+  get lastPinAt() {}
   send() {}
   sendMessage() {}
   sendEmbed() {}

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -36,6 +36,12 @@ class TextChannel extends GuildChannel {
      * @type {?Snowflake}
      */
     this.lastMessageID = data.last_message_id;
+
+    /**
+     * The timestamp when the last pinned message was pinned, if there was one
+     * @type {?number}
+     */
+    this.lastPinTimestamp = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
   }
 
   /**
@@ -99,6 +105,7 @@ class TextChannel extends GuildChannel {
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
+  get lastPinAt() {}
   send() { }
   sendMessage() { }
   sendEmbed() { }

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -30,6 +30,12 @@ class TextBasedChannel {
      * @type {?Message}
      */
     this.lastMessage = null;
+
+    /**
+     * The timestamp when the last pinned message was pinned, if there was one
+     * @type {?number}
+     */
+    this.lastPinTimestamp = null;
   }
 
   /**
@@ -390,6 +396,15 @@ class TextBasedChannel {
   }
 
   /**
+   * The date when the last pinned message was pinned, if there was one
+   * @type {?Date}
+   * @readonly
+   */
+  get lastPinAt() {
+    return this.lastPinTimestamp ? new Date(this.lastPinTimestamp) : null;
+  }
+
+  /**
    * Creates a Message Collector
    * @param {CollectorFilter} filter The filter to create the collector with
    * @param {MessageCollectorOptions} [options={}] The options to pass to the collector
@@ -584,6 +599,7 @@ exports.applyToClass = (structure, full = false, ignore = []) => {
       'fetchMessages',
       'fetchMessage',
       'search',
+      'lastPinAt',
       'bulkDelete',
       'startTyping',
       'stopTyping',

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1552,6 +1552,8 @@ declare module 'discord.js' {
 	};
 
 	type TextBasedChannelFields = {
+		lastPinTimestamp: number;
+		readonly lastPinAt: Date;
 		typing: boolean;
 		typingCount: number;
 		awaitMessages(filter: CollectorFilter, options?: AwaitMessagesOptions): Promise<Collection<string, Message>>;


### PR DESCRIPTION
And clarify Client#channelPinsUpdate's time parameter.

**Please describe the changes this PR makes and why it should be merged:**

This PR backports #2813 and #2823.
Adding `TextBasedChannel#lastPinTimestamp` and `TextBasedChannel#lastPinAt`.
As well as clarifying `Client#channelPinsUpdate`'s time parameter.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
