### PR TITLE
feat(Presence): Backport info tag in ActivityType.

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -368,6 +368,7 @@ exports.Events = {
 };
 
 /**
+ * <info>Bots cannot set a `CUSTOM_STATUS`, it is only for custom statuses received from users</info>
  * The type of an activity of a users presence, e.g. `PLAYING`. Here are the available types:
  * * PLAYING
  * * STREAMING


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pr backports #3757 by adding an info tag to ActivityType explaining that bots cannot set custom statuses and it is only for custom statuses received from users

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
