### PR TITLE
fix(GuildMemberStore): make timeout refresh after every packet

### DIFF
--- a/src/stores/GuildMemberStore.js
+++ b/src/stores/GuildMemberStore.js
@@ -207,6 +207,7 @@ class GuildMemberStore extends DataStore {
       const fetchedMembers = new Collection();
       const handler = (members, guild) => {
         if (guild.id !== this.guild.id) return;
+        timeout.refresh();
         for (const member of members.values()) {
           if (query || limit) fetchedMembers.set(member.id, member);
         }
@@ -217,11 +218,11 @@ class GuildMemberStore extends DataStore {
           resolve(query || limit ? fetchedMembers : this);
         }
       };
-      this.guild.client.on(Events.GUILD_MEMBERS_CHUNK, handler);
-      this.guild.client.setTimeout(() => {
+      const timeout = this.guild.client.setTimeout(() => {
         this.guild.client.removeListener(Events.GUILD_MEMBERS_CHUNK, handler);
         reject(new Error('GUILD_MEMBERS_TIMEOUT'));
       }, 120e3);
+      this.guild.client.on(Events.GUILD_MEMBERS_CHUNK, handler);
     });
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes `GuildMemberStore._fetchMany()` to have a more dynamic timeout.  The timeout used to be static and set at the start of the fetch call, now, the timeout will refresh every time a packet is received, this will fix the issue of the timeout triggering due to a large amount of members being fetched, and it will remove the need for users to change the hardcoded timeout if they must fetch a very large amount of guildMembers.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
