### PR TITLE
fix(ShardClientUtil#id): erroneously reporting as an array

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -55,7 +55,7 @@ class Client extends BaseClient {
         this.options.totalShardCount = this.options.shardCount;
       }
     }
-    if (!this.options.shards && this.options.shardCount) {
+    if (typeof this.options.shards === 'undefined' && this.options.shardCount) {
       this.options.shards = [];
       for (let i = 0; i < this.options.shardCount; ++i) this.options.shards.push(i);
     }
@@ -233,7 +233,7 @@ class Client extends BaseClient {
       this.emit(Events.DEBUG, `Using recommended shard count ${res.shards}`);
       this.options.shardCount = res.shards;
       this.options.totalShardCount = res.shards;
-      if (!this.options.shards || !this.options.shards.length) {
+      if (typeof this.options.shards === 'undefined' || !this.options.shards.length) {
         this.options.shards = [];
         for (let i = 0; i < this.options.shardCount; ++i) this.options.shards.push(i);
       }

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -7,7 +7,7 @@ const browser = exports.browser = typeof window !== 'undefined';
 /**
  * Options for a client.
  * @typedef {Object} ClientOptions
- * @property {number|number[]} [shards=0] ID of the shard to run, or an array of shard IDs
+ * @property {number|number[]} [shards] ID of the shard to run, or an array of shard IDs
  * @property {number} [shardCount=1] Total number of shards that will be spawned by this Client
  * @property {number} [totalShardCount=1] The total amount of shards used by all processes of this bot
  * (e.g. recommended shard count, shard count of the ShardingManager)
@@ -37,7 +37,6 @@ const browser = exports.browser = typeof window !== 'undefined';
  * @property {HTTPOptions} [http] HTTP options
  */
 exports.DefaultOptions = {
-  shards: 0,
   shardCount: 1,
   totalShardCount: 1,
   messageCacheMaxSize: 200,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fixes #3017 where `ShardClientUtil#id` would return `[0]` if the current shard was 0.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
