### PR TITLE
src: Fix race condition

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -373,7 +373,6 @@ class WebSocketShard extends EventEmitter {
         this.debug(`[READY] Session ${this.sessionID}.`);
         this.lastHeartbeatAcked = true;
         this.sendHeartbeat('ReadyHeartbeat');
-        this.checkReady();
         break;
       case WSEvents.RESUMED: {
         /**

--- a/src/client/websocket/handlers/READY.js
+++ b/src/client/websocket/handlers/READY.js
@@ -16,4 +16,6 @@ module.exports = (client, { d: data }, shard) => {
     guild.shardID = shard.id;
     client.guilds.add(guild);
   }
+
+  shard.checkReady();
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

If your bot was in 0 guilds, the call to `WebSocketShard#checkReady` would've triggered the `Client#ready` event BEFORE the packet was actually parsed, making `Client#user` null. This PR fixes that

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
