### PR TITLE
Add maximum to typedef ChannelLogsQueryOptions

### DIFF
--- a/src/stores/MessageStore.js
+++ b/src/stores/MessageStore.js
@@ -29,7 +29,7 @@ class MessageStore extends DataStore {
    * The parameters to pass in when requesting previous messages from a channel. `around`, `before` and
    * `after` are mutually exclusive. All the parameters are optional.
    * @typedef {Object} ChannelLogsQueryOptions
-   * @property {number} [limit=50] Number of messages to acquire
+   * @property {number} [limit=50] Number of messages to acquire (Maximum 100)
    * @property {Snowflake} [before] ID of a message to get the messages that were posted before it
    * @property {Snowflake} [after] ID of a message to get the messages that were posted after it
    * @property {Snowflake} [around] ID of a message to get the messages that were posted around it


### PR DESCRIPTION
Based off of https://discordapp.com/developers/docs/resources/channel#get-channel-messages-query-string-params
"max number of messages to return (1-100)"

**Please describe the changes this PR makes and why it should be merged:**
It's small but I found myself having to run all the way to the discord api docs so i thought it'd be nice.
Just adds a maximum of 100 to the channellogsqueryoptions so its easier to find

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
