### PR TITLE
feat(Partials): add DMChannel/MessageReaction#fetch() and PartialTypes.REACTION

### DIFF
--- a/docs/topics/partials.md
+++ b/docs/topics/partials.md
@@ -9,7 +9,7 @@ discard the event. With partials, you're able to receive the event, with a Messa
 Partials are opt-in, and you can enable them in the Client options by specifying [PartialTypes](../typedef/PartialType):
 
 ```js
-// Accept partial messages, DM channels and reactions when emitting events
+// Accept partial messages, DM channels, and reactions when emitting events
 new Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
 ```
 

--- a/docs/topics/partials.md
+++ b/docs/topics/partials.md
@@ -45,10 +45,10 @@ client.on('messageReactionAdd', async (reaction, user) => {
   if (reaction.message.partial) await reaction.message.fetch();
   // Now the message has been cached and is fully available:
   console.log(`${reaction.message.author}'s message "${reaction.message.content}" gained a reaction!`);
-  // Fetches and caches the reaction itself, updating resources that were possibly defunt.
+  // Fetches and caches the reaction itself, updating resources that were possibly defunct.
   if (reaction.partial) await reaction.fetch();
   // Now the reaction is fully available and the properties will be reflected accurately:
-  console.log(`This reaction contains ${reaction.count} reaction(s)!`);
+  console.log(`${reaction.count} user(s) have given the same reaction this message!`);
 });
 ```
 

--- a/docs/topics/partials.md
+++ b/docs/topics/partials.md
@@ -9,8 +9,8 @@ discard the event. With partials, you're able to receive the event, with a Messa
 Partials are opt-in, and you can enable them in the Client options by specifying [PartialTypes](../typedef/PartialType):
 
 ```js
-// Accept partial messages and DM channels when emitting events
-new Client({ partials: ['MESSAGE', 'CHANNEL'] });
+// Accept partial messages, DM channels and reactions when emitting events
+new Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
 ```
 
 ## Usage & warnings
@@ -45,6 +45,10 @@ client.on('messageReactionAdd', async (reaction, user) => {
   if (reaction.message.partial) await reaction.message.fetch();
   // Now the message has been cached and is fully available:
   console.log(`${reaction.message.author}'s message "${reaction.message.content}" gained a reaction!`);
