### PR TITLE
feat: allow MessageEmbed#setTimestamp to take a timestamp

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -267,10 +267,11 @@ class MessageEmbed {
 
   /**
    * Sets the timestamp of this embed.
-   * @param {Date} [timestamp=current date] The timestamp
+   * @param {Date|number} [timestamp=current date] The timestamp
    * @returns {MessageEmbed}
    */
   setTimestamp(timestamp = new Date()) {
+    if (typeof timestamp === 'number') timestamp = new Date(timestamp);
     this.timestamp = timestamp.getTime();
     return this;
   }

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -267,12 +267,12 @@ class MessageEmbed {
 
   /**
    * Sets the timestamp of this embed.
-   * @param {Date|number} [timestamp=current date] The timestamp
+   * @param {Date|number} [timestamp=Date.now()] The timestamp or date
    * @returns {MessageEmbed}
    */
-  setTimestamp(timestamp = new Date()) {
-    if (typeof timestamp === 'number') timestamp = new Date(timestamp);
-    this.timestamp = timestamp.getTime();
+  setTimestamp(timestamp = Date.now()) {
+    if (timestamp instanceof Date) timestamp = timestamp.getTime();
+    this.timestamp = timestamp;
     return this;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -741,7 +741,7 @@ declare module 'discord.js' {
 		public setFooter(text: StringResolvable, iconURL?: string): this;
 		public setImage(url: string): this;
 		public setThumbnail(url: string): this;
-		public setTimestamp(timestamp?: Date): this;
+		public setTimestamp(timestamp?: Date | number): this;
 		public setTitle(title: StringResolvable): this;
 		public setURL(url: string): this;
 		public toJSON(): object;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds the ability to provide a timestamp as opposed to just a date object, otherwise would throw an `is not a function` error.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
