### PR TITLE
Docs: ReactionStore.resolveID should take Reaction, not role

### DIFF
--- a/src/stores/ReactionStore.js
+++ b/src/stores/ReactionStore.js
@@ -38,7 +38,7 @@ class ReactionStore extends DataStore {
     * @method resolveID
     * @memberof ReactionStore
     * @instance
-    * @param {MessageReactionResolvable} role The role resolvable to resolve
+    * @param {MessageReactionResolvable} Reaction The MessageReaction to resolve
     * @returns {?Snowflake}
     */
 

--- a/src/stores/ReactionStore.js
+++ b/src/stores/ReactionStore.js
@@ -38,7 +38,7 @@ class ReactionStore extends DataStore {
     * @method resolveID
     * @memberof ReactionStore
     * @instance
-    * @param {MessageReactionResolvable} Reaction The MessageReaction to resolve
+    * @param {MessageReactionResolvable} reaction The MessageReaction to resolve
     * @returns {?Snowflake}
     */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR simply fixes a bug in the documentation of `ReactionStore.resolveID()` which mentions the parameter should be a `Role`, not a `MessageReactionResolvable`

**Status**
- 

- [x] Code changes have been tested against the Discord API, or there are no code changes

- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
