### PR TITLE
webpack: Fix module warning when building

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "node-opus": false,
     "tweetnacl": false,
     "sodium": false,
+    "worker_threads": false,
     "zlib-sync": false,
     "src/sharding/Shard.js": false,
     "src/sharding/ShardClientUtil.js": false,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the warning displayed on console (after every webpack build):
```
WARNING in ./src/client/Client.js
Module not found: Error: Can't resolve 'worker_threads' in 'D:\Repositories\discordjs\discord.js\src\client'
 @ ./src/client/Client.js
 @ ./src/index.js
```

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
