### PR TITLE
feat: add VoiceState#streaming

### DIFF
--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -54,6 +54,11 @@ class VoiceState extends Base {
      */
     this.sessionID = data.session_id;
     /**
+     * Whether this member is streaming using "Go Live"
+     * @type {boolean}
+     */
+    this.streaming = data.self_stream || false;
+    /**
      * The ID of the voice channel that this member is in
      * @type {?Snowflake}
      */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1579,6 +1579,7 @@ declare module 'discord.js' {
 		public serverDeaf?: boolean;
 		public serverMute?: boolean;
 		public sessionID?: string;
+		public streaming: boolean;
 		public readonly speaking: boolean | null;
 
 		public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;


### PR DESCRIPTION
The `|| false` is because discord doesn't include the [`self_stream`](https://discordapp.com/developers/docs/resources/voice#voice-state-object-voice-state-structure
) field when the member isn't streaming anymore for some reason

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
