### PR TITLE
use Permissions.FLAGS for VoiceChannel#speakable

### DIFF
--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -88,7 +88,7 @@ class VoiceChannel extends GuildChannel {
    * @readonly
    */
   get speakable() {
-    return this.permissionsFor(this.client.user).has('SPEAK', false);
+    return this.permissionsFor(this.client.user).has(Permissions.FLAGS.SPEAK, false);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR just changes the permissions check for VoiceChannel#spekable to use Permissions.FLAGS.SPEAK instead of 'SPEAK' directly

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
