### PR TITLE
typings(GuildEmoji): make url not-nullable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -843,6 +843,7 @@ declare module 'discord.js' {
 		public managed: boolean;
 		public requiresColons: boolean;
 		public roles: GuildEmojiRoleStore;
+		public url: string;
 		public delete(reason?: string): Promise<GuildEmoji>;
 		public edit(data: GuildEmojiEditData, reason?: string): Promise<GuildEmoji>;
 		public equals(other: GuildEmoji | object): boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -843,7 +843,7 @@ declare module 'discord.js' {
 		public managed: boolean;
 		public requiresColons: boolean;
 		public roles: GuildEmojiRoleStore;
-		public url: string;
+		public readonly url: string;
 		public delete(reason?: string): Promise<GuildEmoji>;
 		public edit(data: GuildEmojiEditData, reason?: string): Promise<GuildEmoji>;
 		public equals(other: GuildEmoji | object): boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since [`Emoji.url`](https://discord.js.org/#/docs/main/master/class/Emoji?scrollTo=url) is only available for custom emotes, it would make sense to have [`GuildEmoji.url`](https://discord.js.org/#/docs/main/master/class/GuildEmoji?scrollTo=url) not nullable because it is guaranteed to be a custom emote.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
