### PR TITLE
feat(GuildChannel): allow to set all options when cloning

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -447,35 +447,37 @@ class GuildChannel extends Channel {
     return invites;
   }
 
+  /* eslint-disable max-len */
   /**
    * Clones this channel.
    * @param {Object} [options] The options
-   * @param {string} [options.name=this.name] Optional name for the new channel, otherwise it has the name
-   * of this channel
-   * @param {boolean} [options.withPermissions=true] Whether to clone the channel with this channel's
-   * permission overwrites
-   * @param {boolean} [options.withTopic=true] Whether to clone the channel with this channel's topic
+   * @param {string} [options.name=this.name] Name of the new channel
+   * @param {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [options.permissionOverwrites=this.permissionOverwrites]
+   * Permission overwrites of the new channel
+   * @param {string} [options.type=this.type] Type of the new channel
+   * @param {string} [options.topic=this.topic] Topic of the new channel (only text)
    * @param {boolean} [options.nsfw=this.nsfw] Whether the new channel is nsfw (only text)
    * @param {number} [options.bitrate=this.bitrate] Bitrate of the new channel in bits (only voice)
    * @param {number} [options.userLimit=this.userLimit] Maximum amount of users allowed in the new channel (only voice)
-   * @param {ChannelResolvable} [options.parent=this.parent] The parent of the new channel
+   * @param {number} [options.rateLimitPerUser=ThisType.rateLimitPerUser] Ratelimit per user for the new channel (only text)
+   * @param {ChannelResolvable} [options.parent=this.parent] Parent of the new channel
    * @param {string} [options.reason] Reason for cloning this channel
    * @returns {Promise<GuildChannel>}
    */
+  /* eslint-enable max-len */
   clone(options = {}) {
-    if (typeof options.withPermissions === 'undefined') options.withPermissions = true;
-    if (typeof options.withTopic === 'undefined') options.withTopic = true;
     Util.mergeDefault({
       name: this.name,
-      permissionOverwrites: options.withPermissions ? this.permissionOverwrites : [],
-      topic: options.withTopic ? this.topic : undefined,
+      permissionOverwrites: this.permissionOverwrites,
+      topic: this.topic,
+      type: this.type,
       nsfw: this.nsfw,
       parent: this.parent,
       bitrate: this.bitrate,
       userLimit: this.userLimit,
+      rateLimitPerUser: this.rateLimitPerUser,
       reason: null,
     }, options);
-    options.type = this.type;
     return this.guild.channels.create(options.name, options);
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -523,7 +523,7 @@ declare module 'discord.js' {
 		public readonly permissionsLocked: boolean;
 		public readonly position: number;
 		public rawPosition: number;
-		public clone(options?: GuildChannelCloneOptions): Promise<GuildChannel>;
+		public clone(options?: GuildCreateChannelOptions): Promise<GuildChannel>;
 		public createInvite(options?: InviteOptions): Promise<Invite>;
 		public createOverwrite(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<GuildChannel>;
 		public edit(data: ChannelData, reason?: string): Promise<GuildChannel>;
@@ -1770,17 +1770,6 @@ declare module 'discord.js' {
 		WEBHOOK?: string;
 		EMOJI?: string;
 		MESSAGE?: string;
-	};
-
-	type GuildChannelCloneOptions = {
-		bitrate?: number;
-		name?: string;
-		nsfw?: boolean;
-		parent?: ChannelResolvable;
-		reason?: string;
-		userLimit?: number;
-		withPermissions?: boolean;
-		withTopic?: boolean;
 	};
 
 	type GuildChannelResolvable = Snowflake | GuildChannel;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR allows to specify a different `topic` and `permissionOverwrites` when cloning a `GuildChannel` (rather than current one or none).
Additionally it allows you to set a `type`, and clone / override the current `rateLimitPerUser` (if text).

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
