### PR TITLE
feat(Webhook): add ability to change channel and specify reason to edit

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -801,11 +801,20 @@ class RESTMethods {
       .then(data => new Webhook(this.client, data));
   }
 
-  editWebhook(webhook, name, avatar) {
-    return this.rest.makeRequest('patch', Endpoints.Webhook(webhook.id, webhook.token), false, {
-      name,
-      avatar,
-    }).then(data => {
+  editWebhook(webhook, options, reason) {
+    let endpoint;
+    let auth;
+
+    // Changing the channel of a webhook or specifying a reason requires a bot token
+    if (options.channel_id || reason) {
+      endpoint = Endpoints.Webhook(webhook.id);
+      auth = true;
+    } else {
+      endpoint = Endpoints.Webhook(webhook.id, webhook.token);
+      auth = false;
+    }
+
+    return this.rest.makeRequest('patch', endpoint, auth, options, undefined, reason).then(data => {
       webhook.name = data.name;
       webhook.avatar = data.avatar;
       return webhook;

--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -817,6 +817,7 @@ class RESTMethods {
     return this.rest.makeRequest('patch', endpoint, auth, options, undefined, reason).then(data => {
       webhook.name = data.name;
       webhook.avatar = data.avatar;
+      webhook.channelID = data.channel_id;
       return webhook;
     });
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1578,7 +1578,8 @@ declare module 'discord.js' {
 		public owner: User | object;
 		public token: string;
 		public delete(reason?: string): Promise<void>;
-		public edit(name: string, avatar: BufferResolvable): Promise<Webhook>;
+		public edit(name?: string, avatar?: BufferResolvable): Promise<Webhook>;
+		public edit(options?: WebhookEditOptions, reason?: string): Promise<Webhook>;
 		public send(content?: StringResolvable, options?: WebhookMessageOptions | RichEmbed | Attachment): Promise<Message | Message[]>;
 		public send(options?: WebhookMessageOptions | RichEmbed | Attachment): Promise<Message | Message[]>;
 		public sendCode(lang: string, content: StringResolvable, options?: WebhookMessageOptions): Promise<Message | Message[]>;
@@ -2199,6 +2200,12 @@ declare module 'discord.js' {
 	type UserResolvable = User | Snowflake | Message | Guild | GuildMember;
 
 	type VoiceStatus = number;
+
+	type WebhookEditOptions = {
+		name?: string;
+		avatar?: BufferResolvable;
+		channel?: ChannelResolvable;
+	};
 
 	type WebhookMessageOptions = {
 		username?: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #2039 allowing one to edit the channel of a webhook to the 11.5-dev branch.

The old style `name, avatar` parameters are being deprecated in favor of `options, reason` as we do have in our master branch.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
