### PR TITLE
Fix(typings): Use IterableIterator instead of Iterator

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -121,7 +121,7 @@ declare module 'discord.js' {
 		public toArray(): S[];
 		public toJSON(): number;
 		public valueOf(): number;
-		public [Symbol.iterator](): Iterator<S>;
+		public [Symbol.iterator](): IterableIterator<S>;
 		public static FLAGS: object;
 		public static resolve(bit?: BitFieldResolvable<any>): number;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Changes Iterator to IterableIterator for BitField

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
