### PR TITLE
feat: addition of MessageOptions#spoiler

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -80,6 +80,7 @@ class APIMessage {
     const isSplit = typeof this.options.split !== 'undefined' && this.options.split !== false;
     const isCode = typeof this.options.code !== 'undefined' && this.options.code !== false;
     const splitOptions = isSplit ? { ...this.options.split } : undefined;
+    const isSpoiler = typeof this.options.spoiler !== 'undefined' && this.options.spoiler !== false;
 
     let mentionPart = '';
     if (this.options.reply && !this.isUser && this.target.type !== 'dm') {
@@ -107,6 +108,10 @@ class APIMessage {
         this.options.disableEveryone;
       if (disableEveryone) {
         content = (content || '').replace(/@(everyone|here)/g, '@\u200b$1');
+      }
+
+      if (isSpoiler) {
+        content = `||${content}||`;
       }
 
       if (isSplit) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1797,8 +1797,8 @@ declare module 'discord.js' {
 		public readonly highest: Role;
 
 		public create(options?: { data?: RoleData, reason?: string }): Promise<Role>;
-		public fetch(id: Snowflake, cache?: boolean): Promise<Role | null>;
 		public fetch(id?: Snowflake, cache?: boolean): Promise<this>;
+		public fetch(id: Snowflake, cache?: boolean): Promise<Role | null>;
 	}
 
 	export class UserStore extends DataStore<Snowflake, User, typeof User, UserResolvable> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1797,8 +1797,8 @@ declare module 'discord.js' {
 		public readonly highest: Role;
 
 		public create(options?: { data?: RoleData, reason?: string }): Promise<Role>;
-		public fetch(id?: Snowflake, cache?: boolean): Promise<this>;
 		public fetch(id: Snowflake, cache?: boolean): Promise<Role | null>;
+		public fetch(id?: Snowflake, cache?: boolean): Promise<this>;
 	}
 
 	export class UserStore extends DataStore<Snowflake, User, typeof User, UserResolvable> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR introduces MessageOptions#spoiler. It will take the content when generating the API Message and wrap it `|| in spoiler pipes ||`. Typings have also been changed. This also includes less file changes than pr #3259. 

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
