### PR TITLE
fix typings for RichPresenceAssets#largeImageURL (and smallImageURL)

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1197,8 +1197,8 @@ declare module 'discord.js' {
 		public largeText: string | null;
 		public smallImage: Snowflake | null;
 		public smallText: string | null;
-		public largeImageURL(options: ImageURLOptions): string | null;
-		public smallImageURL(options: ImageURLOptions): string | null;
+		public largeImageURL(options?: ImageURLOptions): string | null;
+		public smallImageURL(options?: ImageURLOptions): string | null;
 	}
 
 	export class Role extends Base {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR marks the `options` parameter in `RichPresenceAssets#largeImageURL` and `RichPresenceAssets#smallImageURL` as optional, (see [here](https://github.com/discordjs/discord.js/blob/master/src/structures/Presence.js#L304))

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
