### PR TITLE
github: add support file and redirect to it

### DIFF
--- a/.github/ISSUE_TEMPLATE/question---general-support-request.md
+++ b/.github/ISSUE_TEMPLATE/question---general-support-request.md
@@ -6,8 +6,5 @@ about: Ask for help in Discord instead - https://discord.gg/bRCvFy9
 
 Seriously, we only use this issue tracker for bugs in the library itself and feature requests for it.
 We don't typically answer questions or help with support issues here.
-Instead, please ask in one of the support channels in our Discord server:
 
-https://discord.gg/bRCvFy9
-
-Any issues that don't directly involve a bug in the library or a feature request will likely be closed and redirected to the Discord server.
+If you have a question or need support on our library, please read our [Support Document](https://github.com/discordjs/discord.js/blob/master/.github/SUPPORT.md)

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,4 +1,4 @@
-# Seeking for support?
+# Seeking support?
 
 We're sorry, we only use this issue tracker for bugs in the library itself and feature requests for it. We are not able to provide general support or answser questions on the issue tracker.
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,7 @@
+# Seeking for support?
+
+We're sorry, we only use this issue tracker for bugs in the library itself and feature requests for it. We are not able to provide general support or answser questions on the issue tracker.
+
+Should you want to ask such questions, please post in one of our support channels in our Discord server: https://discord.gg/bRCvFy9
+
+Any issues that don't directly involve a bug in the library or a feature request will likely be closed and redirected to the Discord server.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Recently, GitHub added [support resources](https://help.github.com/en/articles/adding-support-resources-to-your-project), which are there to, well, show ways of getting support (similar to what was done in the general questions issue template). This PR initializes this feature and redirects the general question template to the support document

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
