### PR TITLE
feat(Webhook): add url getter

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -219,7 +219,7 @@ class Webhook {
    * @readonly
    */
   get url() {
-    return this.client.options.http.api + this.client.api.webhooks[this.id][this.token];
+    return this.client.options.http.api + this.client.api.webhooks(this.id, this.token);
   }
 
   static applyToClass(structure) {

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -213,6 +213,15 @@ class Webhook {
     return this.client.api.webhooks(this.id, this.token).delete({ reason });
   }
 
+  /**
+   * The url of this webhook
+   * @type {string}
+   * @readonly
+   */
+  get url() {
+    return `https://discordapp.com/api/webhooks/${this.id}/${this.token}`;
+  }
+
   static applyToClass(structure) {
     for (const prop of [
       'send',

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -219,7 +219,7 @@ class Webhook {
    * @readonly
    */
   get url() {
-    return `https://discordapp.com/api/webhooks/${this.id}/${this.token}`;
+    return this.client.options.http.api + this.client.api.webhooks[this.id][this.token];
   }
 
   static applyToClass(structure) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1270,7 +1270,7 @@ declare module 'discord.js' {
 		public guildID: Snowflake;
 		public name: string;
 		public owner: User | object;
-		public url: string;
+		public readonly url: string;
 	}
 
 	export class WebhookClient extends WebhookMixin(BaseClient) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1270,6 +1270,7 @@ declare module 'discord.js' {
 		public guildID: Snowflake;
 		public name: string;
 		public owner: User | object;
+		public url: string;
 	}
 
 	export class WebhookClient extends WebhookMixin(BaseClient) {


### PR DESCRIPTION
You're able to retrieve this using the client, so it would be a nice little helper getter that the library could provide instead of having to construct this yourself.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
