### PR TITLE
feat(Collection): add isCollection, findIndex, keyIndex

### DIFF
--- a/src/rest/DiscordAPIError.js
+++ b/src/rest/DiscordAPIError.js
@@ -41,6 +41,7 @@ class DiscordAPIError extends Error {
    * @param {Object} obj Discord errors object
    * @param {string} [key] Used internally to determine key names of nested fields
    * @returns {string[]}
+   * @static
    * @private
    */
   static flattenErrors(obj, key = '') {

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -196,6 +196,7 @@ class ShardClientUtil {
    * @param {Client} client The client to use
    * @param {ShardingManagerMode} mode Mode the shard was spawned with
    * @returns {ShardClientUtil}
+   * @static
    */
   static singleton(client, mode) {
     if (!this._singleton) {

--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -32,7 +32,7 @@ class GuildEmojiRoleStore extends Collection {
    * @returns {Promise<GuildEmoji>}
    */
   add(roleOrRoles) {
-    if (roleOrRoles instanceof Collection) return this.add(roleOrRoles.keyArray());
+    if (Collection.isCollection(roleOrRoles)) return this.add(roleOrRoles.keyArray());
     if (!(roleOrRoles instanceof Array)) return this.add([roleOrRoles]);
     roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
 
@@ -51,7 +51,7 @@ class GuildEmojiRoleStore extends Collection {
    * @returns {Promise<GuildEmoji>}
    */
   remove(roleOrRoles) {
-    if (roleOrRoles instanceof Collection) return this.remove(roleOrRoles.keyArray());
+    if (Collection.isCollection(roleOrRoles)) return this.remove(roleOrRoles.keyArray());
     if (!(roleOrRoles instanceof Array)) return this.remove([roleOrRoles]);
     roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
 

--- a/src/stores/GuildEmojiStore.js
+++ b/src/stores/GuildEmojiStore.js
@@ -45,7 +45,7 @@ class GuildEmojiStore extends DataStore {
       const data = { image: attachment, name };
       if (roles) {
         data.roles = [];
-        for (let role of roles instanceof Collection ? roles.values() : roles) {
+        for (let role of Collection.isCollection(roles) ? roles.values() : roles) {
           role = this.guild.roles.resolve(role);
           if (!role) {
             return Promise.reject(new TypeError('INVALID_TYPE', 'options.roles',

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -65,7 +65,7 @@ class GuildMemberRoleStore extends Collection {
    * @returns {Promise<GuildMember>}
    */
   async add(roleOrRoles, reason) {
-    if (roleOrRoles instanceof Collection || roleOrRoles instanceof Array) {
+    if (Collection.isCollection(roleOrRoles) || roleOrRoles instanceof Array) {
       roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
       if (roleOrRoles.includes(null)) {
         throw new TypeError('INVALID_TYPE', 'roles',
@@ -96,7 +96,7 @@ class GuildMemberRoleStore extends Collection {
    * @returns {Promise<GuildMember>}
    */
   async remove(roleOrRoles, reason) {
-    if (roleOrRoles instanceof Collection || roleOrRoles instanceof Array) {
+    if (Collection.isCollection(roleOrRoles) || roleOrRoles instanceof Array) {
       roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
       if (roleOrRoles.includes(null)) {
         throw new TypeError('INVALID_TYPE', 'roles',

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -226,6 +226,7 @@ class APIMessage {
    * Resolves a single file into an object sendable to the API.
    * @param {BufferResolvable|Stream|FileOptions|MessageAttachment} fileLike Something that could be resolved to a file
    * @returns {Object}
+   * @static
    */
   static async resolveFile(fileLike) {
     let attachment;
@@ -262,6 +263,7 @@ class APIMessage {
    * Partitions embeds and attachments.
    * @param {Array<MessageEmbed|MessageAttachment>} items Items to partition
    * @returns {Array<MessageEmbed[], MessageAttachment[]>}
+   * @static
    */
   static partitionMessageAdditions(items) {
     const embeds = [];
@@ -285,6 +287,7 @@ class APIMessage {
    * @param {MessageOptions|WebhookMessageOptions} [extra={}] Extra options to add onto transformed options
    * @param {boolean} [isWebhook=false] Whether or not to use WebhookMessageOptions as the result
    * @returns {MessageOptions|WebhookMessageOptions}
+   * @static
    */
   static transformOptions(content, options, extra = {}, isWebhook = false) {
     if (!options && typeof content === 'object' && !(content instanceof Array)) {
@@ -320,6 +323,7 @@ class APIMessage {
    * @param {MessageOptions|WebhookMessageOptions|MessageAdditions} [options={}] Options to use
    * @param {MessageOptions|WebhookMessageOptions} [extra={}] - Extra options to add onto transformed options
    * @returns {MessageOptions|WebhookMessageOptions}
+   * @static
    */
   static create(target, content, options, extra = {}) {
     const Webhook = require('./Webhook');

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -613,7 +613,7 @@ class Guild extends Base {
     options.access_token = options.accessToken;
     if (options.roles) {
       const roles = [];
-      for (let role of options.roles instanceof Collection ? options.roles.values() : options.roles) {
+      for (let role of Collection.isCollection(options.roles) ? options.roles.values() : options.roles) {
         role = this.roles.resolve(role);
         if (!role) {
           return Promise.reject(new TypeError('INVALID_TYPE', 'options.roles',

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -137,6 +137,7 @@ class GuildAuditLogs {
   /**
    * Handles possible promises for entry targets.
    * @returns {Promise<GuildAuditLogs>}
+   * @static
    */
   static build(...args) {
     const logs = new GuildAuditLogs(...args);
@@ -160,6 +161,7 @@ class GuildAuditLogs {
    * Finds the target type from the entry action.
    * @param {AuditLogAction} target The action target
    * @returns {AuditLogTargetType}
+   * @static
    */
   static targetType(target) {
     if (target < 10) return Targets.GUILD;
@@ -186,6 +188,7 @@ class GuildAuditLogs {
    * Finds the action type from the entry action.
    * @param {AuditLogAction} action The action target
    * @returns {AuditLogActionType}
+   * @static
    */
   static actionType(action) {
     if ([

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -375,6 +375,7 @@ class MessageEmbed {
    * @param {StringResolvable} value The value of the field
    * @param {boolean} [inline=false] Set the field to display inline
    * @returns {EmbedField}
+   * @static
    */
   static checkField(name, value, inline = false) {
     name = Util.resolveString(name);

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -38,7 +38,7 @@ class MessageMentions {
     this.everyone = Boolean(everyone);
 
     if (users) {
-      if (users instanceof Collection) {
+      if (Collection.isCollection(users)) {
         /**
          * Any users that were mentioned
          * @type {Collection<Snowflake, User>}
@@ -56,7 +56,7 @@ class MessageMentions {
     }
 
     if (roles) {
-      if (roles instanceof Collection) {
+      if (Collection.isCollection(roles)) {
         /**
          * Any roles that were mentioned
          * @type {Collection<Snowflake, Role>}

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -115,6 +115,7 @@ class PermissionOverwrites {
    * @param {PermissionResolvable} initialPermissions.allow Initial allowed permissions
    * @param {PermissionResolvable} initialPermissions.deny Initial denied permissions
    * @returns {ResolvedOverwriteOptions}
+   * @static
    */
   static resolveOverwriteOptions(options, { allow, deny } = {}) {
     allow = new Permissions(allow);
@@ -164,6 +165,7 @@ class PermissionOverwrites {
    * @param {OverwriteResolvable} overwrite The overwrite-like data to resolve
    * @param {Guild} guild The guild to resolve from
    * @returns {RawOverwriteData}
+   * @static
    */
   static resolve(overwrite, guild) {
     if (overwrite instanceof this) return overwrite.toJSON();

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -135,6 +135,7 @@ class ReactionCollector extends Collector {
    * Gets the collector key for a reaction.
    * @param {MessageReaction} reaction The message reaction to get the key for
    * @returns {Snowflake|string}
+   * @static
    */
   static key(reaction) {
     return reaction.emoji.id || reaction.emoji.name;

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -381,6 +381,7 @@ class Role extends Base {
    * @param {Role} role2 Second role to compare
    * @returns {number} Negative number if the first role's position is lower (second role's is higher),
    * positive number if the first's is higher (second's is lower), 0 if equal
+   * @static
    */
   static comparePositions(role1, role2) {
     if (role1.position === role2.position) return role2.id - role1.id;

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -296,8 +296,8 @@ class TextBasedChannel {
    *   .catch(console.error);
    */
   async bulkDelete(messages, filterOld = false) {
-    if (messages instanceof Array || messages instanceof Collection) {
-      let messageIDs = messages instanceof Collection ? messages.keyArray() : messages.map(m => m.id || m);
+    if (messages instanceof Array || Collection.isCollection(messages)) {
+      let messageIDs = Collection.isCollection(messages) ? messages.keyArray() : messages.map(m => m.id || m);
       if (filterOld) {
         messageIDs = messageIDs.filter(id =>
           Date.now() - Snowflake.deconstruct(id).date.getTime() < 1209600000

--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -132,6 +132,7 @@ class BitField {
    * Resolves bitfields to their numeric form.
    * @param {BitFieldResolvable} [bit=0] - bit(s) to resolve
    * @returns {number}
+   * @static
    */
   static resolve(bit = 0) {
     if (typeof bit === 'number' && bit >= 0) return bit;

--- a/src/util/Collection.js
+++ b/src/util/Collection.js
@@ -28,6 +28,16 @@ class Collection extends Map {
     Object.defineProperty(this, '_keyArray', { value: null, writable: true, configurable: true });
   }
 
+  /**
+   * Determines whether the passed values is a {@link Collection}.
+   * @param {*} c The value to be checked.
+   * @returns {boolean} `true` if the value is a {@link Collection}; otherwise `false`.
+   * @static
+   */
+  static isCollection(c) {
+    return c instanceof this;
+  }
+
   set(key, val) {
     this._array = null;
     this._keyArray = null;
@@ -94,6 +104,21 @@ class Collection extends Map {
     const iter = this.keys();
     for (let i = 0; i < amount; i++) arr[i] = iter.next().value;
     return arr;
+  }
+
+  /**
+   * Searches for the index of a key that is found within the collection, or -1 if it's not present. This behaves like
+   * [Array.indexOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf),
+   * @param {*} key The key to locate in the collection
+   * @returns {number}
+   */
+  keyIndex(key) {
+    if (!this.has(key)) return -1;
+    const iter = this.keys();
+    for (let i = 0; i < this.size; i++) {
+      if (key === iter.next().value) return i;
+    }
+    return -1;
   }
 
   /**
@@ -178,6 +203,24 @@ class Collection extends Map {
   }
 
   /* eslint-disable max-len */
+  /**
+   * Searches for the index of a key on a single item where the given function returns a truthy value, or -1 if no elements passes the given function.
+   * This behaves like [Array.findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex),
+   * @param {Function} fn The function to test with (should return boolean)
+   * @param {*} [thisArg] Value to use as `this` when executing function
+   * @returns {number}
+   * @example collection.findIndex(user => user.username === 'Bob');
+   */
+  findIndex(fn, thisArg) {
+    if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+    let i = 0;
+    for (const [key, val] of this) {
+      if (fn(val, key, this)) return i;
+      ++i;
+    }
+    return -1;
+  }
+
   /**
    * Searches for the key of a single item where the given function returns a truthy value. This behaves like
    * [Array.findIndex()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex),

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -27,6 +27,7 @@ class DataResolver {
    * Resolves InviteResolvable to an invite code.
    * @param {InviteResolvable} data The invite resolvable to resolve
    * @returns {string}
+   * @static
    */
   static resolveInviteCode(data) {
     const inviteRegex = /discord(?:app\.com\/invite|\.gg(?:\/invite)?)\/([\w-]{2,255})/i;
@@ -39,6 +40,7 @@ class DataResolver {
    * Resolves a Base64Resolvable, a string, or a BufferResolvable to a Base 64 image.
    * @param {BufferResolvable|Base64Resolvable} image The image to be resolved
    * @returns {Promise<?string>}
+   * @static
    */
   static async resolveImage(image) {
     if (!image) return null;
@@ -60,6 +62,7 @@ class DataResolver {
    * Resolves a Base64Resolvable to a Base 64 image.
    * @param {Base64Resolvable} data The base 64 resolvable you want to resolve
    * @returns {?string}
+   * @static
    */
   static resolveBase64(data) {
     if (data instanceof Buffer) return `data:image/jpg;base64,${data.toString('base64')}`;
@@ -83,6 +86,7 @@ class DataResolver {
    * Resolves a BufferResolvable to a Buffer.
    * @param {BufferResolvable|Stream} resource The buffer or stream resolvable to resolve
    * @returns {Promise<Buffer>}
+   * @static
    */
   static resolveFile(resource) {
     if (!browser && resource instanceof Buffer) return Promise.resolve(resource);

--- a/src/util/Snowflake.js
+++ b/src/util/Snowflake.js
@@ -31,6 +31,7 @@ class SnowflakeUtil {
    * <info>This hardcodes the worker ID as 1 and the process ID as 0.</info>
    * @param {number|Date} [timestamp=Date.now()] Timestamp or date of the snowflake to generate
    * @returns {Snowflake} The generated snowflake
+   * @static
    */
   static generate(timestamp = Date.now()) {
     if (timestamp instanceof Date) timestamp = timestamp.getTime();
@@ -60,6 +61,7 @@ class SnowflakeUtil {
    * Deconstructs a Discord snowflake.
    * @param {Snowflake} snowflake Snowflake to deconstruct
    * @returns {DeconstructedSnowflake} Deconstructed snowflake
+   * @static
    */
   static deconstruct(snowflake) {
     const BINARY = Util.idToBinary(snowflake).toString(2).padStart(64, '0');

--- a/src/util/Structures.js
+++ b/src/util/Structures.js
@@ -12,6 +12,7 @@ class Structures {
    * Retrieves a structure class.
    * @param {string} structure Name of the structure to retrieve
    * @returns {Function}
+   * @static
    */
   static get(structure) {
     if (typeof structure === 'string') return structures[structure];
@@ -26,6 +27,7 @@ class Structures {
    * @param {Function} extender Function that takes the base class to extend as its only parameter and returns the
    * extended class/prototype
    * @returns {Function} Extended class/prototype returned from the extender
+   * @static
    * @example
    * const { Structures } = require('discord.js');
    *

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -20,6 +20,7 @@ class Util {
    * @param {Object} obj The object to flatten.
    * @param {...Object<string, boolean|string>} [props] Specific properties to include/exclude.
    * @returns {Object}
+   * @static
    */
   static flatten(obj, ...props) {
     if (!isObject(obj)) return obj;
@@ -54,6 +55,7 @@ class Util {
    * @param {StringResolvable} text Content to split
    * @param {SplitOptions} [options] Options controlling the behavior of the split
    * @returns {string|string[]}
+   * @static
    */
   static splitMessage(text, { maxLength = 2000, char = '\n', prepend = '', append = '' } = {}) {
     text = this.resolveString(text);
@@ -78,6 +80,7 @@ class Util {
    * @param {boolean} [onlyCodeBlock=false] Whether to only escape codeblocks (takes priority)
    * @param {boolean} [onlyInlineCode=false] Whether to only escape inline code
    * @returns {string}
+   * @static
    */
   static escapeMarkdown(text, onlyCodeBlock = false, onlyInlineCode = false) {
     if (onlyCodeBlock) return text.replace(/```/g, '`\u200b``');
@@ -90,6 +93,7 @@ class Util {
    * @param {string} token Discord auth token
    * @param {number} [guildsPerShard=1000] Number of guilds per shard
    * @returns {Promise<number>} The recommended number of shards
+   * @static
    */
   static fetchRecommendedShards(token, guildsPerShard = 1000) {
     if (!token) throw new DiscordError('TOKEN_MISSING');
@@ -109,6 +113,7 @@ class Util {
    * * A Discord custom emoji (`<:name:id>` or `<a:name:id>`)
    * @param {string} text Emoji string to parse
    * @returns {Object} Object with `animated`, `name`, and `id` properties
+   * @static
    * @private
    */
   static parseEmoji(text) {
@@ -123,6 +128,7 @@ class Util {
    * Shallow-copies an object with its class/prototype intact.
    * @param {Object} obj Object to clone
    * @returns {Object}
+   * @static
    * @private
    */
   static cloneObject(obj) {
@@ -134,6 +140,7 @@ class Util {
    * @param {Object} def Default properties
    * @param {Object} given Object to assign defaults to
    * @returns {Object}
+   * @static
    * @private
    */
   static mergeDefault(def, given) {
@@ -153,6 +160,7 @@ class Util {
    * Converts an ArrayBuffer or string to a Buffer.
    * @param {ArrayBuffer|string} ab ArrayBuffer to convert
    * @returns {Buffer}
+   * @static
    * @private
    */
   static convertToBuffer(ab) {
@@ -164,6 +172,7 @@ class Util {
    * Converts a string to an ArrayBuffer.
    * @param {string} str String to convert
    * @returns {ArrayBuffer}
+   * @static
    * @private
    */
   static str2ab(str) {
@@ -180,6 +189,7 @@ class Util {
    * @param {string} obj.message Message for the error
    * @param {string} obj.stack Stack for the error
    * @returns {Error}
+   * @static
    * @private
    */
   static makeError(obj) {
@@ -193,6 +203,7 @@ class Util {
    * Makes a plain error info object from an Error.
    * @param {Error} err Error to get info from
    * @returns {Object}
+   * @static
    * @private
    */
   static makePlainError(err) {
@@ -210,6 +221,7 @@ class Util {
    * @param {number} newIndex Index or offset to move the element to
    * @param {boolean} [offset=false] Move the element by an offset amount rather than to a set index
    * @returns {number}
+   * @static
    * @private
    */
   static moveElementInArray(array, element, newIndex, offset = false) {
@@ -234,6 +246,7 @@ class Util {
    * Resolves a StringResolvable to a string.
    * @param {StringResolvable} data The string resolvable to resolve
    * @returns {string}
+   * @static
    */
   static resolveString(data) {
     if (typeof data === 'string') return data;
@@ -280,6 +293,7 @@ class Util {
    * Resolves a ColorResolvable into a color number.
    * @param {ColorResolvable} color Color to resolve
    * @returns {number} A color
+   * @static
    */
   static resolveColor(color) {
     if (typeof color === 'string') {
@@ -300,6 +314,7 @@ class Util {
    * Sorts by Discord's position and ID.
    * @param  {Collection} collection Collection of objects to sort
    * @returns {Collection}
+   * @static
    */
   static discordSort(collection) {
     return collection.sort((a, b) =>
@@ -318,6 +333,7 @@ class Util {
    * @param {APIRouter} route Route to call PATCH on
    * @param {string} [reason] Reason for the change
    * @returns {Promise<Object[]>} Updated item list, with `id` and `position` properties
+   * @static
    * @private
    */
   static setPosition(item, position, relative, sorted, route, reason) {
@@ -332,6 +348,7 @@ class Util {
    * @param {string} path Path to get the basename of
    * @param {string} [ext] File extension to remove
    * @returns {string} Basename of the path
+   * @static
    * @private
    */
   static basename(path, ext) {
@@ -343,6 +360,7 @@ class Util {
    * Transforms a snowflake from a decimal string to a bit string.
    * @param  {Snowflake} num Snowflake to be transformed
    * @returns {string}
+   * @static
    * @private
    */
   static idToBinary(num) {
@@ -364,6 +382,7 @@ class Util {
    * Transforms a snowflake from a bit string to a decimal string.
    * @param  {string} num Bit string to be transformed
    * @returns {Snowflake}
+   * @static
    * @private
    */
   static binaryToID(num) {
@@ -391,6 +410,7 @@ class Util {
    * @param {string} str The string to be converted
    * @param {Message} message The message object to reference
    * @returns {string}
+   * @static
    */
   static cleanContent(str, message) {
     return str
@@ -425,6 +445,7 @@ class Util {
    * Creates a Promise that resolves after a specified duration.
    * @param {number} ms How long to wait before resolving (in milliseconds)
    * @returns {Promise<void>}
+   * @static
    * @private
    */
   static delayFor(ms) {
@@ -437,6 +458,7 @@ class Util {
    * Adds methods from collections and maps onto the provided store
    * @param {DataStore} store The store to mixin
    * @param {string[]} ignored The properties to ignore
+   * @static
    * @private
    */
   /* eslint-disable func-names */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -295,12 +295,14 @@ declare module 'discord.js' {
 		public every(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): boolean;
 		public filter(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): Collection<K, V>;
 		public find(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): V | undefined;
+		public findIndex(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): number;
 		public findKey(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): K | undefined;
 		public first(): V | undefined;
 		public first(count: number): V[];
 		public firstKey(): K | undefined;
 		public firstKey(count: number): K[];
 		public keyArray(): K[];
+		public keyIndex(key: any): number;
 		public last(): V | undefined;
 		public last(count: number): V[];
 		public lastKey(): K | undefined;
@@ -317,6 +319,8 @@ declare module 'discord.js' {
 		public sweep(fn: (value: V, key: K, collection: Collection<K, V>) => boolean, thisArg?: any): number;
 		public tap(fn: (collection: Collection<K, V>) => void, thisArg?: any): Collection<K, V>;
 		public toJSON(): object;
+
+		public static isCollection(c: any): boolean;
 	}
 
 	export abstract class Collector<K, V> extends EventEmitter {


### PR DESCRIPTION
Many of the methods within the Collection are based of Array methods, this PR adds some completion towards that. 
- `isCollection`: has the same functionality as [Array.isArray()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray), the implementation is the same as it's done for [Buffer.isBuffer()](https://nodejs.org/api/buffer.html#buffer_class_method_buffer_isbuffer_obj). This method is used internally where applicable.
- `keyIndex`: Often in the Discord, people ask how they can get the index of an element within a Collection (for example getting the position of a Collection of GuildMembers sorted by GuildMember#joinedTimeStamp to obtain the relative join position), this is a helper method for that and somewhat behaves like [Array.indexOf()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf).
- `findIndex`: Similar to the above but adds more flexibility for searching the element. Pretty much the same as [Collection#findKey()](https://discord.js.org/#/docs/main/master/class/Collection?scrollTo=findKey) except the index/position is returned.

This PR also marks static methods using the [`@static`](http://usejsdoc.org/tags-static.html) JSDoc tag.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.