### PR TITLE
feat(MessageAttachment): add spoiler property

### DIFF
--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -79,12 +79,14 @@ class MessageAttachment {
      * @type {?number}
      */
     this.width = typeof data.width !== 'undefined' ? data.width : null;
+  }
 
-    /**
-     * Whether or not this attachment has been marked as a spoiler
-     * @type {boolean}
-     */
-    this.spoiler = this.url.split('/').pop().startsWith('SPOILER_');
+  /**
+   * Whether or not this attachment has been marked as a spoiler
+   * @type {boolean}
+   */
+  get spoiler() {
+    return Util.basename(this.url).startsWith('SPOILER_');
   }
 
   toJSON() {

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -79,6 +79,12 @@ class MessageAttachment {
      * @type {?number}
      */
     this.width = typeof data.width !== 'undefined' ? data.width : null;
+
+    /**
+     * Whether or not this attachment has been marked as a spoiler
+     * @type {boolean}
+     */
+    this.spoiler = this.url.split('/').pop().startsWith('SPOILER_');
   }
 
   toJSON() {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1006,7 +1006,7 @@ declare module 'discord.js' {
 		public size: number;
 		public url: string;
 		public width: number | null;
-		public spoiler: boolean;
+		public readonly spoiler: boolean;
 		public setFile(attachment: BufferResolvable | Stream, name?: string): this;
 		public setName(name: string): this;
 		public toJSON(): object;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1006,6 +1006,7 @@ declare module 'discord.js' {
 		public size: number;
 		public url: string;
 		public width: number | null;
+		public spoiler: boolean;
 		public setFile(attachment: BufferResolvable | Stream, name?: string): this;
 		public setName(name: string): this;
 		public toJSON(): object;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
QoL addition for checking if the attachment has been marked as a spoiler.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
