### PR TITLE
feat: dynamic property for ImageURLOptions

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -426,9 +426,9 @@ class Guild extends Base {
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
-  iconURL({ format, size } = {}) {
+  iconURL({ format, size, dynamic } = {}) {
     if (!this.icon) return null;
-    return this.client.rest.cdn.Icon(this.id, this.icon, format, size);
+    return this.client.rest.cdn.Icon(this.id, this.icon, format, size, dynamic);
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -133,9 +133,9 @@ class User extends Base {
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
-  avatarURL({ format, size } = {}) {
+  avatarURL({ format, size, dynamic } = {}) {
     if (!this.avatar) return null;
-    return this.client.rest.cdn.Avatar(this.id, this.avatar, format, size);
+    return this.client.rest.cdn.Avatar(this.id, this.avatar, format, size, dynamic);
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -131,13 +131,13 @@ exports.Endpoints = {
       Emoji: (emojiID, format = 'png') => `${root}/emojis/${emojiID}.${format}`,
       Asset: name => `${root}/assets/${name}`,
       DefaultAvatar: discriminator => `${root}/embed/avatars/${discriminator}.png`,
-      Avatar: (userID, hash, format = 'webp', dynamic = true, size) => {
+      Avatar: (userID, hash, format = 'webp', size, dynamic = true) => {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/avatars/${userID}/${hash}`, { format, size });
       },
       Banner: (guildID, hash, format = 'webp', size) =>
         makeImageUrl(`${root}/banners/${guildID}/${hash}`, { format, size }),
-      Icon: (guildID, hash, format = 'webp', dynamic = true, size) => {
+      Icon: (guildID, hash, format = 'webp', size, dynamic = true) => {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size });
       },

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -121,7 +121,7 @@ function makeImageUrl(root, { format = 'webp', size } = {}) {
  * @property {string} [format] One of `webp`, `png`, `jpg`, `gif`. If no format is provided,
  * defaults to `webp`.
  * @property {boolean} [dynamic] If true, the format will dynamically change to `gif` for
- * animated avatars; the default is true.
+ * animated avatars; the default is false.
  * @property {number} [size] One of `16`, `32`, `64`, `128`, `256`, `512`, `1024`, `2048`
  */
 
@@ -131,13 +131,13 @@ exports.Endpoints = {
       Emoji: (emojiID, format = 'png') => `${root}/emojis/${emojiID}.${format}`,
       Asset: name => `${root}/assets/${name}`,
       DefaultAvatar: discriminator => `${root}/embed/avatars/${discriminator}.png`,
-      Avatar: (userID, hash, format = 'webp', size, dynamic = true) => {
+      Avatar: (userID, hash, format = 'webp', size, dynamic = false) => {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/avatars/${userID}/${hash}`, { format, size });
       },
       Banner: (guildID, hash, format = 'webp', size) =>
         makeImageUrl(`${root}/banners/${guildID}/${hash}`, { format, size }),
-      Icon: (guildID, hash, format = 'webp', size, dynamic = true) => {
+      Icon: (guildID, hash, format = 'webp', size, dynamic = false) => {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size });
       },

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -119,7 +119,9 @@ function makeImageUrl(root, { format = 'webp', size } = {}) {
  * Options for Image URLs.
  * @typedef {Object} ImageURLOptions
  * @property {string} [format] One of `webp`, `png`, `jpg`, `gif`. If no format is provided,
- * it will be `gif` for animated avatars or otherwise `webp`
+ * defaults to `webp`.
+ * @property {boolean} [dynamic] If true, the format will dynamically change to `gif` for
+ * animated avatars; the default is true.
  * @property {number} [size] One of `16`, `32`, `64`, `128`, `256`, `512`, `1024`, `2048`
  */
 
@@ -129,14 +131,14 @@ exports.Endpoints = {
       Emoji: (emojiID, format = 'png') => `${root}/emojis/${emojiID}.${format}`,
       Asset: name => `${root}/assets/${name}`,
       DefaultAvatar: discriminator => `${root}/embed/avatars/${discriminator}.png`,
-      Avatar: (userID, hash, format = 'default', size) => {
-        if (format === 'default') format = hash.startsWith('a_') ? 'gif' : 'webp';
+      Avatar: (userID, hash, format = 'webp', dynamic = true, size) => {
+        if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/avatars/${userID}/${hash}`, { format, size });
       },
       Banner: (guildID, hash, format = 'webp', size) =>
         makeImageUrl(`${root}/banners/${guildID}/${hash}`, { format, size }),
-      Icon: (guildID, hash, format = 'default', size) => {
-        if (format === 'default') format = hash.startsWith('a_') ? 'gif' : 'webp';
+      Icon: (guildID, hash, format = 'webp', dynamic = true, size) => {
+        if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size });
       },
       AppIcon: (clientID, hash, { format = 'webp', size } = {}) =>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -258,9 +258,9 @@ declare module 'discord.js' {
 		public name: string;
 		public owner: User | Team | null;
 		public rpcOrigins: string[];
-		public coverImage(options?: AvatarOptions): string;
+		public coverImage(options?: ImageURLOptions): string;
 		public fetchAssets(): Promise<ClientApplicationAsset>;
-		public iconURL(options?: AvatarOptions): string;
+		public iconURL(options?: ImageURLOptions): string;
 		public toJSON(): object;
 		public toString(): string;
 	}
@@ -277,7 +277,7 @@ declare module 'discord.js' {
 		public readonly createdAt: Date;
 		public readonly createdTimestamp: number;
 
-		public iconURL(options?: AvatarOptions): string;
+		public iconURL(options?: ImageURLOptions): string;
 		public toJSON(): object;
 		public toString(): string;
 	}
@@ -703,7 +703,7 @@ declare module 'discord.js' {
 		public widgetChannelID: Snowflake | null;
 		public widgetEnabled: boolean | null;
 		public addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
-		public bannerURL(options?: AvatarOptions): string | null;
+		public bannerURL(options?: ImageURLOptions): string | null;
 		public createIntegration(data: IntegrationData, reason?: string): Promise<Guild>;
 		public delete(): Promise<Guild>;
 		public edit(data: GuildEditData, reason?: string): Promise<Guild>;
@@ -717,7 +717,7 @@ declare module 'discord.js' {
 		public fetchVanityCode(): Promise<string>;
 		public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
-		public iconURL(options?: AvatarOptions): string | null;
+		public iconURL(options?: ImageURLOptions): string | null;
 		public leave(): Promise<Guild>;
 		public member(user: UserResolvable): GuildMember | null;
 		public setAFKChannel(afkChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
@@ -735,7 +735,7 @@ declare module 'discord.js' {
 		public setSplash(splash: Base64Resolvable | null, reason?: string): Promise<Guild>;
 		public setSystemChannel(systemChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
 		public setVerificationLevel(verificationLevel: number, reason?: string): Promise<Guild>;
-		public splashURL(options?: AvatarOptions): string | null;
+		public splashURL(options?: ImageURLOptions): string | null;
 		public toJSON(): object;
 		public toString(): string;
 	}
@@ -1149,8 +1149,8 @@ declare module 'discord.js' {
 		public largeText: string | null;
 		public smallImage: Snowflake | null;
 		public smallText: string | null;
-		public largeImageURL(options: AvatarOptions): string | null;
-		public smallImageURL(options: AvatarOptions): string | null;
+		public largeImageURL(options: ImageURLOptions): string | null;
+		public smallImageURL(options: ImageURLOptions): string | null;
 	}
 
 	export class Role extends Base {
@@ -1374,10 +1374,10 @@ declare module 'discord.js' {
 		public readonly presence: Presence;
 		public readonly tag: string;
 		public username: string;
-		public avatarURL(options?: AvatarOptions): string | null;
+		public avatarURL(options?: ImageURLOptions): string | null;
 		public createDM(): Promise<DMChannel>;
 		public deleteDM(): Promise<DMChannel>;
-		public displayAvatarURL(options?: AvatarOptions): string;
+		public displayAvatarURL(options?: ImageURLOptions): string;
 		public equals(user: User): boolean;
 		public fetch(): Promise<User>;
 		public toString(): string;
@@ -1947,8 +1947,9 @@ declare module 'discord.js' {
 		new?: any;
 	}
 
-	interface AvatarOptions {
+	interface ImageURLOptions {
 		format?: ImageExt;
+		dynamic?: boolean;
 		size?: ImageSize;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -717,7 +717,7 @@ declare module 'discord.js' {
 		public fetchVanityCode(): Promise<string>;
 		public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
-		public iconURL(options?: ImageURLOptions): string | null;
+		public iconURL(options?: ImageURLOptions & {dynamic?: boolean}): string | null;
 		public leave(): Promise<Guild>;
 		public member(user: UserResolvable): GuildMember | null;
 		public setAFKChannel(afkChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
@@ -1374,10 +1374,10 @@ declare module 'discord.js' {
 		public readonly presence: Presence;
 		public readonly tag: string;
 		public username: string;
-		public avatarURL(options?: ImageURLOptions): string | null;
+		public avatarURL(options?: ImageURLOptions & {dynamic?: boolean}): string | null;
 		public createDM(): Promise<DMChannel>;
 		public deleteDM(): Promise<DMChannel>;
-		public displayAvatarURL(options?: ImageURLOptions): string;
+		public displayAvatarURL(options?: ImageURLOptions & {dynamic?: boolean}): string;
 		public equals(user: User): boolean;
 		public fetch(): Promise<User>;
 		public toString(): string;
@@ -1950,7 +1950,6 @@ declare module 'discord.js' {
 	interface ImageURLOptions {
 		format?: ImageExt;
 		size?: ImageSize;
-		dynamic?: boolean;
 	}
 
 	interface AwaitMessagesOptions extends MessageCollectorOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1949,8 +1949,8 @@ declare module 'discord.js' {
 
 	interface ImageURLOptions {
 		format?: ImageExt;
-		dynamic?: boolean;
 		size?: ImageSize;
+		dynamic?: boolean;
 	}
 
 	interface AwaitMessagesOptions extends MessageCollectorOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -717,7 +717,7 @@ declare module 'discord.js' {
 		public fetchVanityCode(): Promise<string>;
 		public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
-		public iconURL(options?: ImageURLOptions & {dynamic?: boolean}): string | null;
+		public iconURL(options?: ImageURLOptions & { dynamic?: boolean }): string | null;
 		public leave(): Promise<Guild>;
 		public member(user: UserResolvable): GuildMember | null;
 		public setAFKChannel(afkChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
@@ -1374,10 +1374,10 @@ declare module 'discord.js' {
 		public readonly presence: Presence;
 		public readonly tag: string;
 		public username: string;
-		public avatarURL(options?: ImageURLOptions & {dynamic?: boolean}): string | null;
+		public avatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string | null;
 		public createDM(): Promise<DMChannel>;
 		public deleteDM(): Promise<DMChannel>;
-		public displayAvatarURL(options?: ImageURLOptions & {dynamic?: boolean}): string;
+		public displayAvatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string;
 		public equals(user: User): boolean;
 		public fetch(): Promise<User>;
 		public toString(): string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I added a property named `dynamic` to `ImageURLOptions` which will return a `gif` url if the image is animated, and a url in the type of format you specified otherwise (`webp` if nothing is specified). `webp` images don't display on my phone, so personally I would prefer to have a `png` link instead. 

Example:
```ts
//Returns gif url if the icon is animated, png otherwise. 
message.guild.iconURL({format: "png", dynamic: true}) 
```
Again maybe I'm wrong, but `AvatarOptions` in the typings seems to refer to the same thing as `ImageURLOptions`, so I renamed it since it's the name used in the docs. 

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed) (Minor)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
