### PR TITLE
fix(GuildMember): add explicit channel resolve error to member edit

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -496,7 +496,11 @@ class RESTMethods {
 
   updateGuildMember(member, data, reason) {
     if (data.channel) {
-      data.channel_id = this.client.resolver.resolveChannel(data.channel).id;
+      const channel = this.client.resolver.resolveChannel(data.channel);
+      if (!channel || channel.guild.id !== member.guild.id || channel.type !== 'voice') {
+        return Promise.reject(new Error('Could not resolve channel to a guild voice channel.'));
+      }
+      data.channel_id = channel.id;
       data.channel = null;
     }
     if (data.roles) data.roles = data.roles.map(role => role instanceof Role ? role.id : role);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #2958 to the 11.4-dev branch throwing an explicit/better error when passing bad input to `GuildMember#setVoiceChannel` or its `GuildMember#edit` variant.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
