### PR TITLE
Update package.json and secretbox.js to use a different JS libsodium library

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ For production bots, using node-opus should be considered a necessity, especiall
 - [zlib-sync](https://www.npmjs.com/package/zlib-sync) for significantly faster WebSocket data inflation (`npm install zlib-sync`)
 - [erlpack](https://github.com/discordapp/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install discordapp/erlpack`)
 - One of the following packages can be installed for faster voice packet encryption and decryption:
-    - [sodium](https://www.npmjs.com/package/sodium) (`npm install sodium`)
-    - [libsodium.js](https://www.npmjs.com/package/libsodium-wrappers) (`npm install libsodium-wrappers`)
+    - [libsodium.js](https://www.npmjs.com/package/libsodium) (`npm install libsodium`)
+    - [libsodium.js-wrappers](https://www.npmjs.com/package/libsodium-wrappers) (`npm install libsodium-wrappers`)
 - [uws](https://www.npmjs.com/package/@discordjs/uws) for a much faster WebSocket connection (`npm install @discordjs/uws`)
 - [bufferutil](https://www.npmjs.com/package/bufferutil) for a much faster WebSocket connection when *not* using uws (`npm install bufferutil`)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For production bots, using node-opus should be considered a necessity, especiall
 ### Optional packages
 - [zlib-sync](https://www.npmjs.com/package/zlib-sync) for significantly faster WebSocket data inflation (`npm install zlib-sync`)
 - [erlpack](https://github.com/discordapp/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install discordapp/erlpack`)
-- The following packages can be installed for faster voice packet encryption and decryption:
+- The following packages can be installed for faster voice packet encryption and decryption (both of them must be installed in order for the functionality to work):
     - [libsodium.js](https://www.npmjs.com/package/libsodium) (`npm install libsodium`)
     - [libsodium.js-wrappers](https://www.npmjs.com/package/libsodium-wrappers) (`npm install libsodium-wrappers`)
 - [uws](https://www.npmjs.com/package/@discordjs/uws) for a much faster WebSocket connection (`npm install @discordjs/uws`)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For production bots, using node-opus should be considered a necessity, especiall
 ### Optional packages
 - [zlib-sync](https://www.npmjs.com/package/zlib-sync) for significantly faster WebSocket data inflation (`npm install zlib-sync`)
 - [erlpack](https://github.com/discordapp/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install discordapp/erlpack`)
-- One of the following packages can be installed for faster voice packet encryption and decryption:
+- The following packages can be installed for faster voice packet encryption and decryption:
     - [libsodium.js](https://www.npmjs.com/package/libsodium) (`npm install libsodium`)
     - [libsodium.js-wrappers](https://www.npmjs.com/package/libsodium-wrappers) (`npm install libsodium-wrappers`)
 - [uws](https://www.npmjs.com/package/@discordjs/uws) for a much faster WebSocket connection (`npm install @discordjs/uws`)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ For production bots, using node-opus should be considered a necessity, especiall
 ### Optional packages
 - [zlib-sync](https://www.npmjs.com/package/zlib-sync) for significantly faster WebSocket data inflation (`npm install zlib-sync`)
 - [erlpack](https://github.com/discordapp/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install discordapp/erlpack`)
-- The following packages can be installed for faster voice packet encryption and decryption (both of them must be installed in order for the functionality to work):
-    - [libsodium.js](https://www.npmjs.com/package/libsodium) (`npm install libsodium`)
+- The following package can be installed for faster voice packet encryption and decryption:
     - [libsodium.js-wrappers](https://www.npmjs.com/package/libsodium-wrappers) (`npm install libsodium-wrappers`)
 - [uws](https://www.npmjs.com/package/@discordjs/uws) for a much faster WebSocket connection (`npm install @discordjs/uws`)
 - [bufferutil](https://www.npmjs.com/package/bufferutil) for a much faster WebSocket connection when *not* using uws (`npm install bufferutil`)

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "bufferutil": "^4.0.1",
     "erlpack": "discordapp/erlpack",
     "libsodium-wrappers": "^0.7.4",
-    "sodium": "^3.0.2",
+    "libsodium": "^0.7.4",
     "zlib-sync": "^0.1.4"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "bufferutil": "^4.0.1",
     "erlpack": "discordapp/erlpack",
     "libsodium-wrappers": "^0.7.4",
-    "libsodium": "^0.7.4",
     "zlib-sync": "^0.1.4"
   },
   "devDependencies": {

--- a/src/client/voice/util/Secretbox.js
+++ b/src/client/voice/util/Secretbox.js
@@ -1,11 +1,6 @@
 'use strict';
 
 const libs = {
-  'libsodium': sodium => ({
-    open: sodium.crypto_secretbox_open_easy,
-    close: sodium.crypto_secretbox_easy,
-    random: n => sodium.randombytes_buf(n),
-  }),
   'libsodium-wrappers': sodium => ({
     open: sodium.crypto_secretbox_open_easy,
     close: sodium.crypto_secretbox_easy,

--- a/src/client/voice/util/Secretbox.js
+++ b/src/client/voice/util/Secretbox.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const libs = {
-  sodium: sodium => ({
+  'libsodium': sodium => ({
     open: sodium.api.crypto_secretbox_open_easy,
     close: sodium.api.crypto_secretbox_easy,
     random: n => sodium.randombytes_buf(n),

--- a/src/client/voice/util/Secretbox.js
+++ b/src/client/voice/util/Secretbox.js
@@ -2,8 +2,8 @@
 
 const libs = {
   'libsodium': sodium => ({
-    open: sodium.api.crypto_secretbox_open_easy,
-    close: sodium.api.crypto_secretbox_easy,
+    open: sodium.crypto_secretbox_open_easy,
+    close: sodium.crypto_secretbox_easy,
     random: n => sodium.randombytes_buf(n),
   }),
   'libsodium-wrappers': sodium => ({


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This patch replaces the JS libsodium library (which is currently broken) to the one we already have the wrappers for. This should fix npm installs of discord.js from here on in, and will fix issue #3093.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.