### PR TITLE
Implement caching of members from message data

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -64,6 +64,13 @@ class Message {
     this.author = this.client.dataManager.newUser(data.author, !data.webhook_id);
 
     /**
+     * Represents the author of the message as a guild member
+     * Only available if the message comes from a guild where the author is still a member
+     * @type {?GuildMember}
+     */
+    this.member = this.guild ? this.guild.member(this.author) || null : null;
+
+    /**
      * Whether or not this message is pinned
      * @type {boolean}
      */
@@ -183,16 +190,6 @@ class Message {
       'mentions_roles' in data ? data.mentions_roles : this.mentions.roles,
       'mention_everyone' in data ? data.mention_everyone : this.mentions.everyone
     );
-  }
-
-  /**
-   * Represents the author of the message as a guild member
-   * Only available if the message comes from a guild where the author is still a member
-   * @type {?GuildMember}
-   * @readonly
-   */
-  get member() {
-    return this.guild ? this.guild.member(this.author) || null : null;
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -149,7 +149,7 @@ class Message {
      */
     this._edits = [];
 
-    if (data.member && this.guild && this.author & !this.guild.members.has(data.member.id)) {
+    if (data.member && this.guild && this.author && !this.guild.members.has(this.author.id)) {
       this.guild._addMember(Object.assign(data.member, { user: this.author }), false);
     }
 
@@ -542,12 +542,12 @@ class Message {
     if (embedUpdate) return this.id === message.id && this.embeds.length === message.embeds.length;
 
     let equal = this.id === message.id &&
-        this.author.id === message.author.id &&
-        this.content === message.content &&
-        this.tts === message.tts &&
-        this.nonce === message.nonce &&
-        this.embeds.length === message.embeds.length &&
-        this.attachments.length === message.attachments.length;
+      this.author.id === message.author.id &&
+      this.content === message.content &&
+      this.tts === message.tts &&
+      this.nonce === message.nonce &&
+      this.embeds.length === message.embeds.length &&
+      this.attachments.length === message.attachments.length;
 
     if (equal && rawData) {
       equal = this.mentions.everyone === message.mentions.everyone &&

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -64,13 +64,6 @@ class Message {
     this.author = this.client.dataManager.newUser(data.author, !data.webhook_id);
 
     /**
-     * Represents the author of the message as a guild member
-     * Only available if the message comes from a guild where the author is still a member
-     * @type {?GuildMember}
-     */
-    this.member = this.guild ? this.guild.member(this.author) || null : null;
-
-    /**
      * Whether or not this message is pinned
      * @type {boolean}
      */
@@ -186,6 +179,16 @@ class Message {
       'mentions_roles' in data ? data.mentions_roles : this.mentions.roles,
       'mention_everyone' in data ? data.mention_everyone : this.mentions.everyone
     );
+  }
+
+  /**
+   * Represents the author of the message as a guild member
+   * Only available if the message comes from a guild where the author is still a member
+   * @type {?GuildMember}
+   * @readonly
+   */
+  get member() {
+    return this.guild ? this.guild.member(this.author) || null : null;
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -151,9 +151,15 @@ class Message {
 
     if (data.member && this.guild && this.author) {
       if (!this.guild.members.has(data.member.id)) {
-        this.guild._addMember(this.author, false);
+        this.guild._addMember(Object.assign(data.member, { user: this.author }), false);
       }
     }
+
+    /**
+     * Represents the author of the message as a guild member
+     * Only available if the message comes from a guild where the author is still a member
+     * @type {?GuildMember}
+     */
     this.member = this.guild ? this.guild.member(this.author) || null : null;
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -64,13 +64,6 @@ class Message {
     this.author = this.client.dataManager.newUser(data.author, !data.webhook_id);
 
     /**
-     * Represents the author of the message as a guild member
-     * Only available if the message comes from a guild where the author is still a member
-     * @type {?GuildMember}
-     */
-    this.member = this.guild ? this.guild.member(this.author) || null : null;
-
-    /**
      * Whether or not this message is pinned
      * @type {boolean}
      */
@@ -157,8 +150,11 @@ class Message {
     this._edits = [];
 
     if (data.member && this.guild && this.author) {
-      this.guild.members.set(data.member.id, Object.assign(data.member, { user: this.author }));
+      if (!this.guild.members.has(data.member.id)) {
+        this.guild._addMember(this.author, false);
+      }
     }
+    this.member = this.guild ? this.guild.member(this.author) || null : null;
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -148,6 +148,10 @@ class Message {
      * @private
      */
     this._edits = [];
+
+    if (data.member && this.guild && this.author) {
+      this.guild.members.set(data.member.id, Object.assign(data.member, { user: this.author }));
+    }
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -542,12 +542,12 @@ class Message {
     if (embedUpdate) return this.id === message.id && this.embeds.length === message.embeds.length;
 
     let equal = this.id === message.id &&
-      this.author.id === message.author.id &&
-      this.content === message.content &&
-      this.tts === message.tts &&
-      this.nonce === message.nonce &&
-      this.embeds.length === message.embeds.length &&
-      this.attachments.length === message.attachments.length;
+        this.author.id === message.author.id &&
+        this.content === message.content &&
+        this.tts === message.tts &&
+        this.nonce === message.nonce &&
+        this.embeds.length === message.embeds.length &&
+        this.attachments.length === message.attachments.length;
 
     if (equal && rawData) {
       equal = this.mentions.everyone === message.mentions.everyone &&

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -149,10 +149,8 @@ class Message {
      */
     this._edits = [];
 
-    if (data.member && this.guild && this.author) {
-      if (!this.guild.members.has(data.member.id)) {
-        this.guild._addMember(Object.assign(data.member, { user: this.author }), false);
-      }
+    if (data.member && this.guild && this.author & !this.guild.members.has(data.member.id)) {
+      this.guild._addMember(Object.assign(data.member, { user: this.author }), false);
     }
 
     /**

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -21,12 +21,12 @@ class MessageMentions {
       } else {
         this.users = new Collection();
         for (const mention of users) {
-          if (mention.member && message.guild) {
-            message.guild.members.set(mention.id, Object.assign(mention.member, { user: mention }));
-          }
           let user = message.client.users.get(mention.id);
           if (!user) user = message.client.dataManager.newUser(mention);
           this.users.set(user.id, user);
+          if (mention.member && message.guild && !message.guild.members.has(mention.id)) {
+            this.guild._addMember(user, false);
+          }
         }
       }
     } else {

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -25,7 +25,7 @@ class MessageMentions {
           if (!user) user = message.client.dataManager.newUser(mention);
           this.users.set(user.id, user);
           if (mention.member && message.guild && !message.guild.members.has(mention.id)) {
-            this.guild._addMember(Object.assign(mention.member, { user }), false);
+            message.guild._addMember(Object.assign(mention.member, { user }), false);
           }
         }
       }

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -21,6 +21,9 @@ class MessageMentions {
       } else {
         this.users = new Collection();
         for (const mention of users) {
+          if (mention.member && message.guild) {
+            message.guild.members.set(mention.id, Object.assign(mention.member, { user: mention }));
+          }
           let user = message.client.users.get(mention.id);
           if (!user) user = message.client.dataManager.newUser(mention);
           this.users.set(user.id, user);

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -25,7 +25,7 @@ class MessageMentions {
           if (!user) user = message.client.dataManager.newUser(mention);
           this.users.set(user.id, user);
           if (mention.member && message.guild && !message.guild.members.has(mention.id)) {
-            this.guild._addMember(user, false);
+            this.guild._addMember(Object.assign(mention.member, { user }), false);
           }
         }
       }


### PR DESCRIPTION
- Backports https://github.com/discordjs/discord.js/commit/8152841bab23eb37b2c83c4d2dc136ddc0c01cb4
- Backports #3601 

Also changes `Message#member` to a getter as per current v12 src

https://github.com/discordjs/discord.js/projects/5#card-31519290
https://github.com/discordjs/discord.js/projects/5#card-31518970

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
