### PR TITLE
feat(Presence): Add info tag to ActivityType regarding custom status

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -423,6 +423,7 @@ exports.MessageTypes = [
 ];
 
 /**
+ * <info>Bots cannot set a `CUSTOM_STATUS`, it is only for custom statuses received from users</info>
  * The type of an activity of a users presence, e.g. `PLAYING`. Here are the available types:
  * * PLAYING
  * * STREAMING


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pr adds an info tag explaining that `CUSTOM_STATUS` is only for custom statuses received from users and that bots cannot set them, as currently setActivity states the activity's type can be any of ActivityType

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
