### PR TITLE
docs: Clarify what zlib-sync does

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Using opusscript is only recommended for development environments where @discord
 For production bots, using @discordjs/opus should be considered a necessity, especially if they're going to be running on multiple servers.
 
 ### Optional packages
-- [zlib-sync](https://www.npmjs.com/package/zlib-sync) for faster WebSocket data inflation (`npm install zlib-sync`)
+- [zlib-sync](https://www.npmjs.com/package/zlib-sync) for WebSocket data compression and inflation (`npm install zlib-sync`)
 - [erlpack](https://github.com/discordapp/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install discordapp/erlpack`)
 - One of the following packages can be installed for faster voice packet encryption and decryption:
     - [sodium](https://www.npmjs.com/package/sodium) (`npm install sodium`)

--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -46,7 +46,7 @@ Using opusscript is only recommended for development environments where @discord
 For production bots, using @discordjs/opus should be considered a necessity, especially if they're going to be running on multiple servers.
 
 ### Optional packages
-- [zlib-sync](https://www.npmjs.com/package/zlib-sync) for faster WebSocket data inflation (`npm install zlib-sync`)
+- [zlib-sync](https://www.npmjs.com/package/zlib-sync) for WebSocket data compression and inflation (`npm install zlib-sync`)
 - [erlpack](https://github.com/discordapp/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install discordapp/erlpack`)
 - One of the following packages can be installed for faster voice packet encryption and decryption:
     - [sodium](https://www.npmjs.com/package/sodium) (`npm install sodium`)

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -61,7 +61,6 @@ exports.DefaultOptions = {
    * WebSocket options (these are left as snake_case to match the API)
    * @typedef {Object} WebsocketOptions
    * @property {number} [large_threshold=250] Number of members in a guild to be considered large
-   * @property {boolean} [compress=false] Whether to compress data sent on the connection
    * (defaults to `false` for browsers)
    */
   ws: {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -61,7 +61,6 @@ exports.DefaultOptions = {
    * WebSocket options (these are left as snake_case to match the API)
    * @typedef {Object} WebsocketOptions
    * @property {number} [large_threshold=250] Number of members in a guild to be considered large
-   * (defaults to `false` for browsers)
    */
   ws: {
     large_threshold: 250,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Minor tweak to the doc string, nothing major. Closes #3783 

### Why?

Because the ClientOption `ws.compress` is deprecated in favor of the query string parameter; this PR explains what enabled data compression.
This PR also removes the documentation for the `ws.compress` as you shouldn't use it unless you have zlib-sync installed, which automatically enabled compression anyways

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
