### PR TITLE
Add missing property for GuildChannel typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -805,7 +805,7 @@ declare module 'discord.js' {
 		public readonly deletable: boolean;
 		public guild: Guild;
 		public readonly manageable: boolean;
-		public readonly members: Collection<Snowflake, GuildMember>
+		public readonly members: Collection<Snowflake, GuildMember>;
 		public name: string;
 		public readonly parent: CategoryChannel | null;
 		public parentID: Snowflake;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -805,6 +805,7 @@ declare module 'discord.js' {
 		public readonly deletable: boolean;
 		public guild: Guild;
 		public readonly manageable: boolean;
+		public readonly members: Collection<Snowflake, GuildMember>
 		public name: string;
 		public readonly parent: CategoryChannel | null;
 		public parentID: Snowflake;


### PR DESCRIPTION
The property "members" is defined at [GuildChannel.js#L270](https://github.com/discordjs/discord.js/blob/master/src/structures/GuildChannel.js#L270) but never defined at the typings for TypeScript support.
Added property "members" to GuildChannel typings

**Please describe the changes this PR makes and why it should be merged:**
Added the missing "members" property for GuildChannel in typings file.  

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
