### PR TITLE
fix(GuildChannel): Move createInvite() and fetchInvites() from GuildChannel to TextChannel/VoiceChannel

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -2,7 +2,6 @@
 
 const Channel = require('./Channel');
 const Role = require('./Role');
-const Invite = require('./Invite');
 const PermissionOverwrites = require('./PermissionOverwrites');
 const Util = require('../util/Util');
 const Permissions = require('../util/Permissions');

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -415,44 +415,6 @@ class GuildChannel extends Channel {
       });
   }
 
-  /**
-   * Creates an invite to this guild channel.
-   * @param {Object} [options={}] Options for the invite
-   * @param {boolean} [options.temporary=false] Whether members that joined via the invite should be automatically
-   * kicked after 24 hours if they have not yet received a role
-   * @param {number} [options.maxAge=86400] How long the invite should last (in seconds, 0 for forever)
-   * @param {number} [options.maxUses=0] Maximum number of uses
-   * @param {boolean} [options.unique=false] Create a unique invite, or use an existing one with similar settings
-   * @param {string} [options.reason] Reason for creating this
-   * @returns {Promise<Invite>}
-   * @example
-   * // Create an invite to a channel
-   * channel.createInvite()
-   *   .then(invite => console.log(`Created an invite with a code of ${invite.code}`))
-   *   .catch(console.error);
-   */
-  createInvite({ temporary = false, maxAge = 86400, maxUses = 0, unique, reason } = {}) {
-    return this.client.api.channels(this.id).invites.post({ data: {
-      temporary, max_age: maxAge, max_uses: maxUses, unique,
-    }, reason })
-      .then(invite => new Invite(this.client, invite));
-  }
-
-  /**
-   * Fetches a collection of invites to this guild channel.
-   * Resolves with a collection mapping invites by their codes.
-   * @returns {Promise<Collection<string, Invite>>}
-   */
-  async fetchInvites() {
-    const inviteItems = await this.client.api.channels(this.id).invites.get();
-    const invites = new Collection();
-    for (const inviteItem of inviteItems) {
-      const invite = new Invite(this.client, inviteItem);
-      invites.set(invite.code, invite);
-    }
-    return invites;
-  }
-
   /* eslint-disable max-len */
   /**
    * Clones this channel.

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -72,7 +72,7 @@ class Invite extends Base {
 
     /**
      * The channel the invite is for
-     * @type {Channel}
+     * @type {TextChannel|VoiceChannel}
      */
     this.channel = this.client.channels.add(data.channel, this.guild, false);
 

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -85,6 +85,44 @@ class TextChannel extends GuildChannel {
   }
 
   /**
+   * Creates an invite to this guild channel.
+   * @param {Object} [options={}] Options for the invite
+   * @param {boolean} [options.temporary=false] Whether members that joined via the invite should be automatically
+   * kicked after 24 hours if they have not yet received a role
+   * @param {number} [options.maxAge=86400] How long the invite should last (in seconds, 0 for forever)
+   * @param {number} [options.maxUses=0] Maximum number of uses
+   * @param {boolean} [options.unique=false] Create a unique invite, or use an existing one with similar settings
+   * @param {string} [options.reason] Reason for creating this
+   * @returns {Promise<Invite>}
+   * @example
+   * // Create an invite to a channel
+   * channel.createInvite()
+   *   .then(invite => console.log(`Created an invite with a code of ${invite.code}`))
+   *   .catch(console.error);
+   */
+  createInvite({ temporary = false, maxAge = 86400, maxUses = 0, unique, reason } = {}) {
+    return this.client.api.channels(this.id).invites.post({ data: {
+      temporary, max_age: maxAge, max_uses: maxUses, unique,
+    }, reason })
+      .then(invite => new Invite(this.client, invite));
+  }
+
+  /**
+   * Fetches a collection of invites to this guild channel.
+   * Resolves with a collection mapping invites by their codes.
+   * @returns {Promise<Collection<string, Invite>>}
+   */
+  async fetchInvites() {
+    const inviteItems = await this.client.api.channels(this.id).invites.get();
+    const invites = new Collection();
+    for (const inviteItem of inviteItems) {
+      const invite = new Invite(this.client, inviteItem);
+      invites.set(invite.code, invite);
+    }
+    return invites;
+  }
+
+  /**
    * Fetches all webhooks for the channel.
    * @returns {Promise<Collection<Snowflake, Webhook>>}
    * @example

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -91,7 +91,7 @@ class TextChannel extends GuildChannel {
    * @param {boolean} [options.temporary=false] Whether members that joined via the invite should be automatically
    * kicked after 24 hours if they have not yet received a role
    * @param {number} [options.maxAge=86400] How long the invite should last (in seconds, 0 for forever)
-   * @param {number} [options.maxUses=0] Maximum number of uses
+   * @param {number} [options.maxUses=0] Maximum number of uses (0 for unlimited)
    * @param {boolean} [options.unique=false] Create a unique invite, or use an existing one with similar settings
    * @param {string} [options.reason] Reason for creating this
    * @returns {Promise<Invite>}

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const GuildChannel = require('./GuildChannel');
-const Invite = require('./Invite');
 const Webhook = require('./Webhook');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const Collection = require('../util/Collection');
+const Invite = require('./Invite');
 const DataResolver = require('../util/DataResolver');
 const MessageStore = require('../stores/MessageStore');
 
@@ -102,11 +102,9 @@ class TextChannel extends GuildChannel {
    *   .catch(console.error);
    */
   createInvite({ temporary = false, maxAge = 86400, maxUses = 0, unique, reason } = {}) {
-    return this.client.api.channels(this.id).invites.post({
-      data: {
-        temporary, max_age: maxAge, max_uses: maxUses, unique,
-      }, reason
-    })
+    return this.client.api.channels(this.id).invites.post({ data: {
+      temporary, max_age: maxAge, max_uses: maxUses, unique,
+    }, reason })
       .then(invite => new Invite(this.client, invite));
   }
 
