### PR TITLE
docs(Presence): add ClientPresenceStatus typedef

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -13,12 +13,19 @@ const { ActivityTypes } = require('../util/Constants');
 
 /**
  * The status of this presence:
- *
  * * **`online`** - user is online
  * * **`idle`** - user is AFK
  * * **`offline`** - user is offline or invisible
  * * **`dnd`** - user is in Do Not Disturb
  * @typedef {string} PresenceStatus
+ */
+
+/**
+ * The status of this presence:
+ * * **`online`** - user is online
+ * * **`idle`** - user is AFK
+ * * **`dnd`** - user is in Do Not Disturb
+ * @typedef {string} ClientPresenceStatus
  */
 
 /**
@@ -80,10 +87,10 @@ class Presence {
 
     /**
      * The devices this presence is on
-     * @type {?object}
-     * @property {?PresenceStatus} web The current presence in the web application
-     * @property {?PresenceStatus} mobile The current presence in the mobile application
-     * @property {?PresenceStatus} desktop The current presence in the desktop application
+     * @type {?Object}
+     * @property {?ClientPresenceStatus} web The current presence in the web application
+     * @property {?ClientPresenceStatus} mobile The current presence in the mobile application
+     * @property {?ClientPresenceStatus} desktop The current presence in the desktop application
      */
     this.clientStatus = data.client_status || null;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2075,9 +2075,9 @@ declare module 'discord.js' {
 	type ClientPresenceStatus = 'online' | 'idle' | 'dnd';
 
 	interface ClientPresenceStatusData {
-		web?: PresenceStatus;
-		mobile?: PresenceStatus;
-		desktop?: PresenceStatus;
+		web?: ClientPresenceStatus;
+		mobile?: ClientPresenceStatus;
+		desktop?: ClientPresenceStatus;
 	}
 
 	type PartialTypes = 'USER'


### PR DESCRIPTION
This PR partially reverts https://github.com/discordjs/discord.js/pull/3127/commits/4ac9c5ddca2380ecd0854fe42d2adf6872a46fe2, since the types were correct before as Presence#clientStatus [doesn't](https://discordapp.com/developers/docs/topics/gateway#client-status-object) include the "offline" status and adds a ClientPresenceStatus typedef (which excludes "offline" from the PresenceStatus's typedef) to match the typings.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
