### PR TITLE
Move Guild#defaultRole to RoleStore#everyone

### DIFF
--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -118,7 +118,7 @@ class RoleStore extends DataStore {
   get defaultRole() {
     return this.get(this.guild.id) || null;
   }
-  
+
   /**
    * The role with the highest position in the store
    * @type {Role}

--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -115,7 +115,7 @@ class RoleStore extends DataStore {
    * @type {?Role}
    * @readonly
    */
-  get defaultRole() {
+  get everyone() {
     return this.get(this.guild.id) || null;
   }
 

--- a/src/stores/RoleStore.js
+++ b/src/stores/RoleStore.js
@@ -111,6 +111,15 @@ class RoleStore extends DataStore {
   }
 
   /**
+   * The `@everyone` role of the guild
+   * @type {?Role}
+   * @readonly
+   */
+  get defaultRole() {
+    return this.get(this.guild.id) || null;
+  }
+  
+  /**
    * The role with the highest position in the store
    * @type {Role}
    * @readonly

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -482,16 +482,7 @@ class Guild extends Base {
   get embedChannel() {
     return this.client.channels.get(this.embedChannelID) || null;
   }
-
-  /**
-   * The `@everyone` role of the guild
-   * @type {?Role}
-   * @readonly
-   */
-  get defaultRole() {
-    return this.roles.get(this.id) || null;
-  }
-
+  
   /**
    * The client user as a GuildMember of this guild
    * @type {?GuildMember}

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -482,7 +482,7 @@ class Guild extends Base {
   get embedChannel() {
     return this.client.channels.get(this.embedChannelID) || null;
   }
-  
+
   /**
    * The client user as a GuildMember of this guild
    * @type {?GuildMember}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1501,7 +1501,7 @@ declare module 'discord.js' {
 
 	export class RoleStore extends DataStore<Snowflake, Role, typeof Role, RoleResolvable> {
 		constructor(guild: Guild, iterable?: Iterable<any>);
-		public readonly defaultRole: Role | null;
+		public readonly everyone: Role | null;
 		public readonly highest: Role;
 
 		public create(options?: { data?: RoleData, reason?: string }): Promise<Role>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -403,7 +403,6 @@ declare module 'discord.js' {
 		public readonly createdAt: Date;
 		public readonly createdTimestamp: number;
 		public defaultMessageNotifications: DefaultMessageNotifications | number;
-		public readonly defaultRole: Role | null;
 		public deleted: boolean;
 		public description: string | null;
 		public embedChannel: GuildChannel | null;
@@ -1502,6 +1501,7 @@ declare module 'discord.js' {
 
 	export class RoleStore extends DataStore<Snowflake, Role, typeof Role, RoleResolvable> {
 		constructor(guild: Guild, iterable?: Iterable<any>);
+		public readonly defaultRole: Role | null;
 		public readonly highest: Role;
 
 		public create(options?: { data?: RoleData, reason?: string }): Promise<Role>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Moves Guild#defaultRole to RoleStore, which suits the use of stores far better.
Also renames it to `everyone`, as others have suggested.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
