### PR TITLE
Fix: GuildEmoji#id isn't nullable

### DIFF
--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -23,7 +23,7 @@ class GuildEmoji extends Emoji {
      * @type {Guild}
      */
     this.guild = guild;
-    
+
     /**
      * The ID of this emoji
      * @type {Snowflake}

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -23,6 +23,12 @@ class GuildEmoji extends Emoji {
      * @type {Guild}
      */
     this.guild = guild;
+    
+    /**
+     * The ID of this emoji
+     * @type {Snowflake}
+     * @name GuildEmoji#id
+     */
 
     this._roles = [];
     this._patch(data);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -838,6 +838,7 @@ declare module 'discord.js' {
 		constructor(client: Client, data: object, guild: Guild);
 		private _roles: string[];
 
+		public id: Snowflake;
 		public available: boolean;
 		public readonly deletable: boolean;
 		public guild: Guild;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -838,10 +838,10 @@ declare module 'discord.js' {
 		constructor(client: Client, data: object, guild: Guild);
 		private _roles: string[];
 
-		public id: Snowflake;
 		public available: boolean;
 		public readonly deletable: boolean;
 		public guild: Guild;
+		public id: Snowflake;
 		public managed: boolean;
 		public requiresColons: boolean;
 		public roles: GuildEmojiRoleStore;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
GuildEmoji's are custom emojis, which means they always have an ID.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
