### PR TITLE
fix(User): dmChannel recipient check for partials

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -202,7 +202,7 @@ class User extends Base {
    * @readonly
    */
   get dmChannel() {
-    return this.client.channels.find(c => c.type === 'dm' && c.recipient.id === this.id) || null;
+    return this.client.channels.find(c => c.type === 'dm' && (c.recipient && c.recipient.id === this.id)) || null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes `TypeError: Cannot read property 'id' of undefined` error from occurring sometimes when sending DM messages to users while `Message` and `Channel` partials are enabled.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
