### PR TITLE
src: Add missing events in constants

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const Package = exports.Package = require('../../package.json');
 const { Error, RangeError } = require('../errors');
 const browser = exports.browser = typeof window !== 'undefined';

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const Package = exports.Package = require('../../package.json');
 const { Error, RangeError } = require('../errors');
 const browser = exports.browser = typeof window !== 'undefined';
@@ -249,6 +247,7 @@ exports.Events = {
   USER_NOTE_UPDATE: 'userNoteUpdate',
   USER_SETTINGS_UPDATE: 'clientUserSettingsUpdate',
   PRESENCE_UPDATE: 'presenceUpdate',
+  VOICE_SERVER_UPDATE: 'voiceServerUpdate',
   VOICE_STATE_UPDATE: 'voiceStateUpdate',
   VOICE_BROADCAST_SUBSCRIBE: 'subscribe',
   VOICE_BROADCAST_UNSUBSCRIBE: 'unsubscribe',
@@ -316,6 +315,7 @@ exports.PartialTypes = keyMirror([
  * * PRESENCE_UPDATE
  * * VOICE_STATE_UPDATE
  * * TYPING_START
+ * * VOICE_STATE_UPDATE
  * * VOICE_SERVER_UPDATE
  * * WEBHOOKS_UPDATE
  * @typedef {string} WSEventType
@@ -352,6 +352,7 @@ exports.WSEvents = keyMirror([
   'PRESENCE_UPDATE',
   'VOICE_STATE_UPDATE',
   'TYPING_START',
+  'VOICE_STATE_UPDATE',
   'VOICE_SERVER_UPDATE',
   'WEBHOOKS_UPDATE',
 ]);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2145,6 +2145,7 @@ declare module 'discord.js' {
 		| 'PRESENCE_UPDATE'
 		| 'VOICE_STATE_UPDATE'
 		| 'TYPING_START'
+		| 'VOICE_STATE_UPDATE'
 		| 'VOICE_SERVER_UPDATE'
 		| 'WEBHOOKS_UPDATE';
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

And added `VOICE_SERVER_UPDATE` to `constants.Events`. Though unused inside discord.js, it's still a valid name outside it, and may be used in the future if we expose this event outside raw.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
