### PR TITLE
feat(GuildMemberStore) add options.count to prune

### DIFF
--- a/src/stores/GuildMemberStore.js
+++ b/src/stores/GuildMemberStore.js
@@ -106,11 +106,13 @@ class GuildMemberStore extends DataStore {
 
   /**
    * Prunes members from the guild based on how long they have been inactive.
+   * <info>It's recommended to set options.count to `false` for large guilds.</info>
    * @param {Object} [options] Prune options
    * @param {number} [options.days=7] Number of days of inactivity required to kick
    * @param {boolean} [options.dry=false] Get number of users that will be kicked, without actually kicking them
+   * @param {boolean} [options.count=true] Whether or not to return the number of users that have been kicked.
    * @param {string} [options.reason] Reason for this prune
-   * @returns {Promise<number>} The number of members that were/will be kicked
+   * @returns {Promise<number|null>} The number of members that were/will be kicked
    * @example
    * // See how many members will be pruned
    * guild.members.prune({ dry: true })
@@ -122,9 +124,12 @@ class GuildMemberStore extends DataStore {
    *   .then(pruned => console.log(`I just pruned ${pruned} people!`))
    *   .catch(console.error);
    */
-  prune({ days = 7, dry = false, reason } = {}) {
+  prune({ days = 7, dry = false, count = true, reason } = {}) {
     if (typeof days !== 'number') throw new TypeError('PRUNE_DAYS_TYPE');
-    return this.client.api.guilds(this.guild.id).prune[dry ? 'get' : 'post']({ query: { days }, reason })
+    return this.client.api.guilds(this.guild.id).prune[dry ? 'get' : 'post']({ query: {
+      days,
+      compute_prune_count: count,
+    }, reason })
       .then(data => data.pruned);
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1417,6 +1417,7 @@ declare module 'discord.js' {
 		public fetch(options: UserResolvable | FetchMemberOptions): Promise<GuildMember>;
 		public fetch(): Promise<GuildMemberStore>;
 		public fetch(options: FetchMembersOptions): Promise<Collection<Snowflake, GuildMember>>;
+		public prune(options: GuildPruneMembersOptions & { dry?: false, count: false }): Promise<null>;
 		public prune(options?: GuildPruneMembersOptions): Promise<number>;
 		public unban(user: UserResolvable, reason?: string): Promise<User>;
 	}
@@ -1886,6 +1887,7 @@ declare module 'discord.js' {
 	type GuildResolvable = Guild | Snowflake;
 
 	interface GuildPruneMembersOptions {
+		count?: boolean;
 		days?: number;
 		dry?: boolean;
 		reason?: string;


### PR DESCRIPTION
This PR adds support for the [compute_prune_count](https://discordapp.com/developers/docs/resources/guild#begin-guild-prune-query-string-params) query string param by adding a `count` option. I'm not sure about the typings since there's probably a nicer way instead of just having the return type as `Promise<number | null>`? So, I'll just leave that for now.


**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
