### PR TITLE
Typings: restore deletable on GuildEmoji

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -833,7 +833,6 @@ declare module 'discord.js' {
 		private _roles: string[];
 
 		public available: boolean;
-		public deleted: boolean;
 		public readonly deletable: boolean;
 		public guild: Guild;
 		public managed: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -834,6 +834,7 @@ declare module 'discord.js' {
 
 		public available: boolean;
 		public deleted: boolean;
+		public readonly deletable: boolean;
 		public guild: Guild;
 		public managed: boolean;
 		public requiresColons: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Typings-only update.
PR #3542 accidentally resulted in removal of `deletable` on `GuildEmoji` - this PR fixes it.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
