### PR TITLE
Adding method te remove message by ID

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1387,7 +1387,7 @@ declare module 'discord.js' {
 
 	export class MessageStore extends DataStore<Snowflake, Message, typeof Message, MessageResolvable> {
 		constructor(channel: TextChannel | DMChannel | GroupDMChannel, iterable?: Iterable<any>);
-		public remove(messageID: string, options?: { timeout?: number, reason?: string }): Promise<void>;
+		public remove(messageID: Snowflake, options?: { timeout?: number, reason?: string }): Promise<void>;
 		public fetch(message: Snowflake): Promise<Message>;
 		public fetch(options?: ChannelLogsQueryOptions): Promise<Collection<Snowflake, Message>>;
 		public fetchPinned(): Promise<Collection<Snowflake, Message>>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1387,6 +1387,7 @@ declare module 'discord.js' {
 
 	export class MessageStore extends DataStore<Snowflake, Message, typeof Message, MessageResolvable> {
 		constructor(channel: TextChannel | DMChannel | GroupDMChannel, iterable?: Iterable<any>);
+		public remove(messageID: string, options?: { timeout?: number, reason?: string }): Promise<void>;
 		public fetch(message: Snowflake): Promise<Message>;
 		public fetch(options?: ChannelLogsQueryOptions): Promise<Collection<Snowflake, Message>>;
 		public fetchPinned(): Promise<Collection<Snowflake, Message>>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If I'd like to remove a message, and I have the ID, but the message is not cached, I first need to fetch it, before I can delete it. That means one useless API call. This PR adds `MessageStore.remove(id, options)` so that's no longer necessary. The options object is the same as `message.delete()` for consistency.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.