### PR TITLE
docs/typings(MessageAttachment): mark spoiler as readonly, order spoiler in typings

### DIFF
--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -84,6 +84,7 @@ class MessageAttachment {
   /**
    * Whether or not this attachment has been marked as a spoiler
    * @type {boolean}
+   * @readonly
    */
   get spoiler() {
     return Util.basename(this.url).startsWith('SPOILER_');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1013,9 +1013,9 @@ declare module 'discord.js' {
 		public name?: string;
 		public proxyURL: string;
 		public size: number;
+		public readonly spoiler: boolean;
 		public url: string;
 		public width: number | null;
-		public readonly spoiler: boolean;
 		public setFile(attachment: BufferResolvable | Stream, name?: string): this;
 		public setName(name: string): this;
 		public toJSON(): object;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR marks `MessageAttachment#spoiler` as readonly and moves the property in the typings to the correct place.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
