### PR TITLE
typings(Util): use StringResolvable (fixes old pull)

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1447,7 +1447,7 @@ declare module 'discord.js' {
 			route: object,
 			reason?: string
 		): Promise<{ id: Snowflake; position: number }[]>;
-		public static splitMessage(text: string, options?: SplitOptions): string[];
+		public static splitMessage(text: StringResolvable, options?: SplitOptions): string[];
 		public static str2ab(str: string): ArrayBuffer;
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes my extremely old pull #3212 that didn't actually update the typing (Didn't know at the time, I thought it just meant the jsdoc comments). Apologies! I'm not sure how I suddenly remembered 200 days later after learning some typescript.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating
*^ actually made sure this time*

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
