### PR TITLE
fix(Voice): Allow webpack to know what secretbox lib to use

### DIFF
--- a/src/client/voice/util/Secretbox.js
+++ b/src/client/voice/util/Secretbox.js
@@ -14,20 +14,29 @@ const libs = {
 };
 
 exports.methods = {};
-
-for (const libName of Object.keys(libs)) {
+(function initSecretBox() {
+  let lib;
   try {
-    const lib = require(libName);
-    if (libName === 'libsodium-wrappers' && lib.ready) {
-      lib.ready.then(() => {
-        exports.methods = libs[libName](lib);
-      }).catch(() => {
-        const tweetnacl = require('tweetnacl');
-        exports.methods = libs.tweetnacl(tweetnacl);
-      }).catch(() => undefined);
-    } else {
-      exports.methods = libs[libName](lib);
-    }
-    break;
+    lib = require('sodium');
+    exports.methods = libs.sodium(lib);
+    return;
   } catch (err) {} // eslint-disable-line no-empty
-}
+
+  try {
+    lib = require('libsodium-wrappers');
+    if (lib.ready) {
+      lib.ready.then(() => {
+        exports.methods = libs['libsodium-wrappers'](lib);
+      }).catch(() => {
+        lib = require('tweetnacl');
+        exports.methods = libs.tweetnacl(lib);
+      });
+    }
+    return;
+  } catch (err) {} // eslint-disable-line no-empty
+
+  try {
+    lib = require('tweetnacl');
+    exports.methods = libs.tweetnacl(lib);
+  } catch (err) {} // eslint-disable-line no-empty
+}());


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**


**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

Made the imports more webpack-conscious for when webpacking to a node environment