### PR TITLE
Fix: stats can't be falsy

### DIFF
--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -96,7 +96,7 @@ class DataResolver {
           const file = browser ? resource : path.resolve(resource);
           fs.stat(file, (err, stats) => {
             if (err) return reject(err);
-            if (!stats || !stats.isFile()) return reject(new DiscordError('FILE_NOT_FOUND', file));
+            if (!stats.isFile()) return reject(new DiscordError('FILE_NOT_FOUND', file));
             fs.readFile(file, (err2, data) => {
               if (err2) reject(err2);
               else resolve(data);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In DataResolver, stats can't be falsy if no error occurred.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
