### PR TITLE
feature: teams support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,8 @@ module.exports = {
   ReactionEmoji: require('./structures/ReactionEmoji'),
   RichPresenceAssets: require('./structures/Presence').RichPresenceAssets,
   Role: require('./structures/Role'),
+  Team: require('./structures/Team'),
+  TeamMember: require('./structures/TeamMember'),
   TextChannel: require('./structures/TextChannel'),
   User: require('./structures/User'),
   VoiceChannel: require('./structures/VoiceChannel'),

--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -3,6 +3,7 @@
 const Snowflake = require('../util/Snowflake');
 const { ClientApplicationAssetTypes, Endpoints } = require('../util/Constants');
 const Base = require('./Base');
+const Team = require('./Team');
 
 const AssetTypes = Object.keys(ClientApplicationAssetTypes);
 
@@ -67,9 +68,9 @@ class ClientApplication extends Base {
 
     /**
      * The owner of this OAuth application
-     * @type {?User}
+     * @type {User|Team}
      */
-    this.owner = data.owner ? this.client.users.add(data.owner) : null;
+    this.owner = data.team ? new Team(this.client, data.team) : this.client.users.add(data.owner);
   }
 
   /**

--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const Snowflake = require('../util/Snowflake');
+const Collection = require('../util/Collection');
+const Base = require('./Base');
+const TeamMember = require('./TeamMember');
+
+/**
+ * Represents a Client OAuth2 Application Team.
+ * @extends {Base}
+ */
+class Team extends Base {
+  constructor(client, data) {
+    super(client);
+    this._patch(data);
+  }
+
+  _patch(data) {
+    /**
+     * The ID of the Team
+     * @type {Snowflake}
+     */
+    this.id = data.id;
+
+    /**
+     * The name of the Team
+     * @type {string}
+     */
+    this.name = data.name;
+
+    /**
+     * The Team's icon hash
+     * @type {string}
+     */
+    this.icon = data.icon;
+
+    /**
+     * The Team's owner id
+     * @type {?string}
+     */
+    this.ownerID = data.owner_user_id || null;
+
+    /**
+     * The Team's members
+     * @type {Collection<Snowflake, TeamMember>}
+     */
+    this.members = new Collection();
+
+    for (const memberData of data.members) {
+      const member = new TeamMember(this.client, this, memberData);
+      this.members.set(member.id, member);
+    }
+  }
+
+  /**
+   * The owner of this team
+   * @type {?TeamMember}
+   * @readonly
+   */
+  get owner() {
+    return this.members.get(this.ownerID) || null;
+  }
+
+  /**
+   * The timestamp the app was created at
+   * @type {number}
+   * @readonly
+   */
+  get createdTimestamp() {
+    return Snowflake.deconstruct(this.id).timestamp;
+  }
+
+  /**
+   * The time the app was created at
+   * @type {Date}
+   * @readonly
+   */
+  get createdAt() {
+    return new Date(this.createdTimestamp);
+  }
+
+  /**
+   * A link to the application's icon.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string} URL to the icon
+   */
+  iconURL({ format, size } = {}) {
+    if (!this.icon) return null;
+    return this.client.rest.cdn.AppIcon(this.id, this.icon, { format, size });
+  }
+
+  /**
+   * When concatenated with a string, this automatically returns the Team's name instead of the
+   * Team object.
+   * @returns {string}
+   * @example
+   * // Logs: Team name: My Team
+   * console.log(`Team name: ${application}`);
+   */
+  toString() {
+    return this.name;
+  }
+
+  toJSON() {
+    return super.toJSON({ createdTimestamp: true });
+  }
+}
+
+module.exports = Team;

--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -86,7 +86,7 @@ class Team extends Base {
    */
   iconURL({ format, size } = {}) {
     if (!this.icon) return null;
-    return this.client.rest.cdn.AppIcon(this.id, this.icon, { format, size });
+    return this.client.rest.cdn.TeamIcon(this.id, this.icon, { format, size });
   }
 
   /**

--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -95,7 +95,7 @@ class Team extends Base {
    * @returns {string}
    * @example
    * // Logs: Team name: My Team
-   * console.log(`Team name: ${application}`);
+   * console.log(`Team name: ${team}`);
    */
   toString() {
     return this.name;

--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -30,9 +30,9 @@ class Team extends Base {
 
     /**
      * The Team's icon hash
-     * @type {string}
+     * @type {?string}
      */
-    this.icon = data.icon;
+    this.icon = data.icon || null;
 
     /**
      * The Team's owner id

--- a/src/structures/TeamMember.js
+++ b/src/structures/TeamMember.js
@@ -35,7 +35,7 @@ class TeamMember extends Base {
 
     /**
      * The permissions this Team Member has with reguard to the team
-     * @type {string}
+     * @type {MembershipStates}
      */
     this.membershipState = MembershipStates[data.membership_state];
 

--- a/src/structures/TeamMember.js
+++ b/src/structures/TeamMember.js
@@ -12,7 +12,7 @@ class TeamMember extends Base {
     super(client);
 
     /**
-     * The Team
+     * The Team this member is part of
      * @type {Team}
      */
     this.team = team;

--- a/src/structures/TeamMember.js
+++ b/src/structures/TeamMember.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const Base = require('./Base');
+const { MembershipStates } = require('../util/Constants');
+
+/**
+ * Represents a Client OAuth2 Application Team Member.
+ * @extends {Base}
+ */
+class TeamMember extends Base {
+  constructor(client, team, data) {
+    super(client);
+
+    /**
+     * The Team
+     * @type {Team}
+     */
+    this.team = team;
+
+    this._patch(data);
+  }
+
+  _patch(data) {
+    /**
+     * The ID of the Team Member
+     * @type {Snowflake}
+     */
+    this.id = data.user.id;
+
+    /**
+     * The permissions this Team Member has with reguard to the team
+     * @type {string[]}
+     */
+    this.permissions = data.permissions;
+
+    /**
+     * The permissions this Team Member has with reguard to the team
+     * @type {string}
+     */
+    this.membershipState = MembershipStates[data.membership_state];
+
+    /**
+     * The user for this Team Member
+     * @type {User}
+     */
+    this.user = this.client.users.add(data.user);
+  }
+
+  /**
+   * When concatenated with a string, this automatically returns the team members's name instead of the
+   * TeamMember object.
+   * @returns {string}
+   * @example
+   * // Logs: Team Member's username: Hydrabolt
+   * console.log(`Team Member's name: ${teamMember}`);
+   */
+  toString() {
+    return this.user.username;
+  }
+
+  toJSON() {
+    return super.toJSON();
+  }
+}
+
+module.exports = TeamMember;

--- a/src/structures/TeamMember.js
+++ b/src/structures/TeamMember.js
@@ -22,12 +22,6 @@ class TeamMember extends Base {
 
   _patch(data) {
     /**
-     * The ID of the Team Member
-     * @type {Snowflake}
-     */
-    this.id = data.user.id;
-
-    /**
      * The permissions this Team Member has with reguard to the team
      * @type {string[]}
      */
@@ -44,22 +38,24 @@ class TeamMember extends Base {
      * @type {User}
      */
     this.user = this.client.users.add(data.user);
+
+    /**
+     * The ID of the Team Member
+     * @type {Snowflake}
+     */
+    this.id = this.user.id;
   }
 
   /**
-   * When concatenated with a string, this automatically returns the team members's name instead of the
+   * When concatenated with a string, this automatically returns the team members's tag instead of the
    * TeamMember object.
    * @returns {string}
    * @example
-   * // Logs: Team Member's username: Hydrabolt
-   * console.log(`Team Member's name: ${teamMember}`);
+   * // Logs: Team Member's tag: @Hydrabolt
+   * console.log(`Team Member's tag: ${teamMember}`);
    */
   toString() {
-    return this.user.username;
-  }
-
-  toJSON() {
-    return super.toJSON();
+    return this.user.toString();
   }
 }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -578,6 +578,8 @@ exports.DefaultMessageNotifications = [
  * @typedef {string} MembershipStates
  */
 exports.MembershipStates = [
+  // They start at 1
+  null,
   'INVITED',
   'ACCEPTED',
 ];

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -569,6 +569,17 @@ exports.DefaultMessageNotifications = [
   'MENTIONS',
 ];
 
+/**
+ * The value set for a team members's membership state:
+ * * INVITED
+ * * ACCEPTED
+ * @typedef {string} MembershipStates
+ */
+exports.MembershipStates = [
+  'INVITED',
+  'ACCEPTED',
+];
+
 function keyMirror(arr) {
   let tmp = Object.create(null);
   for (const value of arr) tmp[value] = value;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -145,6 +145,8 @@ exports.Endpoints = {
         makeImageUrl(`${root}/channel-icons/${channelID}/${hash}`, { size, format }),
       Splash: (guildID, hash, format = 'webp', size) =>
         makeImageUrl(`${root}/splashes/${guildID}/${hash}`, { size, format }),
+      TeamIcon: (teamID, hash, format = 'webp', size) =>
+        makeImageUrl(`${root}/team-icons/${teamID}/${hash}`, { size, format }),
     };
   },
   invite: (root, code) => `${root}/${code}`,

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -145,7 +145,7 @@ exports.Endpoints = {
         makeImageUrl(`${root}/channel-icons/${channelID}/${hash}`, { size, format }),
       Splash: (guildID, hash, format = 'webp', size) =>
         makeImageUrl(`${root}/splashes/${guildID}/${hash}`, { size, format }),
-      TeamIcon: (teamID, hash, format = 'webp', size) =>
+      TeamIcon: (teamID, hash, { format = 'webp', size } = {}) =>
         makeImageUrl(`${root}/team-icons/${teamID}/${hash}`, { size, format }),
     };
   },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -255,7 +255,7 @@ declare module 'discord.js' {
 		public icon: string;
 		public id: Snowflake;
 		public name: string;
-		public owner: User | null;
+		public owner: User | Team;
 		public rpcOrigins: string[];
 		public coverImage(options?: AvatarOptions): string;
 		public fetchAssets(): Promise<ClientApplicationAsset>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -270,7 +270,7 @@ declare module 'discord.js' {
 		public name: string;
 		public icon: string;
 		public ownerID: Snowflake | null;
-		public members: Collection<Snowflake, TeamMember>
+		public members: Collection<Snowflake, TeamMember>;
 
 		public readonly owner: TeamMember;
 		public readonly createdAt: Date;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -264,6 +264,34 @@ declare module 'discord.js' {
 		public toString(): string;
 	}
 
+	export class Team extends Base {
+		constructor(client: Client, data: object);
+		public id: Snowflake;
+		public name: string;
+		public icon: string;
+		public ownerID: Snowflake | null;
+		public members: Collection<Snowflake, TeamMember>
+
+		public readonly owner: TeamMember;
+		public readonly createdAt: Date;
+		public readonly createdTimestamp: number;
+
+		public iconURL(options?: AvatarOptions): string;
+		public toJSON(): object;
+		public toString(): string;
+	}
+
+	export class TeamMember extends Base {
+		constructor(client: Client, team: Team, data: object);
+		public team: Team;
+		public id: Snowflake;
+		public permissions: string[];
+		public membershipState: MembershipStates;
+		public user: User;
+
+		public toString(): string;
+	}
+
 	export interface ActivityOptions {
 		name?: string;
 		url?: string;
@@ -1991,6 +2019,9 @@ declare module 'discord.js' {
 	}
 
 	type InviteResolvable = string;
+
+	type MembershipStates = 'INVITED'
+		| 'ACCEPTED';
 
 	interface MessageCollectorOptions extends CollectorOptions {
 		max?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -268,7 +268,7 @@ declare module 'discord.js' {
 		constructor(client: Client, data: object);
 		public id: Snowflake;
 		public name: string;
-		public icon: string;
+		public icon: string | null;
 		public ownerID: Snowflake | null;
 		public members: Collection<Snowflake, TeamMember>;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This adds support structures for Discord Teams. If you run Client#fetchApplication() you will now have a ClientApplication object that's owned by either a User or a Team along with all the other things the Teams data brings with it.

Note: TeamMember#permissions is likely to change in the future when proper permissions are implemented for them. I assume that property should become more like a BitField type object, but all of that data isn't available at this time as far as I am aware.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
