### PR TITLE
fix(Emoji): reject explicit error when MANAGE_EMOJI permissions are missing

### DIFF
--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -162,6 +162,11 @@ class Emoji {
    */
   fetchAuthor() {
     if (this.managed) return Promise.reject(new Error('Emoji is managed and has no Author.'));
+    if (!this.guild.me.permissions.has(Permissions.FLAGS.MANAGE_EMOJIS)) {
+      return Promise.reject(
+        new Error(`Client must have Manage Emoji permission in guild ${this.guild} to see emoji authors.`)
+      );
+    }
     return this.client.rest.makeRequest('get', Constants.Endpoints.Guild(this.guild).Emoji(this.id), true)
       .then(emoji => this.client.dataManager.newUser(emoji.user));
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #2788 throwing an explicit / better error when trying to fetch the author of an emoji when the client has no `MANAGE_EMOJIS` permission.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
