### PR TITLE
Remove BroadcastAudioPlayer

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1476,7 +1476,6 @@ declare module 'discord.js' {
 		constructor(client: Client);
 		public client: Client;
 		public subscribers: StreamDispatcher[];
-		private player: BroadcastAudioPlayer;
 		public readonly dispatcher: BroadcastDispatcher;
 		public play(input: string | Readable, options?: StreamOptions): BroadcastDispatcher;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
BroadcastAudioPlayer doesn't exist in the typings, so this causes build errors.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
