### PR TITLE
Mark peer dependencies as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,29 @@
     "libsodium-wrappers": "^0.7.3",
     "uws": "^9.14.0"
   },
+  "peerDependenciesMeta": {
+    "bufferutil": {
+      "optional": true
+    },
+    "erlpack": {
+      "optional": true
+    },
+    "node-opus": {
+      "optional": true
+    },
+    "opusscript": {
+      "optional": true
+    },
+    "sodium": {
+      "optional": true
+    },
+    "libsodium-wrappers": {
+      "optional": true
+    },
+    "uws": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^9.4.6",
     "discord.js-docgen": "discordjs/docgen",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Mark peer dependencies as optional to quiet warnings from yarn.
This structure was approved as https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md
Support was released in Yarn 1.13.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
