### PR TITLE
fix: only setMaxListeners when max listeners is not 0

### DIFF
--- a/src/client/websocket/packets/handlers/Ready.js
+++ b/src/client/websocket/packets/handlers/Ready.js
@@ -63,11 +63,13 @@ class ReadyHandler extends AbstractHandler {
       client.ws.connection.triggerReady();
     }, 1200 * data.guilds.length);
 
-    client.setMaxListeners(data.guilds.length + 10);
+    const guildCount = data.guilds.length;
+
+    if (client.getMaxListeners() !== 0) client.setMaxListeners(client.getMaxListeners() + guildCount);
 
     client.once('ready', () => {
       client.syncGuilds();
-      client.setMaxListeners(10);
+      if (client.getMaxListeners() !== 0) client.setMaxListeners(client.getMaxListeners() - guildCount);
       client.clearTimeout(t);
     });
 

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -33,7 +33,7 @@ class MessageCollector extends Collector {
      */
     this.received = 0;
 
-    this.client.setMaxListeners(this.client.getMaxListeners() + 1);
+    if (this.client.getMaxListeners() !== 0) this.client.setMaxListeners(this.client.getMaxListeners() + 1);
     this.client.on('message', this.listener);
 
     // For backwards compatibility (remove in v12)
@@ -93,7 +93,7 @@ class MessageCollector extends Collector {
   cleanup() {
     this.removeListener('collect', this._reEmitter);
     this.client.removeListener('message', this.listener);
-    this.client.setMaxListeners(this.client.getMaxListeners() - 1);
+    if (this.client.getMaxListeners() !== 0) this.client.setMaxListeners(this.client.getMaxListeners() - 1);
   }
 }
 

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -39,7 +39,7 @@ class ReactionCollector extends Collector {
      */
     this.total = 0;
 
-    this.client.setMaxListeners(this.client.getMaxListeners() + 1);
+    if (this.client.getMaxListeners() !== 0) this.client.setMaxListeners(this.client.getMaxListeners() + 1);
     this.client.on('messageReactionAdd', this.listener);
   }
 
@@ -78,7 +78,7 @@ class ReactionCollector extends Collector {
    */
   cleanup() {
     this.client.removeListener('messageReactionAdd', this.listener);
-    this.client.setMaxListeners(this.client.getMaxListeners() - 1);
+    if (this.client.getMaxListeners() !== 0) this.client.setMaxListeners(this.client.getMaxListeners() - 1);
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #3504 by only using `EventEmitter#setMaxListeners` if the listener count is not `0` (no limit).

This PR also handles this edge case when using the `fetchAllMembers` option where the listener could would be reset to 10 whatever it was before.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
