### PR TITLE
fix(GuildAuditLogsEntry): provide count on bulk deletion

### DIFF
--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -323,6 +323,10 @@ class GuildAuditLogsEntry {
           count: data.options.count,
           channel: guild.channels.get(data.options.channel_id),
         };
+      } else if (data.action_type === Actions.MESSAGE_BULK_DELETE) {
+        this.extra = {
+          count: data.options.count,
+        };
       } else {
         switch (data.options.type) {
           case 'member':


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

* GuildAuditLogsEntry should provide count as extra in case of  MESSAGE_BULK_DELETE
* The API does provide that information, discord.js does not currently expose it to the user in the GuildAuditLogsEntry
* This PR aims to fix this
* ℹI assume typings need no updating as they are typed as [`object | Role | GuildMember | null;`](https://github.com/discordjs/discord.js/blob/master/typings/index.d.ts#L790)

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
