### PR TITLE
typings: GuildChannel#parent and #parentID are nullable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -625,8 +625,8 @@ declare module 'discord.js' {
 		public readonly messageNotifications: GuildChannelMessageNotifications;
 		public readonly muted: boolean;
 		public name: string;
-		public readonly parent: CategoryChannel;
-		public parentID: Snowflake;
+		public readonly parent: CategoryChannel | null;
+		public parentID: Snowflake | null;
 		public permissionOverwrites: Collection<Snowflake, PermissionOverwrites>;
 		public position: number;
 		public clone(name?: string, withPermissions?: boolean, withTopic?: boolean, reason?: string): Promise<GuildChannel>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Target: 11.5-dev**

According to both discord.js and discord API docs GuildChannel#parentID as well as GuildChannel#parent are marked as nullable. This PR adapts the typings to reflect this behavior and as such acts as backport and addition to #3508.
ref: https://discordapp.com/developers/docs/resources/channel#channel-object
ref: https://discord.js.org/#/docs/main/master/class/GuildChannel?scrollTo=parentID

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
