### PR TITLE
Remove acknowledge method from TextChannel & DMChannel

### DIFF
--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -83,7 +83,6 @@ class DMChannel extends Channel {
   createMessageCollector() {}
   awaitMessages() {}
   // Doesn't work on DM channels; bulkDelete() {}
-  acknowledge() {}
   _cacheMessage() {}
 }
 

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -138,7 +138,6 @@ class TextChannel extends GuildChannel {
   createMessageCollector() {}
   awaitMessages() {}
   bulkDelete() {}
-  acknowledge() {}
 }
 
 TextBasedChannel.applyToClass(TextChannel, true);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR removes the acknowledge method from `TextChannel` and `DMChannel` as they no longer do anything

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
