### PR TITLE
backport GuildChannel#permissionsLocked

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -74,6 +74,22 @@ class GuildChannel extends Channel {
   }
 
   /**
+   * If the permissionOverwrites match the parent channel, null if no parent
+   * @type {?boolean}
+   * @readonly
+   */
+  get permissionsLocked() {
+    if (!this.parent) return null;
+    if (this.permissionOverwrites.size !== this.parent.permissionOverwrites.size) return false;
+    return this.permissionOverwrites.every((value, key) => {
+      const testVal = this.parent.permissionOverwrites.get(key);
+      return testVal !== undefined &&
+        testVal.deny === value.deny &&
+        testVal.allow === value.allow;
+    });
+  }
+
+  /**
    * Gets the overall set of permissions for a user in this channel, taking into account channel overwrites.
    * @param {GuildMemberResolvable} member The user that you want to obtain the overall permissions for
    * @returns {?Permissions}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -629,6 +629,7 @@ declare module 'discord.js' {
 		public parentID: Snowflake;
 		public permissionOverwrites: Collection<Snowflake, PermissionOverwrites>;
 		public position: number;
+		public permissionsLocked: boolean | null;
 		public clone(name?: string, withPermissions?: boolean, withTopic?: boolean, reason?: string): Promise<GuildChannel>;
 		public createInvite(options?: InviteOptions, reason?: string): Promise<Invite>;
 		public delete(reason?: string): Promise<GuildChannel>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -629,7 +629,7 @@ declare module 'discord.js' {
 		public parentID: Snowflake;
 		public permissionOverwrites: Collection<Snowflake, PermissionOverwrites>;
 		public position: number;
-		public permissionsLocked: boolean | null;
+		public readonly permissionsLocked: boolean | null;
 		public clone(name?: string, withPermissions?: boolean, withTopic?: boolean, reason?: string): Promise<GuildChannel>;
 		public createInvite(options?: InviteOptions, reason?: string): Promise<Invite>;
 		public delete(reason?: string): Promise<GuildChannel>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**target: 11.5-dev**
Backports the utility getter Guild#permissionsLocked to 11.5-dev

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
