### PR TITLE
fix(Util): throw an explicit error if a chunk exceeds the max length

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -73,8 +73,7 @@ const Messages = {
 
   TYPING_COUNT: 'Count must be at least 1',
 
-  SPLIT_MAX_LEN: 'Message exceeds the max length and contains no split characters.',
-  SPLIT_CHUNK_TOO_LARGE: 'Chunk exceeds max length without a split character.',
+  SPLIT_CHUNK_TOO_LARGE: 'Chunk exceeds max length and contains no split characters.',
 
   BAN_RESOLVE_ID: (ban = false) => `Couldn't resolve the user ID to ${ban ? 'ban' : 'unban'}.`,
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -73,15 +73,13 @@ const Messages = {
 
   TYPING_COUNT: 'Count must be at least 1',
 
-  SPLIT_MAX_LEN: 'Chunk exceeds max length and contains no split characters.',
+  SPLIT_MAX_LEN: 'Chunk exceeds the max length and contains no split characters.',
 
   BAN_RESOLVE_ID: (ban = false) => `Couldn't resolve the user ID to ${ban ? 'ban' : 'unban'}.`,
 
   PRUNE_DAYS_TYPE: 'Days must be a number',
 
   SEARCH_CHANNEL_TYPE: 'Target must be a TextChannel, DMChannel, GroupDMChannel, or Guild.',
-
-  MESSAGE_SPLIT_MISSING: 'Message exceeds the max length and contains no split characters.',
 
   GUILD_CHANNEL_RESOLVE: 'Could not resolve channel to a guild channel.',
   GUILD_CHANNEL_ORPHAN: 'Could not find a parent to this guild channel.',

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -73,7 +73,7 @@ const Messages = {
 
   TYPING_COUNT: 'Count must be at least 1',
 
-  SPLIT_CHUNK_TOO_LARGE: 'Chunk exceeds max length and contains no split characters.',
+  SPLIT_MAX_LEN: 'Chunk exceeds max length and contains no split characters.',
 
   BAN_RESOLVE_ID: (ban = false) => `Couldn't resolve the user ID to ${ban ? 'ban' : 'unban'}.`,
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -74,6 +74,7 @@ const Messages = {
   TYPING_COUNT: 'Count must be at least 1',
 
   SPLIT_MAX_LEN: 'Message exceeds the max length and contains no split characters.',
+  SPLIT_CHUNK_TOO_LARGE: 'Chunk exceeds max length without a split character.',
 
   BAN_RESOLVE_ID: (ban = false) => `Couldn't resolve the user ID to ${ban ? 'ban' : 'unban'}.`,
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -56,13 +56,10 @@ class Util {
   static splitMessage(text, { maxLength = 2000, char = '\n', prepend = '', append = '' } = {}) {
     if (text.length <= maxLength) return text;
     const splitText = text.split(char);
-    if (splitText.length === 1) throw new RangeError('SPLIT_MAX_LEN');
+    if (splitText.some(chunk => chunk.length > maxLength)) throw new RangeError('SPLIT_CHUNK_TOO_LARGE');
     const messages = [];
     let msg = '';
     for (const chunk of splitText) {
-      if (chunk.length > maxLength) {
-        throw new RangeError('SPLIT_CHUNK_TOO_LARGE');
-      }
       if (msg && (msg + char + chunk + append).length > maxLength) {
         messages.push(msg + append);
         msg = prepend;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -60,6 +60,9 @@ class Util {
     const messages = [];
     let msg = '';
     for (const chunk of splitText) {
+      if (chunk.length > maxLength) {
+        throw new RangeError('SPLIT_CHUNK_TOO_LARGE');
+      }
       if (msg && (msg + char + chunk + append).length > maxLength) {
         messages.push(msg + append);
         msg = prepend;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -56,7 +56,7 @@ class Util {
   static splitMessage(text, { maxLength = 2000, char = '\n', prepend = '', append = '' } = {}) {
     if (text.length <= maxLength) return text;
     const splitText = text.split(char);
-    if (splitText.some(chunk => chunk.length > maxLength)) throw new RangeError('SPLIT_CHUNK_TOO_LARGE');
+    if (splitText.some(chunk => chunk.length > maxLength)) throw new RangeError('SPLIT_MAX_LEN');
     const messages = [];
     let msg = '';
     for (const chunk of splitText) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This will cause the `Util.splitMessage` function to throw an error if a chunk is too large after splitting.
This is to fix #2935 and seems to be the intended behaviour, looking at the other error being thrown (`SPLIT_MAX_LEN`) in case of the message being too long without a split char.

Also gets rid of a duplicated error code.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
