### PR TITLE
Add explicit channel resolve error to member edit

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -84,6 +84,7 @@ const Messages = {
   MESSAGE_SPLIT_MISSING: 'Message exceeds the max length and contains no split characters.',
 
   GUILD_CHANNEL_RESOLVE: 'Could not resolve channel to a guild channel.',
+	GUILD_VOICE_CHANNEL_RESOLVE: 'Could not resolve channel to a guild voice channel.',
   GUILD_CHANNEL_ORPHAN: 'Could not find a parent to this guild channel.',
   GUILD_OWNED: 'Guild is owned by the client.',
   GUILD_RESTRICTED: (state = false) => `Guild is ${state ? 'already' : 'not'} restricted.`,

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -84,7 +84,7 @@ const Messages = {
   MESSAGE_SPLIT_MISSING: 'Message exceeds the max length and contains no split characters.',
 
   GUILD_CHANNEL_RESOLVE: 'Could not resolve channel to a guild channel.',
-	GUILD_VOICE_CHANNEL_RESOLVE: 'Could not resolve channel to a guild voice channel.',
+  GUILD_VOICE_CHANNEL_RESOLVE: 'Could not resolve channel to a guild voice channel.',
   GUILD_CHANNEL_ORPHAN: 'Could not find a parent to this guild channel.',
   GUILD_OWNED: 'Guild is owned by the client.',
   GUILD_RESTRICTED: (state = false) => `Guild is ${state ? 'already' : 'not'} restricted.`,

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -248,7 +248,7 @@ class GuildMember extends Base {
    */
   edit(data, reason) {
     if (data.channel) {
-      data.channel = this.client.channels.resolve(data.channel);
+      data.channel = this.guild.channels.resolve(data.channel);
       if (!data.channel) throw new Error('GUILD_CHANNEL_RESOLVE');
       data.channel_id = data.channel.id;
       data.channel = null;

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -248,7 +248,9 @@ class GuildMember extends Base {
    */
   edit(data, reason) {
     if (data.channel) {
-      data.channel_id = this.client.channels.resolve(data.channel).id;
+      data.channel = this.client.channels.resolve(data.channel);
+      if (!data.channel) throw new Error('GUILD_CHANNEL_RESOLVE');
+      data.channel_id = data.channel.id;
       data.channel = null;
     }
     if (data.roles) data.roles = data.roles.map(role => role instanceof Role ? role.id : role);

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -249,7 +249,9 @@ class GuildMember extends Base {
   edit(data, reason) {
     if (data.channel) {
       data.channel = this.guild.channels.resolve(data.channel);
-      if (!data.channel) throw new Error('GUILD_CHANNEL_RESOLVE');
+      if (!data.channel || data.channel.type !== 'voice') {
+        throw new Error('GUILD_VOICE_CHANNEL_RESOLVE');
+      }
       data.channel_id = data.channel.id;
       data.channel = null;
     }


### PR DESCRIPTION
Currently if one does `<member>.edit({channel: 'invalidChannel'})`, whether it's a bad channel id, a random string or whatever, you get the error 
```
TypeError: Cannot read property 'id' of null
 at Object.edit (/.../node_modules/discord.js/src/structures/GuildMember.js:251:67)
```

Adding the explicit error here might make the issue a bit more clear to users.


**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
