### PR TITLE
fix(BitField): remove for..in in favor of Object.entries

### DIFF
--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -103,7 +103,7 @@ class BitField {
    */
   serialize(...hasParams) {
     const serialized = {};
-    for (const flag of Object.keys(this.constructor.FLAGS)) serialized[flag] = this.has(flag, ...hasParams);
+    for (const [flag, bit] of Object.entries(this.constructor.FLAGS)) serialized[flag] = this.has(bit, ...hasParams);
     return serialized;
   }
 

--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -103,7 +103,7 @@ class BitField {
    */
   serialize(...hasParams) {
     const serialized = {};
-    for (const perm in this.constructor.FLAGS) serialized[perm] = this.has(perm, ...hasParams);
+    for (const flag of Object.keys(this.constructor.FLAGS)) serialized[flag] = this.has(flag, ...hasParams);
     return serialized;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #3567 by replacing the `for..in` with an `Object.keys` making it ignore inherited properties.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
