### PR TITLE
Fix Util#splitMessage when destructured

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -56,7 +56,7 @@ class Util {
    * @returns {string[]}
    */
   static splitMessage(text, { maxLength = 2000, char = '\n', prepend = '', append = '' } = {}) {
-    text = this.resolveString(text);
+    text = Util.resolveString(text);
     if (text.length <= maxLength) return [text];
     const splitText = text.split(char);
     if (splitText.some(chunk => chunk.length > maxLength)) throw new RangeError('SPLIT_MAX_LEN');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
this PR fixes the `Utils#splitMessage` method because resolveString should be called as `Util.resolveString` since it's a static method.

___
**Update**
kyranet posted a better reason why this PR should be merged [here](https://github.com/discordjs/discord.js/pull/3456#issuecomment-526960062).

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
