### PR TITLE
TextChannel.topic can be null, backport NewsChannel typings

### DIFF
--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -13,11 +13,8 @@ class NewsChannel extends TextChannel {
   setup(data) {
     super.setup(data);
 
-    /**
-     * The ratelimit per user for this channel (always 0)
-     * @type {number}
-     */
-    this.rateLimitPerUser = 0;
+    // News channels don't have a rate limit per user, remove it
+    this.rateLimitPerUser = undefined;
   }
 }
 

--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -13,8 +13,11 @@ class NewsChannel extends TextChannel {
   setup(data) {
     super.setup(data);
 
-    // News channels don't have a rate limit per user, remove it
-    this.rateLimitPerUser = undefined;
+    /**
+     * The ratelimit per user for this channel (always 0)
+     * @type {number}
+     */
+    this.rateLimitPerUser = 0;
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -918,9 +918,14 @@ declare module 'discord.js' {
 		public remove(user?: UserResolvable): Promise<MessageReaction>;
 	}
 
-	export class NewsChannel extends TextChannel {
+	export class NewsChannel extends TextBasedChannel(GuildChannel) {
 		constructor(guild: Guild, data: object);
-		public rateLimitPerUser: 0;
+		public messages: Collection<Snowflake, Message>;
+		public nsfw: boolean;
+		public topic: string | null;
+		public createWebhook(name: string, avatar: BufferResolvable, reason?: string): Promise<Webhook>;
+		public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
+		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
 	}
 
 	export class OAuth2Application {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1276,7 +1276,7 @@ declare module 'discord.js' {
 		public readonly members: Collection<Snowflake, GuildMember>;
 		public messages: Collection<Snowflake, Message>;
 		public nsfw: boolean;
-		public topic: string;
+		public topic: string | null;
 		public rateLimitPerUser: number;
 		public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
 		public createWebhook(name: string, avatar: BufferResolvable, reason?: string): Promise<Webhook>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -918,15 +918,9 @@ declare module 'discord.js' {
 		public remove(user?: UserResolvable): Promise<MessageReaction>;
 	}
 
-	export class NewsChannel extends TextBasedChannel(GuildChannel) {
+	export class NewsChannel extends TextChannel {
 		constructor(guild: Guild, data: object);
 		public rateLimitPerUser: 0;
-		public messages: Collection<Snowflake, Message>;
-		public nsfw: boolean;
-		public topic: string | null;
-		public createWebhook(name: string, avatar: BufferResolvable, reason?: string): Promise<Webhook>;
-		public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
-		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
 	}
 
 	export class OAuth2Application {


### PR DESCRIPTION
Effectively backports #3628

While doing this I noticed `NewsChannel` directly extends `TextBasedChannel(GuildChannel)` in v12 and doesn't have `rateLimitPerUser`, so that has also been backported.

https://github.com/discordjs/discord.js/projects/5#card-31518940

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
