### PR TITLE
typings: Add missing ImageSize numbers

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1846,7 +1846,10 @@ declare module 'discord.js' {
 		| 'jpg'
 		| 'gif';
 
-	type ImageSize = 128
+	type ImageSize = 16
+		| 32
+		| 64
+		| 128
 		| 256
 		| 512
 		| 1024


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

To match the JS typedef: https://discord.js.org/#/docs/main/master/typedef/ImageURLOptions and the [`AllowedImageSizes`](https://github.com/discordjs/discord.js/blob/3dff5058f0beae01cec0abe27e3a43c8fd7c60ce/src/util/Constants.js#L105) constant which is `[16, 32, 64, 128, 256, 512, 1024, 2048]`.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
