### PR TITLE
docs: give the unit for collectoroptions time parameter

### DIFF
--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -15,7 +15,7 @@ const EventEmitter = require('events');
 /**
  * Options to be applied to the collector.
  * @typedef {Object} CollectorOptions
- * @property {number} [time] How long to run the collector for
+ * @property {number} [time] How long to run the collector for in milliseconds
  * @property {boolean} [dispose=false] Whether to dispose data when it's deleted
  */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The collector options typedef doesn't give what unit the collector is for, this PR fixes that

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
