### PR TITLE
docs(MessageMentions): channels are actually in order

### DIFF
--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -42,7 +42,7 @@ class MessageMentions {
       if (users instanceof Collection) {
         /**
          * Any users that were mentioned
-         * <info>Order as received from the API, not left to right by occurence in the message content</info>
+         * <info>Order as received from the API, not as they appear in the message content</info>
          * @type {Collection<Snowflake, User>}
          */
         this.users = new Collection(users);
@@ -64,7 +64,7 @@ class MessageMentions {
       if (roles instanceof Collection) {
         /**
          * Any roles that were mentioned
-         * <info>Order as received from the API, not left to right by occurence in the message content</info>
+         * <info>Order as received from the API, not as they appear in the message content</info>
          * @type {Collection<Snowflake, Role>}
          */
         this.roles = new Collection(roles);
@@ -106,7 +106,7 @@ class MessageMentions {
       if (crosspostedChannels instanceof Collection) {
         /**
          * A collection of crossposted channels
-         * <info>Order as received from the API, not left to right by occurence in the message content</info>
+         * <info>Order as received from the API, not as they appear in the message content</info>
          * @type {Collection<Snowflake, CrosspostedChannel>}
          */
         this.crosspostedChannels = new Collection(crosspostedChannels);
@@ -130,7 +130,7 @@ class MessageMentions {
 
   /**
    * Any members that were mentioned (only in {@link TextChannel}s)
-   * <info>Order as received from the API, not left to right by occurence in the message content</info>
+   * <info>Order as received from the API, not as they appear in the message content</info>
    * @type {?Collection<Snowflake, GuildMember>}
    * @readonly
    */

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -147,6 +147,7 @@ class MessageMentions {
 
   /**
    * Any channels that were mentioned
+   * <info>Order as they appear first in the message content</info>
    * @type {Collection<Snowflake, GuildChannel>}
    * @readonly
    */

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -147,7 +147,6 @@ class MessageMentions {
 
   /**
    * Any channels that were mentioned
-   * <info>Order as received from the API, not left to right by occurence in the message content</info>
    * @type {Collection<Snowflake, GuildChannel>}
    * @readonly
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since the channels mentions are parsed from the message content, it's fairly safe to assume they are in that order.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
