### PR TITLE
lockPermissions parameter added to the GuildChannel create method

### DIFF
--- a/src/stores/GuildChannelStore.js
+++ b/src/stores/GuildChannelStore.js
@@ -57,6 +57,7 @@ class GuildChannelStore extends DataStore {
    * @param {number} [options.bitrate] Bitrate of the new channel in bits (only voice)
    * @param {number} [options.userLimit] Maximum amount of users allowed in the new channel (only voice)
    * @param {ChannelResolvable} [options.parent] Parent of the new channel
+   * @param {boolean} [options.lockPermissions] Set the permissions of parent
    * @param {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [options.permissionOverwrites]
    * Permission overwrites of the new channel
    * @param {number} [options.position] Position of the new channel
@@ -88,6 +89,7 @@ class GuildChannelStore extends DataStore {
       bitrate,
       userLimit,
       parent,
+      lockPermissions,
       permissionOverwrites,
       position,
       rateLimitPerUser,
@@ -96,6 +98,13 @@ class GuildChannelStore extends DataStore {
     if (parent) parent = this.client.channels.resolveID(parent);
     if (permissionOverwrites) {
       permissionOverwrites = permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
+    }
+    if (lockPermissions) {
+      if (!parent) return Promise.reject(new Error('GUILD_CHANNEL_ORPHAN'));
+      permissionOverwrites = PermissionOverwrites.concatOverwritePermissions(
+        parent.permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild)),
+        permissionOverwrites
+      );
     }
 
     const data = await this.client.api.guilds(this.guild.id).channels.post({

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -137,6 +137,24 @@ class PermissionOverwrites {
   }
 
   /**
+   * Concat two Overwrite Permissions.
+   * @param {Array<OverwriteResolvable>} initialPermissions The initial permissions
+   * @param {Array<OverwriteResolvable>} newPermissions The permissions to concat
+   * @returns {Array<OverwriteResolvable>}
+   */
+  static concatOverwritePermissions(initialPermissions, newPermissions) {
+    const permissions = initialPermissions.concat(newPermissions);
+    let result = [];
+    for (const permission of permissions) {
+      if (!result.some(({ id }) => id === permission.id)) {
+        result.push(permission);
+      }
+    }
+
+    return result;
+  }
+
+  /**
    * The raw data for a permission overwrite
    * @typedef {Object} RawOverwriteData
    * @property {Snowflake} id The id of the overwrite

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2243,6 +2243,7 @@ declare module 'discord.js' {
 
 	interface GuildCreateChannelOptions {
 		permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
+		lockPermissions?: boolean;
 		topic?: string;
 		type?: Exclude<keyof typeof ChannelType, 'dm' | 'group' | 'unknown'>;
 		nsfw?: boolean;


### PR DESCRIPTION
We can see that there isn't any lockPermissions to the create method of GuildChannel, so that pull request will add it

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
