### PR TITLE
fix: Updated deprecated method of Collection#find

### DIFF
--- a/docs/examples/greeting.js
+++ b/docs/examples/greeting.js
@@ -19,7 +19,7 @@ client.on('ready', () => {
 // Create an event listener for new guild members
 client.on('guildMemberAdd', member => {
   // Send the message to a designated channel on a server:
-  const channel = member.guild.channels.find('name', 'member-log');
+  const channel = member.guild.channels.find(ch => ch.name === 'member-log');
   // Do nothing if the channel wasn't found on this server
   if (!channel) return;
   // Send the message, mentioning the member


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `Collection#find` method takes in an argument instead of a key/value pair. This example has been updated to adhere to that.

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
