### PR TITLE
fix: re-add presence parsing from ClientOptions

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -206,6 +206,9 @@ class Client extends BaseClient {
     let endpoint = this.api.gateway;
     if (this.options.shardCount === 'auto') endpoint = endpoint.bot;
     const res = await endpoint.get();
+    if (this.options.presence) {
+      this.options.ws.presence = await this.presences._parse(this.options.presence);
+    }
     if (res.session_start_limit && res.session_start_limit.remaining === 0) {
       const { session_start_limit: { reset_after } } = res;
       this.emit(Events.DEBUG, `Exceeded identify threshold, setting a timeout for ${reset_after} ms`);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Support for parsing the client's presence as provided in `ClientOptions` disappeared somewhere along the road on the road to getting internal sharding, so I re-added it.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
