### PR TITLE
Return an empty collection if guild is undefined in GuildEmojiRoleStore

### DIFF
--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -23,6 +23,7 @@ class GuildEmojiRoleStore extends Collection {
    * @readonly
    */
   get _filtered() {
+    if (!this.guild) return new this.constructor[Symbol.species]();
     return this.guild.roles.filter(role => this.emoji._roles.includes(role.id));
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR Fixes this issue where in this.guild is undefined.
```js
TypeError: Cannot read property 'roles' of undefined
    at Map.get _filtered [as _filtered] (/home/admuser/prod/node_modules/discord.js/src/stores/GuildEmojiRoleStore.js:26:23)
    at Map.get (/home/admuser/prod/node_modules/discord.js/src/util/Util.js:590:27)
    at KashimaEmoji.equals (/home/admuser/prod/node_modules/discord.js/src/structures/GuildEmoji.js:172:43)
    at GuildEmojisUpdateAction.handle (/home/admuser/prod/node_modules/discord.js/src/client/actions/GuildEmojisUpdate.js:17:26)
    at Guild._patch (/home/admuser/prod/node_modules/discord.js/src/structures/Guild.js:361:45)
    at Guild._update (/home/admuser/prod/node_modules/discord.js/src/structures/Base.js:27:10)
    at GuildUpdateAction.handle (/home/admuser/prod/node_modules/discord.js/src/client/actions/GuildUpdate.js:12:25)
    at Object.module.exports [as GUILD_UPDATE] (/home/admuser/prod/node_modules/discord.js/src/client/websocket/handlers/GUILD_UPDATE.js:4:30)
    at WebSocketManager.handlePacket (/home/admuser/prod/node_modules/discord.js/src/client/websocket/WebSocketManager.js:391:31)
    at Immediate.client.setImmediate (/home/admuser/prod/node_modules/discord.js/src/client/websocket/WebSocketManager.js:386:14)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
```

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
