### PR TITLE
fix: emit voiceStateUpdate on guildMemberRemove

### DIFF
--- a/src/client/websocket/packets/handlers/VoiceStateUpdate.js
+++ b/src/client/websocket/packets/handlers/VoiceStateUpdate.js
@@ -26,8 +26,10 @@ class VoiceStateUpdateHandler extends AbstractHandler {
       }
 
       // Emit event
-      if (member) {
-        if (member.user.id === client.user.id && data.channel_id) client.emit('self.voiceStateUpdate', data);
+      if (member && member.user.id === client.user.id && data.channel_id) {
+        client.emit('self.voiceStateUpdate', data);
+      }
+      if (oldState || newState) {
         client.emit(Events.VOICE_STATE_UPDATE, oldState, newState);
       }
     }

--- a/src/client/websocket/packets/handlers/VoiceStateUpdate.js
+++ b/src/client/websocket/packets/handlers/VoiceStateUpdate.js
@@ -39,8 +39,8 @@ class VoiceStateUpdateHandler extends AbstractHandler {
 /**
  * Emitted whenever a member changes voice state - e.g. joins/leaves a channel, mutes/unmutes.
  * @event Client#voiceStateUpdate
- * @param {VoiceState} oldState The voice state before the update
- * @param {VoiceState} newState The voice state after the update
+ * @param {?VoiceState} oldState The voice state before the update
+ * @param {?VoiceState} newState The voice state after the update
  */
 
 module.exports = VoiceStateUpdateHandler;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -195,7 +195,7 @@ declare module 'discord.js' {
 		public on(event: 'roleUpdate', listener: (oldRole: Role, newRole: Role) => void): this;
 		public on(event: 'typingStart' | 'typingStop', listener: (channel: Channel, user: User) => void): this;
 		public on(event: 'userUpdate', listener: (oldUser: User, newUser: User) => void): this;
-		public on(event: 'voiceStateUpdate', listener: (oldState: VoiceState, newState: VoiceState) => void): this;
+		public on(event: 'voiceStateUpdate', listener: (oldState?: VoiceState, newState?: VoiceState) => void): this;
 		public on(event: 'webhookUpdate', listener: (channel: TextChannel) => void): this;
 		public on(event: string, listener: Function): this;
 
@@ -227,7 +227,7 @@ declare module 'discord.js' {
 		public once(event: 'roleUpdate', listener: (oldRole: Role, newRole: Role) => void): this;
 		public once(event: 'typingStart' | 'typingStop', listener: (channel: Channel, user: User) => void): this;
 		public once(event: 'userUpdate', listener: (oldUser: User, newUser: User) => void): this;
-		public once(event: 'voiceStateUpdate', listener: (oldState: VoiceState, newState: VoiceState) => void): this;
+		public once(event: 'voiceStateUpdate', listener: (oldState?: VoiceState, newState?: VoiceState) => void): this;
 		public once(event: 'webhookUpdate', listener: (channel: TextChannel) => void): this;
 		public once(event: string, listener: Function): this;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allows `Client#voiceStateUpdate` to emit when someone leaves *the server* while in a Voice Channel. I figured this acceptable because you have the ID of the member in the state anyway, so there is no need to concern ourselves with partials here or anything like that.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
