### PR TITLE
fix(messageDeleteBulk): Use Action.getMessage to correctly handle Partials

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const MessageCollector = require('../MessageCollector');
+const Action = require('../../client/actions/Action');
 const Snowflake = require('../../util/Snowflake');
 const Collection = require('../../util/Collection');
 const { RangeError, TypeError } = require('../../errors');
@@ -315,10 +316,9 @@ class TextBasedChannel {
       }
       await this.client.api.channels[this.id].messages['bulk-delete']
         .post({ data: { messages: messageIDs } });
-      return this.client.actions.MessageDeleteBulk.handle({
-        channel_id: this.id,
-        ids: messageIDs,
-      }).messages;
+      return messageIDs.reduce((col, id) => col.set(id, Action.getMessage({
+        message_id: id,
+      }, this, false), new Collection()));
     }
     if (!isNaN(messages)) {
       const msgs = await this.messages.fetch({ limit: messages });


### PR DESCRIPTION
Fixes #3658

With Partial `MESSAGE` enabled, `messageBulkDelete` was firing twice - once with all messages in the Collection marked as partial and once with none of them marked, regardless of the actual cache/uncached state.

This will now correctly create and emit a single `Collection<Snowflake, Message>` to the event, some of which may be partial.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
