### PR TITLE
Specify maximum range for the days option when banning (docs)

### DIFF
--- a/src/stores/GuildMemberStore.js
+++ b/src/stores/GuildMemberStore.js
@@ -137,7 +137,7 @@ class GuildMemberStore extends DataStore {
    * Bans a user from the guild.
    * @param {UserResolvable} user The user to ban
    * @param {Object} [options] Options for the ban
-   * @param {number} [options.days=0] Number of days of messages to delete
+   * @param {number} [options.days=0] Number of days of messages to delete (maximum of 7)
    * @param {string} [options.reason] Reason for banning
    * @returns {Promise<GuildMember|User|Snowflake>} Result object will be resolved as specifically as possible.
    * If the GuildMember cannot be resolved, the User will instead be attempted to be resolved. If that also cannot

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -348,7 +348,7 @@ class GuildMember extends Base {
   /**
    * Bans this guild member.
    * @param {Object} [options] Options for the ban
-   * @param {number} [options.days=0] Number of days of messages to delete
+   * @param {number} [options.days=0] Number of days of messages to delete (maximum of 7)
    * @param {string} [options.reason] Reason for banning
    * @returns {Promise<GuildMember>}
    * @example


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR specifies a maximum range for the days option when banning (in the documentation). I have tested and found that any value over 7 days will throw an error.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
