### PR TITLE
feat(RoleStore): Handle managed roles during modification

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -83,6 +83,8 @@ const Messages = {
 
   INVALID_TYPE: (name, expected, an = false) => `Supplied ${name} is not a${an ? 'n' : ''} ${expected}.`,
 
+  INVALID_ROLE: 'One or more supplied roles are managed.',
+
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
 
   EMOJI_TYPE: 'Emoji must be a string or GuildEmoji/ReactionEmoji',

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -149,22 +149,21 @@ class GuildMemberRoleStore extends Collection {
    *   .catch(console.error);
    */
   set(roles, reason) {
-    if (roles === undefined) return Promise.resolve(this.member);
-    if (!(roles instanceof Collection || Array.isArray(roles))) {
-      throw new TypeError('INVALID_TYPE', 'roles',
-        'Array or Collection of Roles or Snowflakes', true);
-    }
+    // eslint-disable-next-line eqeqeq
+    if (roles == undefined) return Promise.resolve(this.member);
 
     if (!(roles instanceof Collection)) {
-      roles = new Collection(roles.map(role => {
-        let resolvedRole = this.guild.roles.resolve(role);
-        if (resolvedRole === null) {
-          throw new TypeError('INVALID_TYPE', 'roles',
-            'Array or Collection of Roles or Snowflakes', true);
-        }
+      if (!Array.isArray(roles)) {
+        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+          'Array or Collection of Roles or Snowflakes', true));
+      }
 
-        return [role, resolvedRole];
-      }));
+      roles = roles.map(role => [role, this.guild.roles.resolve(role)]);
+      if (roles.some(role => !role[1])) {
+        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+          'Array or Collection of Roles or Snowflakes', true));
+      }
+      roles = new Collection(roles);
     }
     roles = roles.filter(role => !role.managed).concat(this.filter(role => role.managed));
     return this.member.edit({ roles }, reason);

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -148,9 +148,23 @@ class GuildMemberRoleStore extends Collection {
    *   .then(member => console.log(`Member roles is now of ${member.roles.size} size`))
    *   .catch(console.error);
    */
-  set(roles = [], reason) {
+  set(roles, reason) {
+    if (roles === undefined) return Promise.resolve(this.member);
+    if (!(roles instanceof Collection || Array.isArray(roles))) {
+      throw new TypeError('INVALID_TYPE', 'roles',
+        'Array or Collection of Roles or Snowflakes', true);
+    }
+
     if (!(roles instanceof Collection)) {
-      roles = new Collection(roles.map(role => [role, this.guild.roles.resolve(role)]));
+      roles = new Collection(roles.map(role => {
+        let resolvedRole = this.guild.roles.resolve(role);
+        if (resolvedRole === null) {
+          throw new TypeError('INVALID_TYPE', 'roles',
+            'Array or Collection of Roles or Snowflakes', true);
+        }
+
+        return [role, resolvedRole];
+      }));
     }
     roles = roles.filter(role => !role.managed).concat(this.filter(role => role.managed));
     return this.member.edit({ roles }, reason);

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -72,7 +72,7 @@ class GuildMemberRoleStore extends Collection {
           'Array or Collection of Roles or Snowflakes', true);
       }
       if (roleOrRoles.some(role => role.managed)) {
-        throw new TypeError('INVALID_Role');
+        throw new TypeError('INVALID_ROLE');
       }
 
       const newRoles = [...new Set(roleOrRoles.concat(...this.values()))];
@@ -84,7 +84,7 @@ class GuildMemberRoleStore extends Collection {
           'Array or Collection of Roles or Snowflakes', true);
       }
       if (roleOrRoles.managed) {
-        throw new TypeError('INVALID_Role');
+        throw new TypeError('INVALID_ROLE');
       }
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put({ reason });
 
@@ -108,7 +108,7 @@ class GuildMemberRoleStore extends Collection {
           'Array or Collection of Roles or Snowflakes', true);
       }
       if (roleOrRoles.some(role => role.managed)) {
-        throw new TypeError('INVALID_Role');
+        throw new TypeError('INVALID_ROLE');
       }
 
       const newRoles = this.filter(role => !roleOrRoles.includes(role));
@@ -120,7 +120,7 @@ class GuildMemberRoleStore extends Collection {
           'Array or Collection of Roles or Snowflakes', true);
       }
       if (roleOrRoles.managed) {
-        throw new TypeError('INVALID_Role');
+        throw new TypeError('INVALID_ROLE');
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].delete({ reason });
@@ -149,12 +149,10 @@ class GuildMemberRoleStore extends Collection {
    *   .catch(console.error);
    */
   set(roles = [], reason) {
-    for (let [Snowflake, Role] of this) {
-      if (Role.managed) {
-        if (typeof roles[0] === 'string' && !roles.includes(Snowflake)) roles.push(Snowflake);
-        else if (!roles.some(role => role.id === Snowflake)) roles.push(Snowflake);
-      }
+    if (!(roles instanceof Collection)) {
+      roles = new this.constructor(roles.map(role => [role, this.guild.roles.resolve(role)]));
     }
+    roles = roles.filter(role => !role.managed).concat(this.filter(role => role.managed));
     return this.member.edit({ roles }, reason);
   }
 

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -150,7 +150,7 @@ class GuildMemberRoleStore extends Collection {
    */
   set(roles = [], reason) {
     if (!(roles instanceof Collection)) {
-      roles = new this.constructor(roles.map(role => [role, this.guild.roles.resolve(role)]));
+      roles = new Collection(roles.map(role => [role, this.guild.roles.resolve(role)]));
     }
     roles = roles.filter(role => !role.managed).concat(this.filter(role => role.managed));
     return this.member.edit({ roles }, reason);

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -152,18 +152,14 @@ class GuildMemberRoleStore extends Collection {
     // eslint-disable-next-line eqeqeq
     if (roles == undefined) return Promise.resolve(this.member);
 
-    if (!(roles instanceof Collection)) {
-      if (!Array.isArray(roles)) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
-          'Array or Collection of Roles or Snowflakes', true));
-      }
-
-      roles = roles.map(role => [role, this.guild.roles.resolve(role)]);
-      if (roles.some(role => !role[1])) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
-          'Array or Collection of Roles or Snowflakes', true));
-      }
-      roles = new Collection(roles);
+    if (!((roles instanceof Collection) || Array.isArray(roles))) {
+      return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+        'Array or Collection of Roles or Snowflakes', true));
+    }
+    roles = roles.map(role => this.guild.roles.resolve(role));
+    if (roles.includes(null)) {
+      return Promise.reject(new TypeError('INVALID_TYPE', 'roles',
+        'Array or Collection of Roles or Snowflakes', true));
     }
     roles = roles.filter(role => !role.managed).concat(this.filter(role => role.managed));
     return this.member.edit({ roles }, reason);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Throw INVALID_ROLE Type error when adding or removing

- Auto append managed roles to the set() roles array if they don't already exist

Managed roles cause issues when attempting to use GuildMemberRoleStore.set() for guild members who have integrated roles like the server boosting role. I added detection to add and remove to be consistent.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
