### PR TITLE
typings(GuildAuditLogsFetchOptions): fix options.type typing

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2222,7 +2222,7 @@ declare module 'discord.js' {
 		before?: Snowflake | GuildAuditLogsEntry;
 		limit?: number;
 		user?: UserResolvable;
-		type?: string | number;
+		type?: GuildAuditLogsAction | number;
 	}
 
 	type GuildAuditLogsTarget = keyof GuildAuditLogsTargets;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`GuildAuditLogsFetchOptions.type` was originally defined as a `string | number`, so Typescript does not detect any errors when providing an invalid string for the type. This PR fixes this, and also allows suggestions for what is allowed in the field.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
