### PR TITLE
feat(Collectors): allow collectors to be consumed by for-await-of loops

### DIFF
--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -175,6 +175,37 @@ class Collector extends EventEmitter {
     if (reason) this.stop(reason);
   }
 
+  /**
+   * Allows collectors to be consumed with for-await-of loops
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of}
+   */
+  async *[Symbol.asyncIterator]() {
+    const queue = [];
+    const onCollect = item => queue.push(item);
+    this.on('collect', onCollect);
+
+    try {
+      while (queue.length || !this.ended) {
+        if (queue.length) {
+          yield queue.shift();
+        } else {
+          // eslint-disable-next-line no-await-in-loop
+          await new Promise(resolve => {
+            const tick = () => {
+              this.off('collect', tick);
+              this.off('end', tick);
+              return resolve();
+            };
+            this.on('collect', tick);
+            this.on('end', tick);
+          });
+        }
+      }
+    } finally {
+      this.off('collect', onCollect);
+    }
+  }
+
   toJSON() {
     return Util.flatten(this);
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -333,6 +333,7 @@ declare module 'discord.js' {
 		public handleCollect(...args: any[]): void;
 		public handleDispose(...args: any[]): void;
 		public stop(reason?: string): void;
+		public [Symbol.asyncIterator](): AsyncIterableIterator<V>;
 		public toJSON(): object;
 
 		protected listener: Function;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
A remake of #3239 with the requested changes, since that pr/branch was closed. This adds the ability to consume collectors with the for-await-of syntax.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
