### PR TITLE
Remove listener

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -272,6 +272,7 @@ class Message {
    * const filter = (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someID'
    * const collector = message.createReactionCollector(filter, { time: 15000 });
    * collector.on('collect', r => console.log(`Collected ${r.emoji.name}`));
+   * collector.on('remove', m => console.log(`Collected ${m.content}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
   createReactionCollector(filter, options = {}) {

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -93,6 +93,8 @@ class MessageCollector extends Collector {
   cleanup() {
     this.removeListener('collect', this._reEmitter);
     this.client.removeListener('message', this.listener);
+    // This doesn't have a purpose for MessageCollector.
+    this.client.removeListener('remove', this.removeListener);
     this.client.setMaxListeners(this.client.getMaxListeners() - 1);
   }
 }

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -49,6 +49,7 @@ class MessageCollector extends Collector {
       this.emit('message', message);
     };
     this.on('collect', this._reEmitter);
+    this.on('remove', this._reEmitter);
   }
 
   // Remove in v12
@@ -75,6 +76,21 @@ class MessageCollector extends Collector {
   }
 
   /**
+   * Handle an incoming message for possible collection.
+   * @param {Message} message The message that could be collected
+   * @returns {?{key: Snowflake, value: Message}}
+   * @private
+   */
+  remove(message) {
+    if (message.channel.id !== this.channel.id) return null;
+    this.received--;
+    return {
+      key: message.id,
+      value: message,
+    };
+  }
+
+  /**
    * Check after collection to see if the collector is done.
    * @returns {?string} Reason to end the collector, if any
    * @private
@@ -92,6 +108,7 @@ class MessageCollector extends Collector {
    */
   cleanup() {
     this.removeListener('collect', this._reEmitter);
+    this.removeListener('remove', this._reEmitter);
     this.client.removeListener('message', this.listener);
     this.client.setMaxListeners(this.client.getMaxListeners() - 1);
   }

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -1,4 +1,5 @@
 const Collector = require('./interfaces/Collector');
+const Collection = require('../util/Collection');
 const util = require('util');
 
 /**
@@ -26,6 +27,12 @@ class MessageCollector extends Collector {
      * @type {TextBasedChannel}
      */
     this.channel = channel;
+
+    /**
+     * The users which have reacted to this message
+     * @type {Collection}
+     */
+    this.users = new Collection();
 
     /**
      * Total number of messages that were received in the channel during message collection
@@ -69,21 +76,6 @@ class MessageCollector extends Collector {
   handle(message) {
     if (message.channel.id !== this.channel.id) return null;
     this.received++;
-    return {
-      key: message.id,
-      value: message,
-    };
-  }
-
-  /**
-   * Handle an incoming message for possible collection.
-   * @param {Message} message The message that could be collected
-   * @returns {?{key: Snowflake, value: Message}}
-   * @private
-   */
-  remove(message) {
-    if (message.channel.id !== this.channel.id) return null;
-    this.received--;
     return {
       key: message.id,
       value: message,

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -35,7 +35,6 @@ class MessageCollector extends Collector {
 
     this.client.setMaxListeners(this.client.getMaxListeners() + 1);
     this.client.on('message', this.listener);
-    this.client.on('messageDelete', this.removeListener);
 
     // For backwards compatibility (remove in v12)
     if (this.options.max) this.options.maxProcessed = this.options.max;
@@ -73,20 +72,6 @@ class MessageCollector extends Collector {
       key: message.id,
       value: message,
     };
-  }
-
-  /**
-   * Handles a message for possible disposal.
-   * @param {Message} message The message that could be disposed of
-   * @returns {?Snowflake}
-   */
-  remove(message) {
-    /**
-     * Emitted whenever a message is disposed of.
-     * @event MessageCollector#dispose
-     * @param {Message} message The message that was disposed of
-     */
-    return message.channel.id === this.channel.id ? message.id : null;
   }
 
   /**

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -39,7 +39,7 @@ class ReactionCollector extends Collector {
      */
     this.total = 0;
 
-    this.client.setMaxListeners(this.client.getMaxListeners() + 2);
+    this.client.setMaxListeners(this.client.getMaxListeners() + 1);
     this.client.on('messageReactionAdd', this.listener);
     this.client.on('messageReactionRemove', this.removeListener);
   }
@@ -47,13 +47,14 @@ class ReactionCollector extends Collector {
   /**
    * Handle an incoming reaction for possible collection.
    * @param {MessageReaction} reaction The reaction to possibly collect
+   * @param {User} user The user that added the reaction
    * @returns {?{key: Snowflake, value: MessageReaction}}
    * @private
    */
-  handle(reaction) {
+  handle(reaction, user) {
     if (reaction.message.id !== this.message.id) return null;
     return {
-      key: reaction.emoji.id || reaction.emoji.name,
+      key: `${user.id}-${reaction.emoji.id || reaction.emoji.name}`,
       value: reaction,
     };
   }
@@ -66,28 +67,9 @@ class ReactionCollector extends Collector {
    * @private
    */
   remove(reaction, user) {
-    /**
-     * Emitted whenever a reaction is removed of.
-     * @event ReactionCollector#remove
-     * @param {MessageReaction} reaction The reaction that was removed of
-     * @param {User} user The user that removed the reaction
-     */
     if (reaction.message.id !== this.message.id) return null;
-
-    /**
-     * Emitted whenever a reaction is removed from a message. Will emit on all reaction removals,
-     * as opposed to {@link Collector#end} which will only be emitted when the entire reaction
-     * is removed.
-     * @event ReactionCollector#remove
-     * @param {MessageReaction} reaction The reaction that was removed
-     * @param {User} user The user that removed the reaction
-     */
-    if (this.collected.has(reaction.emoji.id || reaction.emoji.name) && this.users.has(user.id)) {
-      this.emit('remove', reaction, user);
-    }
-
     return {
-      key: reaction.emoji.id || reaction.emoji.name,
+      key: `${user.id}-${reaction.emoji.id || reaction.emoji.name}`,
       value: reaction,
     };
   }
@@ -114,7 +96,7 @@ class ReactionCollector extends Collector {
   cleanup() {
     this.client.removeListener('messageReactionAdd', this.listener);
     this.client.removeListener('messageReactionRemove', this.removeListener);
-    this.client.setMaxListeners(this.client.getMaxListeners() - 2);
+    this.client.setMaxListeners(this.client.getMaxListeners() - 1);
   }
 }
 

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -104,12 +104,12 @@ class Collector extends EventEmitter {
    */
   _handleRemove(...args) {
     const remove = this.remove(...args);
-    if (!remove || !this.filter(...args) || !this.collected.has(remove.key)) return;
+    if (!remove || !this.filter(...args, this.collected)) return;
     this.collected.delete(remove.key);
 
     /**
      * Emitted whenever an element is removed.
-     * @event Collector#collect
+     * @event Collector#remove
      * @param {*} element The element that got removed.
      * @param {Collector} collector The collector
      */

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -69,6 +69,7 @@ class Collector extends EventEmitter {
      * @private
      */
     this.listener = this._handle.bind(this);
+    this.removeListener = this._handleRemove.bind(this);
     if (options.time) this._timeout = this.client.setTimeout(() => this.stop('time'), options.time);
   }
 
@@ -96,6 +97,29 @@ class Collector extends EventEmitter {
   }
 
   /**
+   * Call this to remove an element from the collection. Accepts any event data as parameters.
+   * @param {...*} args The arguments emitted by the listener
+   * @emits Collector#remove
+   * @private
+   */
+  _handleRemove(...args) {
+    const remove = this.remove(...args);
+    if (!remove || !this.filter(...args) || !this.collected.has(remove.key)) return;
+    this.collected.delete(remove.key);
+
+    /**
+     * Emitted whenever an element is removed.
+     * @event Collector#collect
+     * @param {*} element The element that got removed.
+     * @param {Collector} collector The collector
+     */
+    this.emit('remove', remove.value, this);
+
+    const post = this.postCheck(...args);
+    if (post) this.stop(post);
+  }
+
+  /**
    * Return a promise that resolves with the next collected element;
    * rejects with collected elements if the collector finishes without receiving a next element
    * @type {Promise}
@@ -110,6 +134,7 @@ class Collector extends EventEmitter {
 
       const cleanup = () => {
         this.removeListener('collect', onCollect);
+        this.removeListener('remove', onRemove);
         this.removeListener('end', onEnd);
       };
 
@@ -118,12 +143,17 @@ class Collector extends EventEmitter {
         resolve(item);
       };
 
+      const onRemove = item => {
+        cleanup();
+        resolve(item);
+      };
+
       const onEnd = () => {
         cleanup();
         reject(this.collected); // eslint-disable-line prefer-promise-reject-errors
       };
-
       this.on('collect', onCollect);
+      this.on('remove', onRemove);
       this.on('end', onEnd);
     });
   }
@@ -167,6 +197,16 @@ class Collector extends EventEmitter {
    * @abstract
    */
   postCheck() {}
+
+  /**
+   * Handles incoming events from the `removeListener` function. Returns null if the event should not
+   * be removed, or returns the key that should be removed.
+   * @see Collector#removeListener
+   * @param {...*} args Any args the event listener emits
+   * @returns {?{key: string, value}} Data to insert into collection, if any
+   * @abstract
+   */
+  remove() {}
 
   /**
    * Called when the collector is ending.

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -433,7 +433,6 @@ class TextBasedChannel {
    * const filter = m => m.content.includes('discord');
    * const collector = channel.createMessageCollector(filter, { time: 15000 });
    * collector.on('collect', m => console.log(`Collected ${m.content}`));
-   * collector.on('remove', m => console.log(`Collected ${m.content}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
   createMessageCollector(filter, options = {}) {

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -433,6 +433,7 @@ class TextBasedChannel {
    * const filter = m => m.content.includes('discord');
    * const collector = channel.createMessageCollector(filter, { time: 15000 });
    * collector.on('collect', m => console.log(`Collected ${m.content}`));
+   * collector.on('remove', m => console.log(`Collected ${m.content}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
   createMessageCollector(filter, options = {}) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -379,12 +379,12 @@ declare module 'discord.js' {
 		public abstract postCheck(...args: any[]): string | null;
 
 		public on(event: 'collect', listener: (element: V, collector: Collector<K, V>) => void): this;
-		public on(event: 'remove', listener: (...args: any[]) => void): this;
+		public on(event: 'remove', listener: (element: V, collector: Collector<K, V>) => void): this;
 		public on(event: 'end', listener: (collected: Collection<K, V>, reason: string) => void): this;
 		public on(event: string, listener: Function): this;
 
 		public once(event: 'collect', listener: (element: V, collector: Collector<K, V>) => void): this;
-		public on(event: 'remove', listener: (...args: any[]) => void): this;
+		public once(event: 'remove', listener: (element: V, collector: Collector<K, V>) => void): this;
 		public once(event: 'end', listener: (collected: Collection<K, V>, reason: string) => void): this;
 		public once(event: string, listener: Function): this;
 	}
@@ -1019,7 +1019,7 @@ declare module 'discord.js' {
 
 		public cleanup(): void;
 		public remove(reaction: MessageReaction, user: User): CollectorHandler<Snowflake, MessageReaction>;
-		public handle(reaction: MessageReaction): CollectorHandler<Snowflake, MessageReaction>;
+		public handle(reaction: MessageReaction, user: User): CollectorHandler<Snowflake, MessageReaction>;
 		public postCheck(reaction: MessageReaction, user: User): string;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,6 +5,8 @@
 //   Zack Campbell <zajrik@gmail.com> (https://github.com/zajrik)
 // License: MIT
 
+import {MessageReaction, Snowflake, User} from 'discord.js';
+
 declare module 'discord.js' {
 	import { EventEmitter } from 'events';
 	import { Stream, Readable as ReadableStream } from 'stream';
@@ -360,6 +362,7 @@ declare module 'discord.js' {
 		constructor(client: Client, filter: CollectorFilter, options?: CollectorOptions);
 		private _timeout: NodeJS.Timer;
 		private _handle(...args: any[]): void;
+		private _handleRemove(...args: any[]): void;
 
 		public readonly client: Client;
 		public collected: Collection<K, V>;
@@ -371,14 +374,17 @@ declare module 'discord.js' {
 
 		protected listener: Function;
 		public abstract cleanup(): void;
+		public abstract remove(...args: any[]): CollectorHandler<K, V>;
 		public abstract handle(...args: any[]): CollectorHandler<K, V>;
 		public abstract postCheck(...args: any[]): string | null;
 
 		public on(event: 'collect', listener: (element: V, collector: Collector<K, V>) => void): this;
+		public on(event: 'remove', listener: (...args: any[]) => void): this;
 		public on(event: 'end', listener: (collected: Collection<K, V>, reason: string) => void): this;
 		public on(event: string, listener: Function): this;
 
 		public once(event: 'collect', listener: (element: V, collector: Collector<K, V>) => void): this;
+		public on(event: 'remove', listener: (...args: any[]) => void): this;
 		public once(event: 'end', listener: (collected: Collection<K, V>, reason: string) => void): this;
 		public once(event: string, listener: Function): this;
 	}
@@ -799,6 +805,7 @@ declare module 'discord.js' {
 		public received: number;
 
 		public cleanup(): void;
+		public remove(message: Message): CollectorHandler<Snowflake, Message>;
 		public handle(message: Message): CollectorHandler<Snowflake, Message>;
 		public postCheck(): string;
 	}
@@ -1011,6 +1018,7 @@ declare module 'discord.js' {
 		public users: Collection<Snowflake, User>;
 
 		public cleanup(): void;
+		public remove(reaction: MessageReaction, user: User): CollectorHandler<Snowflake, MessageReaction>;
 		public handle(reaction: MessageReaction): CollectorHandler<Snowflake, MessageReaction>;
 		public postCheck(reaction: MessageReaction, user: User): string;
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5,8 +5,6 @@
 //   Zack Campbell <zajrik@gmail.com> (https://github.com/zajrik)
 // License: MIT
 
-import {MessageReaction, Snowflake, User} from 'discord.js';
-
 declare module 'discord.js' {
 	import { EventEmitter } from 'events';
 	import { Stream, Readable as ReadableStream } from 'stream';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds a listener to remove on emoji collectors. Changed the key to include user id like user_id-emoji_id, probably not best way, but 🤷‍♂ hope this motivates someone to do better.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
- [  ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
