### PR TITLE
typings(ChannelLogsQueryOptions): update before and after options

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2073,8 +2073,8 @@ declare module 'discord.js' {
 
 	interface ChannelLogsQueryOptions {
 		limit?: number;
-		before?: Snowflake;
-		after?: Snowflake;
+		before?: Snowflake | number;
+		after?: Snowflake | number;
 		around?: Snowflake;
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR updates the `ChannelLogsQueryOptions` interface changing the `before` and `after` types to both Snowflake and number. 

This is done to accommodate the ability to fetch messages based on their order in a channel (for example, the 10th message of the channel). 

Example code to return the first message of a channel:
```js
<TextChannel>.fetch({ limit: 1, after: 1 });
``` 

**Status**
- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
