### PR TITLE
feat: Presence#clientStatus

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -17,8 +17,18 @@ const { ActivityTypes } = require('../util/Constants');
 class Presence {
   constructor(client, data = {}) {
     Object.defineProperty(this, 'client', { value: client });
+    /**
+     * The userID of this presence
+     * @type {string}
+     */
     this.userID = data.user.id;
+
+    /**
+     * The guild of this presence
+     * @type {Guild}
+     */
     this.guild = data.guild;
+
     this.patch(data);
   }
 
@@ -40,7 +50,7 @@ class Presence {
 
   patch(data) {
     /**
-     * The status of the presence:
+     * The status of this presence:
      *
      * * **`online`** - user is online
      * * **`offline`** - user is offline or invisible
@@ -52,10 +62,19 @@ class Presence {
 
     const activity = data.game || data.activity;
     /**
-     * The activity of the presence
+     * The activity of this presence
      * @type {?Activity}
      */
     this.activity = activity ? new Activity(this, activity) : null;
+
+    /**
+     * The devices this presence is on
+     * @type {?object}
+     * @property {string} web
+     * @property {string} mobile
+     * @property {string} desktop
+     */
+    this.clientStatus = data.client_status ? data.client_status : null;
 
     return this;
   }
@@ -75,7 +94,8 @@ class Presence {
     return this === presence || (
       presence &&
       this.status === presence.status &&
-      this.activity ? this.activity.equals(presence.activity) : !presence.activity
+      this.activity ? this.activity.equals(presence.activity) : !presence.activity &&
+        this.clientStatus === presence.clientStatus
     );
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -820,6 +820,7 @@ declare module 'discord.js' {
 		public activity: Activity;
 		public flags: Readonly<ActivityFlags>;
 		public status: 'online' | 'offline' | 'idle' | 'dnd';
+		public clientStatus: { web?: string, mobile?: string, desktop?: string};
 		public readonly user: User;
 		public readonly member?: GuildMember;
 		public equals(presence: Presence): boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Discord now tells you what device you're on and the status of that specific client, so this adds support for that.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
