### PR TITLE
fix(ChannelStore): return existing DMChannels within add()

### DIFF
--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -54,8 +54,8 @@ class ChannelStore extends DataStore {
 
   add(data, guild, cache = true) {
     const existing = this.get(data.id);
-    if (existing && existing._patch && cache) existing._patch(data);
     if (existing) {
+      if (existing._patch && cache) existing._patch(data);
       if (guild) guild.channels.add(existing);
       return existing;
     }

--- a/src/stores/ChannelStore.js
+++ b/src/stores/ChannelStore.js
@@ -55,8 +55,8 @@ class ChannelStore extends DataStore {
   add(data, guild, cache = true) {
     const existing = this.get(data.id);
     if (existing && existing._patch && cache) existing._patch(data);
-    if (existing && guild) {
-      guild.channels.add(existing);
+    if (existing) {
+      if (guild) guild.channels.add(existing);
       return existing;
     }
 


### PR DESCRIPTION
Fixes #3324 and fixes #3437 

When ChannelStore#add() was being called for DMs [here](https://github.com/discordjs/discord.js/blob/master/src/client/actions/ChannelCreate.js#L10), the existing DM wouldn't be returned since `guild` param will be falsy
https://github.com/discordjs/discord.js/blob/3fcc862c5fa336bb26c570655245d57e2e532f20/src/stores/ChannelStore.js#L58-L61
This led to Channel.create() getting [called](https://github.com/discordjs/discord.js/blob/master/src/stores/ChannelStore.js#L63) where a new instance of a DMChannel was being [created](https://github.com/discordjs/discord.js/blob/master/src/structures/Channel.js#L99) everytime which explains #3437 and since its being initialised with an empty message store everytime, the initial message (which would have called createDM) will be added resulting in `dm.messages.size` always being 1 hence #3324 .

This PR simply just returns the DMChannel if it already exists.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
