### PR TITLE
feat(Emoji): add delete method

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -754,7 +754,7 @@ class RESTMethods {
 
   deleteEmoji(emoji, reason) {
     return this.rest.makeRequest('delete', Endpoints.Guild(emoji.guild).Emoji(emoji.id), true, undefined, reason)
-      .then(() => this.client.actions.GuildEmojiDelete.handle(emoji).data);
+      .then(() => this.client.actions.GuildEmojiDelete.handle(emoji).emoji);
   }
 
   getGuildAuditLogs(guild, options = {}) {

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -222,6 +222,16 @@ class Emoji {
     return this.edit({ roles: newRoles });
   }
 
+
+  /**
+   * Deletes the emoji.
+   * @param {string} [reason] Reason for deleting the emoji
+   * @returns {Promise<Emoji>}
+   */
+  delete(reason) {
+    return this.client.rest.methods.deleteEmoji(this, reason);
+  }
+
   /**
    * When concatenated with a string, this automatically returns the emoji mention rather than the object.
    * @returns {string}

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1322,11 +1322,12 @@ class Guild {
    * @param {Emoji|string} emoji The emoji to delete
    * @param {string} [reason] Reason for deleting the emoji
    * @returns {Promise}
+   * @deprecated
    */
   deleteEmoji(emoji, reason) {
     if (typeof emoji === 'string') emoji = this.emojis.get(emoji);
     if (!(emoji instanceof Emoji)) throw new TypeError('Emoji must be either an instance of Emoji or an ID');
-    return this.client.rest.methods.deleteEmoji(emoji, reason);
+    return emoji.delete(reason);
   }
 
   /**
@@ -1594,5 +1595,8 @@ Guild.prototype.search =
 
 Guild.prototype.sync =
   util.deprecate(Guild.prototype.sync, 'Guild#sync:, userbot methods will be removed');
+
+Guild.prototype.deleteEmoji =
+  util.deprecate(Guild.prototype.deleteEmoji, 'Guild#deleteEmoji: use Emoji#delete instead');
 
 module.exports = Guild;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -420,6 +420,7 @@ declare module 'discord.js' {
 		public addRestrictedRoles(roles: Role[]): Promise<Emoji>;
 		public edit(data: EmojiEditData, reason?: string): Promise<Emoji>;
 		public equals(other: Emoji | object): boolean;
+		public delete(reason?: string): Promise<this>;
 		public fetchAuthor(): Promise<User>;
 		public removeRestrictedRole(role: Role): Promise<Emoji>;
 		public removeRestrictedRoles(roles: Role[]): Promise<Emoji>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #1877 (c93c4ad21fc2272ab2269083dd94bbb6af4f7aa7) in a semver-minor manner.

- Add `Emoji#delete` method
- Deprecate `Guild#deleteEmoji`

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
