### PR TITLE
fix(TextBasedChannel): added missing lastMessage functionality in textchannels

### DIFF
--- a/src/client/actions/MessageCreate.js
+++ b/src/client/actions/MessageCreate.js
@@ -16,7 +16,6 @@ class MessageCreateAction extends Action {
         }
         const lastMessage = messages[messages.length - 1];
         channel.lastMessageID = lastMessage.id;
-        channel.lastMessage = lastMessage;
         if (user) {
           user.lastMessageID = lastMessage.id;
           user.lastMessage = lastMessage;
@@ -31,7 +30,6 @@ class MessageCreateAction extends Action {
       } else {
         const message = channel._cacheMessage(new Message(channel, data, client));
         channel.lastMessageID = data.id;
-        channel.lastMessage = message;
         if (user) {
           user.lastMessageID = data.id;
           user.lastMessage = message;

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -396,6 +396,15 @@ class TextBasedChannel {
   }
 
   /**
+   * The Message object of the last message in the channel, if one was sent
+   * @type {?Message}
+   * @readonly
+   */
+  get lastMessage() {
+    return this.messages.get(this.lastMessageID) || null;
+  }
+
+  /**
    * The date when the last pinned message was pinned, if there was one
    * @type {?Date}
    * @readonly
@@ -599,6 +608,7 @@ exports.applyToClass = (structure, full = false, ignore = []) => {
       'fetchMessages',
       'fetchMessage',
       'search',
+      'lastMessage',
       'lastPinAt',
       'bulkDelete',
       'startTyping',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This is a partial backport of #2384 without breaking changes so that #2986 doesn't break with the error
`TypeError: Cannot set property lastMessage of [object Object] which has only a getter`

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
