### PR TITLE
feat: bring embed builder field manipulation in line with underlying array functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ discord.js is a powerful [Node.js](https://nodejs.org) module that allows you to
 - 100% coverage of the Discord API
 
 ## Installation
-**Node.js 10.2.0 or newer is required.**  
+**Node.js 11.0.0 or newer is required.**  
 Ignore any warnings about unmet peer dependencies, as they're all optional.
 
 Without voice support: `npm install discordjs/discord.js`  

--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -3,7 +3,7 @@ These questions are some of the most frequently asked.
 
 
 ## No matter what, I get `SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode`‽
-Update to Node.js 10.0.0 or newer.
+Update to Node.js 11.0.0 or newer.
 
 ## How do I get voice working?
 - Install FFMPEG.

--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -33,7 +33,7 @@ discord.js is a powerful [Node.js](https://nodejs.org) module that allows you to
 - 100% coverage of the Discord API
 
 ## Installation
-**Node.js 10.0.0 or newer is required.**  
+**Node.js 11.0.0 or newer is required.**  
 Ignore any warnings about unmet peer dependencies, as they're all optional.
 
 Without voice support: `npm install discordjs/discord.js`  

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "webpack-cli": "^3.2.3"
   },
   "engines": {
-    "node": ">=10.2.0"
+    "node": ">=11.0.0"
   },
   "browser": {
     "@discordjs/opus": false,

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -215,16 +215,11 @@ class MessageEmbed {
    * Removes, replaces, and inserts fields in the embed (max 25).
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of fields to remove
-   * @param {...EmbedField} [fields] The replacing field objects
+   * @param {...EmbedField|EmbedField[]} [fields] The replacing field objects
    * @returns {MessageEmbed}
    */
   spliceFields(index, deleteCount, ...fields) {
-    if (fields) {
-      const mapper = ({ name, value, inline }) => this.constructor.checkField(name, value, inline);
-      this.fields.splice(index, deleteCount, ...fields.map(mapper));
-    } else {
-      this.fields.splice(index, deleteCount);
-    }
+    this.fields.splice(index, deleteCount, ...this.constructor.normalizeFields(...fields));
     return this;
   }
 
@@ -381,6 +376,15 @@ class MessageEmbed {
     value = Util.resolveString(value);
     if (!value) throw new RangeError('EMBED_FIELD_VALUE');
     return { name, value, inline };
+  }
+
+  /**
+   * Check for valid field input and resolves strings
+   * @param  {...EmbedField|EmbedField[]} fields Fields to normalize
+   * @returns {EmbedField[]}
+   */
+  static normalizeFields(...fields) {
+    return fields.flat(2).map(({ name, value, inline }) => this.normalizeField(name, value, inline));
   }
 }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -375,7 +375,7 @@ class MessageEmbed {
    * @param {boolean} [inline=false] Set the field to display inline
    * @returns {EmbedField}
    */
-  static checkField(name, value, inline = false) {
+  static normalizeField(name, value, inline = false) {
     name = Util.resolveString(name);
     if (!name) throw new RangeError('EMBED_FIELD_NAME');
     value = Util.resolveString(value);

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -215,14 +215,13 @@ class MessageEmbed {
    * Removes, replaces, and inserts fields in the embed (max 25).
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of fields to remove
-   * @param {StringResolvable} [name] The name of the field
-   * @param {StringResolvable} [value] The value of the field
-   * @param {boolean} [inline=false] Set the field to display inline
+   * @param {...EmbedField} [fields] The replacing field objects
    * @returns {MessageEmbed}
    */
-  spliceField(index, deleteCount, name, value, inline) {
-    if (name && value) {
-      this.fields.splice(index, deleteCount, this.constructor.checkField(name, value, inline));
+  spliceFields(index, deleteCount, ...fields) {
+    if (fields) {
+      const mapper = ({ name, value, inline }) => this.constructor.checkField(name, value, inline);
+      this.fields.splice(index, deleteCount, ...fields.map(mapper));
     } else {
       this.fields.splice(index, deleteCount);
     }

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -201,15 +201,6 @@ class MessageEmbed {
   }
 
   /**
-   * Convenience function for `<MessageEmbed>.addField('\u200B', '\u200B', inline)`.
-   * @param {boolean} [inline=false] Set the field to display inline
-   * @returns {MessageEmbed}
-   */
-  addBlankField(inline) {
-    return this.addField('\u200B', '\u200B', inline);
-  }
-
-  /**
    * Removes, replaces, and inserts fields in the embed (max 25).
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of fields to remove

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -191,14 +191,12 @@ class MessageEmbed {
   }
 
   /**
-   * Adds a field to the embed (max 25).
-   * @param {StringResolvable} name The name of the field
-   * @param {StringResolvable} value The value of the field
-   * @param {boolean} [inline=false] Set the field to display inline
+   * Adds a fields to the embed (max 25).
+   * @param {...EmbedField|EmbedField[]} fields The fields to add
    * @returns {MessageEmbed}
    */
-  addField(name, value, inline) {
-    this.fields.push(this.constructor.checkField(name, value, inline));
+  addFields(...fields) {
+    this.fields.push(...this.constructor.normalizeFields(fields));
     return this;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1071,7 +1071,7 @@ declare module 'discord.js' {
 		public setTimestamp(timestamp?: Date | number): this;
 		public setTitle(title: StringResolvable): this;
 		public setURL(url: string): this;
-		public spliceField(index: number, deleteCount: number, name?: StringResolvable, value?: StringResolvable, inline?: boolean): this;
+		public spliceFields(index: number, deleteCount: number, ...fields: EmbedField[]): this;
 		public toJSON(): object;
 
 		public static checkField(name: StringResolvable, value: StringResolvable, inline?: boolean): Required<EmbedField>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1060,7 +1060,7 @@ declare module 'discord.js' {
 		public url: string;
 		public readonly video: { url?: string; proxyURL?: string; height?: number; width?: number } | null;
 		public addBlankField(inline?: boolean): this;
-		public addField(name: StringResolvable, value: StringResolvable, inline?: boolean): this;
+		public addFields(...fields: EmbedField[] | EmbedField[][]): this;
 		public attachFiles(file: (MessageAttachment | FileOptions | string)[]): this;
 		public setAuthor(name: StringResolvable, iconURL?: string, url?: string): this;
 		public setColor(color: ColorResolvable): this;
@@ -1071,10 +1071,11 @@ declare module 'discord.js' {
 		public setTimestamp(timestamp?: Date | number): this;
 		public setTitle(title: StringResolvable): this;
 		public setURL(url: string): this;
-		public spliceFields(index: number, deleteCount: number, ...fields: EmbedField[]): this;
+		public spliceFields(index: number, deleteCount: number, ...fields: EmbedField[] | EmbedField[][]): this;
 		public toJSON(): object;
 
-		public static checkField(name: StringResolvable, value: StringResolvable, inline?: boolean): Required<EmbedField>;
+		public static normalizeField(name: StringResolvable, value: StringResolvable, inline?: boolean): Required<EmbedField>;
+		public static normalizeFields(...fields: EmbedField[] | EmbedField[][]): Required<EmbedField>[];
 	}
 
 	export class MessageMentions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1059,7 +1059,6 @@ declare module 'discord.js' {
 		public type: string;
 		public url: string;
 		public readonly video: { url?: string; proxyURL?: string; height?: number; width?: number } | null;
-		public addBlankField(inline?: boolean): this;
 		public addFields(...fields: EmbedField[] | EmbedField[][]): this;
 		public attachFiles(file: (MessageAttachment | FileOptions | string)[]): this;
 		public setAuthor(name: StringResolvable, iconURL?: string, url?: string): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

* remove MessageEmbed#spliceField
* add MessageEmbed#spliceFields
* allow multiple fields to be replaced/inserted
* update typings accordingly
* add MessageEmbed#addFields
* remove MessageEmbed#addField
* support multi-field input as Array and rest parameters
* bump node to 11 for Array#flat

The applied approach brings the embed utility methods more in line with the underlying actions done on the raw field array (push, splice) while (hopefully) cleanly handling both rest parameters as well as array passing.

While it does remove some convenience, namely  `.addField("foo", "bar")` we discussed that keeping both #addField and #addFields simultaneously should not be the way to go, adding more noise to the interface than necessary (see the earlier deprecation of #addFile in favor of #addFiles) 

- If there are really strong opinions of library maintainers i can of course revert the #addField removal
- the change to splice however adds utility in freely modifying embed fields while not removing any functionality that is currently in and should definitely be considered

**Example**

```js
const e = new Discord.MessageEmbed()
			.addFields(
				{ name: 1, value: 1 },
				{ name: 2, value: 2 },
				{ name: 3, value: 3 },
				{ name: 4, value: 4 }
			)
			.spliceFields(2, 1,
				{ name: 'foo', value: 'bar', inline: true },
				{ name: 'foo2', value: 'bar2', inline: true });
message.channel.send(e);
```
ℹ Both methods also support the fields to be provided as an Array
⚠Due to the use of Array#flat this will require a min node bump to 11

**TODO:**
- [x] refactor checkField to accept multiples and be named normalizeFields
- [x] add MessageEmbed#addFields
- [x] remove MessageEmbed#addFields
- [x] bump min node
- [x] test typings

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
