### PR TITLE
src: Cleanup event listeners on WebSocket connections

### DIFF
--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -245,6 +245,8 @@ class WebSocketManager extends EventEmitter {
       });
 
       shard.on(ShardEvents.DESTROYED, () => {
+        shard._cleanupConnection();
+
         this.debug('Shard was destroyed but no WebSocket connection was present! Reconnecting...', shard);
 
         this.client.emit(Events.SHARD_RECONNECTING, shard.id);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1717,6 +1717,7 @@ declare module 'discord.js' {
 		private _send(data: object): void;
 		private processQueue(): void;
 		private destroy(closeCode: number): void;
+		private _cleanupConnection(): void;
 
 		public send(data: object): void;
 		public on(event: 'ready', listener: () => void): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR should prevent #3641 from happening again, as well as prevent double connections on a shard. It cleans up the event listeners on the connection before doing anything.

### Ok Vlad, but how do we know you tested this?

Well, you can see the code I used down in the details below, but, again, I am not fool proof. Those that encountered issues like #3641 should give this PR a shot.

<details not-open>
<summary>The code I used in a simple message listener to test different close scenarios</summary>

<!-- leave a blank line above -->
```js
if (message.content === '1000') client.ws.shards.get(0).connection.close(1000);
if (message.content === '1001') client.ws.shards.get(0).connection.close(1001);
if (message.content === '1002') client.ws.shards.get(0).connection.close(1002);
if (message.content === '4000') client.ws.shards.get(0).connection.close(4000);

if (message.content === 'test') {
  const shard = client.ws.shards.first();
  shard.sessionID = `${shard.sessionID}a`;
  shard.connection.close(1001);
  message.reply('done');
}
if (message.content === 'test2') {
  const shard = client.ws.shards.first();
  shard.connection.close(4009);
  message.reply('done2');
}
if (message.content === 'test3') {
  const shard = client.ws.shards.first();
  shard.lastHeartbeatAcked = false;
  message.reply('done3');
}
if (message.content === 'test4') {
  const shard = client.ws.shards.first();
  shard.lastHeartbeatAcked = false;
  shard.sessionID = 'no';
  message.reply('done4');
}
if (message.content === 'test5') {
  const shard = client.ws.shards.first();
  shard.connection.close(4000);
  shard.destroy(1000);
  message.reply('done5');
  return;
}

// The following was used to cause the WS connection to hang in a closing state, while not actually working (by attempting to close with an invalid close code, usually 1006 (which you can't use))
const int = parseInt(message.content);
if (!isNaN(int)) {
  const shard = client.ws.shards.first();
  try {
    shard.connection.close(int);
  } catch (err) {
    console.error(err);
  }
}
```
</details>


**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
