### PR TITLE
feat(Actions): use partials for MessageDeleteBulk

### DIFF
--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -33,14 +33,14 @@ class GenericAction {
       this.client.channels.get(id));
   }
 
-  getMessage(data, channel) {
+  getMessage(data, channel, cache = true) {
     const id = data.message_id || data.id;
     return data.message || (this.client.options.partials.includes(PartialTypes.MESSAGE) ?
       channel.messages.add({
         id,
         channel_id: channel.id,
         guild_id: data.guild_id || (channel.guild ? channel.guild.id : null),
-      }) :
+      }, cache) :
       channel.messages.get(id));
   }
 

--- a/src/client/actions/MessageDeleteBulk.js
+++ b/src/client/actions/MessageDeleteBulk.js
@@ -13,7 +13,10 @@ class MessageDeleteBulkAction extends Action {
       const ids = data.ids;
       const messages = new Collection();
       for (const id of ids) {
-        const message = this.getMessage(data, channel, false);
+        const message = this.getMessage({
+          id,
+          guild_id: data.guild_id,
+        }, channel, false);
         if (message) {
           message.deleted = true;
           messages.set(message.id, message);

--- a/src/client/actions/MessageDeleteBulk.js
+++ b/src/client/actions/MessageDeleteBulk.js
@@ -13,7 +13,7 @@ class MessageDeleteBulkAction extends Action {
       const ids = data.ids;
       const messages = new Collection();
       for (const id of ids) {
-        const message = this.getMessage(data, channel);
+        const message = this.getMessage(data, channel, false);
         if (message) {
           message.deleted = true;
           messages.set(message.id, message);

--- a/src/client/actions/MessageDeleteBulk.js
+++ b/src/client/actions/MessageDeleteBulk.js
@@ -13,7 +13,7 @@ class MessageDeleteBulkAction extends Action {
       const ids = data.ids;
       const messages = new Collection();
       for (const id of ids) {
-        const message = channel.messages.get(id);
+        const message = this.getMessage(data, channel);
         if (message) {
           message.deleted = true;
           messages.set(message.id, message);


### PR DESCRIPTION
Make use of partials for the MessageDeleteBulk event. Although it doesn't provide much use as for retrieving accurate properties of the messages (such as the content) as you can't fetch a message that was deleted for obvious reasons, it should allow developers to monitor the messageDeleteBulk event for uncached messages.

The `cache` param on DataStore.add(...) will be set to `false` for this since the message will immediately be deleted anyways, so it would be a bit redundant to cache the messages.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
