### PR TITLE
backport: rateLimitPerUser

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -331,6 +331,8 @@ class RESTMethods {
     data.parent_id = _data.parent;
     data.permission_overwrites = _data.permissionOverwrites ?
       resolvePermissions.call(this, _data.permissionOverwrites, channel.guild) : undefined;
+    data.rate_limit_per_user = typeof _data.rateLimitPerUser !== 'undefined' ?
+      _data.rateLimitPerUser : channel.rateLimitPerUser;
     return this.rest.makeRequest('patch', Endpoints.Channel(channel), true, data, undefined, reason).then(newData =>
       this.client.actions.ChannelUpdate.handle(newData).updated
     );

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -36,6 +36,12 @@ class TextChannel extends GuildChannel {
      * @type {?Snowflake}
      */
     this.lastMessageID = data.last_message_id;
+
+    /**
+     * The ratelimit per user for this channel
+     * @type {number}
+     */
+    this.rateLimitPerUser = data.rate_limit_per_user || 0;
   }
 
   /**
@@ -95,6 +101,16 @@ class TextChannel extends GuildChannel {
         this.client.rest.methods.createWebhook(this, name, data, reason)
       );
     }
+  }
+
+  /**
+   * Sets the rate limit per user for this channel.
+   * @param {number} rateLimitPerUser The new ratelimit
+   * @param {string} [reason] Reason for changing the channel's ratelimits
+   * @returns {Promise<TextChannel>}
+   */
+  setRateLimitPerUser(rateLimitPerUser, reason) {
+    return this.edit({ rateLimitPerUser }, reason);
   }
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1201,6 +1201,7 @@ declare module 'discord.js' {
 		public messages: Collection<Snowflake, Message>;
 		public nsfw: boolean;
 		public topic: string;
+		public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
 		public createWebhook(name: string, avatar: BufferResolvable, reason?: string): Promise<Webhook>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
 		public setNSFW(nsfw: boolean, reason: string): Promise<this>;
@@ -1619,6 +1620,7 @@ declare module 'discord.js' {
 		nsfw?: boolean;
 		bitrate?: number;
 		userLimit?: number;
+		rateLimitPerUser?: number;
 	};
 
 	type ChannelLogsQueryOptions = {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Backports the brand spanking new feature of setting ratelimits per user in a channel.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
