### PR TITLE
Small changes to parseEmoji regex

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -244,9 +244,9 @@ class Util {
   static parseEmoji(text) {
     if (text.includes('%')) text = decodeURIComponent(text);
     if (!text.includes(':')) return { animated: false, name: text, id: null };
-    const m = text.match(/<?(a)?:(\w{2,32}):(\d{17,19})?>?/);
+    const m = text.match(/<?(?:(a):)?(\w{2,32}):(\d{17,19})?>?/);
     if (!m) return null;
-    return { animated: Boolean(m[1]), name: m[2], id: m[3] || null};
+    return { animated: Boolean(m[1]), name: m[2], id: m[3] || null };
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -244,9 +244,9 @@ class Util {
   static parseEmoji(text) {
     if (text.includes('%')) text = decodeURIComponent(text);
     if (!text.includes(':')) return { animated: false, name: text, id: null };
-    const m = text.match(/<?(a)?:?(\w{2,32}):(\d{17,19})>?/);
+    const m = text.match(/<?(a)?:(\w{2,32}):(\d{17,19})?>?/);
     if (!m) return null;
-    return { animated: Boolean(m[1]), name: m[2], id: m[3] };
+    return { animated: Boolean(m[1]), name: m[2], id: m[3] || null};
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
**Paragraph on this PR**
I changed the regex to output the results if you provide `<aemoji:123456789012345678>` and `<:aemoji:123456789012345678>` which will output `{ animated: false, name: "aemoji", id: "123456789012345678" }` or `<:emojiname:>` which outputs `{ animated: false, name: "emojiname", id: null }` or `<a:emoji:>` which would output `{ animated: true, name: "emoji", id: null }`. Before this PR the method would return that the emoji was animated if you provided something like `<anemojiname:emoji_id>` because the name started with an `a`.

---
**Simplified description of this PR (using examples)**
I changed the regex a bit for the `parseEmoji` function to fix a few parsing issues.
Parsing results before this PR:
```js
• "<anemojiname:123456789012345678>"	-	{ animated: true, name: "nemojiname", id: "123456789012345678" } // [this would be a possible false positive because the name starts with an 'a' but doesn't include an ':' to separate it from the name.]
• "<atest:>"				-	null
• "<:emojiName:>"			-	null
• "<a:emojiName:>"			-	null
• "<atest>"				-	null
```
Parsing results after this PR:
```js

• "<anemojiname:123456789012345678>"	-	{ animated: false, name: "anemojiname", id: "123456789012345678" }
• "<atest:>"				-	{ animated: false, name: "atest", id: null }
• "<:emojiName:>"			-	{ animated: false, name: "emojiName", id: null }
• "<a:emojiName:>"			-	{ animated: true, name: "emojiName", id: null }
• "<atest>"				-	null // [since it's an invalid emoji.]
```

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
