### PR TITLE
chore: mark optional peerDependencies as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,29 @@
     "zlib-sync": "^0.1.4",
     "zucc": "^0.1.0"
   },
+  "peerDependenciesMeta": {
+    "@discordjs/uws": {
+      "optional": true
+    },
+    "bufferutil": {
+      "optional": true
+    },
+    "erlpack": {
+      "optional": true
+    },
+    "libsodium-wrappers": {
+      "optional": true
+    },
+    "sodium": {
+      "optional": true
+    },
+    "zlib-sync": {
+      "optional": true
+    },
+    "zucc": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@types/node": "^10.12.24",
     "@types/ws": "^6.0.1",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

A while ago a RFC was made for yarn to allow marking peer dependencies as optional and with that silencing the warnings about missing peer dependencies. [You can read that RFC here](https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md). This was added in yarn in version 1.13.0 ([PR](https://github.com/yarnpkg/yarn/pull/6671) and pnpm version 3.2.0-1 ([PR](https://github.com/pnpm/pnpm/issues/1486)). Later it was also added to npm in version 6.11.0 ([Changelog](https://github.com/npm/cli/blob/latest/CHANGELOG.md#v6110-2019-08-20))

Since it is now available in all 3 major package managing CLI tools I think this repo should make use of the additional fields in package.json to silence the warnings.

Note: a similar PR has been made to the Commando repository: https://github.com/discordjs/Commando/pull/278

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.