### PR TITLE
fix: @\u202eeveryone interpreted as @everyone mention

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -106,7 +106,7 @@ class APIMessage {
         this.target.client.options.disableEveryone :
         this.options.disableEveryone;
       if (disableEveryone) {
-        content = (content || '').replace(/@(everyone|here)/g, '@\u200b$1').replace(/\u202e/g, '');
+        content = (content || '').replace(/@\u202e?(everyone|here)/g, '@\u200b$1');
       }
 
       if (isSplit) {

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -106,7 +106,7 @@ class APIMessage {
         this.target.client.options.disableEveryone :
         this.options.disableEveryone;
       if (disableEveryone) {
-        content = (content || '').replace(/@(everyone|here)/g, '@\u200b$1');
+        content = (content || '').replace(/@(everyone|here)/g, '@\u200b$1').replace(/\u202e/g, '');
       }
 
       if (isSplit) {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -524,8 +524,7 @@ class Util {
    */
   static cleanContent(str, message) {
     return str
-      .replace(/@(everyone|here)/g, '@\u200b$1')
-      .replace(/\u202e/g, '')
+      .replace(/@\u202e?(everyone|here)/g, '@\u200b$1')
       .replace(/<@!?[0-9]+>/g, input => {
         const id = input.replace(/<|!|>|@/g, '');
         if (message.channel.type === 'dm') {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -525,6 +525,7 @@ class Util {
   static cleanContent(str, message) {
     return str
       .replace(/@(everyone|here)/g, '@\u200b$1')
+      .replace(/\u202e/g, '')
       .replace(/<@!?[0-9]+>/g, input => {
         const id = input.replace(/<|!|>|@/g, '');
         if (message.channel.type === 'dm') {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
~Due to a bug on Discords end,~ "@\u202eeveryone" is interpreted as an actual `@everyone` mention. 
Discord.js replaces `@everyone` with @\u200beveryone (same with `@here` mentions) if it is set as MessageOption or ClientOption, but this does not apply for the mentioned bug. Although I have only tested this on stable, I'm sure it does the same on master.
The provided code is a bit hacky and I'm unsure if there is another character similar to this one, but this provides a temporary fix.

Reproducable code:
```js
// Normal behavior, sends @\u200beveryone: not a mention
message.channel.send("@everyone", {
    disableEveryone: true
});
// Mentioned bug, sends @\u202eeveryone and is interpreted as a normal @everyone mention
message.channel.send("@\u202eeveryone", {
    disableEveryone: true
});
```
![image](https://user-images.githubusercontent.com/30553356/69912798-84f63300-142e-11ea-8292-2b19d920fa31.png)


**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
