### PR TITLE
fix(rate-limits): reactions buckets need to be shared with sub-routes

### DIFF
--- a/src/rest/APIRouter.js
+++ b/src/rest/APIRouter.js
@@ -13,13 +13,18 @@ function buildRoute(manager) {
     get(target, name) {
       if (reflectors.includes(name)) return () => route.join('/');
       if (methods.includes(name)) {
+        const routeBucket = [];
+        for (let i = 0; i < route.length; i++) {
+          // Reactions routes and sub-routes all share the same bucket
+          if (route[i - 1] === 'reactions') break;
+          // Literal IDs should only be taken account if they are the Major ID (the Channel/Guild ID)
+          if (/\d{16,19}/g.test(route[i]) && !/channels|guilds/.test(route[i - 1])) routeBucket.push(':id');
+          // All other parts of the route should be considered as part of the bucket identifier
+          else routeBucket.push(route[i]);
+        }
         return options => manager.request(name, route.join('/'), Object.assign({
           versioned: manager.versioned,
-          route: route.map((r, i) => {
-            if (/\d{16,19}/g.test(r)) return /channels|guilds/.test(route[i - 1]) ? r : ':id';
-            if (route[i - 1] === 'reactions') return ':reaction';
-            return r;
-          }).join('/'),
+          route: routeBucket.join('/'),
         }, options));
       }
       route.push(name);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`/reactions` endpoint shares rate-limits with `/reactions/:reaction` and `/reactions/:reaction/:id`. This corrects those 429s.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
