### PR TITLE
Presence does not extend Base, therefore presence.client was undocumented

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -37,6 +37,12 @@ class Presence {
    * @param {Object} [data={}] The data for the presence
    */
   constructor(client, data = {}) {
+    /**
+     * The client that instantiated this
+     * @name Presence#client
+     * @type {Client}
+     * @readonly
+     */
     Object.defineProperty(this, 'client', { value: client });
     /**
      * The user ID of this presence


### PR DESCRIPTION
As per the title, documentation-only update to add the `Presence.client` as raised by Buckshot on Discord.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
