### PR TITLE
fix(BaseManager): BaseManager#valueOf should return cache

### DIFF
--- a/src/managers/BaseManager.js
+++ b/src/managers/BaseManager.js
@@ -72,6 +72,10 @@ class BaseManager {
     if (typeof idOrInstance === 'string') return idOrInstance;
     return null;
   }
+
+  valueOf() {
+    return this.cache;
+  }
 }
 
 module.exports = BaseManager;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -36,8 +36,10 @@ class Util {
       const elemIsObj = isObject(element);
       const valueOf = elemIsObj && typeof element.valueOf === 'function' ? element.valueOf() : null;
 
-      // If it's a collection, make the array of keys
+      // If it's a Collection, make the array of keys
       if (element instanceof require('./Collection')) out[newProp] = Array.from(element.keys());
+      // If the valueOf is a Collection, use it's array of keys
+      else if (valueOf instanceof require('./Collection')) out[newProp] = Array.from(valueOf.keys());
       // If it's an array, flatten each element
       else if (Array.isArray(element)) out[newProp] = element.map(e => Util.flatten(e));
       // If it's an object with a primitive `valueOf`, use that value

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -38,7 +38,7 @@ class Util {
 
       // If it's a Collection, make the array of keys
       if (element instanceof require('./Collection')) out[newProp] = Array.from(element.keys());
-      // If the valueOf is a Collection, use it's array of keys
+      // If the valueOf is a Collection, use its array of keys
       else if (valueOf instanceof require('./Collection')) out[newProp] = Array.from(valueOf.keys());
       // If it's an array, flatten each element
       else if (Array.isArray(element)) out[newProp] = element.map(e => Util.flatten(e));


### PR DESCRIPTION
`BaseManager#valueOf` should be it's cache, for `Util.flatten` and probably other purposes also.

Updates `Util#flatten` to handle the `valueOf instanceof Collection` use-case.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
