### PR TITLE
feat(Presence/Game): multiple activities and custom status

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -1,4 +1,5 @@
 const { ActivityFlags, Endpoints } = require('../util/Constants');
+const ReactionEmoji = require('./ReactionEmoji');
 
 /**
  * The status of this presence:
@@ -159,8 +160,36 @@ class Game {
      */
     this.assets = data.assets ? new RichPresenceAssets(this, data.assets) : null;
 
+    if (data.emoji) {
+      /**
+       * Emoji for a custom activity
+       * <warn>There is no `reaction` property for this emoji.</warn>
+       * @type {?ReactionEmoji}
+       */
+      this.emoji = new ReactionEmoji({ message: { client: this.presence.client } }, data.emoji);
+      this.emoji.reaction = null;
+    } else {
+      this.emoji = null;
+    }
+
+
+    /**
+     * Creation date of the activity
+     * @type {number}
+     */
+    this.createdTimestamp = new Date(data.created_at).getTime();
+
     this.syncID = data.sync_id;
     this._flags = data.flags;
+  }
+
+  /**
+   * The time the activity was created at
+   * @type {Date}
+   * @readonly
+   */
+  get createdAt() {
+    return new Date(this.createdTimestamp);
   }
 
   get flags() {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -438,6 +438,7 @@ declare module 'discord.js' {
 		public applicationID: string;
 		public assets: RichPresenceAssets;
 		public details: string;
+		public emoji: Omit<ReactionEmoji, 'reaction'> | null;
 		public name: string;
 		public readonly streaming: boolean;
 		public party: {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1010,6 +1010,7 @@ declare module 'discord.js' {
 
 	export class Presence {
 		constructor(data: object, client: Client);
+		public activities: Game[];
 		public readonly client: Client;
 		public game: Game;
 		public status: PresenceStatusData;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #3661 and #3703 by adding support for multiple activities.
This PR also backports #3353 by adding `emoji`, `createdAt`, and `createdTimestamp` to `Game`.

I removed the duplicated code in Presence by putting the initializing part into the update method.

The hack using MessageReaction is a bit ugly, but I couldn't come up with anything better.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
