### PR TITLE
src: Update Webhook#sendSlackMessage to be accurate with what the API returns

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -154,7 +154,7 @@ class Webhook {
   /**
    * Sends a raw slack message with this webhook.
    * @param {Object} body The raw body to send
-   * @returns {Promise<Message|Object>}
+   * @returns {Promise<boolean>}
    * @example
    * // Send a slack message
    * webhook.sendSlackMessage({
@@ -173,10 +173,7 @@ class Webhook {
       query: { wait: true },
       auth: false,
       data: body,
-    }).then(data => {
-      if (!this.client.channels) return data;
-      return this.client.channels.get(data.channel_id).messages.add(data, false);
-    });
+    }).then(data => data.toString() === 'ok');
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1858,7 +1858,7 @@ declare module 'discord.js' {
 		send(content?: StringResolvable, options?: WebhookMessageOptions & { split: true | SplitOptions } | MessageAdditions): Promise<Message[]>;
 		send(options?: WebhookMessageOptions & { split?: false } | MessageAdditions | APIMessage): Promise<Message>;
 		send(options?: WebhookMessageOptions & { split: true | SplitOptions } | MessageAdditions | APIMessage): Promise<Message[]>;
-		sendSlackMessage(body: object): Promise<Message | object>;
+		sendSlackMessage(body: object): Promise<boolean>;
 	}
 
 //#endregion


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Executing a Webhook under the Slack route will return just "ok" if the result worked. See https://github.com/discordapp/discord-api-docs/issues/1067

We could also add manual fetch, but that wouldn't work for the WebhookClient..

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
