### PR TITLE
src: Add message embed suppression

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -6,6 +6,7 @@ const MessageAttachment = require('./MessageAttachment');
 const { browser } = require('../util/Constants');
 const Util = require('../util/Util');
 const { RangeError } = require('../errors');
+const MessageFlags = require('../util/MessageFlags');
 
 /**
  * Represents a message to be sent to the API.
@@ -61,6 +62,16 @@ class APIMessage {
     const User = require('./User');
     const GuildMember = require('./GuildMember');
     return this.target instanceof User || this.target instanceof GuildMember;
+  }
+
+  /**
+   * Whether or not the target is a message
+   * @type {boolean}
+   * @readonly
+   */
+  get isMessage() {
+    const Message = require('./Message');
+    return this.target instanceof Message;
   }
 
   /**
@@ -126,6 +137,7 @@ class APIMessage {
 
     const content = this.makeContent();
     const tts = Boolean(this.options.tts);
+
     let nonce;
     if (typeof this.options.nonce !== 'undefined') {
       nonce = parseInt(this.options.nonce);
@@ -149,6 +161,12 @@ class APIMessage {
       if (this.options.avatarURL) avatarURL = this.options.avatarURL;
     }
 
+    let flags;
+    if (this.isMessage) {
+      // eslint-disable-next-line eqeqeq
+      flags = this.options.flags != null ? new MessageFlags(this.options.flags).bitfield : this.target.flags.bitfield;
+    }
+
     this.data = {
       content,
       tts,
@@ -157,6 +175,7 @@ class APIMessage {
       embeds,
       username,
       avatar_url: avatarURL,
+      flags,
     };
     return this;
   }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -530,6 +530,23 @@ class Message extends Base {
   }
 
   /**
+   * Suppresses or unsuppresses embeds on a message
+   * @param {boolean} [suppress=true] If the embeds should be suppressed or not
+   * @returns {Promise<Message>}
+   */
+  suppressEmbeds(suppress = true) {
+    const flags = new MessageFlags(this.flags.bitfield);
+
+    if (suppress) {
+      flags.add(MessageFlags.FLAGS.SUPPRESS_EMBEDS);
+    } else {
+      flags.remove(MessageFlags.FLAGS.SUPPRESS_EMBEDS);
+    }
+
+    return this.edit({ flags });
+  }
+
+  /**
    * Used mainly internally. Whether two messages are identical in properties. If you want to compare messages
    * without checking all the properties, use `message.id === message2.id`, which is much more efficient. This
    * method allows you to see if there are differences in content, embeds, attachments, nonce and tts properties.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -998,6 +998,7 @@ declare module 'discord.js' {
 		public reply(options?: MessageOptions | MessageAdditions | APIMessage): Promise<Message>;
 		public reply(options?: MessageOptions & { split?: false } | MessageAdditions | APIMessage): Promise<Message>;
 		public reply(options?: MessageOptions & { split: true | SplitOptions } | MessageAdditions | APIMessage): Promise<Message[]>;
+		public suppressEmbeds(suppress?: boolean): Promise<Message>;
 		public toJSON(): object;
 		public toString(): string;
 		public unpin(): Promise<Message>;
@@ -2409,6 +2410,7 @@ declare module 'discord.js' {
 		content?: string;
 		embed?: MessageEmbedOptions | null;
 		code?: string | boolean;
+		flags?: BitFieldResolvable<MessageFlagsString>;
 	}
 
 	interface MessageEmbedOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Keeping it simple, adds support for suppressing and unsuppressing message embeds. Closes #3627

## TL;DR

```js
// Suppresses embeds
await m.suppressEmbeds();

// Unsuppresses embeds
await m.suppressEmbeds(false);

// Also suppresses embeds
await m.edit({ flags: ['SUPPRESS_EMBEDS'] });

// Also unsuppresses embeds
// Note however that this method may cause other issues if Discord decides to add more flags that can be added (or removed) by the end user. 
// Message#suppressEmbeds handles it differently, adding (or removing) just the bits for SUPPRESS_EMBEDS
await m.edit({ flags: [] });
```

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
