### PR TITLE
fix(typings): Collection#find & Collection#findKey

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -294,7 +294,7 @@ declare module 'discord.js' {
 		public equals(collection: Collection<any, any>): boolean;
 		public every(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): boolean;
 		public filter(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): Collection<K, V>;
-		public find(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): V;
+		public find(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): V | undefined;
 		public findKey(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): K;
 		public first(): V | undefined;
 		public first(count: number): V[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -295,7 +295,7 @@ declare module 'discord.js' {
 		public every(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): boolean;
 		public filter(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): Collection<K, V>;
 		public find(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): V | undefined;
-		public findKey(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): K;
+		public findKey(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): K | undefined;
 		public first(): V | undefined;
 		public first(count: number): V[];
 		public firstKey(): K | undefined;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The [typings for `Collection#find` and `Collection#findKey`](https://github.com/discordjs/discord.js/blob/master/typings/index.d.ts#L297) currently suggest neither can return undefined, yet that is untrue.

- [Collection#find](https://github.com/discordjs/discord.js/blob/master/src/util/Collection.js#L172)
- [Collection#findKey](https://github.com/discordjs/discord.js/blob/master/src/util/Collection.js#L190)

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
