### PR TITLE
Added missing property to MessageEmbed.video

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -100,11 +100,17 @@ class MessageEmbed {
      * The video of this embed (if there is one)
      * @type {?Object}
      * @property {string} url URL of this video
+     * @property {string} proxyURL ProxyURL for this video
      * @property {number} height Height of this video
      * @property {number} width Width of this video
      * @readonly
      */
-    this.video = data.video;
+    this.video = data.video ? {
+      url: data.video.url,
+      proxyURL: data.video.proxy_url,
+      height: data.video.height,
+      width: data.video.width,
+    } : null;
 
     /**
      * The author of this embed (if there is one)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -721,7 +721,7 @@ declare module 'discord.js' {
 		public title: string;
 		public type: string;
 		public url: string;
-		public readonly video: { url?: string; height?: number; width?: number };
+		public readonly video: { url?: string; proxyURL?: string; height?: number; width?: number };
 		public addBlankField(inline?: boolean): this;
 		public addField(name: StringResolvable, value: StringResolvable, inline?: boolean): this;
 		public attachFiles(file: (MessageAttachment | FileOptions | string)[]): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The video object provided from Discord contains a proxy_url property. This is not reflected in the documentation, and furthermore, the naming convention is proxyURL, so I made the video property of MessageEmbed behave identically to MessageEmbed.image.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
