### PR TITLE
fix(Role): throw TypeError in comparePositionTo

### DIFF
--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -150,7 +150,7 @@ class Role extends Base {
    */
   comparePositionTo(role) {
     role = this.guild.roles.resolve(role);
-    if (!role) return Promise.reject(new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake'));
+    if (!role) throw new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake');
     return this.constructor.comparePositions(this, role);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Role#comparePositionTo` will reject with a type error when an invalid `RoleResolvable` is passed. However this is a synchronous method and should throw instead.
This PR takes care of that.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
