### PR TITLE
fix(ChannelDelete): mark messages of a deleted channel as deleted

### DIFF
--- a/src/client/actions/ChannelDelete.js
+++ b/src/client/actions/ChannelDelete.js
@@ -1,4 +1,5 @@
 const Action = require('./Action');
+const DMChannel = require('../../structures/DMChannel');
 
 class ChannelDeleteAction extends Action {
   constructor(client) {
@@ -17,7 +18,14 @@ class ChannelDeleteAction extends Action {
     } else {
       channel = this.deleted.get(data.id) || null;
     }
-    if (channel) channel.deleted = true;
+    if (channel) {
+      if (channel.messages && !(channel instanceof DMChannel)) {
+        for (const message of channel.messages.values()) {
+          message.deleted = true;
+        }
+      }
+      channel.deleted = true;
+    }
 
     return { channel };
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #3519, setting `Message#delete` to true once their channel was deleted.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
