### PR TITLE
src: Hopefully fix random broken reconnects

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -311,10 +311,14 @@ class WebSocketShard extends EventEmitter {
   onClose(event) {
     this.closeSequence = this.sequence;
     this.sequence = -1;
+
     this.debug(`WebSocket was closed.
       Event Code: ${event.code}
       Clean: ${event.wasClean}
       Reason: ${event.reason || 'No reason received'}`);
+
+    this.setHeartbeatTimer(-1);
+    this.setHelloTimeout(-1);
 
     this.status = Status.DISCONNECTED;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Seems like more internal sharding issues showed themselves, but that's alright, I'll patch them all, one at a time.

Per the following logs:

<details>
<summary>Debug Logs</summary>

```
[04:06:30] - [36mverbose[39m: [Novus FM -- Shard 0] [WS => Shard 0] Session ID is present, attempting an immediate reconnect...
[04:06:30] - [36mverbose[39m: [Novus FM -- Shard 0] [WS => Shard 0] Trying to connect to wss://gateway.discord.gg/, version 6
[04:06:30] - [36mverbose[39m: [Novus FM -- Shard 0] [WS => Shard 0] Setting a HELLO timeout for 20s.
[04:06:30] - [36mverbose[39m: [Novus FM -- Shard 0] [WS => Shard 0] Opened a connection to the gateway successfully.
[04:06:30] - [36mverbose[39m: [Novus FM -- Shard 0] [WS => Shard 0] Clearing the HELLO timeout.
[04:06:30] - [36mverbose[39m: [Novus FM -- Shard 0] [WS => Shard 0] Setting a heartbeat interval for 41250ms.
[04:06:30] - [36mverbose[39m: [Novus FM -- Shard 0] [WS => Shard 0] Attempting to resume session 47de158f32d4bd290f392e4e65e7bcbf at sequence -1
[04:06:31] - [36mverbose[39m: [Novus FM -- Shard 0] [WS => Shard 0] Didn't receive a heartbeat ack last time, assuming zombie conenction. Destroying and reconnecting.
[04:06:31] - [36mverbose[39m: [Novus FM -- Shard 0] [WS => Shard 0] Clearing the heartbeat interval.
[04:06:31] - [36mverbose[39m: [Novus FM -- Shard 0] [WS => Shard 0] WebSocket was closed.
      Event Code: 4009
      Clean: true
      Reason: No reason received
```

</details>

It seems like the heartbeat timer is not cleared on a close that is immediately reconnect-able, thus getting overwritten, never cleared. This also means theere was technically a memory leak, yikes. This PR should solve that, and prevent what my logs showed from happening again!

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
