### PR TITLE
new Discord() instead of new Discord.Client()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For production bots, using node-opus should be considered a necessity, especiall
 ## Example usage
 ```js
 const Discord = require('discord.js');
-const client = new Discord.Client();
+const client = new Discord();
 
 client.on('ready', () => {
   console.log(`Logged in as ${client.user.tag}!`);

--- a/src/index.js
+++ b/src/index.js
@@ -1,66 +1,64 @@
 const Util = require('./util/Util');
+const Client = require('./client/Client');
 
-module.exports = {
-  // "Root" classes (starting points)
-  Client: require('./client/Client'),
-  Shard: require('./sharding/Shard'),
-  ShardClientUtil: require('./sharding/ShardClientUtil'),
-  ShardingManager: require('./sharding/ShardingManager'),
-  WebhookClient: require('./client/WebhookClient'),
+function Discord() {
+  return new Client();
+}
 
-  // Utilities
-  Collection: require('./util/Collection'),
-  Constants: require('./util/Constants'),
-  DiscordAPIError: require('./client/rest/DiscordAPIError'),
-  EvaluatedPermissions: require('./util/Permissions'),
-  Permissions: require('./util/Permissions'),
-  Snowflake: require('./util/Snowflake'),
-  SnowflakeUtil: require('./util/Snowflake'),
-  Util: Util,
-  util: Util,
-  version: require('../package').version,
+Discord.Client = Client;
+Discord.Shard = require('./sharding/Shard');
+Discord.ShardClientUtil = require('./sharding/ShardClientUtil');
+Discord.ShardingManager = require('./sharding/ShardingManager');
+Discord.WebhookClient = require('./client/WebhookClient');
+Discord.Collection = require('./util/Collection');
+Discord.Constants = require('./util/Constants');
+Discord.DiscordAPIError = require('./client/rest/DiscordAPIError');
+Discord.EvaluatedPermissions = require('./util/Permissions');
+Discord.Permissions = require('./util/Permissions');
+Discord.Snowflake = require('./util/Snowflake');
+Discord.SnowflakeUtil = require('./util/Snowflake');
+Discord.Util = Util;
+Discord.util = Util;
+Discord.version = require('../package').version;
+Discord.escapeMarkdown = Util.escapeMarkdown;
+Discord.fetchRecommendedShards = Util.fetchRecommendedShards;
+Discord.splitMessage = Util.splitMessage;
+Discord.Attachment = require('./structures/Attachment');
+Discord.CategoryChannel = require('./structures/CategoryChannel');
+Discord.Channel = require('./structures/Channel');
+Discord.ClientUser = require('./structures/ClientUser');
+Discord.ClientUserSettings = require('./structures/ClientUserSettings');
+Discord.Collector = require('./structures/interfaces/Collector');
+Discord.DMChannel = require('./structures/DMChannel');
+Discord.Emoji = require('./structures/Emoji');
+Discord.Game = require('./structures/Presence').Game;
+Discord.GroupDMChannel = require('./structures/GroupDMChannel');
+Discord.Guild = require('./structures/Guild');
+Discord.GuildAuditLogs = require('./structures/GuildAuditLogs');
+Discord.GuildChannel = require('./structures/GuildChannel');
+Discord.GuildMember = require('./structures/GuildMember');
+Discord.Invite = require('./structures/Invite');
+Discord.Message = require('./structures/Message');
+Discord.MessageAttachment = require('./structures/MessageAttachment');
+Discord.MessageCollector = require('./structures/MessageCollector');
+Discord.MessageEmbed = require('./structures/MessageEmbed');
+Discord.MessageMentions = require('./structures/MessageMentions');
+Discord.MessageReaction = require('./structures/MessageReaction');
+Discord.NewsChannel = require('./structures/NewsChannel');
+Discord.OAuth2Application = require('./structures/OAuth2Application');
+Discord.ClientOAuth2Application = require('./structures/OAuth2Application');
+Discord.PartialGuild = require('./structures/PartialGuild');
+Discord.PartialGuildChannel = require('./structures/PartialGuildChannel');
+Discord.PermissionOverwrites = require('./structures/PermissionOverwrites');
+Discord.Presence = require('./structures/Presence').Presence;
+Discord.ReactionEmoji = require('./structures/ReactionEmoji');
+Discord.ReactionCollector = require('./structures/ReactionCollector');
+Discord.RichEmbed = require('./structures/RichEmbed');
+Discord.Role = require('./structures/Role');
+Discord.StoreChannel = require('./structures/StoreChannel');
+Discord.TextChannel = require('./structures/TextChannel');
+Discord.User = require('./structures/User');
+Discord.VoiceChannel = require('./structures/VoiceChannel');
+Discord.Webhook = require('./structures/Webhook');
 
-  // Shortcuts to Util methods
-  escapeMarkdown: Util.escapeMarkdown,
-  fetchRecommendedShards: Util.fetchRecommendedShards,
-  splitMessage: Util.splitMessage,
-
-  // Structures
-  Attachment: require('./structures/Attachment'),
-  CategoryChannel: require('./structures/CategoryChannel'),
-  Channel: require('./structures/Channel'),
-  ClientUser: require('./structures/ClientUser'),
-  ClientUserSettings: require('./structures/ClientUserSettings'),
-  Collector: require('./structures/interfaces/Collector'),
-  DMChannel: require('./structures/DMChannel'),
-  Emoji: require('./structures/Emoji'),
-  Game: require('./structures/Presence').Game,
-  GroupDMChannel: require('./structures/GroupDMChannel'),
-  Guild: require('./structures/Guild'),
-  GuildAuditLogs: require('./structures/GuildAuditLogs'),
-  GuildChannel: require('./structures/GuildChannel'),
-  GuildMember: require('./structures/GuildMember'),
-  Invite: require('./structures/Invite'),
-  Message: require('./structures/Message'),
-  MessageAttachment: require('./structures/MessageAttachment'),
-  MessageCollector: require('./structures/MessageCollector'),
-  MessageEmbed: require('./structures/MessageEmbed'),
-  MessageMentions: require('./structures/MessageMentions'),
-  MessageReaction: require('./structures/MessageReaction'),
-  NewsChannel: require('./structures/NewsChannel'),
-  OAuth2Application: require('./structures/OAuth2Application'),
-  ClientOAuth2Application: require('./structures/OAuth2Application'),
-  PartialGuild: require('./structures/PartialGuild'),
-  PartialGuildChannel: require('./structures/PartialGuildChannel'),
-  PermissionOverwrites: require('./structures/PermissionOverwrites'),
-  Presence: require('./structures/Presence').Presence,
-  ReactionEmoji: require('./structures/ReactionEmoji'),
-  ReactionCollector: require('./structures/ReactionCollector'),
-  RichEmbed: require('./structures/RichEmbed'),
-  Role: require('./structures/Role'),
-  StoreChannel: require('./structures/StoreChannel'),
-  TextChannel: require('./structures/TextChannel'),
-  User: require('./structures/User'),
-  VoiceChannel: require('./structures/VoiceChannel'),
-  Webhook: require('./structures/Webhook'),
-};
+module.exports = Discord;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,8 +4,9 @@
 //   acdenisSK <acdenissk69@gmail.com> (https://github.com/acdenisSK)
 //   Zack Campbell <zajrik@gmail.com> (https://github.com/zajrik)
 // License: MIT
+declare function Discord(): Discord.Client;
 
-declare module 'discord.js' {
+declare namespace Discord {
 	import { EventEmitter } from 'events';
 	import { Stream, Readable as ReadableStream } from 'stream';
 	import { ChildProcess } from 'child_process';
@@ -50,7 +51,6 @@ declare module 'discord.js' {
 		public readonly client: Client;
 		public readonly createdAt: Date;
 		public readonly createdTimestamp: number;
-		public deleted: boolean;
 		public id: Snowflake;
 		public type: 'dm' | 'group' | 'text' | 'voice' | 'category' | 'news' | 'store';
 		public delete(): Promise<Channel>;
@@ -404,12 +404,10 @@ declare module 'discord.js' {
 	export class Emoji {
 		constructor(guild: Guild, data: object);
 		public animated: boolean;
-		public available: boolean;
 		public readonly client: Client;
 		public readonly createdAt: Date;
 		public readonly createdTimestamp: number;
 		public readonly deletable: boolean;
-		public deleted: boolean;
 		public guild: Guild;
 		public id: Snowflake;
 		public readonly identifier: string;
@@ -422,7 +420,6 @@ declare module 'discord.js' {
 		public addRestrictedRoles(roles: Role[]): Promise<Emoji>;
 		public edit(data: EmojiEditData, reason?: string): Promise<Emoji>;
 		public equals(other: Emoji | object): boolean;
-		public delete(reason?: string): Promise<this>;
 		public fetchAuthor(): Promise<User>;
 		public removeRestrictedRole(role: Role): Promise<Emoji>;
 		public removeRestrictedRoles(roles: Role[]): Promise<Emoji>;
@@ -486,10 +483,6 @@ declare module 'discord.js' {
 		public afkTimeout: number;
 		public applicationID: string;
 		public available: boolean;
-		public banner: string | null;
-		public readonly bannerURL: string | null;
-		public deleted: boolean;
-		public description: string | null;
 		public channels: Collection<Snowflake, GuildChannel>;
 		public defaultMessageNotifications: DefaultMessageNotifications | number;
 		public readonly client: Client;
@@ -497,8 +490,6 @@ declare module 'discord.js' {
 		public readonly createdTimestamp: number;
 		public readonly defaultChannel: TextChannel;
 		public readonly defaultRole: Role;
-		public readonly embedChannel: TextChannel | null;
-		public embedChannelID: Snowflake | null;
 		public embedEnabled: boolean;
 		public emojis: Collection<Snowflake, Emoji>;
 		public explicitContentFilter: number;
@@ -509,8 +500,6 @@ declare module 'discord.js' {
 		public readonly joinedAt: Date;
 		public joinedTimestamp: number;
 		public large: boolean;
-		public maximumMembers?: number;
-		public maximumPresences?: number;
 		public readonly me: GuildMember;
 		public memberCount: number;
 		public members: Collection<Snowflake, GuildMember>;
@@ -521,8 +510,6 @@ declare module 'discord.js' {
 		public readonly nameAcronym: string;
 		public readonly owner: GuildMember;
 		public ownerID: string;
-		public premiumSubscriptionCount: number | null;
-		public premiumTier: PremiumTier;
 		public readonly position: number;
 		public presences: Collection<Snowflake, Presence>;
 		public region: string;
@@ -532,13 +519,9 @@ declare module 'discord.js' {
 		public readonly suppressEveryone: boolean;
 		public readonly systemChannel: GuildChannel;
 		public systemChannelID: Snowflake;
-		public vanityURLCode: string;
 		public readonly verified: boolean;
 		public verificationLevel: number;
 		public readonly voiceConnection: VoiceConnection;
-		public readonly widgetChannel: TextChannel | null;
-		public widgetChannelID?: Snowflake;
-		public widgetEnabled?: boolean;
 		public acknowledge(): Promise<Guild>;
 		public addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
 		public allowDMs(allow: boolean): Promise<Guild>;
@@ -551,7 +534,6 @@ declare module 'discord.js' {
 		public deleteEmoji(emoji: Emoji | string, reason?: string): Promise<void>;
 		public edit(data: GuildEditData, reason?: string): Promise<Guild>;
 		public equals(guild: Guild): boolean;
-		public fetch(): Promise<Guild>;
 		public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
 		public fetchBan(user: UserResolvable): Promise<BanInfo>;
 		public fetchBans(withReasons?: false): Promise<Collection<Snowflake, User>>;
@@ -572,7 +554,7 @@ declare module 'discord.js' {
 		public setAFKTimeout(afkTimeout: number, reason?: string): Promise<Guild>;
 		public setChannelPosition(channel: string | GuildChannel, position: number, relative?: boolean): Promise<Guild>;
 		public setChannelPositions(channelPositions: ChannelPosition[]): Promise<Guild>;
-		public setDefaultMessageNotifications(defaultMessageNotifications: DefaultMessageNotifications, reason?: string): Promise<Guild>;
+		public setDefaultMessageNotifications(defaultMessageNotifications: DefaultMessageNotifications, reason: string): Promise<Guild>;
 		public setEmbed(embed: GuildEmbedData, reason?: string): Promise<Guild>;
 		public setExplicitContentFilter(explicitContentFilter: number, reason?: string): Promise<Guild>;
 		public setIcon(icon: Base64Resolvable, reason?: string): Promise<Guild>;
@@ -581,7 +563,6 @@ declare module 'discord.js' {
 		public setPosition(position: number, relative?: boolean): Promise<Guild>;
 		public setRegion(region: string, reason?: string): Promise<Guild>;
 		public setRolePosition(role: string | Role, position: number, relative?: boolean): Promise<Guild>;
-		public setRolePositions(rolePositions: RolePosition[]): Promise<Guild>;
 		public setSplash(splash: Base64Resolvable, reason?: string): Promise<Guild>;
 		public setSystemChannel(systemChannel: ChannelResolvable, reason?: string): Promise<Guild>;
 		public setVerificationLevel(verificationLevel: number, reason?: string): Promise<Guild>;
@@ -628,11 +609,10 @@ declare module 'discord.js' {
 		public readonly messageNotifications: GuildChannelMessageNotifications;
 		public readonly muted: boolean;
 		public name: string;
-		public readonly parent: CategoryChannel | null;
-		public parentID: Snowflake | null;
+		public readonly parent: CategoryChannel;
+		public parentID: Snowflake;
 		public permissionOverwrites: Collection<Snowflake, PermissionOverwrites>;
 		public position: number;
-		public readonly permissionsLocked: boolean | null;
 		public clone(name?: string, withPermissions?: boolean, withTopic?: boolean, reason?: string): Promise<GuildChannel>;
 		public createInvite(options?: InviteOptions, reason?: string): Promise<Invite>;
 		public delete(reason?: string): Promise<GuildChannel>;
@@ -658,7 +638,6 @@ declare module 'discord.js' {
 		public readonly client: Client;
 		public readonly colorRole: Role;
 		public readonly deaf: boolean;
-		public deleted: boolean;
 		public readonly displayColor: number;
 		public readonly displayHexColor: string;
 		public readonly displayName: string;
@@ -671,16 +650,13 @@ declare module 'discord.js' {
 		public readonly kickable: boolean;
 		public lastMessageID: string;
 		public readonly mute: boolean;
-		public nickname: string | null;
+		public nickname: string;
 		public readonly manageable: boolean;
 		public readonly permissions: Permissions;
-		public readonly premiumSince: Date | null;
-		public premiumSinceTimestamp: number | null;
 		public readonly presence: Presence;
 		public readonly roles: Collection<Snowflake, Role>;
 		public selfDeaf: boolean;
 		public selfMute: boolean;
-		public selfStream: boolean;
 		public serverDeaf: boolean;
 		public serverMute: boolean;
 		public speaking: boolean;
@@ -747,7 +723,6 @@ declare module 'discord.js' {
 		public readonly createdAt: Date;
 		public createdTimestamp: number;
 		public readonly deletable: boolean;
-		public deleted: boolean;
 		public readonly editable: boolean;
 		public readonly editedAt: Date;
 		public editedTimestamp: number;
@@ -942,7 +917,6 @@ declare module 'discord.js' {
 		public rpcApplicationState: boolean;
 		public rpcOrigins: string[];
 		public secret: string;
-		public team: Team | null;
 		public reset(): OAuth2Application;
 		public toString(): string;
 	}
@@ -1089,7 +1063,6 @@ declare module 'discord.js' {
 		public color: number;
 		public readonly createdAt: Date;
 		public readonly createdTimestamp: number;
-		public deleted: boolean;
 		public readonly editable: boolean;
 		public guild: Guild;
 		public readonly hexColor: string;
@@ -1241,34 +1214,6 @@ declare module 'discord.js' {
 		public setBitrate(bitrate: number | 'auto'): void;
 	}
 
-	export class Team {
-		constructor(client: Client, data: object);
-		public readonly client: Client;
-		public readonly createdAt: Date;
-		public readonly createdTimestamp: number;
-		public icon: string | null;
-		public readonly iconURL: string;
-		public id: Snowflake;
-		public members: Collection<Snowflake, TeamMember>;
-		public name: string;
-		public readonly owner: TeamMember;
-		public ownerID: Snowflake | null;
-
-		public toString(): string;
-	}
-
-	export class TeamMember {
-		constructor(client: Client, team: Team, data: object);
-		public readonly client: Client;
-		public id: Snowflake;
-		public membershipState: MembershipStates;
-		public permissions: string[];
-		public team: Team;
-		public user: User;
-
-		public toString(): string;
-	}
-
 	export class TextChannel extends TextBasedChannel(GuildChannel) {
 		constructor(guild: Guild, data: object);
 		public lastMessageID: string;
@@ -1276,11 +1221,10 @@ declare module 'discord.js' {
 		public messages: Collection<Snowflake, Message>;
 		public nsfw: boolean;
 		public topic: string;
-		public rateLimitPerUser: number;
 		public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
 		public createWebhook(name: string, avatar: BufferResolvable, reason?: string): Promise<Webhook>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
-		public setNSFW(nsfw: boolean, reason?: string): Promise<this>;
+		public setNSFW(nsfw: boolean, reason: string): Promise<this>;
 	}
 
 	export class User extends PartialTextBasedChannel() {
@@ -1707,7 +1651,6 @@ declare module 'discord.js' {
 		parent?: ChannelResolvable;
 		permissionOverwrites?: PermissionOverwrites[] | ChannelCreationOverwrites[];
 		rateLimitPerUser?: number;
-		reason?: string;
 	};
 
 	type ChannelLogsQueryOptions = {
@@ -1912,9 +1855,6 @@ declare module 'discord.js' {
 
 	type InviteResolvable = string;
 
-	type MembershipStates = 'INVITED'
-	| 'ACCEPTED';
-
 	type MessageCollectorOptions = CollectorOptions & {
 		max?: number;
 		maxMatches?: number;
@@ -2007,7 +1947,6 @@ declare module 'discord.js' {
 		ADD_REACTIONS?: number;
 		VIEW_AUDIT_LOG?: number;
 		PRIORITY_SPEAKER?: number;
-		STREAM?: number;
 		VIEW_CHANNEL?: number;
 		READ_MESSAGES?: number;
 		SEND_MESSAGES?: number;
@@ -2043,7 +1982,6 @@ declare module 'discord.js' {
 		ADD_REACTIONS?: boolean;
 		VIEW_AUDIT_LOG?: boolean;
 		PRIORITY_SPEAKER?: boolean;
-		STREAM?: boolean;
 		VIEW_CHANNEL?: boolean;
 		READ_MESSAGES?: boolean;
 		SEND_MESSAGES?: boolean;
@@ -2078,7 +2016,6 @@ declare module 'discord.js' {
 		| 'ADD_REACTIONS'
 		| 'VIEW_AUDIT_LOG'
 		| 'PRIORITY_SPEAKER'
-		| 'STREAM'
 		| 'VIEW_CHANNEL'
 		| 'READ_MESSAGES'
 		| 'SEND_MESSAGES'
@@ -2108,8 +2045,6 @@ declare module 'discord.js' {
 	interface RecursiveArray<T> extends Array<T | RecursiveArray<T>> { }
 
 	type PermissionResolvable = RecursiveArray<Permissions | PermissionString | number> | Permissions | PermissionString | number;
-
-	type PremiumTier = number;
 
 	type PresenceData = {
 		status?: PresenceStatus;
@@ -2167,11 +2102,6 @@ declare module 'discord.js' {
 		position?: number;
 		permissions?: PermissionResolvable;
 		mentionable?: boolean;
-	};
-
-	type RolePosition = {
-		role: RoleResolvable;
-		position: number;
 	};
 
 	type RoleResolvable = Role | string;
@@ -2259,3 +2189,5 @@ declare module 'discord.js' {
 
 //#endregion
 }
+
+export = Discord;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -51,6 +51,7 @@ declare namespace Discord {
 		public readonly client: Client;
 		public readonly createdAt: Date;
 		public readonly createdTimestamp: number;
+		public deleted: boolean;
 		public id: Snowflake;
 		public type: 'dm' | 'group' | 'text' | 'voice' | 'category' | 'news' | 'store';
 		public delete(): Promise<Channel>;
@@ -404,10 +405,12 @@ declare namespace Discord {
 	export class Emoji {
 		constructor(guild: Guild, data: object);
 		public animated: boolean;
+		public available: boolean;
 		public readonly client: Client;
 		public readonly createdAt: Date;
 		public readonly createdTimestamp: number;
 		public readonly deletable: boolean;
+		public deleted: boolean;
 		public guild: Guild;
 		public id: Snowflake;
 		public readonly identifier: string;
@@ -420,6 +423,7 @@ declare namespace Discord {
 		public addRestrictedRoles(roles: Role[]): Promise<Emoji>;
 		public edit(data: EmojiEditData, reason?: string): Promise<Emoji>;
 		public equals(other: Emoji | object): boolean;
+		public delete(reason?: string): Promise<this>;
 		public fetchAuthor(): Promise<User>;
 		public removeRestrictedRole(role: Role): Promise<Emoji>;
 		public removeRestrictedRoles(roles: Role[]): Promise<Emoji>;
@@ -483,6 +487,10 @@ declare namespace Discord {
 		public afkTimeout: number;
 		public applicationID: string;
 		public available: boolean;
+		public banner: string | null;
+		public readonly bannerURL: string | null;
+		public deleted: boolean;
+		public description: string | null;
 		public channels: Collection<Snowflake, GuildChannel>;
 		public defaultMessageNotifications: DefaultMessageNotifications | number;
 		public readonly client: Client;
@@ -490,6 +498,8 @@ declare namespace Discord {
 		public readonly createdTimestamp: number;
 		public readonly defaultChannel: TextChannel;
 		public readonly defaultRole: Role;
+		public readonly embedChannel: TextChannel | null;
+		public embedChannelID: Snowflake | null;
 		public embedEnabled: boolean;
 		public emojis: Collection<Snowflake, Emoji>;
 		public explicitContentFilter: number;
@@ -500,6 +510,8 @@ declare namespace Discord {
 		public readonly joinedAt: Date;
 		public joinedTimestamp: number;
 		public large: boolean;
+		public maximumMembers?: number;
+		public maximumPresences?: number;
 		public readonly me: GuildMember;
 		public memberCount: number;
 		public members: Collection<Snowflake, GuildMember>;
@@ -510,6 +522,8 @@ declare namespace Discord {
 		public readonly nameAcronym: string;
 		public readonly owner: GuildMember;
 		public ownerID: string;
+		public premiumSubscriptionCount: number | null;
+		public premiumTier: PremiumTier;
 		public readonly position: number;
 		public presences: Collection<Snowflake, Presence>;
 		public region: string;
@@ -519,9 +533,13 @@ declare namespace Discord {
 		public readonly suppressEveryone: boolean;
 		public readonly systemChannel: GuildChannel;
 		public systemChannelID: Snowflake;
+		public vanityURLCode: string;
 		public readonly verified: boolean;
 		public verificationLevel: number;
 		public readonly voiceConnection: VoiceConnection;
+		public readonly widgetChannel: TextChannel | null;
+		public widgetChannelID?: Snowflake;
+		public widgetEnabled?: boolean;
 		public acknowledge(): Promise<Guild>;
 		public addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
 		public allowDMs(allow: boolean): Promise<Guild>;
@@ -534,6 +552,7 @@ declare namespace Discord {
 		public deleteEmoji(emoji: Emoji | string, reason?: string): Promise<void>;
 		public edit(data: GuildEditData, reason?: string): Promise<Guild>;
 		public equals(guild: Guild): boolean;
+		public fetch(): Promise<Guild>;
 		public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
 		public fetchBan(user: UserResolvable): Promise<BanInfo>;
 		public fetchBans(withReasons?: false): Promise<Collection<Snowflake, User>>;
@@ -554,7 +573,7 @@ declare namespace Discord {
 		public setAFKTimeout(afkTimeout: number, reason?: string): Promise<Guild>;
 		public setChannelPosition(channel: string | GuildChannel, position: number, relative?: boolean): Promise<Guild>;
 		public setChannelPositions(channelPositions: ChannelPosition[]): Promise<Guild>;
-		public setDefaultMessageNotifications(defaultMessageNotifications: DefaultMessageNotifications, reason: string): Promise<Guild>;
+		public setDefaultMessageNotifications(defaultMessageNotifications: DefaultMessageNotifications, reason?: string): Promise<Guild>;
 		public setEmbed(embed: GuildEmbedData, reason?: string): Promise<Guild>;
 		public setExplicitContentFilter(explicitContentFilter: number, reason?: string): Promise<Guild>;
 		public setIcon(icon: Base64Resolvable, reason?: string): Promise<Guild>;
@@ -563,6 +582,7 @@ declare namespace Discord {
 		public setPosition(position: number, relative?: boolean): Promise<Guild>;
 		public setRegion(region: string, reason?: string): Promise<Guild>;
 		public setRolePosition(role: string | Role, position: number, relative?: boolean): Promise<Guild>;
+		public setRolePositions(rolePositions: RolePosition[]): Promise<Guild>;
 		public setSplash(splash: Base64Resolvable, reason?: string): Promise<Guild>;
 		public setSystemChannel(systemChannel: ChannelResolvable, reason?: string): Promise<Guild>;
 		public setVerificationLevel(verificationLevel: number, reason?: string): Promise<Guild>;
@@ -609,10 +629,11 @@ declare namespace Discord {
 		public readonly messageNotifications: GuildChannelMessageNotifications;
 		public readonly muted: boolean;
 		public name: string;
-		public readonly parent: CategoryChannel;
-		public parentID: Snowflake;
+		public readonly parent: CategoryChannel | null;
+		public parentID: Snowflake | null;
 		public permissionOverwrites: Collection<Snowflake, PermissionOverwrites>;
 		public position: number;
+		public readonly permissionsLocked: boolean | null;
 		public clone(name?: string, withPermissions?: boolean, withTopic?: boolean, reason?: string): Promise<GuildChannel>;
 		public createInvite(options?: InviteOptions, reason?: string): Promise<Invite>;
 		public delete(reason?: string): Promise<GuildChannel>;
@@ -638,6 +659,7 @@ declare namespace Discord {
 		public readonly client: Client;
 		public readonly colorRole: Role;
 		public readonly deaf: boolean;
+		public deleted: boolean;
 		public readonly displayColor: number;
 		public readonly displayHexColor: string;
 		public readonly displayName: string;
@@ -650,13 +672,16 @@ declare namespace Discord {
 		public readonly kickable: boolean;
 		public lastMessageID: string;
 		public readonly mute: boolean;
-		public nickname: string;
+		public nickname: string | null;
 		public readonly manageable: boolean;
 		public readonly permissions: Permissions;
+		public readonly premiumSince: Date | null;
+		public premiumSinceTimestamp: number | null;
 		public readonly presence: Presence;
 		public readonly roles: Collection<Snowflake, Role>;
 		public selfDeaf: boolean;
 		public selfMute: boolean;
+		public selfStream: boolean;
 		public serverDeaf: boolean;
 		public serverMute: boolean;
 		public speaking: boolean;
@@ -723,6 +748,7 @@ declare namespace Discord {
 		public readonly createdAt: Date;
 		public createdTimestamp: number;
 		public readonly deletable: boolean;
+		public deleted: boolean;
 		public readonly editable: boolean;
 		public readonly editedAt: Date;
 		public editedTimestamp: number;
@@ -917,6 +943,7 @@ declare namespace Discord {
 		public rpcApplicationState: boolean;
 		public rpcOrigins: string[];
 		public secret: string;
+		public team: Team | null;
 		public reset(): OAuth2Application;
 		public toString(): string;
 	}
@@ -1063,6 +1090,7 @@ declare namespace Discord {
 		public color: number;
 		public readonly createdAt: Date;
 		public readonly createdTimestamp: number;
+		public deleted: boolean;
 		public readonly editable: boolean;
 		public guild: Guild;
 		public readonly hexColor: string;
@@ -1214,6 +1242,34 @@ declare namespace Discord {
 		public setBitrate(bitrate: number | 'auto'): void;
 	}
 
+	export class Team {
+		constructor(client: Client, data: object);
+		public readonly client: Client;
+		public readonly createdAt: Date;
+		public readonly createdTimestamp: number;
+		public icon: string | null;
+		public readonly iconURL: string;
+		public id: Snowflake;
+		public members: Collection<Snowflake, TeamMember>;
+		public name: string;
+		public readonly owner: TeamMember;
+		public ownerID: Snowflake | null;
+
+		public toString(): string;
+	}
+
+	export class TeamMember {
+		constructor(client: Client, team: Team, data: object);
+		public readonly client: Client;
+		public id: Snowflake;
+		public membershipState: MembershipStates;
+		public permissions: string[];
+		public team: Team;
+		public user: User;
+
+		public toString(): string;
+	}
+
 	export class TextChannel extends TextBasedChannel(GuildChannel) {
 		constructor(guild: Guild, data: object);
 		public lastMessageID: string;
@@ -1221,10 +1277,11 @@ declare namespace Discord {
 		public messages: Collection<Snowflake, Message>;
 		public nsfw: boolean;
 		public topic: string;
+		public rateLimitPerUser: number;
 		public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
 		public createWebhook(name: string, avatar: BufferResolvable, reason?: string): Promise<Webhook>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
-		public setNSFW(nsfw: boolean, reason: string): Promise<this>;
+		public setNSFW(nsfw: boolean, reason?: string): Promise<this>;
 	}
 
 	export class User extends PartialTextBasedChannel() {
@@ -1651,6 +1708,7 @@ declare namespace Discord {
 		parent?: ChannelResolvable;
 		permissionOverwrites?: PermissionOverwrites[] | ChannelCreationOverwrites[];
 		rateLimitPerUser?: number;
+		reason?: string;
 	};
 
 	type ChannelLogsQueryOptions = {
@@ -1855,6 +1913,9 @@ declare namespace Discord {
 
 	type InviteResolvable = string;
 
+	type MembershipStates = 'INVITED'
+	| 'ACCEPTED';
+
 	type MessageCollectorOptions = CollectorOptions & {
 		max?: number;
 		maxMatches?: number;
@@ -1947,6 +2008,7 @@ declare namespace Discord {
 		ADD_REACTIONS?: number;
 		VIEW_AUDIT_LOG?: number;
 		PRIORITY_SPEAKER?: number;
+		STREAM?: number;
 		VIEW_CHANNEL?: number;
 		READ_MESSAGES?: number;
 		SEND_MESSAGES?: number;
@@ -1982,6 +2044,7 @@ declare namespace Discord {
 		ADD_REACTIONS?: boolean;
 		VIEW_AUDIT_LOG?: boolean;
 		PRIORITY_SPEAKER?: boolean;
+		STREAM?: boolean;
 		VIEW_CHANNEL?: boolean;
 		READ_MESSAGES?: boolean;
 		SEND_MESSAGES?: boolean;
@@ -2016,6 +2079,7 @@ declare namespace Discord {
 		| 'ADD_REACTIONS'
 		| 'VIEW_AUDIT_LOG'
 		| 'PRIORITY_SPEAKER'
+		| 'STREAM'
 		| 'VIEW_CHANNEL'
 		| 'READ_MESSAGES'
 		| 'SEND_MESSAGES'
@@ -2045,6 +2109,8 @@ declare namespace Discord {
 	interface RecursiveArray<T> extends Array<T | RecursiveArray<T>> { }
 
 	type PermissionResolvable = RecursiveArray<Permissions | PermissionString | number> | Permissions | PermissionString | number;
+
+	type PremiumTier = number;
 
 	type PresenceData = {
 		status?: PresenceStatus;
@@ -2102,6 +2168,11 @@ declare namespace Discord {
 		position?: number;
 		permissions?: PermissionResolvable;
 		mentionable?: boolean;
+	};
+
+	type RolePosition = {
+		role: RoleResolvable;
+		position: number;
 	};
 
 	type RoleResolvable = Role | string;
@@ -2189,5 +2260,5 @@ declare namespace Discord {
 
 //#endregion
 }
-
+							
 export = Discord;


### PR DESCRIPTION
I made this pull request so you can only type `new Discord()` instead of `new Discord.Client()`.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
