### PR TITLE
Fix broken opus voice streams

### DIFF
--- a/src/client/voice/receiver/PacketHandler.js
+++ b/src/client/voice/receiver/PacketHandler.js
@@ -63,7 +63,9 @@ class PacketHandler extends EventEmitter {
         if (byte === 0) continue;
         offset += 1 + (0b1111 & (byte >> 4));
       }
-      while (packet[offset] === 0) offset++;
+      // Skip over undocumented Discord byte
+      offset++;
+
       packet = packet.slice(offset);
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes https://github.com/discordjs/discord.js/issues/3550. 

As mentioned in [my comment](https://github.com/discordjs/discord.js/issues/3550#issuecomment-546559404) a wrong assumption was seemingly made about incoming discord voice packets, which got revealed during a recent discord change that broke Opus voice streams. Right after the RTP Header Extensions and just before the Opus packet is a single undocumented byte that is seemingly used by the Discord client. Previously this byte was always 0x00 and probably assumed to be padding, but now it is 0x02 for most regular voice packets and 0x00 for tiny/silent voice packets.

Inspecting many packets I could always only find this single byte. This change ensures it is always skipped over, so the Opus packet is correctly isolated again.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
