### PR TITLE
feat(Guild): add setBanner method and banner to edit

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -851,6 +851,7 @@ class Guild {
    * @property {ChannelResolvable} [systemChannel] The system channel of the guild
    * @property {number} [afkTimeout] The AFK timeout of the guild
    * @property {Base64Resolvable} [icon] The icon of the guild
+   * @property {Base64Resolvable} [banner] The banner of the guild
    * @property {GuildMemberResolvable} [owner] The owner of the guild
    * @property {Base64Resolvable} [splash] The splash screen of the guild
    */
@@ -884,6 +885,7 @@ class Guild {
     if (typeof data.icon !== 'undefined') _data.icon = data.icon;
     if (data.owner) _data.owner_id = this.client.resolver.resolveUser(data.owner).id;
     if (typeof data.splash !== 'undefined') _data.splash = data.splash;
+    if (typeof data.banner !== 'undefined') _data.banner = data.banner;
     if (typeof data.explicitContentFilter !== 'undefined') {
       _data.explicit_content_filter = Number(data.explicitContentFilter);
     }
@@ -893,6 +895,16 @@ class Guild {
         Number(data.defaultMessageNotifications);
     }
     return this.client.rest.methods.updateGuild(this, _data, reason);
+  }
+
+  /**
+   * Sets a new guild banner.
+   * @param {BufferResolvable|Base64Resolvable} banner The new banner of the guild
+   * @param {string} [reason] Reason for changing the guild's banner
+   * @returns {Guild}
+   */
+  setBanner(banner, reason) {
+    return this.client.resolver.resolveImage(banner).then(data => this.edit({ banner: data }, reason));
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -570,6 +570,7 @@ declare module 'discord.js' {
 		public search(options?: MessageSearchOptions): Promise<MessageSearchResult>;
 		public setAFKChannel(afkChannel: ChannelResolvable, reason?: string): Promise<Guild>;
 		public setAFKTimeout(afkTimeout: number, reason?: string): Promise<Guild>;
+		public setBanner(banner: Base64Resolvable, reason?: string): Promise<Guild>;
 		public setChannelPosition(channel: string | GuildChannel, position: number, relative?: boolean): Promise<Guild>;
 		public setChannelPositions(channelPositions: ChannelPosition[]): Promise<Guild>;
 		public setDefaultMessageNotifications(defaultMessageNotifications: DefaultMessageNotifications, reason?: string): Promise<Guild>;
@@ -1877,6 +1878,7 @@ declare module 'discord.js' {
 		afkChannel?: ChannelResolvable;
 		systemChannel?: ChannelResolvable;
 		afkTimeout?: number;
+		banner?: Base64Resolvable;
 		icon?: Base64Resolvable;
 		owner?: GuildMemberResolvable;
 		splash?: Base64Resolvable;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #3364 adding `Guild#setBanner` and `banner` to `Guild#edit`.

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
> I don't have a qualifying guild at hand to test this.
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
