### PR TITLE
Fix displayed resumed event count

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -49,7 +49,7 @@ class WebSocketShard extends EventEmitter {
      * @type {number}
      * @private
      */
-    this.closeSequence = 0;
+    this.closeSequence = oldShard ? oldShard.closeSequence : 0;
 
     /**
      * The current session id of the WebSocket
@@ -223,7 +223,7 @@ class WebSocketShard extends EventEmitter {
       case WSEvents.RESUMED: {
         this.trace = packet.d._trace;
         this.status = Status.READY;
-        const replayed = packet.s - this.sequence;
+        const replayed = packet.s - this.closeSequence;
         this.debug(`RESUMED ${this.trace.join(' -> ')} | replayed ${replayed} events.`);
         this.heartbeat();
         break;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR attemps to fix the displayed resumed event count in the debug output (where it is always displayed only as 1 event replayed) and in the emitted `resumed` event, where it passed the current sequence instead of passing the actual replayed event count (which was an utopic high number for smaller bots on resume).

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
