### PR TITLE
Removed code and documentation for Guild.fetchAuditLogs "after" option

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -566,7 +566,6 @@ class Guild extends Base {
    * Fetches audit logs for this guild.
    * @param {Object} [options={}] Options for fetching audit logs
    * @param {Snowflake|GuildAuditLogsEntry} [options.before] Limit to entries from before specified entry
-   * @param {Snowflake|GuildAuditLogsEntry} [options.after] Limit to entries from after specified entry
    * @param {number} [options.limit] Limit number of entries
    * @param {UserResolvable} [options.user] Only show entries involving this user
    * @param {AuditLogAction|number} [options.type] Only show entries involving this action type
@@ -579,12 +578,10 @@ class Guild extends Base {
    */
   fetchAuditLogs(options = {}) {
     if (options.before && options.before instanceof GuildAuditLogs.Entry) options.before = options.before.id;
-    if (options.after && options.after instanceof GuildAuditLogs.Entry) options.after = options.after.id;
     if (typeof options.type === 'string') options.type = GuildAuditLogs.Actions[options.type];
 
     return this.client.api.guilds(this.id)['audit-logs'].get({ query: {
       before: options.before,
-      after: options.after,
       limit: options.limit,
       user_id: this.client.users.resolveID(options.user),
       action_type: options.type,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1744,7 +1744,6 @@ declare module 'discord.js' {
 
 	interface GuildAuditLogsFetchOptions {
 		before?: Snowflake | GuildAuditLogsEntry;
-		after?: Snowflake | GuildAuditLogsEntry;
 		limit?: number;
 		user?: UserResolvable;
 		type?: string | number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fixes #3141 
Removes the code and JSDoc for `options.after` in `Guild.fetchAuditLogs()` as this parameter is not supported by the API.  
Reference: https://discordapp.com/developers/docs/resources/audit-log#get-guild-audit-log-query-string-parameters

I tested the code - `Guild.fetchAuditLogs()` still works, and if anyone passes an `options.after` parameter it still does exactly what it did before: nothing. Therefore I consider this a non-breaking change.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
