### PR TITLE
fix(VoiceConnection): use Client#clearTimeout to clear timeouts

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -229,7 +229,7 @@ class VoiceConnection extends EventEmitter {
     const { token, endpoint, sessionID } = this.authentication;
 
     if (token && endpoint && sessionID) {
-      clearTimeout(this.connectTimeout);
+      this.client.clearTimeout(this.connectTimeout);
       this.status = Constants.VoiceStatus.CONNECTING;
       /**
        * Emitted when we successfully initiate a voice connection.
@@ -246,7 +246,7 @@ class VoiceConnection extends EventEmitter {
    * @private
    */
   authenticateFailed(reason) {
-    clearTimeout(this.connectTimeout);
+    this.client.clearTimeout(this.connectTimeout);
     if (this.status === Constants.VoiceStatus.AUTHENTICATING) {
       /**
        * Emitted when we fail to initiate a voice connection.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #3553 by using `Client#clearTimeout` to clear timeouts.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
