### PR TITLE
Proper AwaitMessages Handling For 1 Message

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -277,7 +277,7 @@ class TextBasedChannel {
         if (options.errors && options.errors.includes(reason)) {
           reject(collection);
         } else {
-          resolve(collection);
+          resolve(options.max && options.max === 1 ? collection.first() : collection);
         }
       });
     });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1875,7 +1875,7 @@ declare module 'discord.js' {
 	interface TextBasedChannelFields extends PartialTextBasedChannelFields {
 		typing: boolean;
 		typingCount: number;
-		awaitMessages(filter: CollectorFilter, options?: AwaitMessagesOptions & { max: 1 }): Promise<Message>;
+		awaitMessages(filter: CollectorFilter, options?: AwaitMessagesOptions & { max: 1 }): Promise<Message | undefined>;
 		awaitMessages(filter: CollectorFilter, options?: AwaitMessagesOptions): Promise<Collection<Snowflake, Message>>;
 		bulkDelete(messages: Collection<Snowflake, Message> | Message[] | Snowflake[] | number, filterOld?: boolean): Promise<Collection<Snowflake, Message>>;
 		createMessageCollector(filter: CollectorFilter, options?: MessageCollectorOptions): MessageCollector;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1875,6 +1875,7 @@ declare module 'discord.js' {
 	interface TextBasedChannelFields extends PartialTextBasedChannelFields {
 		typing: boolean;
 		typingCount: number;
+		awaitMessages(filter: CollectorFilter, options?: AwaitMessagesOptions & { max: 1 }): Promise<Message>;
 		awaitMessages(filter: CollectorFilter, options?: AwaitMessagesOptions): Promise<Collection<Snowflake, Message>>;
 		bulkDelete(messages: Collection<Snowflake, Message> | Message[] | Snowflake[] | number, filterOld?: boolean): Promise<Collection<Snowflake, Message>>;
 		createMessageCollector(filter: CollectorFilter, options?: MessageCollectorOptions): MessageCollector;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the proper handling of awaitMessages when you are only requesting one response. If a user provides a `{ max: 1 }` then it should NOT return a collection. It is like if `messages.fetch(id)` would return a collection of 1 message when you provide 1 id.

```js
const responses = await message.channel.awaitMessages(r => r.author === message.author, { max: 1, time: x });
const response = responses.first();
if (!response) return null;

// do something with a message
```

**Suggested:**
```js
const response = await message.channel.awaitMessages(r => r.author === message.author, { max: 1, time: x });
if (!response) return null;

// do something with a message
```

Reference:
```ts
public fetch(message: Snowflake, cache?: boolean): Promise<Message>;
public fetch(options?: ChannelLogsQueryOptions, cache?: boolean): Promise<Collection<Snowflake, Message>>;
```

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
