### PR TITLE
GuildMemberManager#fetch returns a collection

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1827,8 +1827,7 @@ declare module 'discord.js' {
 		public guild: Guild;
 		public ban(user: UserResolvable, options?: BanOptions): Promise<GuildMember | User | Snowflake>;
 		public fetch(options: UserResolvable | FetchMemberOptions): Promise<GuildMember>;
-		public fetch(): Promise<GuildMemberManager>;
-		public fetch(options: FetchMembersOptions): Promise<Collection<Snowflake, GuildMember>>;
+		public fetch(options?: FetchMembersOptions): Promise<Collection<Snowflake, GuildMember>>;
 		public prune(options: GuildPruneMembersOptions & { dry?: false, count: false }): Promise<null>;
 		public prune(options?: GuildPruneMembersOptions): Promise<number>;
 		public unban(user: UserResolvable, reason?: string): Promise<User>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the typings showing that GuildMemberManager#fetch with no arguments returns a GuildMemberManager, it infact returns the cache of the manager

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
