### PR TITLE
Message#edit shouldn't remove content

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -365,7 +365,7 @@ class Message extends Base {
 
   /**
    * Edits the content of the message.
-   * @param {StringResolvable|APIMessage} [content=''] The new content for the message
+   * @param {StringResolvable|APIMessage} [content] The new content for the message
    * @param {MessageEditOptions|MessageEmbed} [options] The options to provide
    * @returns {Promise<Message>}
    * @example

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -56,7 +56,7 @@ declare module 'discord.js' {
 			isWebhook?: boolean
 		): MessageOptions | WebhookMessageOptions;
 
-		public makeContent(): string | string[];
+		public makeContent(): string | string[] | void;
 		public resolve(): Promise<this>;
 		public resolveData(): this;
 		public resolveFiles(): Promise<this>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -56,7 +56,7 @@ declare module 'discord.js' {
 			isWebhook?: boolean
 		): MessageOptions | WebhookMessageOptions;
 
-		public makeContent(): string | string[] | void;
+		public makeContent(): string | string[] | undefined;
 		public resolve(): Promise<this>;
 		public resolveData(): this;
 		public resolveFiles(): Promise<this>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes an inconsistency with the api. If you patch only a data embed on a message, the content will be maintained. This allows Message#edit to match that behavior.

```js
const msg = await message.channel.send('test');
const edit = await msg.edit({ embed: { description: 'more tests' } });
return edit.content;
```
Before this pr the content would be '', after this pr the content will be 'test'.

Please note this also maintains the consistency for passing { content: null } which will remove the content, just as { embed: null } would remove the embed.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.

Although this has breaking behavior in terms of the current library expectations, this should technically be considered a bugfix.
