### PR TITLE
feat(Collectors): make Collectors auto-stop when relevant structures are deleted

### DIFF
--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -11,7 +11,7 @@ const { Events } = require('../util/Constants');
 
 /**
  * Collects messages on a channel.
- * Will automatically stop if the Channel or Guild are deleted.
+ * Will automatically stop if the channel (`'channelDelete'`) or guild (`'guildDelete'`) are deleted.
  * @extends {Collector}
  */
 class MessageCollector extends Collector {
@@ -102,7 +102,7 @@ class MessageCollector extends Collector {
   }
 
   /**
-   * Handles checking if the Channel has been deleted, and if so, stops the Collector with a reason of 'channelDelete'.
+   * Handles checking if the channel has been deleted, and if so, stops the collector with the reason 'channelDelete'.
    * @private
    * @param {GuildChannel} channel The channel that was deleted
    * @returns {void}
@@ -114,7 +114,7 @@ class MessageCollector extends Collector {
   }
 
   /**
-   * Handles checking if the Guild has been deleted, and if so, stops the Collector with a reason of 'guildDelete'.
+   * Handles checking if the guild has been deleted, and if so, stops the collector with the reason 'guildDelete'.
    * @private
    * @param {Guild} guild The guild that was deleted
    * @returns {void}

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -121,7 +121,7 @@ class MessageCollector extends Collector {
    * @returns {Guild|null}
    */
   _handleGuildDeletion(guild) {
-    if (guild.id === this.message.guild.id) {
+    if (this.message.guild && guild.id === this.message.guild.id) {
       this.stop('guildDelete');
       return guild;
     }

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -11,6 +11,7 @@ const { Events } = require('../util/Constants');
 
 /**
  * Collects messages on a channel.
+ * Will automatically stop if the Channel or Guild are deleted.
  * @extends {Collector}
  */
 class MessageCollector extends Collector {
@@ -103,29 +104,25 @@ class MessageCollector extends Collector {
   /**
    * Handles checking if the Channel has been deleted, and if so, stops the Collector with a reason of 'channelDelete'.
    * @private
-   * @param {GuildChannel} channel The channel that was deleted.
-   * @returns {TextChannel|null}
+   * @param {GuildChannel} channel The channel that was deleted
+   * @returns {void}
    */
   _handleChannelDeletion(channel) {
     if (channel.id === this.channel.id) {
       this.stop('channelDelete');
-      return channel;
     }
-    return null;
   }
 
   /**
    * Handles checking if the Guild has been deleted, and if so, stops the Collector with a reason of 'guildDelete'.
    * @private
-   * @param {Guild} guild The guild that was deleted.
-   * @returns {Guild|null}
+   * @param {Guild} guild The guild that was deleted
+   * @returns {void}
    */
   _handleGuildDeletion(guild) {
-    if (this.channel.guild && guild.id === this.channel.guild) {
+    if (this.channel.guild && guild.id === this.channel.guild.id) {
       this.stop('guildDelete');
-      return guild;
     }
-    return null;
   }
 }
 

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -107,7 +107,7 @@ class MessageCollector extends Collector {
    * @returns {TextChannel|null}
    */
   _handleChannelDeletion(channel) {
-    if (channel.id === this.message.channel.id) {
+    if (channel.id === this.channel.id) {
       this.stop('channelDelete');
       return channel;
     }
@@ -121,7 +121,7 @@ class MessageCollector extends Collector {
    * @returns {Guild|null}
    */
   _handleGuildDeletion(guild) {
-    if (this.message.guild && guild.id === this.message.guild.id) {
+    if (this.channel.guild && guild.id === this.channel.guild) {
       this.stop('guildDelete');
       return guild;
     }

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -13,7 +13,8 @@ const { Events } = require('../util/Constants');
 
 /**
  * Collects reactions on messages.
- * Will automatically stop if the message (`'messageDelete'`), channel (`'channelDelete'`), or guild (`'guildDelete'`) are deleted.
+ * Will automatically stop if the message (`'messageDelete'`),
+ *  channel (`'channelDelete'`), or guild (`'guildDelete'`) are deleted.
  * @extends {Collector}
  */
 class ReactionCollector extends Collector {

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -14,7 +14,7 @@ const { Events } = require('../util/Constants');
 /**
  * Collects reactions on messages.
  * Will automatically stop if the message (`'messageDelete'`),
- *  channel (`'channelDelete'`), or guild (`'guildDelete'`) are deleted.
+ * channel (`'channelDelete'`), or guild (`'guildDelete'`) are deleted.
  * @extends {Collector}
  */
 class ReactionCollector extends Collector {

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -13,7 +13,7 @@ const { Events } = require('../util/Constants');
 
 /**
  * Collects reactions on messages.
- * Will automatically stop if the Message, Channel, or Guild are deleted.
+ * Will automatically stop if the message (`'messageDelete'`), channel (`'channelDelete'`), or guild (`'guildDelete'`) are deleted.
  * @extends {Collector}
  */
 class ReactionCollector extends Collector {
@@ -142,7 +142,7 @@ class ReactionCollector extends Collector {
   }
 
   /**
-   * Handles checking if the Message has been deleted, and if so, stops the Collector with a reason of 'messageDelete'.
+   * Handles checking if the message has been deleted, and if so, stops the collector with the reason 'messageDelete'.
    * @private
    * @param {Message} message The message that was deleted
    * @returns {void}
@@ -154,7 +154,7 @@ class ReactionCollector extends Collector {
   }
 
   /**
-   * Handles checking if the Channel has been deleted, and if so, stops the Collector with a reason of 'channelDelete'.
+   * Handles checking if the channel has been deleted, and if so, stops the collector with the reason 'channelDelete'.
    * @private
    * @param {GuildChannel} channel The channel that was deleted
    * @returns {void}
@@ -166,7 +166,7 @@ class ReactionCollector extends Collector {
   }
 
   /**
-   * Handles checking if the Guild has been deleted, and if so, stops the Collector with a reason of 'guildDelete'.
+   * Handles checking if the guild has been deleted, and if so, stops the collector with the reason 'guildDelete'.
    * @private
    * @param {Guild} guild The guild that was deleted
    * @returns {void}

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -161,7 +161,7 @@ class ReactionCollector extends Collector {
    * @returns {Guild|null}
    */
   _handleGuildDeletion(guild) {
-    if (guild.id === this.message.guild.id) {
+    if (this.message.guild && guild.id === this.message.guild.id) {
       this.stop('guildDelete');
       return guild;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1149,7 +1149,7 @@ declare module 'discord.js' {
 		private _handleChannelDeletion(channel: GuildChannel): TextChannel | null;
 		private _handleGuildDeletion(guild: Guild): Guild | null;
 		private _handleMessageDeletion(message: Message): Message | null;
-		
+
 		public message: Message;
 		public options: ReactionCollectorOptions;
 		public total: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1018,8 +1018,8 @@ declare module 'discord.js' {
 
 	export class MessageCollector extends Collector<Snowflake, Message> {
 		constructor(channel: TextChannel | DMChannel, filter: CollectorFilter, options?: MessageCollectorOptions);
-		private _handleChannelDeletion(channel: GuildChannel): TextChannel | null;
-		private _handleGuildDeletion(guild: Guild): Guild | null;
+		private _handleChannelDeletion(channel: GuildChannel): void;
+		private _handleGuildDeletion(guild: Guild): void;
 
 		public channel: Channel;
 		public options: MessageCollectorOptions;
@@ -1146,9 +1146,9 @@ declare module 'discord.js' {
 
 	export class ReactionCollector extends Collector<Snowflake, MessageReaction> {
 		constructor(message: Message, filter: CollectorFilter, options?: ReactionCollectorOptions);
-		private _handleChannelDeletion(channel: GuildChannel): TextChannel | null;
-		private _handleGuildDeletion(guild: Guild): Guild | null;
-		private _handleMessageDeletion(message: Message): Message | null;
+		private _handleChannelDeletion(channel: GuildChannel): void;
+		private _handleGuildDeletion(guild: Guild): void;
+		private _handleMessageDeletion(message: Message): void;
 
 		public message: Message;
 		public options: ReactionCollectorOptions;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1018,11 +1018,12 @@ declare module 'discord.js' {
 
 	export class MessageCollector extends Collector<Snowflake, Message> {
 		constructor(channel: TextChannel | DMChannel, filter: CollectorFilter, options?: MessageCollectorOptions);
+		private _handleChannelDeletion(channel: GuildChannel): TextChannel | null;
+		private _handleGuildDeletion(guild: Guild): Guild | null;
+
 		public channel: Channel;
 		public options: MessageCollectorOptions;
 		public received: number;
-		private _handleChannelDeletion(channel: GuildChannel): TextChannel | null;
-		private _handleGuildDeletion(guild: Guild): Guild | null;
 
 		public collect(message: Message): Snowflake;
 		public dispose(message: Message): Snowflake;
@@ -1145,6 +1146,10 @@ declare module 'discord.js' {
 
 	export class ReactionCollector extends Collector<Snowflake, MessageReaction> {
 		constructor(message: Message, filter: CollectorFilter, options?: ReactionCollectorOptions);
+		private _handleChannelDeletion(channel: GuildChannel): TextChannel | null;
+		private _handleGuildDeletion(guild: Guild): Guild | null;
+		private _handleMessageDeletion(message: Message): Message | null;
+		
 		public message: Message;
 		public options: ReactionCollectorOptions;
 		public total: number;
@@ -1156,9 +1161,6 @@ declare module 'discord.js' {
 		public dispose(reaction: MessageReaction, user: User): Snowflake | string;
 		public empty(): void;
 		public endReason(): string | null;
-		private _handleChannelDeletion(channel: GuildChannel): TextChannel | null;
-		private _handleGuildDeletion(guild: Guild): Guild | null;
-		private _handleMessageDeletion(message: Message): Message | null;
 
 		public on(event: 'collect', listener: (reaction: MessageReaction, user: User) => void): this;
 		public on(event: 'dispose', listener: (reaction: MessageReaction, user: User) => void): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1021,6 +1021,8 @@ declare module 'discord.js' {
 		public channel: Channel;
 		public options: MessageCollectorOptions;
 		public received: number;
+		private _handleChannelDeletion(channel: GuildChannel): TextChannel | null;
+		private _handleGuildDeletion(guild: Guild): Guild | null;
 
 		public collect(message: Message): Snowflake;
 		public dispose(message: Message): Snowflake;
@@ -1154,6 +1156,9 @@ declare module 'discord.js' {
 		public dispose(reaction: MessageReaction, user: User): Snowflake | string;
 		public empty(): void;
 		public endReason(): string | null;
+		private _handleChannelDeletion(channel: GuildChannel): TextChannel | null;
+		private _handleGuildDeletion(guild: Guild): Guild | null;
+		private _handleMessageDeletion(message: Message): Message | null;
 
 		public on(event: 'collect', listener: (reaction: MessageReaction, user: User) => void): this;
 		public on(event: 'dispose', listener: (reaction: MessageReaction, user: User) => void): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR makes it so `ReactionCollector` and `MessageCollector` are automatically stopped if the guild or channel is deleted, in the case of `ReactionCollector`, deleting the message also stops the collector. This would reduce needless collectors which do not have to be kept running.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
