### PR TITLE
feat: support for CUSTOM_STATUS activity type

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -3,6 +3,7 @@
 const Util = require('../util/Util');
 const ActivityFlags = require('../util/ActivityFlags');
 const { ActivityTypes } = require('../util/Constants');
+const Emoji = require('./Emoji');
 
 /**
  * Activity sent in a message.
@@ -205,6 +206,18 @@ class Activity {
      * @type {Readonly<ActivityFlags>}
      */
     this.flags = new ActivityFlags(data.flags).freeze();
+
+    /**
+     * Emoji for a custom activity
+     * @type {?Emoji}
+     */
+    this.emoji = data.emoji ? new Emoji(presence.client, data.emoji) : null;
+
+    /**
+     * Creation date of the activity
+     * @type {number}
+     */
+    this.createdTimestamp = new Date(data.created_at).getTime();
   }
 
   /**
@@ -219,6 +232,15 @@ class Activity {
       this.type === activity.type &&
       this.url === activity.url
     );
+  }
+
+  /**
+   * The time the activity was created at
+   * @type {Date}
+   * @readonly
+   */
+  get createdAt() {
+    return new Date(this.createdTimestamp);
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -411,6 +411,7 @@ exports.MessageTypes = [
  * * STREAMING
  * * LISTENING
  * * WATCHING
+ * * CUSTOM_STATUS
  * @typedef {string} ActivityType
  */
 exports.ActivityTypes = [
@@ -418,6 +419,7 @@ exports.ActivityTypes = [
   'STREAMING',
   'LISTENING',
   'WATCHING',
+  'CUSTOM_STATUS',
 ];
 
 exports.ChannelTypes = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -23,6 +23,7 @@ declare module 'discord.js' {
 
 	export class Activity {
 		constructor(presence: Presence, data?: object);
+		public readonly createdAt: Date;
 		public applicationID: Snowflake | null;
 		public assets: RichPresenceAssets | null;
 		public details: string | null;
@@ -38,6 +39,8 @@ declare module 'discord.js' {
 		} | null;
 		public type: ActivityType;
 		public url: string | null;
+		public emoji: Emoji | null;
+		public createdTimestamp: number;
 		public equals(activity: Activity): boolean;
 	}
 
@@ -1911,7 +1914,8 @@ declare module 'discord.js' {
 	type ActivityType = 'PLAYING'
 		| 'STREAMING'
 		| 'LISTENING'
-		| 'WATCHING';
+		| 'WATCHING'
+		| 'CUSTOM_STATUS';
 
 	type MessageFlagsString = 'CROSSPOSTED'
 		| 'IS_CROSSPOST'

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -23,10 +23,12 @@ declare module 'discord.js' {
 
 	export class Activity {
 		constructor(presence: Presence, data?: object);
-		public readonly createdAt: Date;
 		public applicationID: Snowflake | null;
 		public assets: RichPresenceAssets | null;
+		public readonly createdAt: Date;
+		public createdTimestamp: number;
 		public details: string | null;
+		public emoji: Emoji | null;
 		public name: string;
 		public party: {
 			id: string | null;
@@ -39,8 +41,6 @@ declare module 'discord.js' {
 		} | null;
 		public type: ActivityType;
 		public url: string | null;
-		public emoji: Emoji | null;
-		public createdTimestamp: number;
 		public equals(activity: Activity): boolean;
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR covers the custom status Discord recently released to the public. The PR was initially created 4 months ago based on data mined data but now that custom statuses are in the public the PR should enter the merge track.

Evals performed with code changes:

![image](https://user-images.githubusercontent.com/4019718/67621573-cdf40f80-f810-11e9-83be-656169f3142d.png)![image](https://user-images.githubusercontent.com/4019718/67621574-d0ef0000-f810-11e9-887e-17806801eb22.png)


---

**_Original post from 4 months ago:_**

This is an upcoming feature that has been data mined from the Canary client. Presumably these few lines are all that is needed since in ClientPresence the number gets matched to the indexOf the ActivityType constant and the new options are as follows:

```json5
{
    PLAYING: 0,
    STREAMING: 1,
    LISTENING: 2,
    WATCHING: 3,
    CUSTOM_STATUS: 4 // the newly added type
}
```

Example images after enabling the option, courtesy of a friend of mine who has it as I do not have it myself.

![image](https://user-images.githubusercontent.com/4019718/59964973-95fa5a00-9508-11e9-882e-9498edef3fe7.png)

![image](https://user-images.githubusercontent.com/4019718/59964979-af030b00-9508-11e9-8541-a5c85cf8388e.png)


As an aside, there also seems to be an upcoming custom voice status however there is not sufficient enough information for that yet to suggest any code changes. That said, I can guarantee my friend and I will keep our eyes out and I'll be back with another PR if required for that.



**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.