### PR TITLE
Remove client from TeamMember constructor

### DIFF
--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -47,7 +47,7 @@ class Team extends Base {
     this.members = new Collection();
 
     for (const memberData of data.members) {
-      const member = new TeamMember(this.client, this, memberData);
+      const member = new TeamMember(this, memberData);
       this.members.set(member.id, member);
     }
   }

--- a/src/structures/TeamMember.js
+++ b/src/structures/TeamMember.js
@@ -8,8 +8,8 @@ const { MembershipStates } = require('../util/Constants');
  * @extends {Base}
  */
 class TeamMember extends Base {
-  constructor(client, team, data) {
-    super(client);
+  constructor(team, data) {
+    super(team.client);
 
     /**
      * The Team this member is part of

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -283,7 +283,7 @@ declare module 'discord.js' {
 	}
 
 	export class TeamMember extends Base {
-		constructor(client: Client, team: Team, data: object);
+		constructor(team: Team, data: object);
 		public team: Team;
 		public readonly id: Snowflake;
 		public permissions: string[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The client property is already present on the Team object, so it doesn't need to be passed to the team member constructor when adding them to the Collection.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
