### PR TITLE
fix: Properly sort roles for Role#position

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -982,7 +982,7 @@ class Guild extends Base {
    * @private
    */
   _sortedRoles() {
-    return Util.discordSort(this.roles);
+    return Util.discordSort(this.roles, (a, b) => b.rawPosition - a.rawPosition);
   }
 
   /**

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -378,8 +378,10 @@ class Role extends Base {
    * positive number if the first's is higher (second's is lower), 0 if equal
    */
   static comparePositions(role1, role2) {
-    if (role1.position === role2.position) return role2.id - role1.id;
-    return role1.position - role2.position;
+    const { position: position1 } = role1;
+    const { position: position2 } = role2;
+    if (position1 === position2) return role2.id - role1.id;
+    return position2 - position1;
   }
 }
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -296,12 +296,13 @@ class Util {
 
   /**
    * Sorts by Discord's position and ID.
-   * @param  {Collection} collection Collection of objects to sort
+   * @param {Collection} collection Collection of objects to sort
+   * @param {Function} [positionSort] Function that determines the position order to sort as
    * @returns {Collection}
    */
-  static discordSort(collection) {
+  static discordSort(collection, positionSort = (a, b) => a.rawPosition - b.rawPosition) {
     return collection.sort((a, b) =>
-      a.rawPosition - b.rawPosition ||
+      positionSort(a, b) ||
       parseInt(b.id.slice(0, -10)) - parseInt(a.id.slice(0, -10)) ||
       parseInt(b.id.slice(10)) - parseInt(a.id.slice(10))
     );


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Sorting by position was wrong for roles (thanks to inconsistencies when it comes to rawPosition (thanks Discord)), and would sort bottom->top, while channels were top->bottom (depending on the channel type, and parent, if applicable).

This PR solves that, by implementing a `positionSort` argument for Util.discordSort.

Now, roles are sorted top->bottom (like on the client) and channels sort the same was as before

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
