### PR TITLE
fix(TextChannel#bulkDelete): Use GenericAction#getMessage to handle return value correctly

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -315,10 +315,9 @@ class TextBasedChannel {
       }
       await this.client.api.channels[this.id].messages['bulk-delete']
         .post({ data: { messages: messageIDs } });
-      return this.client.actions.MessageDeleteBulk.handle({
-        channel_id: this.id,
-        ids: messageIDs,
-      }).messages;
+      return messageIDs.reduce((col, id) => col.set(id, this.client.actions.MessageDeleteBulk.getMessage({
+        message_id: id,
+      }, this)), new Collection());
     }
     if (!isNaN(messages)) {
       const msgs = await this.messages.fetch({ limit: messages });

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -305,13 +305,11 @@ class TextBasedChannel {
       }
       if (messageIDs.length === 0) return new Collection();
       if (messageIDs.length === 1) {
-        return this.client.api.channels(this.id).messages(messageIDs[0]).delete()
-          .then(() => {
-            const message = this.client.actions.MessageDelete.getMessage({
-              message_id: messageIDs[0],
-            }, this);
-            return message ? new Collection([[message.id, message]]) : new Collection();
-          });
+        await this.client.api.channels(this.id).messages(messageIDs[0]).delete();
+        const message = this.client.actions.MessageDelete.getMessage({
+          message_id: messageIDs[0],
+        }, this);
+        return message ? new Collection([[message.id, message]]) : new Collection();
       }
       await this.client.api.channels[this.id].messages['bulk-delete']
         .post({ data: { messages: messageIDs } });

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -305,13 +305,13 @@ class TextBasedChannel {
       }
       if (messageIDs.length === 0) return new Collection();
       if (messageIDs.length === 1) {
-        await this.client.api.channels(this.id).messages(messageIDs[0]).delete();
-        const message = this.client.actions.MessageDelete.handle({
-          channel_id: this.id,
-          id: messageIDs[0],
-        }).message;
-        if (message) return new Collection([[message.id, message]]);
-        return new Collection();
+        return this.client.api.channels(this.id).messages(messageIDs[0]).delete()
+          .then(() => {
+            const message = this.client.actions.MessageDelete.getMessage({
+              message_id: messageIDs[0],
+            }, this);
+            return message ? new Collection([[message.id, message]]) : new Collection();
+          });
       }
       await this.client.api.channels[this.id].messages['bulk-delete']
         .post({ data: { messages: messageIDs } });


### PR DESCRIPTION
Calling MessageDeleteBulk#handle in order to return a Collection from TextChannel#bulkDelete was resulting in the event firing twice on the bot which performs the bulkDelete action.

This ensures that the method returns the Collection without handling it twice.
Actually fixes #3658 - I probably didn't need to close the other PR after all.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
