### PR TITLE
Add MessageStore.edit

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1477,6 +1477,8 @@ declare module 'discord.js' {
 		public fetch(options?: ChannelLogsQueryOptions, cache?: boolean): Promise<Collection<Snowflake, Message>>;
 		public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;
 		public remove(message: MessageResolvable, reason?: string): Promise<void>;
+		public edit(messageID: Snowflake, content: StringResolvable, options?: MessageEditOptions | MessageEmbed): Promise<Message>;
+		public edit(messageID: Snowflake, options: MessageEditOptions | MessageEmbed | APIMessage): Promise<Message>;
 	}
 
 	export class PresenceStore extends DataStore<Snowflake, Presence, typeof Presence, PresenceResolvable> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If you have the ID of a (possibly) uncached message that you'd like to edit, you should be able to do that without fetching the message first (useless API call)

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
