### PR TITLE
fix: Util.parseEmoji

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -247,7 +247,9 @@ class Util {
     const uEmoji = /(?<unicode>[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}])/u;
     const dEmoji = /<?(?:(?<animated>a):)?(?<name>\w{2,32}):(?<id>\d{17,19})?>?/;
     const regex = new RegExp(`${dEmoji.source}|${uEmoji.source}`, 'u');
-    const { groups: { animated, name, id, unicode } } = text.match(regex);
+    const match = text.match(regex);
+    if (!match) return null;
+    const { groups: { animated, name, id, unicode } } = match;
     return { animated: Boolean(animated), name: name || unicode, id: id || null };
   }
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -246,8 +246,7 @@ class Util {
     // eslint-disable-next-line max-len
     const uEmoji = /(?<unicode>[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}])/u;
     const dEmoji = /<?(?:(?<animated>a):)?(?<name>\w{2,32}):(?<id>\d{17,19})?>?/;
-    const regex = new RegExp(`${dEmoji.source}|${uEmoji.source}`, 'u');
-    const match = text.match(regex);
+    const match = text.match(dEmoji) || text.match(uEmoji);
     if (!match) return null;
     const { groups: { animated, name, id, unicode } } = match;
     return { animated: Boolean(animated), name: name || unicode, id: id || null };

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -242,9 +242,17 @@ class Util {
    * @private
    */
   static parseEmoji(text) {
-    if (text.includes('%')) text = decodeURIComponent(text);
-    if (!text.includes(':')) return { animated: false, name: text, id: null };
-    const m = text.match(/<?(?:(a):)?(\w{2,32}):(\d{17,19})?>?/);
+    if (text !== decodeURIComponent(text)) text = decodeURIComponent(text);
+    // eslint-disable-next-line max-len
+    const emojiRegex = /[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}]/u;
+    const discordRegex = /<?(?:(a):)?(\w{2,32}):(\d{17,19})?>?/;
+    let m;
+    if (!text.match(discordRegex)) {
+      m = text.match(emojiRegex);
+      if(!m) return null;
+      return { animated: false, name: m[0], id: null };
+    }
+    m = text.match(discordRegex);
     if (!m) return null;
     return { animated: Boolean(m[1]), name: m[2], id: m[3] || null };
   }

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -244,17 +244,11 @@ class Util {
   static parseEmoji(text) {
     if (text !== decodeURIComponent(text)) text = decodeURIComponent(text);
     // eslint-disable-next-line max-len
-    const emojiRegex = /[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}]/u;
-    const discordRegex = /<?(?:(a):)?(\w{2,32}):(\d{17,19})?>?/;
-    let m;
-    if (!text.match(discordRegex)) {
-      m = text.match(emojiRegex);
-      if (!m) return null;
-      return { animated: false, name: m[0], id: null };
-    }
-    m = text.match(discordRegex);
-    if (!m) return null;
-    return { animated: Boolean(m[1]), name: m[2], id: m[3] || null };
+    const uEmoji = /(?<unicode>[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}])/u;
+    const dEmoji = /<?(?:(?<animated>a):)?(?<name>\w{2,32}):(?<id>\d{17,19})?>?/;
+    const regex = new RegExp(`${dEmoji.source}|${uEmoji.source}`, 'u');
+    const { groups: { animated, name, id, unicode } } = text.match(regex);
+    return { animated: Boolean(animated), name: name || unicode, id: id || null };
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -249,7 +249,7 @@ class Util {
     let m;
     if (!text.match(discordRegex)) {
       m = text.match(emojiRegex);
-      if(!m) return null;
+      if (!m) return null;
       return { animated: false, name: m[0], id: null };
     }
     m = text.match(discordRegex);

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -242,9 +242,10 @@ class Util {
    * @private
    */
   static parseEmoji(text) {
-    if (text !== decodeURIComponent(text)) text = decodeURIComponent(text);
+    const decoded = decodeURIComponent(text);
+    if (text !== decoded) text = decoded;
     // eslint-disable-next-line max-len
-    const uEmoji = /(?<unicode>[\u{1f300}-\u{1f5ff}\u{1f900}-\u{1f9ff}\u{1f600}-\u{1f64f}\u{1f680}-\u{1f6ff}\u{2600}-\u{26ff}\u{2700}-\u{27bf}\u{1f1e6}-\u{1f1ff}\u{1f191}-\u{1f251}\u{1f004}\u{1f0cf}\u{1f170}-\u{1f171}\u{1f17e}-\u{1f17f}\u{1f18e}\u{3030}\u{2b50}\u{2b55}\u{2934}-\u{2935}\u{2b05}-\u{2b07}\u{2b1b}-\u{2b1c}\u{3297}\u{3299}\u{303d}\u{00a9}\u{00ae}\u{2122}\u{23f3}\u{24c2}\u{23e9}-\u{23ef}\u{25b6}\u{23f8}-\u{23fa}])/u;
+    const uEmoji = /(?<unicode>\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])/;
     const dEmoji = /<?(?:(?<animated>a):)?(?<name>\w{2,32}):(?<id>\d{17,19})?>?/;
     const match = text.match(dEmoji) || text.match(uEmoji);
     if (!match) return null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fixes Util.parseEmoji, currently if you provide a string like "hello this is a ❤ emoji" it would return:
```js
{ animated: false, name: 'hello this is a ❤ emoji', id: null }
```
which is unexpected behaviour, as it should return "❤" as `.name`, this PR fixes that.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
