### PR TITLE
Fix typings for WebSocket (ws)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "runkitExampleFilename": "./docs/examples/ping.js",
   "unpkg": "./webpack/discord.min.js",
   "dependencies": {
+    "@types/ws": "^6.0.1",
     "form-data": "^2.3.3",
     "node-fetch": "^2.3.0",
     "pako": "^1.0.8",
@@ -53,7 +54,6 @@
   },
   "devDependencies": {
     "@types/node": "^10.12.24",
-    "@types/ws": "^6.0.1",
     "discord.js-docgen": "discordjs/docgen",
     "eslint": "^5.13.0",
     "json-filter-loader": "^1.0.0",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

In commit 3f5161eb76b71ab8984e39ff39bf2937b82f5b43 a reference to the `ws` package was added in the typings, however the `@types/ws` were added to `devDepedencies` which are skipped when installing this lib through the NPM registry. This would then cause the TypeScript compiler to crash, giving the following error:

```
$ tsc
node_modules/discord.js/typings/index.d.ts:5:29 - error TS7016: Could not find a declaration file for module 'ws'. '/Users/favna/dev/ribbon/node_modules/ws/index.js' implicitly has an 'any' type.
  Try `npm install @types/ws` if it exists or add a new declaration (.d.ts) file containing `declare module 'ws';`

5  import * as WebSocket from 'ws';
                              ~~~~


Found 1 error.

error Command failed with exit code 2.
```

Found it as I publish my own fork under a different name which ran into the issue.

Please note that another solution would be to add `@types/ws` to `peerDependencies`, however since it's a must-have for TypeScript users I think it's better to add it to `dependencies` as the other `peerDependencies` are optional and this would not be (again, for TS users). Regardless it has to be somewhere other than `devDepedencies`.
That all said, if you guys want me to move it to peer just let me know.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