@@ -162,26 +160,24 @@ class TextChannel extends GuildChannel {
     if (typeof avatar === 'string' && !avatar.startsWith('data:')) {
       avatar = await DataResolver.resolveImage(avatar);
     }
-    return this.client.api.channels[this.id].webhooks.post({
-      data: {
-        name, avatar,
-      }, reason
-    }).then(data => new Webhook(this.client, data));
+    return this.client.api.channels[this.id].webhooks.post({ data: {
+      name, avatar,
+    }, reason }).then(data => new Webhook(this.client, data));
   }
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
-  get lastMessage() { }
-  get lastPinAt() { }
-  send() { }
-  startTyping() { }
-  stopTyping() { }
-  get typing() { }
-  get typingCount() { }
-  createMessageCollector() { }
-  awaitMessages() { }
-  bulkDelete() { }
-  acknowledge() { }
+  get lastMessage() {}
+  get lastPinAt() {}
+  send() {}
+  startTyping() {}
+  stopTyping() {}
+  get typing() {}
+  get typingCount() {}
+  createMessageCollector() {}
+  awaitMessages() {}
+  bulkDelete() {}
+  acknowledge() {}
 }
 
 TextBasedChannel.applyToClass(TextChannel, true);

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const GuildChannel = require('./GuildChannel');
+const Invite = require('./Invite');
 const Webhook = require('./Webhook');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const Collection = require('../util/Collection');
