### PR TITLE
feat(RichEmbed): add length getter

### DIFF
--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -236,6 +236,21 @@ class RichEmbed {
   }
 
   /**
+   * The accumulated length for the embed title, description, fields, author and footer text
+   * @type {number}
+   * @readonly
+   */
+  get length() {
+    return (
+      (this.title ? this.title.length : 0) +
+      (this.description ? this.description.length : 0) +
+      (this.fields.length >= 1 ? this.fields.reduce((prev, curr) =>
+        prev + curr.name.length + curr.value.length, 0) : 0) +
+      (this.footer ? this.footer.text.length : 0) +
+      (this.author ? this.author.name.length : 0));
+  }
+
+  /**
    * Transforms the embed object to be processed.
    * @returns {Object} The raw data of this embed
    * @private

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1014,6 +1014,7 @@ declare module 'discord.js' {
 		public files?: Array<Attachment | string | FileOptions>;
 		public footer?: { text?: string; icon_url?: string; };
 		public image?: { url: string; proxy_url?: string; height?: number; width?: number; };
+		public readonly length: number;
 		public thumbnail?: { url: string; height?: number; width?: number; };
 		public timestamp?: Date;
 		public title?: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #3003 to the 11.4-dev branch adding `RichEmbed#length`.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
