### PR TITLE
Fix typings for Emoji class on master

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -651,13 +651,13 @@ declare module 'discord.js' {
 	export class Emoji extends Base {
 		constructor(client: Client, emoji: object);
 		public animated: boolean;
-		public readonly createdAt: Date;
-		public readonly createdTimestamp: number;
-		public readonly deletable: boolean;
-		public id: Snowflake;
+		public readonly createdAt: Date | null;
+		public readonly createdTimestamp: number | null;
+		public deleted: boolean;
+		public id: Snowflake | null;
 		public name: string;
 		public readonly identifier: string;
-		public readonly url: string;
+		public readonly url: string | null;
 		public toJSON(): object;
 		public toString(): string;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes typing being inconsistent with the master version of Emoji class.
Originally found in Discord: https://discordapp.com/channels/222078108977594368/223867697312694272/63465929058549760

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
