### PR TITLE
fix(VoiceReceiver): delete opus encoder from map in stoppedSpeaking

### DIFF
--- a/src/client/voice/receiver/VoiceReceiver.js
+++ b/src/client/voice/receiver/VoiceReceiver.js
@@ -112,6 +112,7 @@ class VoiceReceiver extends EventEmitter {
     }
     if (opusEncoder) {
       opusEncoder.destroy();
+      this.opusEncoders.delete(user.id);
     }
   }
 
@@ -132,7 +133,7 @@ class VoiceReceiver extends EventEmitter {
 
   /**
    * Creates a readable stream for a user that provides PCM data while the user is speaking. When the user
-   * stops speaking, the stream is destroyed. The stream is 32-bit signed stereo PCM at 48KHz.
+   * stops speaking, the stream is destroyed. The stream is 16-bit signed stereo PCM at 48KHz.
    * @param {UserResolvable} user The user to create the stream for
    * @returns {ReadableStream}
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes `VoiceReceiver`s failing to decode PCM data after the first silence of a user.

The cause is that the relevant `OpusEncoder` got reused after being destroyed.
It was destroyed here, but not removed from the map like it should.
https://github.com/discordjs/discord.js/blob/505df2ebb3b49503d98f635534e9644db7375925/src/client/voice/receiver/VoiceReceiver.js#L113-L115
After removing it from the map a new one was created in case the user starts speaking again and valid PCM data could be decoded.

This PR also fixes the documentation about the PCM format, it's actually `s16` and not `s32`.

 
**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
