### PR TITLE
feat(Partials.GuildMember): GuildMemberRemove & Guild#me

### DIFF
--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -61,7 +61,7 @@ class GenericAction {
     const userID = data.user.id;
     const existing = guild.members.get(userID);
     if (!existing && this.client.options.partials.includes(PartialTypes.GUILD_MEMBER)) {
-      return this.members.add({ user: { id: userID } });
+      return guild.members.add({ user: { id: userID } });
     }
     return existing;
   }

--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -56,6 +56,15 @@ class GenericAction {
     }
     return existing;
   }
+
+  getMember(data, guild) {
+    const userID = data.user.id;
+    const existing = guild.members.get(userID);
+    if (!existing && this.client.options.partials.includes(PartialTypes.GUILD_MEMBER)) {
+      return this.members.add({ user: { id: userID } });
+    }
+    return existing;
+  }
 }
 
 module.exports = GenericAction;

--- a/src/client/actions/GuildMemberRemove.js
+++ b/src/client/actions/GuildMemberRemove.js
@@ -9,7 +9,7 @@ class GuildMemberRemoveAction extends Action {
     const guild = client.guilds.get(data.guild_id);
     let member = null;
     if (guild) {
-      member = guild.members.get(data.user.id);
+      member = this.getMember(data, guild);
       guild.memberCount--;
       if (member) {
         guild.voiceStates.delete(member.id);

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -393,7 +393,9 @@ class Guild extends Base {
    * @readonly
    */
   get me() {
-    return this.members.get(this.client.user.id) || null;
+    return this.members.get(this.client.user.id) || (this.client.options.partials.includes(PartialTypes.GUILD_MEMBER) ?
+      this.members.add({ user: { id: this.this.client.user.id } }, true) :
+      null);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -394,7 +394,7 @@ class Guild extends Base {
    */
   get me() {
     return this.members.get(this.client.user.id) || (this.client.options.partials.includes(PartialTypes.GUILD_MEMBER) ?
-      this.members.add({ user: { id: this.this.client.user.id } }, true) :
+      this.members.add({ user: { id: this.client.user.id } }, true) :
       null);
   }
 


### PR DESCRIPTION
Make use of partials for the GuildMemberRemove event as well as Guild#me. Although it doesn't provide much use as for retrieving accurate properties of the member (such as roles) as you can't fetch a member that left the guild for obvious reasons, it should allow developers to monitor the `guildMemberRemove` event for uncached members.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.