### PR TITLE
typings(Bitfield): add hasParams to toArray, fix serialize's type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1124,7 +1124,7 @@ declare module 'discord.js' {
 		public static FLAGS: PermissionFlags;
 		public static resolve(permission?: PermissionResolvable): number;
 
-		public missing(bit: BitFieldResolvable<PermissionString>, checkAdmin?: boolean): PermissionString[];
+		public missing(bits: BitFieldResolvable<PermissionString>, checkAdmin?: boolean): PermissionString[];
 		public serialize(checkAdmin?: boolean): Record<PermissionString, boolean>;
 		public toArray(checkAdmin?: boolean): PermissionString[];
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -117,8 +117,8 @@ declare module 'discord.js' {
 		public has(bit: BitFieldResolvable<S>): boolean;
 		public missing(bits: BitFieldResolvable<S>, ...hasParams: any[]): S[];
 		public remove(...bits: BitFieldResolvable<S>[]): BitField<S>;
-		public serialize(...hasParams: BitFieldResolvable<S>[]): Record<S, boolean>;
-		public toArray(): S[];
+		public serialize(...hasParams: any[]): Record<S, boolean>;
+		public toArray(...hasParams: any[]): S[];
 		public toJSON(): number;
 		public valueOf(): number;
 		public [Symbol.iterator](): Iterator<S>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1118,15 +1118,14 @@ declare module 'discord.js' {
 	export class Permissions extends BitField<PermissionString> {
 		public any(permission: PermissionResolvable, checkAdmin?: boolean): boolean;
 		public has(permission: PermissionResolvable, checkAdmin?: boolean): boolean;
+		public missing(bits: BitFieldResolvable<PermissionString>, checkAdmin?: boolean): PermissionString[];
+		public serialize(checkAdmin?: boolean): Record<PermissionString, boolean>;
+		public toArray(checkAdmin?: boolean): PermissionString[];
 
 		public static ALL: number;
 		public static DEFAULT: number;
 		public static FLAGS: PermissionFlags;
 		public static resolve(permission?: PermissionResolvable): number;
-
-		public missing(bits: BitFieldResolvable<PermissionString>, checkAdmin?: boolean): PermissionString[];
-		public serialize(checkAdmin?: boolean): Record<PermissionString, boolean>;
-		public toArray(checkAdmin?: boolean): PermissionString[];
 	}
 
 	export class Presence {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -115,10 +115,10 @@ declare module 'discord.js' {
 		public equals(bit: BitFieldResolvable<S>): boolean;
 		public freeze(): Readonly<BitField<S>>;
 		public has(bit: BitFieldResolvable<S>): boolean;
-		public missing(bits: BitFieldResolvable<S>, ...hasParams: any[]): S[];
+		public missing(bits: BitFieldResolvable<S>, ...hasParam: readonly unknown[]): S[];
 		public remove(...bits: BitFieldResolvable<S>[]): BitField<S>;
-		public serialize(...hasParams: any[]): Record<S, boolean>;
-		public toArray(...hasParams: any[]): S[];
+		public serialize(...hasParam: readonly unknown[]): Record<S, boolean>;
+		public toArray(...hasParam: readonly unknown[]): S[];
 		public toJSON(): number;
 		public valueOf(): number;
 		public [Symbol.iterator](): Iterator<S>;
@@ -1123,6 +1123,10 @@ declare module 'discord.js' {
 		public static DEFAULT: number;
 		public static FLAGS: PermissionFlags;
 		public static resolve(permission?: PermissionResolvable): number;
+		
+		public missing(bit: BitFieldResolvable<PermissionString>, checkAdmin: boolean) : PermissionString[];
+		public serialize(checkAdmin: boolean) : Record<PermissionString, boolean>;
+		public toArray(checkAdmin: boolean) : PermissionString[];
 	}
 
 	export class Presence {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1124,9 +1124,9 @@ declare module 'discord.js' {
 		public static FLAGS: PermissionFlags;
 		public static resolve(permission?: PermissionResolvable): number;
 
-		public missing(bit: BitFieldResolvable<PermissionString>, checkAdmin: boolean): PermissionString[];
-		public serialize(checkAdmin: boolean): Record<PermissionString, boolean>;
-		public toArray(checkAdmin: boolean): PermissionString[];
+		public missing(bit: BitFieldResolvable<PermissionString>, checkAdmin?: boolean): PermissionString[];
+		public serialize(checkAdmin?: boolean): Record<PermissionString, boolean>;
+		public toArray(checkAdmin?: boolean): PermissionString[];
 	}
 
 	export class Presence {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1123,10 +1123,10 @@ declare module 'discord.js' {
 		public static DEFAULT: number;
 		public static FLAGS: PermissionFlags;
 		public static resolve(permission?: PermissionResolvable): number;
-		
-		public missing(bit: BitFieldResolvable<PermissionString>, checkAdmin: boolean) : PermissionString[];
-		public serialize(checkAdmin: boolean) : Record<PermissionString, boolean>;
-		public toArray(checkAdmin: boolean) : PermissionString[];
+
+		public missing(bit: BitFieldResolvable<PermissionString>, checkAdmin: boolean): PermissionString[];
+		public serialize(checkAdmin: boolean): Record<PermissionString, boolean>;
+		public toArray(checkAdmin: boolean): PermissionString[];
 	}
 
 	export class Presence {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the `hasParams` parameter type of `Bitfield#serialize` and `Bitfield#missing` and adds the same parameter to `Bitfield#toArray`.

It also overrides the above mentioned methods in `Permissions` and specifies the concrete parameter list.


Fixes #3564.


**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
