### PR TITLE
backport(Guild): createChannel with options object

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -260,12 +260,19 @@ class RESTMethods {
     });
   }
 
-  createChannel(guild, channelName, channelType, overwrites, reason) {
+  createChannel(guild, name, { type, topic, nsfw, bitrate, userLimit, parent, permissionOverwrites, reason }) {
     return this.rest.makeRequest('post', Endpoints.Guild(guild).channels, true, {
-      name: channelName,
-      type: channelType ? Constants.ChannelTypes[channelType.toUpperCase()] : 'text',
-      permission_overwrites: resolvePermissions.call(this, overwrites, guild),
-    }, undefined, reason).then(data => this.client.actions.ChannelCreate.handle(data).channel);
+      name,
+      topic,
+      type: type ? Constants.ChannelTypes[type.toUpperCase()] : 'text',
+      nsfw,
+      bitrate,
+      user_limit: userLimit,
+      parent_id: parent instanceof Channel ? parent.id : parent,
+      permission_overwrites: resolvePermissions.call(this, permissionOverwrites, guild),
+    },
+    undefined,
+    reason).then(data => this.client.actions.ChannelCreate.handle(data).channel);
   }
 
   createDM(recipient) {
@@ -328,7 +335,7 @@ class RESTMethods {
     data.position = _data.position || channel.position;
     data.bitrate = _data.bitrate || (channel.bitrate ? channel.bitrate * 1000 : undefined);
     data.user_limit = typeof _data.userLimit !== 'undefined' ? _data.userLimit : channel.userLimit;
-    data.parent_id = _data.parent;
+    data.parent_id = _data.parent instanceof Channel ? _data.parent.id : _data.parent;
     data.permission_overwrites = _data.permissionOverwrites ?
       resolvePermissions.call(this, _data.permissionOverwrites, channel.guild) : undefined;
     data.rate_limit_per_user = typeof _data.rateLimitPerUser !== 'undefined' ?

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1022,9 +1022,12 @@ class Guild {
   /**
    * Creates a new channel in the guild.
    * @param {string} name The name of the new channel
-   * @param {string} [type='text'] The type of the new channel, either `text` or `voice` or `category`
-   * @param {ChannelCreationOverwrites[]|Collection<Snowflake, PermissionOverwrites>} [overwrites] Permission overwrites
-   * @param {string} [reason] Reason for creating this channel
+   * @param {string|ChannelData} [typeOrOptions='text']
+   * The type of the new channel, either `text` or `voice` or `category`. **(deprecated, use options)**
+   * Alternatively options for the new channel, overriding the following parameters.
+   * @param {ChannelCreationOverwrites[]|Collection<Snowflake, PermissionOverwrites>} [permissionOverwrites]
+   * Permission overwrites **(deprecated, use options)**
+   * @param {string} [reason] Reason for creating this channel **(deprecated, use options)**
    * @returns {Promise<CategoryChannel|TextChannel|VoiceChannel>}
    * @example
    * // Create a new text channel
@@ -1041,8 +1044,21 @@ class Guild {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  createChannel(name, type, overwrites, reason) {
-    return this.client.rest.methods.createChannel(this, name, type, overwrites, reason);
+  createChannel(name, typeOrOptions, permissionOverwrites, reason) {
+    if (!typeOrOptions || (typeof typeOrOptions === 'string')) {
+      if (typeOrOptions) {
+        process.emitWarning(
+          'Guild#createChannel: Create channels with an options object instead of separate parameters',
+          'DeprecationWarning'
+        );
+      }
+      typeOrOptions = {
+        type: typeOrOptions,
+        permissionOverwrites,
+        reason,
+      };
+    }
+    return this.client.rest.methods.createChannel(this, name, typeOrOptions);
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -276,14 +276,15 @@ class GuildChannel extends Channel {
   /**
    * The data for a guild channel.
    * @typedef {Object} ChannelData
+   * @property {string} [type] The type of the channel (Only when creating)
    * @property {string} [name] The name of the channel
    * @property {number} [position] The position of the channel
    * @property {string} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel
-   * @property {string} [parent] The parent ID of the channel
-   * @property {ChannelCreationOverwrites[]|Collection<Snowflake, PermissionOverwrites>} [overwrites]
+   * @property {CategoryChannel|Snowflake} [parent] The parent or parent ID of the channel
+   * @property {ChannelCreationOverwrites[]|Collection<Snowflake, PermissionOverwrites>} [permissionOverwrites]
    * Overwrites of the channel
    */
 
@@ -398,8 +399,12 @@ class GuildChannel extends Channel {
    *   .catch(console.error);
    */
   clone(name = this.name, withPermissions = true, withTopic = true, reason) {
-    return this.guild.createChannel(name, this.type, withPermissions ? this.permissionOverwrites : [], reason)
-      .then(channel => withTopic ? channel.setTopic(this.topic) : channel);
+    return this.guild.createChannel(name, {
+      type: this.type,
+      overwritePermissions: withPermissions ? this.overwritePermissions : undefined,
+      topic: withTopic ? this.topic : undefined,
+      reason,
+    });
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -524,7 +524,8 @@ declare module 'discord.js' {
 		public addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
 		public allowDMs(allow: boolean): Promise<Guild>;
 		public ban(user: UserResolvable, options?: BanOptions | number | string): Promise<GuildMember | User | string>;
-		public createChannel(name: string, type?: 'category' | 'text' | 'voice', overwrites?: PermissionOverwrites[] | ChannelCreationOverwrites[], reason?: string): Promise<CategoryChannel | TextChannel | VoiceChannel>;
+		public createChannel(name: string, options?: ChannelData): Promise<CategoryChannel | TextChannel | VoiceChannel>;
+		public createChannel(name: string, type?: 'category' | 'text' | 'voice', permissionOverwrites?: PermissionOverwrites[] | ChannelCreationOverwrites[], reason?: string): Promise<CategoryChannel | TextChannel | VoiceChannel>;
 		public createEmoji(attachment: BufferResolvable | Base64Resolvable, name: string, roles?: Collection<Snowflake, Role> | Role[], reason?: string): Promise<Emoji>;
 		public createRole(data?: RoleData, reason?: string): Promise<Role>;
 		public delete(): Promise<Guild>;
@@ -1615,12 +1616,15 @@ declare module 'discord.js' {
 	};
 
 	type ChannelData = {
+		type?: 'category' | 'text' | 'voice';
 		name?: string;
 		position?: number;
 		topic?: string;
 		nsfw?: boolean;
 		bitrate?: number;
 		userLimit?: number;
+		parent?: ChannelResolvable;
+		permissionOverwrites?: PermissionOverwrites[] | ChannelCreationOverwrites[];
 		rateLimitPerUser?: number;
 	};
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds an options object "overload" to `Guild#createChannel` allowing to specify all available properties upon creating, rather than having to edit after creating again.
This also deprecates the old way of using multiple parameters, emitting a process warning.

Regarding `ChannelData#overwrites` ->`ChannelData#permissionOverwrites`:
- The property has been added with https://github.com/discordjs/discord.js/pull/2734 (after the last release)
- The actual code is also using `permissionOverwrites` (stable and current 11.4-dev) https://github.com/discordjs/discord.js/blob/b5df8603e8768b9b50ece24f94e455c3410ef9a2/src/client/rest/RESTMethods.js#L325-L326

So that's a documentation fix purely inside of 11.4-dev, and not a breaking change.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
