### PR TITLE
Add internal support for @discordjs/opus to v11

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ To get ready to work on the codebase, please do the following:
 
 1. Fork & clone the repository, and make sure you're on the **master** branch
 2. Run `npm install`
-3. If you're working on voice, also run `npm install node-opus` or `npm install opusscript`
+3. If you're working on voice, also run `npm install @discordjs/opus` or `npm install opusscript`
 4. Code your heart out!
 5. Run `npm test` to run ESLint and ensure any JSDoc changes are valid
 6. [Submit a pull request](https://github.com/discordjs/discord.js/compare)

--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ discord.js is a powerful [node.js](https://nodejs.org) module that allows you to
 Ignore any warnings about unmet peer dependencies, as they're all optional.
 
 Without voice support: `npm install discord.js`  
-With voice support ([node-opus](https://www.npmjs.com/package/node-opus)): `npm install discord.js node-opus`  
+With voice support ([@discordjs/opus](https://www.npmjs.com/package/@discordjs/opus)): `npm install discord.js @discordjs/opus`  
 With voice support ([opusscript](https://www.npmjs.com/package/opusscript)): `npm install discord.js opusscript`
 
 ### Audio engines
-The preferred audio engine is node-opus, as it performs significantly better than opusscript. When both are available, discord.js will automatically choose node-opus.
-Using opusscript is only recommended for development environments where node-opus is tough to get working.
-For production bots, using node-opus should be considered a necessity, especially if they're going to be running on multiple servers.
+The preferred audio engine is @discordjs/opus, as it performs significantly better than opusscript. When both are available, discord.js will automatically choose @discordjs/opus.
+Using opusscript is only recommended for development environments where @discordjs/opus is tough to get working.
+For production bots, using @discordjs/opus should be considered a necessity, especially if they're going to be running on multiple servers.
 
 ### Optional packages
 - [bufferutil](https://www.npmjs.com/package/bufferutil) to greatly speed up the WebSocket when *not* using uws (`npm install bufferutil`)

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -8,8 +8,8 @@ Update to Node.js 6.0.0 or newer.
 
 ## How do I get voice working?
 - Install FFMPEG.
-- Install either the `node-opus` package or the `opusscript` package.
-  node-opus is greatly preferred, due to it having significantly better performance.
+- Install either the `@discordjs/opus` package or the `opusscript` package.
+  @discordjs/opus is greatly preferred, due to it having significantly better performance.
 
 ## How do I install FFMPEG?
 - **npm:** `npm install ffmpeg-binaries`
@@ -17,7 +17,7 @@ Update to Node.js 6.0.0 or newer.
 - **Ubuntu 14.04:** `sudo apt-get install libav-tools`
 - **Windows:** `npm install ffmpeg-binaries` or see the [FFMPEG section of AoDude's guide](https://github.com/bdistin/OhGodMusicBot/blob/master/README.md#download-ffmpeg).
 
-## How do I set up node-opus?
-- **Ubuntu:** Simply run `npm install node-opus`, and it's done. Congrats!
+## How do I set up @discordjs/opus?
+- **Ubuntu:** Simply run `npm install @discordjs/opus`, and it's done. Congrats!
 - **Windows:** Run `npm install --global --production windows-build-tools` in an admin command prompt or PowerShell.
-  Then, running `npm install node-opus` in your bot's directory should successfully build it. Woo!
+  Then, running `npm install @discordjs/opus` in your bot's directory should successfully build it. Woo!

--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -38,13 +38,13 @@ discord.js is a powerful [Node.js](https://nodejs.org) module that allows you to
 Ignore any warnings about unmet peer dependencies, as they're all optional.
 
 Without voice support: `npm install discord.js`  
-With voice support ([node-opus](https://www.npmjs.com/package/node-opus)): `npm install discord.js node-opus`  
+With voice support ([@discordjs/opus](https://www.npmjs.com/package/@discordjs/opus)): `npm install discord.js @discordjs/opus`  
 With voice support ([opusscript](https://www.npmjs.com/package/opusscript)): `npm install discord.js opusscript`
 
 ### Audio engines
-The preferred audio engine is node-opus, as it performs significantly better than opusscript. When both are available, discord.js will automatically choose node-opus.
-Using opusscript is only recommended for development environments where node-opus is tough to get working.
-For production bots, using node-opus should be considered a necessity, especially if they're going to be running on multiple servers.
+The preferred audio engine is @discordjs/opus, as it performs significantly better than opusscript. When both are available, discord.js will automatically choose @discordjs/opus.
+Using opusscript is only recommended for development environments where @discordjs/opus is tough to get working.
+For production bots, using @discordjs/opus should be considered a necessity, especially if they're going to be running on multiple servers.
 
 ### Optional packages
 - [bufferutil](https://www.npmjs.com/package/bufferutil) to greatly speed up the WebSocket when *not* using uws (`npm install bufferutil`)

--- a/docs/topics/voice.md
+++ b/docs/topics/voice.md
@@ -7,12 +7,12 @@ To get started, make sure you have:
 * FFmpeg - `npm install ffmpeg-binaries`
 * an opus encoder, choose one from below:
   * `npm install opusscript`
-  * `npm install node-opus`
+  * `npm install @discordjs/opus`
 * a good network connection
 
-The preferred opus engine is node-opus, as it performs significantly better than opusscript. When both are available, discord.js will automatically choose node-opus.
-Using opusscript is only recommended for development environments where node-opus is tough to get working.
-For production bots, using node-opus should be considered a necessity, especially if they're going to be running on multiple servers.
+The preferred opus engine is @discordjs/opus, as it performs significantly better than opusscript. When both are available, discord.js will automatically choose @discordjs/opus.
+Using opusscript is only recommended for development environments where @discordjs/opus is tough to get working.
+For production bots, using @discordjs/opus should be considered a necessity, especially if they're going to be running on multiple servers.
 
 ## Joining a voice channel
 The example below reacts to a message and joins the sender's voice channel, catching any errors. This is important

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "src/client/voice/dispatcher/StreamDispatcher.js": false,
     "src/client/voice/opus/BaseOpusEngine.js": false,
     "src/client/voice/opus/NodeOpusEngine.js": false,
+    "src/client/voice/opus/DiscordJsOpusEngine.js": false,
     "src/client/voice/opus/OpusEngineList.js": false,
     "src/client/voice/opus/OpusScriptEngine.js": false,
     "src/client/voice/pcm/ConverterEngine.js": false,

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "erlpack": {
       "optional": true
     },
+    "@discordjs/opus": {
+      "optional": true
+    },
     "node-opus": {
       "optional": true
     },
@@ -94,6 +97,7 @@
     "prism-media": false,
     "opusscript": false,
     "node-opus": false,
+    "@discordjs/opus": false,
     "tweetnacl": false,
     "sodium": false,
     "src/sharding/Shard.js": false,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "runkitExampleFilename": "./docs/examples/ping.js",
   "dependencies": {
     "long": "^4.0.0",
-    "prism-media": "^0.0.3",
+    "prism-media": "^0.0.4",
     "snekfetch": "^3.6.4",
     "tweetnacl": "^1.0.0",
     "ws": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "bufferutil": "^4.0.0",
     "erlpack": "discordapp/erlpack",
     "libsodium-wrappers": "^0.7.3",
+    "@discordjs/opus": "^0.1.0",
     "node-opus": "^0.2.7",
     "opusscript": "^0.0.6",
     "sodium": "^2.0.3"

--- a/src/client/voice/opus/DiscordJsOpus.js
+++ b/src/client/voice/opus/DiscordJsOpus.js
@@ -1,11 +1,9 @@
 const OpusEngine = require('./BaseOpusEngine');
 
-let opus;
-
 class NodeOpusEngine extends OpusEngine {
   constructor(player) {
     super(player);
-    opus = require('@discordjs/opus');
+    const opus = require('@discordjs/opus');
     this.encoder = new opus.OpusEncoder(this.samplingRate, this.channels);
     super.init();
   }

--- a/src/client/voice/opus/DiscordJsOpus.js
+++ b/src/client/voice/opus/DiscordJsOpus.js
@@ -1,0 +1,40 @@
+const OpusEngine = require('./BaseOpusEngine');
+
+let opus;
+
+class NodeOpusEngine extends OpusEngine {
+  constructor(player) {
+    super(player);
+    try {
+      opus = require('@discordjs/opus');
+    } catch (err) {
+      throw err;
+    }
+    this.encoder = new opus.OpusEncoder(this.samplingRate, this.channels);
+    super.init();
+  }
+
+  setBitrate(bitrate) {
+    this.encoder.applyEncoderCTL(this.ctl.BITRATE, Math.min(128, Math.max(16, bitrate)) * 1000);
+  }
+
+  setFEC(enabled) {
+    this.encoder.applyEncoderCTL(this.ctl.FEC, enabled ? 1 : 0);
+  }
+
+  setPLP(percent) {
+    this.encoder.applyEncoderCTL(this.ctl.PLP, Math.min(100, Math.max(0, percent * 100)));
+  }
+
+  encode(buffer) {
+    super.encode(buffer);
+    return this.encoder.encode(buffer, 1920);
+  }
+
+  decode(buffer) {
+    super.decode(buffer);
+    return this.encoder.decode(buffer, 1920);
+  }
+}
+
+module.exports = NodeOpusEngine;

--- a/src/client/voice/opus/DiscordJsOpus.js
+++ b/src/client/voice/opus/DiscordJsOpus.js
@@ -11,7 +11,7 @@ class NodeOpusEngine extends OpusEngine {
   }
 
   setBitrate(bitrate) {
-    this.encoder.applyEncoderCTL(this.ctl.BITRATE, Math.min(128, Math.max(16, bitrate)) * 1000);
+    this.encoder.setBitrate(Math.min(128, Math.max(16, bitrate)) * 1000);
   }
 
   setFEC(enabled) {

--- a/src/client/voice/opus/DiscordJsOpus.js
+++ b/src/client/voice/opus/DiscordJsOpus.js
@@ -5,11 +5,7 @@ let opus;
 class NodeOpusEngine extends OpusEngine {
   constructor(player) {
     super(player);
-    try {
-      opus = require('@discordjs/opus');
-    } catch (err) {
-      throw err;
-    }
+    opus = require('@discordjs/opus');
     this.encoder = new opus.OpusEncoder(this.samplingRate, this.channels);
     super.init();
   }

--- a/src/client/voice/opus/DiscordJsOpusEngine.js
+++ b/src/client/voice/opus/DiscordJsOpusEngine.js
@@ -1,6 +1,6 @@
 const OpusEngine = require('./BaseOpusEngine');
 
-class NodeOpusEngine extends OpusEngine {
+class DiscordJsOpusEngine extends OpusEngine {
   constructor(player) {
     super(player);
     const opus = require('@discordjs/opus');
@@ -31,4 +31,4 @@ class NodeOpusEngine extends OpusEngine {
   }
 }
 
-module.exports = NodeOpusEngine;
+module.exports = DiscordJsOpusEngine;

--- a/src/client/voice/opus/NodeOpusEngine.js
+++ b/src/client/voice/opus/NodeOpusEngine.js
@@ -1,11 +1,9 @@
 const OpusEngine = require('./BaseOpusEngine');
 
-let opus;
-
 class NodeOpusEngine extends OpusEngine {
   constructor(player) {
     super(player);
-    opus = require('node-opus');
+    const opus = require('node-opus');
     this.encoder = new opus.OpusEncoder(this.samplingRate, this.channels);
     super.init();
   }

--- a/src/client/voice/opus/NodeOpusEngine.js
+++ b/src/client/voice/opus/NodeOpusEngine.js
@@ -5,11 +5,7 @@ let opus;
 class NodeOpusEngine extends OpusEngine {
   constructor(player) {
     super(player);
-    try {
-      opus = require('node-opus');
-    } catch (err) {
-      throw err;
-    }
+    opus = require('node-opus');
     this.encoder = new opus.OpusEncoder(this.samplingRate, this.channels);
     super.init();
   }

--- a/src/client/voice/opus/OpusEngineList.js
+++ b/src/client/voice/opus/OpusEngineList.js
@@ -1,4 +1,5 @@
 const list = [
+  require('./DiscordJsOpus'),
   require('./NodeOpusEngine'),
   require('./OpusScriptEngine'),
 ];

--- a/src/client/voice/opus/OpusEngineList.js
+++ b/src/client/voice/opus/OpusEngineList.js
@@ -1,5 +1,5 @@
 const list = [
-  require('./DiscordJsOpus'),
+  require('./DiscordJsOpusEngine'),
   require('./NodeOpusEngine'),
   require('./OpusScriptEngine'),
 ];

--- a/src/client/voice/opus/OpusScriptEngine.js
+++ b/src/client/voice/opus/OpusScriptEngine.js
@@ -5,11 +5,7 @@ let OpusScript;
 class OpusScriptEngine extends OpusEngine {
   constructor(player) {
     super(player);
-    try {
-      OpusScript = require('opusscript');
-    } catch (err) {
-      throw err;
-    }
+    OpusScript = require('opusscript');
     this.encoder = new OpusScript(this.samplingRate, this.channels);
     super.init();
   }

--- a/src/client/voice/opus/OpusScriptEngine.js
+++ b/src/client/voice/opus/OpusScriptEngine.js
@@ -1,11 +1,9 @@
 const OpusEngine = require('./BaseOpusEngine');
 
-let OpusScript;
-
 class OpusScriptEngine extends OpusEngine {
   constructor(player) {
     super(player);
-    OpusScript = require('opusscript');
+    const OpusScript = require('opusscript');
     this.encoder = new OpusScript(this.samplingRate, this.channels);
     super.init();
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds support for `@discordjs/opus`, a performant alternative to `node-opus` with better audio quality.


**To-do:**

- [x] Update code to work with @discordjs/opus
- [x] Update documentation to reflect the preference of @discordjs/opus

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
