### PR TITLE
backport(#3496): Default channel type incorrectly set

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -276,7 +276,7 @@ class RESTMethods {
     return this.rest.makeRequest('post', Endpoints.Guild(guild).channels, true, {
       name,
       topic,
-      type: type ? Constants.ChannelTypes[type.toUpperCase()] : 'text',
+      type: type ? Constants.ChannelTypes[type.toUpperCase()] : Constants.ChannelTypes.TEXT,
       nsfw,
       bitrate,
       user_limit: userLimit,


### PR DESCRIPTION
Backports #3496 to 11.5-dev

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
