### PR TITLE
typings: GuildChannel#parentID is nullable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -794,7 +794,7 @@ declare module 'discord.js' {
 		public readonly members: Collection<Snowflake, GuildMember>;
 		public name: string;
 		public readonly parent: CategoryChannel | null;
-		public parentID: Snowflake;
+		public parentID: Snowflake | null;
 		public permissionOverwrites: Collection<Snowflake, PermissionOverwrites>;
 		public readonly permissionsLocked: boolean | null;
 		public readonly position: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

According to both discord.js and discord API docs GuildChannel#parentID is marked as nullable. This PR adapts the typings to reflect this behavior.
ref: https://discordapp.com/developers/docs/resources/channel#channel-object
ref: https://discord.js.org/#/docs/main/master/class/GuildChannel?scrollTo=parentID

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
