### PR TITLE
fix(Message): check for edited_timestamp in data when patching message

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -219,7 +219,7 @@ class Message extends Base {
     const clone = this._clone();
     this._edits.unshift(clone);
 
-	if ('edited_timestamp' in data) this.editedTimestamp = new Date(data.edited_timestamp).getTime();
+    if ('edited_timestamp' in data) this.editedTimestamp = new Date(data.edited_timestamp).getTime();
     if ('content' in data) this.content = data.content;
     if ('pinned' in data) this.pinned = data.pinned;
     if ('tts' in data) this.tts = data.tts;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -219,7 +219,7 @@ class Message extends Base {
     const clone = this._clone();
     this._edits.unshift(clone);
 
-    this.editedTimestamp = new Date(data.edited_timestamp).getTime();
+    this.editedTimestamp = data.edited_timestamp ? new Date(data.edited_timestamp).getTime() : null;
     if ('content' in data) this.content = data.content;
     if ('pinned' in data) this.pinned = data.pinned;
     if ('tts' in data) this.tts = data.tts;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -219,7 +219,7 @@ class Message extends Base {
     const clone = this._clone();
     this._edits.unshift(clone);
 
-    this.editedTimestamp = data.edited_timestamp ? new Date(data.edited_timestamp).getTime() : null;
+	if ('edited_timestamp' in data) this.editedTimestamp = new Date(data.edited_timestamp).getTime();
     if ('content' in data) this.content = data.content;
     if ('pinned' in data) this.pinned = data.pinned;
     if ('tts' in data) this.tts = data.tts;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

If `data.edited_timestamp` is `undefined`, `this.editedTimestamp` becomes `NaN`. An example of when this happens is when you send an embed.

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
