### PR TITLE
Make Message.author not nullable in typescript

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -946,7 +946,7 @@ declare module 'discord.js' {
 		public activity: GroupActivity | null;
 		public application: ClientApplication | null;
 		public attachments: Collection<Snowflake, MessageAttachment>;
-		public author: User | null;
+		public author: User;
 		public channel: TextChannel | DMChannel;
 		public readonly cleanContent: string;
 		public content: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Message.author is marked as nullable in typescript but should not be

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
