### PR TITLE
docs/typings(SystemChannelFlags): properly document and use resolvable

### DIFF
--- a/src/util/SystemChannelFlags.js
+++ b/src/util/SystemChannelFlags.js
@@ -8,16 +8,16 @@ const BitField = require('./BitField');
  * and by setting their corresponding flags you are disabling them</info>
  * @extends {BitField}
  */
-class SystemChannelFlags extends BitField {
-  /**
-   * Data that can be resolved to give a sytem channel flag bitfield. This can be:
-   * * A string (see {@link SystemChannelFlags.FLAGS})
-   * * A sytem channel flag
-   * * An instance of SystemChannelFlags
-   * * An Array of SystemChannelFlagsResolvable
-   * @typedef {string|number|SystemChannelFlags|SystemChannelFlagsResolvable[]} SystemChannelFlagsResolvable
-   */
-}
+class SystemChannelFlags extends BitField {}
+
+/**
+ * Data that can be resolved to give a sytem channel flag bitfield. This can be:
+ * * A string (see {@link SystemChannelFlags.FLAGS})
+ * * A sytem channel flag
+ * * An instance of SystemChannelFlags
+ * * An Array of SystemChannelFlagsResolvable
+ * @typedef {string|number|SystemChannelFlags|SystemChannelFlagsResolvable[]} SystemChannelFlagsResolvable
+ */
 
 /**
  * Numeric system channel flags. All available properties:

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2317,7 +2317,7 @@ declare module 'discord.js' {
 		defaultMessageNotifications?: DefaultMessageNotifications | number;
 		afkChannel?: ChannelResolvable;
 		systemChannel?: ChannelResolvable;
-		systemChannelFlags?: SystemChannelFlags;
+		systemChannelFlags?: SystemChannelFlagsResolvable;
 		afkTimeout?: number;
 		icon?: Base64Resolvable;
 		owner?: GuildMemberResolvable;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently the typedef for `SystemChannelFlagsResolvable` does not appear on the docs, this somehow is fixed by moving it outside of the class' definition.

Currently `GuildEditData#systemChannelFlags` is typed as `SystemChannelFlags`, but it should actually be `SystemChannelFlagsResolvable`.

This PR takes care of both.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
