### PR TITLE
fix end method in VoiceBroadcast

### DIFF
--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -37,7 +37,7 @@ class ClientVoiceManager {
    * @returns {VoiceBroadcast}
    */
   createBroadcast() {
-    const broadcast = new VoiceBroadcast(this);
+    const broadcast = new VoiceBroadcast(this.client);
     this.broadcasts.push(broadcast);
     return broadcast;
   }

--- a/src/client/voice/VoiceBroadcast.js
+++ b/src/client/voice/VoiceBroadcast.js
@@ -67,8 +67,8 @@ class VoiceBroadcast extends EventEmitter {
    */
   end() {
     for (const dispatcher of this.dispatchers) this.delete(dispatcher);
-    const index = this.client.voice.broadcasts.indexOf(this);
-    if (index !== -1) this.client.voice.broadcasts.splice(index, 1);
+    const index = this.client.broadcasts.indexOf(this);
+    if (index !== -1) this.client.broadcasts.splice(index, 1);
   }
 
   add(dispatcher) {

--- a/src/client/voice/VoiceBroadcast.js
+++ b/src/client/voice/VoiceBroadcast.js
@@ -67,8 +67,8 @@ class VoiceBroadcast extends EventEmitter {
    */
   end() {
     for (const dispatcher of this.dispatchers) this.delete(dispatcher);
-    const index = this.client.broadcasts.indexOf(this);
-    if (index !== -1) this.client.broadcasts.splice(index, 1);
+    const index = this.client.voice.broadcasts.indexOf(this);
+    if (index !== -1) this.client.voice.broadcasts.splice(index, 1);
   }
 
   add(dispatcher) {


### PR DESCRIPTION
this.client is a ClientVoiceManager and thus its this.client.broadcasts  instead of this.client.voice.broascasts

**Please describe the changes this PR makes and why it should be merged:**


**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
