### PR TITLE
fix: remove for..in in favor of Object.keys

### DIFF
--- a/src/client/rest/RESTMethods.js
+++ b/src/client/rest/RESTMethods.js
@@ -238,7 +238,7 @@ class RESTMethods {
       include_nsfw: options.nsfw,
     };
 
-    for (const key in options) if (options[key] === undefined) delete options[key];
+    for (const key of Object.keys(options)) if (options[key] === undefined) delete options[key];
     const queryString = (querystring.stringify(options).match(/[^=&?]+=[^=&?]+/g) || []).join('&');
 
     let endpoint;

--- a/src/client/voice/util/SecretKey.js
+++ b/src/client/voice/util/SecretKey.js
@@ -9,7 +9,7 @@ class SecretKey {
      * @type {Uint8Array}
      */
     this.key = new Uint8Array(new ArrayBuffer(key.length));
-    for (const index in key) this.key[index] = key[index];
+    for (const index of Object.keys(key)) this.key[index] = key[index];
   }
 }
 

--- a/src/client/websocket/packets/handlers/Ready.js
+++ b/src/client/websocket/packets/handlers/Ready.js
@@ -36,7 +36,7 @@ class ReadyHandler extends AbstractHandler {
     }
 
     if (data.notes) {
-      for (const user in data.notes) {
+      for (const user of Object.keys(data.notes)) {
         let note = data.notes[user];
         if (!note.length) note = null;
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -258,7 +258,7 @@ class GuildChannel extends Channel {
       payload.deny = prevOverwrite.deny;
     }
 
-    for (const perm in options) {
+    for (const perm of Object.keys(options)) {
       if (options[perm] === true) {
         payload.allow |= Permissions.FLAGS[perm] || 0;
         payload.deny &= ~(Permissions.FLAGS[perm] || 0);

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -126,7 +126,7 @@ class Permissions {
    */
   serialize(checkAdmin = true) {
     const serialized = {};
-    for (const perm in this.constructor.FLAGS) serialized[perm] = this.has(perm, checkAdmin);
+    for (const perm of Object.keys(this.constructor.FLAGS)) serialized[perm] = this.has(perm, checkAdmin);
     return serialized;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #3567 by replacing all for..in with Object.keys which do not enumerate inherited properties.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
(Only the non-userbot parts)
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
