### PR TITLE
[WIP] Added more accurate typing for GuildChannelStore.create

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1346,7 +1346,9 @@ declare module 'discord.js' {
 
 	export class GuildChannelStore extends DataStore<Snowflake, GuildChannel, typeof GuildChannel, GuildChannelResolvable> {
 		constructor(guild: Guild, iterable?: Iterable<any>);
-		public create(name: string, options?: GuildCreateChannelOptions): Promise<TextChannel | VoiceChannel>;
+		public create(name: string, options?: GuildCreateTextChannelOptions): Promise<TextChannel>;
+		public create(name: string, options?: GuildCreateVoiceChannelOptions): Promise<VoiceChannel>;
+		public create(name: string, options?: GuildCreateCategoryChannelOptions): Promise<CategoryChannel>;
 	}
 
 	// Hacky workaround because changing the signature of an overriden method errors
@@ -1774,16 +1776,29 @@ declare module 'discord.js' {
 
 	type GuildChannelResolvable = Snowflake | GuildChannel;
 
-	type GuildCreateChannelOptions = {
-		type?: 'text' | 'voice' | 'category'
+	type GuildCreateChannelPartial = {
+		permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
+		reason?: string;
+	};
+	
+	type GuildCreateTextChannelOptions = {
+		type?: 'text';
 		nsfw?: boolean;
+		topic?: string;
+		parent?: ChannelResolvable;
+		rateLimitPerUser?: number;
+	} & GuildCreateChannelPartial;
+	
+	type GuildCreateVoiceChannelOptions = {
+		type?: 'voice';
+		parent?: ChannelResolvable;
 		bitrate?: number;
 		userLimit?: number;
-		parent?: ChannelResolvable;
-		permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
-		rateLimitPerUser?: number;
-		reason?: string
-	};
+	} & GuildCreateChannelPartial;
+
+	type GuildCreateCategoryChannelOptions = {
+		type?: 'category';
+	} & GuildCreateChannelPartial;
 
 	type GuildEmojiCreateOptions = {
 		roles?: Collection<Snowflake, Role> | RoleResolvable[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1790,14 +1790,14 @@ declare module 'discord.js' {
 	} & GuildCreateChannelPartial;
 	
 	type GuildCreateVoiceChannelOptions = {
-		type?: 'voice';
+		type: 'voice';
 		parent?: ChannelResolvable;
 		bitrate?: number;
 		userLimit?: number;
 	} & GuildCreateChannelPartial;
 
 	type GuildCreateCategoryChannelOptions = {
-		type?: 'category';
+		type: 'category';
 	} & GuildCreateChannelPartial;
 
 	type GuildEmojiCreateOptions = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1780,7 +1780,7 @@ declare module 'discord.js' {
 		permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
 		reason?: string;
 	};
-	
+
 	type GuildCreateTextChannelOptions = {
 		type?: 'text';
 		nsfw?: boolean;
@@ -1788,7 +1788,7 @@ declare module 'discord.js' {
 		parent?: ChannelResolvable;
 		rateLimitPerUser?: number;
 	} & GuildCreateChannelPartial;
-	
+
 	type GuildCreateVoiceChannelOptions = {
 		type: 'voice';
 		parent?: ChannelResolvable;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

A small change to the typing of the `GuildChannelStore#create` which

- Adds the missing `topic` option
- Only allows compatible properties
- Makes the return type accurate to the options given

There are a few problems that need to be resolved though, this typing only allows a valid options object, however it throws unhelpful errors, and doesn't seem to support vscode's intellisense properly

```js
Guild.channels.create('my-channel', {
  type: 'voice', // error TS2322: Type '"voice"' is not assignable to type '"category"'
  topic: 'A Channel by a Bot'
})
// Preferred error would be:
// TS2322: Type '{ type: 'voice',  topic: 'A Channel by a Bot' }' is not assignable to type 'GuildCreateVoiceChannelOptions'.
// Object literal may only specify known properties, and 'topic' does not exist in type 'GuildCreateVoiceChannelOptions'
```
```js
Guild.channels.create('my-channel', {
  type: 'text',
  top // Does not autocomplete to 'topic'
})
```
**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
