### PR TITLE
<channel>.readable

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -514,7 +514,17 @@ class GuildChannel extends Channel {
   get deletable() {
     return this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false);
   }
-
+  
+  /**
+   * Whether the channel is readable by the client user
+   * @type {boolean}
+   * @readonly
+   */
+  
+  get readable() {
+    return this.permissionsFor(this.client.user).has(Permissions.FLAGS.VIEW_CHANNEL, false);
+  }
+  
   /**
    * Whether the channel is manageable by the client user
    * @type {boolean}


### PR DESCRIPTION
Instead of checking permissions for the client user to see if they have VIEW_CHANNEL, now it just takes <channel>.readable

**Please describe the changes this PR makes and why it should be merged:**
Well, I simply copied how <channel>.deleteable is and added a readable. I think this should be added only because it's more convenient then needing to check if the client user has VIEW_CHANNEL in that channel.


**Status**
- Updated Typings

**Semantic versioning classification:**  
- Param added