### PR TITLE
utilize URLSearchParams

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -338,11 +338,15 @@ class Client extends BaseClient {
    *   .then(link => console.log(`Generated bot invite link: ${link}`))
    *   .catch(console.error);
    */
-  generateInvite(permissions) {
+  async generateInvite(permissions) {
     permissions = Permissions.resolve(permissions);
-    return this.fetchApplication().then(application =>
-      `https://discordapp.com/oauth2/authorize?client_id=${application.id}&permissions=${permissions}&scope=bot`
-    );
+    const application = await this.fetchApplication();
+    const query = new URLSearchParams({
+      client_id: application.id,
+      permissions: permissions,
+      scope: 'bot',
+    });
+    return `${this.options.http.api}${this.api.oauth2.authorize}?${query}`;
   }
 
   toJSON() {

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -15,9 +15,12 @@ class APIRequest {
     this.route = options.route;
     this.options = options;
 
-    // Filter out undefined query options
-    const query = Object.entries(options.query).filter(([, value]) => typeof value !== 'undefined');
-    const queryString = new URLSearchParams(query).toString();
+    let queryString;
+    if (options.query) {
+      // Filter out undefined query options
+      const query = Object.entries(options.query).filter(([, value]) => typeof value !== 'undefined');
+      queryString = new URLSearchParams(query).toString();
+    }
     this.path = `${path}${queryString || `?${queryString}`}`;
   }
 

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -21,7 +21,7 @@ class APIRequest {
       const query = Object.entries(options.query).filter(([, value]) => typeof value !== 'undefined');
       queryString = new URLSearchParams(query).toString();
     }
-    this.path = `${path}${queryString || `?${queryString}`}`;
+    this.path = `${path}${queryString ? `?${queryString}` : ''}`;
   }
 
   make() {

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -15,13 +15,13 @@ class APIRequest {
     this.route = options.route;
     this.options = options;
 
-    let queryString;
+    let queryString = '';
     if (options.query) {
       // Filter out undefined query options
       const query = Object.entries(options.query).filter(([, value]) => typeof value !== 'undefined');
       queryString = new URLSearchParams(query).toString();
     }
-    this.path = `${path}${queryString ? `?${queryString}` : ''}`;
+    this.path = `${path}${queryString && `?${queryString}`}`;
   }
 
   make() {

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const querystring = require('querystring');
 const FormData = require('form-data');
 const https = require('https');
 const { browser, UserAgent } = require('../util/Constants');
@@ -16,8 +15,10 @@ class APIRequest {
     this.route = options.route;
     this.options = options;
 
-    const queryString = (querystring.stringify(options.query).match(/[^=&?]+=[^=&?]+/g) || []).join('&');
-    this.path = `${path}${queryString ? `?${queryString}` : ''}`;
+    // Filter out undefined query options
+    const query = Object.entries(options.query).filter(([, value]) => typeof value !== 'undefined');
+    const queryString = new URLSearchParams(query).toString();
+    this.path = `${path}${queryString || `?${queryString}`}`;
   }
 
   make() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pr removes the reliance on querystring and switches to the new node global URLSearchParams (which is also a browser API). This also removes a place where the base API URL is hardcoded so that we use the constants/client.options base URL in case that's ever changed.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
