### PR TITLE
docs(Guild): fetchBan returns a promise

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -557,7 +557,7 @@ class Guild extends Base {
   /**
   * Fetches information on a banned user from this guild.
    * @param {UserResolvable} user The User to fetch the ban info of
-   * @returns {BanInfo}
+   * @returns {Promise<BanInfo>}
    */
   fetchBan(user) {
     const id = this.client.users.resolveID(user);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Guild#fetchBan()` should be marked as returning a Promise. Even the [typings](https://github.com/discordjs/discord.js/blob/master/typings/index.d.ts#L738) state that it should return a Promise.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.