### PR TITLE
chore: Remove User account from Bug Report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,11 +28,11 @@ You won't receive any basic help here.
 - Priority this issue should have – please be realistic and elaborate if possible:
 
 <!--
-If either of these applies to you, please check the respective checkbox: [ ] becomes [x].
+If this applies to you, please check the respective checkbox: [ ] becomes [x].
 You don't have to modify the text to suit your particular situation – if you want to
 elaborate, please do so in the description.
 While it's not a requirement to test your issue on the master branch, it would make fixing
 the problem a lot easier for us, so please do so if possible.
 -->
-- [ ] I found this issue while running code on a __user account__
+
 - [ ] I have also tested the issue on latest master, commit hash:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The following PR deletes the user checkbox from the Bug Report issue template, since Discord.JS version 12 doesn't support user accounts

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
[ ci skip ]