### PR TITLE
fix: add connection to voice state typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1271,7 +1271,7 @@ declare module 'discord.js' {
 		constructor(guild: Guild, data: object);
 		public readonly channel: VoiceChannel | null;
 		public channelID?: Snowflake;
-		public connection?: VoiceConnection;
+		public readonly connection: VoiceConnection | null;
 		public readonly deaf?: boolean;
 		public guild: Guild;
 		public id: Snowflake;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1271,6 +1271,7 @@ declare module 'discord.js' {
 		constructor(guild: Guild, data: object);
 		public readonly channel: VoiceChannel | null;
 		public channelID?: Snowflake;
+		public connection?: VoiceConnection;
 		public readonly deaf?: boolean;
 		public guild: Guild;
 		public id: Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
VoiceState has a connection property that is not described in the typings.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
