### PR TITLE
MessageEmbed.reset();

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -337,6 +337,49 @@ class MessageEmbed {
     return this;
   }
 
+  /**
+   * Resets an embed.
+   * @param {Object} [options] Which areas to reset on the embed
+   * @returns {MessageEmbed}
+   */
+  reset(options) {
+    if (!options) {
+      options = {
+        type: true,
+        title: true,
+        description: true,
+        url: true,
+        color: true,
+        timestamp: true,
+        fields: true,
+        thumbnail: true,
+        image: true,
+        video: true,
+        author: true,
+        provider: true,
+        footer: true,
+        files: true,
+      };
+    }
+
+    if (options.type) this.type = undefined;
+    if (options.title) this.title = undefined;
+    if (options.description) this.description = undefined;
+    if (options.url) this.url = undefined;
+    if (options.color) this.color = undefined;
+    if (options.timestamp) this.timestamp = undefined;
+    if (options.fields) this.fields = undefined;
+    if (options.thumbnail) this.thumbnail = undefined;
+    if (options.image) this.image = undefined;
+    if (options.video) this.video = undefined;
+    if (options.author) this.author = undefined;
+    if (options.provider) this.provider = undefined;
+    if (options.footer) this.footer = undefined;
+    if (options.files) this.files = undefined;
+
+    return this;
+  }
+
   toJSON() {
     return Util.flatten(this, { hexColor: true });
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This adds a reset method to the MessageEmbed reset. A clearField method was suggested in #3176, but I believe it would be more practical to have a reset method. By default, it resets everything in the embed, but you can pass an object into it specifying what to reset.

**Examples:**
`<MessageEmbed>.reset();` - resets all of the data inside of a MessageEmbed.
`<MessageEmbed>.reset({ fields: true });` - resets the fields inside of a MessageEmbed.

**Status:**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
