### PR TITLE
Fix typos across discord.js repository

### DIFF
--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -297,7 +297,7 @@ class WebSocketManager extends EventEmitter {
     } catch (error) {
       this.debug(`Couldn't reconnect or fetch information about the gateway. ${error}`);
       if (error.httpStatus !== 401) {
-        this.debug(`Possible network error occured. Retrying in 5s...`);
+        this.debug(`Possible network error occurred. Retrying in 5s...`);
         await Util.delayFor(5000);
         this.reconnecting = false;
         return this.reconnect();

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -465,7 +465,7 @@ class WebSocketShard extends EventEmitter {
    */
   sendHeartbeat() {
     if (!this.lastHeartbeatAcked) {
-      this.debug("Didn't receive a heartbeat ack last time, assuming zombie conenction. Destroying and reconnecting.");
+      this.debug("Didn't receive a heartbeat ack last time, assuming zombie connection. Destroying and reconnecting.");
       this.destroy(4009);
       return;
     }

--- a/src/client/websocket/handlers/CHANNEL_PINS_UPDATE.js
+++ b/src/client/websocket/handlers/CHANNEL_PINS_UPDATE.js
@@ -14,7 +14,7 @@ module.exports = (client, { d: data }) => {
      * Emitted whenever the pins of a channel are updated. Due to the nature of the WebSocket event,
      * not much information can be provided easily here - you need to manually check the pins yourself.
      * @event Client#channelPinsUpdate
-     * @param {DMChannel|TextChannel} channel The channel that the pins update occured in
+     * @param {DMChannel|TextChannel} channel The channel that the pins update occurred in
      * @param {Date} time The time of the pins update
      */
     client.emit(Events.CHANNEL_PINS_UPDATE, channel, time);

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -319,7 +319,7 @@ class Shard extends EventEmitter {
     }
 
     /**
-     * Emitted upon recieving a message from the child process/worker.
+     * Emitted upon receiving a message from the child process/worker.
      * @event Shard#message
      * @param {*} message Message that was received
      */

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -73,7 +73,7 @@ class ShardingManager extends EventEmitter {
       if (this.shardList.length < 1) throw new RangeError('CLIENT_INVALID_OPTION', 'shardList', 'at least 1 ID.');
       if (this.shardList.some(shardID => typeof shardID !== 'number' || isNaN(shardID) ||
         !Number.isInteger(shardID) || shardID < 0)) {
-        throw new TypeError('CLIENT_INVALID_OPTION', 'shardList', 'an array of postive integers.');
+        throw new TypeError('CLIENT_INVALID_OPTION', 'shardList', 'an array of positive integers.');
       }
     }
 

--- a/travis/deploy.sh
+++ b/travis/deploy.sh
@@ -11,7 +11,7 @@ fi
 DONT_COMMIT=false
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-  echo -e "\e[36m\e[1mBuild triggered for PR #${TRAVIS_PULL_REQUEST} to branch \"${TRAVIS_BRANCH}\" - not commiting"
+  echo -e "\e[36m\e[1mBuild triggered for PR #${TRAVIS_PULL_REQUEST} to branch \"${TRAVIS_BRANCH}\" - not committing"
   SOURCE_TYPE="pr"
   DONT_COMMIT=true
 elif [ -n "$TRAVIS_TAG" ]; then
@@ -29,7 +29,7 @@ npm run docs
 NODE_ENV=production npm run build:browser
 
 if [ $DONT_COMMIT == true ]; then
-  echo -e "\e[36m\e[1mNot commiting - exiting early"
+  echo -e "\e[36m\e[1mNot committing - exiting early"
   exit 0
 fi
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1736,7 +1736,7 @@ declare module 'discord.js' {
 		public create(name: string, options?: GuildCreateChannelOptions): Promise<TextChannel | VoiceChannel | CategoryChannel>;
 	}
 
-	// Hacky workaround because changing the signature of an overriden method errors
+	// Hacky workaround because changing the signature of an overridden method errors
 	class OverridableDataStore<V, K, VConstructor = Constructable<V>, R = any> extends DataStore<V, K, VConstructor, R> {
 		public add(data: any, cache: any): any;
 		public set(key: any): any;


### PR DESCRIPTION
:blue_heart: Fix typos across **discord.js repository**

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
discord.js/src/client/websocket/WebSocketManager.js:300:43: "occured" is a misspelling of "occurred"
discord.js/src/client/websocket/WebSocketShard.js:468:76: "conenction" is a misspelling of "connection"
discord.js/src/client/websocket/handlers/CHANNEL_PINS_UPDATE.js:17:79: "occured" is a misspelling of "occurred"
discord.js/src/sharding/Shard.js:322:20: "recieving" is a misspelling of "receiving"
discord.js/src/sharding/ShardingManager.js:76:79: "postive" is a misspelling of "positive"
discord.js/travis/deploy.sh:14:106: "commiting" is a misspelling of "committing"
discord.js/travis/deploy.sh:32:26: "commiting" is a misspelling of "committing"
discord.js/typings/index.d.ts:1739:58: "overriden" is a misspelling of "overridden"
```

</p>
</details>

**FYI:** I used [**Go Spellchecker**](https://github.com/liamzdenek/go-spellcheck) :smile_cat: