### PR TITLE
Presence: Added guildID as property, moved guild as getter.

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -45,10 +45,10 @@ class Presence {
     this.userID = data.user.id;
 
     /**
-     * The guild of this presence
-     * @type {?Guild}
+     * The guild ID of this presence
+     * @type {?Snowflake}
      */
-    this.guild = data.guild;
+    this.guildID = data.guild ? data.guild.id : null;
 
     this.patch(data);
   }
@@ -60,6 +60,15 @@ class Presence {
    */
   get user() {
     return this.client.users.get(this.userID) || null;
+  }
+
+  /**
+   * The guild of this presence
+   * @type {?Guild}
+   * @readonly
+   */
+  get guild() {
+    return this.client.guilds.get(this.guildID) || null;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,3 +1,5 @@
+import {GuildMember} from "discord.js";
+
 declare module 'discord.js' {
 	import { EventEmitter } from 'events';
 	import { Stream, Readable, Writable } from 'stream';
@@ -820,6 +822,7 @@ declare module 'discord.js' {
 		public status: PresenceStatus;
 		public clientStatus: ClientPresenceStatusData | null;
 		public readonly user: User | null;
+		public readonly guild: Guild | null;
 		public readonly member: GuildMember | null;
 		public equals(presence: Presence): boolean;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Instead of caching the whole guild object in presence, cache the ID only instead and move the original guild property as a getter.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
