### PR TITLE
feat(GuildMember): filter out duplicate roles when updating

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -522,7 +522,7 @@ class RESTMethods {
       data.channel_id = null;
       data.channel = undefined;
     }
-    if (data.roles) data.roles = data.roles.map(role => role instanceof Role ? role.id : role);
+    if (data.roles) data.roles = [...new Set(data.roles.map(role => role instanceof Role ? role.id : role))];
 
     let endpoint = Endpoints.Member(member);
     // Fix your endpoints, discord ;-;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR filters out duplicated duplicated roles when patching a `GuildMember`.

The intend behind this is to apply this to `GuildMember#addRoles` where an error occurs when one is trying to add a role which is already there.

That behavior would be identical to the behaviour of `addRole`, `removeRole`, and `removeRoles` then.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
