### PR TITLE
Remove delay parameter from setImmediate typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -102,7 +102,7 @@ declare module 'discord.js' {
 		public destroy(): void;
 		public setInterval(fn: Function, delay: number, ...args: any[]): NodeJS.Timer;
 		public setTimeout(fn: Function, delay: number, ...args: any[]): NodeJS.Timer;
-		public setImmediate(fn: Function, delay: number, ...args: any[]): NodeJS.Immediate;
+		public setImmediate(fn: Function, ...args: any[]): NodeJS.Immediate;
 		public toJSON(...props: { [key: string]: boolean | string }[]): object;
 	}
 


### PR DESCRIPTION
There is no delay parameter on setImmediate in Node.JS docs:
https://nodejs.org/docs/latest-v12.x/api/timers.html#timers_setimmediate_callback_args

**Please describe the changes this PR makes and why it should be merged:**


**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
