### PR TITLE
feat(MessageAttachment): add spoiler getter

### DIFF
--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -1,3 +1,5 @@
+const { basename } = require('path');
+
 /**
  * Represents an attachment in a message.
  */
@@ -62,6 +64,15 @@ class MessageAttachment {
      * @type {?number}
      */
     this.width = data.width;
+  }
+
+  /**
+   * Whether or not this attachment has been marked as a spoiler
+   * @type {boolean}
+   * @readonly
+   */
+  get spoiler() {
+    return basename(this.url).startsWith('SPOILER_');
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -795,6 +795,7 @@ declare module 'discord.js' {
 		public id: Snowflake;
 		public message: Message;
 		public proxyURL: string;
+		public readonly spoiler: boolean;
 		public url: string;
 		public width: number;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #3561 by adding `MessageAttachment#spoiler`.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
