### PR TITLE
Feat: GuildChannelStore#create with rateLimitPerUser

### DIFF
--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -33,6 +33,7 @@ class GuildChannelStore extends DataStore {
    * @param {ChannelResolvable} [options.parent] Parent of the new channel
    * @param {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [options.overwrites]
    * Permission overwrites of the new channel
+   * @param {number} [options.rateLimitPerUser] The ratelimit per user for the channel
    * @param {string} [options.reason] Reason for creating the channel
    * @returns {Promise<GuildChannel>}
    * @example

--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -52,7 +52,7 @@ class GuildChannelStore extends DataStore {
    *   ],
    * })
    */
-  async create(name, { type, topic, nsfw, bitrate, userLimit, parent, overwrites, reason } = {}) {
+  async create(name, { type, topic, nsfw, bitrate, userLimit, parent, overwrites, rateLimitPerUser, reason } = {}) {
     if (parent) parent = this.client.channels.resolveID(parent);
 
     const data = await this.client.api.guilds(this.guild.id).channels.post({
@@ -65,6 +65,7 @@ class GuildChannelStore extends DataStore {
         user_limit: userLimit,
         parent_id: parent,
         permission_overwrites: overwrites && overwrites.map(o => PermissionOverwrites.resolve(o, this.guild)),
+        rate_limit_per_user: rateLimitPerUser,
       },
       reason,
     });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1751,6 +1751,7 @@ declare module 'discord.js' {
 		userLimit?: number;
 		parent?: ChannelResolvable;
 		overwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
+		rateLimitPerUser?: number;
 		reason?: string
 	};
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allows channels to be created with the `rate_limit_per_user` property for API coverage.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
