### PR TITLE
Message.guild and Message.hit are optional properties

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -727,8 +727,8 @@ declare module 'discord.js' {
 		public editedTimestamp: number;
 		public readonly edits: Message[];
 		public embeds: MessageEmbed[];
-		public readonly guild: Guild;
-		public hit: boolean;
+		public readonly guild?: Guild;
+		public hit?: boolean;
 		public id: Snowflake;
 		public member: GuildMember;
 		public mentions: MessageMentions;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -727,8 +727,8 @@ declare module 'discord.js' {
 		public editedTimestamp: number;
 		public readonly edits: Message[];
 		public embeds: MessageEmbed[];
-		public readonly guild?: Guild;
-		public hit?: boolean;
+		public readonly guild: Guild | null;
+		public hit: boolean | null;
 		public id: Snowflake;
 		public member: GuildMember;
 		public mentions: MessageMentions;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It seems that no properties have optional property (or null) markers, except function arguments. Even though they can be null or undefined. Why is this?
This caused a linter error for me because `if (message.guild)` will always be truthy, according to the typings.
I think there are a lot more properties which aren't marked like this.
If you don't merge, it's fine, I'm only wondering _why_ the properties aren't marked as optional.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating
**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
