### PR TITLE
Add CategoryChannel To `channels.create`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1435,7 +1435,7 @@ declare module 'discord.js' {
 
 	export class GuildChannelStore extends DataStore<Snowflake, GuildChannel, typeof GuildChannel, GuildChannelResolvable> {
 		constructor(guild: Guild, iterable?: Iterable<any>);
-		public create(name: string, options?: GuildCreateChannelOptions): Promise<TextChannel | VoiceChannel>;
+		public create(name: string, options?: GuildCreateChannelOptions): Promise<TextChannel | VoiceChannel | CategoryChannel>;
 	}
 
 	// Hacky workaround because changing the signature of an overriden method errors


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the typings to help allow the creation of `category` channels.

![image](https://user-images.githubusercontent.com/23035000/58886962-b75ae980-86b2-11e9-9014-369dfba9dc96.png)

![image](https://user-images.githubusercontent.com/23035000/58887024-d0fc3100-86b2-11e9-947e-2ec47e543873.png)

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
