### PR TITLE
fix(Guild): sort roles with the same position in the correct order

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1415,7 +1415,7 @@ class Guild {
     return collection.sort((a, b) =>
       a.position !== b.position ?
         a.position - b.position :
-        Long.fromString(a.id).sub(Long.fromString(b.id)).toNumber()
+        Long.fromString(b.id).sub(Long.fromString(a.id)).toNumber()
     );
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Roles are currently sorted in the incorrect order.

For example once created the roles will appear in the role manager as the following:
* old role, `position` 2
* new role1, `position` 1
* new role2, `position` 1
* new role3, `position` 1
* `@everyone`, `position` 0

They would however be incorrectly sorted as:
* old role, `calculatedPosition` 4
* new role3, `calculatedPosition` 3
* new role2, `calculatedPosition` 2
* new role1, `calculatedPosition` 1
* `@everyone`, `calculatedPosition` 0

With this pr they are sorted correctly:
* old role, `calculatedPosition` 4
* new role1, `calculatedPosition` 3
* new role2, `calculatedPosition` 2
* new role3, `calculatedPosition` 1
* `@everyone`, `calculatedPosition` 0

For reference the code I used to create the roles:
```js
const guild = message.guild;

const roles = [];
for (const roleName of ['new role1', 'new role2', 'new role3']) {
	roles.push(await guild.createRole({ name: roleName }));
}

console.log(roles.map(role => [role.name, role.position, role.calculatedPosition]));
```

The code responsible for sorting the roles is doing `a.id - b.id` while it should be `b.id - a.id`:
https://github.com/discordjs/discord.js/blob/ebfbf20f07574b14f6425aaec2fd0288f3d7c872/src/structures/Guild.js#L1321

`Role.comparePositions` however does it "correctly":
https://github.com/discordjs/discord.js/blob/ebfbf20f07574b14f6425aaec2fd0288f3d7c872/src/structures/Role.js#L367

On master this seems to be fixed already:
https://github.com/discordjs/discord.js/blob/bfab203934395ebd8884b3fb6360d2d44a0778dd/src/util/Util.js#L305-L306

Closes #3175

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
