### PR TITLE
src: Client#readyAt should be updated when triggerReady is called

### DIFF
--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -424,7 +424,10 @@ class WebSocketManager {
       this.debug('Tried to mark self as ready, but already ready');
       return;
     }
+
     this.status = Status.READY;
+
+    this.client.readyAt = new Date();
 
     /**
      * Emitted when the client becomes ready to start working.

--- a/src/client/websocket/handlers/READY.js
+++ b/src/client/websocket/handlers/READY.js
@@ -6,7 +6,6 @@ module.exports = (client, { d: data }, shard) => {
   if (!ClientUser) ClientUser = require('../../../structures/ClientUser');
   const clientUser = new ClientUser(client, data.user);
   client.user = clientUser;
-  client.readyAt = new Date();
   client.users.set(clientUser.id, clientUser);
 
   for (const guild of data.guilds) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

For some reason, Client#readyAt was set by the shard turning ready, not the Client turning ready... This PR fixes that

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
