### PR TITLE
docs(*Manager): fix child classes' cache type annotations

### DIFF
--- a/src/managers/ChannelManager.js
+++ b/src/managers/ChannelManager.js
@@ -14,9 +14,8 @@ class ChannelManager extends BaseManager {
 
   /**
   * The cache of Channels
-  * @property {Collection<Snowflake, Channel>} cache
-  * @memberof ChannelManager
-  * @instance
+  * @type {Collection<Snowflake, Channel>}
+  * @name ChannelManager#cache
   */
 
   add(data, guild, cache = true) {

--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -22,9 +22,8 @@ class GuildChannelManager extends BaseManager {
 
   /**
    * The cache of this Manager
-   * @property {Collection<Snowflake, GuildChannel>} cache
-   * @memberof GuildChannelManager
-   * @instance
+   * @type {Collection<Snowflake, GuildChannel>}
+   * @name GuildChannelManager#cache
    */
 
   add(channel) {

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -23,9 +23,8 @@ class GuildEmojiManager extends BaseManager {
 
   /**
   * The cache of GuildEmojis
-  * @property {Collection<Snowflake, GuildEmoji>} cache
-  * @memberof GuildEmojiManager
-  * @instance
+  * @type {Collection<Snowflake, GuildEmoji>}
+  * @name GuildEmojiManager#cache
   */
 
   add(data, cache) {

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -19,9 +19,8 @@ class GuildManager extends BaseManager {
 
   /**
    * The cache of this Manager
-   * @property {Collection<Snowflake, Guild>} cache
-   * @memberof GuildManager
-   * @instance
+   * @type {Collection<Snowflake, Guild>}
+   * @name GuildManager#cache
    */
 
   /**

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -22,9 +22,8 @@ class GuildMemberManager extends BaseManager {
 
   /**
    * The cache of this Manager
-   * @property {Collection<Snowflake, GuildMember>} cache
-   * @memberof GuildMemberManager
-   * @instance
+   * @type {Collection<Snowflake, GuildMember>}
+   * @name GuildMemberManager#cache
    */
 
   add(data, cache = true) {

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -21,9 +21,8 @@ class MessageManager extends BaseManager {
 
   /**
   * The cache of Messages
-  * @property {LimitedCollection<Snowflake, Message>} cache
-  * @memberof MessageManager
-  * @instance
+  * @type {LimitedCollection<Snowflake, Message>}
+  * @name MessageManager#cache
   */
 
   add(data, cache) {

--- a/src/managers/PresenceManager.js
+++ b/src/managers/PresenceManager.js
@@ -14,9 +14,8 @@ class PresenceManager extends BaseManager {
 
   /**
   * The cache of Presences
-  * @property {Collection<Snowflake, Presence>} cache
-  * @memberof PresenceManager
-  * @instance
+  * @type {Collection<Snowflake, Presence>}
+  * @name PresenceManager#cache
   */
 
   add(data, cache) {

--- a/src/managers/ReactionManager.js
+++ b/src/managers/ReactionManager.js
@@ -24,9 +24,8 @@ class ReactionManager extends BaseManager {
 
   /**
    * The reaction cache of this manager
-   * @property {Collection<Snowflake, MessageReaction>} cache
-   * @memberof ReactionManager
-   * @instance
+   * @type {Collection<Snowflake, MessageReaction>}
+   * @name ReactionManager#cache
    */
 
   /**

--- a/src/managers/ReactionUserManager.js
+++ b/src/managers/ReactionUserManager.js
@@ -20,9 +20,8 @@ class ReactionUserManager extends BaseManager {
 
   /**
    * The cache of this manager
-   * @property {Collection<Snowflake, User>} cache
-   * @memberof GuildManager
-   * @instance
+   * @type {Collection<Snowflake, User>}
+   * @name ReactionUserManager#cache
    */
 
   /**

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -21,9 +21,8 @@ class RoleManager extends BaseManager {
 
   /**
    * The role cache of this manager
-   * @property {Collection<Snowflake, Role>} cache
-   * @memberof RoleManager
-   * @instance
+   * @type {Collection<Snowflake, Role>}
+   * @name RoleManager#cache
    */
 
   add(data, cache) {

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -16,9 +16,8 @@ class UserManager extends BaseManager {
 
   /**
    * The cache of this manager
-   * @property {Collection<Snowflake, User>} cache
-   * @memberof UserManager
-   * @instance
+   * @type {Collection<Snowflake, User>}
+   * @name UserManager#cache
    */
 
   /**

--- a/src/managers/VoiceStateManager.js
+++ b/src/managers/VoiceStateManager.js
@@ -19,9 +19,8 @@ class VoiceStateManager extends BaseManager {
 
   /**
    * The cache of this manager
-   * @property {Collection<Snowflake, VoiceState>} cache
-   * @memberof VoiceStateManager
-   * @instance
+   * @type {Collection<Snowflake, VoiceState>}
+   * @name VoiceStateManager#cache
    */
 
   add(data, cache = true) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Apparently you need to use different annotations for properties instead of methods.
This PR takes care of them.

**Status**
- [x] ~~Code~~ changes have been tested ~~against the Discord API, or there are no code changes~~
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
