### PR TITLE
Add spoilers to escapeMarkdown and update strikeout matching

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -79,7 +79,7 @@ class Util {
   static escapeMarkdown(text, onlyCodeBlock = false, onlyInlineCode = false) {
     if (onlyCodeBlock) return text.replace(/```/g, '`\u200b``');
     if (onlyInlineCode) return text.replace(/\\(`|\\)/g, '$1').replace(/(`|\\)/g, '\\$1');
-    return text.replace(/\\(\*|_|`|~|\\)/g, '$1').replace(/(\*|_|`|~|\\)/g, '\\$1');
+    return text.replace(/\\(\*|_|`|~|\||\\)/g, '$1').replace(/(\*|_|`|~|\||\\)/g, '\\$1');
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -79,7 +79,7 @@ class Util {
   static escapeMarkdown(text, onlyCodeBlock = false, onlyInlineCode = false) {
     if (onlyCodeBlock) return text.replace(/```/g, '`\u200b``');
     if (onlyInlineCode) return text.replace(/\\(`|\\)/g, '$1').replace(/(`|\\)/g, '\\$1');
-    return text.replace(/\\(\*|_|`|~|\||\\)/g, '$1').replace(/(\*|_|`|~|\||\\)/g, '\\$1');
+    return text.replace(/\\(\*|_|`|~~|\|\||\\)/g, '$1').replace(/(\*|_|`|~~|\|\||\\)/g, '\\$1');
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since spoilers have just been added with the `|| test||` syntax, add that to the escapeMarkdown function.

The same changes could be added to 11.4-dev as well I imagine.

edit: This also forces the regex to match two ~ in order to capture strikeouts instead of just a single one
This produces then
`\~~test\~~` and `\||test\||` instead of the previous `\~\~test\~\~` and `\|\|test\|\|`

Resolves #3048

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
