### PR TITLE
Handle voice errors outside of authenticated event

### DIFF
--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -93,12 +93,13 @@ class ClientVoiceManager {
         reject(reason);
       });
 
+      connection.on('error', reject);
+
       connection.once('authenticated', () => {
         connection.once('ready', () => {
           resolve(connection);
           connection.removeListener('error', reject);
         });
-        connection.on('error', reject);
         connection.once('disconnect', () => this.connections.delete(channel.guild.id));
       });
     });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Listening on the error event *outside* of the `authenticated` event.
While in most cases it works to only listen inside the `authenticated` event, sometimes it doesn't work and causes an unhandled error event which forces node to close.
See Issues:
https://github.com/discordjs/discord.js/issues/3487
https://github.com/discordjs/discord.js/issues/3476

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
