### PR TITLE
fix doc for ratelimit data, fixes #3131

### DIFF
--- a/src/client/rest/RequestHandlers/Sequential.js
+++ b/src/client/rest/RequestHandlers/Sequential.js
@@ -95,10 +95,10 @@ class SequentialRequestHandler extends RequestHandler {
                * Emitted when the client hits a rate limit while making a request
                * @event Client#rateLimit
                * @param {Object} rateLimitInfo Object containing the rate limit info
-               * @param {number} rateLimitInfo.requestLimit Number of requests that can be made to this endpoint
+               * @param {number} rateLimitInfo.limit Number of requests that can be made to this endpoint
                * @param {number} rateLimitInfo.timeDifference Delta-T in ms between your system and Discord servers
-               * @param {string} rateLimitInfo.method HTTP method used for request that triggered this event
                * @param {string} rateLimitInfo.path Path used for request that triggered this event
+               * @param {string} rateLimitInfo.method HTTP method used for request that triggered this event
                */
               this.client.emit(RATE_LIMIT, {
                 limit: this.requestLimit,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,7 +12,7 @@ declare module 'discord.js' {
 
 	export const version: string;
 
-	//#region Classes
+//#region Classes
 
 	class Attachment {
 		constructor(file: BufferResolvable | Stream, name?: string);
@@ -1531,9 +1531,9 @@ declare module 'discord.js' {
 		public setTimeout(fn: Function, delay: number, ...args: any[]): NodeJS.Timer;
 	}
 
-	//#endregion
+//#endregion
 
-	//#region Mixins
+//#region Mixins
 
 	// Model the TextBasedChannel mixin system, allowing application of these fields
 	// to the classes that use these methods without having to manually add them
@@ -1573,9 +1573,9 @@ declare module 'discord.js' {
 		stopTyping(force?: boolean): void;
 	} & PartialTextBasedChannelFields;
 
-	//#endregion
+//#endregion
 
-	//#region Typedefs
+//#region Typedefs
 
 	type ActivityType = 'PLAYING'
 		| 'STREAMING'
@@ -2166,5 +2166,5 @@ declare module 'discord.js' {
 		| 'RELATIONSHIP_ADD'
 		| 'RELATIONSHIP_REMOVE';
 
-	//#endregion
+//#endregion
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -12,7 +12,7 @@ declare module 'discord.js' {
 
 	export const version: string;
 
-//#region Classes
+	//#region Classes
 
 	class Attachment {
 		constructor(file: BufferResolvable | Stream, name?: string);
@@ -1531,9 +1531,9 @@ declare module 'discord.js' {
 		public setTimeout(fn: Function, delay: number, ...args: any[]): NodeJS.Timer;
 	}
 
-//#endregion
+	//#endregion
 
-//#region Mixins
+	//#region Mixins
 
 	// Model the TextBasedChannel mixin system, allowing application of these fields
 	// to the classes that use these methods without having to manually add them
@@ -1573,9 +1573,9 @@ declare module 'discord.js' {
 		stopTyping(force?: boolean): void;
 	} & PartialTextBasedChannelFields;
 
-//#endregion
+	//#endregion
 
-//#region Typedefs
+	//#region Typedefs
 
 	type ActivityType = 'PLAYING'
 		| 'STREAMING'
@@ -2037,7 +2037,7 @@ declare module 'discord.js' {
 
 	type ClientPresenceStatus = 'online' | 'idle' | 'dnd';
 
-	type PresenceStatus = ClientPresenceStatus | 'invisible' ;
+	type PresenceStatus = ClientPresenceStatus | 'invisible';
 	type PresenceStatusData = ClientPresenceStatus | 'offline';
 
 	type ClientPresenceStatusData = {
@@ -2047,7 +2047,7 @@ declare module 'discord.js' {
 	};
 
 	type RateLimitInfo = {
-		requestLimit: number;
+		limit: number;
 		timeDifference: number;
 		method: string;
 		path: string;
@@ -2166,5 +2166,5 @@ declare module 'discord.js' {
 		| 'RELATIONSHIP_ADD'
 		| 'RELATIONSHIP_REMOVE';
 
-//#endregion
+	//#endregion
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**


1.  Adapt the `rateLimit` event documentation to use the actual data property `limit` instead of the current `requestLimit` as actually emitted in:
https://github.com/discordjs/discord.js/blob/b5df8603e8768b9b50ece24f94e455c3410ef9a2/src/client/rest/RequestHandlers/Sequential.js#L97-L102

2. Change the order properties are documented in to reflect the emitted data

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
