### PR TITLE
fix(Voice*): fix speaking event and voice receive

### DIFF
--- a/src/client/voice/VoiceWebSocket.js
+++ b/src/client/voice/VoiceWebSocket.js
@@ -184,9 +184,9 @@ class VoiceWebSocket extends EventEmitter {
         /**
          * Emitted whenever a speaking packet is received.
          * @param {Object} data
-         * @event VoiceWebSocket#speaking
+         * @event VoiceWebSocket#startSpeaking
          */
-        this.emit('speaking', packet.d);
+        this.emit('startSpeaking', packet.d);
         break;
       default:
         /**

--- a/src/client/voice/receiver/VoiceReceiver.js
+++ b/src/client/voice/receiver/VoiceReceiver.js
@@ -175,9 +175,9 @@ class VoiceReceiver extends EventEmitter {
         }
         offset += 1 + (0b1111 & (byte >> 4));
       }
-      while (data[offset] === 0) {
-        offset++;
-      }
+      // Skip over undocumented Discord byte
+      offset++;
+
       data = data.slice(offset);
     }
 

--- a/src/client/voice/receiver/VoiceReceiver.js
+++ b/src/client/voice/receiver/VoiceReceiver.js
@@ -43,7 +43,7 @@ class VoiceReceiver extends EventEmitter {
 
     this._listener = msg => {
       const ssrc = +msg.readUInt32BE(8).toString(10);
-      const user = this.voiceConnection.ssrcMap.get(ssrc);
+      const user = connection.client.users.get(connection.ssrcMap.get(ssrc));
       if (!user) {
         if (!this.queues.has(ssrc)) this.queues.set(ssrc, []);
         this.queues.get(ssrc).push(msg);

--- a/src/client/voice/util/Silence.js
+++ b/src/client/voice/util/Silence.js
@@ -1,0 +1,16 @@
+const { Readable } = require('stream');
+
+const SILENCE_FRAME = Buffer.from([0xF8, 0xFF, 0xFE]);
+
+/**
+ * A readable emitting silent opus frames.
+ * @extends {Readable}
+ * @private
+ */
+class Silence extends Readable {
+  _read() {
+    this.push(SILENCE_FRAME);
+  }
+}
+
+module.exports = Silence;

--- a/src/client/voice/util/SingleSilence.js
+++ b/src/client/voice/util/SingleSilence.js
@@ -1,0 +1,17 @@
+const Silence = require('./Silence');
+
+/**
+ * Only emits a single silent opus frame.
+ * This is used as a workaround for Discord now requiring
+ * silence to be sent before being able to receive audio.
+ * @extends {Silence}
+ * @private
+ */
+class SingleSilence extends Silence {
+  _read() {
+    super._read();
+    this.push(null);
+  }
+}
+
+module.exports = SingleSilence;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1415,7 +1415,8 @@ declare module 'discord.js' {
 		constructor(voiceManager: ClientVoiceManager, channel: VoiceChannel);
 		private authentication: object;
 		private sockets: object;
-		private ssrcMap: Map<number, boolean>;
+		private ssrcMap: Map<number, Snowflake>;
+		private speakingTimeouts: Map<number, NodeJS.Timer>;
 		private authenticate(): void;
 		private authenticateFailed(reason: string): void;
 		private checkAuthenticated(): void;
@@ -1540,14 +1541,14 @@ declare module 'discord.js' {
 
 		public on(event: 'ready', listener: (packet: object) => void): this;
 		public on(event: 'sessionDescription', listener: (encryptionMode: string, secretKey: SecretKey) => void): this;
-		public on(event: 'speaking', listener: (data: object) => void): this;
+		public on(event: 'startSpeaking', listener: (data: object) => void): this;
 		public on(event: 'unknownPacket', listener: (packet: object) => void): this;
 		public on(event: 'warn', listener: (warn: string) => void): this;
 		public on(event: string, listener: Function): this;
 
 		public once(event: 'ready', listener: (packet: object) => void): this;
 		public once(event: 'sessionDescription', listener: (encryptionMode: string, secretKey: SecretKey) => void): this;
-		public once(event: 'speaking', listener: (data: object) => void): this;
+		public once(event: 'startSpeaking', listener: (data: object) => void): this;
 		public once(event: 'unknownPacket', listener: (packet: object) => void): this;
 		public once(event: 'warn', listener: (warn: string) => void): this;
 		public once(event: string, listener: Function): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #3578 by synthesizing the speaking events from UDP packets.
- `Client#guildMemberSpeaking`, `VoiceConnection#speaking`

This PR backports #3555 by skipping over the undocumented Discord byte.
- Allowing opus packets to be decoded again.

This PR backports f826c9c75e976a8dca3fb4c88c130a1e12147a80 by playing a frame of silence before emitting ready on the voice connection.
- Allowing voice receive to work without sending anything further. (Since d.js does that now)

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
