### PR TITLE
feat(GuildChannelStore): add support for create to accept a position

### DIFF
--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -33,6 +33,7 @@ class GuildChannelStore extends DataStore {
    * @param {ChannelResolvable} [options.parent] Parent of the new channel
    * @param {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [options.permissionOverwrites]
    * Permission overwrites of the new channel
+   * @param {number} [options.position] Position of the new channel
    * @param {number} [options.rateLimitPerUser] The ratelimit per user for the channel
    * @param {string} [options.reason] Reason for creating the channel
    * @returns {Promise<GuildChannel>}
@@ -54,7 +55,18 @@ class GuildChannelStore extends DataStore {
    * })
    */
   async create(name, options = {}) {
-    let { type, topic, nsfw, bitrate, userLimit, parent, permissionOverwrites, rateLimitPerUser, reason } = options;
+    let {
+      type,
+      topic,
+      nsfw,
+      bitrate,
+      userLimit,
+      parent,
+      permissionOverwrites,
+      position,
+      rateLimitPerUser,
+      reason,
+    } = options;
     if (parent) parent = this.client.channels.resolveID(parent);
     if (permissionOverwrites) {
       permissionOverwrites = permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
@@ -69,6 +81,7 @@ class GuildChannelStore extends DataStore {
         bitrate,
         user_limit: userLimit,
         parent_id: parent,
+        position,
         permission_overwrites: permissionOverwrites,
         rate_limit_per_user: rateLimitPerUser,
       },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1782,6 +1782,7 @@ declare module 'discord.js' {
 		parent?: ChannelResolvable;
 		permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
 		rateLimitPerUser?: number;
+		position?: number;
 		reason?: string
 	};
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds support for `GuildChannelStore#create` to accept a position option directly.
See [Discord Docs](https://discordapp.com/developers/docs/resources/guild#create-guild-channel) on that endpoint.

**"Issue"**
This currently accepts `position` as `GuildChannel#rawPosition` and not as `GuildChannel#position` (the calculated one).
- Should it be the other way? (Potentially a bit more complicated to achieve)
- Should that behaviour additionally be documented?
- Or is it fine as is?

**Status**
- [x] ~~Resolve ^~~ "rawPosition" it is then.
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
