### PR TITLE
Resolve color in embed constructor

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -40,7 +40,7 @@ class MessageEmbed {
 
     /**
      * The color of this embed
-     * @type {?ColorResolvable}
+     * @type {?number}
      */
     this.color = Util.resolveColor(data.color);
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -40,7 +40,7 @@ class MessageEmbed {
 
     /**
      * The color of this embed
-     * @type {?number}
+     * @type {?ColorResolvable}
      */
     this.color = Util.resolveColor(data.color);
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -42,7 +42,7 @@ class MessageEmbed {
      * The color of this embed
      * @type {?number}
      */
-    this.color = data.color;
+    this.color = Util.resolveColor(data.color);
 
     /**
      * The timestamp of this embed

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1876,7 +1876,7 @@ declare module 'discord.js' {
 		description?: string;
 		url?: string;
 		timestamp?: Date | number;
-		color?: number | string;
+		color?: ColorResolvable;
 		fields?: { name: string; value: string; inline?: boolean; }[];
 		files?: (MessageAttachment | string | FileOptions)[];
 		author?: { name?: string; url?: string; icon_url?: string; iconURL?: string; };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Make use of `resolveColor` utility method in `MessageEmbed` constructor to mirror `setColor`

https://github.com/discordjs/discord.js/blob/b759fc415e89c1f3eb3523deb23c5b514968c845/src/structures/MessageEmbed.js#L237-L240

Alternatively, I would say that this `resolveColor` method is kinda extraneous anyway, and I'd remove the whole thing. It might just not be worth it for backwards compatibility though

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
