### PR TITLE
feat(Webhook): add type property and created* getters

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -31,9 +31,9 @@ class Webhook {
     /**
      * The token for the webhook
      * @name Webhook#token
-     * @type {string}
+     * @type {?string}
      */
-    Object.defineProperty(this, 'token', { value: data.token, writable: true, configurable: true });
+    Object.defineProperty(this, 'token', { value: data.token || null, writable: true, configurable: true });
 
     /**
      * The avatar for the webhook

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { WebhookTypes } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const Snowflake = require('../util/Snowflake');
 const Channel = require('./Channel');
@@ -45,6 +46,12 @@ class Webhook {
      * @type {Snowflake}
      */
     this.id = data.id;
+
+    /**
+     * The type of the webhook
+     * @type {WebhookTypes}
+     */
+    this.type = WebhookTypes[data.type];
 
     /**
      * The guild the webhook belongs to

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const DataResolver = require('../util/DataResolver');
+const Snowflake = require('../util/Snowflake');
 const Channel = require('./Channel');
 const APIMessage = require('./APIMessage');
 
@@ -210,6 +211,23 @@ class Webhook {
   delete(reason) {
     return this.client.api.webhooks(this.id, this.token).delete({ reason });
   }
+  /**
+   * The timestamp the webhook was created at
+   * @type {number}
+   * @readonly
+   */
+  get createdTimestamp() {
+    return Snowflake.deconstruct(this.id).timestamp;
+  }
+
+  /**
+   * The time the webhook was created at
+   * @type {Date}
+   * @readonly
+   */
+  get createdAt() {
+    return new Date(this.createdTimestamp);
+  }
 
   /**
    * The url of this webhook
@@ -226,6 +244,9 @@ class Webhook {
       'sendSlackMessage',
       'edit',
       'delete',
+      'createdTimestamp',
+      'createdAt',
+      'url',
     ]) {
       Object.defineProperty(structure.prototype, prop,
         Object.getOwnPropertyDescriptor(Webhook.prototype, prop));

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -619,6 +619,19 @@ exports.MembershipStates = [
   'ACCEPTED',
 ];
 
+/**
+ * The value set for a webhook's type:
+ * * Incoming
+ * * Channel Follower
+ * @typedef {string} WebhookTypes
+ */
+exports.WebhookTypes = [
+  // They start at 1
+  null,
+  'Incoming',
+  'Channel Follower',
+];
+
 function keyMirror(arr) {
   let tmp = Object.create(null);
   for (const value of arr) tmp[value] = value;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1620,11 +1620,13 @@ declare module 'discord.js' {
 		public guildID: Snowflake;
 		public name: string;
 		public owner: User | object | null;
+		public token: string | null;
 		public type: WebhookTypes;
 	}
 
 	export class WebhookClient extends WebhookMixin(BaseClient) {
 		constructor(id: string, token: string, options?: ClientOptions);
+		public token: string;
 	}
 
 	export class WebSocketManager extends EventEmitter {
@@ -1888,7 +1890,6 @@ declare module 'discord.js' {
 	interface WebhookFields {
 		readonly client: Client;
 		id: Snowflake;
-		token: string;
 		readonly createdAt: Date;
 		readonly createdTimestamp: number;
 		readonly url: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1620,7 +1620,6 @@ declare module 'discord.js' {
 		public guildID: Snowflake;
 		public name: string;
 		public owner: User | object | null;
-		public readonly url: string;
 	}
 
 	export class WebhookClient extends WebhookMixin(BaseClient) {
@@ -1889,6 +1888,9 @@ declare module 'discord.js' {
 		readonly client: Client;
 		id: Snowflake;
 		token: string;
+		readonly createdAt: Date;
+		readonly createdTimestamp: number;
+		readonly url: String;
 		delete(reason?: string): Promise<void>;
 		edit(options: WebhookEditData): Promise<Webhook>;
 		send(content?: StringResolvable, options?: WebhookMessageOptions & { split?: false } | MessageAdditions): Promise<Message>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1620,6 +1620,7 @@ declare module 'discord.js' {
 		public guildID: Snowflake;
 		public name: string;
 		public owner: User | object | null;
+		public type: WebhookTypes;
 	}
 
 	export class WebhookClient extends WebhookMixin(BaseClient) {
@@ -2615,6 +2616,8 @@ declare module 'discord.js' {
 		code?: string | boolean;
 		split?: boolean | SplitOptions;
 	}
+
+	type WebhookTypes = 'Incoming' | 'Channel Follower';
 
 	interface WebSocketOptions {
 		large_threshold?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1891,7 +1891,7 @@ declare module 'discord.js' {
 		token: string;
 		readonly createdAt: Date;
 		readonly createdTimestamp: number;
-		readonly url: String;
+		readonly url: string;
 		delete(reason?: string): Promise<void>;
 		edit(options: WebhookEditData): Promise<Webhook>;
 		send(content?: StringResolvable, options?: WebhookMessageOptions & { split?: false } | MessageAdditions): Promise<Message>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #3605

This PR adds `Webhook#type` to distinguish between incoming and channel follower webhooks.
See: https://github.com/discordapp/discord-api-docs/commit/b36723bcbcd708bc17fae935cc2e5ec396fa36bb

It also adds `createdAt` and `createdTimestamp` to `Webhook`  and adds those, as well as `url`, to the list of applied properties to `WebhookClient`.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
