### PR TITLE
misc: Automatically add labels to issues that use the template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,7 @@
 ---
 name: Bug report
 about: Report incorrect or unexpected behaviour of discord.js
+labels: s: unverified, type: bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Request a feature for the core discord.js library
+labels: type: enhancement
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/question---general-support-request.md
+++ b/.github/ISSUE_TEMPLATE/question---general-support-request.md
@@ -1,6 +1,7 @@
 ---
 name: Question / General support request
 about: Ask for help in Discord instead - https://discord.gg/bRCvFy9
+labels: question (please use Discord instead)
 
 ---
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

GitHub lets issue templates automatically add certain labels to an issue, and this PR adds that to discord.js's issue templates

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
