### PR TITLE
fix(ClientUser) verified and enabled properties resetting

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -30,7 +30,9 @@ class ClientUser extends Structures.get('User') {
        * @type {?boolean}
        */
       this.mfaEnabled = typeof data.mfa_enabled === 'boolean' ? data.mfa_enabled : null;
-    } else if (typeof this.mfaEnabled === 'undefined') this.mfaEnbled = null;
+    } else if (typeof this.mfaEnabled === 'undefined') {
+      this.mfaEnbled = null;
+    }
 
     if (data.token) this.client.token = data.token;
   }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -16,17 +16,21 @@ class ClientUser extends Structures.get('User') {
   _patch(data) {
     super._patch(data);
 
-    /**
-     * Whether or not this account has been verified
-     * @type {boolean}
-     */
-    this.verified = data.verified;
+    if ('verified' in data) {
+      /**
+       * Whether or not this account has been verified
+       * @type {boolean}
+       */
+      this.verified = data.verified;
+    }
 
-    /**
-     * If the bot's {@link ClientApplication#owner Owner} has MFA enabled on their account
-     * @type {?boolean}
-     */
-    this.mfaEnabled = typeof data.mfa_enabled === 'boolean' ? data.mfa_enabled : null;
+    if ('mfa_enabled' in data) {
+      /**
+       * If the bot's {@link ClientApplication#owner Owner} has MFA enabled on their account
+       * @type {?boolean}
+       */
+      this.mfaEnabled = typeof data.mfa_enabled === 'boolean' ? data.mfa_enabled : null;
+    }
 
     if (data.token) this.client.token = data.token;
   }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -30,7 +30,7 @@ class ClientUser extends Structures.get('User') {
        * @type {?boolean}
        */
       this.mfaEnabled = typeof data.mfa_enabled === 'boolean' ? data.mfa_enabled : null;
-    }
+    } else if (typeof this.mfaEnabled === 'undefined') this.mfaEnbled = null;
 
     if (data.token) this.client.token = data.token;
   }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -31,7 +31,7 @@ class ClientUser extends Structures.get('User') {
        */
       this.mfaEnabled = typeof data.mfa_enabled === 'boolean' ? data.mfa_enabled : null;
     } else if (typeof this.mfaEnabled === 'undefined') {
-      this.mfaEnbled = null;
+      this.mfaEnabled = null;
     }
 
     if (data.token) this.client.token = data.token;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes `ClientUser#verified` and `ClientUser#mfaEnabled` properties resetting when something triggers the _patch method, by only setting the properties if they exist in the data

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
