### PR TITLE
websocket send error handling

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -435,7 +435,7 @@ class WebSocketShard extends EventEmitter {
       this.debug(`Tried to send packet ${data} but no WebSocket is available!`);
       return;
     }
-    this.ws.send(WebSocket.pack(data));
+    this.ws.send(WebSocket.pack(data), err => this.manager.client.emit(Events.ERROR, err));
   }
 
   /**

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -435,7 +435,9 @@ class WebSocketShard extends EventEmitter {
       this.debug(`Tried to send packet ${data} but no WebSocket is available!`);
       return;
     }
-    this.ws.send(WebSocket.pack(data), err => err && this.manager.client.emit(Events.ERROR, err));
+    this.ws.send(WebSocket.pack(data), err => {
+      if (err) this.manager.client.emit(Events.ERROR, err);
+    });
   }
 
   /**

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -435,7 +435,7 @@ class WebSocketShard extends EventEmitter {
       this.debug(`Tried to send packet ${data} but no WebSocket is available!`);
       return;
     }
-    this.ws.send(WebSocket.pack(data), err => this.manager.client.emit(Events.ERROR, err));
+    this.ws.send(WebSocket.pack(data), err => err && this.manager.client.emit(Events.ERROR, err));
   }
 
   /**

--- a/test/tester1000.js
+++ b/test/tester1000.js
@@ -13,6 +13,7 @@ client.on('ready', () => {
   log('READY', client.user.tag, client.user.id);
 });
 client.on('rateLimit', log);
+client.on('error', console.error);
 
 const commands = {
   eval: message => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In accordance with the [ws docs](https://github.com/websockets/ws#error-handling-best-practices), we should have a callback to handle errors encountered while sending a message over the websocket.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
