### PR TITLE
feat(Permissions): Add new method Permissions#any

### DIFF
--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -24,8 +24,6 @@ class BitField {
    */
   any(bit) {
     return (this.bitfield & this.constructor.resolve(bit)) !== 0;
-    bit = this.constructor.resolve(bit);
-    return (this.bitfield & bit) === bit;
   }
 
   /**

--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -18,6 +18,17 @@ class BitField {
   }
 
   /**
+   * Checks whether the bitfield has a bit, or any of multiple bits.
+   * @param {BitFieldResolvable} bit Bit(s) to check for
+   * @returns {boolean}
+   */
+  any(bit) {
+    if (Array.isArray(bit)) return bit.some(p => this.has(p));
+    bit = this.constructor.resolve(bit);
+    return (this.bitfield & bit) === bit;
+  }
+
+  /**
    * Checks if this bitfield equals another
    * @param {BitFieldResolvable} bit Bit(s) to check for
    * @returns {boolean}

--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -23,7 +23,7 @@ class BitField {
    * @returns {boolean}
    */
   any(bit) {
-    if (Array.isArray(bit)) return bit.some(p => this.has(p));
+    return (this.bitfield & this.constructor.resolve(bit)) !== 0;
     bit = this.constructor.resolve(bit);
     return (this.bitfield & bit) === bit;
   }

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -17,7 +17,7 @@ class Permissions extends BitField {
    * * An Array of PermissionResolvable
    * @typedef {string|number|Permissions|PermissionResolvable[]} PermissionResolvable
    */
-  
+
   /**
    * Checks whether the bitfield has a permission, or any of multiple permissions.
    * @param {PermissionResolvable} permission Permission(s) to check for

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -17,6 +17,17 @@ class Permissions extends BitField {
    * * An Array of PermissionResolvable
    * @typedef {string|number|Permissions|PermissionResolvable[]} PermissionResolvable
    */
+  
+  /**
+   * Checks whether the bitfield has a permission, or any of multiple permissions.
+   * @param {PermissionResolvable} permission Permission(s) to check for
+   * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
+   * @returns {boolean}
+   */
+  any(permission, checkAdmin = true) {
+    if (checkAdmin && super.has(this.constructor.FLAGS.ADMINISTRATOR)) return true;
+    return super.any(permission);
+  }
 
   /**
    * Checks whether the bitfield has a permission, or multiple permissions.

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -25,8 +25,7 @@ class Permissions extends BitField {
    * @returns {boolean}
    */
   any(permission, checkAdmin = true) {
-    if (checkAdmin && super.has(this.constructor.FLAGS.ADMINISTRATOR)) return true;
-    return super.any(permission);
+    return (checkAdmin && super.has(this.constructor.FLAGS.ADMINISTRATOR)) || super.any(permission);
   }
 
   /**
@@ -36,8 +35,7 @@ class Permissions extends BitField {
    * @returns {boolean}
    */
   has(permission, checkAdmin = true) {
-    if (checkAdmin && super.has(this.constructor.FLAGS.ADMINISTRATOR)) return true;
-    return super.has(permission);
+    return (checkAdmin && super.has(this.constructor.FLAGS.ADMINISTRATOR)) || super.has(permission);
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -99,6 +99,7 @@ declare module 'discord.js' {
 		constructor(bits?: BitFieldResolvable<S>);
 		public bitfield: number;
 		public add(...bits: BitFieldResolvable<S>[]): BitField<S>;
+		public any(bit: BitFieldResolvable<S>): boolean;
 		public equals(bit: BitFieldResolvable<S>): boolean;
 		public freeze(): Readonly<BitField<S>>;
 		public has(bit: BitFieldResolvable<S>): boolean;
@@ -1111,6 +1112,7 @@ declare module 'discord.js' {
 	}
 
 	export class Permissions extends BitField<PermissionString> {
+		public any(permission: PermissionResolvable, checkAdmin?: boolean): boolean;
 		public has(permission: PermissionResolvable, checkAdmin?: boolean): boolean;
 
 		public static ALL: number;


### PR DESCRIPTION
From `you never knew#0717` in d.js support who had the idea for this method.
It does what Permissions#has does (its basically a copypasta of it), but will return true if any of the Permissions provided exist, rather than all of them.

I'm not sure how common the use-case will be, but here it is for consideration.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
