### PR TITLE
fix(typings): Guild#member did not have null as a possible return type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -459,7 +459,7 @@ declare module 'discord.js' {
 		public fetchEmbed(): Promise<GuildEmbedData>;
 		public iconURL(options?: AvatarOptions): string;
 		public leave(): Promise<Guild>;
-		public member(user: UserResolvable): GuildMember | undefined;
+		public member(user: UserResolvable): GuildMember | null;
 		public setAFKChannel(afkChannel: ChannelResolvable, reason?: string): Promise<Guild>;
 		public setAFKTimeout(afkTimeout: number, reason?: string): Promise<Guild>;
 		public setChannelPositions(channelPositions: ChannelPosition[]): Promise<Guild>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -459,7 +459,7 @@ declare module 'discord.js' {
 		public fetchEmbed(): Promise<GuildEmbedData>;
 		public iconURL(options?: AvatarOptions): string;
 		public leave(): Promise<Guild>;
-		public member(user: UserResolvable): GuildMember;
+		public member(user: UserResolvable): GuildMember | undefined;
 		public setAFKChannel(afkChannel: ChannelResolvable, reason?: string): Promise<Guild>;
 		public setAFKTimeout(afkTimeout: number, reason?: string): Promise<Guild>;
 		public setChannelPositions(channelPositions: ChannelPosition[]): Promise<Guild>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently, [`Guild#member()`](https://github.com/discordjs/discord.js/blob/master/src/structures/Guild.js#L493) can return null, but the typings guranteed that it would return a `GuildMember`, this PR fixes that.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
