### PR TITLE
refactor: Remove `util` alias export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,6 @@ module.exports = {
   Structures: require('./util/Structures'),
   SystemChannelFlags: require('./util/SystemChannelFlags'),
   Util: Util,
-  util: Util,
   version: require('../package.json').version,
 
   // Stores


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removes the `util` export from the library, as discussed from the team.
`Util` refers to a namespace, which name convention is to be PascalCase, it did not make sense for it to be camelCase (and less lowercase).

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
