### PR TITLE
docs(MessageMentions): add sort order notice

### DIFF
--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -42,6 +42,7 @@ class MessageMentions {
       if (users instanceof Collection) {
         /**
          * Any users that were mentioned
+         * <info>Order as received from the API, not left to right by occurence in the message content</info>
          * @type {Collection<Snowflake, User>}
          */
         this.users = new Collection(users);
@@ -63,6 +64,7 @@ class MessageMentions {
       if (roles instanceof Collection) {
         /**
          * Any roles that were mentioned
+         * <info>Order as received from the API, not left to right by occurence in the message content</info>
          * @type {Collection<Snowflake, Role>}
          */
         this.roles = new Collection(roles);
@@ -104,6 +106,7 @@ class MessageMentions {
       if (crosspostedChannels instanceof Collection) {
         /**
          * A collection of crossposted channels
+         * <info>Order as received from the API, not left to right by occurence in the message content</info>
          * @type {Collection<Snowflake, CrosspostedChannel>}
          */
         this.crosspostedChannels = new Collection(crosspostedChannels);
@@ -127,6 +130,7 @@ class MessageMentions {
 
   /**
    * Any members that were mentioned (only in {@link TextChannel}s)
+   * <info>Order as received from the API, not left to right by occurence in the message content</info>
    * @type {?Collection<Snowflake, GuildMember>}
    * @readonly
    */
@@ -143,6 +147,7 @@ class MessageMentions {
 
   /**
    * Any channels that were mentioned
+   * <info>Order as received from the API, not left to right by occurence in the message content</info>
    * @type {Collection<Snowflake, GuildChannel>}
    * @readonly
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Apparently the sort order of collections returned from the MessageMentions structure rise issues occasionally both on the discord server as well as the repository
<https://github.com/discordjs/discord.js/issues/2669>  and even upstream <https://github.com/IanMitchell/aquarius/issues/344>

This PR attempts to make the sort order of mention collections clearer on the documentation to prevent this sort of misunderstanding in the future.

If the text can be clearer/improved or changed from info to warning please let me know!

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
