### PR TITLE
feat(RichEmbed): add timestamp support for setTimestamp

### DIFF
--- a/src/structures/RichEmbed.js
+++ b/src/structures/RichEmbed.js
@@ -140,10 +140,11 @@ class RichEmbed {
 
   /**
    * Sets the timestamp of this embed.
-   * @param {Date} [timestamp=new Date()] The timestamp
+   * @param {Date|number} [timestamp=Date.now()] The timestamp or date
    * @returns {RichEmbed} This embed
    */
-  setTimestamp(timestamp = new Date()) {
+  setTimestamp(timestamp = Date.now()) {
+    if (timestamp instanceof Date) timestamp = timestamp.getTime();
     this.timestamp = timestamp;
     return this;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1028,7 +1028,7 @@ declare module 'discord.js' {
 		public setFooter(text: StringResolvable, icon?: string): this;
 		public setImage(url: string): this;
 		public setThumbnail(url: string): this;
-		public setTimestamp(timestamp?: Date): this;
+		public setTimestamp(timestamp?: Date | number): this;
 		public setTitle(title: StringResolvable): this;
 		public setURL(url: string): this;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #2875 allowing `RichEmbed#setTimestamp` to also accept a timestamp.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
