### PR TITLE
fix: guildBanRemove event name

### DIFF
--- a/src/client/actions/GuildBanRemove.js
+++ b/src/client/actions/GuildBanRemove.js
@@ -14,7 +14,7 @@ class GuildBanRemove extends Action {
      * @param {Guild} guild The guild that the unban occurred in
      * @param {User} user The user that was unbanned
      */
-    if (guild && user) client.emit(Events.GUILD_BAN_REMOVEGUILD_BAN_REMOVE, guild, user);
+    if (guild && user) client.emit(Events.GUILD_BAN_REMOVE, guild, user);
   }
 }
 


### PR DESCRIPTION
- "Events.GUILD_BAN_REMOVEGUILD_BAN_REMOVE" -> "Events.GUILD_BAN_REMOVE"

**Please describe the changes this PR makes and why it should be merged:**
Basically fixes the Event string.

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