@@ -101,9 +102,11 @@ class TextChannel extends GuildChannel {
    *   .catch(console.error);
    */
   createInvite({ temporary = false, maxAge = 86400, maxUses = 0, unique, reason } = {}) {
-    return this.client.api.channels(this.id).invites.post({ data: {
-      temporary, max_age: maxAge, max_uses: maxUses, unique,
-    }, reason })
+    return this.client.api.channels(this.id).invites.post({
+      data: {
+        temporary, max_age: maxAge, max_uses: maxUses, unique,
+      }, reason
+    })
       .then(invite => new Invite(this.client, invite));
   }
 
@@ -159,24 +162,26 @@ class TextChannel extends GuildChannel {
     if (typeof avatar === 'string' && !avatar.startsWith('data:')) {
       avatar = await DataResolver.resolveImage(avatar);
     }
-    return this.client.api.channels[this.id].webhooks.post({ data: {
-      name, avatar,
-    }, reason }).then(data => new Webhook(this.client, data));
+    return this.client.api.channels[this.id].webhooks.post({
+      data: {
+        name, avatar,
+      }, reason
+    }).then(data => new Webhook(this.client, data));
   }
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */
-  get lastMessage() {}
-  get lastPinAt() {}
-  send() {}
-  startTyping() {}
-  stopTyping() {}
-  get typing() {}
-  get typingCount() {}
-  createMessageCollector() {}
-  awaitMessages() {}
-  bulkDelete() {}
-  acknowledge() {}
+  get lastMessage() { }
+  get lastPinAt() { }
+  send() { }
+  startTyping() { }
+  stopTyping() { }
+  get typing() { }
+  get typingCount() { }
+  createMessageCollector() { }
+  awaitMessages() { }
+  bulkDelete() { }
+  acknowledge() { }
 }
 
 TextBasedChannel.applyToClass(TextChannel, true);

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -98,7 +98,7 @@ class VoiceChannel extends GuildChannel {
    * @param {boolean} [options.temporary=false] Whether members that joined via the invite should be automatically
    * kicked after 24 hours if they have not yet received a role
    * @param {number} [options.maxAge=86400] How long the invite should last (in seconds, 0 for forever)
-   * @param {number} [options.maxUses=0] Maximum number of uses
+   * @param {number} [options.maxUses=0] Maximum number of uses (0 for unlimited)
    * @param {boolean} [options.unique=false] Create a unique invite, or use an existing one with similar settings
    * @param {string} [options.reason] Reason for creating this
    * @returns {Promise<Invite>}

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -109,11 +109,9 @@ class VoiceChannel extends GuildChannel {
    *   .catch(console.error);
    */
   createInvite({ temporary = false, maxAge = 86400, maxUses = 0, unique, reason } = {}) {
-    return this.client.api.channels(this.id).invites.post({
-      data: {
-        temporary, max_age: maxAge, max_uses: maxUses, unique,
-      }, reason
-    })
+    return this.client.api.channels(this.id).invites.post({ data: {
+      temporary, max_age: maxAge, max_uses: maxUses, unique,
+    }, reason })
       .then(invite => new Invite(this.client, invite));
   }
 

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const GuildChannel = require('./GuildChannel');
+const Invite = require('./Invite');
 const { browser } = require('../util/Constants');
 const Permissions = require('../util/Permissions');
 const Collection = require('../util/Collection');
@@ -108,9 +109,11 @@ class VoiceChannel extends GuildChannel {
    *   .catch(console.error);
    */
   createInvite({ temporary = false, maxAge = 86400, maxUses = 0, unique, reason } = {}) {
-    return this.client.api.channels(this.id).invites.post({ data: {
-      temporary, max_age: maxAge, max_uses: maxUses, unique,
-    }, reason })
+    return this.client.api.channels(this.id).invites.post({
+      data: {
+        temporary, max_age: maxAge, max_uses: maxUses, unique,
+      }, reason
+    })
       .then(invite => new Invite(this.client, invite));
   }
 

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -92,6 +92,44 @@ class VoiceChannel extends GuildChannel {
   }
 
   /**
+   * Creates an invite to this guild channel.
+   * @param {Object} [options={}] Options for the invite
+   * @param {boolean} [options.temporary=false] Whether members that joined via the invite should be automatically
+   * kicked after 24 hours if they have not yet received a role
+   * @param {number} [options.maxAge=86400] How long the invite should last (in seconds, 0 for forever)
+   * @param {number} [options.maxUses=0] Maximum number of uses
+   * @param {boolean} [options.unique=false] Create a unique invite, or use an existing one with similar settings
+   * @param {string} [options.reason] Reason for creating this
+   * @returns {Promise<Invite>}
+   * @example
+   * // Create an invite to a channel
+   * channel.createInvite()
+   *   .then(invite => console.log(`Created an invite with a code of ${invite.code}`))
+   *   .catch(console.error);
+   */
+  createInvite({ temporary = false, maxAge = 86400, maxUses = 0, unique, reason } = {}) {
+    return this.client.api.channels(this.id).invites.post({ data: {
+      temporary, max_age: maxAge, max_uses: maxUses, unique,
+    }, reason })
+      .then(invite => new Invite(this.client, invite));
+  }
+
+  /**
+   * Fetches a collection of invites to this guild channel.
+   * Resolves with a collection mapping invites by their codes.
+   * @returns {Promise<Collection<string, Invite>>}
+   */
+  async fetchInvites() {
+    const inviteItems = await this.client.api.channels(this.id).invites.get();
+    const invites = new Collection();
+    for (const inviteItem of inviteItems) {
+      const invite = new Invite(this.client, inviteItem);
+      invites.set(invite.code, invite);
+    }
+    return invites;
+  }
+
+  /**
    * Sets the bitrate of the channel.
    * @param {number} bitrate The new bitrate
    * @param {string} [reason] Reason for changing the channel's bitrate

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -915,7 +915,7 @@ declare module 'discord.js' {
 
 	export class Invite extends Base {
 		constructor(client: Client, data: object);
-		public channel: GuildChannel;
+		public channel: TextChannel | VoiceChannel;
 		public code: string;
 		public readonly deletable: boolean;
 		public readonly createdAt: Date | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,7 +7,7 @@ declare module 'discord.js' {
 
 	export const version: string;
 
-//#region Classes
+	//#region Classes
 
 	export class Activity {
 		constructor(presence: Presence, data?: object);
@@ -814,11 +814,9 @@ declare module 'discord.js' {
 		public rawPosition: number;
 		public readonly viewable: boolean;
 		public clone(options?: GuildChannelCloneOptions): Promise<GuildChannel>;
-		public createInvite(options?: InviteOptions): Promise<Invite>;
 		public createOverwrite(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<GuildChannel>;
 		public edit(data: ChannelData, reason?: string): Promise<GuildChannel>;
 		public equals(channel: GuildChannel): boolean;
-		public fetchInvites(): Promise<Collection<string, Invite>>;
 		public lockPermissions(): Promise<GuildChannel>;
 		public overwritePermissions(options?: { permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string }): Promise<GuildChannel>;
 		public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
@@ -1361,7 +1359,9 @@ declare module 'discord.js' {
 		public nsfw: boolean;
 		public rateLimitPerUser: number;
 		public topic: string;
+		public createInvite(options?: InviteOptions): Promise<Invite>;
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable, reason?: string }): Promise<Webhook>;
+		public fetchInvites(): Promise<Collection<string, Invite>>;
 		public setNSFW(nsfw: boolean, reason?: string): Promise<TextChannel>;
 		public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
@@ -1476,6 +1476,8 @@ declare module 'discord.js' {
 		public readonly members: Collection<Snowflake, GuildMember>;
 		public readonly speakable: boolean;
 		public userLimit: number;
+		public createInvite(options?: InviteOptions): Promise<Invite>;
+		public fetchInvites(): Promise<Collection<string, Invite>>;
 		public join(): Promise<VoiceConnection>;
 		public leave(): void;
 		public setBitrate(bitrate: number, reason?: string): Promise<VoiceChannel>;
@@ -1697,9 +1699,9 @@ declare module 'discord.js' {
 		public once(event: string, listener: Function): this;
 	}
 
-//#endregion
+	//#endregion
 
-//#region Stores
+	//#region Stores
 
 	export class ChannelStore extends DataStore<Snowflake, Channel, typeof Channel, ChannelResolvable> {
 		constructor(client: Client, iterable: Iterable<any>, options?: { lru: boolean });
@@ -1810,9 +1812,9 @@ declare module 'discord.js' {
 		constructor(guild: Guild, iterable?: Iterable<any>);
 	}
 
-//#endregion
+	//#endregion
 
-//#region Mixins
+	//#region Mixins
 
 	// Model the TextBasedChannel mixin system, allowing application of these fields
 	// to the classes that use these methods without having to manually add them
@@ -1855,9 +1857,9 @@ declare module 'discord.js' {
 		sendSlackMessage(body: object): Promise<Message | object>;
 	}
 
-//#endregion
+	//#endregion
 
-//#region Typedefs
+	//#region Typedefs
 
 	type ActivityFlagsString = 'INSTANCE'
 		| 'JOIN'
@@ -2587,5 +2589,5 @@ declare module 'discord.js' {
 	type CloseEvent = { wasClean: boolean; code: number; reason: string; target: WebSocket; };
 	type ErrorEvent = { error: any, message: string, type: string, target: WebSocket; };
 
-//#endregion
+	//#endregion
 }


### PR DESCRIPTION
When calling `fetchInvites()` on a CategoryChannel, the Discord API rejects the request with an "Unknown Channel" error.

As a result, `createInvite()` and `fetchInvites()` should not be on GuildChannel, as it is not usable on all classes that extend GuildChannel.

This PR moves `createInvite()` and `fetchInvites()` from GuildChannel to TextChannel and VoiceChannel, both of which the API accepts.
This also means that NewsChannel, which extends TextChannel will have the method but I haven't been able to test that.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
