### PR TITLE
src: Fix missing defaultRole property under Guild in typings.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -386,6 +386,7 @@ declare module 'discord.js' {
 		public readonly createdAt: Date;
 		public readonly createdTimestamp: number;
 		public defaultMessageNotifications: DefaultMessageNotifications | number;
+		public defaultRole: Role;
 		public deleted: boolean;
 		public embedEnabled: boolean;
 		public emojis: GuildEmojiStore;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -386,7 +386,7 @@ declare module 'discord.js' {
 		public readonly createdAt: Date;
 		public readonly createdTimestamp: number;
 		public defaultMessageNotifications: DefaultMessageNotifications | number;
-		public defaultRole: Role;
+		public readonly defaultRole: Role;
 		public deleted: boolean;
 		public embedEnabled: boolean;
 		public emojis: GuildEmojiStore;


### PR DESCRIPTION
I don't know how this wasn't already there, but I added the missing defaultRole property to the typings. Did this because I found this issue myself when needing to use it and realized that it wasn't already in the typings file.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
