### PR TITLE
docs: clarify example for Collection#tap

### DIFF
--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -349,9 +349,9 @@ class Collection extends Map {
    * @returns {Collection}
    * @example
    * collection
-   *  .tap(coll => coll.size)
+   *  .tap(coll => console.log(`${coll.size} users including bots`))
    *  .filter(user => user.bot)
-   *  .tap(coll => coll.size)
+   *  .tap(coll => console.log(`${coll.size} users without bots`))
    */
   tap(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -349,9 +349,9 @@ class Collection extends Map {
    * @returns {Collection}
    * @example
    * collection
-   *  .tap(coll => console.log(`${coll.size} users including bots`))
+   *  .tap(coll => console.log(`${coll.size} users, including bots`))
    *  .filter(user => user.bot)
-   *  .tap(coll => console.log(`${coll.size} users without bots`))
+   *  .tap(coll => console.log(`${coll.size} users, excluding bots`))
    */
   tap(fn, thisArg) {
     if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The current example for `Collection.tap()` does not really demonstrate the functionality tap provides.
Changing it to verbose log instead provides a visual feedback for the user as to what's happening (size prior and after the filter) without modifying `this`

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
