### PR TITLE
fix(Presence): account for multiple activities everywhere

### DIFF
--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -68,7 +68,7 @@ class ClientPresence extends Presence {
     };
 
     if ((status || afk || since) && !activity) {
-      packet.game = this.activity;
+      packet.game = this.activities[0] || null;
     }
 
     if (packet.game) {

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -149,7 +149,7 @@ class ClientUser extends Structures.get('User') {
    * @example
    * // Set the client user's activity
    * client.user.setActivity('discord.js', { type: 'WATCHING' })
-   *   .then(presence => console.log(`Activity set to ${presence.activity.name}`))
+   *   .then(presence => console.log(`Activity set to ${presence.activities[0].name}`))
    *   .catch(console.error);
    */
   setActivity(name, options = {}) {

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -85,15 +85,17 @@ class Presence {
      */
     this.status = data.status || this.status || 'offline';
 
-    /**
-     * The activities of this presence
-     * @type {Activity[]}
-     */
-    this.activities = data.activities ?
-      data.activities.map(activity => new Activity(this, activity)) :
-      data.game || data.activity ?
-        [new Activity(this, data.game || data.activity)] :
-        [];
+    if (data.activities) {
+      /**
+       * The activities of this presence
+       * @type {Activity[]}
+       */
+      this.activities = data.activities.map(activity => new Activity(this, activity));
+    } else if (data.activity || data.game) {
+      this.activities = [new Activity(this, data.game || data.activity)];
+    } else {
+      this.activities = [];
+    }
 
     /**
      * The devices this presence is on
@@ -121,12 +123,12 @@ class Presence {
   equals(presence) {
     return this === presence || (
       presence &&
-        this.status === presence.status &&
-        this.activities.length === presence.activities.length &&
-        this.activities.every((activity, index) => activity.equals(presence.activities[index])) &&
-        this.clientStatus.web === presence.clientStatus.web &&
-        this.clientStatus.mobile === presence.clientStatus.mobile &&
-        this.clientStatus.desktop === presence.clientStatus.desktop
+      this.status === presence.status &&
+      this.activities.length === presence.activities.length &&
+      this.activities.every((activity, index) => activity.equals(presence.activities[index])) &&
+      this.clientStatus.web === presence.clientStatus.web &&
+      this.clientStatus.mobile === presence.clientStatus.mobile &&
+      this.clientStatus.desktop === presence.clientStatus.desktop
     );
   }
 

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -89,7 +89,11 @@ class Presence {
      * The activities of this presence
      * @type {Activity[]}
      */
-    this.activities = data.activities ? data.activities.map(activity => new Activity(this, activity)) : [];
+    this.activities = data.activities ?
+      data.activities.map(activity => new Activity(this, activity)) :
+      data.game || data.activity ?
+        [new Activity(this, data.game || data.activity)] :
+        [];
 
     /**
      * The devices this presence is on
@@ -105,7 +109,7 @@ class Presence {
 
   _clone() {
     const clone = Object.assign(Object.create(this), this);
-    if (this.activity) clone.activity = this.activity._clone();
+    if (this.activities) clone.activities = this.activities.map(activity => activity._clone());
     return clone;
   }
 
@@ -117,8 +121,9 @@ class Presence {
   equals(presence) {
     return this === presence || (
       presence &&
-      this.status === presence.status &&
-      this.activity ? this.activity.equals(presence.activity) : !presence.activity &&
+        this.status === presence.status &&
+        this.activities.length === presence.activities.length &&
+        this.activities.every((activity, index) => activity.equals(presence.activities[index])) &&
         this.clientStatus.web === presence.clientStatus.web &&
         this.clientStatus.mobile === presence.clientStatus.mobile &&
         this.clientStatus.desktop === presence.clientStatus.desktop


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #3695 by accounting for the activities array from `Presence` in multiple places:
- Default `packet.game` to the first activity or null if none was set.
- Update example still using `activity`
- Use single activity / game if activities array is missing (for example when patching the `ClientPresence`)
- `_clone` the `activities` array
- Account for an `activities` array in `equals`

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
