### PR TITLE
fix(Channel): Default channel type incorrectly set

### DIFF
--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -102,7 +102,7 @@ class GuildChannelStore extends DataStore {
       data: {
         name,
         topic,
-        type: type ? ChannelTypes[type.toUpperCase()] : 'text',
+        type: type ? ChannelTypes[type.toUpperCase()] : ChannelTypes.TEXT,
         nsfw,
         bitrate,
         user_limit: userLimit,


### PR DESCRIPTION
When creating a channel without specifying the `type` option, the default was set to `text` instead of using the `ChannelTypes` enum constants.

This was throwing a Discord API error.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
