### PR TITLE
feat(VoiceChannel): add editable

### DIFF
--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -77,7 +77,7 @@ class VoiceChannel extends GuildChannel {
    * @readonly
    */
   get editable() {
-    return super.manageable && this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false);
+    return this.manageable && this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false);
   }
 
   /**

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -72,6 +72,15 @@ class VoiceChannel extends GuildChannel {
   }
 
   /**
+   * Whether the channel is editable by the client user
+   * @type {boolean}
+   * @readonly
+   */
+  get editable() {
+    return super.manageable && this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false);
+  }
+
+  /**
    * Whether the channel is joinable by the client user
    * @type {boolean}
    * @readonly

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1136,6 +1136,7 @@ declare module 'discord.js' {
 		constructor(guild: Guild, data?: object);
 		public bitrate: number;
 		public readonly connection: VoiceConnection;
+		public readonly editable: boolean;
 		public readonly full: boolean;
 		public readonly joinable: boolean;
 		public readonly members: Collection<Snowflake, GuildMember>;


### PR DESCRIPTION
The purpose of this PR is to accommodate for an edge case which is the fact that Discord requires the user to have the `CONNECT` and `MANAGE_CHANNELS` permissions in order to edit a VoiceChannel.

The reason why I didn't just override the `manageable` method inherited from GuildChannel is due to the fact that, you could "manage" the channel by modifying the position of the VoiceChannel even when you lack the `CONNECT` permission... Discord permissions are nice. However, not sure if this is the best way to go about this since changing the position of the channel is still technically editing the channel, which contradicts with this method. Also I'm not sure if the GuildChannel should also have this method to maintain consistency, since for other channel types the editable method wouldn't require any other permissions in addition to `MANAGE_CHANNELS`.

Feel free to let me know if you have any other ideas.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
