### PR TITLE
fix(*Collector): always run postCheck, remove 'translatation' of message collector options

### DIFF
--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -36,15 +36,6 @@ class MessageCollector extends Collector {
     this.client.setMaxListeners(this.client.getMaxListeners() + 1);
     this.client.on('message', this.listener);
 
-    // For backwards compatibility (remove in v12)
-    if (this.options.max) {
-      this.options.maxProcessed = this.options.max;
-      delete this.options.max;
-    }
-    if (this.options.maxMatches) {
-      this.options.max = this.options.maxMatches;
-      delete this.options.maxMatches;
-    }
     this._reEmitter = message => {
       /**
        * Emitted when the collector receives a message.
@@ -87,8 +78,8 @@ class MessageCollector extends Collector {
    */
   postCheck() {
     // Consider changing the end reasons for v12
-    if (this.options.maxMatches && this.collected.size >= this.options.max) return 'matchesLimit';
-    if (this.options.max && this.received >= this.options.maxProcessed) return 'limit';
+    if (this.options.maxMatches && this.collected.size >= this.options.maxMatches) return 'matchesLimit';
+    if (this.options.max && this.received >= this.options.max) return 'limit';
     return null;
   }
 

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -37,8 +37,14 @@ class MessageCollector extends Collector {
     this.client.on('message', this.listener);
 
     // For backwards compatibility (remove in v12)
-    if (this.options.max) this.options.maxProcessed = this.options.max;
-    if (this.options.maxMatches) this.options.max = this.options.maxMatches;
+    if (this.options.max) {
+      this.options.maxProcessed = this.options.max;
+      delete this.options.max;
+    }
+    if (this.options.maxMatches) {
+      this.options.max = this.options.maxMatches;
+      delete this.options.maxMatches;
+    }
     this._reEmitter = message => {
       /**
        * Emitted when the collector receives a message.

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -79,17 +79,17 @@ class Collector extends EventEmitter {
    */
   _handle(...args) {
     const collect = this.handle(...args);
-    if (!collect || !this.filter(...args, this.collected)) return;
+    if (collect && this.filter(...args, this.collected)) {
+      this.collected.set(collect.key, collect.value);
 
-    this.collected.set(collect.key, collect.value);
-
-    /**
-     * Emitted whenever an element is collected.
-     * @event Collector#collect
-     * @param {*} element The element that got collected
-     * @param {Collector} collector The collector
-     */
-    this.emit('collect', collect.value, this);
+      /**
+       * Emitted whenever an element is collected.
+       * @event Collector#collect
+       * @param {*} element The element that got collected
+       * @param {Collector} collector The collector
+       */
+      this.emit('collect', collect.value, this);
+    }
 
     const post = this.postCheck(...args);
     if (post) this.stop(post);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the "translation" of the `MessageCollectorOptions` from `{ max, maxMatches }` (v11) to `{ maxProcessed, max }` (v12), which did not clear `max` after assigning it to maxProcessed leaving it always set if specified.

This PR also ensures that `Collector#postCheck` (and potentially `Collector#stop`) is always getting called, even if nothing was collected.

Resolves #3717 

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
