### PR TITLE
typings: Add `string[]` overload to bulkDelete

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1441,7 +1441,7 @@ declare module 'discord.js' {
 		typing: boolean;
 		typingCount: number;
 		awaitMessages(filter: CollectorFilter, options?: AwaitMessagesOptions): Promise<Collection<Snowflake, Message>>;
-		bulkDelete(messages: Collection<Snowflake, Message> | Message[] | number, filterOld?: boolean): Promise<Collection<Snowflake, Message>>;
+		bulkDelete(messages: Collection<Snowflake, Message> | Message[] | string[] | number, filterOld?: boolean): Promise<Collection<Snowflake, Message>>;
 		createMessageCollector(filter: CollectorFilter, options?: MessageCollectorOptions): MessageCollector;
 		startTyping(count?: number): Promise<void>;
 		stopTyping(force?: boolean): void;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1441,7 +1441,7 @@ declare module 'discord.js' {
 		typing: boolean;
 		typingCount: number;
 		awaitMessages(filter: CollectorFilter, options?: AwaitMessagesOptions): Promise<Collection<Snowflake, Message>>;
-		bulkDelete(messages: Collection<Snowflake, Message> | Message[] | string[] | number, filterOld?: boolean): Promise<Collection<Snowflake, Message>>;
+		bulkDelete(messages: Collection<Snowflake, Message> | Message[] | Snowflake[] | number, filterOld?: boolean): Promise<Collection<Snowflake, Message>>;
 		createMessageCollector(filter: CollectorFilter, options?: MessageCollectorOptions): MessageCollector;
 		startTyping(count?: number): Promise<void>;
 		stopTyping(force?: boolean): void;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since we can do `message.channel.bulkDelete([id1, id2, id3]);`

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
