### PR TITLE
feat(Webhook): addition of Webhook#avatarURL function 

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -219,7 +219,7 @@ class Webhook {
   get url() {
     return this.client.options.http.api + this.client.api.webhooks(this.id, this.token);
   }
-  
+
   /**
    * A link to the user's avatar.
    * @param {ImageURLOptions} [options={}] Options for the Image URL

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -221,7 +221,7 @@ class Webhook {
   }
 
   /**
-   * A link to the user's avatar.
+   * A link to the webhooks's avatar.
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -221,7 +221,7 @@ class Webhook {
   }
 
   /**
-   * A link to the webhooks's avatar.
+   * A link to the webhook's avatar.
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -219,6 +219,16 @@ class Webhook {
   get url() {
     return this.client.options.http.api + this.client.api.webhooks(this.id, this.token);
   }
+  
+  /**
+   * A link to the user's avatar.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string}
+   */
+  avatarURL({ format, size } = {}) {
+    if (!this.avatar) return null;
+    return this.client.rest.cdn.Avatar(this.id, this.avatar, format, size);
+  }
 
   static applyToClass(structure) {
     for (const prop of [

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1620,6 +1620,7 @@ declare module 'discord.js' {
 	export class Webhook extends WebhookMixin() {
 		constructor(client: Client, data?: object);
 		public avatar: string;
+		public avatarURL(options?: AvatarOptions): string | null;
 		public channelID: Snowflake;
 		public guildID: Snowflake;
 		public name: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds support for a `Webhook#avatarURL` function. Although not documented, a webhook's avatar follows the same format as a users.

I tested this with the following code in my eval command:
```js
(async () => {
  const webhook = await msg.channel.fetchWebhooks().then(h => h.first());
  return this.client.rest.cdn.Avatar(webhook.id, webhook.avatar);
})()
```

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
