### PR TITLE
feat(Guild): default iconURL to gif if animated

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -131,12 +131,12 @@ exports.Endpoints = {
         if (format === 'default') format = hash.startsWith('a_') ? 'gif' : 'webp';
         return makeImageUrl(`${root}/avatars/${userID}/${hash}`, { format, size });
       },
-      Banner: (guildID, hash, format = 'default', size) => {
+      Banner: (guildID, hash, format = 'webp', size) =>
+        makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size }),
+      Icon: (guildID, hash, format = 'default', size) => {
         if (format === 'default') format = hash.startsWith('a_') ? 'gif' : 'webp';
         return makeImageUrl(`${root}/banners/${guildID}/${hash}`, { format, size });
       },
-      Icon: (guildID, hash, format = 'webp', size) =>
-        makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size }),
       AppIcon: (clientID, hash, { format = 'webp', size } = {}) =>
         makeImageUrl(`${root}/app-icons/${clientID}/${hash}`, { size, format }),
       AppAsset: (clientID, hash, { format = 'webp', size } = {}) =>

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -131,8 +131,10 @@ exports.Endpoints = {
         if (format === 'default') format = hash.startsWith('a_') ? 'gif' : 'webp';
         return makeImageUrl(`${root}/avatars/${userID}/${hash}`, { format, size });
       },
-      Banner: (guildID, hash, format = 'webp', size) =>
-        makeImageUrl(`${root}/banners/${guildID}/${hash}`, { format, size }),
+      Banner: (guildID, hash, format = 'default', size) => {
+        if (format === 'default') format = hash.startsWith('a_') ? 'gif' : 'webp';
+        return makeImageUrl(`${root}/banners/${guildID}/${hash}`, { format, size });
+      },
       Icon: (guildID, hash, format = 'webp', size) =>
         makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size }),
       AppIcon: (clientID, hash, { format = 'webp', size } = {}) =>

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -132,10 +132,10 @@ exports.Endpoints = {
         return makeImageUrl(`${root}/avatars/${userID}/${hash}`, { format, size });
       },
       Banner: (guildID, hash, format = 'webp', size) =>
-        makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size }),
+        makeImageUrl(`${root}/banners/${guildID}/${hash}`, { format, size }),
       Icon: (guildID, hash, format = 'default', size) => {
         if (format === 'default') format = hash.startsWith('a_') ? 'gif' : 'webp';
-        return makeImageUrl(`${root}/banners/${guildID}/${hash}`, { format, size });
+        return makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size });
       },
       AppIcon: (clientID, hash, { format = 'webp', size } = {}) =>
         makeImageUrl(`${root}/app-icons/${clientID}/${hash}`, { size, format }),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes `Guild#iconURL` to default to a `gif` extension for animated guild icons.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
