### PR TITLE
Add ability to kick members from VoiceChannels and remove duplicated methods

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -293,35 +293,6 @@ class GuildMember extends Base {
   }
 
   /**
-   * Mutes/unmutes this member.
-   * @param {boolean} mute Whether or not the member should be muted
-   * @param {string} [reason] Reason for muting or unmuting
-   * @returns {Promise<GuildMember>}
-   */
-  setMute(mute, reason) {
-    return this.edit({ mute }, reason);
-  }
-
-  /**
-   * Deafens/undeafens this member.
-   * @param {boolean} deaf Whether or not the member should be deafened
-   * @param {string} [reason] Reason for deafening or undeafening
-   * @returns {Promise<GuildMember>}
-   */
-  setDeaf(deaf, reason) {
-    return this.edit({ deaf }, reason);
-  }
-
-  /**
-   * Moves this member to the given channel.
-   * @param {ChannelResolvable} channel The channel to move the member to
-   * @returns {Promise<GuildMember>}
-   */
-  setVoiceChannel(channel) {
-    return this.edit({ channel });
-  }
-
-  /**
    * Sets the nickname for this member.
    * @param {string} nick The nickname for the guild member
    * @param {string} [reason] Reason for setting the nickname

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -254,7 +254,8 @@ class GuildMember extends Base {
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles or role IDs to apply
    * @property {boolean} [mute] Whether or not the member should be muted
    * @property {boolean} [deaf] Whether or not the member should be deafened
-   * @property {ChannelResolvable} [channel] Channel to move member to (if they are connected to voice)
+   * @property {ChannelResolvable|null} [channel] Channel to move member to (if they are connected to voice), or `null`
+   * if you want to kick them from voice
    */
 
   /**
@@ -270,8 +271,10 @@ class GuildMember extends Base {
         throw new Error('GUILD_VOICE_CHANNEL_RESOLVE');
       }
       data.channel_id = data.channel.id;
-      data.channel = null;
+    } else if (data.channel === null) {
+      data.channel_id = null;
     }
+    data.channel = undefined;
     if (data.roles) data.roles = data.roles.map(role => role instanceof Role ? role.id : role);
     let endpoint = this.client.api.guilds(this.guild.id);
     if (this.user.id === this.client.user.id) {

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -84,7 +84,7 @@ class VoiceState extends Base {
    * @readonly
    */
   get connection() {
-    if (browser || this.id !== this.guild.me.id) return null;
+    if (browser || this.id !== this.client.user.id) return null;
     return this.client.voice.connections.get(this.guild.id) || null;
   }
 

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -138,6 +138,19 @@ class VoiceState extends Base {
     return this.member ? this.member.edit({ deaf }, reason) : Promise.reject(new Error('VOICE_STATE_UNCACHED_MEMBER'));
   }
 
+  /**
+   * Moves the member to a different channel, or kick them from the one they're in.
+   * @param {ChannelResolvable|null} [channel] Channel to move the member to, or `null` if you want to kick them from
+   * voice
+   * @param {string} [reason] Reason for moving member to another channel or kicking
+   * @returns {Promise<GuildMember>}
+   */
+  setChannel(channel, reason) {
+    return this.member ?
+      this.member.edit({ channel }, reason) :
+      Promise.reject(new Error('VOICE_STATE_UNCACHED_MEMBER'));
+  }
+
   toJSON() {
     return super.toJSON({
       id: true,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -576,10 +576,7 @@ declare module 'discord.js' {
 		public hasPermission(permission: PermissionResolvable, options?: { checkAdmin?: boolean; checkOwner?: boolean }): boolean;
 		public kick(reason?: string): Promise<GuildMember>;
 		public permissionsIn(channel: ChannelResolvable): Readonly<Permissions>;
-		public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;
-		public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
 		public setNickname(nickname: string, reason?: string): Promise<GuildMember>;
-		public setVoiceChannel(voiceChannel: ChannelResolvable): Promise<GuildMember>;
 		public toJSON(): object;
 		public toString(): string;
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1260,6 +1260,7 @@ declare module 'discord.js' {
 
 		public setDeaf(mute: boolean, reason?: string): Promise<GuildMember>;
 		public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
+		public setChannel(channel: ChannelResolvable | null, reason?: string): Promise<GuildMember>;
 	}
 
 	class VolumeInterface extends EventEmitter {
@@ -1898,7 +1899,7 @@ declare module 'discord.js' {
 		roles?: Collection<Snowflake, Role> | RoleResolvable[];
 		mute?: boolean;
 		deaf?: boolean;
-		channel?: ChannelResolvable;
+		channel?: ChannelResolvable | null;
 	}
 
 	type GuildMemberResolvable = GuildMember | UserResolvable;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Please see https://github.com/discordapp/discord-api-docs/pull/933/.

- Allows members to be kicked from voice channels
- Adds `VoiceState#setChannel`
- Improves reliability of using `voiceState.connection`
- Removes duplicated methods on GuildMember
  - `member.setDeaf` => `member.voice.setDeaf`
  - `member.setMute` => `member.voice.setMute`
  - `member.setVoiceChannel` => `member.voice.setChannel`

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
