### PR TITLE
Consider messages deleted if their channel is deleted

### DIFF
--- a/src/client/actions/ChannelDelete.js
+++ b/src/client/actions/ChannelDelete.js
@@ -2,6 +2,7 @@
 
 const Action = require('./Action');
 const { Events } = require('../../util/Constants');
+const DMChannel = require('../../structures/DMChannel');
 
 class ChannelDeleteAction extends Action {
   constructor(client) {
@@ -16,6 +17,11 @@ class ChannelDeleteAction extends Action {
     if (channel) {
       client.channels.remove(channel.id);
       channel.deleted = true;
+      if (channel.messages && !(channel instanceof DMChannel)) {
+        for (const message of channel.messages.values()) {
+          message.deleted = true;
+        }
+      }
       /**
        * Emitted whenever a channel is deleted.
        * @event Client#channelDelete


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Message#deleted as well as Message#deletable currently return false/true if the messages channel is deleted. Since our users use these properties to check if a message can be deleted before doing so this can lead to unexpected behavior.

If the channel is deleted the API will respond with an error since the respective endpoint is unavailable.

This PR attempts to change this behavior by setting messages deleted on channel_delete.
Since discord.js receives channel close events if DM channels are closed they should be excluded from this change. The typeof check should be more robust than checking the `.type` property and is possibly more likely to be detected should the class responsible for direct message channels be changed in the future.

The deletable getter will automatically carry the changes, since it checks `.deleted` implicitly.
 
I see no need to update typings, might have missed something though.
Unsure if this functionality should be considered breaking, as it does change the behavior of a property.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
