### PR TITLE
fix(TextChannel): remove old nsfw regex check

### DIFF
--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -41,7 +41,7 @@ class TextChannel extends GuildChannel {
      * @type {boolean}
      * @readonly
      */
-    this.nsfw = data.nsfw || /^nsfw(-|$)/.test(this.name);
+    this.nsfw = data.nsfw;
 
     /**
      * The ID of the last message sent in this channel, if one was sent


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR removes the old regex check for the nsfw property on a TextChannel, as channels are no longer labeled nsfw when naming it with the 'nsfw-' prefix

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
