### PR TITLE
modified Collector to implement AsyncIterable

### DIFF
--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -162,7 +162,7 @@ class Collector extends EventEmitter {
     while (!this.ended) {
       const { value, done } = await new Promise(resolve => { // eslint-disable-line no-await-in-loop
         if (queue.length > 0) {
-          resolve(queue.shift());
+          resolve({ value: queue.shift(), done: false });
           return;
         }
 

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -153,7 +153,7 @@ class Collector extends EventEmitter {
    */
   async * [Symbol.asyncIterator]() {
     while (!this.ended) {
-      const { value, done } = await new Promise(resolve => {
+      const { value, done } = await new Promise(resolve => { // eslint-disable-line no-await-in-loop
         const cleanup = () => {
           this.removeListener('collect', onCollect);
           this.removeListener('end', onEnd);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -332,7 +332,7 @@ declare module 'discord.js' {
 		public checkEnd(): void;
 		public handleCollect(...args: any[]): void;
 		public handleDispose(...args: any[]): void;
-		public [Symbol.asyncIterator](): AsyncIterator<V>;
+		public [Symbol.asyncIterator](): AsyncIterableIterator<V>;
 		public stop(reason?: string): void;
 		public toJSON(): object;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -319,7 +319,7 @@ declare module 'discord.js' {
 		public toJSON(): object;
 	}
 
-	export abstract class Collector<K, V> extends EventEmitter {
+	export abstract class Collector<K, V> extends EventEmitter implements AsyncIterable<V> {
 		constructor(client: Client, filter: CollectorFilter, options?: CollectorOptions);
 		private _timeout: NodeJS.Timer | null;
 
@@ -332,6 +332,7 @@ declare module 'discord.js' {
 		public checkEnd(): void;
 		public handleCollect(...args: any[]): void;
 		public handleDispose(...args: any[]): void;
+		public [Symbol.asyncIterator](): AsyncIterator<V>;
 		public stop(reason?: string): void;
 		public toJSON(): object;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This provides the ability to consume the `Collector` abstract class with `for await...of` syntax by implementing the `AsyncIterable` interface. I've tested this using `npm run test`, but performed no other testing. I believe the implementation is correct, using the `next` readonly property as reference.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
