### PR TITLE
feat(DataStore): support disabled stores

### DIFF
--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -43,11 +43,16 @@ class DataStore extends Collection {
     if (existing) return existing;
 
     const entry = this.holds ? new this.holds(this.client, data, ...extras) : data;
-    if (cache && !this.disabled) this.set(id || entry.id, entry);
+    if (cache) this.set(id || entry.id, entry);
     return entry;
   }
 
   remove(key) { return this.delete(key); }
+
+  set(key, value) {
+    if (this.disabled) return this;
+    return super.set(key, value);
+  }
 
   /**
    * Resolves a data entry to a data Object.

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -28,11 +28,6 @@ class DataStore extends Collection {
 
   constructor(client, iterable, holds) {
     super();
-    if (!Structures) Structures = require('../util/Structures');
-    Object.defineProperty(this, 'client', { value: client });
-    Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) || holds });
-    if (iterable) for (const item of iterable) this.add(item);
-
     /**
      * Whether this store is disabled.
      * @type {boolean}
@@ -45,6 +40,11 @@ class DataStore extends Collection {
      * @type {number}
      */
     this.count = 0;
+
+    if (!Structures) Structures = require('../util/Structures');
+    Object.defineProperty(this, 'client', { value: client });
+    Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) || holds });
+    if (iterable) for (const item of iterable) this.add(item);
   }
 
   /**

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -12,6 +12,22 @@ class DataStore extends Collection {
     Object.defineProperty(this, 'client', { value: client });
     Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) || holds });
     if (iterable) for (const item of iterable) this.add(item);
+
+    /**
+     * Whether this store is disabled.
+     * @type {boolean}
+     */
+    this.disabled = false;
+  }
+
+  /**
+   * Enable or disable caching anything in this store.
+   * @param {boolean} [disabled=true] Whether to disable this store
+   * @returns {boolean}
+   */
+  disable(disabled = true) {
+    this.disabled = disabled;
+    return this.disabled;
   }
 
   add(data, cache = true, { id, extras = [] } = {}) {
@@ -19,7 +35,7 @@ class DataStore extends Collection {
     if (existing) return existing;
 
     const entry = this.holds ? new this.holds(this.client, data, ...extras) : data;
-    if (cache) this.set(id || entry.id, entry);
+    if (cache && !this.disabled) this.set(id || entry.id, entry);
     return entry;
   }
 

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -6,6 +6,26 @@ let Structures;
  * @extends {Collection}
  */
 class DataStore extends Collection {
+  /**
+   * Disable caching data in all new stores of this type.
+   * @static
+   * @returns {true}
+   */
+  static disable() {
+    this.disabled = true;
+    return this.disabled;
+  }
+
+  /**
+   * Enable caching data in all new stores of this type.
+   * @static
+   * @returns {false}
+   */
+  static enable() {
+    this.disabled = false;
+    return this.disabled;
+  }
+
   constructor(client, iterable, holds) {
     super();
     if (!Structures) Structures = require('../util/Structures');
@@ -17,7 +37,14 @@ class DataStore extends Collection {
      * Whether this store is disabled.
      * @type {boolean}
      */
-    this.disabled = false;
+    this.disabled = this.constructor.disabled;
+
+    /**
+     * A count of elements that would be in this store if it wasn't disabled. Equal to the size property if this store
+     * has never been disabled.
+     * @type {number}
+     */
+    this.count = 0;
   }
 
   /**
@@ -49,9 +76,20 @@ class DataStore extends Collection {
 
   remove(key) { return this.delete(key); }
 
+  clear() {
+    this.count = 0;
+    return super.clear();
+  }
+
+  delete(key) {
+    this.count -= 1;
+    return super.delete(key);
+  }
+
   set(key, value) {
-    if (this.disabled) return this;
-    return super.set(key, value);
+    this.count += 1;
+    if (!this.disabled) super.set(key, value);
+    return this;
   }
 
   /**
@@ -80,5 +118,7 @@ class DataStore extends Collection {
     return Collection;
   }
 }
+
+DataStore.disabled = false;
 
 module.exports = DataStore;

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -21,12 +21,20 @@ class DataStore extends Collection {
   }
 
   /**
-   * Enable or disable caching anything in this store.
-   * @param {boolean} [disabled=true] Whether to disable this store
-   * @returns {boolean}
+   * Disable caching data in this store.
+   * @returns {true}
    */
-  disable(disabled = true) {
-    this.disabled = disabled;
+  disable() {
+    this.disabled = true;
+    return this.disabled;
+  }
+
+  /**
+   * Enable caching data in this store.
+   * @returns {false}
+   */
+  enable() {
+    this.disabled = false;
     return this.disabled;
   }
 

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -29,7 +29,7 @@ class DataStore extends Collection {
   constructor(client, iterable, holds) {
     super();
     /**
-     * Whether this store is disabled.
+     * Whether this store is disabled. If true, data will still be set but its value will be null.
      * @type {boolean}
      */
     this.disabled = this.constructor.disabled;

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -34,13 +34,6 @@ class DataStore extends Collection {
      */
     this.disabled = this.constructor.disabled;
 
-    /**
-     * A count of elements that would be in this store if it wasn't disabled. Equal to the size property if this store
-     * has never been disabled.
-     * @type {number}
-     */
-    this.count = 0;
-
     if (!Structures) Structures = require('../util/Structures');
     Object.defineProperty(this, 'client', { value: client });
     Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) || holds });
@@ -76,20 +69,8 @@ class DataStore extends Collection {
 
   remove(key) { return this.delete(key); }
 
-  clear() {
-    this.count = 0;
-    return super.clear();
-  }
-
-  delete(key) {
-    this.count -= 1;
-    return super.delete(key);
-  }
-
   set(key, value) {
-    this.count += 1;
-    if (!this.disabled) super.set(key, value);
-    return this;
+    return super.set(key, this.disabled ? null : value);
   }
 
   /**

--- a/src/stores/GuildMemberStore.js
+++ b/src/stores/GuildMemberStore.js
@@ -203,7 +203,7 @@ class GuildMemberStore extends DataStore {
         for (const member of members.values()) {
           if (query || limit) fetchedMembers.set(member.id, member);
         }
-        if (this.guild.memberCount <= this.count ||
+        if (this.guild.memberCount <= this.size ||
           ((query || limit) && members.size < 1000) ||
           (limit && fetchedMembers.size >= limit)) {
           this.guild.client.removeListener(Events.GUILD_MEMBERS_CHUNK, handler);

--- a/src/stores/GuildMemberStore.js
+++ b/src/stores/GuildMemberStore.js
@@ -185,7 +185,7 @@ class GuildMemberStore extends DataStore {
 
   _fetchMany({ query = '', limit = 0 } = {}) {
     return new Promise((resolve, reject) => {
-      if (this.guild.memberCount === this.size) {
+      if (this.guild.memberCount === this.size && !this.disabled) {
         resolve(query || limit ? new Collection() : this);
         return;
       }

--- a/src/stores/GuildMemberStore.js
+++ b/src/stores/GuildMemberStore.js
@@ -203,7 +203,7 @@ class GuildMemberStore extends DataStore {
         for (const member of members.values()) {
           if (query || limit) fetchedMembers.set(member.id, member);
         }
-        if (this.guild.memberCount <= this.size ||
+        if (this.guild.memberCount <= this.count ||
           ((query || limit) && members.size < 1000) ||
           (limit && fetchedMembers.size >= limit)) {
           this.guild.client.removeListener(Events.GUILD_MEMBERS_CHUNK, handler);

--- a/src/stores/GuildStore.js
+++ b/src/stores/GuildStore.js
@@ -51,7 +51,8 @@ class GuildStore extends DataStore {
       return new Promise((resolve, reject) =>
         this.client.api.guilds.post({ data: { name, region, icon } })
           .then(data => {
-            if (this.client.guilds.has(data.id)) return resolve(this.client.guilds.get(data.id));
+            const cached = this.client.guilds.get(data.id);
+            if (cached) return resolve(cached);
 
             const handleGuild = guild => {
               if (guild.id === data.id) {

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1,0 +1,16 @@
+for (const store of [
+  'ChannelStore',
+  'GuildChannelStore',
+  'GuildEmojiRoleStore',
+  'GuildEmojiStore',
+  'GuildMemberRoleStore',
+  'GuildMemberStore',
+  'GuildStore',
+  'MessageStore',
+  'PresenceStore',
+  'ReactionStore',
+  'ReactionUserStore',
+  'RoleStore',
+  'UserStore',
+  'VoiceStateStore',
+]) exports[store] = require(`./${store}`);

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -43,15 +43,10 @@ class MessageReaction {
    * @readonly
    */
   get emoji() {
-    if (this._emoji instanceof GuildEmoji) return this._emoji;
     // Check to see if the emoji has become known to the client
-    if (this._emoji.id) {
-      const emojis = this.message.client.emojis;
-      if (emojis.has(this._emoji.id)) {
-        const emoji = emojis.get(this._emoji.id);
-        this._emoji = emoji;
-        return emoji;
-      }
+    if (!(this._emoji instanceof GuildEmoji) && this._emoji.id) {
+      const emoji = this.message.client.emojis.get(this._emoji.id);
+      if (emoji) this._emoji = emoji;
     }
     return this._emoji;
   }

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -29,6 +29,10 @@ const browser = exports.browser = typeof window !== 'undefined';
  * processed, potentially resulting in performance improvements for larger bots. Only disable events you are
  * 100% certain you don't need, as many are important, but not obviously so. The safest one to disable with the
  * most impact is typically `TYPING_START`.
+ * @property {string[]} [disabledStores] An array of stores to disable. Any new data will not be added to these stores.
+ * Use with caution, since this may disable certain events if a resource can't be found and make some expected resources
+ * unavailable. The specified strings should be the constructor names of the stores, e.g. 'GuildEmojiStore',
+ * 'GuildMemberStore'.
  * @property {WebsocketOptions} [ws] Options for the WebSocket
  * @property {HTTPOptions} [http] HTTP options
  */
@@ -43,6 +47,7 @@ exports.DefaultOptions = {
   disableEveryone: false,
   restWsBridgeTimeout: 5000,
   disabledEvents: [],
+  disabledStores: [],
   retryLimit: 1,
   restTimeOffset: 500,
   restSweepInterval: 60,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1289,7 +1289,8 @@ declare module 'discord.js' {
 		public client: Client;
 		public holds: VConstructor;
 		public disabled: boolean;
-		public disable(disabled: boolean): boolean;
+		public disable(): boolean;
+		public enable(): boolean;
 		public add(data: any, cache?: boolean, { id, extras }?: { id: K, extras: any[] }): V;
 		public remove(key: K): void;
 		public resolve(resolvable: R): V;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1286,9 +1286,13 @@ declare module 'discord.js' {
 	export class DataStore<K, V, VConstructor = Constructable<V>, R = any> extends Collection<K, V> {
 		constructor(client: Client, iterable: Iterable<any>, holds: VConstructor);
 		public static readonly [Symbol.species]: typeof Collection;
+		public static disabled: boolean;
+		public static disable(): boolean;
+		public static enable(): boolean;
 		public client: Client;
 		public holds: VConstructor;
 		public disabled: boolean;
+		public count: number;
 		public disable(): boolean;
 		public enable(): boolean;
 		public add(data: any, cache?: boolean, { id, extras }?: { id: K, extras: any[] }): V;
@@ -1572,6 +1576,7 @@ declare module 'discord.js' {
 		restTimeOffset?: number;
 		retryLimit?: number,
 		disabledEvents?: WSEventType[];
+		disabledStores?: string[];
 		ws?: WebSocketOptions;
 		http?: HTTPOptions;
 	};

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1292,7 +1292,6 @@ declare module 'discord.js' {
 		public client: Client;
 		public holds: VConstructor;
 		public disabled: boolean;
-		public count: number;
 		public disable(): boolean;
 		public enable(): boolean;
 		public add(data: any, cache?: boolean, { id, extras }?: { id: K, extras: any[] }): V;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1288,6 +1288,8 @@ declare module 'discord.js' {
 		public static readonly [Symbol.species]: typeof Collection;
 		public client: Client;
 		public holds: VConstructor;
+		public disabled: boolean;
+		public disable(disabled: boolean): boolean;
 		public add(data: any, cache?: boolean, { id, extras }?: { id: K, extras: any[] }): V;
 		public remove(key: K): void;
 		public resolve(resolvable: R): V;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This change allows users to disable unused stores in their application, reducing RAM usage.  This is one half of #1409.  Current changes:

- Stores set null instead of data when they are disabled
- Client has another option `disabledStores` that accepts an array of strings corresponding to the store constructor name (e.g. "GuildEmojiStore")
- `Store.disabled` determines the initial disability state of new stores of that type
- `Store#disabled` determines whether an individual store is disabled
- `Store` has `enable` and `disable` static and instance methods to toggle disability
- There is now a default export in the `src/stores` directory which exports all data stores

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
