### PR TITLE
move members property

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -263,21 +263,6 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * A collection of members that can see this channel, mapped by their ID
-   * @type {Collection<Snowflake, GuildMember>}
-   * @readonly
-   */
-  get members() {
-    const members = new Collection();
-    for (const member of this.guild.members.values()) {
-      if (this.permissionsFor(member).has('VIEW_CHANNEL', false)) {
-        members.set(member.id, member);
-      }
-    }
-    return members;
-  }
-
-  /**
    * The data for a guild channel.
    * @typedef {Object} ChannelData
    * @property {string} [name] The name of the channel

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -65,6 +65,21 @@ class TextChannel extends GuildChannel {
   }
 
   /**
+   * A collection of members that can see this channel, mapped by their ID
+   * @type {Collection<Snowflake, GuildMember>}
+   * @readonly
+   */
+  get members() {
+    const members = new Collection();
+    for (const member of this.guild.members.values()) {
+      if (this.permissionsFor(member).has('VIEW_CHANNEL', false)) {
+        members.set(member.id, member);
+      }
+    }
+    return members;
+  }
+
+  /**
    * Sets the rate limit per user for this channel.
    * @param {number} rateLimitPerUser The new ratelimit in seconds
    * @param {string} [reason] Reason for changing the channel's ratelimits


### PR DESCRIPTION
Moved members property from GuildChannel to TextChannel

**Please describe the changes this PR makes and why it should be merged:**
As requested in the PR [#3445](https://github.com/discordjs/discord.js/pull/3445) (which I deleted my bad, I just didn't know how to resolve conflicts ;-;) so I thought of moving this property since VoiceChannel wasn't inheriting the property properly (they don't do the same thing), TextChannel and NewsChannel use the property differently. It won't matter in NewsChannel since it extends TextChannel anyways.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
