### PR TITLE
fix(Partials): Client#event:messageUpdate(oldMessage) and MessageReactionAdd on guild channels

### DIFF
--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -23,47 +23,52 @@ class GenericAction {
     return data;
   }
 
-  getChannel(data) {
-    const id = data.channel_id || data.id;
-    return data.channel || (this.client.options.partials.includes(PartialTypes.CHANNEL) ?
-      this.client.channels.add({
-        id,
-        guild_id: data.guild_id,
-      }) :
-      this.client.channels.get(id));
+  getPayload(data, store, id, partialType, cache = true) {
+    const existing = store.get(id);
+    if (!existing && this.client.options.partials.includes(partialType)) {
+      return store.add(data, cache);
+    }
+    return existing;
   }
 
-  getMessage(data, channel, cache = true) {
+  getChannel(data) {
+    const id = data.channel_id || data.id;
+    return this.getPayload({
+      id,
+      guild_id: data.guild_id,
+    }, this.client.channels, id, PartialTypes.CHANNEL);
+  }
+
+  getMessage(data, channel, cache) {
     const id = data.message_id || data.id;
-    return data.message || (this.client.options.partials.includes(PartialTypes.MESSAGE) ?
-      channel.messages.add({
-        id,
-        channel_id: channel.id,
-        guild_id: data.guild_id || (channel.guild ? channel.guild.id : null),
-      }, cache) :
-      channel.messages.get(id));
+    return this.getPayload({
+      id,
+      channel_id: channel.id,
+      guild_id: data.guild_id || (channel.guild ? channel.guild.id : null),
+    }, channel.messages, id, PartialTypes.MESSAGE, cache);
   }
 
   getReaction(data, message, user) {
-    const emojiID = data.emoji.id || decodeURIComponent(data.emoji.name);
-    const existing = message.reactions.get(emojiID);
-    if (!existing && this.client.options.partials.includes(PartialTypes.MESSAGE)) {
-      return message.reactions.add({
-        emoji: data.emoji,
-        count: 0,
-        me: user.id === this.client.user.id,
-      });
-    }
-    return existing;
+    const id = data.emoji.id || decodeURIComponent(data.emoji.name);
+    return this.getPayload({
+      emoji: data.emoji,
+      count: 0,
+      me: user.id === this.client.user.id,
+    }, message.reactions, id, PartialTypes.MESSAGE);
   }
 
   getMember(data, guild) {
-    const userID = data.user.id;
-    const existing = guild.members.get(userID);
-    if (!existing && this.client.options.partials.includes(PartialTypes.GUILD_MEMBER)) {
-      return guild.members.add({ user: { id: userID } });
-    }
-    return existing;
+    const id = data.user.id;
+    return this.getPayload({
+      user: {
+        id,
+      },
+    }, guild.members, id, PartialTypes.GUILD_MEMBER);
+  }
+
+  getUser(data) {
+    const id = data.user_id;
+    return this.getPayload({ id }, this.client.users, id, PartialTypes.USER);
   }
 }
 

--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -23,7 +23,7 @@ class GenericAction {
     return data;
   }
 
-  getPayload(data, store, id, partialType, cache = true) {
+  getPayload(data, store, id, partialType, cache) {
     const existing = store.get(id);
     if (!existing && this.client.options.partials.includes(partialType)) {
       return store.add(data, cache);
@@ -33,7 +33,7 @@ class GenericAction {
 
   getChannel(data) {
     const id = data.channel_id || data.id;
-    return this.getPayload({
+    return data.channel || this.getPayload({
       id,
       guild_id: data.guild_id,
     }, this.client.channels, id, PartialTypes.CHANNEL);
@@ -41,7 +41,7 @@ class GenericAction {
 
   getMessage(data, channel, cache) {
     const id = data.message_id || data.id;
-    return this.getPayload({
+    return data.message || this.getPayload({
       id,
       channel_id: channel.id,
       guild_id: data.guild_id || (channel.guild ? channel.guild.id : null),
@@ -68,7 +68,7 @@ class GenericAction {
 
   getUser(data) {
     const id = data.user_id;
-    return this.getPayload({ id }, this.client.users, id, PartialTypes.USER);
+    return data.user || this.getPayload({ id }, this.client.users, id, PartialTypes.USER);
   }
 }
 

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -14,7 +14,7 @@ class MessageReactionAdd extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const user = data.user || this.client.users.get(data.user_id);
+    const user = this.getUser(data);
     if (!user) return false;
 
     // Verify channel

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -14,7 +14,7 @@ class MessageReactionRemove extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const user = this.client.users.get(data.user_id);
+    const user = this.getUser(data);
     if (!user) return false;
 
     // Verify channel


### PR DESCRIPTION
This PR fixes #3248. 
When a message gets updated, the MessageUpdate action handler was passing [`data.author`](https://github.com/discordjs/discord.js/blob/master/src/client/actions/MessageUpdate.js#L10) into [Action.getMessage(...)](https://github.com/discordjs/discord.js/blob/master/src/client/actions/Action.js#L36-L45), if the developer has partials enabled for messages it will call [MessageStore.add(...)](https://github.com/discordjs/discord.js/blob/master/src/client/actions/Action.js#L39-L43) which will call [DataStore.add(...)](https://github.com/discordjs/discord.js/blob/master/src/stores/MessageStore.js#L18). 

Here's where the issue happens; since the passed `data` will exist within the store as it's previously been cached and Message._patch exists it will end up [calling the Message._patch(data)](https://github.com/discordjs/discord.js/blob/master/src/stores/DataStore.js#L21) so
https://github.com/discordjs/discord.js/blob/8b83e2fdcbead62ef018b6423f02e07ade0cd40f/src/structures/Message.js#L68
will set Message.author to `null` (as `data.author` isn't being passed here) which will implicitly convert the message to a partial. 

To fix this, Action.getPayload(...) has been added in this PR which will preemptively check the store and return the existing payload before calling *Store.add(...).
Action.getUser(data) has also been added in this PR so developers can make more use of the user partials and for completion with the other methods.

This PR also indirectly fixes #3247.
Within the handler for MessageReaction [Action.getChannel(...)](https://github.com/discordjs/discord.js/blob/master/src/client/actions/Action.js#L29-L33) is [called](https://github.com/discordjs/discord.js/blob/master/src/client/actions/MessageReactionAdd.js#L21), the issue is that the `guild` doesn't also get passed along so the existing channel doesn't get returned and instead 
https://github.com/discordjs/discord.js/blob/8b83e2fdcbead62ef018b6423f02e07ade0cd40f/src/stores/ChannelStore.js#L63
will be called, since the `data.type` also wasn't passed [Channel.create(...)](https://github.com/discordjs/discord.js/blob/master/src/structures/Channel.js#L94-L134) would return `undefined` therefore, the `messageReactionAdd` event will [never](https://github.com/discordjs/discord.js/blob/master/src/client/actions/MessageReactionAdd.js#L22) emit. The usage of Action.getPayload(...) will handle this in a similar manner.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
