### PR TITLE
update SnowflakeUtil typing

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -991,7 +991,7 @@ declare module 'discord.js' {
 
 	export class SnowflakeUtil {
 		public static deconstruct(snowflake: Snowflake): DeconstructedSnowflake;
-		public static generate(): Snowflake;
+		public static generate(timestamp?: number | Date): Snowflake;
 	}
 
 	const VolumeMixin: <T>(base: Constructable<T>) => Constructable<T & VolumeInterface>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The typings for SnowflakeUtil didn't support the [optional argument "timestamp"](https://discord.js.org/#/docs/main/stable/class/SnowflakeUtil). This PR adds the timestamp argument to the typings

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
