### PR TITLE
feat(GuildMemberStore): add options.withPresences to fetch()

### DIFF
--- a/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
+++ b/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
@@ -9,6 +9,9 @@ module.exports = (client, { d: data }) => {
   const members = new Collection();
 
   for (const member of data.members) members.set(member.user.id, guild.members.add(member));
+  if (data.presences) {
+    for (const presence of data.presences) guild.presences.add(Object.assign(presence, { guild }));
+  }
   /**
    * Emitted whenever a chunk of guild members is received (all members come from the same guild).
    * @event Client#guildMembersChunk

--- a/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
+++ b/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
@@ -10,7 +10,7 @@ module.exports = (client, { d: data }) => {
 
   for (const member of data.members) members.set(member.user.id, guild.members.add(member));
   if (data.presences) {
-    for (const presence of data.presences) guild.presences.add(Object.assign(presence, { guild }));
+    for (const presence of data.presences) guild.presences.cache.add(Object.assign(presence, { guild }));
   }
   /**
    * Emitted whenever a chunk of guild members is received (all members come from the same guild).

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -72,8 +72,10 @@ class GuildMemberManager extends BaseManager {
   /**
    * Options used to fetch multiple members from a guild.
    * @typedef {Object} FetchMembersOptions
-   * @property {string} [query=''] Limit fetch to members with similar usernames
+   * @property {UserResolvable|UserResolvable[]} user The user(s) to fetch
+   * @property {?string} query Limit fetch to members with similar usernames
    * @property {number} [limit=0] Maximum number of members to request
+   * @property {boolean} [withPresences=false] Whether or not to include the presences
    */
 
   /**
@@ -98,6 +100,11 @@ class GuildMemberManager extends BaseManager {
    *   .then(console.log)
    *   .catch(console.error);
    * @example
+   * // Fetch by an array of users including their presences
+   * guild.members.fetch({ user: ['66564597481480192', '191615925336670208'], withPresences: true })
+   *   .then(console.log)
+   *   .catch(console.error);
+   * @example
    * // Fetch by query
    * guild.members.fetch({ query: 'hydra', limit: 1 })
    *   .then(console.log)
@@ -108,8 +115,13 @@ class GuildMemberManager extends BaseManager {
     const user = this.client.users.resolveID(options);
     if (user) return this._fetchSingle({ user, cache: true });
     if (options.user) {
-      options.user = this.client.users.resolveID(options.user);
-      if (options.user) return this._fetchSingle(options);
+      if (Array.isArray(options.user)) {
+        options.user = options.user.map(u => this.client.users.resolveID(u));
+        return this._fetchMany(options);
+      } else {
+        options.user = this.client.users.resolveID(options.user);
+      }
+      if (!options.limit && !options.withPresences) return this._fetchSingle(options);
     }
     return this._fetchMany(options);
   }
@@ -200,32 +212,38 @@ class GuildMemberManager extends BaseManager {
       .then(data => this.add(data, cache));
   }
 
-  _fetchMany({ query = '', limit = 0 } = {}) {
+  _fetchMany({ limit = 0, withPresences: presences = false, user: user_ids, query } = {}) {
     return new Promise((resolve, reject) => {
-      if (this.guild.memberCount === this.cache.size && !query && !limit) {
+      if (this.guild.memberCount === this.size && (!query && !limit && !presences && !user_ids)) {
         resolve(this.cache);
         return;
       }
+      if (!query && !user_ids) query = '';
       this.guild.shard.send({
         op: OPCodes.REQUEST_GUILD_MEMBERS,
         d: {
           guild_id: this.guild.id,
+          presences,
+          user_ids,
           query,
           limit,
         },
       });
       const fetchedMembers = new Collection();
+      const option = query || limit || presences || user_ids;
       const handler = (members, guild) => {
         if (guild.id !== this.guild.id) return;
         timeout.refresh();
         for (const member of members.values()) {
-          if (query || limit) fetchedMembers.set(member.id, member);
+          if (option) fetchedMembers.set(member.id, member);
         }
         if (this.guild.memberCount <= this.cache.size ||
-          ((query || limit) && members.size < 1000) ||
+          (option && members.size < 1000) ||
           (limit && fetchedMembers.size >= limit)) {
           this.guild.client.removeListener(Events.GUILD_MEMBERS_CHUNK, handler);
-          resolve(query || limit ? fetchedMembers : this.cache);
+          let fetched = option ? fetchedMembers : this.cache;
+          if (user_ids && !Array.isArray(user_ids) && fetched.size) fetched = fetched.first();
+          resolve(fetched);
         }
       };
       const timeout = this.guild.client.setTimeout(() => {

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -214,7 +214,7 @@ class GuildMemberManager extends BaseManager {
 
   _fetchMany({ limit = 0, withPresences: presences = false, user: user_ids, query } = {}) {
     return new Promise((resolve, reject) => {
-      if (this.guild.memberCount === this.size && (!query && !limit && !presences && !user_ids)) {
+      if (this.guild.memberCount === this.cache.size && (!query && !limit && !presences && !user_ids)) {
         resolve(this.cache);
         return;
       }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1795,8 +1795,9 @@ declare module 'discord.js' {
 		public guild: Guild;
 		public ban(user: UserResolvable, options?: BanOptions): Promise<GuildMember | User | Snowflake>;
 		public fetch(options: UserResolvable | FetchMemberOptions): Promise<GuildMember>;
+		public fetch(options: FetchMembersOptions & { user: UserResolvable }): Promise<GuildMember>;
 		public fetch(options?: FetchMembersOptions): Promise<Collection<Snowflake, GuildMember>>;
-		public prune(options: GuildPruneMembersOptions & { dry?: false; count: false; }): Promise<null>;
+		public prune(options: GuildPruneMembersOptions & { dry?: false, count: false }): Promise<null>;
 		public prune(options?: GuildPruneMembersOptions): Promise<number>;
 		public unban(user: UserResolvable, reason?: string): Promise<User>;
 	}
@@ -2175,8 +2176,10 @@ declare module 'discord.js' {
 	}
 
 	interface FetchMembersOptions {
+		user?: UserResolvable | UserResolvable[];
 		query?: string;
 		limit?: number;
+		withPresences?: boolean;
 	}
 
 	interface FileOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1794,10 +1794,9 @@ declare module 'discord.js' {
 		constructor(guild: Guild, iterable?: Iterable<any>);
 		public guild: Guild;
 		public ban(user: UserResolvable, options?: BanOptions): Promise<GuildMember | User | Snowflake>;
-		public fetch(options: UserResolvable | FetchMemberOptions): Promise<GuildMember>;
-		public fetch(options: FetchMembersOptions & { user: UserResolvable }): Promise<GuildMember>;
+		public fetch(options: UserResolvable | FetchMemberOptions | (FetchMembersOptions & { user: UserResolvable })): Promise<GuildMember>;
 		public fetch(options?: FetchMembersOptions): Promise<Collection<Snowflake, GuildMember>>;
-		public prune(options: GuildPruneMembersOptions & { dry?: false, count: false }): Promise<null>;
+		public prune(options: GuildPruneMembersOptions & { dry?: false; count: false; }): Promise<null>;
 		public prune(options?: GuildPruneMembersOptions): Promise<number>;
 		public unban(user: UserResolvable, reason?: string): Promise<User>;
 	}


### PR DESCRIPTION

This PR adds support for [`presences`](https://github.com/discordapp/discord-api-docs/pull/1116/commits/12b414ee6627a1882452dc795c9b263a23ea28b9) field for the "Request Guild Members" gateway command along with making use of the [`user_ids`](https://discordapp.com/developers/docs/topics/gateway#request-guild-members-guild-request-members-structure) field which essentially allows you to fetch a presence on a member which is pretty useful for those who disable the `PRESENCE_UPDATE` event. The default value of an empty string for `options.query` has been removed in this PR since discord takes precedence on that over `user_ids` so it would always end up with all members being fetched and instead an empty string will be set within the `_fetchMany` method based on whether a `query` / `user` was passed into the options.



**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
