### PR TITLE
fix(stores): Add symbol.species for not-actual-stores

### DIFF
--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -106,8 +106,8 @@ class GuildEmojiRoleStore extends Collection {
     return this._filtered;
   }
 
-  static get [Symbol.species]() { 
-    return Collection; 
+  static get [Symbol.species]() {
+    return Collection;
   }
 }
 

--- a/src/stores/GuildEmojiRoleStore.js
+++ b/src/stores/GuildEmojiRoleStore.js
@@ -105,6 +105,10 @@ class GuildEmojiRoleStore extends Collection {
   valueOf() {
     return this._filtered;
   }
+
+  static get [Symbol.species]() { 
+    return Collection; 
+  }
 }
 
 Util.mixin(GuildEmojiRoleStore, ['set']);

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -155,8 +155,8 @@ class GuildMemberRoleStore extends Collection {
     return this._filtered;
   }
 
-  static get [Symbol.species]() { 
-    return Collection; 
+  static get [Symbol.species]() {
+    return Collection;
   }
 }
 

--- a/src/stores/GuildMemberRoleStore.js
+++ b/src/stores/GuildMemberRoleStore.js
@@ -154,6 +154,10 @@ class GuildMemberRoleStore extends Collection {
   valueOf() {
     return this._filtered;
   }
+
+  static get [Symbol.species]() { 
+    return Collection; 
+  }
 }
 
 Util.mixin(GuildMemberRoleStore, ['set']);


### PR DESCRIPTION
This defines Symbol.species as a Collection for both GuildMemberRoleStore and GuildEmojiRoleStore, as these don't actually extend DataStores.

Fixes a bug that I think comes from the polymorphic `new this` return values for functions like `<DataStore>.filter()`

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
