### PR TITLE
docs: make voice public

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -86,7 +86,6 @@ class Client extends BaseClient {
     /**
      * The voice manager of the client (`null` in browsers)
      * @type {?ClientVoiceManager}
-     * @private
      */
     this.voice = !browser ? new ClientVoiceManager(this) : null;
 

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -157,16 +157,6 @@ class Client extends BaseClient {
   }
 
   /**
-   * All active voice connections that have been established, mapped by guild ID
-   * @type {Collection<Snowflake, VoiceConnection>}
-   * @readonly
-   */
-  get voiceConnections() {
-    if (browser) return new Collection();
-    return this.voice.connections;
-  }
-
-  /**
    * All custom emojis that the client has access to, mapped by their IDs
    * @type {GuildEmojiStore<Snowflake, GuildEmoji>}
    * @readonly

--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -14,8 +14,10 @@ class ClientVoiceManager {
     /**
      * The client that instantiated this voice manager
      * @type {Client}
+     * @readonly
+     * @name ClientVoiceManager#client
      */
-    this.client = client;
+    Object.defineProperty(this, 'client', { value: client });
 
     /**
      * A collection mapping connection IDs to the Connection objects

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -234,7 +234,7 @@ declare module 'discord.js' {
 
 	export class ClientVoiceManager {
 		constructor(client: Client);
-		public client: Client;
+		public readonly client: Client;
 		public connections: Collection<Snowflake, VoiceConnection>;
 		public broadcasts: VoiceBroadcast[];
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -145,7 +145,7 @@ declare module 'discord.js' {
 		public user: ClientUser | null;
 		public users: UserStore;
 		public readonly voiceConnections: Collection<Snowflake, VoiceConnection>;
-		public voice: ClientVoiceManager;
+		public voice: ClientVoiceManager | null;
 		public ws: WebSocketManager;
 		public destroy(): void;
 		public fetchApplication(): Promise<ClientApplication>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -144,7 +144,6 @@ declare module 'discord.js' {
 		public readonly uptime: number;
 		public user: ClientUser | null;
 		public users: UserStore;
-		public readonly voiceConnections: Collection<Snowflake, VoiceConnection>;
 		public voice: ClientVoiceManager | null;
 		public ws: WebSocketManager;
 		public destroy(): void;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -131,11 +131,9 @@ declare module 'discord.js' {
 	export class Client extends BaseClient {
 		constructor(options?: ClientOptions);
 		private actions: object;
-		private voice: object;
 		private _eval(script: string): any;
 		private _validateOptions(options?: ClientOptions): void;
 
-		public broadcasts: VoiceBroadcast[];
 		public channels: ChannelStore;
 		public readonly emojis: GuildEmojiStore;
 		public guilds: GuildStore;
@@ -147,8 +145,8 @@ declare module 'discord.js' {
 		public user: ClientUser | null;
 		public users: UserStore;
 		public readonly voiceConnections: Collection<Snowflake, VoiceConnection>;
+		public voice: ClientVoiceManager;
 		public ws: WebSocketManager;
-		public createVoiceBroadcast(): VoiceBroadcast;
 		public destroy(): void;
 		public fetchApplication(): Promise<ClientApplication>;
 		public fetchInvite(invite: InviteResolvable): Promise<Invite>;
@@ -232,6 +230,15 @@ declare module 'discord.js' {
 		public once(event: 'shardReady', listener: (id: number) => void): this;
 		public once(event: 'shardResumed', listener: (id: number) => void): this;
 		public once(event: string, listener: Function): this;
+	}
+
+	export class ClientVoiceManager {
+		constructor(client: Client);
+		public client: Client;
+		public connections: Collection<Snowflake, VoiceConnection>;
+		public broadcasts: VoiceBroadcast[];
+
+		public createBroadcast(): VoiceBroadcast;
 	}
 
 	export class ClientApplication extends Base {
@@ -1114,6 +1121,7 @@ declare module 'discord.js' {
 	class VoiceBroadcast extends EventEmitter {
 		constructor(client: Client);
 		public client: Client;
+		public dispatchers: StreamDispatcher[];
 		public readonly dispatcher: BroadcastDispatcher;
 		public play(input: string | Readable, options?: StreamOptions): BroadcastDispatcher;
 
@@ -1148,10 +1156,11 @@ declare module 'discord.js' {
 	}
 
 	class VoiceConnection extends EventEmitter {
-		constructor(voiceManager: object, channel: VoiceChannel);
+		constructor(voiceManager: ClientVoiceManager, channel: VoiceChannel);
 		private authentication: object;
 		private sockets: object;
 		private ssrcMap: Map<number, boolean>;
+		private _speaking: Map<Snowflake, Readonly<Speaking>>;
 		private _disconnect(): void;
 		private authenticate(): void;
 		private authenticateFailed(reason: string): void;
@@ -1175,7 +1184,7 @@ declare module 'discord.js' {
 		public receiver: VoiceReceiver;
 		public speaking: Readonly<Speaking>;
 		public status: VoiceStatus;
-		public voiceManager: object;
+		public voiceManager: ClientVoiceManager;
 		public disconnect(): void;
 		public play(input: VoiceBroadcast | Readable | string, options?: StreamOptions): StreamDispatcher;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Ever since commit c8225631c9f7906c0aa4966db701fe594074f27c, to create a broadcast you have to use `Client#voice#createBroadcast`. The property, however, was marked as private in the docs, meaning you had to toggle the privates to visible to find it. This PR updates that, and the typings for it.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
