### PR TITLE
Feat: Abort Requests that takes a lot of time to resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "runkitExampleFilename": "./docs/examples/ping.js",
   "unpkg": "./webpack/discord.min.js",
   "dependencies": {
+    "abort-controller": "^3.0.0",
     "form-data": "^2.3.3",
     "node-fetch": "^2.3.0",
     "pako": "^1.0.8",

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -392,6 +392,9 @@ class Client extends BaseClient {
     if (typeof options.restWsBridgeTimeout !== 'number' || isNaN(options.restWsBridgeTimeout)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'restWsBridgeTimeout', 'a number');
     }
+    if (typeof options.restRequestTimeout !== 'number' || isNaN(options.restSweepInterval)) {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'restRequestTimeout', 'a number');
+    }
     if (typeof options.restSweepInterval !== 'number' || isNaN(options.restSweepInterval)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'restSweepInterval', 'a number');
     }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -392,7 +392,7 @@ class Client extends BaseClient {
     if (typeof options.restWsBridgeTimeout !== 'number' || isNaN(options.restWsBridgeTimeout)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'restWsBridgeTimeout', 'a number');
     }
-    if (typeof options.restRequestTimeout !== 'number' || isNaN(options.restSweepInterval)) {
+    if (typeof options.restRequestTimeout !== 'number' || isNaN(options.restRequestTimeout)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'restRequestTimeout', 'a number');
     }
     if (typeof options.restSweepInterval !== 'number' || isNaN(options.restSweepInterval)) {

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -46,7 +46,7 @@ class APIRequest {
       body = JSON.stringify(this.options.data);
       headers['Content-Type'] = 'application/json';
     }
-    
+
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 10000);
     return fetch(url, {
@@ -54,11 +54,11 @@ class APIRequest {
       headers,
       agent,
       body,
-      signal: controller.signal
-    }).then((res) => {
+      signal: controller.signal,
+    }).then(res => {
       clearTimeout(timeout);
       return res;
-    }, (error) => {
+    }, error => {
       clearTimeout(timeout);
       throw error;
     });

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -42,7 +42,7 @@ class APIRequest {
       for (const file of this.options.files) if (file && file.file) body.append(file.name, file.file, file.name);
       if (typeof this.options.data !== 'undefined') body.append('payload_json', JSON.stringify(this.options.data));
       if (!browser) headers = Object.assign(headers, body.getHeaders());
-    } else if (this.options.data != null) { // eslint-disable-line 
+    } else if (this.options.data != null) { // eslint-disable-line eqeqeq
       body = JSON.stringify(this.options.data);
       headers['Content-Type'] = 'application/json';
     }

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -61,7 +61,7 @@ class APIRequest {
     }, (error) => {
       clearTimeout(timeout);
       throw error;
-    })
+    });
   }
 }
 

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -48,14 +48,14 @@ class APIRequest {
     }
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.client.options.restRequestTimeout);
+    const timeout = this.client.setTimeout(() => controller.abort(), this.client.options.restRequestTimeout);
     return fetch(url, {
       method: this.method,
       headers,
       agent,
       body,
       signal: controller.signal,
-    }).finally(() => clearTimeout(timeout));
+    }).finally(() => this.client.clearTimeout(timeout));
   }
 }
 

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -42,26 +42,20 @@ class APIRequest {
       for (const file of this.options.files) if (file && file.file) body.append(file.name, file.file, file.name);
       if (typeof this.options.data !== 'undefined') body.append('payload_json', JSON.stringify(this.options.data));
       if (!browser) headers = Object.assign(headers, body.getHeaders());
-    } else if (this.options.data != null) { // eslint-disable-line eqeqeq
+    } else if (this.options.data != null) { // eslint-disable-line 
       body = JSON.stringify(this.options.data);
       headers['Content-Type'] = 'application/json';
     }
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 10000);
+    const timeout = setTimeout(() => controller.abort(), this.client.options.restRequestTimeout);
     return fetch(url, {
       method: this.method,
       headers,
       agent,
       body,
       signal: controller.signal,
-    }).then(res => {
-      clearTimeout(timeout);
-      return res;
-    }, error => {
-      clearTimeout(timeout);
-      throw error;
-    });
+    }).finally(() => clearTimeout(timeout));
   }
 }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -28,6 +28,7 @@ const browser = exports.browser = typeof window !== 'undefined';
  * corresponding websocket events
  * @property {number} [restTimeOffset=500] Extra time in millseconds to wait before continuing to make REST
  * requests (higher values will reduce rate-limiting errors on bad connections)
+ * @property {number} [restRequestTimeout=15000] Time to wait before cancelling a REST request
  * @property {number} [restSweepInterval=60] How frequently to delete inactive request buckets, in seconds
  * (or 0 for never)
  * @property {number} [retryLimit=1] How many times to retry on 5XX errors (Infinity for indefinite amount of retries)
@@ -50,6 +51,7 @@ exports.DefaultOptions = {
   partials: [],
   restWsBridgeTimeout: 5000,
   disabledEvents: [],
+  restRequestTimeout: 15000,
   retryLimit: 1,
   restTimeOffset: 500,
   restSweepInterval: 60,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1707,6 +1707,7 @@ declare module 'discord.js' {
 		partials?: PartialTypes[];
 		restWsBridgeTimeout?: number;
 		restTimeOffset?: number;
+		restRequestTimeout?: number;
 		restSweepInterval?: number;
 		retryLimit?: number;
 		presence?: PresenceData;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Lately I suffered from some requests that gets too long to resolve, and due to this, our bot slowed down a lot, as well causing us some problems specially in some of our modules. By adding a request timeout feature for Discord.js requests, we can make sure that requests that takes too long to resolve could get cancelled, hence solving the problem of requests that takes an inconsiderable amount of time to resolve.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
