### PR TITLE
Use StringResolvable in Util.splitMessage

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -51,11 +51,12 @@ class Util {
 
   /**
    * Splits a string into multiple chunks at a designated character that do not exceed a specific length.
-   * @param {string} text Content to split
+   * @param {StringResolvable} text Content to split
    * @param {SplitOptions} [options] Options controlling the behavior of the split
    * @returns {string|string[]}
    */
   static splitMessage(text, { maxLength = 2000, char = '\n', prepend = '', append = '' } = {}) {
+    text = this.resolveString(text);
     if (text.length <= maxLength) return text;
     const splitText = text.split(char);
     if (splitText.some(chunk => chunk.length > maxLength)) throw new RangeError('SPLIT_MAX_LEN');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Changes `Util.splitMessage` to allow a StringResolvable to be passed in instead of just a string, just a super tiny but useful improvement. I noticed that MessageEmbed had this in most of its methods and it would be great for this too.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
