### PR TITLE
feat(ClientUser): Allow options as first parameter to ClientUser#setActivity

### DIFF
--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -8,7 +8,7 @@ class ClientPresence extends Presence {
     super(client, Object.assign(data, { status: 'online', user: { id: null } }));
   }
 
-  async setClientPresence(presence) {
+  async set(presence) {
     const packet = await this._parse(presence);
     this.patch(packet);
     this.client.ws.send({ op: OPCodes.STATUS_UPDATE, d: packet });

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -97,7 +97,7 @@ class ClientUser extends Structures.get('User') {
    *   .catch(console.error);
    */
   setPresence(data) {
-    return this.client.presence.setClientPresence(data);
+    return this.client.presence.set(data);
   }
 
   /**
@@ -124,11 +124,17 @@ class ClientUser extends Structures.get('User') {
   }
 
   /**
+   * Options for setting an activity
+   * @typedef ActivityOptions
+   * @type {Object}
+   * @property {string} [url] Twitch stream URL
+   * @property {ActivityType|number} [type] Type of the activity
+   */
+
+  /**
    * Sets the activity the client user is playing.
-   * @param {?string} name Activity being played
-   * @param {Object} [options] Options for setting the activity
-   * @param {string} [options.url] Twitch stream URL
-   * @param {ActivityType|number} [options.type] Type of the activity
+   * @param {string|ActivityOptions} [name] Activity being played, or options for setting the activity
+   * @param {ActivityOptions} [options] Options for setting the activity
    * @returns {Promise<Presence>}
    * @example
    * // Set the client user's activity
@@ -136,11 +142,11 @@ class ClientUser extends Structures.get('User') {
    *   .then(presence => console.log(`Activity set to ${presence.game.name}`))
    *   .catch(console.error);
    */
-  setActivity(name, { url, type } = {}) {
+  setActivity(name, options = {}) {
     if (!name) return this.setPresence({ activity: null });
-    return this.setPresence({
-      activity: { name, type, url },
-    });
+
+    const activity = Object.assign({}, options, typeof name === 'object' ? name : { name });
+    return this.setPresence({ activity });
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -260,11 +260,18 @@ declare module 'discord.js' {
 		public connectToWebSocket(token: string, resolve: Function, reject: Function): void;
 	}
 
+	export interface ActivityOptions {
+		name?: string;
+		url?: string;
+		type?: ActivityType | number;
+	}
+
 	export class ClientUser extends User {
 		public mfaEnabled: boolean;
 		public verified: boolean;
 		public createGroupDM(recipients: GroupDMRecipientOptions[]): Promise<GroupDMChannel>;
-		public setActivity(name: string, options?: { url?: string, type?: ActivityType | number }): Promise<Presence>;
+		public setActivity(options?: ActivityOptions): Promise<Presence>;
+		public setActivity(name: string, options?: ActivityOptions): Promise<Presence>;
 		public setAFK(afk: boolean): Promise<Presence>;
 		public setAvatar(avatar: BufferResolvable | Base64Resolvable): Promise<ClientUser>;
 		public setPresence(data: PresenceData): Promise<Presence>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allows people to specify a single object for setting an activity, rather than splitting it between a string param and options objects.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
