### PR TITLE
typings(Extendable): add missing channels

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2135,6 +2135,8 @@ declare module 'discord.js' {
 		TextChannel: typeof TextChannel;
 		VoiceChannel: typeof VoiceChannel;
 		CategoryChannel: typeof CategoryChannel;
+		NewsChannel: typeof NewsChannel;
+		StoreChannel: typeof StoreChannel;
 		GuildMember: typeof GuildMember;
 		Guild: typeof Guild;
 		Message: typeof Message;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds the missing `NewsChannel` and `StoreChannel`s to the `Extendable` type to allow extending those using `Structures.extend`.

For reference:
https://github.com/discordjs/discord.js/blob/1352bff2fd969092b48368ebc1f05a080572f827/src/util/Structures.js#L78-L79

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
