### PR TITLE
Fix(Node): use proper symbol for util.inspect

### DIFF
--- a/src/rest/APIRouter.js
+++ b/src/rest/APIRouter.js
@@ -4,7 +4,7 @@ const noop = () => {}; // eslint-disable-line no-empty-function
 const methods = ['get', 'post', 'delete', 'patch', 'put'];
 const reflectors = [
   'toString', 'valueOf', 'inspect', 'constructor',
-  Symbol.toPrimitive, Symbol.for('util.inspect.custom'),
+  Symbol.toPrimitive, Symbol.for('nodejs.util.inspect.custom'),
 ];
 
 function buildRoute(manager) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
NodeJS v10+ Util.inspect symbol name has changed from Node v8

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
