### PR TITLE
[WIP] fix: VoiceChannel#join -> master

### DIFF
--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -50,6 +50,10 @@ class ClientVoiceManager {
    */
   joinChannel(channel) {
     return new Promise((resolve, reject) => {
+      if (!channel.viewable) {
+        throw new Error('VOICE_VIEW_CHANNEL');
+      }
+
       if (!channel.joinable) {
         throw new Error('VOICE_JOIN_CHANNEL', channel.full);
       }

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -42,6 +42,7 @@ const Messages = {
   VOICE_INVALID_HEARTBEAT: 'Tried to set voice heartbeat but no valid interval was specified.',
   VOICE_USER_MISSING: 'Couldn\'t resolve the user to create stream.',
   VOICE_STREAM_EXISTS: 'There is already an existing stream for that user.',
+  VOICE_VIEW_CHANNEL: 'You do not have permission to view this voice channel.',
   VOICE_JOIN_CHANNEL: (full = false) =>
     `You do not have permission to join this voice channel${full ? '; it is full.' : '.'}`,
   VOICE_CONNECTION_TIMEOUT: 'Connection not established within 15 seconds.',

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -132,6 +132,7 @@ class VoiceChannel extends GuildChannel {
    */
   join() {
     if (browser) return Promise.reject(new Error('VOICE_NO_BROWSER'));
+    if (!this.joinable) return Promise.reject(new Error('VOICE_NOT_JOINABLE'));
     return this.client.voice.joinChannel(this);
   }
 

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -92,6 +92,17 @@ class VoiceChannel extends GuildChannel {
   }
 
   /**
+   * Checks if the client has permission to view the voice channel
+   * @type {boolean}
+   * @readonly
+   */
+  get viewable() {
+    if (browser) return false;
+    if (this.permissionsFor(this.client.user).has('VIEW_CHANNEL', false)) return false;
+    return true;
+  }
+
+  /**
    * Sets the bitrate of the channel.
    * @param {number} bitrate The new bitrate
    * @param {string} [reason] Reason for changing the channel's bitrate

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -132,7 +132,6 @@ class VoiceChannel extends GuildChannel {
    */
   join() {
     if (browser) return Promise.reject(new Error('VOICE_NO_BROWSER'));
-    if (!this.joinable) return Promise.reject(new Error('VOICE_NOT_JOINABLE'));
     return this.client.voice.joinChannel(this);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Voice channel permissions should be checked before attempting to join a channel. As described in the tagged issue, the created connection would timeout after 15 seconds when failing to do so.

*Intention is to push this to stable as well, but the stable version is 11.4.1 not 11.4.2*
Related to #3005, but does not close until patch is forwarded to the correct versions / branches.
This branch was tested using `./test/voice.js` with modules `node-opus` and `opusscript`.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
