### PR TITLE
CategoryChannel#children returns store

### DIFF
--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -102,7 +102,11 @@ class GuildChannelStore extends DataStore {
       rateLimitPerUser,
       reason,
     } = options;
-    if (parent) parent = this.client.channels.resolveID(parent);
+    if (this._parent) {
+      parent = this.client.channels.resolveID(this._parent);
+    } else if (parent) {
+      parent = this.client.channels.resolveID(parent);
+    }
     if (permissionOverwrites) {
       permissionOverwrites = permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
     }

--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -102,10 +102,10 @@ class GuildChannelStore extends DataStore {
       rateLimitPerUser,
       reason,
     } = options;
-    if (this._parent) {
-      parent = this.client.channels.resolveID(this._parent);
-    } else if (parent) {
+    if (parent) {
       parent = this.client.channels.resolveID(parent);
+    } else if (this._parent) {
+      parent = this.client.channels.resolveID(this._parent);
     }
     if (permissionOverwrites) {
       permissionOverwrites = permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));

--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -23,11 +23,11 @@ class GuildChannelStore extends DataStore {
   }
 
   /**
-     * The parent {@link Channel} of the {@link GuildChannel}s in this store *(Only if the store
-     * was retrieved from {@link CategoryChannel}.children)*.
-     * @type {?GuildChannel}
-     * @readonly
-     */
+   * The parent {@link Channel} of the {@link GuildChannel}s in this store *(Only if the store
+   * was retrieved from {@link CategoryChannel}.children)*.
+   * @type {?GuildChannel}
+   * @readonly
+   */
   get parent() {
     return this._parent;
   }

--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -25,7 +25,7 @@ class GuildChannelStore extends DataStore {
   /**
      * The parent {@link Channel} of the {@link GuildChannel}s in this store *(Only if the store
      * was retrieved from {@link CategoryChannel}.children)*.
-     * @type {?GuildChannel>}
+     * @type {?GuildChannel}
      * @readonly
      */
   get parent() {

--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -23,6 +23,15 @@ class GuildChannelStore extends DataStore {
   }
 
   /**
+     * The parent {@link Channel} of the {@link GuildChannel}s in this store *(Only if the store
+     * was retrieved from {@link CategoryChannel}.children)*.
+     * @type {?GuildChannel>}
+     * @readonly
+     */
+  get parent() {
+    return this._parent;
+  }
+  /**
    * Data that can be resolved to give a Guild Channel object. This can be:
    * * A GuildChannel object
    * * A Snowflake

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -10,7 +10,7 @@ const GuildChannelStore = require('../stores/GuildChannelStore');
 class CategoryChannel extends GuildChannel {
   /**
    * Channels that are a part of this category
-   * @type {?Collection<Snowflake, GuildChannel>}
+   * @type {?GuildChannelStore<Snowflake, GuildChannel>}
    * @readonly
    */
   get children() {

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -14,7 +14,7 @@ class CategoryChannel extends GuildChannel {
    * @readonly
    */
   get children() {
-    const children = new GuildChannelStore(this.guild, this.guild.channels.filter(c => c.parentID === this.id));
+    const children = new GuildChannelStore(this.guild, this.guild.channels.filter(c => c.parentID === this.id).array());
     children._parent = this;
     return children;
   }

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -13,7 +13,9 @@ class CategoryChannel extends GuildChannel {
    * @readonly
    */
   get children() {
-    return this.guild.channels.filter(c => c.parentID === this.id);
+    const children = this.guild.channels.filter(c => c.parentID === this.id);
+    children._parent = this;
+    return children;
   }
 
   /**

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const GuildChannel = require('./GuildChannel');
+const GuildChannelStore = require('../stores/GuildChannelStore');
 
 /**
  * Represents a guild category channel on Discord.
@@ -13,7 +14,7 @@ class CategoryChannel extends GuildChannel {
    * @readonly
    */
   get children() {
-    const children = this.guild.channels.filter(c => c.parentID === this.id);
+    const children = new GuildChannelStore(this.guild, this.guild.channels.filter(c => c.parentID === this.id));
     children._parent = this;
     return children;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
CategoryChannel#children now returns a GuildChannelStore.
GuildChannelStore now has a read only property: parent. GuildChannelStore#create has been updated to check this property and use it if set.
CategoryChannel#children sets this property on the returned GuildChannelStore.

This allows CategoryChannel#children#create to be a thing. Honours OOP principles.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
