### PR TITLE
fix: StreamOptions#volume typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2183,7 +2183,7 @@ declare module 'discord.js' {
 	interface StreamOptions {
 		type?: StreamType;
 		seek?: number;
-		volume?: number;
+		volume?: number | boolean;
 		passes?: number;
 		plp?: number;
 		fec?: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
StreamOptions#volume takes a boolean to disable the volume transformer.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