+  // Fetches and caches the reaction itself, updating resources that were possibly defunt.
+  if (reaction.partial) await reaction.fetch();
+  // Now the reaction is fully available and the properties will be reflected accurately:
+  console.log(`This reaction contains ${reaction.count} reaction(s)!`);
 });
 ```
 

--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -53,7 +53,7 @@ class GenericAction {
     const id = data.emoji.id || decodeURIComponent(data.emoji.name);
     return this.getPayload({
       emoji: data.emoji,
-      count: 0,
+      count: message.partial ? null : 0,
       me: user.id === this.client.user.id,
     }, message.reactions, id, PartialTypes.MESSAGE);
   }

--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -55,7 +55,7 @@ class GenericAction {
       emoji: data.emoji,
       count: message.partial ? null : 0,
       me: user.id === this.client.user.id,
-    }, message.reactions, id, PartialTypes.MESSAGE);
+    }, message.reactions, id, PartialTypes.REACTION);
   }
 
   getMember(data, guild) {

--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -36,6 +36,7 @@ class GenericAction {
     return data.channel || this.getPayload({
       id,
       guild_id: data.guild_id,
+      recipients: [data.author || { id: data.user_id }],
     }, this.client.channels, id, PartialTypes.CHANNEL);
   }
 

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -26,11 +26,8 @@ class MessageReactionAdd extends Action {
     if (!message) return false;
 
     // Verify reaction
-    const reaction = message.reactions.add({
-      emoji: data.emoji,
-      count: 0,
-      me: user.id === this.client.user.id,
-    });
+    const reaction = this.getReaction(data, message, user);
+    if (!reaction) return false;
     reaction._add(user);
     /**
      * Emitted whenever a reaction is added to a cached message.

--- a/src/stores/ReactionStore.js
+++ b/src/stores/ReactionStore.js
@@ -51,19 +51,24 @@ class ReactionStore extends DataStore {
       .then(() => this.message);
   }
 
-  _partial(reaction) {
-    const id = reaction.id || decodeURIComponent(reaction.name);
+  _partial(emoji) {
+    const id = emoji.id || emoji.name;
     const existing = this.get(id);
     return !existing || existing.partial;
   }
 
   async _fetchReaction(reactionEmoji, cache) {
-    const id = reactionEmoji.id || decodeURIComponent(reactionEmoji.name);
+    const id = reactionEmoji.id || reactionEmoji.name;
     const existing = this.get(id);
     if (!this._partial(reactionEmoji)) return existing;
     const data = await this.client.api.channels(this.message.channel.id).messages(this.message.id).get();
+    if (!data.reactions || !data.reactions.some(r => (r.emoji.id || r.emoji.name) === id)) {
+      reactionEmoji.reaction._patch({ count: 0 });
+      this.message.reactions.remove(id);
+      return existing;
+    }
     for (const reaction of data.reactions) {
-      if (this._partial(reaction)) this.add(reaction, cache);
+      if (this._partial(reaction.emoji)) this.add(reaction, cache);
     }
     return existing;
   }

--- a/src/stores/ReactionStore.js
+++ b/src/stores/ReactionStore.js
@@ -51,14 +51,21 @@ class ReactionStore extends DataStore {
       .then(() => this.message);
   }
 
-  async _fetchReaction(emojiID, cache) {
+  _partial(reaction) {
+    const id = reaction.id || decodeURIComponent(reaction.name);
+    const existing = this.get(id);
+    return !existing || existing.partial;
+  }
+
+  async _fetchReaction(reactionEmoji, cache) {
+    const id = reactionEmoji.id || decodeURIComponent(reactionEmoji.name);
+    const existing = this.get(id);
+    if (!this._partial(reactionEmoji)) return existing;
     const data = await this.client.api.channels(this.message.channel.id).messages(this.message.id).get();
     for (const reaction of data.reactions) {
-      const id = reaction.id || decodeURIComponent(reaction.name);
-      const existing = this.get(id);
-      if (!existing || existing.partial) this.add(reaction, cache);
+      if (this._partial(reaction)) this.add(reaction, cache);
     }
-    return this.get(emojiID);
+    return existing;
   }
 }
 

--- a/src/stores/ReactionStore.js
+++ b/src/stores/ReactionStore.js
@@ -50,6 +50,16 @@ class ReactionStore extends DataStore {
     return this.client.api.channels(this.message.channel.id).messages(this.message.id).reactions.delete()
       .then(() => this.message);
   }
+
+  async _fetchReaction(emojiID, cache) {
+    const data = await this.client.api.channels(this.message.channel.id).messages(this.message.id).get();
+    for (const reaction of data.reactions) {
+      const id = reaction.id || decodeURIComponent(reaction.name);
+      const existing = this.get(id);
+      if (!existing || existing.partial) this.add(reaction, cache);
+    }
+    return this.get(emojiID);
+  }
 }
 
 module.exports = ReactionStore;

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -56,7 +56,15 @@ class DMChannel extends Channel {
    * @readonly
    */
   get partial() {
-    return !this.recipient;
+    return this.lastMessageID === undefined;
+  }
+
+  /**
+   * Fetch this DMChannel.
+   * @returns {Promise<DMChannel>}
+   */
+  fetch() {
+    return this.recipient.createDM();
   }
 
   /**

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -28,18 +28,22 @@ class MessageReaction {
     this.me = data.me;
 
     /**
-     * The number of people that have given the same reaction
-     * @type {number}
-     */
-    this.count = data.count || 0;
-
-    /**
      * The users that have given this reaction, mapped by their ID
      * @type {ReactionUserStore<Snowflake, User>}
      */
     this.users = new ReactionUserStore(client, undefined, this);
 
     this._emoji = new ReactionEmoji(this, data.emoji);
+
+    this._patch(data);
+  }
+
+  _patch(data) {
+    /**
+     * The number of people that have given the same reaction
+     * @type {?number}
+     */
+    this.count = typeof data.count === 'number' ? data.count : null;
   }
 
   /**
@@ -63,18 +67,37 @@ class MessageReaction {
     return this._emoji;
   }
 
+  /**
+   * Whether or not this reaction is a partial
+   * @type {boolean}
+   * @readonly
+   */
+  get partial() {
+    return this.count === null;
+  }
+
+  /**
+   * Fetch this reaction.
+   * @returns {Promise<MessageReaction>}
+   */
+  fetch() {
+    const emojiID = this.emoji.id || decodeURIComponent(this.emoji.name);
+    return this.message.reactions._fetchReaction(emojiID, true);
+  }
 
   toJSON() {
     return Util.flatten(this, { emoji: 'emojiID', message: 'messageID' });
   }
 
   _add(user) {
+    if (this.partial) return;
     this.users.set(user.id, user);
     if (!this.me || user.id !== this.message.client.user.id || this.count === 0) this.count++;
     if (!this.me) this.me = user.id === this.message.client.user.id;
   }
 
   _remove(user) {
+    if (this.partial) return;
     this.users.delete(user.id);
     if (!this.me || user.id !== this.message.client.user.id) this.count--;
     if (user.id === this.message.client.user.id) this.me = false;

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -81,8 +81,7 @@ class MessageReaction {
    * @returns {Promise<MessageReaction>}
    */
   fetch() {
-    const emojiID = this.emoji.id || decodeURIComponent(this.emoji.name);
-    return this.message.reactions._fetchReaction(emojiID, true);
+    return this.message.reactions._fetchReaction(this.emoji, true);
   }
 
   toJSON() {

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -211,7 +211,7 @@ class User extends Base {
    */
   async createDM() {
     const { dmChannel } = this;
-    if (dmChannel) return dmChannel;
+    if (dmChannel && !dmChannel.partial) return dmChannel;
     const data = await this.client.api.users(this.client.user.id).channels.post({ data: {
       recipient_id: this.id,
     } });

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -281,6 +281,7 @@ exports.ShardEvents = {
  * * CHANNEL (only affects DMChannels)
  * * GUILD_MEMBER
  * * MESSAGE
+ * * REACTION
  * <warn>Partials require you to put checks in place when handling data, read the Partials topic listed in the
  * sidebar for more information.</warn>
  * @typedef {string} PartialType
@@ -290,6 +291,7 @@ exports.PartialTypes = keyMirror([
   'CHANNEL',
   'GUILD_MEMBER',
   'MESSAGE',
+  'REACTION',
 ]);
 
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -799,7 +799,7 @@ declare module 'discord.js' {
 		public readonly emoji: GuildEmoji | ReactionEmoji;
 		public me: boolean;
 		public message: Message;
-		public partial: boolean;
+		public readonly partial: boolean;
 		public users: ReactionUserStore;
 		public fetch(): Promise<MessageReaction>;
 		public toJSON(): object;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2125,7 +2125,8 @@ declare module 'discord.js' {
 	type PartialTypes = 'USER'
 		| 'CHANNEL'
 		| 'GUILD_MEMBER'
-		| 'MESSAGE';
+		| 'MESSAGE'
+		| 'REACTION';
 
 	type PresenceStatus = ClientPresenceStatus | 'offline';
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -795,7 +795,7 @@ declare module 'discord.js' {
 		constructor(client: Client, data: object, message: Message);
 		private _emoji: GuildEmoji | ReactionEmoji;
 
-		public count: number;
+		public count: number | null;
 		public readonly emoji: GuildEmoji | ReactionEmoji;
 		public me: boolean;
 		public message: Message;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -371,6 +371,7 @@ declare module 'discord.js' {
 		public messages: MessageStore;
 		public recipient: User;
 		public readonly partial: boolean;
+		public fetch(): Promise<DMChannel>;
 	}
 
 	export class Emoji extends Base {
@@ -798,7 +799,9 @@ declare module 'discord.js' {
 		public readonly emoji: GuildEmoji | ReactionEmoji;
 		public me: boolean;
 		public message: Message;
+		public partial: boolean;
 		public users: ReactionUserStore;
+		public fetch(): Promise<MessageReaction>;
 		public toJSON(): object;
 	}
 


### PR DESCRIPTION
In partial DM channels the `recipient` is used to determine whether the channel is partial or not, however this property can safely be assumed since the author's id can be accessed in the scopes of where Action#getChannel() is called. This is done in this PR and now DMChannel#lastMessageID is used to determine whether the channel is partial. Since the recipient of the channel will now be present for partial channel this enables a DMChannel#fetch() to retrieve accurate properties of the partial channel, which has been added in this PR

 ___

When you have PartialTypes.MESSAGE enabled, the `messageReactionAdd` (and `messageReactionRemove`) client events behave like so for uncached messages:

```js
client.on('messageReactionAdd', async (reaction) => {
  console.log(reaction.count); // will always be 1 and -1 for messageReactionRemove
  // in order to update the MessageReaction itself it has to fetched
  // and then grabbed from the Message#reactions collection
  const key = reaction.emoji.id || reaction.emoji.name;
  reaction = await reaction.message.fetch().then((message) => message.reactions.get(key));
  console.log(reaction.count); // will now output the correct amount
});
```

The reason why this happens is due to the "filler" reaction that is passed within [Action#getReaction()](https://github.com/discordjs/discord.js/blob/master/src/client/actions/Action.js#L55) and within the action handler of [MessageReactionAdd](https://github.com/discordjs/discord.js/blob/master/src/client/actions/MessageReactionAdd.js#L31) will initialise MessageReaction#count as `0`, which will be incremented/decremented when MessageReaction#[_add()](https://github.com/discordjs/discord.js/blob/master/src/structures/MessageReaction.js#L73)/[_remove()](https://github.com/discordjs/discord.js/blob/master/src/structures/MessageReaction.js#L79) is called.

 Although the properties on partial structures should be assumed as defunct, it would be more appropriate to set it as `null` which is done over on [Message#author](https://github.com/discordjs/discord.js/blob/master/src/structures/Message.js#L68).

 To resolve this issue, PartialTypes.REACTION has been added within this PR, along with MessageReaction#partial/fetch(). Action#getReaction() will now initialise MessageReaction#count as `null` which will be used to determine whether the reaciton is a partial or not. With these changes, the `messageReactionAdd` event can now look something like this:

 ```js
client.on('messageReactionAdd', async (reaction) => {
    console.log(reaction.count); // null since it's a partial reaction
    if (reaction.partial) await reaction.fetch(); // which will now update the MessageReaction itself
    console.log(reaction.count); // will now be accurate
});
```

ReactionStore#_fetchReaction() will now do the "fetching" of reactions internally, by fetching the message itself and then updating each reaction that isn't a partial by calling ReactionStore#add() -> DataStore#add() -> [MessageReaction#_patch()](https://github.com/discordjs/discord.js/blob/master/src/stores/DataStore.js#L21), which will update the `count` property. This method will also accomondate for reactions that were completely removed by checking whether the message doesn't contain any reactions at all or whether there aren't any reactions corresponding to the emoji within the reactions of the message.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
