### PR TITLE
Changed send message function signature to have overloading

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1433,8 +1433,10 @@ declare module 'discord.js' {
 		readonly lastMessage: Message;
 		lastPinTimestamp: number;
 		readonly lastPinAt: Date;
-		send(content?: StringResolvable, options?: MessageOptions | MessageAdditions): Promise<Message | Message[]>;
-		send(options?: MessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
+		send(options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+		send(options?: MessageOptions & { split?: false } | MessageAdditions | APIMessage): Promise<Message>;
+		send(content?: StringResolvable, options?: MessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
+		send(content?: StringResolvable, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
 	};
 
 	type TextBasedChannelFields = {
@@ -1455,8 +1457,10 @@ declare module 'discord.js' {
 		token: string;
 		delete(reason?: string): Promise<void>;
 		edit(options: WebhookEditData): Promise<Webhook>;
-		send(content?: StringResolvable, options?: WebhookMessageOptions | MessageAdditions): Promise<Message | Message[]>;
-		send(options?: WebhookMessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
+		send(content?: StringResolvable, options?: WebhookMessageOptions & { split: true }): Promise<Message[]>;
+		send(content?: StringResolvable, options?: WebhookMessageOptions & { split?: false } | MessageAdditions): Promise<Message>;
+		send(options?: WebhookMessageOptions & { split: true }): Promise<Message[]>;
+		send(options?: WebhookMessageOptions & { split?: false } | MessageAdditions | APIMessage): Promise<Message>;
 		sendSlackMessage(body: object): Promise<Message|object>;
 	};
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Changes typescript `send` message typings so that it only returns an array of `Message[]` if the split option was specified. This prevents unnecessary type checking or casting to get a `Message` object if desired.

Consider the following code

```message.channel.send("Hello").then(msg => (<Message><unknown>prompt).edit("hi");```

which can be reduced to 

```message.channel.send("Hello").then(msg => msg.edit("hi"));```

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
