### PR TITLE
docs: add missing docstring for Client#userUpdate

### DIFF
--- a/src/client/actions/UserUpdate.js
+++ b/src/client/actions/UserUpdate.js
@@ -9,12 +9,12 @@ class UserUpdateAction extends Action {
     const oldUser = newUser._update(data.user);
 
     if (!oldUser.equals(newUser)) {
-      /**
-         * Emitted whenever a user's details (e.g. username) are changed.
-         * @event Client#userUpdate
-         * @param {User} oldUser The user before the update
-         * @param {User} newUser The user after the update
-         */
+     /**
+      * Emitted whenever a user's details (e.g. username) are changed.
+      * @event Client#userUpdate
+      * @param {User} oldUser The user before the update
+      * @param {User} newUser The user after the update
+      */
       client.emit(Events.USER_UPDATE, oldUser, newUser);
       return {
         old: oldUser,

--- a/src/client/actions/UserUpdate.js
+++ b/src/client/actions/UserUpdate.js
@@ -9,12 +9,12 @@ class UserUpdateAction extends Action {
     const oldUser = newUser._update(data.user);
 
     if (!oldUser.equals(newUser)) {
-     /**
-      * Emitted whenever a user's details (e.g. username) are changed.
-      * @event Client#userUpdate
-      * @param {User} oldUser The user before the update
-      * @param {User} newUser The user after the update
-      */
+      /**
+       * Emitted whenever a user's details (e.g. username) are changed.
+       * @event Client#userUpdate
+       * @param {User} oldUser The user before the update
+       * @param {User} newUser The user after the update
+       */
       client.emit(Events.USER_UPDATE, oldUser, newUser);
       return {
         old: oldUser,

--- a/src/client/actions/UserUpdate.js
+++ b/src/client/actions/UserUpdate.js
@@ -9,6 +9,12 @@ class UserUpdateAction extends Action {
     const oldUser = newUser._update(data.user);
 
     if (!oldUser.equals(newUser)) {
+      /**
+         * Emitted whenever a user's details (e.g. username) are changed.
+         * @event Client#userUpdate
+         * @param {User} oldUser The user before the update
+         * @param {User} newUser The user after the update
+         */
       client.emit(Events.USER_UPDATE, oldUser, newUser);
       return {
         old: oldUser,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds the `Client#userUpdate` docstring - that somehow went missing on master - back

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
