### PR TITLE
Added Collection#partition typings from master

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -344,6 +344,7 @@ declare module 'discord.js' {
 		public lastKey(): K;
 		public lastKey(count: number): K[];
 		public map<T>(fn: (value: V, key: K, collection: Collection<K, V>) => T, thisArg?: any): T[];
+		public partition(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): [Collection<K, V>, Collection<K, V>];
 		public random(): V;
 		public random(count: number): V[];
 		public randomKey(): K;


### PR DESCRIPTION
The typings for Collection#partition were missing from typings/index.d.ts, thanks DubiousDoggo for pointing that out.

This PR adds them back to it

**Status**
- [] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
