### PR TITLE
feat: Guild#partnered

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -403,7 +403,7 @@ class Guild extends Base {
   get joinedAt() {
     return new Date(this.joinedTimestamp);
   }
-  
+
   /**
    * If this guild is partnered
    * @type {boolean}

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -403,6 +403,15 @@ class Guild extends Base {
   get joinedAt() {
     return new Date(this.joinedTimestamp);
   }
+  
+  /**
+   * If this guild is partnered
+   * @type {boolean}
+   * @readonly
+   */
+  get partnered() {
+    return this.features.includes('PARTNERED');
+  }
 
   /**
    * If this guild is verified

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -709,6 +709,7 @@ declare module 'discord.js' {
 		public readonly nameAcronym: string;
 		public readonly owner: GuildMember | null;
 		public ownerID: Snowflake;
+		public partnered: boolean;
 		public premiumSubscriptionCount: number | null;
 		public premiumTier: PremiumTier;
 		public presences: PresenceStore;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -709,7 +709,7 @@ declare module 'discord.js' {
 		public readonly nameAcronym: string;
 		public readonly owner: GuildMember | null;
 		public ownerID: Snowflake;
-		public partnered: boolean;
+		public readonly partnered: boolean;
 		public premiumSubscriptionCount: number | null;
 		public premiumTier: PremiumTier;
 		public presences: PresenceStore;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a `Guild#partnered` property, taking advantage of #3441 and [discordapp/discord-api-docs@`a8e12a2`](https://github.com/discordapp/discord-api-docs/commit/a8e12a2d18df9a71c97ba7940e7cd2779d289196).

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
