### PR TITLE
TextChannel.topic & NewsChannel.topic should be optional

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1373,7 +1373,7 @@ declare module 'discord.js' {
 		public messages: MessageStore;
 		public nsfw: boolean;
 		public rateLimitPerUser: number;
-		public topic: string;
+		public topic?: string;
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable, reason?: string }): Promise<Webhook>;
 		public setNSFW(nsfw: boolean, reason?: string): Promise<TextChannel>;
 		public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
@@ -1384,7 +1384,7 @@ declare module 'discord.js' {
 		constructor(guild: Guild, data?: object);
 		public messages: MessageStore;
 		public nsfw: boolean;
-		public topic: string;
+		public topic?: string;
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable, reason?: string }): Promise<Webhook>;
 		public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1384,7 +1384,7 @@ declare module 'discord.js' {
 		constructor(guild: Guild, data?: object);
 		public messages: MessageStore;
 		public nsfw: boolean;
-		public topic?: string;
+		public topic: string | null;
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable, reason?: string }): Promise<Webhook>;
 		public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1373,7 +1373,7 @@ declare module 'discord.js' {
 		public messages: MessageStore;
 		public nsfw: boolean;
 		public rateLimitPerUser: number;
-		public topic?: string;
+		public topic: string | null;
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable, reason?: string }): Promise<Webhook>;
 		public setNSFW(nsfw: boolean, reason?: string): Promise<TextChannel>;
 		public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In the typings the topic on TextChannels and NewsChannels suggests it is always a string. It is in fact optional.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
