### PR TITLE
fix(Guild): allow fetchMember to be used with an uncached user

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -499,8 +499,8 @@ class RESTMethods {
       .then(data => this.client.actions.GuildMemberGet.handle(guild, data).member);
   }
 
-  getGuildMember(guild, user, cache) {
-    return this.rest.makeRequest('get', Endpoints.Guild(guild).Member(user.id), true).then(data => {
+  getGuildMember(guild, userID, cache) {
+    return this.rest.makeRequest('get', Endpoints.Guild(guild).Member(userID), true).then(data => {
       if (cache) return this.client.actions.GuildMemberGet.handle(guild, data).member;
       else return new GuildMember(guild, data);
     });

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -649,11 +649,11 @@ class Guild {
    *   .catch(console.error);
    */
   fetchMember(user, cache = true) {
-    user = this.client.resolver.resolveUser(user);
-    if (!user) return Promise.reject(new Error('Invalid or uncached id provided.'));
-    const member = this.members.get(user.id);
+    const userID = this.client.resolver.resolveUserID(user);
+    if (!userID) return Promise.reject(new Error('Invalid id provided.'));
+    const member = this.members.get(userID);
     if (member && member.joinedTimestamp) return Promise.resolve(member);
-    return this.client.rest.methods.getGuildMember(this, user, cache);
+    return this.client.rest.methods.getGuildMember(this, userID, cache);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a bug not allowing one to fetch a member without having the user cached already.
Leading you to have more code and make more requests than necessary:
`client.fetchUser('id).then(u => guild.fetchMember(u)).then(member => /* ... */);`
to just
`guild.fetchMember(u).then(member => /* ... */);`

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
