### PR TITLE
feat: add custom error message for uncached Guild#me

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -79,6 +79,7 @@ const Messages = {
   GUILD_CHANNEL_ORPHAN: 'Could not find a parent to this guild channel.',
   GUILD_OWNED: 'Guild is owned by the client.',
   GUILD_MEMBERS_TIMEOUT: 'Members didn\'t arrive in time.',
+  GUILD_UNCACHED_ME: 'The client user as a member of this guild is uncached.',
 
   INVALID_TYPE: (name, expected, an = false) => `Supplied ${name} is not a${an ? 'n' : ''} ${expected}.`,
 

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -349,19 +349,21 @@ class GuildAuditLogsEntry {
             guild_id: guild.id,
           }));
     } else if (targetType === Targets.INVITE) {
-      if (guild.me.permissions.has('MANAGE_GUILD')) {
-        const change = this.changes.find(c => c.key === 'code');
-        this.target = guild.fetchInvites()
-          .then(invites => {
-            this.target = invites.find(i => i.code === (change.new || change.old));
-            return this.target;
-          });
-      } else {
-        this.target = this.changes.reduce((o, c) => {
-          o[c.key] = c.new || c.old;
-          return o;
-        }, {});
-      }
+      guild.members.fetch(guild.client.id).then(me => {
+        if (me.permissions.has('MANAGE_GUILD')) {
+          const change = this.changes.find(c => c.key === 'code');
+          this.target = guild.fetchInvites()
+            .then(invites => {
+              this.target = invites.find(i => i.code === (change.new || change.old));
+              return this.target;
+            });
+        } else {
+          this.target = this.changes.reduce((o, c) => {
+            o[c.key] = c.new || c.old;
+            return o;
+          }, {});
+        }
+      });
     } else if (targetType === Targets.MESSAGE) {
       this.target = guild.client.users.get(data.target_id);
     } else {

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -349,19 +349,18 @@ class GuildAuditLogsEntry {
             guild_id: guild.id,
           }));
     } else if (targetType === Targets.INVITE) {
-      guild.members.fetch(guild.client.user.id).then(me => {
+      this.target = guild.members.fetch(guild.client.user.id).then(me => {
         if (me.permissions.has('MANAGE_GUILD')) {
           const change = this.changes.find(c => c.key === 'code');
-          this.target = guild.fetchInvites()
-            .then(invites => {
-              this.target = invites.find(i => i.code === (change.new || change.old));
-              return this.target;
-            });
+          return guild.fetchInvites().then(invites => {
+            this.target = invites.find(i => i.code === (change.new || change.old));
+          });
         } else {
           this.target = this.changes.reduce((o, c) => {
             o[c.key] = c.new || c.old;
             return o;
           }, {});
+          return this.target;
         }
       });
     } else if (targetType === Targets.MESSAGE) {

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -349,7 +349,7 @@ class GuildAuditLogsEntry {
             guild_id: guild.id,
           }));
     } else if (targetType === Targets.INVITE) {
-      guild.members.fetch(guild.client.id).then(me => {
+      guild.members.fetch(guild.client.user.id).then(me => {
         if (me.permissions.has('MANAGE_GUILD')) {
           const change = this.changes.find(c => c.key === 'code');
           this.target = guild.fetchInvites()

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -60,6 +60,7 @@ class GuildEmoji extends Emoji {
    * @readonly
    */
   get deletable() {
+    if (!this.guild.me) throw new Error('GUILD_UNCACHED_ME');
     return !this.managed &&
       this.guild.me.hasPermission(Permissions.FLAGS.MANAGE_EMOJIS);
   }
@@ -80,8 +81,11 @@ class GuildEmoji extends Emoji {
   fetchAuthor() {
     if (this.managed) {
       return Promise.reject(new Error('EMOJI_MANAGED'));
-    } else if (!this.guild.me.permissions.has(Permissions.FLAGS.MANAGE_EMOJIS)) {
-      return Promise.reject(new Error('MISSING_MANAGE_EMOJIS_PERMISSION', this.guild));
+    } else {
+      if (!this.guild.me) return Promise.reject(new Error('GUILD_UNCACHED_ME'));
+      if (!this.guild.me.permissions.has(Permissions.FLAGS.MANAGE_EMOJIS)) {
+        return Promise.reject(new Error('MISSING_MANAGE_EMOJIS_PERMISSION', this.guild));
+      }
     }
     return this.client.api.guilds(this.guild.id).emojis(this.id).get()
       .then(emoji => this.client.users.add(emoji.user));

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -201,6 +201,7 @@ class GuildMember extends Base {
   get manageable() {
     if (this.user.id === this.guild.ownerID) return false;
     if (this.user.id === this.client.user.id) return false;
+    if (!this.guild.me) throw new Error('GUILD_UNCACHED_ME');
     return this.guild.me.roles.highest.comparePositionTo(this.roles.highest) > 0;
   }
 
@@ -210,6 +211,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get kickable() {
+    if (!this.guild.me) throw new Error('GUILD_UNCACHED_ME');
     return this.manageable && this.guild.me.permissions.has(Permissions.FLAGS.KICK_MEMBERS);
   }
 
@@ -219,6 +221,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get bannable() {
+    if (!this.guild.me) throw new Error('GUILD_UNCACHED_ME');
     return this.manageable && this.guild.me.permissions.has(Permissions.FLAGS.BAN_MEMBERS);
   }
 

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -211,7 +211,6 @@ class GuildMember extends Base {
    * @readonly
    */
   get kickable() {
-    if (!this.guild.me) throw new Error('GUILD_UNCACHED_ME');
     return this.manageable && this.guild.me.permissions.has(Permissions.FLAGS.KICK_MEMBERS);
   }
 
@@ -221,7 +220,6 @@ class GuildMember extends Base {
    * @readonly
    */
   get bannable() {
-    if (!this.guild.me) throw new Error('GUILD_UNCACHED_ME');
     return this.manageable && this.guild.me.permissions.has(Permissions.FLAGS.BAN_MEMBERS);
   }
 

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -100,6 +100,7 @@ class Invite extends Base {
   get deletable() {
     const guild = this.guild;
     if (!guild || !this.client.guilds.has(guild.id)) return false;
+    if (!guild.me) throw new Error('GUILD_UNCACHED_ME');
     return this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false) ||
       guild.me.permissions.has(Permissions.FLAGS.MANAGE_GUILD);
   }


### PR DESCRIPTION
Although it's very unlikely, Guild#me is nullable and could throw some unhelpful error messages in cases where it's uncached. This PR aims to avoid that by adding a custom error message that will be thrown instead.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
