### PR TITLE
chore: explicitly mark everything deprecated as `@deprecated`

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -116,6 +116,7 @@ class Client extends EventEmitter {
      * Presences that have been received for the client user's friends, mapped by user IDs
      * <warn>This is only filled when using a user account.</warn>
      * @type {Collection<Snowflake, Presence>}
+     * @deprecated
      */
     this.presences = new Collection();
 
@@ -296,6 +297,7 @@ class Client extends EventEmitter {
    * <info>This can be done automatically every 30 seconds by enabling {@link ClientOptions#sync}.</info>
    * <warn>This is only available when using a user account.</warn>
    * @param {Guild[]|Collection<Snowflake, Guild>} [guilds=this.guilds] An array or collection of guilds to sync
+   * @deprecated
    */
   syncGuilds(guilds = this.guilds) {
     if (this.user.bot) return;

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -23,6 +23,7 @@ class ClientUser extends User {
      * The email of this account
      * <warn>This is only filled when using a user account.</warn>
      * @type {?string}
+     * @deprecated
      */
     this.email = data.email;
     this.localPresence = {};
@@ -32,6 +33,7 @@ class ClientUser extends User {
      * A Collection of friends for the logged in user
      * <warn>This is only filled when using a user account.</warn>
      * @type {Collection<Snowflake, User>}
+     * @deprecated
      */
     this.friends = new Collection();
 
@@ -39,6 +41,7 @@ class ClientUser extends User {
      * A Collection of blocked users for the logged in user
      * <warn>This is only filled when using a user account.</warn>
      * @type {Collection<Snowflake, User>}
+     * @deprecated
      */
     this.blocked = new Collection();
 
@@ -46,6 +49,7 @@ class ClientUser extends User {
      * A Collection of notes for the logged in user
      * <warn>This is only filled when using a user account.</warn>
      * @type {Collection<Snowflake, string>}
+     * @deprecated
      */
     this.notes = new Collection();
 
@@ -53,20 +57,21 @@ class ClientUser extends User {
      * If the user has Discord premium (nitro)
      * <warn>This is only filled when using a user account.</warn>
      * @type {?boolean}
+     * @deprecated
      */
     this.premium = typeof data.premium === 'boolean' ? data.premium : null;
 
     /**
      * If the user has MFA enabled on their account
-     * <warn>This is only filled when using a user account.</warn>
-     * @type {?boolean}
+     * @type {boolean}
      */
-    this.mfaEnabled = typeof data.mfa_enabled === 'boolean' ? data.mfa_enabled : null;
+    this.mfaEnabled = data.mfa_enabled;
 
     /**
      * If the user has ever used a mobile device on Discord
      * <warn>This is only filled when using a user account.</warn>
      * @type {?boolean}
+     * @deprecated
      */
     this.mobile = typeof data.mobile === 'boolean' ? data.mobile : null;
 
@@ -74,6 +79,7 @@ class ClientUser extends User {
      * Various settings for this user
      * <warn>This is only filled when using a user account.</warn>
      * @type {?ClientUserSettings}
+     * @deprecated
      */
     this.settings = data.user_settings ? new ClientUserSettings(this, data.user_settings) : null;
 
@@ -81,6 +87,7 @@ class ClientUser extends User {
      * All of the user's guild settings
      * <warn>This is only filled when using a user account</warn>
      * @type {Collection<Snowflake, ClientUserGuildSettings>}
+     * @deprecated
      */
     this.guildSettings = new Collection();
     if (data.user_guild_settings) {
@@ -117,6 +124,7 @@ class ClientUser extends User {
    * @param {string} email New email to change to
    * @param {string} password Current password
    * @returns {Promise<ClientUser>}
+   * @deprecated
    * @example
    * // Set email
    * client.user.setEmail('bob@gmail.com', 'some amazing password 123')
@@ -133,6 +141,7 @@ class ClientUser extends User {
    * @param {string} newPassword New password to change to
    * @param {string} oldPassword Current password
    * @returns {Promise<ClientUser>}
+   * @deprecated
    * @example
    * // Set password
    * client.user.setPassword('some new amazing password 456', 'some amazing password 123')
@@ -310,6 +319,7 @@ class ClientUser extends User {
    * @param {boolean} [options.everyone=true] Whether to include everyone/here mentions
    * @param {GuildResolvable} [options.guild] Limit the search to a specific guild
    * @returns {Promise<Message[]>}
+   * @deprecated
    * @example
    * // Fetch mentions
    * client.user.fetchMentions()
@@ -330,6 +340,7 @@ class ClientUser extends User {
    * <warn>This is only available when using a user account.</warn>
    * @param {UserResolvable} user The user to send the friend request to
    * @returns {Promise<User>} The user the friend request was sent to
+   * @deprecated
    */
   addFriend(user) {
     user = this.client.resolver.resolveUser(user);
@@ -341,6 +352,7 @@ class ClientUser extends User {
    * <warn>This is only available when using a user account.</warn>
    * @param {UserResolvable} user The user to remove from your friends
    * @returns {Promise<User>} The user that was removed
+   * @deprecated
    */
   removeFriend(user) {
     user = this.client.resolver.resolveUser(user);
@@ -404,11 +416,15 @@ class ClientUser extends User {
    * <warn>This is only available when using a user account.</warn>
    * @param {Invite|string} invite Invite or code to accept
    * @returns {Promise<Guild>} Joined guild
+   * @deprecated
    */
   acceptInvite(invite) {
     return this.client.rest.methods.acceptInvite(invite);
   }
 }
+
+ClientUser.prototype.acceptInvite =
+  util.deprecate(ClientUser.prototype.acceptInvite, 'ClientUser#acceptInvite: userbot methods will be removed');
 
 ClientUser.prototype.setGame =
   util.deprecate(ClientUser.prototype.setGame, 'ClientUser#setGame: use ClientUser#setActivity instead');

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -361,6 +361,7 @@ class Guild {
    * <warn>This is only available when using a user account.</warn>
    * @type {?number}
    * @readonly
+   * @deprecated
    */
   get position() {
     if (this.client.user.bot) return null;
@@ -373,6 +374,7 @@ class Guild {
    * <warn>This is only available when using a user account.</warn>
    * @type {?boolean}
    * @readonly
+   * @deprecated
    */
   get muted() {
     if (this.client.user.bot) return null;
@@ -388,6 +390,7 @@ class Guild {
    * <warn>This is only available when using a user account.</warn>
    * @type {?MessageNotificationType}
    * @readonly
+   * @deprecated
    */
   get messageNotifications() {
     if (this.client.user.bot) return null;
@@ -403,6 +406,7 @@ class Guild {
    * <warn>This is only available when using a user account.</warn>
    * @type {?boolean}
    * @readonly
+   * @deprecated
    */
   get mobilePush() {
     if (this.client.user.bot) return null;
@@ -418,6 +422,7 @@ class Guild {
    * <warn>This is only available when using a user account.</warn>
    * @type {?boolean}
    * @readonly
+   * @deprecated
    */
   get suppressEveryone() {
     if (this.client.user.bot) return null;
@@ -699,6 +704,7 @@ class Guild {
    * <warn>This is only available when using a user account.</warn>
    * @param {MessageSearchOptions} [options={}] Options to pass to the search
    * @returns {Promise<MessageSearchResult>}
+   * @deprecated
    * @example
    * guild.search({
    *   content: 'discord.js',
@@ -926,6 +932,7 @@ class Guild {
    * @param {number} position Absolute or relative position
    * @param {boolean} [relative=false] Whether to position relatively or absolutely
    * @returns {Promise<Guild>}
+   * @deprecated
    */
   setPosition(position, relative) {
     if (this.client.user.bot) {
@@ -938,6 +945,7 @@ class Guild {
    * Marks all messages in this guild as read.
    * <warn>This is only available when using a user account.</warn>
    * @returns {Promise<Guild>}
+   * @deprecated
    */
   acknowledge() {
     return this.client.rest.methods.ackGuild(this);
@@ -948,6 +956,7 @@ class Guild {
    * <warn>This is only available when using a user account.</warn>
    * @param {boolean} allow Whether to allow direct messages
    * @returns {Promise<Guild>}
+   * @deprecated
    */
   allowDMs(allow) {
     const settings = this.client.user.settings;
@@ -1026,6 +1035,7 @@ class Guild {
   /**
    * Syncs this guild (already done automatically every 30 seconds).
    * <warn>This is only available when using a user account.</warn>
+   * @deprecated
    */
   sync() {
     if (!this.client.user.bot) this.client.syncGuilds([this]);
@@ -1432,6 +1442,9 @@ Object.defineProperty(Guild.prototype, 'defaultChannel', {
     return this.channels.get(this.id);
   }, 'Guild#defaultChannel: This property is obsolete, will be removed in v12.0.0, and may not function as expected.'),
 });
+
+Guild.prototype.allowDMs =
+  util.deprecate(Guild.prototype.allowDMs, 'Guild#allowDMs: userbot methods will be removed');
 
 Guild.prototype.acknowledge =
   util.deprecate(Guild.prototype.acknowledge, 'Guild#acknowledge: userbot methods will be removed');

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -492,6 +492,7 @@ class GuildChannel extends Channel {
    * <warn>This is only available when using a user account.</warn>
    * @type {?boolean}
    * @readonly
+   * @deprecated
    */
   get muted() {
     if (this.client.user.bot) return null;
@@ -507,6 +508,7 @@ class GuildChannel extends Channel {
    * <warn>This is only available when using a user account.</warn>
    * @type {?MessageNotificationType}
    * @readonly
+   * @deprecated
    */
   get messageNotifications() {
     if (this.client.user.bot) return null;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -509,6 +509,7 @@ class Message {
    * Marks the message as read.
    * <warn>This is only available when using a user account.</warn>
    * @returns {Promise<Message>}
+   * @deprecated
    */
   acknowledge() {
     return this.client.rest.methods.ackMessage(this);

--- a/src/structures/OAuth2Application.js
+++ b/src/structures/OAuth2Application.js
@@ -127,6 +127,7 @@ class OAuth2Application {
    * Reset the app's secret and bot token.
    * <warn>This is only available when using a user account.</warn>
    * @returns {OAuth2Application}
+   * @deprecated
    */
   reset() {
     return this.client.rest.methods.resetApplication(this.id);

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -32,26 +32,26 @@ class PermissionOverwrites {
     /**
      * The permissions that are denied for the user or role as a bitfield.
      * @type {number}
-     * @deprecated
      */
     this.deny = data.deny;
 
     /**
      * The permissions that are allowed for the user or role as a bitfield.
      * @type {number}
-     * @deprecated
      */
     this.allow = data.allow;
 
     /**
      * The permissions that are denied for the user or role.
      * @type {Permissions}
+     * @deprecated
      */
     this.denied = new Permissions(data.deny).freeze();
 
     /**
      * The permissions that are allowed for the user or role.
      * @type {Permissions}
+     * @deprecated
      */
     this.allowed = new Permissions(data.allow).freeze();
   }

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -147,6 +147,7 @@ class User {
    * <warn>This is only available when using a user account.</warn>
    * @type {?string}
    * @readonly
+   * @deprecated
    */
   get note() {
     return this.client.user.notes.get(this.id) || null;
@@ -211,6 +212,7 @@ class User {
    * Sends a friend request to the user.
    * <warn>This is only available when using a user account.</warn>
    * @returns {Promise<User>}
+   * @deprecated
    */
   addFriend() {
     return this.client.rest.methods.addFriend(this);
@@ -220,6 +222,7 @@ class User {
    * Removes the user from your friends.
    * <warn>This is only available when using a user account.</warn>
    * @returns {Promise<User>}
+   * @deprecated
    */
   removeFriend() {
     return this.client.rest.methods.removeFriend(this);
@@ -229,6 +232,7 @@ class User {
    * Blocks the user.
    * <warn>This is only available when using a user account.</warn>
    * @returns {Promise<User>}
+   * @deprecated
    */
   block() {
     return this.client.rest.methods.blockUser(this);
@@ -238,6 +242,7 @@ class User {
    * Unblocks the user.
    * <warn>This is only available when using a user account.</warn>
    * @returns {Promise<User>}
+   * @deprecated
    */
   unblock() {
     return this.client.rest.methods.unblockUser(this);
@@ -247,6 +252,7 @@ class User {
    * Get the profile of the user.
    * <warn>This is only available when using a user account.</warn>
    * @returns {Promise<UserProfile>}
+   * @deprecated
    */
   fetchProfile() {
     return this.client.rest.methods.fetchUserProfile(this);
@@ -257,6 +263,7 @@ class User {
    * <warn>This is only available when using a user account.</warn>
    * @param {string} note The note to set for the user
    * @returns {Promise<User>}
+   * @deprecated
    */
   setNote(note) {
     return this.client.rest.methods.setNote(this, note);

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -181,9 +181,7 @@ class TextBasedChannel {
   }
 
   /**
-   * Gets a single message from this channel, regardless of it being cached or not. Since the single message fetching
-   * endpoint is reserved for bot accounts, this abstracts the `fetchMessages` method to obtain the single message when
-   * using a user account.
+   * Gets a single message from this channel, regardless of it being cached or not.
    * @param {Snowflake} messageID ID of the message to get
    * @returns {Promise<Message>}
    * @example
@@ -309,6 +307,7 @@ class TextBasedChannel {
    * <warn>This is only available when using a user account.</warn>
    * @param {MessageSearchOptions} [options={}] Options to pass to the search
    * @returns {Promise<MessageSearchResult>}
+   * @deprecated
    * @example
    * channel.search({
    *   content: 'discord.js',
@@ -506,6 +505,7 @@ class TextBasedChannel {
    * Marks all messages in this channel as read.
    * <warn>This is only available when using a user account.</warn>
    * @returns {Promise<TextChannel|GroupDMChannel|DMChannel>}
+   * @deprecated
    */
   acknowledge() {
     if (!this.lastMessageID) return Promise.resolve(this);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR marks everything deprecated as `@deprecated` to generate a more prominent warning in the documentation.

---

`ClientUser#mfaEnabled` is not user account only, on bots it reflects the mfa status of the owning user account.
This is useful to determine whether the bot can make use of its administrative permissions, if it has them, when the guild requires server-wide 2fa.

---

`PermissionOverwrites#allow` and `#deny` have been undeprecated. (Although the type changes in v12)

`#allowed` and `#denied` however have been deprecated.

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
