### PR TITLE
src: Add deprecation warning related to uws

### DIFF
--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -21,7 +21,8 @@ const WebSocket = (function findWebSocket() {
     const uws = require('@discordjs/uws');
     if (!warnedUWS) {
       warnedUWS = true;
-      process.emitWarning('uws support is being removed in the next version of discord.js', 'DeprecationWarning', findWebSocket);
+      process.emitWarning('uws support is being removed in the next version of discord.js',
+        'DeprecationWarning', findWebSocket);
     }
     return uws;
   } catch (e) {

--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -13,17 +13,12 @@ const erlpack = (function findErlpack() {
   }
 }());
 
-let warnedUWS;
-
 const WebSocket = (function findWebSocket() {
   if (browser) return window.WebSocket; // eslint-disable-line no-undef
   try {
     const uws = require('@discordjs/uws');
-    if (!warnedUWS) {
-      warnedUWS = true;
-      process.emitWarning('uws support is being removed in the next version of discord.js',
-        'DeprecationWarning', findWebSocket);
-    }
+    process.emitWarning('uws support is being removed in the next version of discord.js',
+      'DeprecationWarning', findWebSocket);
     return uws;
   } catch (e) {
     return require('ws');

--- a/src/client/websocket/WebSocketConnection.js
+++ b/src/client/websocket/WebSocketConnection.js
@@ -13,10 +13,17 @@ const erlpack = (function findErlpack() {
   }
 }());
 
+let warnedUWS;
+
 const WebSocket = (function findWebSocket() {
   if (browser) return window.WebSocket; // eslint-disable-line no-undef
   try {
-    return require('@discordjs/uws');
+    const uws = require('@discordjs/uws');
+    if (!warnedUWS) {
+      warnedUWS = true;
+      process.emitWarning('uws support is being removed in the next version of discord.js', 'DeprecationWarning', findWebSocket);
+    }
+    return uws;
   } catch (e) {
     return require('ws');
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

As uws support was removed from master, it is good to give the users of 11.x a heads up
This mimics what `require('util').deprecate` does to an extent

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
