### PR TITLE
fixes 2931 (GuildChannel#clone not taking overwrites into account)

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -401,7 +401,7 @@ class GuildChannel extends Channel {
   clone(name = this.name, withPermissions = true, withTopic = true, reason) {
     return this.guild.createChannel(name, {
       type: this.type,
-      overwritePermissions: withPermissions ? this.overwritePermissions : undefined,
+      permissionOverwrites: withPermissions ? this.permissionOverwrites : undefined,
       topic: withTopic ? this.topic : undefined,
       reason,
     });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Wrong property names as of #2888 resulting in `GuildChannel#clone` ignoring overwrites.
Should fix #2931 

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
