### PR TITLE
CategoryChannel#createChannel()

### DIFF
--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -17,6 +17,36 @@ class CategoryChannel extends GuildChannel {
   get children() {
     return this.guild.channels.filter(c => c.parentID === this.id);
   }
+  /**
+   * Creates a new channel with this category as its parent.
+   * @param {string} name The name of the new channel
+   * @param {ChannelData} [options] Options for the new channel
+   * @returns {Promise<CategoryChannel|TextChannel|VoiceChannel>}
+   * @example
+   * // Create a new text channel
+   * category.createChannel('new-general')
+   *   .then(console.log)
+   *   .catch(console.error);
+   * @example
+   * // Create a new channel with permission overwrites
+   * category.createChannel('new-restricted', {
+   *   permissionOverwrites: [{
+   *     id: guild.id,
+   *     deny: ['MANAGE_MESSAGES'],
+   *     allow: ['SEND_MESSAGES']
+   *   }]
+   * })
+   *   .then(console.log)
+   *   .catch(console.error);
+   */
+  createChannel(name, options) {
+	if (!options) {
+	  options = { parent: this.id };
+	} else {
+	  options.parent = this.id;
+	}
+    return this.guild.createChannel(name, options);
+  }
 }
 
 module.exports = CategoryChannel;

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -40,11 +40,11 @@ class CategoryChannel extends GuildChannel {
    *   .catch(console.error);
    */
   createChannel(name, options) {
-	if (!options) {
-	  options = { parent: this.id };
-	} else {
-	  options.parent = this.id;
-	}
+    if (!options) {
+      options = { parent: this.id };
+    } else {
+      options.parent = this.id;
+    }
     return this.guild.createChannel(name, options);
   }
 }

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -21,7 +21,7 @@ class CategoryChannel extends GuildChannel {
    * Creates a new channel with this category as its parent.
    * @param {string} name The name of the new channel
    * @param {ChannelData} [options] Options for the new channel
-   * @returns {Promise<CategoryChannel|TextChannel|VoiceChannel>}
+   * @returns {Promise<TextChannel|VoiceChannel>}
    * @example
    * // Create a new text channel
    * category.createChannel('new-general')


### PR DESCRIPTION
Adds CategoryChannel#createChannel() as a convenience function

**Please describe the changes this PR makes and why it should be merged:**
Takes a name and optional ChannelData object. Adds the CategoryChannel as the parent in ChannelData  (Creating the object if necessary), passes the parameters to guild#CreateChannel()and returns the resultant promise..
Feels in keeping with existing convenience functions.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
