### PR TITLE
Fix(Structure): ReactionUserStore#remove() cause event messageReactionRemove to fires twice

### DIFF
--- a/src/stores/ReactionUserStore.js
+++ b/src/stores/ReactionUserStore.js
@@ -48,14 +48,7 @@ class ReactionUserStore extends DataStore {
     return message.client.api.channels[message.channel.id].messages[message.id]
       .reactions[this.reaction.emoji.identifier][userID === message.client.user.id ? '@me' : userID]
       .delete()
-      .then(() =>
-        message.client.actions.MessageReactionRemove.handle({
-          user_id: userID,
-          message_id: message.id,
-          emoji: this.reaction.emoji,
-          channel_id: message.channel.id,
-        }).reaction
-      );
+      .then(() => this.reaction);
   }
 }
 


### PR DESCRIPTION
This PR fixes #3268.
**Please describe the changes this PR makes and why it should be merged:**
Same problem as #3252.

[`ReactionUserStore#remove()`](https://github.com/discordjs/discord.js/blob/97de79bd5e34ab043a75db1f4fdb738bd20f21c3/src/stores/ReactionUserStore.js#L44) [execute](https://github.com/discordjs/discord.js/blob/97de79bd5e34ab043a75db1f4fdb738bd20f21c3/src/stores/ReactionUserStore.js#L52) messageReactionRemove action handler.
After that, it [got executed](https://github.com/discordjs/discord.js/blob/97de79bd5e34ab043a75db1f4fdb738bd20f21c3/src/client/websocket/handlers/MESSAGE_REACTION_REMOVE.js#L4) again by the WebSocketManager.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
