### PR TITLE
Add systemChannelFlags bitfield to Guild

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ module.exports = {
   Snowflake: require('./util/Snowflake'),
   SnowflakeUtil: require('./util/Snowflake'),
   Structures: require('./util/Structures'),
+  SystemChannelFlags: require('./util/SystemChannelFlags'),
   Util: Util,
   util: Util,
   version: require('../package.json').version,

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -277,8 +277,8 @@ class Guild extends Base {
       data.default_message_notifications;
 
     /**
-     * The value set for the guild's default message notifications
-     * @type {SystemChannelFlags}
+     * The value set for the guild's system channel flags
+     * @type {ReadOnly<SystemChannelFlags>}
      */
     this.systemChannelFlags = new SystemChannelFlags(data.system_channel_flags).freeze();
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -10,6 +10,7 @@ const Collection = require('../util/Collection');
 const Util = require('../util/Util');
 const DataResolver = require('../util/DataResolver');
 const Snowflake = require('../util/Snowflake');
+const SystemChannelFlags = require('../util/SystemChannelFlags');
 const GuildMemberStore = require('../stores/GuildMemberStore');
 const RoleStore = require('../stores/RoleStore');
 const GuildEmojiStore = require('../stores/GuildEmojiStore');
@@ -274,6 +275,12 @@ class Guild extends Base {
      */
     this.defaultMessageNotifications = DefaultMessageNotifications[data.default_message_notifications] ||
       data.default_message_notifications;
+
+    /**
+     * The value set for the guild's default message notifications
+     * @type {SystemChannelFlags}
+     */
+    this.systemChannelFlags = new SystemChannelFlags(data.system_channel_flags).freeze();
 
     /**
      * The maximum amount of members the guild can have
@@ -773,6 +780,7 @@ class Guild extends Base {
    * @property {Base64Resolvable} [splash] The splash screen of the guild
    * @property {Base64Resolvable} [banner] The banner of the guild
    * @property {DefaultMessageNotifications|number} [defaultMessageNotifications] The default message notifications
+   * @property {SystemChannelFlags} [systemChannelFlags] The system channel settings of the guild
    */
 
   /**
@@ -813,6 +821,9 @@ class Guild extends Base {
         DefaultMessageNotifications.indexOf(data.defaultMessageNotifications) :
         Number(data.defaultMessageNotifications);
     }
+    if (typeof data.systemChannelFlags !== 'undefined') {
+      _data.systemChannelFlags = SystemChannelFlags.resolve(data.systemChannelFlags);
+    }
     return this.client.api.guilds(this.id).patch({ data: _data, reason })
       .then(newData => this.client.actions.GuildUpdate.handle(newData).updated);
   }
@@ -838,6 +849,16 @@ class Guild extends Base {
     return this.edit({ defaultMessageNotifications }, reason);
   }
   /* eslint-enable max-len */
+
+  /**
+   * Edits the setting of the default message notifications of the guild.
+   * @param {SystemChannelFlags} systemChannelFlags The new setting for the default message notifications
+   * @param {string} [reason] Reason for changing the setting of the default message notifications
+   * @returns {Promise<Guild>}
+   */
+  setSystemChannelFlags(systemChannelFlags, reason) {
+    return this.edit({ systemChannelFlags }, reason);
+  }
 
   /**
    * Edits the name of the guild.

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -780,7 +780,7 @@ class Guild extends Base {
    * @property {Base64Resolvable} [splash] The splash screen of the guild
    * @property {Base64Resolvable} [banner] The banner of the guild
    * @property {DefaultMessageNotifications|number} [defaultMessageNotifications] The default message notifications
-   * @property {SystemChannelFlags} [systemChannelFlags] The system channel flags of the guild
+   * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The system channel flags of the guild
    */
 
   /**
@@ -852,7 +852,7 @@ class Guild extends Base {
 
   /**
    * Edits the flags of the default message notifications of the guild.
-   * @param {SystemChannelFlags} systemChannelFlags The new flags for the default message notifications
+   * @param {SystemChannelFlagsResolvable} systemChannelFlags The new flags for the default message notifications
    * @param {string} [reason] Reason for changing the flags of the default message notifications
    * @returns {Promise<Guild>}
    */

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -278,7 +278,7 @@ class Guild extends Base {
 
     /**
      * The value set for the guild's system channel flags
-     * @type {ReadOnly<SystemChannelFlags>}
+     * @type {Readonly<SystemChannelFlags>}
      */
     this.systemChannelFlags = new SystemChannelFlags(data.system_channel_flags).freeze();
 
@@ -780,7 +780,7 @@ class Guild extends Base {
    * @property {Base64Resolvable} [splash] The splash screen of the guild
    * @property {Base64Resolvable} [banner] The banner of the guild
    * @property {DefaultMessageNotifications|number} [defaultMessageNotifications] The default message notifications
-   * @property {SystemChannelFlags} [systemChannelFlags] The system channel settings of the guild
+   * @property {SystemChannelFlags} [systemChannelFlags] The system channel flags of the guild
    */
 
   /**
@@ -851,9 +851,9 @@ class Guild extends Base {
   /* eslint-enable max-len */
 
   /**
-   * Edits the setting of the default message notifications of the guild.
-   * @param {SystemChannelFlags} systemChannelFlags The new setting for the default message notifications
-   * @param {string} [reason] Reason for changing the setting of the default message notifications
+   * Edits the flags of the default message notifications of the guild.
+   * @param {SystemChannelFlags} systemChannelFlags The new flags for the default message notifications
+   * @param {string} [reason] Reason for changing the flags of the default message notifications
    * @returns {Promise<Guild>}
    */
   setSystemChannelFlags(systemChannelFlags, reason) {

--- a/src/util/SystemChannelFlags.js
+++ b/src/util/SystemChannelFlags.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const BitField = require('./BitField');
+
+/**
+ * Data structure that makes it easy to interact with an {@link SystemChannelFlags#flags} bitfield.
+ * <info>Note that both welcome messages and boost messages are enabled by default,
+ * and by setting their corresponding flags you are disabling them.</info>
+ * @extends {BitField}
+ */
+class SystemChannelFlags extends BitField {}
+
+/**
+ * Numeric system channel flags. All available properties:
+ * * `WELCOME_MESSAGE_DISABLED`
+ * * `BOOST_MESSAGE_DISABLED`
+ * @type {Object}
+ */
+SystemChannelFlags.FLAGS = {
+  BOOST_MESSAGE_DISABLED: 1 << 0,
+  WELCOME_MESSAGE_DISABLED: 1 << 1,
+};
+
+module.exports = SystemChannelFlags;

--- a/src/util/SystemChannelFlags.js
+++ b/src/util/SystemChannelFlags.js
@@ -12,8 +12,8 @@ class SystemChannelFlags extends BitField {}
 
 /**
  * Numeric system channel flags. All available properties:
- * * `WELCOME_MESSAGE_DISABLED`
  * * `BOOST_MESSAGE_DISABLED`
+ * * `WELCOME_MESSAGE_DISABLED`
  * @type {Object}
  */
 SystemChannelFlags.FLAGS = {

--- a/src/util/SystemChannelFlags.js
+++ b/src/util/SystemChannelFlags.js
@@ -3,22 +3,22 @@
 const BitField = require('./BitField');
 
 /**
- * Data structure that makes it easy to interact with an {@link SystemChannelFlags#flags} bitfield.
- * <info>Note that both welcome messages and boost messages are enabled by default,
- * and by setting their corresponding flags you are disabling them.</info>
+ * Data structure that makes it easy to interact with a {@link Guild#systemChannelFlags} bitfield.
+ * <info>Note that all event message types are enabled by default,
+ * and by setting their corresponding flags you are disabling them</info>
  * @extends {BitField}
  */
 class SystemChannelFlags extends BitField {}
 
 /**
  * Numeric system channel flags. All available properties:
- * * `BOOST_MESSAGE_DISABLED`
  * * `WELCOME_MESSAGE_DISABLED`
+ * * `BOOST_MESSAGE_DISABLED`
  * @type {Object}
  */
 SystemChannelFlags.FLAGS = {
-  BOOST_MESSAGE_DISABLED: 1 << 0,
-  WELCOME_MESSAGE_DISABLED: 1 << 1,
+  WELCOME_MESSAGE_DISABLED: 1 << 0,
+  BOOST_MESSAGE_DISABLED: 1 << 1,
 };
 
 module.exports = SystemChannelFlags;

--- a/src/util/SystemChannelFlags.js
+++ b/src/util/SystemChannelFlags.js
@@ -8,7 +8,16 @@ const BitField = require('./BitField');
  * and by setting their corresponding flags you are disabling them</info>
  * @extends {BitField}
  */
-class SystemChannelFlags extends BitField {}
+class SystemChannelFlags extends BitField {
+  /**
+   * Data that can be resolved to give a sytem channel flag bitfield. This can be:
+   * * A string (see {@link SystemChannelFlags.FLAGS})
+   * * A sytem channel flag
+   * * An instance of SystemChannelFlags
+   * * An Array of SystemChannelFlagsResolvable
+   * @typedef {string|number|SystemChannelFlags|SystemChannelFlagsResolvable[]} SystemChannelFlagsResolvable
+   */
+}
 
 /**
  * Numeric system channel flags. All available properties:

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -753,7 +753,7 @@ declare module 'discord.js' {
 		public setRolePositions(rolePositions: RolePosition[]): Promise<Guild>;
 		public setSplash(splash: Base64Resolvable | null, reason?: string): Promise<Guild>;
 		public setSystemChannel(systemChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
-		public setSystemChannelFlags(systemChannelFlags: SystemChannelFlags, reason?: string): Promise<Guild>;
+		public setSystemChannelFlags(systemChannelFlags: SystemChannelFlagsResolvable, reason?: string): Promise<Guild>;
 		public setVerificationLevel(verificationLevel: number, reason?: string): Promise<Guild>;
 		public splashURL(options?: AvatarOptions): string | null;
 		public toJSON(): object;
@@ -2598,6 +2598,8 @@ declare module 'discord.js' {
 
 	type SystemChannelFlagsString = 'WELCOME_MESSAGE_DISABLED'
 		| 'BOOST_MESSAGE_DISABLED';
+
+	type SystemChannelFlagsResolvable = BitFieldResolvable<SystemChannelFlagsString>;
 
 	type TargetUser = number;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -711,6 +711,7 @@ declare module 'discord.js' {
 		public shardID: number;
 		public splash: string | null;
 		public readonly systemChannel: TextChannel | null;
+		public readonly systemChannelFlags: SystemChannelFlags;
 		public systemChannelID: Snowflake | null;
 		public vanityURLCode: string | null;
 		public verificationLevel: number;
@@ -752,6 +753,7 @@ declare module 'discord.js' {
 		public setRolePositions(rolePositions: RolePosition[]): Promise<Guild>;
 		public setSplash(splash: Base64Resolvable | null, reason?: string): Promise<Guild>;
 		public setSystemChannel(systemChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
+		public setSystemChannelFlags(systemChannelFlags: SystemChannelFlags, reason?: string): Promise<Guild>;
 		public setVerificationLevel(verificationLevel: number, reason?: string): Promise<Guild>;
 		public splashURL(options?: AvatarOptions): string | null;
 		public toJSON(): object;
@@ -1361,6 +1363,11 @@ declare module 'discord.js' {
 		static get(structure: string): Function;
 		static extend<K extends keyof Extendable, T extends Extendable[K]>(structure: K, extender: (baseClass: Extendable[K]) => T): T;
 		static extend<T extends Function>(structure: string, extender: (baseClass: typeof Function) => T): T;
+	}
+
+	export class SystemChannelFlags extends BitField<SystemChannelFlagsString> {
+		public static FLAGS: Record<SystemChannelFlagsString, number>;
+		public static resolve(bit?: BitFieldResolvable<SystemChannelFlagsString>): number;
 	}
 
 	export class TextChannel extends TextBasedChannel(GuildChannel) {
@@ -2260,6 +2267,7 @@ declare module 'discord.js' {
 		defaultMessageNotifications?: DefaultMessageNotifications | number;
 		afkChannel?: ChannelResolvable;
 		systemChannel?: ChannelResolvable;
+		systemChannelFlags?: SystemChannelFlags;
 		afkTimeout?: number;
 		icon?: Base64Resolvable;
 		owner?: GuildMemberResolvable;
@@ -2587,6 +2595,9 @@ declare module 'discord.js' {
 	type StreamType = 'unknown' | 'converted' | 'opus' | 'ogg/opus' | 'webm/opus';
 
 	type StringResolvable = string | string[] | any;
+
+	type SystemChannelFlagsString = 'WELCOME_MESSAGE_DISABLED'
+		| 'BOOST_MESSAGE_DISABLED';
 
 	type TargetUser = number;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -711,7 +711,7 @@ declare module 'discord.js' {
 		public shardID: number;
 		public splash: string | null;
 		public readonly systemChannel: TextChannel | null;
-		public readonly systemChannelFlags: SystemChannelFlags;
+		public systemChannelFlags: Readonly<SystemChannelFlags>;
 		public systemChannelID: Snowflake | null;
 		public vanityURLCode: string | null;
 		public verificationLevel: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The current library lacks a field in the `Guild` object for the `system_channel_flags` bitfield, which indicates if welcome messages and boost messages are enabled. This PR adds this property to the `Guild` object.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
