### PR TITLE
Only reset sessionID when close code is 1000 or 4006

### DIFF
--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -216,7 +216,7 @@ class WebSocketManager {
           return;
         }
 
-        if (event.code >= 1002 && event.code <= 2000) {
+        if (event.code === 1000 || event.code === 4006) {
           // Any event code in this range cannot be resumed.
           shard.sessionID = undefined;
         }

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -216,7 +216,7 @@ class WebSocketManager {
           return;
         }
 
-        if (event.code >= 1000 && event.code <= 2000) {
+        if (event.code >= 1002 && event.code <= 2000) {
           // Any event code in this range cannot be resumed.
           shard.sessionID = undefined;
         }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This resolves #3191 where in resumed never fires. 

I don't think 1001 should be included on resetting the sessionID based on Line 372 & 373 of https://github.com/discordjs/discord.js/blob/master/src/client/websocket/WebSocketShard.js

Using latest master with this modification fixed my issue entirely, refer to screenshot below.
https://media.discordapp.net/attachments/222197033908436994/568036331452891146/unknown.png?width=297&height=211

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
