### PR TITLE
WIP Expose the ratelimit information to users

### DIFF
--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -117,6 +117,15 @@ class RequestHandler {
       this.reset = reset ? calculateReset(reset, serverDate) : Date.now();
       this.retryAfter = retryAfter ? Number(retryAfter) : -1;
 
+      this.manager.client.emit('ratelimit-response', {
+        route: request.route,
+        limit: this.limit,
+        remaining: this.remaining,
+        reset: this.reset,
+        timeout: this.reset - Date.now(),
+        retryAfter: this.retryAfter,
+      });
+
       // https://github.com/discordapp/discord-api-docs/issues/182
       if (item.request.route.includes('reactions')) {
         this.reset = new Date(serverDate).getTime() - getAPIOffset(serverDate) + 250;


### PR DESCRIPTION
I've seen a lot of questions and requests on the discord.js discord server about how ratelimits can be accessed, and looking through the request code, there is no simple way for a user to make use of the `x-ratelimit` headers in the responses

In my opinion, the most versatile solution to this is simply adding a new event which carries information about the ratelimit details for each route. users can then parse this information on a case-by-case basis, while adding next to no overhead in cases where it is not used.

Alternatively, it would be possible to keep a cache of the `limit` and `timout`s of each endpoint (ignoring IDs) and update it in cases it is incorrect. This would be easier to read from, and also shouldn't add much delay to the requests

Is there a better solution to this, or some reason not to allow access to the ratelimit data?

The commit I added to this is only meant to be used for testing - A better name needs to be chosen and the `timeout` property probably isn't necessary

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.