### PR TITLE
ref(WebSocket): utilize URLSearchParams

### DIFF
--- a/src/WebSocket.js
+++ b/src/WebSocket.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { browser } = require('./util/Constants');
-const querystring = require('querystring');
 try {
   var erlpack = require('erlpack');
   if (!erlpack.pack) erlpack = null;
@@ -30,8 +29,8 @@ exports.unpack = data => {
 exports.create = (gateway, query = {}, ...args) => {
   const [g, q] = gateway.split('?');
   query.encoding = exports.encoding;
-  if (q) query = Object.assign(querystring.parse(q), query);
-  const ws = new exports.WebSocket(`${g}?${querystring.stringify(query)}`, ...args);
+  if (q) new URLSearchParams(q).forEach((v, k) => Object.assign(query, { [k]: v }));
+  const ws = new exports.WebSocket(`${g}?${new URLSearchParams(query)}`, ...args);
   if (browser) ws.binaryType = 'arraybuffer';
   return ws;
 };

--- a/src/WebSocket.js
+++ b/src/WebSocket.js
@@ -29,8 +29,9 @@ exports.unpack = data => {
 exports.create = (gateway, query = {}, ...args) => {
   const [g, q] = gateway.split('?');
   query.encoding = exports.encoding;
-  if (q) new URLSearchParams(q).forEach((v, k) => Object.assign(query, { [k]: v }));
-  const ws = new exports.WebSocket(`${g}?${new URLSearchParams(query)}`, ...args);
+  query = new URLSearchParams(query);
+  if (q) new URLSearchParams(q).forEach((v, k) => query.set(k, v));
+  const ws = new exports.WebSocket(`${g}?${query}`, ...args);
   if (browser) ws.binaryType = 'arraybuffer';
   return ws;
 };


### PR DESCRIPTION
#3180 removed the reliance on the `querystring` package by making use of `URLSearchParams` within the APIRequest, this PR pretty much does the same but within the WebSocket.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
