### PR TITLE
Feat(VoiceState): self mute/deaf methods

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -177,6 +177,7 @@ class VoiceConnection extends EventEmitter {
   /**
    * Sends a request to the main gateway to join a voice channel.
    * @param {Object} [options] The options to provide
+   * @returns {Promise<Shard>}
    * @private
    */
   sendVoiceStateUpdate(options = {}) {
@@ -190,7 +191,7 @@ class VoiceConnection extends EventEmitter {
     const queueLength = this.channel.guild.shard.ratelimit.queue.length;
     this.emit('debug', `Sending voice state update (queue length is ${queueLength}): ${JSON.stringify(options)}`);
 
-    this.channel.guild.shard.send({
+    return this.channel.guild.shard.send({
       op: OPCodes.VOICE_STATE_UPDATE,
       d: options,
     });

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -183,8 +183,8 @@ class VoiceConnection extends EventEmitter {
     options = Util.mergeDefault({
       guild_id: this.channel.guild.id,
       channel_id: this.channel.id,
-      self_mute: false,
-      self_deaf: false,
+      self_mute: Boolean(this.voice.selfMute),
+      self_deaf: Boolean(this.voice.selfDeaf),
     }, options);
 
     const queueLength = this.channel.guild.shard.ratelimit.queue.length;

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -184,8 +184,8 @@ class VoiceConnection extends EventEmitter {
     options = Util.mergeDefault({
       guild_id: this.channel.guild.id,
       channel_id: this.channel.id,
-      self_mute: Boolean(this.voice.selfMute),
-      self_deaf: Boolean(this.voice.selfDeaf),
+      self_mute: this.voice ? this.voice.selfMute : false,
+      self_deaf: this.voice ? this.voice.selfDeaf : false,
     }, options);
 
     const queueLength = this.channel.guild.shard.ratelimit.queue.length;

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -51,7 +51,7 @@ const Messages = {
   VOICE_PRISM_DEMUXERS_NEED_STREAM: 'To play a webm/ogg stream, you need to pass a ReadableStream.',
 
   VOICE_STATE_UNCACHED_MEMBER: 'The member of this voice state is uncached.',
-  VOICE_STATE_NOT_OWN: ' You cannot self-deafen/mute on VoiceStates that do not belong to the ClientUser.',
+  VOICE_STATE_NOT_OWN: 'You cannot self-deafen/mute on VoiceStates that do not belong to the ClientUser.',
   VOICE_STATE_INVALID_TYPE: name => `${name} must be a boolean.`,
 
   UDP_SEND_FAIL: 'Tried to send a UDP packet, but there is no socket available.',

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -51,7 +51,7 @@ const Messages = {
   VOICE_PRISM_DEMUXERS_NEED_STREAM: 'To play a webm/ogg stream, you need to pass a ReadableStream.',
 
   VOICE_STATE_UNCACHED_MEMBER: 'The member of this voice state is uncached.',
-  VOICE_STATE_NOT_OWN: ' You cannot self-deafen/mute on VoiceStates that do not belong to the ClientUser',
+  VOICE_STATE_NOT_OWN: ' You cannot self-deafen/mute on VoiceStates that do not belong to the ClientUser.',
   VOICE_STATE_INVALID_TYPE: name => `${name} must be a boolean.`,
 
   UDP_SEND_FAIL: 'Tried to send a UDP packet, but there is no socket available.',

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -51,6 +51,8 @@ const Messages = {
   VOICE_PRISM_DEMUXERS_NEED_STREAM: 'To play a webm/ogg stream, you need to pass a ReadableStream.',
 
   VOICE_STATE_UNCACHED_MEMBER: 'The member of this voice state is uncached.',
+  VOICE_STATE_NOT_OWN: ' You cannot self-deafen/mute on VoiceStates that do not belong to the ClientUser',
+  VOICE_STATE_INVALID_TYPE: name => `${name} must be a boolean.`,
 
   UDP_SEND_FAIL: 'Tried to send a UDP packet, but there is no socket available.',
   UDP_ADDRESS_MALFORMED: 'Malformed UDP address or port.',

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -146,8 +146,9 @@ class VoiceState extends Base {
   setSelfMute(mute) {
     if (this.id !== this.client.user.id) throw new Error('VOICE_STATE_NOT_OWN');
     if (typeof mute !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'mute');
+    if (!this.connection) return;
     this.selfMute = mute;
-    if (this.connection) this.connection.sendVoiceStateUpdate();
+    this.connection.sendVoiceStateUpdate();
   }
 
   /**
@@ -157,8 +158,9 @@ class VoiceState extends Base {
   setSelfDeaf(deaf) {
     if (this.id !== this.client.user.id) throw new Error('VOICE_STATE_NOT_OWN');
     if (typeof mute !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'deaf');
+    if (!this.connection) return;
     this.selfDeaf = deaf;
-    if (this.connection) this.connection.sendVoiceStateUpdate();
+    this.connection.sendVoiceStateUpdate();
   }
 
   toJSON() {

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -156,7 +156,7 @@ class VoiceState extends Base {
   /**
    * Self-deafens/undeafens the bot for this voice state.
    * @param {boolean} deaf Whether or not the bot should be self-deafened
-   * @returns {Promise<boolean>} Returns false if there is no connection, true if voice state is updated
+   * @returns {Promise<boolean>} true if the voice state was successfully updated, otherwise false
    */
   async setSelfDeaf(deaf) {
     if (this.id !== this.client.user.id) return new Error('VOICE_STATE_NOT_OWN');

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -142,7 +142,7 @@ class VoiceState extends Base {
   /**
    * Self-mutes/unmutes the bot for this voice state.
    * @param {boolean} mute Whether or not the bot should be self-muted
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} Returns false if there is no connection, true if voice state is updated
    */
   async setSelfMute(mute) {
     if (this.id !== this.client.user.id) throw new Error('VOICE_STATE_NOT_OWN');
@@ -156,7 +156,7 @@ class VoiceState extends Base {
   /**
    * Self-deafens/undeafens the bot for this voice state.
    * @param {boolean} deaf Whether or not the bot should be self-deafened
-   * @returns {Promise<boolean>}
+   * @returns {Promise<boolean>} Returns false if there is no connection, true if voice state is updated
    */
   async setSelfDeaf(deaf) {
     if (this.id !== this.client.user.id) return new Error('VOICE_STATE_NOT_OWN');

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -142,7 +142,7 @@ class VoiceState extends Base {
   /**
    * Self-mutes/unmutes the bot for this voice state.
    * @param {boolean} mute Whether or not the bot should be self-muted
-   * @returns {Promise<boolean>} Returns false if there is no connection, true if voice state is updated
+   * @returns {Promise<boolean>} true if the voice state was successfully updated, otherwise false
    */
   async setSelfMute(mute) {
     if (this.id !== this.client.user.id) throw new Error('VOICE_STATE_NOT_OWN');

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -142,25 +142,29 @@ class VoiceState extends Base {
   /**
    * Self-mutes/unmutes the bot for this voice state.
    * @param {boolean} mute Whether or not the bot should be self-muted
+   * @returns {Promise<boolean>}
    */
-  setSelfMute(mute) {
+  async setSelfMute(mute) {
     if (this.id !== this.client.user.id) throw new Error('VOICE_STATE_NOT_OWN');
     if (typeof mute !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'mute');
-    if (!this.connection) return;
+    if (!this.connection) return false;
     this.selfMute = mute;
-    this.connection.sendVoiceStateUpdate();
+    await this.connection.sendVoiceStateUpdate();
+    return true;
   }
 
   /**
    * Self-deafens/undeafens the bot for this voice state.
    * @param {boolean} deaf Whether or not the bot should be self-deafened
+   * @returns {Promise<boolean>}
    */
-  setSelfDeaf(deaf) {
-    if (this.id !== this.client.user.id) throw new Error('VOICE_STATE_NOT_OWN');
-    if (typeof mute !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'deaf');
-    if (!this.connection) return;
+  async setSelfDeaf(deaf) {
+    if (this.id !== this.client.user.id) return new Error('VOICE_STATE_NOT_OWN');
+    if (typeof mute !== 'boolean') return new TypeError('VOICE_STATE_INVALID_TYPE', 'deaf');
+    if (!this.connection) return false;
     this.selfDeaf = deaf;
-    this.connection.sendVoiceStateUpdate();
+    await this.connection.sendVoiceStateUpdate();
+    return true;
   }
 
   toJSON() {

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -160,7 +160,7 @@ class VoiceState extends Base {
    */
   async setSelfDeaf(deaf) {
     if (this.id !== this.client.user.id) return new Error('VOICE_STATE_NOT_OWN');
-    if (typeof mute !== 'boolean') return new TypeError('VOICE_STATE_INVALID_TYPE', 'deaf');
+    if (typeof deaf !== 'boolean') return new TypeError('VOICE_STATE_INVALID_TYPE', 'deaf');
     if (!this.connection) return false;
     this.selfDeaf = deaf;
     await this.connection.sendVoiceStateUpdate();

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -2,6 +2,7 @@
 
 const Base = require('./Base');
 const { browser } = require('../util/Constants');
+const { Error, TypeError } = require('../errors');
 
 /**
  * Represents the voice state for a Guild Member.
@@ -136,6 +137,28 @@ class VoiceState extends Base {
    */
   setDeaf(deaf, reason) {
     return this.member ? this.member.edit({ deaf }, reason) : Promise.reject(new Error('VOICE_STATE_UNCACHED_MEMBER'));
+  }
+
+  /**
+   * Self-mutes/unmutes the bot for this voice state.
+   * @param {boolean} mute Whether or not the bot should be self-muted
+   */
+  setSelfMute(mute) {
+    if (this.id !== this.client.user.id) throw new Error('VOICE_STATE_NOT_OWN');
+    if (typeof mute !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'mute');
+    this.selfMute = mute;
+    if (this.connection) this.connection.sendVoiceStateUpdate();
+  }
+
+  /**
+   * Self-deafens/undeafens the bot for this voice state.
+   * @param {boolean} deaf Whether or not the bot should be self-deafened
+   */
+  setSelfDeaf(deaf) {
+    if (this.id !== this.client.user.id) throw new Error('VOICE_STATE_NOT_OWN');
+    if (typeof mute !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'deaf');
+    this.selfDeaf = deaf;
+    if (this.connection) this.connection.sendVoiceStateUpdate();
   }
 
   toJSON() {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1185,6 +1185,7 @@ declare module 'discord.js' {
 		public channel: VoiceChannel;
 		public readonly client: Client;
 		public readonly dispatcher: StreamDispatcher;
+		public readonly voice: VoiceState;
 		public player: object;
 		public receiver: VoiceReceiver;
 		public speaking: Readonly<Speaking>;
@@ -1258,8 +1259,10 @@ declare module 'discord.js' {
 		public sessionID?: string;
 		public readonly speaking: boolean | null;
 
-		public setDeaf(mute: boolean, reason?: string): Promise<GuildMember>;
 		public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
+		public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;
+		public setSelfMute(mute: boolean): void;
+		public setSelfDeaf(deaf: boolean): void;
 	}
 
 	class VolumeInterface extends EventEmitter {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1185,11 +1185,11 @@ declare module 'discord.js' {
 		public channel: VoiceChannel;
 		public readonly client: Client;
 		public readonly dispatcher: StreamDispatcher;
-		public readonly voice: VoiceState;
 		public player: object;
 		public receiver: VoiceReceiver;
 		public speaking: Readonly<Speaking>;
 		public status: VoiceStatus;
+		public readonly voice: VoiceState;
 		public voiceManager: ClientVoiceManager;
 		public disconnect(): void;
 		public play(input: VoiceBroadcast | Readable | string, options?: StreamOptions): StreamDispatcher;
@@ -1259,10 +1259,10 @@ declare module 'discord.js' {
 		public sessionID?: string;
 		public readonly speaking: boolean | null;
 
-		public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
 		public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;
-		public setSelfMute(mute: boolean): Promise<boolean>;
+		public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
 		public setSelfDeaf(deaf: boolean): Promise<boolean>;
+		public setSelfMute(mute: boolean): Promise<boolean>;
 	}
 
 	class VolumeInterface extends EventEmitter {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1176,7 +1176,7 @@ declare module 'discord.js' {
 		private onSessionDescription(mode: string, secret: string): void;
 		private onSpeaking(data: object): void;
 		private reconnect(token: string, endpoint: string): void;
-		private sendVoiceStateUpdate(options: object): void;
+		private sendVoiceStateUpdate(options: object): Promise<Shard>;
 		private setSessionID(sessionID: string): void;
 		private setSpeaking(value: BitFieldResolvable<SpeakingString>): void;
 		private setTokenAndEndpoint(token: string, endpoint: string): void;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1261,8 +1261,8 @@ declare module 'discord.js' {
 
 		public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
 		public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;
-		public setSelfMute(mute: boolean): void;
-		public setSelfDeaf(deaf: boolean): void;
+		public setSelfMute(mute: boolean): Promise<boolean>;
+		public setSelfDeaf(deaf: boolean): Promise<boolean>;
 	}
 
 	class VolumeInterface extends EventEmitter {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In this PR I've added `setSelfMute` & `setSelfDeaf` methods to the `VoiceState` class, I've also managed to add typings for implemented methods and `VoiceConnection#voice`.
Also managed to fix a slight bug where Error wasn't imported in VoiceState so some errors weren't being thrown with the proper string.

replaces #3171 

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
