### PR TITLE
Fixed the Update Guide Link

### DIFF
--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -77,7 +77,7 @@ client.login('token');
 * [Website](https://discord.js.org/) ([source](https://github.com/discordjs/website))
 * [Documentation](https://discord.js.org/#/docs/main/master/general/welcome)
 * [Guide](https://discordjs.guide/) ([source](https://github.com/discordjs/guide)) - this is still for stable  
-  See also the WIP [Update Guide](https://github.com/discordjs/guide/blob/master/guide/additional-info/changes-in-v12.md) also including updated and removed items in the library.
+  See also the WIP [Update Guide](https://discordjs.guide/additional-info/changes-in-v12.html) also including updated and removed items in the library.
 * [Discord.js Discord server](https://discord.gg/bRCvFy9)
 * [Discord API Discord server](https://discord.gg/discord-api)
 * [GitHub](https://github.com/discordjs/discord.js)

--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -77,7 +77,7 @@ client.login('token');
 * [Website](https://discord.js.org/) ([source](https://github.com/discordjs/website))
 * [Documentation](https://discord.js.org/#/docs/main/master/general/welcome)
 * [Guide](https://discordjs.guide/) ([source](https://github.com/discordjs/guide)) - this is still for stable  
-  See also the WIP [Update Guide](https://github.com/discordjs/guide/blob/v12-changes/guide/additional-info/changes-in-v12.md) also including updated and removed items in the library.
+  See also the WIP [Update Guide](https://github.com/discordjs/guide/blob/master/guide/additional-info/changes-in-v12.md) also including updated and removed items in the library.
 * [Discord.js Discord server](https://discord.gg/bRCvFy9)
 * [Discord API Discord server](https://discord.gg/discord-api)
 * [GitHub](https://github.com/discordjs/discord.js)


### PR DESCRIPTION
Original link pointed to https://github.com/discordjs/guide/blob/v12-changes/guide/additional-info/changes-in-v12.md, which is invalid. I have changed the link to direct users to the Discord.JS guide (https://discordjs.guide/additional-info/changes-in-v12.html), as per @Androz2091's feedback.

**Please describe the changes this PR makes and why it should be merged:**
On the documentation for `master`, the original link to the Update Guide points to a "404 Not Found" page. 

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
