### PR TITLE
fix(typings): DataStore#resolve & DataStore#resolveID can also return null

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1716,8 +1716,8 @@ declare module 'discord.js' {
 		public holds: VConstructor;
 		public add(data: any, cache?: boolean, { id, extras }?: { id: K, extras: any[] }): V;
 		public remove(key: K): void;
-		public resolve(resolvable: R): V;
-		public resolveID(resolvable: R): K;
+		public resolve(resolvable: R): V | null;
+		public resolveID(resolvable: R): K | null;
 	}
 
 	export class GuildEmojiRoleStore extends OverridableDataStore<Snowflake, Role, typeof Role, RoleResolvable> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1715,7 +1715,7 @@ declare module 'discord.js' {
 		public client: Client;
 		public holds: VConstructor;
 		public add(data: any, cache?: boolean, { id, extras }?: { id: K, extras: any[] }): V;
-		public remove(key: K): void;
+		public remove(key: K): boolean;
 		public resolve(resolvable: R): V | null;
 		public resolveID(resolvable: R): K | null;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently the typings indicate that [DataStore#resolve](https://github.com/discordjs/discord.js/blob/master/typings/index.d.ts#L1719) and [DataStore#resolveID](https://github.com/discordjs/discord.js/blob/master/typings/index.d.ts#L1720) are guranteed to return said object that the store keeps, or an id, which is, however, incorrect.

Also DataStore#remove correction.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
