### PR TITLE
fix(Util): splitMessage throws an error if a chunk is too large

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -19,7 +19,9 @@ class Util {
   static splitMessage(text, { maxLength = 1950, char = '\n', prepend = '', append = '' } = {}) {
     if (text.length <= maxLength) return text;
     const splitText = text.split(char);
-    if (splitText.length === 1) throw new Error('Message exceeds the max length and contains no split characters.');
+    if (splitText.some(chunk => chunk.length > maxLength)) {
+      throw new Error('Message exceeds the max length and contains no split characters.');
+    }
     const messages = [''];
     let msg = 0;
     for (let i = 0; i < splitText.length; i++) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #2936 to the 11.4-dev branch making `Util.splitMessage` throw an error when any chunk, not just the first, exceeds the max length.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
