### PR TITLE
Refactor(Structures): Allow the use of Structures outside Discord.JS DataStores

### DIFF
--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -15,6 +15,7 @@ class DataStore extends Collection {
     Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) || holds });
     if (iterable) for (const item of iterable) this.add(item);
   }
+
   add(data, cache = true, { id, extras = [] } = {}) {
     const existing = this.get(id || data.id);
     if (existing && existing._patch && cache) existing._patch(data);

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Collection = require('../util/Collection');
-let Structures;
+const Structures = require('../util/Structures');
 
 /**
  * Manages the creation, retrieval and deletion of a specific data model.
@@ -10,12 +10,10 @@ let Structures;
 class DataStore extends Collection {
   constructor(client, iterable, holds) {
     super();
-    if (!Structures) Structures = require('../util/Structures');
     Object.defineProperty(this, 'client', { value: client });
     Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) || holds });
     if (iterable) for (const item of iterable) this.add(item);
   }
-
   add(data, cache = true, { id, extras = [] } = {}) {
     const existing = this.get(id || data.id);
     if (existing && existing._patch && cache) existing._patch(data);

--- a/src/stores/DataStore.js
+++ b/src/stores/DataStore.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Collection = require('../util/Collection');
-const Structures = require('../util/Structures');
+let Structures;
 
 /**
  * Manages the creation, retrieval and deletion of a specific data model.
@@ -10,6 +10,7 @@ const Structures = require('../util/Structures');
 class DataStore extends Collection {
   constructor(client, iterable, holds) {
     super();
+    if (!Structures) Structures = require('../util/Structures');
     Object.defineProperty(this, 'client', { value: client });
     Object.defineProperty(this, 'holds', { value: Structures.get(holds.name) || holds });
     if (iterable) for (const item of iterable) this.add(item);

--- a/src/util/Structures.js
+++ b/src/util/Structures.js
@@ -2,20 +2,12 @@
 
 /**
  * Allows for the extension of built-in Discord.js structures that are instantiated by {@link DataStore DataStores}.
+ * @extends {Map}
  */
-class Structures {
-  constructor() {
-    throw new Error(`The ${this.constructor.name} class may not be instantiated.`);
-  }
-
-  /**
-   * Retrieves a structure class.
-   * @param {string} structure Name of the structure to retrieve
-   * @returns {Function}
-   */
-  static get(structure) {
-    if (typeof structure === 'string') return Structures.structures[structure];
-    throw new TypeError(`"structure" argument must be a string (received ${typeof structure})`);
+class Structures extends Map {
+  set(key, value) {
+    if (this.has(key)) throw new Error(`${key} already exists`);
+    return super.set(key, value);
   }
 
   /**
@@ -40,8 +32,8 @@ class Structures {
    *   return CoolGuild;
    * });
    */
-  static extend(name, extender) {
-    const structure = Structures.structures[name];
+  extend(name, extender) {
+    const structure = this.get(name);
     if (!structure) throw new RangeError(`"${name}" is not a valid extensible structure.`);
     if (typeof extender !== 'function') {
       const received = `(received ${typeof extender})`;
@@ -65,32 +57,26 @@ class Structures {
       );
     }
 
-    Structures.structures[structure] = extended;
+    super.set(name, extended);
     return extended;
   }
 }
 
-/**
- * All the structures you can extend.
- * @type {Object}
- */
-Structures.structures = {
-  GuildEmoji: require('../structures/GuildEmoji'),
-  DMChannel: require('../structures/DMChannel'),
-  TextChannel: require('../structures/TextChannel'),
-  VoiceChannel: require('../structures/VoiceChannel'),
-  CategoryChannel: require('../structures/CategoryChannel'),
-  NewsChannel: require('../structures/NewsChannel'),
-  StoreChannel: require('../structures/StoreChannel'),
-  GuildMember: require('../structures/GuildMember'),
-  Guild: require('../structures/Guild'),
-  Message: require('../structures/Message'),
-  MessageReaction: require('../structures/MessageReaction'),
-  Presence: require('../structures/Presence').Presence,
-  ClientPresence: require('../structures/ClientPresence'),
-  VoiceState: require('../structures/VoiceState'),
-  Role: require('../structures/Role'),
-  User: require('../structures/User'),
-};
-
-module.exports = Structures;
+module.exports = new Structures([
+  ['GuildEmoji', require('../structures/GuildEmoji')],
+  ['DMChannel', require('../structures/DMChannel')],
+  ['TextChannel', require('../structures/TextChannel')],
+  ['VoiceChannel', require('../structures/VoiceChannel')],
+  ['CategoryChannel', require('../structures/CategoryChannel')],
+  ['NewsChannel', require('../structures/NewsChannel')],
+  ['StoreChannel', require('../structures/StoreChannel')],
+  ['GuildMember', require('../structures/GuildMember')],
+  ['Guild', require('../structures/Guild')],
+  ['Message', require('../structures/Message')],
+  ['MessageReaction', require('../structures/MessageReaction')],
+  ['Presence', require('../structures/Presence').Presence],
+  ['ClientPresence', require('../structures/ClientPresence')],
+  ['VoiceState', require('../structures/VoiceState')],
+  ['Role', require('../structures/Role')],
+  ['User', require('../structures/User')],
+]);

--- a/src/util/Structures.js
+++ b/src/util/Structures.js
@@ -14,7 +14,7 @@ class Structures {
    * @returns {Function}
    */
   static get(structure) {
-    if (typeof structure === 'string') return structures[structure];
+    if (typeof structure === 'string') return Structures.structures[structure];
     throw new TypeError(`"structure" argument must be a string (received ${typeof structure})`);
   }
 
@@ -22,7 +22,7 @@ class Structures {
    * Extends a structure.
    * <warn> Make sure to extend all structures before instantiating your client.
    * Extending after doing so may not work as expected. </warn>
-   * @param {string} structure Name of the structure class to extend
+   * @param {string} name Name of the structure class to extend
    * @param {Function} extender Function that takes the base class to extend as its only parameter and returns the
    * extended class/prototype
    * @returns {Function} Extended class/prototype returned from the extender
@@ -40,8 +40,9 @@ class Structures {
    *   return CoolGuild;
    * });
    */
-  static extend(structure, extender) {
-    if (!structures[structure]) throw new RangeError(`"${structure}" is not a valid extensible structure.`);
+  static extend(name, extender) {
+    const structure = Structures.structures[name];
+    if (!structure) throw new RangeError(`"${name}" is not a valid extensible structure.`);
     if (typeof extender !== 'function') {
       const received = `(received ${typeof extender})`;
       throw new TypeError(
@@ -49,27 +50,31 @@ class Structures {
       );
     }
 
-    const extended = extender(structures[structure]);
+    const extended = extender(structure);
     if (typeof extended !== 'function') {
       const received = `(received ${typeof extended})`;
       throw new TypeError(`The extender function must return the extended structure class/prototype ${received}.`);
     }
 
-    if (!(extended.prototype instanceof structures[structure])) {
+    if (!(extended.prototype instanceof structure)) {
       const prototype = Object.getPrototypeOf(extended);
       const received = `${extended.name || 'unnamed'}${prototype.name ? ` extends ${prototype.name}` : ''}`;
       throw new Error(
         'The class/prototype returned from the extender function must extend the existing structure class/prototype' +
-        ` (received function ${received}; expected extension of ${structures[structure].name}).`
+        ` (received function ${received}; expected extension of ${structure.name}).`
       );
     }
 
-    structures[structure] = extended;
+    Structures.structures[structure] = extended;
     return extended;
   }
 }
 
-const structures = {
+/**
+ * All the structures you can extend.
+ * @type {Object}
+ */
+Structures.structures = {
   GuildEmoji: require('../structures/GuildEmoji'),
   DMChannel: require('../structures/DMChannel'),
   TextChannel: require('../structures/TextChannel'),

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1057,9 +1057,7 @@ declare module 'discord.js' {
 		public static resolve(bit?: BitFieldResolvable<SpeakingString>): number;
 	}
 
-	export class Structures {
-		static get<K extends keyof Extendable>(structure: K): Extendable[K];
-		static get(structure: string): Function;
+	export class Structures<K extends keyof Extendable, V extends Extendable[K]> extends Map<K, V> {
 		static extend<K extends keyof Extendable, T extends Extendable[K]>(structure: K, extender: (baseClass: Extendable[K]) => T): T;
 		static extend<T extends Function>(structure: string, extender: (baseClass: typeof Function) => T): T;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The PR aims to allow the use of Structures outside discord.js what I mean by that is, being able to use Structures.extend in frameworks where they might Datastores for some things.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
