### PR TITLE
Make arraysEqual avoid mutating the input arrays

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -84,9 +84,9 @@ class Util {
   }
 
   /**
-   * Checks whether the arrays are equal, also removes duplicated entries from b.
-   * @param {Array<*>} a Array which will not be modified.
-   * @param {Array<*>} b Array to remove duplicated entries from.
+   * Checks whether two arrays are equal or have the same elements.
+   * @param {Array<*>} a The first array.
+   * @param {Array<*>} b The second array.
    * @returns {boolean} Whether the arrays are equal.
    * @private
    */
@@ -94,12 +94,10 @@ class Util {
     if (a === b) return true;
     if (a.length !== b.length) return false;
 
-    for (const item of a) {
-      const ind = b.indexOf(item);
-      if (ind !== -1) b.splice(ind, 1);
-    }
+    const setA = new Set(a);
+    const setB = new Set(b);
 
-    return b.length === 0;
+    return a.every(e => setB.has(e)) && b.every(e => setA.has(e));
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Targetting 11.5-dev**

This method causes bugs where it is used because it mutates the array.
1. Comparing guilds with `Guild#equals` may mutate the guild features array causing it to be inaccurate. (fixed for master in #2544)
2. Comparing `GuildMember._roles` with each other may mutate the underlying roles array which causes the `oldMember` parameter for the `guildMemberUpdate` event to have inaccurate roles.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
