### PR TITLE
fix(typings): HTTPOptions#api missing & Constants not being exported correctly

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2363,7 +2363,7 @@ declare module 'discord.js' {
 	}
 
 	interface HTTPOptions {
-    api?: string;
+		api?: string;
 		version?: number;
 		host?: string;
 		cdn?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -372,7 +372,7 @@ declare module 'discord.js' {
 
 	type AllowedImageFormat = 'webp' | 'png' | 'jpg' | 'gif';
 
-	export interface Constants {
+	export const Constants: {
 		Package: {
 			name: string;
 			version: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -627,7 +627,7 @@ declare module 'discord.js' {
 		ActivityTypes: ActivityType[];
 		DefaultMessageNotifications: DefaultMessageNotifications[];
 		MembershipStates: 'INVITED' | 'ACCEPTED';
-	}
+	};
 
 	export class DataResolver {
 		public static resolveBase64(data: Base64Resolvable): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2363,6 +2363,7 @@ declare module 'discord.js' {
 	}
 
 	interface HTTPOptions {
+    api?: string;
 		version?: number;
 		host?: string;
 		cdn?: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR goes over & fixes two issues regarding the typings:
- The api property was missing from the HTTPOptions interface
- The Constants were being exported as an interface (just a type, didn't actually tell TS that they were usable values)

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
