### PR TITLE
misc(index): Export HTTPError

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ module.exports = {
   DataResolver: require('./util/DataResolver'),
   DataStore: require('./stores/DataStore'),
   DiscordAPIError: require('./rest/DiscordAPIError'),
+  HTTPError: require('./rest/HTTPError'),
   Permissions: require('./util/Permissions'),
   Speaking: require('./util/Speaking'),
   Snowflake: require('./util/Snowflake'),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`HTTPError` is supposed to be public as it's documented, plus it is exported in [typings](https://github.com/discordjs/discord.js/blob/master/typings/index.d.ts#L611-L617).

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
