### PR TITLE
Use match on speaking bitmask to fire _stoppedSpeaking

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -452,7 +452,7 @@ class VoiceConnection extends EventEmitter {
       }
     }
 
-    if (guild && user && old.equals(speaking)) {
+    if (guild && user && !old.equals(speaking)) {
       const member = guild.member(user);
       if (member) {
         /**

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -447,12 +447,12 @@ class VoiceConnection extends EventEmitter {
      */
     if (this.status === VoiceStatus.CONNECTED) {
       this.emit('speaking', user, speaking);
-      if (!speaking.has('SPEAKING')) {
+      if (!speaking.has(Speaking.FLAGS.SPEAKING)) {
         this.receiver.packets._stoppedSpeaking(user_id);
       }
     }
 
-    if (guild && user && old !== speaking) {
+    if (guild && user && old.equals(speaking)) {
       const member = guild.member(user);
       if (member) {
         /**

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -447,7 +447,7 @@ class VoiceConnection extends EventEmitter {
      */
     if (this.status === VoiceStatus.CONNECTED) {
       this.emit('speaking', user, speaking);
-      if (!speaking) {
+      if (!speaking.has('SPEAKING')) {
         this.receiver.packets._stoppedSpeaking(user_id);
       }
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
A bug fix so the `_stoppedSpeaking` event is fired when the user stops speaking. Best I can tell (I'm new to node.js), `speaking` used to be a bool/int, but is now an bitmask object in v12. This (tiny) patch uses the bitmask correctly.

I have attached my code that I use to record voice from Discord. Run it, and then in the text channel where the bot is registered, enter something such as: `!join my voice channel`
[voicebot12.js.zip](https://github.com/discordjs/discord.js/files/2481005/voicebot12.js.zip)


**Status**
- [/] Code changes have been tested against the Discord API, or there are no code changes
- [/] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
