### PR TITLE
fix(Message): Handle undefined/null content in Message#cleanContent

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -301,7 +301,8 @@ class Message extends Base {
    * @readonly
    */
   get cleanContent() {
-    return Util.cleanContent(this.content, this);
+    // eslint-disable-next-line eqeqeq
+    return this.content != null ? Util.cleanContent(this.content, this) : null;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -949,7 +949,7 @@ declare module 'discord.js' {
 		public attachments: Collection<Snowflake, MessageAttachment>;
 		public author: User;
 		public channel: TextChannel | DMChannel;
-		public readonly cleanContent: string | null;
+		public readonly cleanContent: string;
 		public content: string;
 		public readonly createdAt: Date;
 		public createdTimestamp: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -949,7 +949,7 @@ declare module 'discord.js' {
 		public attachments: Collection<Snowflake, MessageAttachment>;
 		public author: User;
 		public channel: TextChannel | DMChannel;
-		public readonly cleanContent: string;
+		public readonly cleanContent: string | null;
 		public content: string;
 		public readonly createdAt: Date;
 		public createdTimestamp: number;


### PR DESCRIPTION
This prevents an error being thrown internally from `Util#cleanContent` when the `Message#cleanContent` getter is accessed on a Partial Message.

eslint intentionally disabled in order to use `!=` to handle both undefined and null.

**Status**
- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
