### PR TITLE
fix(Webhook): edit channel when editing avatar

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -186,20 +186,20 @@ class Webhook {
    * @param {string} [reason] Reason for editing this webhook
    * @returns {Promise<Webhook>}
    */
-  edit({ name = this.name, avatar, channel }, reason) {
+  async edit({ name = this.name, avatar, channel }, reason) {
     if (avatar && (typeof avatar === 'string' && !avatar.startsWith('data:'))) {
-      return DataResolver.resolveImage(avatar).then(image => this.edit({ name, avatar: image }, reason));
+      avatar = await DataResolver.resolveImage(avatar);
     }
     if (channel) channel = channel instanceof Channel ? channel.id : channel;
-    return this.client.api.webhooks(this.id, channel ? undefined : this.token).patch({
+    const data = await this.client.api.webhooks(this.id, channel ? undefined : this.token).patch({
       data: { name, avatar, channel_id: channel },
       reason,
-    }).then(data => {
-      this.name = data.name;
-      this.avatar = data.avatar;
-      this.channelID = data.channel_id;
-      return this;
     });
+
+    this.name = data.name;
+    this.avatar = data.avatar;
+    this.channelID = data.channel_id;
+    return this;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When editing the avatar of a webhook the channel (if provided) was lost and not patched.
This PR fixes my oversight from #2039.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
