### PR TITLE
feat(Guild): add Guild#fetchBan()

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -631,6 +631,14 @@ class RESTMethods {
     });
   }
 
+  getGuildBan(guild, user) {
+    const id = this.client.resolver.resolveUserID(user);
+    return this.rest.makeRequest('get', `${Endpoints.Guild(guild).bans}/${id}`, true).then(ban => ({
+      reason: ban.reason,
+      user: this.client.dataManager.newUser(ban.user),
+    }));
+  }
+
   getGuildBans(guild) {
     return this.rest.makeRequest('get', Endpoints.Guild(guild).bans, true).then(bans =>
       bans.reduce((collection, ban) => {

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -469,8 +469,29 @@ class Guild {
   }
 
   /**
+   * An object containing information about a guild member's ban.
+   * @typedef {Object} BanInfo
+   * @property {User} user User that was banned
+   * @property {?string} reason Reason the user was banned
+   */
+
+  /**
+   * Fetch a ban for a user.
+   * @returns {Promise<BanInfo>}
+   * @param {UserResolvable} user The user to fetch the ban for
+   * @example
+   * // Get ban
+   * guild.fetchBan(message.author)
+   *   .then(({ user, reason }) => console.log(`${user.tag} was banned for the reason: ${reason}.`))
+   *   .catch(console.error);
+   */
+  fetchBan(user) {
+    return this.client.rest.methods.getGuildBan(this, user);
+  }
+
+  /**
    * Fetch a collection of banned users in this guild.
-   * @returns {Promise<Collection<Snowflake, User>>}
+   * @returns {Promise<Collection<Snowflake, BanInfo>>}
    * @example
    * // Fetch bans in guild
    * guild.fetchBans()
@@ -478,12 +499,7 @@ class Guild {
    *   .catch(console.error);
    */
   fetchBans() {
-    return this.client.rest.methods.getGuildBans(this)
-      .then(bans => {
-        const users = new Collection();
-        for (const ban of bans.values()) users.set(ban.user.id, ban.user);
-        return users;
-      });
+    return this.client.rest.methods.getGuildBans(this);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -491,15 +491,22 @@ class Guild {
 
   /**
    * Fetch a collection of banned users in this guild.
-   * @returns {Promise<Collection<Snowflake, BanInfo>>}
+   * @returns {Promise<Collection<Snowflake, User|BanInfo>>}
+   * @param {boolean} [withReasons=false] Whether or not to include the ban reason(s)
    * @example
    * // Fetch bans in guild
    * guild.fetchBans()
    *   .then(bans => console.log(`This guild has ${bans.size} bans`))
    *   .catch(console.error);
    */
-  fetchBans() {
-    return this.client.rest.methods.getGuildBans(this);
+  fetchBans(withReasons = false) {
+    if (withReasons) return this.client.rest.methods.getGuildBans(this);
+    return this.client.rest.methods.getGuildBans(this)
+      .then(bans => {
+        const users = new Collection();
+        for (const ban of bans.values()) users.set(ban.user.id, ban.user);
+        return users;
+      });
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -534,7 +534,7 @@ declare module 'discord.js' {
 		public equals(guild: Guild): boolean;
 		public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
 		public fetchBan(user: UserResolvable): Promise<BanInfo>;
-		public fetchBans(): Promise<Collection<Snowflake, BanInfo>>;
+		public fetchBans(withReasons?: boolean): Promise<Collection<Snowflake, User | BanInfo>>;
 		public fetchEmbed(): Promise<GuildEmbedData>;
 		public fetchInvites(): Promise<Collection<Snowflake, Invite>>;
 		public fetchMember(user: UserResolvable, cache?: boolean): Promise<GuildMember>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1605,7 +1605,7 @@ declare module 'discord.js' {
 
 	type BanInfo = {
 		user: User;
-		reason?: string;
+		reason: string | null;
 	};
 
 	type BanOptions = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -533,7 +533,8 @@ declare module 'discord.js' {
 		public edit(data: GuildEditData, reason?: string): Promise<Guild>;
 		public equals(guild: Guild): boolean;
 		public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
-		public fetchBans(): Promise<Collection<Snowflake, User>>;
+		public fetchBan(user: UserResolvable): Promise<BanInfo>;
+		public fetchBans(): Promise<Collection<Snowflake, BanInfo>>;
 		public fetchEmbed(): Promise<GuildEmbedData>;
 		public fetchInvites(): Promise<Collection<Snowflake, Invite>>;
 		public fetchMember(user: UserResolvable, cache?: boolean): Promise<GuildMember>;
@@ -1599,6 +1600,11 @@ declare module 'discord.js' {
 	type AwaitMessagesOptions = MessageCollectorOptions & { errors?: string[] };
 
 	type AwaitReactionsOptions = ReactionCollectorOptions & { errors?: string[] };
+
+	type BanInfo = {
+		user: User;
+		reason?: string;
+	};
 
 	type BanOptions = {
 		days?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -534,7 +534,9 @@ declare module 'discord.js' {
 		public equals(guild: Guild): boolean;
 		public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
 		public fetchBan(user: UserResolvable): Promise<BanInfo>;
-		public fetchBans(withReasons?: boolean): Promise<Collection<Snowflake, User | BanInfo>>;
+		public fetchBans(withReasons?: false): Promise<Collection<Snowflake, User>>;
+		public fetchBans(withReasons: true): Promise<Collection<Snowflake, BanInfo>>;
+		public fetchBans(withReasons: boolean): Promise<Collection<Snowflake, BanInfo | User>>;
 		public fetchEmbed(): Promise<GuildEmbedData>;
 		public fetchInvites(): Promise<Collection<Snowflake, Invite>>;
 		public fetchMember(user: UserResolvable, cache?: boolean): Promise<GuildMember>;


### PR DESCRIPTION
This PR adds Guild#fetchBan() to make use of the [Get Guild Ban endpoint](https://discordapp.com/developers/docs/resources/guild#get-guild-ban) and backports the `BanInfo` typedef from master. Also, Guild#fetchBans() has been slightly altered so that it also returns the reason  within the Collection... which was already the case within `client.rest.methods.getGuildBans()` but then was being ignored within the method for some reason. This would be pretty handy for those who want to retrieve the ban reason through the `guildBanAdd` event for instance, instead of having to fetch and filter through audit logs.

#2735 (master) is somewhat related to this PR as it also adds this method, although it seems to be pretty stale for past few months.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.