### PR TITLE
Add ShardingManager#options.shardList to typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1285,6 +1285,7 @@ declare module 'discord.js' {
 	export class ShardingManager extends EventEmitter {
 		constructor(file: string, options?: {
 			totalShards?: number | 'auto';
+			shardList?: number[] | 'auto';
 			mode?: ShardingManagerMode;
 			respawn?: boolean;
 			shardArgs?: string[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

options.shardList is present in code here: https://github.com/discordjs/discord.js/blob/97eac663b3e1292cc399c56eb701069301f4637d/src/sharding/ShardingManager.js#L33

options.shardList is absent in typings here: https://github.com/discordjs/discord.js/blob/97eac663b3e1292cc399c56eb701069301f4637d/typings/index.d.ts#L1286

I have fixed this problem by adding shardList to typings.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.