### PR TITLE
Add PartialGroupDMChannel class

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -94,6 +94,9 @@ const Messages = {
   REACTION_RESOLVE_USER: 'Couldn\'t resolve the user ID to remove from the reaction.',
 
   VANITY_URL: 'This guild does not have the VANITY_URL feature enabled.',
+
+  DELETE_GROUP_DM_CHANNEL: 'Bots don\'t have access to Group DM Channels and cannot delete them',
+  FETCH_GROUP_DM_CHANNEL: 'Bots don\'t have access to Group DM Channels and cannot fetch them',
 };
 
 for (const [name, message] of Object.entries(Messages)) register(name, message);

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -83,7 +83,7 @@ class Channel extends Base {
    *   .catch(console.error);
    */
   delete() {
-    if(this.type === 'group') return Promise.reject(new Error('DELETE_GROUP_DM_CHANNEL'));
+    if (this.type === 'group') return Promise.reject(new Error('DELETE_GROUP_DM_CHANNEL'));
     return this.client.api.channels(this.id).delete().then(() => this);
   }
 
@@ -92,7 +92,7 @@ class Channel extends Base {
    * @returns {Promise<Channel>}
    */
   fetch() {
-    if(this.type === 'group') return Promise.reject(new Error('FETCH_GROUP_DM_CHANNEL'));
+    if (this.type === 'group') return Promise.reject(new Error('FETCH_GROUP_DM_CHANNEL'));
     return this.client.channels.fetch(this.id, true);
   }
 
@@ -100,7 +100,7 @@ class Channel extends Base {
     const Structures = require('../util/Structures');
     let channel;
     if (!data.guild_id && !guild) {
-      switch(data.type) {
+      switch (data.type) {
         case ChannelTypes.DM: {
           const DMChannel = Structures.get('DMChannel');
           channel = new DMChannel(client, data);

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -118,6 +118,11 @@ class Channel extends Base {
             channel = new CategoryChannel(guild, data);
             break;
           }
+					case ChannelTypes.GROUP: {
+						const PartialGroupDMChannel = require('./PartialGroupDMChannel');
+						channel = new PartialGroupDMChannel(client, data);
+						break;
+					}
           case ChannelTypes.NEWS: {
             const NewsChannel = Structures.get('NewsChannel');
             channel = new NewsChannel(guild, data);

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -118,11 +118,11 @@ class Channel extends Base {
             channel = new CategoryChannel(guild, data);
             break;
           }
-					case ChannelTypes.GROUP: {
-						const PartialGroupDMChannel = require('./PartialGroupDMChannel');
-						channel = new PartialGroupDMChannel(client, data);
-						break;
-					}
+          case ChannelTypes.GROUP: {
+            const PartialGroupDMChannel = require('./PartialGroupDMChannel');
+            channel = new PartialGroupDMChannel(client, data);
+            break;
+          }
           case ChannelTypes.NEWS: {
             const NewsChannel = Structures.get('NewsChannel');
             channel = new NewsChannel(guild, data);

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -99,9 +99,19 @@ class Channel extends Base {
   static create(client, data, guild) {
     const Structures = require('../util/Structures');
     let channel;
-    if (data.type === ChannelTypes.DM || (data.type !== ChannelTypes.GROUP && !data.guild_id && !guild)) {
-      const DMChannel = Structures.get('DMChannel');
-      channel = new DMChannel(client, data);
+    if (!data.guild_id && !guild) {
+      switch(data.type) {
+        case ChannelTypes.DM: {
+          const DMChannel = Structures.get('DMChannel');
+          channel = new DMChannel(client, data);
+          break;
+        }
+        case ChannelTypes.GROUP: {
+          const PartialGroupDMChannel = require('./PartialGroupDMChannel');
+          channel = new PartialGroupDMChannel(client, data);
+          break;
+        }
+      }
     } else {
       guild = guild || client.guilds.cache.get(data.guild_id);
       if (guild) {
@@ -119,11 +129,6 @@ class Channel extends Base {
           case ChannelTypes.CATEGORY: {
             const CategoryChannel = Structures.get('CategoryChannel');
             channel = new CategoryChannel(guild, data);
-            break;
-          }
-          case ChannelTypes.GROUP: {
-            const PartialGroupDMChannel = require('./PartialGroupDMChannel');
-            channel = new PartialGroupDMChannel(client, data);
             break;
           }
           case ChannelTypes.NEWS: {

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -2,7 +2,6 @@
 
 const Snowflake = require('../util/Snowflake');
 const Base = require('./Base');
-const { Error } = require('../errors');
 const { ChannelTypes } = require('../util/Constants');
 
 /**
@@ -83,7 +82,6 @@ class Channel extends Base {
    *   .catch(console.error);
    */
   delete() {
-    if (this.type === 'group') return Promise.reject(new Error('DELETE_GROUP_DM_CHANNEL'));
     return this.client.api.channels(this.id).delete().then(() => this);
   }
 
@@ -92,7 +90,6 @@ class Channel extends Base {
    * @returns {Promise<Channel>}
    */
   fetch() {
-    if (this.type === 'group') return Promise.reject(new Error('FETCH_GROUP_DM_CHANNEL'));
     return this.client.channels.fetch(this.id, true);
   }
 

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -2,6 +2,7 @@
 
 const Snowflake = require('../util/Snowflake');
 const Base = require('./Base');
+const { Error } = require('../errors');
 const { ChannelTypes } = require('../util/Constants');
 
 /**
@@ -82,6 +83,7 @@ class Channel extends Base {
    *   .catch(console.error);
    */
   delete() {
+    if(this.type === 'group') return Promise.reject(new Error('DELETE_GROUP_DM_CHANNEL'));
     return this.client.api.channels(this.id).delete().then(() => this);
   }
 
@@ -90,6 +92,7 @@ class Channel extends Base {
    * @returns {Promise<Channel>}
    */
   fetch() {
+    if(this.type === 'group') return Promise.reject(new Error('FETCH_GROUP_DM_CHANNEL'));
     return this.client.channels.fetch(this.id, true);
   }
 

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -1,5 +1,5 @@
-const Channel = require("./Channel");
-const { Error } = require("../errors");
+const Channel = require('./Channel');
+const { Error } = require('../errors');
 
 /**
  * Represents a Partial Group DM Channel on Discord.
@@ -25,14 +25,6 @@ class PartialGroupDMChannel extends Channel {
 		if (!this.icon) return null;
 		return this.client.rest.cdn.GDMIcon(this.id, this.icon, format, size);
   	}
-	
-	delete() {
-		throw new Error("DELETE_GROUP_DM_CHANNEL");
-	}
-	
-	fetch() {
-		throw new Error("FETCH_GROUP_DM_CHANNEL");
-	}
 }
 
 module.exports = PartialGroupDMChannel;

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -12,7 +12,7 @@ class PartialGroupDMChannel extends Channel {
 
     /**
      * The hash of the channel icon
-     * type {?string}
+     * @type {?string}
      */
     this.icon = data.icon;
   }

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -7,7 +7,7 @@ const { Error } = require("../errors");
  */
 class PartialGroupDMChannel extends Channel {
 	constructor(client, data) {
-	  super(client, data);
+		super(client, data);
 	
 		/**
 		 * The hash of the channel icon
@@ -17,14 +17,14 @@ class PartialGroupDMChannel extends Channel {
 	}
 
 	/**
-   * The URL to this channel's icon.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
-   * @returns {?string}
-   */
+	 * The URL to this channel's icon.
+	 * @param {ImageURLOptions} [options={}] Options for the Image URL
+	 * @returns {?string}
+	 */
 	iconURL({ format, size } = {}) {
-    if (!this.icon) return null;
-    return this.client.rest.cdn.GDMIcon(this.id, this.icon, format, size);
-  }
+		if (!this.icon) return null;
+		return this.client.rest.cdn.GDMIcon(this.id, this.icon, format, size);
+  	}
 	
 	delete() {
 		throw new Error("DELETE_GROUP_DM_CHANNEL");

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -8,7 +8,7 @@ const { Error } = require('../errors');
 class PartialGroupDMChannel extends Channel {
 	constructor(client, data) {
 		super(client, data);
-	
+
 		/**
 		 * The hash of the channel icon
 		 * type {?string}

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -1,5 +1,5 @@
+'use-strict';
 const Channel = require('./Channel');
-const { Error } = require('../errors');
 
 /**
  * Represents a Partial Group DM Channel on Discord.

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -6,25 +6,25 @@ const { Error } = require('../errors');
  * @extends {Channel}
  */
 class PartialGroupDMChannel extends Channel {
-	constructor(client, data) {
-		super(client, data);
+  constructor(client, data) {
+    super(client, data);
 
-		/**
-		 * The hash of the channel icon
-		 * type {?string}
-		 */
-		this.icon = data.icon;
-	}
+    /**
+     * The hash of the channel icon
+     * type {?string}
+     */
+    this.icon = data.icon;
+  }
 
-	/**
-	 * The URL to this channel's icon.
-	 * @param {ImageURLOptions} [options={}] Options for the Image URL
-	 * @returns {?string}
-	 */
-	iconURL({ format, size } = {}) {
-		if (!this.icon) return null;
-		return this.client.rest.cdn.GDMIcon(this.id, this.icon, format, size);
-  	}
+  /**
+   * The URL to this channel's icon.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string}
+   */
+  iconURL({ format, size } = {}) {
+    if (!this.icon) return null;
+    return this.client.rest.cdn.GDMIcon(this.id, this.icon, format, size);
+  }
 }
 
 module.exports = PartialGroupDMChannel;

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Channel = require('./Channel');
+const { Error } = require('../errors');
 
 /**
  * Represents a Partial Group DM Channel on Discord.
@@ -9,6 +10,12 @@ const Channel = require('./Channel');
 class PartialGroupDMChannel extends Channel {
   constructor(client, data) {
     super(client, data);
+
+    /**
+     * The name of this Group DM Channel
+     * @type {string}
+     */
+    this.name = data.name;
 
     /**
      * The hash of the channel icon
@@ -25,6 +32,14 @@ class PartialGroupDMChannel extends Channel {
   iconURL({ format, size } = {}) {
     if (!this.icon) return null;
     return this.client.rest.cdn.GDMIcon(this.id, this.icon, format, size);
+  }
+
+  delete() {
+    return Promise.reject(new Error('DELETE_GROUP_DM_CHANNEL'));
+  }
+
+  fetch() {
+    return Promise.reject(new Error('FETCH_GROUP_DM_CHANNEL'));
   }
 }
 

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -1,0 +1,38 @@
+const Channel = require("./Channel");
+const { Error } = require("../errors");
+
+/**
+ * Represents a Partial Group DM Channel on Discord.
+ * @extends {Channel}
+ */
+class PartialGroupDMChannel extends Channel {
+	constructor(client, data) {
+	  super(client, data);
+	
+		/**
+		 * The hash of the channel icon
+		 * type {?string}
+		 */
+		this.icon = data.icon;
+	}
+
+	/**
+   * The URL to this channel's icon.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string}
+   */
+	iconURL({ format, size } = {}) {
+    if (!this.icon) return null;
+    return this.client.rest.cdn.GDMIcon(this.id, this.icon, format, size);
+  }
+	
+	delete() {
+		throw new Error("DELETE_GROUP_DM_CHANNEL");
+	}
+	
+	fetch() {
+		throw new Error("FETCH_GROUP_DM_CHANNEL");
+	}
+}
+
+module.exports = PartialGroupDMChannel;

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -1,4 +1,5 @@
-'use-strict';
+'use strict';
+
 const Channel = require('./Channel');
 
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -829,6 +829,12 @@ declare module 'discord.js' {
 		public nsfw: boolean;
 	}
 
+	export class PartialGroupDMChannel extends Channel {
+		constructor(client: Client, data: object);
+		public icon: string | null;
+		public iconURL(options?: ImageURLOptions): string | null;
+	}
+
 	export class GuildEmoji extends Emoji {
 		constructor(client: Client, data: object, guild: Guild);
 		private _roles: string[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -831,6 +831,7 @@ declare module 'discord.js' {
 
 	export class PartialGroupDMChannel extends Channel {
 		constructor(client: Client, data: object);
+		public name: string;
 		public icon: string | null;
 		public iconURL(options?: ImageURLOptions): string | null;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes #3345 by adding a Partial Group DM Channel class for the partial data that is received when fetching an invite to a Group DM

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
