### PR TITLE
feat(Emoji): move createdAt and createdTimestamp getters from GuildEmoji

### DIFF
--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -1,4 +1,6 @@
+const Snowflake = require('../util/Snowflake');
 const Base = require('./Base');
+
 
 /**
  * Represents an emoji, see {@link GuildEmoji} and {@link ReactionEmoji}.
@@ -50,6 +52,26 @@ class Emoji extends Base {
   get url() {
     if (!this.id) return null;
     return this.client.rest.cdn.Emoji(this.id, this.animated ? 'gif' : 'png');
+  }
+
+  /**
+   * The timestamp the emoji was created at, or null if unicode
+   * @type {?number}
+   * @readonly
+   */
+  get createdTimestamp() {
+    if (!this.id) return null;
+    return Snowflake.deconstruct(this.id).timestamp;
+  }
+
+  /**
+   * The time the emoji was created at, or null if unicode
+   * @type {?Date}
+   * @readonly
+   */
+  get createdAt() {
+    if (!this.id) return null;
+    return new Date(this.createdTimestamp);
   }
 
   /**

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -1,7 +1,6 @@
 const GuildEmojiRoleStore = require('../stores/GuildEmojiRoleStore');
 const Permissions = require('../util/Permissions');
 const { Error } = require('../errors');
-const Snowflake = require('../util/Snowflake');
 const Emoji = require('./Emoji');
 
 /**
@@ -63,24 +62,6 @@ class GuildEmoji extends Emoji {
    */
   get roles() {
     return new GuildEmojiRoleStore(this);
-  }
-
-  /**
-   * The timestamp the emoji was created at
-   * @type {number}
-   * @readonly
-   */
-  get createdTimestamp() {
-    return Snowflake.deconstruct(this.id).timestamp;
-  }
-
-  /**
-   * The time the emoji was created at
-   * @type {Date}
-   * @readonly
-   */
-  get createdAt() {
-    return new Date(this.createdTimestamp);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -363,6 +363,8 @@ declare module 'discord.js' {
 	export class Emoji extends Base {
 		constructor(client: Client, emoji: object);
 		public animated: boolean;
+		public readonly createdAt: Date;
+		public readonly createdTimestamp: number;
 		public readonly deletable: boolean;
 		public id: Snowflake;
 		public name: string;
@@ -537,8 +539,6 @@ declare module 'discord.js' {
 		constructor(client: Client, data: object, guild: Guild);
 		private _roles: string[];
 
-		public readonly createdAt: Date;
-		public readonly createdTimestamp: number;
 		public deleted: boolean;
 		public guild: Guild;
 		public managed: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR allows to retrieve the timestamp and the date for when emojis were created from `ReactionEmoji`s by moving the respective getters into the base `Emoji` class.
They will return null for unicode emojis.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
