### PR TITLE
Add Twitch preview link for largeImageURL

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -312,6 +312,8 @@ class RichPresenceAssets {
     if (!this.largeImage) return null;
     if (/^spotify:/.test(this.largeImage)) {
       return `https://i.scdn.co/image/${this.largeImage.slice(8)}`;
+    } else if (/^twitch:/.test(this.largeImage)) {
+      return `https://static-cdn.jtvnw.net/previews-ttv/live_user_${this.largeImage.slice(7)}.png`;
     }
     return this.activity.presence.client.rest.cdn
       .AppAsset(this.activity.applicationID, this.largeImage, { format, size });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Twitch presence large image asset has link leading to different place than discord endpoints, so using `largeImageURL()` returns `https://cdn.discordapp.com/app-assets/null/twitch:tipaka_.webp` instead of actual link.

The url link i added to code gives image in highest possible resolution, which is capped by the stream itself, leaving room for inconsistent picture resolution. However, the cdn is able to dynamically change resolution for the picture, by adding for example `-1920x1080` just before `.png`, or virtually any other resolution, even larger than stream is in or in different ratio (For example resolution in discord client is 108x60).
On the other side, most methods in library assume that pictures are square, so `size: 2048` means 2048x2048. That's not exactly a good idea to apply such resolution on a Full HD preview.


**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
