### PR TITLE
feat(Guild): backport misc properties and setRolePositions

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -499,6 +499,10 @@ class RESTMethods {
       .then(data => this.client.actions.GuildMemberGet.handle(guild, data).member);
   }
 
+  getGuild(guild) {
+    return this.rest.makeRequest('get', Endpoints.Guild(guild), true);
+  }
+
   getGuildMember(guild, userID, cache) {
     return this.rest.makeRequest('get', Endpoints.Guild(guild).Member(userID), true).then(data => {
       if (cache) return this.client.actions.GuildMemberGet.handle(guild, data).member;
@@ -884,23 +888,6 @@ class RESTMethods {
   unblockUser(user) {
     return this.rest.makeRequest('delete', Endpoints.User('@me').Relationship(user.id), true)
       .then(() => user);
-  }
-
-  updateChannelPositions(guildID, channels) {
-    const data = new Array(channels.length);
-    for (let i = 0; i < channels.length; i++) {
-      data[i] = {
-        id: this.client.resolver.resolveChannelID(channels[i].channel),
-        position: channels[i].position,
-      };
-    }
-
-    return this.rest.makeRequest('patch', Endpoints.Guild(guildID).channels, true, data).then(() =>
-      this.client.actions.GuildChannelsPositionUpdate.handle({
-        guild_id: guildID,
-        channels,
-      }).guild
-    );
   }
 
   updateEmbed(guildID, embed, reason) {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -152,6 +152,7 @@ const Endpoints = exports.Endpoints = {
       auditLogs: `${base}/audit-logs`,
       Emoji: emojiID => `${base}/emojis/${emojiID}`,
       Icon: (root, hash) => Endpoints.CDN(root).Icon(guildID, hash),
+      Banner: (root, hash) => Endpoints.CDN(root).Banner(guildID, hash),
       Splash: (root, hash) => Endpoints.CDN(root).Splash(guildID, hash),
       Role: roleID => `${base}/roles/${roleID}`,
       Member: memberID => {
@@ -210,6 +211,7 @@ const Endpoints = exports.Endpoints = {
       Asset: name => `${root}/assets/${name}`,
       Avatar: (userID, hash) => `${root}/avatars/${userID}/${hash}.${hash.startsWith('a_') ? 'gif' : 'png?size=2048'}`,
       Icon: (guildID, hash) => `${root}/icons/${guildID}/${hash}.jpg`,
+      Banner: (guildID, hash) => `${root}/banners/${guildID}/${hash}.jpg`,
       AppIcon: (clientID, hash) => `${root}/app-icons/${clientID}/${hash}.png`,
       AppAsset: (clientID, hash) => `${root}/app-assets/${clientID}/${hash}.png`,
       GDMIcon: (channelID, hash) => `${root}/channel-icons/${channelID}/${hash}.jpg?size=2048`,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -482,6 +482,9 @@ declare module 'discord.js' {
 		public afkTimeout: number;
 		public applicationID: string;
 		public available: boolean;
+		public banner: string | null;
+		public readonly bannerURL: string | null;
+		public description: string | null;
 		public channels: Collection<Snowflake, GuildChannel>;
 		public defaultMessageNotifications: DefaultMessageNotifications | number;
 		public readonly client: Client;
@@ -489,6 +492,8 @@ declare module 'discord.js' {
 		public readonly createdTimestamp: number;
 		public readonly defaultChannel: TextChannel;
 		public readonly defaultRole: Role;
+		public readonly embedChannel: TextChannel | null;
+		public embedChannelID: Snowflake | null;
 		public embedEnabled: boolean;
 		public emojis: Collection<Snowflake, Emoji>;
 		public explicitContentFilter: number;
@@ -499,6 +504,8 @@ declare module 'discord.js' {
 		public readonly joinedAt: Date;
 		public joinedTimestamp: number;
 		public large: boolean;
+		public maximumMembers?: number;
+		public maximumPresences?: number;
 		public readonly me: GuildMember;
 		public memberCount: number;
 		public members: Collection<Snowflake, GuildMember>;
@@ -518,9 +525,13 @@ declare module 'discord.js' {
 		public readonly suppressEveryone: boolean;
 		public readonly systemChannel: GuildChannel;
 		public systemChannelID: Snowflake;
+		public vanityURLCode: string;
 		public readonly verified: boolean;
 		public verificationLevel: number;
 		public readonly voiceConnection: VoiceConnection;
+		public readonly widgetChannel: TextChannel | null;
+		public widgetChannelID?: Snowflake;
+		public widgetEnabled?: boolean;
 		public acknowledge(): Promise<Guild>;
 		public addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
 		public allowDMs(allow: boolean): Promise<Guild>;
@@ -533,6 +544,7 @@ declare module 'discord.js' {
 		public deleteEmoji(emoji: Emoji | string, reason?: string): Promise<void>;
 		public edit(data: GuildEditData, reason?: string): Promise<Guild>;
 		public equals(guild: Guild): boolean;
+		public fetch(): Promise<Guild>;
 		public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
 		public fetchBan(user: UserResolvable): Promise<BanInfo>;
 		public fetchBans(withReasons?: false): Promise<Collection<Snowflake, User>>;
@@ -562,6 +574,7 @@ declare module 'discord.js' {
 		public setPosition(position: number, relative?: boolean): Promise<Guild>;
 		public setRegion(region: string, reason?: string): Promise<Guild>;
 		public setRolePosition(role: string | Role, position: number, relative?: boolean): Promise<Guild>;
+		public setRolePositions(rolePositions: RolePosition[]): Promise<Guild>;
 		public setSplash(splash: Base64Resolvable, reason?: string): Promise<Guild>;
 		public setSystemChannel(systemChannel: ChannelResolvable, reason?: string): Promise<Guild>;
 		public setVerificationLevel(verificationLevel: number, reason?: string): Promise<Guild>;
@@ -2101,6 +2114,11 @@ declare module 'discord.js' {
 		position?: number;
 		permissions?: PermissionResolvable;
 		mentionable?: boolean;
+	};
+
+	type RolePosition = {
+		role: RoleResolvable;
+		position: number;
 	};
 
 	type RoleResolvable = Role | string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports:
* Several properties of `Guild` from #3168
* * `banner` and the `bannerURL` getter
* * `description`
* * `embedChannelID`
* * `maximumMembers`
* * `maximumPresences`
* * `widgetEnabled`
* * `widgetChannelID`
* * `vanityURLCode`
* * `fetch` method
* `Guild#setRolePositions` from #3317

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
