### PR TITLE
fix(ShardingManager): assert shardList to be spawned, not totalShards

### DIFF
--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -235,7 +235,7 @@ class ShardingManager extends EventEmitter {
    */
   fetchClientValues(prop) {
     if (this.shards.size === 0) return Promise.reject(new Error('SHARDING_NO_SHARDS'));
-    if (this.shards.size !== this.totalShards) return Promise.reject(new Error('SHARDING_IN_PROCESS'));
+    if (this.shards.size !== this.shardList.length) return Promise.reject(new Error('SHARDING_IN_PROCESS'));
     const promises = [];
     for (const shard of this.shards.values()) promises.push(shard.fetchClientValue(prop));
     return Promise.all(promises);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #3642 by ensuring that the amount of shards specified in `shardList` are specified rather than the amount of shards being spawned (possibly across sharding managers) in general. 

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
