### PR TITLE
feat(Webhook): backport missing properties

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -110,6 +110,16 @@ class Webhook extends EventEmitter {
   }
 
   /**
+   * The url of this webhook
+   * @type {string}
+   * @readonly
+   */
+  get url() {
+    const API = `${this.client.options.http.host}/api/v${this.client.options.http.version}`;
+    return API + Constants.Endpoints.Webhook(this.id, this.token);
+  }
+
+  /**
    * Options that can be passed into send, sendMessage, sendFile, sendEmbed, and sendCode.
    * @typedef {Object} WebhookMessageOptions
    * @property {string} [username=this.name] Username override for the message

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -3,6 +3,7 @@ const path = require('path');
 const Util = require('../util/Util');
 const Attachment = require('./Attachment');
 const RichEmbed = require('./RichEmbed');
+const Constants = require('../util/Constants');
 
 /**
  * Represents a webhook.
@@ -73,6 +74,16 @@ class Webhook extends EventEmitter {
     } else {
       this.owner = null;
     }
+  }
+
+  /**
+   * A link to the webhook user's avatar
+   * @type {?stirng}
+   * @readonly
+   */
+  get avatarURL() {
+    if (!this.avatar) return null;
+    return Constants.Endpoints.CDN(this.client.options.http.cdn).Avatar(this.id, this.avatar);
   }
 
   /**

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -94,6 +94,8 @@ class Webhook extends EventEmitter {
 
   /**
    * The time the webhook was created at
+   * @type {Date}
+   * @readonly
    */
   get createdAt() {
     return new Date(this.createdTimestamp);

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -4,6 +4,7 @@ const Util = require('../util/Util');
 const Attachment = require('./Attachment');
 const RichEmbed = require('./RichEmbed');
 const Constants = require('../util/Constants');
+const Snowflake = require('../util/Snowflake');
 
 /**
  * Represents a webhook.
@@ -37,9 +38,9 @@ class Webhook extends EventEmitter {
     /**
      * The token for the webhook
      * @name Webhook#token
-     * @type {string}
+     * @type {?string}
      */
-    Object.defineProperty(this, 'token', { value: data.token, writable: true, configurable: true });
+    Object.defineProperty(this, 'token', { value: data.token || null, writable: true, configurable: true });
 
     /**
      * The avatar for the webhook
@@ -52,6 +53,12 @@ class Webhook extends EventEmitter {
      * @type {Snowflake}
      */
     this.id = data.id;
+
+    /**
+     * The type of the webhook
+     * @type {WebhookTypes}
+     */
+    this.type = Constants.WebhookTypes[data.type];
 
     /**
      * The guild the webhook belongs to
@@ -74,6 +81,22 @@ class Webhook extends EventEmitter {
     } else {
       this.owner = null;
     }
+  }
+
+  /**
+   * The timestamp the webhook was created at
+   * @type {number}
+   * @readonly
+   */
+  get createdTimestamp() {
+    return Snowflake.deconstruct(this.id).timestamp;
+  }
+
+  /**
+   * The time the webhook was created at
+   */
+  get createdAt() {
+    return new Date(this.createdTimestamp);
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -898,3 +898,16 @@ exports.MembershipStates = [
   'INVITED',
   'ACCEPTED',
 ];
+
+/**
+ * The value set for a webhook's type:
+ * * Incoming
+ * * Channel Follower
+ * @typedef {string} WebhookTypes
+ */
+exports.WebhookTypes = [
+  // They start at 1
+  null,
+  'Incoming',
+  'Channel Follower',
+];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1580,6 +1580,7 @@ declare module 'discord.js' {
 		public owner: User | object;
 		public token: string | null;
 		public type: WebhookTypes;
+		public readonly url: string;
 		public delete(reason?: string): Promise<void>;
 		public edit(name?: string, avatar?: BufferResolvable): Promise<Webhook>;
 		public edit(options?: WebhookEditOptions, reason?: string): Promise<Webhook>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1578,7 +1578,8 @@ declare module 'discord.js' {
 		public id: Snowflake;
 		public name: string;
 		public owner: User | object;
-		public token: string;
+		public token: string | null;
+		public type: WebhookTypes;
 		public delete(reason?: string): Promise<void>;
 		public edit(name?: string, avatar?: BufferResolvable): Promise<Webhook>;
 		public edit(options?: WebhookEditOptions, reason?: string): Promise<Webhook>;
@@ -1597,6 +1598,7 @@ declare module 'discord.js' {
 		private _timeouts: Set<NodeJS.Timer>;
 		private resolver: ClientDataResolver;
 		private rest: object;
+		public token: string;
 
 		public options: ClientOptions;
 		public clearInterval(interval: NodeJS.Timer): void;
@@ -2221,6 +2223,8 @@ declare module 'discord.js' {
 		code?: string | boolean;
 		split?: boolean | SplitOptions;
 	};
+
+	type WebhookTypes = 'Incoming' | 'Channel Follower';
 
 	type WebSocketOptions = {
 		large_threshold?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1570,7 +1570,8 @@ declare module 'discord.js' {
 
 	export class Webhook {
 		constructor(client: Client, dataOrID: object | string, token: string);
-		public avatar: string;
+		public avatar: string | null;
+		public readonly avatarURL: string | null;
 		public channelID: string;
 		public readonly client: Client;
 		public guildID: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports the following properties of `Webhook`:
- `avatarURL` as a getter from #3625 
- `type`, `createdAt`, and `createdTimestamp` from #3585 
- `url` from #3178

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
