### PR TITLE
src: Backport #3309 (STREAM permission) to 11.5-dev

### DIFF
--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -208,6 +208,7 @@ class Permissions {
  * - `ADD_REACTIONS` (add new reactions to messages)
  * - `VIEW_AUDIT_LOG`
  * - `PRIORITY_SPEAKER`
+ * - `STREAM`
  * - `VIEW_CHANNEL`
  * - `READ_MESSAGES` **(deprecated)**
  * - `SEND_MESSAGES`
@@ -244,6 +245,7 @@ Permissions.FLAGS = {
   ADD_REACTIONS: 1 << 6,
   VIEW_AUDIT_LOG: 1 << 7,
   PRIORITY_SPEAKER: 1 << 8,
+  STREAM: 1 << 9,
 
   VIEW_CHANNEL: 1 << 10,
   READ_MESSAGES: 1 << 10,

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -284,7 +284,7 @@ Permissions.ALL = Object.keys(Permissions.FLAGS).reduce((all, p) => all | Permis
  * Bitfield representing the default permissions for users
  * @type {number}
  */
-Permissions.DEFAULT = 104324097;
+Permissions.DEFAULT = 104324673;
 
 /**
  * @class EvaluatedPermissions

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1997,6 +1997,7 @@ declare module 'discord.js' {
 		ADD_REACTIONS?: number;
 		VIEW_AUDIT_LOG?: number;
 		PRIORITY_SPEAKER?: number;
+		STREAM?: number;
 		VIEW_CHANNEL?: number;
 		READ_MESSAGES?: number;
 		SEND_MESSAGES?: number;
@@ -2032,6 +2033,7 @@ declare module 'discord.js' {
 		ADD_REACTIONS?: boolean;
 		VIEW_AUDIT_LOG?: boolean;
 		PRIORITY_SPEAKER?: boolean;
+		STREAM?: boolean;
 		VIEW_CHANNEL?: boolean;
 		READ_MESSAGES?: boolean;
 		SEND_MESSAGES?: boolean;
@@ -2066,6 +2068,7 @@ declare module 'discord.js' {
 		| 'ADD_REACTIONS'
 		| 'VIEW_AUDIT_LOG'
 		| 'PRIORITY_SPEAKER'
+		| 'STREAM'
 		| 'VIEW_CHANNEL'
 		| 'READ_MESSAGES'
 		| 'SEND_MESSAGES'


### PR DESCRIPTION
Backport #3309 patch for Permissions.STREAM to 11.5-dev branch

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
