### PR TITLE
typings: make TypeScript interaction with channels better

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1710,8 +1710,9 @@ declare module 'discord.js' {
 		constructor(guild: Guild, iterable?: Iterable<any>);
 		public create(name: string, options: GuildCreateChannelOptions & { type: 'voice' }): Promise<VoiceChannel>;
 		public create(name: string, options: GuildCreateChannelOptions & { type: 'category' }): Promise<CategoryChannel>;
+		public create(name: string, options?: GuildCreateChannelOptions & { type?: 'text' }): Promise<TextChannel>;
 		public create(name: string, options: GuildCreateChannelOptions): Promise<TextChannel | VoiceChannel | CategoryChannel>;
-		public create(name: string, options?: GuildCreateChannelOptions): Promise<TextChannel>;
+		
 	}
 
 	// Hacky workaround because changing the signature of an overridden method errors

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -783,20 +783,20 @@ declare module 'discord.js' {
 		public readonly position: number;
 		public rawPosition: number;
 		public readonly viewable: boolean;
-		public clone(options?: GuildChannelCloneOptions): Promise<GuildChannel>;
+		public clone<Ch>(options?: GuildChannelCloneOptions): Promise<Ch>;
 		public createInvite(options?: InviteOptions): Promise<Invite>;
-		public createOverwrite(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<GuildChannel>;
-		public edit(data: ChannelData, reason?: string): Promise<GuildChannel>;
+		public createOverwrite<Ch>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<Ch>;
+		public edit<Ch>(data: ChannelData, reason?: string): Promise<Ch>;
 		public equals(channel: GuildChannel): boolean;
 		public fetchInvites(): Promise<Collection<string, Invite>>;
-		public lockPermissions(): Promise<GuildChannel>;
-		public overwritePermissions(options?: { permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string }): Promise<GuildChannel>;
+		public lockPermissions<Ch>(): Promise<Ch>;
+		public overwritePermissions<Ch>(options?: { permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string }): Promise<Ch>;
 		public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
-		public setName(name: string, reason?: string): Promise<GuildChannel>;
-		public setParent(channel: GuildChannel | Snowflake, options?: { lockPermissions?: boolean, reason?: string }): Promise<GuildChannel>;
-		public setPosition(position: number, options?: { relative?: boolean, reason?: string }): Promise<GuildChannel>;
-		public setTopic(topic: string, reason?: string): Promise<GuildChannel>;
-		public updateOverwrite(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<GuildChannel>;
+		public setName<Ch>(name: string, reason?: string): Promise<Ch>;
+		public setParent<Ch>(channel: GuildChannel | Snowflake, options?: { lockPermissions?: boolean, reason?: string }): Promise<Ch>;
+		public setPosition<Ch>(position: number, options?: { relative?: boolean, reason?: string }): Promise<Ch>;
+		public setTopic<Ch>(topic: string, reason?: string): Promise<Ch>;
+		public updateOverwrite<Ch>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<Ch>;
 	}
 
 	export class StoreChannel extends GuildChannel {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1708,7 +1708,9 @@ declare module 'discord.js' {
 
 	export class GuildChannelStore extends DataStore<Snowflake, GuildChannel, typeof GuildChannel, GuildChannelResolvable> {
 		constructor(guild: Guild, iterable?: Iterable<any>);
-		public create(name: string, options?: GuildCreateChannelOptions): Promise<TextChannel | VoiceChannel | CategoryChannel>;
+		public create(name: string, options?: GuildCreateChannelOptions & { type?: 'text' }): Promise<TextChannel>;
+		public create(name: string, options?: GuildCreateChannelOptions & { type: 'voice' }): Promise<VoiceChannel>;
+		public create(name: string, options?: GuildCreateChannelOptions & { type: 'category' }): Promise<CategoryChannel>;
 	}
 
 	// Hacky workaround because changing the signature of an overridden method errors

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -783,20 +783,20 @@ declare module 'discord.js' {
 		public readonly position: number;
 		public rawPosition: number;
 		public readonly viewable: boolean;
-		public clone<T extends this>(options?: GuildChannelCloneOptions): Promise<T>;
+		public clone(options?: GuildChannelCloneOptions): Promise<this>;
 		public createInvite(options?: InviteOptions): Promise<Invite>;
-		public createOverwrite<T extends this>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<T>;
-		public edit<T extends this>(data: ChannelData, reason?: string): Promise<T>;
+		public createOverwrite(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<this>;
+		public edit(data: ChannelData, reason?: string): Promise<this>;
 		public equals(channel: GuildChannel): boolean;
 		public fetchInvites(): Promise<Collection<string, Invite>>;
-		public lockPermissions<T extends this>(): Promise<T>;
-		public overwritePermissions<T extends this>(options?: { permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string }): Promise<T>;
+		public lockPermissions(): Promise<this>;
+		public overwritePermissions(options?: { permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string }): Promise<this>;
 		public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
-		public setName<T extends this>(name: string, reason?: string): Promise<T>;
-		public setParent<T extends this>(channel: GuildChannel | Snowflake, options?: { lockPermissions?: boolean, reason?: string }): Promise<T>;
-		public setPosition<T extends this>(position: number, options?: { relative?: boolean, reason?: string }): Promise<T>;
-		public setTopic<T extends this>(topic: string, reason?: string): Promise<T>;
-		public updateOverwrite<T extends this>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<T>;
+		public setName(name: string, reason?: string): Promise<this>;
+		public setParent(channel: GuildChannel | Snowflake, options?: { lockPermissions?: boolean, reason?: string }): Promise<this>;
+		public setPosition(position: number, options?: { relative?: boolean, reason?: string }): Promise<this>;
+		public setTopic(topic: string, reason?: string): Promise<this>;
+		public updateOverwrite(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<this>;
 	}
 
 	export class StoreChannel extends GuildChannel {
@@ -1708,8 +1708,9 @@ declare module 'discord.js' {
 
 	export class GuildChannelStore extends DataStore<Snowflake, GuildChannel, typeof GuildChannel, GuildChannelResolvable> {
 		constructor(guild: Guild, iterable?: Iterable<any>);
-		public create(name: string, options?: GuildCreateChannelOptions & { type: 'voice' }): Promise<VoiceChannel>;
-		public create(name: string, options?: GuildCreateChannelOptions & { type: 'category' }): Promise<CategoryChannel>;
+		public create(name: string, options: GuildCreateChannelOptions & { type: 'voice' }): Promise<VoiceChannel>;
+		public create(name: string, options: GuildCreateChannelOptions & { type: 'category' }): Promise<CategoryChannel>;
+		public create(name: string, options: GuildCreateChannelOptions): Promise<TextChannel | VoiceChannel | CategoryChannel>;
 		public create(name: string, options?: GuildCreateChannelOptions): Promise<TextChannel>;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -783,20 +783,20 @@ declare module 'discord.js' {
 		public readonly position: number;
 		public rawPosition: number;
 		public readonly viewable: boolean;
-		public clone<Ch extends this>(options?: GuildChannelCloneOptions): Promise<Ch>;
+		public clone<T extends this>(options?: GuildChannelCloneOptions): Promise<T>;
 		public createInvite(options?: InviteOptions): Promise<Invite>;
-		public createOverwrite<Ch extends this>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<Ch>;
-		public edit<Ch extends this>(data: ChannelData, reason?: string): Promise<Ch>;
+		public createOverwrite<T extends this>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<T>;
+		public edit<T extends this>(data: ChannelData, reason?: string): Promise<T>;
 		public equals(channel: GuildChannel): boolean;
 		public fetchInvites(): Promise<Collection<string, Invite>>;
-		public lockPermissions<Ch extends this>(): Promise<Ch>;
-		public overwritePermissions<Ch extends this>(options?: { permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string }): Promise<Ch>;
+		public lockPermissions<T extends this>(): Promise<T>;
+		public overwritePermissions<T extends this>(options?: { permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string }): Promise<T>;
 		public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
-		public setName<Ch extends this>(name: string, reason?: string): Promise<Ch>;
-		public setParent<Ch extends this>(channel: GuildChannel | Snowflake, options?: { lockPermissions?: boolean, reason?: string }): Promise<Ch>;
-		public setPosition<Ch extends this>(position: number, options?: { relative?: boolean, reason?: string }): Promise<Ch>;
-		public setTopic<Ch extends this>(topic: string, reason?: string): Promise<Ch>;
-		public updateOverwrite<Ch extends this>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<Ch>;
+		public setName<T extends this>(name: string, reason?: string): Promise<T>;
+		public setParent<T extends this>(channel: GuildChannel | Snowflake, options?: { lockPermissions?: boolean, reason?: string }): Promise<T>;
+		public setPosition<T extends this>(position: number, options?: { relative?: boolean, reason?: string }): Promise<T>;
+		public setTopic<T extends this>(topic: string, reason?: string): Promise<T>;
+		public updateOverwrite<T extends this>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<T>;
 	}
 
 	export class StoreChannel extends GuildChannel {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1712,7 +1712,6 @@ declare module 'discord.js' {
 		public create(name: string, options: GuildCreateChannelOptions & { type: 'category' }): Promise<CategoryChannel>;
 		public create(name: string, options?: GuildCreateChannelOptions & { type?: 'text' }): Promise<TextChannel>;
 		public create(name: string, options: GuildCreateChannelOptions): Promise<TextChannel | VoiceChannel | CategoryChannel>;
-		
 	}
 
 	// Hacky workaround because changing the signature of an overridden method errors

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -783,20 +783,20 @@ declare module 'discord.js' {
 		public readonly position: number;
 		public rawPosition: number;
 		public readonly viewable: boolean;
-		public clone<Ch>(options?: GuildChannelCloneOptions): Promise<Ch>;
+		public clone<Ch extends this>(options?: GuildChannelCloneOptions): Promise<Ch>;
 		public createInvite(options?: InviteOptions): Promise<Invite>;
-		public createOverwrite<Ch>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<Ch>;
-		public edit<Ch>(data: ChannelData, reason?: string): Promise<Ch>;
+		public createOverwrite<Ch extends this>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<Ch>;
+		public edit<Ch extends this>(data: ChannelData, reason?: string): Promise<Ch>;
 		public equals(channel: GuildChannel): boolean;
 		public fetchInvites(): Promise<Collection<string, Invite>>;
-		public lockPermissions<Ch>(): Promise<Ch>;
-		public overwritePermissions<Ch>(options?: { permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string }): Promise<Ch>;
+		public lockPermissions<Ch extends this>(): Promise<Ch>;
+		public overwritePermissions<Ch extends this>(options?: { permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string }): Promise<Ch>;
 		public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
-		public setName<Ch>(name: string, reason?: string): Promise<Ch>;
-		public setParent<Ch>(channel: GuildChannel | Snowflake, options?: { lockPermissions?: boolean, reason?: string }): Promise<Ch>;
-		public setPosition<Ch>(position: number, options?: { relative?: boolean, reason?: string }): Promise<Ch>;
-		public setTopic<Ch>(topic: string, reason?: string): Promise<Ch>;
-		public updateOverwrite<Ch>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<Ch>;
+		public setName<Ch extends this>(name: string, reason?: string): Promise<Ch>;
+		public setParent<Ch extends this>(channel: GuildChannel | Snowflake, options?: { lockPermissions?: boolean, reason?: string }): Promise<Ch>;
+		public setPosition<Ch extends this>(position: number, options?: { relative?: boolean, reason?: string }): Promise<Ch>;
+		public setTopic<Ch extends this>(topic: string, reason?: string): Promise<Ch>;
+		public updateOverwrite<Ch extends this>(userOrRole: RoleResolvable | UserResolvable, options: PermissionOverwriteOption, reason?: string): Promise<Ch>;
 	}
 
 	export class StoreChannel extends GuildChannel {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1708,9 +1708,9 @@ declare module 'discord.js' {
 
 	export class GuildChannelStore extends DataStore<Snowflake, GuildChannel, typeof GuildChannel, GuildChannelResolvable> {
 		constructor(guild: Guild, iterable?: Iterable<any>);
-		public create(name: string, options?: GuildCreateChannelOptions & { type?: 'text' }): Promise<TextChannel>;
 		public create(name: string, options?: GuildCreateChannelOptions & { type: 'voice' }): Promise<VoiceChannel>;
 		public create(name: string, options?: GuildCreateChannelOptions & { type: 'category' }): Promise<CategoryChannel>;
+		public create(name: string, options?: GuildCreateChannelOptions): Promise<TextChannel>;
 	}
 
 	// Hacky workaround because changing the signature of an overridden method errors


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR just edits a few types for more clear interaction with channels in TypeScript.
- Creating channels now returns correct type (instead of union) based on specified kind of channel.
- Editing channels also returns correct type that allows to chain promises & assign awaited values
```ts
voiceChannel = await voiceChannel.setName('voice 1337')
    .then(v => v.setBitrate(1337))
    .then(v => v.delete())
```
P.S. I know these requests could be combined into single `.edit`. That's just an example.
**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
