### PR TITLE
cleanup(GuildMember{RoleStore}): Rewrite to async/await

### DIFF
--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -67,8 +67,8 @@ class GuildMemberRoleStore extends Collection {
     if (roleOrRoles instanceof Collection || roleOrRoles instanceof Array) {
       roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
       if (roleOrRoles.includes(null)) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
-          'Array or Collection of Roles or Snowflakes', true));
+        throw new TypeError('INVALID_TYPE', 'roles',
+          'Array or Collection of Roles or Snowflakes', true);
       }
 
       const newRoles = [...new Set(roleOrRoles.concat(...this.values()))];
@@ -76,8 +76,8 @@ class GuildMemberRoleStore extends Collection {
     } else {
       roleOrRoles = this.guild.roles.resolve(roleOrRoles);
       if (roleOrRoles === null) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
-          'Array or Collection of Roles or Snowflakes', true));
+        throw new TypeError('INVALID_TYPE', 'roles',
+          'Array or Collection of Roles or Snowflakes', true);
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put({ reason });
@@ -98,8 +98,8 @@ class GuildMemberRoleStore extends Collection {
     if (roleOrRoles instanceof Collection || roleOrRoles instanceof Array) {
       roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
       if (roleOrRoles.includes(null)) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
-          'Array or Collection of Roles or Snowflakes', true));
+        throw new TypeError('INVALID_TYPE', 'roles',
+          'Array or Collection of Roles or Snowflakes', true);
       }
 
       const newRoles = this.filter(role => !roleOrRoles.includes(role));
@@ -107,8 +107,8 @@ class GuildMemberRoleStore extends Collection {
     } else {
       roleOrRoles = this.guild.roles.resolve(roleOrRoles);
       if (roleOrRoles === null) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
-          'Array or Collection of Roles or Snowflakes', true));
+        throw new TypeError('INVALID_TYPE', 'roles',
+          'Array or Collection of Roles or Snowflakes', true);
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].delete({ reason });

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -248,7 +248,7 @@ class GuildMember extends Base {
    * @param {string} [reason] Reason for editing this user
    * @returns {Promise<GuildMember>}
    */
-  edit(data, reason) {
+  async edit(data, reason) {
     if (data.channel) {
       data.channel = this.guild.channels.resolve(data.channel);
       if (!data.channel || data.channel.type !== 'voice') {
@@ -266,12 +266,12 @@ class GuildMember extends Base {
     } else {
       endpoint = endpoint.members(this.id);
     }
-    return endpoint.patch({ data, reason }).then(() => {
-      const clone = this._clone();
-      data.user = this.user;
-      clone._patch(data);
-      return clone;
-    });
+    await endpoint.patch({ data, reason });
+
+    const clone = this._clone();
+    data.user = this.user;
+    clone._patch(data);
+    return clone;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Cleaned up `GuildMemberRoleStore#{add,remove}`, which were creating a rejected promise inside a promise, instead of rejecting the first one.
- Fixed a bug where `GuildMember#edit` with a specified unknown channel would throw synchronously, instead of rejecting asynchronously. (`message.member.edit({ channel: '1' });` would trigger a `DiscordAPIError` throw instead of `Promise<DiscordAPIError>`)

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
