### PR TITLE
Autofetching of messages during Reaction events, MessageUpdate

### DIFF
--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -9,14 +9,15 @@ const Constants = require('../../util/Constants');
 */
 
 class MessageReactionAdd extends Action {
-  handle(data) {
+  async handle(data) {
     const user = this.client.users.get(data.user_id);
     if (!user) return false;
     // Verify channel
     const channel = this.client.channels.get(data.channel_id);
     if (!channel || channel.type === 'voice') return false;
     // Verify message
-    const message = channel.messages.get(data.message_id);
+    var message = channel.messages.get(data.message_id);
+    if (!message) message = await channel.fetchMessage(data.message_id);
     if (!message) return false;
     if (!data.emoji) return false;
     // Verify reaction

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -9,14 +9,15 @@ const Constants = require('../../util/Constants');
 */
 
 class MessageReactionRemove extends Action {
-  handle(data) {
+  async handle(data) {
     const user = this.client.users.get(data.user_id);
     if (!user) return false;
     // Verify channel
     const channel = this.client.channels.get(data.channel_id);
     if (!channel || channel.type === 'voice') return false;
     // Verify message
-    const message = channel.messages.get(data.message_id);
+    var message = channel.messages.get(data.message_id);
+    if (!message) message = await channel.fetchMessage(data.message_id);
     if (!message) return false;
     if (!data.emoji) return false;
     // Verify reaction

--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -2,11 +2,12 @@ const Action = require('./Action');
 const Constants = require('../../util/Constants');
 
 class MessageReactionRemoveAll extends Action {
-  handle(data) {
+  async handle(data) {
     const channel = this.client.channels.get(data.channel_id);
     if (!channel || channel.type === 'voice') return false;
 
-    const message = channel.messages.get(data.message_id);
+    var message = channel.messages.get(data.message_id);
+    if (!message) message = await channel.fetchMessage(data.message_id);
     if (!message) return false;
 
     message._clearReactions();

--- a/src/client/actions/MessageUpdate.js
+++ b/src/client/actions/MessageUpdate.js
@@ -2,12 +2,13 @@ const Action = require('./Action');
 const Constants = require('../../util/Constants');
 
 class MessageUpdateAction extends Action {
-  handle(data) {
+  async handle(data) {
     const client = this.client;
 
     const channel = client.channels.get(data.channel_id);
     if (channel) {
-      const message = channel.messages.get(data.id);
+      var message = channel.messages.get(data.id);
+      if (!message) message = await channel.fetchMessage(data.id);
       if (message) {
         message.patch(data);
         client.emit(Constants.Events.MESSAGE_UPDATE, message._edits[0], message);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR automatically fetches uncached messages, resolving confusing behavior with event listeners not firing due to a lack of caching. This removes the need for a hacky `client#on('raw',...` fix.

Note: This sets the handler functions as async. This is also not set up to be configurable, since I didn't see a reason for it to be. However, I'd be willing to implement such a thing.

**EDIT: It looks like this requires Node.JS 7.6 to run properly. Not sure how big of a deal that is, but I imagine changing the min version required isn't what you guys want to do.**

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
