### PR TITLE
Fix(Structure): Message#delete() cause event messageDelete to fires twice

### DIFF
--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -23,47 +23,52 @@ class GenericAction {
     return data;
   }
 
-  getChannel(data) {
-    const id = data.channel_id || data.id;
-    return data.channel || (this.client.options.partials.includes(PartialTypes.CHANNEL) ?
-      this.client.channels.add({
-        id,
-        guild_id: data.guild_id,
-      }) :
-      this.client.channels.get(id));
+  getPayload(data, store, id, partialType, cache = true) {
+    const existing = store.get(id);
+    if (!existing && this.client.options.partials.includes(partialType)) {
+      return store.add(data, cache);
+    }
+    return existing;
   }
 
-  getMessage(data, channel, cache = true) {
+  getChannel(data) {
+    const id = data.channel_id || data.id;
+    return this.getPayload({
+      id,
+      guild_id: data.guild_id,
+    }, this.client.channels, id, PartialTypes.CHANNEL);
+  }
+
+  getMessage(data, channel, cache) {
     const id = data.message_id || data.id;
-    return data.message || (this.client.options.partials.includes(PartialTypes.MESSAGE) ?
-      channel.messages.add({
-        id,
-        channel_id: channel.id,
-        guild_id: data.guild_id || (channel.guild ? channel.guild.id : null),
-      }, cache) :
-      channel.messages.get(id));
+    return this.getPayload({
+      id,
+      channel_id: channel.id,
+      guild_id: data.guild_id || (channel.guild ? channel.guild.id : null),
+    }, channel.messages, id, PartialTypes.MESSAGE, cache);
   }
 
   getReaction(data, message, user) {
-    const emojiID = data.emoji.id || decodeURIComponent(data.emoji.name);
-    const existing = message.reactions.get(emojiID);
-    if (!existing && this.client.options.partials.includes(PartialTypes.MESSAGE)) {
-      return message.reactions.add({
-        emoji: data.emoji,
-        count: 0,
-        me: user.id === this.client.user.id,
-      });
-    }
-    return existing;
+    const id = data.emoji.id || decodeURIComponent(data.emoji.name);
+    return this.getPayload({
+      emoji: data.emoji,
+      count: 0,
+      me: user.id === this.client.user.id,
+    }, message.reactions, id, PartialTypes.MESSAGE);
   }
 
   getMember(data, guild) {
-    const userID = data.user.id;
-    const existing = guild.members.get(userID);
-    if (!existing && this.client.options.partials.includes(PartialTypes.GUILD_MEMBER)) {
-      return guild.members.add({ user: { id: userID } });
-    }
-    return existing;
+    const id = data.user.id;
+    return this.getPayload({
+      user: {
+        id,
+      },
+    }, guild.members, id, PartialTypes.GUILD_MEMBER);
+  }
+
+  getUser(data) {
+    const id = data.user_id;
+    return this.getPayload({ id }, this.client.users, id, PartialTypes.USER);
   }
 }
 

--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -23,7 +23,7 @@ class GenericAction {
     return data;
   }
 
-  getPayload(data, store, id, partialType, cache = true) {
+  getPayload(data, store, id, partialType, cache) {
     const existing = store.get(id);
     if (!existing && this.client.options.partials.includes(partialType)) {
       return store.add(data, cache);
@@ -33,7 +33,7 @@ class GenericAction {
 
   getChannel(data) {
     const id = data.channel_id || data.id;
-    return this.getPayload({
+    return data.channel || this.getPayload({
       id,
       guild_id: data.guild_id,
     }, this.client.channels, id, PartialTypes.CHANNEL);
@@ -41,7 +41,7 @@ class GenericAction {
 
   getMessage(data, channel, cache) {
     const id = data.message_id || data.id;
-    return this.getPayload({
+    return data.message || this.getPayload({
       id,
       channel_id: channel.id,
       guild_id: data.guild_id || (channel.guild ? channel.guild.id : null),
@@ -68,7 +68,7 @@ class GenericAction {
 
   getUser(data) {
     const id = data.user_id;
-    return this.getPayload({ id }, this.client.users, id, PartialTypes.USER);
+    return data.user || this.getPayload({ id }, this.client.users, id, PartialTypes.USER);
   }
 }
 

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -14,7 +14,7 @@ class MessageReactionAdd extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const user = data.user || this.client.users.get(data.user_id);
+    const user = this.getUser(data);
     if (!user) return false;
 
     // Verify channel

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -14,7 +14,7 @@ class MessageReactionRemove extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const user = this.client.users.get(data.user_id);
+    const user = this.getUser(data);
     if (!user) return false;
 
     // Verify channel

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -454,11 +454,7 @@ class Message extends Base {
    */
   delete({ timeout = 0, reason } = {}) {
     if (timeout <= 0) {
-      return this.channel.messages.remove(this.id, reason).then(() =>
-        this.client.actions.MessageDelete.handle({
-          id: this.id,
-          channel_id: this.channel.id,
-        }).message);
+      return this.channel.messages.remove(this.id, reason).then(() => this);
     } else {
       return new Promise(resolve => {
         this.client.setTimeout(() => {


### PR DESCRIPTION
**The PR #3250 should be merged before this PR**
**Please describe the changes this PR makes and why it should be merged:**
When a message was deleted using the method [`Message#delete()`](https://github.com/discordjs/discord.js/blob/8b83e2fdcbead62ef018b6423f02e07ade0cd40f/src/structures/Message.js#L455), the MessageDelete action handler [was executed](https://github.com/discordjs/discord.js/blob/8b83e2fdcbead62ef018b6423f02e07ade0cd40f/src/structures/Message.js#L458) by it.
After that, the MessageDelete action handler [got executed](https://github.com/discordjs/discord.js/blob/8b83e2fdcbead62ef018b6423f02e07ade0cd40f/src/client/websocket/handlers/MESSAGE_DELETE.js#L4) again by the WebSocketManager.
Causing double emission.

The same problem can be found in [`TextBasedChannel#bulkDelete()`](https://github.com/discordjs/discord.js/blob/8b83e2fdcbead62ef018b6423f02e07ade0cd40f/src/structures/interfaces/TextBasedChannel.js#L298) but I was unable to fix it due to lack of time.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
