### PR TITLE
Adding cache param to MessageStore#fetchPinned()

### DIFF
--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -74,7 +74,7 @@ class MessageStore extends DataStore {
    *   .then(messages => console.log(`Received ${messages.size} messages`))
    *   .catch(console.error);
    */
-  fetchPinned(cache) {
+  fetchPinned(cache = true) {
     return this.client.api.channels[this.channel.id].pins.get().then(data => {
       const messages = new Collection();
       for (const message of data) messages.set(message.id, this.add(message, cache));

--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -66,6 +66,7 @@ class MessageStore extends DataStore {
    * Fetches the pinned messages of this channel and returns a collection of them.
    * <info>The returned Collection does not contain any reaction data of the messages.
    * Those need to be fetched separately.</info>
+   * @param {boolean} [cache=true] Whether to cache the message(s)
    * @returns {Promise<Collection<Snowflake, Message>>}
    * @example
    * // Get pinned messages
@@ -73,10 +74,10 @@ class MessageStore extends DataStore {
    *   .then(messages => console.log(`Received ${messages.size} messages`))
    *   .catch(console.error);
    */
-  fetchPinned() {
+  fetchPinned(cache) {
     return this.client.api.channels[this.channel.id].pins.get().then(data => {
       const messages = new Collection();
-      for (const message of data) messages.set(message.id, this.add(message));
+      for (const message of data) messages.set(message.id, this.add(message, cache));
       return messages;
     });
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1366,9 +1366,9 @@ declare module 'discord.js' {
 
 	export class MessageStore extends DataStore<Snowflake, Message, typeof Message, MessageResolvable> {
 		constructor(channel: TextChannel | DMChannel, iterable?: Iterable<any>);
-		public fetch(message: Snowflake): Promise<Message>;
-		public fetch(options?: ChannelLogsQueryOptions): Promise<Collection<Snowflake, Message>>;
-		public fetchPinned(): Promise<Collection<Snowflake, Message>>;
+		public fetch(message: Snowflake, cache?: boolean): Promise<Message>;
+		public fetch(options?: ChannelLogsQueryOptions, cache?: boolean): Promise<Collection<Snowflake, Message>>;
+		public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;
 	}
 
 	export class PresenceStore extends DataStore<Snowflake, Presence, typeof Presence, PresenceResolvable> {


### PR DESCRIPTION
As discovered in https://github.com/discordjs/discord.js/issues/3153#issuecomment-473657777, in order to get reactions from a fetched pinned message, you had to uncache the message yourself. This PR allows the developer to specify whether they want the messages to be cached or not via the `cache` param, the same way it's done on MessageStore#fetch().

Missing typings for the `cache` param for MessageStore#fetch() have also been added in this PR.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
