### PR TITLE
docs: VoiceStateUpdate always sends an instance of VoiceState

### DIFF
--- a/src/client/actions/VoiceStateUpdate.js
+++ b/src/client/actions/VoiceStateUpdate.js
@@ -33,7 +33,7 @@ class VoiceStateUpdate extends Action {
       /**
        * Emitted whenever a member changes voice state - e.g. joins/leaves a channel, mutes/unmutes.
        * @event Client#voiceStateUpdate
-       * @param {?VoiceState} oldState The voice state before the update
+       * @param {VoiceState} oldState The voice state before the update
        * @param {VoiceState} newState The voice state after the update
        */
       client.emit(Events.VOICE_STATE_UPDATE, oldState, newState);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -197,7 +197,7 @@ declare module 'discord.js' {
 		public on(event: 'roleUpdate', listener: (oldRole: Role, newRole: Role) => void): this;
 		public on(event: 'typingStart' | 'typingStop', listener: (channel: Channel | PartialChannel, user: User | PartialUser) => void): this;
 		public on(event: 'userUpdate', listener: (oldUser: User | PartialUser, newUser: User | PartialUser) => void): this;
-		public on(event: 'voiceStateUpdate', listener: (oldState: VoiceState | undefined, newState: VoiceState) => void): this;
+		public on(event: 'voiceStateUpdate', listener: (oldState: VoiceState, newState: VoiceState) => void): this;
 		public on(event: 'webhookUpdate', listener: (channel: TextChannel) => void): this;
 		public on(event: 'invalidated', listener: () => void): this;
 		public on(event: 'shardDisconnect', listener: (event: CloseEvent, id: number) => void): this;
@@ -234,7 +234,7 @@ declare module 'discord.js' {
 		public once(event: 'roleUpdate', listener: (oldRole: Role, newRole: Role) => void): this;
 		public once(event: 'typingStart' | 'typingStop', listener: (channel: Channel | PartialChannel, user: User | PartialUser) => void): this;
 		public once(event: 'userUpdate', listener: (oldUser: User | PartialUser, newUser: User | PartialUser) => void): this;
-		public once(event: 'voiceStateUpdate', listener: (oldState: VoiceState | undefined, newState: VoiceState) => void): this;
+		public once(event: 'voiceStateUpdate', listener: (oldState: VoiceState, newState: VoiceState) => void): this;
 		public once(event: 'webhookUpdate', listener: (channel: TextChannel) => void): this;
 		public once(event: 'invalidated', listener: () => void): this;
 		public once(event: 'shardDisconnect', listener: (event: CloseEvent, id: number) => void): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

ref:

https://github.com/discordjs/discord.js/blob/c3228b426370a6cc5d48cb41e28bbe9f731e8473/src/client/actions/VoiceStateUpdate.js#L13-L15

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
