### PR TITLE
Allow suppressing of embeds on messages.

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -155,6 +155,12 @@ class RESTMethods {
     }).then(data => this.client.actions.MessageUpdate.handle(data).updated);
   }
 
+  updateFlags(message) {
+    return this.rest.makeRequest('patch', Endpoints.Message(message), true, {
+      flags: message.flags,
+    }).then(data => this.client.actions.MessageUpdate.handle(data).updated);
+  }
+
   deleteMessage(message) {
     return this.rest.makeRequest('delete', Endpoints.Message(message), true)
       .then(() =>

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -89,6 +89,12 @@ class Message {
     this.nonce = data.nonce;
 
     /**
+     * The flags attached to this message
+     * @type number
+     */
+    this.flags = data.flags;
+
+    /**
      * Whether or not this message was sent by Discord, not actually a user (e.g. pin notifications)
      * @type {boolean}
      */
@@ -402,6 +408,15 @@ class Message {
     }
     if (options instanceof RichEmbed) options = { embed: options };
     return this.client.rest.methods.updateMessage(this, content, options);
+  }
+
+  /**
+   * Suppresses embeds of a message
+   * @returns {Promise<Message>}
+   */
+  suppressEmbeds() {
+    this.flags = this.flags | 4;
+    return this.client.rest.methods.updateFlags(this);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -759,6 +759,7 @@ declare module 'discord.js' {
 		public member: GuildMember;
 		public mentions: MessageMentions;
 		public nonce: string;
+		public readonly flags: number;
 		public readonly pinnable: boolean;
 		public pinned: boolean;
 		public reactions: Collection<Snowflake, MessageReaction>;
@@ -773,6 +774,7 @@ declare module 'discord.js' {
 		public createReactionCollector(filter: CollectorFilter, options?: ReactionCollectorOptions): ReactionCollector;
 		public delete(timeout?: number): Promise<Message>;
 		public edit(content: StringResolvable, options?: MessageEditOptions | RichEmbed): Promise<Message>;
+		public suppressEmbeds(): Promise<Message>;
 		public editCode(lang: string, content: StringResolvable): Promise<Message>;
 		public equals(message: Message, rawData: object): boolean;
 		public fetchWebhook(): Promise<Webhook>;


### PR DESCRIPTION
**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

Currently broken for some reason these requests are being denied with:
```
{
  name: 'DiscordAPIError',
  message: 'Missing Permissions',
  path: '/api/v7/channels/665069305162891266/messages/665265562825392162',
  code: 50013,
  method: 'PATCH'
}
```