### PR TITLE
Added missing MessageEmbed.type documentation

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -16,6 +16,7 @@ class MessageEmbed {
      * The type of this embed, either:
      * * `image` - an image embed
      * * `video` - a video embed
+     * * `gifv` - a gifv embed
      * * `link` - a link embed
      * * `rich` - a rich embed
      * @type {string}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There's a (previously) undocumented embed type.
This PR resolves #3105

Checked the typings, they only specify "string", and thus didn't need to be changed (this was an explanation for the below checkbox about the typings)

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
