### PR TITLE
[RFC] fix: Sharding issues, silent disconnects and code cleanup

### DIFF
--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -245,6 +245,7 @@ class WebSocketManager {
    * @private
    */
   destroy() {
+    if (this.expectingClose) return;
     this.expectingClose = true;
     for (const shard of this.shards.values()) shard.destroy();
   }

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -78,7 +78,7 @@ class WebSocketManager {
     this.sessionStartLimit = null;
 
     /**
-     * If the manager is currently reconnecting a shard
+     * If the manager is currently reconnecting shards
      * @type {boolean}
      * @private
      */

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -21,53 +21,53 @@ const BeforeReadyWhitelist = [
 class WebSocketManager {
   constructor(client) {
     /**
-     * The client that instantiated this WebSocketManager.
+     * The client that instantiated this WebSocketManager
      * @type {Client}
      * @readonly
      */
     Object.defineProperty(this, 'client', { value: client });
 
     /**
-     * The gateway this manager uses.
+     * The gateway this manager uses
      * @type {?string}
      */
     this.gateway = undefined;
 
     /**
-     * A collection of all shards this manager handles.
+     * A collection of all shards this manager handles
      * @type {Collection<number, WebSocketShard>}
      */
     this.shards = new Collection();
 
     /**
-     * An array of shards to be spawned.
+     * An array of shards to be spawned
      * @type {Array<number>}
      * @private
      */
     this.spawnQueue = [];
 
     /**
-     * An array of queued events before this WebSocketManager became ready.
+     * An array of queued events before this WebSocketManager became ready
      * @type {object[]}
      * @private
      */
     this.packetQueue = [];
 
     /**
-     * The current status of this WebSocketManager.
+     * The current status of this WebSocketManager
      * @type {number}
      */
     this.status = Status.IDLE;
 
     /**
-     * If this manager is expected to close.
+     * If this manager is expected to close
      * @type {boolean}
      * @private
      */
     this.expectingClose = false;
 
     /**
-     * The current session limit of the client.
+     * The current session limit of the client
      * @type {?Object}
      * @private
      * @prop {number} total Total number of identifies available
@@ -78,7 +78,7 @@ class WebSocketManager {
   }
 
   /**
-   * The average ping of all WebSocketShards
+   * The average ping of all WebSocketShards.
    * @type {number}
    * @readonly
    */

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -162,16 +162,16 @@ class WebSocketManager {
     if (typeof item === 'string' && !isNaN(item)) item = Number(item);
 
     if (item instanceof WebSocketShard) {
-      item.once(Events.READY, this._shardReady.bind(this, item));
-      item.once(Events.RESUMED, this._shardReady.bind(this, item));
+      item.once(Events.READY, this._shardReady.bind(this));
+      item.once(Events.RESUMED, this._shardReady.bind(this));
       item.connect();
       return;
     }
 
     const shard = new WebSocketShard(this, item);
     this.shards.set(item, shard);
-    shard.once(Events.READY, this._shardReady.bind(this, shard));
-    shard.once(Events.RESUMED, this._shardReady.bind(this, shard));
+    shard.once(Events.READY, this._shardReady.bind(this));
+    shard.once(Events.RESUMED, this._shardReady.bind(this));
   }
 
   /**

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -162,7 +162,7 @@ class WebSocketManager {
   }
 
   /**
-   * Handles the reconnect of a shard
+   * Handles the reconnect of a shard.
    * @param {WebSocketShard} shard The shard to reconnect
    * @private
    */

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -86,7 +86,7 @@ class WebSocketManager {
   }
 
   /**
-   * The average ping of all WebSocketShards.
+   * The average ping of all WebSocketShards
    * @type {number}
    * @readonly
    */
@@ -318,7 +318,7 @@ class WebSocketManager {
   }
 
   /**
-   * Destroys all shards
+   * Destroys all shards.
    * @private
    */
   destroy() {

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -94,7 +94,7 @@ class WebSocketManager {
    * @private
    */
   debug(message) {
-    this.client.emit(Events.WSDEBUG, message);
+    this.client.emit(Events.DEBUG, message);
   }
 
   /**

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -175,7 +175,7 @@ class WebSocketManager {
   }
 
   /**
-   * Shared handler for shards turning ready
+   * Shared handler for shards turning ready or resuming.
    * @private
    */
   _shardReady() {

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -173,8 +173,7 @@ class WebSocketManager {
         this.debug(`Exceeded identify threshold, setting a timeout for ${canSpawn} ms`);
         await Util.delayFor(canSpawn);
       }
-      const newShard = new WebSocketShard(this, shard.id);
-      this.shards.set(shard.id, newShard);
+      shard.connect();
     } catch (error) {
       // If we get an error here, that means the token was invalidated
       if (this.client.listenerCount(Events.INVALIDATED)) {

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -197,7 +197,7 @@ class WebSocketManager {
     try {
       await this._handleSessionLimit();
     } catch (error) {
-      // If we get an error here, that means the token was invalidated
+      // If we get an error at this point, it means we cannot reconnect anymore
       if (this.client.listenerCount(Events.INVALIDATED)) {
         /**
          * Emitted when the client's session becomes invalidated.

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -207,7 +207,9 @@ class WebSocketManager {
       // If we get an error here, that means the token was invalidated
       if (this.client.listenerCount(Events.INVALIDATED)) {
         /**
-         * Emitted when the client's session became invalidated.
+         * Emitted when the client's session becomes invalidated.
+         * You are expected to handle closing the process gracefully and preventing a boot loop
+         * if you are listening to this event.
          * @event Client#invalidated
          */
         this.client.emit(Events.INVALIDATED);

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -176,10 +176,9 @@ class WebSocketManager {
 
   /**
    * Shared handler for shards turning ready
-   * @param {WebSocketShard} shard The shard to cleanup the handler for
    * @private
    */
-  _shardReady(shard) {
+  _shardReady() {
     if (this.shardQueue.length) {
       this.client.setTimeout(this._handleSessionLimit.bind(this), 5000);
     } else {

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -29,7 +29,7 @@ class WebSocketManager {
 
     /**
      * The gateway this manager uses.
-     * @type {string}
+     * @type {?string}
      */
     this.gateway = undefined;
 

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -21,39 +21,39 @@ class WebSocketShard extends EventEmitter {
     super();
 
     /**
-     * The WebSocket Manager of this connection.
+     * The WebSocket Manager of this connection
      * @type {WebSocketManager}
      */
     this.manager = manager;
 
     /**
-     * The id of the this shard.
+     * The id of the this shard
      * @type {number}
      */
     this.id = id;
 
     /**
-     * The current status of the shard.
+     * The current status of the shard
      * @type {Status}
      */
     this.status = Status.IDLE;
 
     /**
-     * The current sequence of the shard.
+     * The current sequence of the shard
      * @type {number}
      * @private
      */
     this.sequence = -1;
 
     /**
-     * The current session ID of the shard.
+     * The current session ID of the shard
      * @type {string}
      * @private
      */
     this.sessionID = undefined;
 
     /**
-     * The previous 3 heartbeat pings of the shard (most recent first).
+     * The previous 3 heartbeat pings of the shard (most recent first)
      * @type {number[]}
      */
     this.pings = [];
@@ -66,7 +66,7 @@ class WebSocketShard extends EventEmitter {
     this.lastPingTimestamp = -1;
 
     /**
-     * If we received a heartbeat ack back. Used to identify zombie connections.
+     * If we received a heartbeat ack back. Used to identify zombie connections
      * @type {boolean}
      * @private
      */

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -309,11 +309,11 @@ class WebSocketShard extends EventEmitter {
           if (this.sessionID) {
             this.sessionID = null;
             await Util.delayFor(2500);
-            this.identify();
+            this.connection.close(1000);
             return;
           }
           await Util.delayFor(5000);
-          this.identify();
+          this.connection.close(1000);
           return;
         }
         this.identifyResume();
@@ -331,12 +331,10 @@ class WebSocketShard extends EventEmitter {
 
   /**
    * Identifies the client on a connection.
-   * @param {?number} [wait=0] Amount of time to wait before identifying
    * @returns {void}
    * @private
    */
-  identify(wait = 0) {
-    if (wait) return this.manager.client.setTimeout(this.identify.bind(this), wait);
+  identify() {
     return this.sessionID ? this.identifyResume() : this.identifyNew();
   }
 

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -310,11 +310,11 @@ class WebSocketShard extends EventEmitter {
           if (this.sessionID) {
             this.sessionID = null;
             await Util.delayFor(2500);
-            this.identify();
+            this.connection.close(1000);
             return;
           }
           await Util.delayFor(5000);
-          this.identify();
+          this.connection.close(1000);
           return;
         }
         this.identifyResume();

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -420,6 +420,22 @@ class WebSocketShard extends EventEmitter {
       this.debug(WSCodes[event.code]);
       return;
     }
+    // Emitted when you reset the token and have an already existent session
+    if (event.code === 4003) {
+      this.debug('Session was invalidated (token reset)');
+      if (this.manager.client.listenerCount(Events.INVALIDATED)) {
+        /**
+         * Emitted when the client's session became invalidated.
+         * @event Client#invalidated
+         */
+        this.manager.client.emit(Events.INVALIDATED);
+        // Destroy just the shards. This means you have to handle the cleanup yourself
+        this.manager.destroy();
+      } else {
+        this.manager.client.destroy();
+      }
+      return;
+    }
 
     this.reconnect();
   }

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -513,7 +513,6 @@ class WebSocketShard extends EventEmitter {
       this.manager.client.clearTimeout(this.ratelimit.timer);
       this.ratelimit.timer = null;
     }
-    this.inflate.push('', zlib.Z_SYNC_FLUSH);
   }
 }
 

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -243,20 +243,6 @@ class WebSocketShard extends EventEmitter {
       this.manager.client.emit(Events.ERROR, err);
       return;
     }
-    if (packet.t === WSEvents.READY) {
-      /**
-       * Emitted when a shard becomes ready.
-       * @event WebSocketShard#ready
-       */
-      this.emit(Events.READY);
-
-      /**
-       * Emitted when a shard becomes ready.
-       * @event Client#shardReady
-       * @param {number} shardID The ID of the shard
-       */
-      this.manager.client.emit(Events.SHARD_READY, this.id);
-    }
     this.onPacket(packet);
   }
 
@@ -267,12 +253,24 @@ class WebSocketShard extends EventEmitter {
    */
   async onPacket(packet) {
     if (!packet) {
-      this.debug('Received null packet');
+      this.debug('Received null or broken packet');
       return;
     }
 
     switch (packet.t) {
       case WSEvents.READY:
+        /**
+         * Emitted when a shard becomes ready.
+         * @event WebSocketShard#ready
+         */
+        this.emit(Events.READY);
+        /**
+         * Emitted when a shard becomes ready.
+         * @event Client#shardReady
+         * @param {number} shardID The ID of the shard
+         */
+        this.manager.client.emit(Events.SHARD_READY, this.id);
+
         this.sessionID = packet.d.session_id;
         this.trace = packet.d._trace;
         this.status = Status.READY;

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -429,9 +429,9 @@ class WebSocketShard extends EventEmitter {
       return;
     }
 
-    this.debug('Queueing a reconnect to the gateway...');
-
     this.destroy();
+
+    this.debug('Queueing a reconnect to the gateway...');
 
     this.status = Status.RECONNECTING;
 

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -14,7 +14,7 @@ try {
 }
 
 /**
- * Represents a shard Websocket connection.
+ * Represents a Shard's WebSocket connection
  */
 class WebSocketShard extends EventEmitter {
   constructor(manager, id) {
@@ -27,7 +27,7 @@ class WebSocketShard extends EventEmitter {
     this.manager = manager;
 
     /**
-     * The id of the this shard
+     * The ID of the this shard
      * @type {number}
      */
     this.id = id;
@@ -499,7 +499,7 @@ class WebSocketShard extends EventEmitter {
   }
 
   /**
-   * Destroys this shard, and closes its connection.
+   * Destroys this shard and closes its connection.
    * @private
    */
   destroy() {

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -3,7 +3,6 @@
 const EventEmitter = require('events');
 const WebSocket = require('../../WebSocket');
 const { Status, Events, OPCodes, WSEvents, WSCodes } = require('../../util/Constants');
-const Util = require('../../util/Util');
 
 let zlib;
 try {
@@ -251,7 +250,7 @@ class WebSocketShard extends EventEmitter {
    * @param {Object} packet Packet received
    * @private
    */
-  async onPacket(packet) {
+  onPacket(packet) {
     if (!packet) {
       this.debug('Received null or broken packet');
       return;

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -424,6 +424,7 @@ class WebSocketShard extends EventEmitter {
   /**
    * Adds data to the queue to be sent.
    * @param {Object} data Packet to send
+   * @private
    * @returns {void}
    */
   send(data) {

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -431,7 +431,7 @@ class WebSocketShard extends EventEmitter {
 
     this.destroy();
 
-    this.debug('Queueing a reconnect to the gateway...');
+    this.debug(`${this.sessionID ? 'Immediately reconnecting' : 'Queueing a reconnect'} to the gateway...`);
 
     this.status = Status.RECONNECTING;
 
@@ -442,7 +442,11 @@ class WebSocketShard extends EventEmitter {
      */
     this.manager.client.emit(Events.RECONNECTING, this.id);
 
-    this.manager.reconnect(this);
+    if (this.sessionID) {
+      this.connect();
+    } else {
+      this.manager.reconnect(this);
+    }
   }
 
   /**

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -277,7 +277,6 @@ class WebSocketShard extends EventEmitter {
         this.debug(`READY ${this.trace.join(' -> ')} | Session ${this.sessionID}`);
         this.lastHeartbeatAcked = true;
         this.sendHeartbeat();
-        this.reconnecting = false;
         break;
       case WSEvents.RESUMED: {
         this.trace = packet.d._trace;
@@ -286,7 +285,6 @@ class WebSocketShard extends EventEmitter {
         this.debug(`RESUMED ${this.trace.join(' -> ')} | replayed ${replayed} events.`);
         this.lastHeartbeatAcked = true;
         this.sendHeartbeat();
-        this.reconnecting = false;
         break;
       }
     }

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -297,7 +297,7 @@ class WebSocketShard extends EventEmitter {
         this.setHeartbeatTimer(packet.d.heartbeat_interval);
         break;
       case OPCodes.RECONNECT:
-        this.reconnect();
+        this.connection.close(1000);
         break;
       case OPCodes.INVALID_SESSION:
         this.debug(`Session was invalidated. ${packet.d ? 'Trying to resume' : 'Identifying as a new session'}.`);

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -432,6 +432,8 @@ class WebSocketShard extends EventEmitter {
 
     this.debug('Reconnecting to the gateway...');
 
+    this.destroy();
+
     this.status = Status.RECONNECTING;
 
     /**
@@ -440,8 +442,6 @@ class WebSocketShard extends EventEmitter {
      * @param {number} shardID The shard ID that is reconnecting
      */
     this.manager.client.emit(Events.RECONNECTING, this.id);
-
-    this.destroy();
 
     if (this.sessionID) {
       this.connect();

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('events');
 const WebSocket = require('../../WebSocket');
 const { Status, Events, OPCodes, WSEvents, WSCodes } = require('../../util/Constants');
+const Util = require('../../util/Util');
 
 let zlib;
 try {
@@ -255,7 +256,7 @@ class WebSocketShard extends EventEmitter {
    * @param {Object} packet Packet received
    * @private
    */
-  onPacket(packet) {
+  async onPacket(packet) {
     if (!packet) {
       this.debug('Received null packet');
       return;
@@ -300,13 +301,15 @@ class WebSocketShard extends EventEmitter {
           // If we had a session ID before
           if (this.sessionID) {
             this.sessionID = null;
-            this.identify(2500);
+            await Util.delayFor(2500);
+            this.reconnect();
             return;
           }
-          this.identify(5000);
+          await Util.delayFor(5000);
+          this.reconnect();
           return;
         }
-        this.identify();
+        this.reconnect();
         break;
       case OPCodes.HEARTBEAT_ACK:
         this.ackHeartbeat();

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -502,7 +502,6 @@ class WebSocketShard extends EventEmitter {
 
   /**
    * Destroys this shard, and closes its connection.
-   * @param {number} [closeCode=1000] The WS Close code
    * @private
    */
   destroy() {

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events');
 const WebSocket = require('../../WebSocket');
 const { Status, Events, OPCodes, WSEvents, WSCodes } = require('../../util/Constants');
-const Util = require('../../util/Util');
+
 let zlib;
 try {
   zlib = require('zlib-sync');
@@ -13,14 +13,14 @@ try {
 }
 
 /**
- * Represents a Shard's Websocket connection.
+ * Represents a shard Websocket connection.
  */
 class WebSocketShard extends EventEmitter {
-  constructor(manager, id, oldShard) {
+  constructor(manager, id) {
     super();
 
     /**
-     * The WebSocket Manager of this connection
+     * The WebSocket Manager of this connection.
      * @type {WebSocketManager}
      */
     this.manager = manager;
@@ -32,34 +32,27 @@ class WebSocketShard extends EventEmitter {
     this.id = id;
 
     /**
-     * The current status of the shard
+     * The current status of the shard.
      * @type {Status}
      */
     this.status = Status.IDLE;
 
     /**
-     * The current sequence of the WebSocket
+     * The current sequence of the shard.
      * @type {number}
      * @private
      */
-    this.sequence = oldShard ? oldShard.sequence : -1;
+    this.sequence = -1;
 
     /**
-     * The sequence on WebSocket close
-     * @type {number}
+     * The current session ID of the shard.
+     * @type {string}
      * @private
      */
-    this.closeSequence = 0;
+    this.sessionID = undefined;
 
     /**
-     * The current session id of the WebSocket
-     * @type {?string}
-     * @private
-     */
-    this.sessionID = oldShard && oldShard.sessionID;
-
-    /**
-     * Previous heartbeat pings of the websocket (most recent first, limited to three elements)
+     * The previous 3 heartbeat pings of the shard (most recent first).
      * @type {number[]}
      */
     this.pings = [];
@@ -70,6 +63,13 @@ class WebSocketShard extends EventEmitter {
      * @private
      */
     this.lastPingTimestamp = -1;
+
+    /**
+     * If we received a heartbeat ack back. Used to identify zombie connections.
+     * @type {boolean}
+     * @private
+     */
+    this.lastHeartbeatAcked = true;
 
     /**
      * List of servers the shard is connected to
@@ -96,7 +96,7 @@ class WebSocketShard extends EventEmitter {
      * @type {?WebSocket}
      * @private
      */
-    this.ws = null;
+    this.connection = null;
 
     /**
      * @external Inflate
@@ -110,13 +110,7 @@ class WebSocketShard extends EventEmitter {
      */
     this.inflate = null;
 
-    /**
-     * Whether or not the WebSocket is expected to be closed
-     * @type {boolean}
-     */
-    this.expectingClose = false;
-
-    this.connect();
+    if (this.manager.gateway) this.connect();
   }
 
   /**
@@ -135,35 +129,40 @@ class WebSocketShard extends EventEmitter {
    * @private
    */
   debug(message) {
-    this.manager.debug(`[shard ${this.id}] ${message}`);
+    this.manager.debug(`[Shard ${this.id}] ${message}`);
   }
 
   /**
-   * Sends a heartbeat or sets an interval for sending heartbeats.
-   * @param {number} [time] If -1, clears the interval, any other number sets an interval
-   * If no value is given, a heartbeat will be sent instantly
+   * Sends a heartbeat to the WebSocket.
+   * If this shard didn't receive a heartbeat last time, it will destroy it and reconnect
    * @private
    */
-  heartbeat(time) {
-    if (!isNaN(time)) {
-      if (time === -1) {
-        this.debug('Clearing heartbeat interval');
-        this.manager.client.clearInterval(this.heartbeatInterval);
-        this.heartbeatInterval = null;
-      } else {
-        this.debug(`Setting a heartbeat interval for ${time}ms`);
-        if (this.heartbeatInterval) this.manager.client.clearInterval(this.heartbeatInterval);
-        this.heartbeatInterval = this.manager.client.setInterval(() => this.heartbeat(), time);
-      }
+  sendHeartbeat() {
+    if (!this.lastHeartbeatAcked) {
+      this.debug("Didn't receive a heartbeat ack last time, assuming zombie conenction. Destroying and reconnecting.");
+      this.reconnect();
       return;
     }
-
     this.debug('Sending a heartbeat');
+    this.lastHeartbeatAcked = false;
     this.lastPingTimestamp = Date.now();
-    this.send({
-      op: OPCodes.HEARTBEAT,
-      d: this.sequence,
-    });
+    this.send({ op: OPCodes.HEARTBEAT, d: this.sequence });
+  }
+
+  /**
+   * Sets the heartbeat timer for this shard.
+   * @param {number} time If -1, clears the interval, any other number sets an interval
+   * @private
+   */
+  setHeartbeatTimer(time) {
+    if (time === -1) {
+      this.debug('Clearing heartbeat interval');
+      this.manager.client.clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+      return;
+    }
+    this.debug(`Setting a heartbeat interval for ${time}ms`);
+    this.heartbeatInterval = this.manager.client.setInterval(() => this.sendHeartbeat(), time);
   }
 
   /**
@@ -171,6 +170,7 @@ class WebSocketShard extends EventEmitter {
    * @private
    */
   ackHeartbeat() {
+    this.lastHeartbeatAcked = true;
     const latency = Date.now() - this.lastPingTimestamp;
     this.debug(`Heartbeat acknowledged, latency of ${latency}ms`);
     this.pings.unshift(latency);
@@ -178,18 +178,19 @@ class WebSocketShard extends EventEmitter {
   }
 
   /**
-   * Connects the shard to a gateway.
+   * Connects this shard to the gateway.
    * @private
    */
   connect() {
+    const { expectingClose, gateway } = this.manager;
+    if (expectingClose) return;
     this.inflate = new zlib.Inflate({
       chunkSize: 65535,
       flush: zlib.Z_SYNC_FLUSH,
       to: WebSocket.encoding === 'json' ? 'string' : '',
     });
-    const gateway = this.manager.gateway;
     this.debug(`Connecting to ${gateway}`);
-    const ws = this.ws = WebSocket.create(gateway, {
+    const ws = this.connection = WebSocket.create(gateway, {
       v: this.manager.client.options.ws.version,
       compress: 'zlib-stream',
     });
@@ -201,72 +202,11 @@ class WebSocketShard extends EventEmitter {
   }
 
   /**
-   * Called whenever a packet is received
-   * @param {Object} packet Packet received
-   * @returns {any}
-   * @private
-   */
-  onPacket(packet) {
-    if (!packet) {
-      this.debug('Received null packet');
-      return false;
-    }
-
-    switch (packet.t) {
-      case WSEvents.READY:
-        this.sessionID = packet.d.session_id;
-        this.trace = packet.d._trace;
-        this.status = Status.READY;
-        this.debug(`READY ${this.trace.join(' -> ')} ${this.sessionID}`);
-        this.heartbeat();
-        break;
-      case WSEvents.RESUMED: {
-        this.trace = packet.d._trace;
-        this.status = Status.READY;
-        const replayed = packet.s - this.sequence;
-        this.debug(`RESUMED ${this.trace.join(' -> ')} | replayed ${replayed} events.`);
-        this.heartbeat();
-        break;
-      }
-    }
-
-    if (packet.s > this.sequence) this.sequence = packet.s;
-
-    switch (packet.op) {
-      case OPCodes.HELLO:
-        this.identify();
-        return this.heartbeat(packet.d.heartbeat_interval);
-      case OPCodes.RECONNECT:
-        return this.reconnect();
-      case OPCodes.INVALID_SESSION:
-        this.sequence = -1;
-        this.debug('Session invalidated');
-        // If the session isn't resumable
-        if (!packet.d) {
-          // If we had a session ID before
-          if (this.sessionID) {
-            this.sessionID = null;
-            return this.identify(2500);
-          }
-          return this.identify(5000);
-        }
-        return this.identify();
-      case OPCodes.HEARTBEAT_ACK:
-        return this.ackHeartbeat();
-      case OPCodes.HEARTBEAT:
-        return this.heartbeat();
-      default:
-        return this.manager.handlePacket(packet, this);
-    }
-  }
-
-  /**
    * Called whenever a connection is opened to the gateway.
-   * @param {Event} event Received open event
    * @private
    */
   onOpen() {
-    this.debug('Connection open');
+    this.debug('Connected to the gateway');
   }
 
   /**
@@ -295,15 +235,15 @@ class WebSocketShard extends EventEmitter {
     }
     if (packet.t === WSEvents.READY) {
       /**
-       * Emitted when a shard becomes ready
+       * Emitted when a shard becomes ready.
        * @event WebSocketShard#ready
        */
       this.emit(Events.READY);
 
       /**
-       * Emitted when a shard becomes ready
+       * Emitted when a shard becomes ready.
        * @event Client#shardReady
-       * @param {number} shardID The id of the shard
+       * @param {number} shardID The ID of the shard
        */
       this.manager.client.emit(Events.SHARD_READY, this.id);
     }
@@ -311,53 +251,72 @@ class WebSocketShard extends EventEmitter {
   }
 
   /**
-   * Called whenever an error occurs with the WebSocket.
-   * @param {Error} error The error that occurred
+   * Called whenever a packet is received.
+   * @param {Object} packet Packet received
    * @private
    */
-  onError(error) {
-    if (error && error.message === 'uWs client connection error') {
-      this.reconnect();
+  onPacket(packet) {
+    if (!packet) {
+      this.debug('Received null packet');
       return;
     }
-    this.emit(Events.INVALIDATED);
 
-    /**
-     * Emitted whenever the client's WebSocket encounters a connection error.
-     * @event Client#error
-     * @param {Error} error The encountered error
-     */
-    this.manager.client.emit(Events.ERROR, error);
-  }
-
-  /**
-   * @external CloseEvent
-   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent}
-   */
-
-  /**
-   * Called whenever a connection to the gateway is closed.
-   * @param {CloseEvent} event Close event that was received
-   * @returns {void}
-   * @private
-   */
-  onClose(event) {
-    this.closeSequence = this.sequence;
-    this.emit('close', event);
-    if (event.code === 1000 ? this.expectingClose : WSCodes[event.code]) {
-      /**
-       * Emitted when the client's WebSocket disconnects and will no longer attempt to reconnect.
-       * @event Client#disconnect
-       * @param {CloseEvent} event The WebSocket close event
-       * @param {number} shardID The shard that disconnected
-       */
-      this.manager.client.emit(Events.DISCONNECT, event, this.id);
-      this.debug(WSCodes[event.code]);
-      this.heartbeat(-1);
-      return;
+    switch (packet.t) {
+      case WSEvents.READY:
+        this.sessionID = packet.d.session_id;
+        this.trace = packet.d._trace;
+        this.status = Status.READY;
+        this.debug(`READY ${this.trace.join(' -> ')} | Session ${this.sessionID}`);
+        this.lastHeartbeatAcked = true;
+        this.sendHeartbeat();
+        break;
+      case WSEvents.RESUMED: {
+        this.trace = packet.d._trace;
+        this.status = Status.READY;
+        const replayed = packet.s - this.sequence;
+        this.debug(`RESUMED ${this.trace.join(' -> ')} | replayed ${replayed} events.`);
+        this.lastHeartbeatAcked = true;
+        this.sendHeartbeat();
+        break;
+      }
     }
-    this.expectingClose = false;
-    this.reconnect(Events.INVALIDATED, 5100);
+
+    if (packet.s > this.sequence) this.sequence = packet.s;
+
+    switch (packet.op) {
+      case OPCodes.HELLO:
+        this.identify();
+        this.setHeartbeatTimer(packet.d.heartbeat_interval);
+        break;
+      case OPCodes.RECONNECT:
+        this.reconnect();
+        break;
+      case OPCodes.INVALID_SESSION:
+        this.debug(`Session was invalidated. ${packet.d ? 'Trying to resume' : 'Identifying as a new session'}.`);
+        // If the session isn't resumable
+        if (!packet.d) {
+          // Reset the sequence, since it isn't valid anymore
+          this.sequence = -1;
+          // If we had a session ID before
+          if (this.sessionID) {
+            this.sessionID = null;
+            this.identify(2500);
+            return;
+          }
+          this.identify(5000);
+          return;
+        }
+        this.identify();
+        break;
+      case OPCodes.HEARTBEAT_ACK:
+        this.ackHeartbeat();
+        break;
+      case OPCodes.HEARTBEAT:
+        this.sendHeartbeat();
+        break;
+      default:
+        this.manager.handlePacket(packet, this);
+    }
   }
 
   /**
@@ -373,7 +332,6 @@ class WebSocketShard extends EventEmitter {
 
   /**
    * Identifies as a new connection on the gateway.
-   * @returns {void}
    * @private
    */
   identifyNew() {
@@ -382,7 +340,7 @@ class WebSocketShard extends EventEmitter {
       return;
     }
     // Clone the generic payload and assign the token
-    const d = Object.assign({ token: this.manager.client.token }, this.manager.client.options.ws);
+    const d = { ...this.manager.client.options.ws, token: this.manager.client.token };
 
     const { totalShardCount } = this.manager.client.options;
     d.shard = [this.id, Number(totalShardCount)];
@@ -402,7 +360,8 @@ class WebSocketShard extends EventEmitter {
       this.debug('Warning: wanted to resume but session ID not available; identifying as a new session instead');
       return this.identifyNew();
     }
-    this.debug(`Attempting to resume session ${this.sessionID}`);
+
+    this.debug(`Attempting to resume session ${this.sessionID} at sequence ${this.sequence}`);
 
     const d = {
       token: this.manager.client.token,
@@ -410,10 +369,56 @@ class WebSocketShard extends EventEmitter {
       seq: this.sequence,
     };
 
-    return this.send({
-      op: OPCodes.RESUME,
-      d,
-    });
+    return this.send({ op: OPCodes.RESUME, d });
+  }
+
+  /**
+   * Called whenever an error occurs with the WebSocket.
+   * @param {Error} error The error that occurred
+   * @private
+   */
+  onError(error) {
+    if (error && error.message === 'uWs client connection error') {
+      this.reconnect();
+      return;
+    }
+
+    /**
+     * Emitted whenever the client's WebSocket encounters a connection error.
+     * @event Client#error
+     * @param {Error} error The encountered error
+     * @param {number} shardID The shard that encountered this error
+     */
+    this.manager.client.emit(Events.ERROR, error, this.id);
+  }
+
+  /**
+   * @external CloseEvent
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent}
+   */
+
+  /**
+   * Called whenever a connection to the gateway is closed.
+   * @param {CloseEvent} event Close event that was received
+   * @private
+   */
+  onClose(event) {
+    this.debug(`WebSocket was closed.
+      Event Code: ${event.code}
+      Reason: ${event.reason}`);
+    if (event.code === 1000 ? this.manager.expectingClose : WSCodes[event.code]) {
+      /**
+       * Emitted when the client's WebSocket disconnects and will no longer attempt to reconnect.
+       * @event Client#disconnect
+       * @param {CloseEvent} event The WebSocket close event
+       * @param {number} shardID The shard that disconnected
+       */
+      this.manager.client.emit(Events.DISCONNECT, event, this.id);
+      this.debug(WSCodes[event.code]);
+      return;
+    }
+
+    this.reconnect();
   }
 
   /**
@@ -433,11 +438,11 @@ class WebSocketShard extends EventEmitter {
    * @private
    */
   _send(data) {
-    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+    if (!this.connection || this.connection.readyState !== WebSocket.OPEN) {
       this.debug(`Tried to send packet ${data} but no WebSocket is available!`);
       return;
     }
-    this.ws.send(WebSocket.pack(data));
+    this.connection.send(WebSocket.pack(data));
   }
 
   /**
@@ -463,38 +468,37 @@ class WebSocketShard extends EventEmitter {
   }
 
   /**
-   * Triggers a shard reconnect.
-   * @param {?string} [event] The event for the shard to emit
-   * @param {?number} [reconnectIn] Time to wait before reconnecting
-   * @returns {Promise<void>}
+   * Shortcut to destroy and connect.
    * @private
    */
-  async reconnect(event, reconnectIn) {
-    this.heartbeat(-1);
-    this.status = Status.RECONNECTING;
+  reconnect() {
+    this.debug('Received reconnect request. Destroying and connecting to the gateway again');
 
     /**
      * Emitted whenever a shard tries to reconnect to the WebSocket.
      * @event Client#reconnecting
+     * @param {number} shardID The shard ID that is reconnecting
      */
     this.manager.client.emit(Events.RECONNECTING, this.id);
 
-    if (event === Events.INVALIDATED) this.emit(event);
-    this.debug(reconnectIn ? `Reconnecting in ${reconnectIn}ms` : 'Reconnecting now');
-    if (reconnectIn) await Util.delayFor(reconnectIn);
-    this.manager.spawn(this.id);
+    this.status = Status.RECONNECTING;
+
+    this.destroy();
+    if (this.sessionID) {
+      this.connect();
+    } else {
+      this.manager.handleSessionLimit(this);
+    }
   }
 
   /**
-   * Destroys the current shard and terminates its connection.
-   * @returns {void}
+   * Destroys this shard, and closes its connection.
    * @private
    */
   destroy() {
-    this.heartbeat(-1);
-    this.expectingClose = true;
-    if (this.ws) this.ws.close(1000);
-    this.ws = null;
+    this.setHeartbeatTimer(-1);
+    if (this.connection) this.connection.close(1000);
+    this.connection = null;
     this.status = Status.DISCONNECTED;
     this.ratelimit.remaining = this.ratelimit.total;
     if (this.ratelimit.timer) {
@@ -503,4 +507,5 @@ class WebSocketShard extends EventEmitter {
     }
   }
 }
+
 module.exports = WebSocketShard;

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -309,11 +309,9 @@ class WebSocketShard extends EventEmitter {
           // If we had a session ID before
           if (this.sessionID) {
             this.sessionID = null;
-            await Util.delayFor(2500);
             this.connection.close(1000);
             return;
           }
-          await Util.delayFor(5000);
           this.connection.close(1000);
           return;
         }

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -148,7 +148,7 @@ class WebSocketShard extends EventEmitter {
   sendHeartbeat() {
     if (!this.lastHeartbeatAcked) {
       this.debug("Didn't receive a heartbeat ack last time, assuming zombie conenction. Destroying and reconnecting.");
-      this.reconnect(1001);
+      this.reconnect(4000);
       return;
     }
     this.debug('Sending a heartbeat');

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -281,8 +281,8 @@ class WebSocketShard extends EventEmitter {
         this.emit(Events.RESUMED);
         this.trace = packet.d._trace;
         this.status = Status.READY;
-        const replayed = packet.s - this.sequence;
-        this.debug(`RESUMED ${this.trace.join(' -> ')} | replayed ${replayed} events.`);
+        const replayed = packet.s - this.closeSequence;
+        this.debug(`RESUMED ${this.trace.join(' -> ')} | Replayed ${replayed} events.`);
         this.lastHeartbeatAcked = true;
         this.sendHeartbeat();
         break;
@@ -367,12 +367,12 @@ class WebSocketShard extends EventEmitter {
       return this.identifyNew();
     }
 
-    this.debug(`Attempting to resume session ${this.sessionID} at sequence ${this.sequence}`);
+    this.debug(`Attempting to resume session ${this.sessionID} at sequence ${this.closeSequence}`);
 
     const d = {
       token: this.manager.client.token,
       session_id: this.sessionID,
-      seq: this.sequence,
+      seq: this.closeSequence,
     };
 
     return this.send({ op: OPCodes.RESUME, d });
@@ -511,6 +511,7 @@ class WebSocketShard extends EventEmitter {
       this.manager.client.clearTimeout(this.ratelimit.timer);
       this.ratelimit.timer = null;
     }
+    this.sequence = -1;
   }
 }
 

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -46,6 +46,13 @@ class WebSocketShard extends EventEmitter {
     this.sequence = -1;
 
     /**
+     * The sequence of the shard after close
+     * @type {number}
+     * @private
+     */
+    this.closeSequence = 0;
+
+    /**
      * The current session ID of the shard
      * @type {string}
      * @private
@@ -408,6 +415,7 @@ class WebSocketShard extends EventEmitter {
    * @private
    */
   onClose(event) {
+    this.closeSequence = this.sequence;
     this.debug(`WebSocket was closed.
       Event Code: ${event.code}
       Reason: ${event.reason}`);
@@ -488,9 +496,8 @@ class WebSocketShard extends EventEmitter {
      */
     this.manager.client.emit(Events.RECONNECTING, this.id);
 
-    this.status = Status.RECONNECTING;
-
     this.destroy(closeCode);
+    this.status = Status.RECONNECTING;
     if (this.sessionID) {
       this.connect();
     } else {

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -523,6 +523,7 @@ class WebSocketShard extends EventEmitter {
     this.connection = null;
     this.status = Status.DISCONNECTED;
     this.ratelimit.remaining = this.ratelimit.total;
+    this.ratelimit.queue.length = 0;
     if (this.ratelimit.timer) {
       this.manager.client.clearTimeout(this.ratelimit.timer);
       this.ratelimit.timer = null;

--- a/src/client/websocket/handlers/GUILD_SYNC.js
+++ b/src/client/websocket/handlers/GUILD_SYNC.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = (client, packet) => {
-  client.actions.GuildSync.handle(packet.d);
-};

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -258,6 +258,7 @@ exports.Events = {
   WARN: 'warn',
   DEBUG: 'debug',
   SHARD_READY: 'shardReady',
+  INVALIDATED: 'invalidated',
   RAW: 'raw',
   // TODO: Vlad don't forget to remove this, use it for debugging then revert it to debug unless told otherwise
   WSDEBUG: 'wsDebug',

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -258,8 +258,9 @@ exports.Events = {
   WARN: 'warn',
   DEBUG: 'debug',
   SHARD_READY: 'shardReady',
-  INVALIDATED: 'invalidated',
   RAW: 'raw',
+  // TODO: Vlad don't forget to remove this, use it for debugging then revert it to debug unless told otherwise
+  WSDEBUG: 'wsDebug',
 };
 
 /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -260,8 +260,6 @@ exports.Events = {
   SHARD_READY: 'shardReady',
   INVALIDATED: 'invalidated',
   RAW: 'raw',
-  // TODO: Vlad don't forget to remove this, use it for debugging then revert it to debug unless told otherwise
-  WSDEBUG: 'wsDebug',
 };
 
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -434,7 +434,7 @@ declare module 'discord.js' {
 		public presences: PresenceStore;
 		public region: string;
 		public roles: RoleStore;
-		public shard: WebSocketShard;
+		public readonly shard: WebSocketShard;
 		public shardID: number;
 		public splash: string;
 		public readonly systemChannel: TextChannel;
@@ -1292,19 +1292,16 @@ declare module 'discord.js' {
 		public gateway: string | undefined;
 		public readonly ping: number;
 		public shards: Collection<number, WebSocketShard>;
-		public sessionStartLimit: { total: number; remaining: number; reset_after: number; };
 		public status: Status;
-		public broadcast(packet: any): void;
 	}
 
 	export class WebSocketShard extends EventEmitter {
-		constructor(manager: WebSocketManager, id: number, oldShard?: WebSocketShard);
+		constructor(manager: WebSocketManager, id: number);
 		public id: number;
 		public readonly ping: number;
 		public pings: number[];
 		public status: Status;
 		public manager: WebSocketManager;
-		public send(data: object): void;
 
 		public on(event: 'ready', listener: () => void): this;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1296,7 +1296,7 @@ declare module 'discord.js' {
 		public shards: Collection<number, WebSocketShard>;
 		public status: Status;
 
-		public broadcast(packet: object): undefined;
+		public broadcast(packet: object): void;
 	}
 
 	export class WebSocketShard extends EventEmitter {
@@ -1307,7 +1307,7 @@ declare module 'discord.js' {
 		public status: Status;
 		public manager: WebSocketManager;
 
-		public send(packet: object): undefined;
+		public send(packet: object): void;
 
 		public on(event: 'ready', listener: () => void): this;
 		public once(event: 'ready', listener: () => void): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1295,6 +1295,8 @@ declare module 'discord.js' {
 		public readonly ping: number;
 		public shards: Collection<number, WebSocketShard>;
 		public status: Status;
+
+		public broadcast(packet: object): undefined;
 	}
 
 	export class WebSocketShard extends EventEmitter {
@@ -1305,8 +1307,9 @@ declare module 'discord.js' {
 		public status: Status;
 		public manager: WebSocketManager;
 
-		public on(event: 'ready', listener: () => void): this;
+		public send(packet: object): undefined;
 
+		public on(event: 'ready', listener: () => void): this;
 		public once(event: 'ready', listener: () => void): this;
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR aims to fix all the sharding issues, from silent disconnects to who knows what happens. I'm waiting for feedback, reviews, suggestions ~~or just people to scream at me~~.

List of things changed:

- Move expectingClose from the WebSocketShard to WebSocketManager
	- In my opinion, all shards should check the same property, on the manager. That should prevent a case where one shard gets destroyed and never reconnects in a process that (as an example) has 3 shards. This way, they are all connected or none, and we can re-use the destroy function for cleaning up before reconnecting. 
- Remove `spawning` property from WebSocketManager
	- Moved the code that adds the shards to the spawn queue in the connect function
- In WebSocketShard, handle zombie connections properly
	- Per `If a client does not receive a heartbeat ack between its attempts at sending heartbeats, it should immediately terminate the connection with a non-1000 close code, reconnect, and attempt to resume.`
	- This might be what solves silent disconnects, not too sure, needs testers
- Handle invalid sessions per https://discordapp.com/developers/docs/topics/gateway#resuming
- Implement the invalidated event under a different form
	- If you listen to it on the client, we assume you'll handle proper cleanup of any sorts, so we destroy just the shard connections, keeping the client alive. 
	- Otherwise we will destroy the entire client
- Hopefully fix null packets and other broken things by completely refactoring the onClose handler
	- Don't implement a function to reconnect, implement all logic in the onClose handler
	- Make all things that need to cause a reconnect close with code **4000**
		- Code 1000 makes a session invalid (un-resumable)

### Discussion topic:

Currently, discord.js doesn't trigger ready if there are any unavailable guilds... That can be bad, assuming your bot launches while one guild has an outage, which might last for a while, causing the shard to never ready, thus making login reject, while the bot could work for the other guilds it is in. In my opinion this needs to be re-taught through, and a better solution should be found.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
