### PR TITLE
Add typescript execution capability to shard file

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -110,6 +110,10 @@ class Shard extends EventEmitter {
     if (this.process) throw new Error('SHARDING_PROCESS_EXISTS', this.id);
     if (this.worker) throw new Error('SHARDING_WORKER_EXISTS', this.id);
 
+    // Use ts-node to execute typescript files.
+    if (path.extname(this.manager.file) === '.ts') {
+      this.execArgv = ["-r", "ts-node/register"];
+    }
     if (this.manager.mode === 'process') {
       this.process = childProcess.fork(path.resolve(this.manager.file), this.args, {
         env: this.env, execArgv: this.execArgv,

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -112,7 +112,7 @@ class Shard extends EventEmitter {
 
     // Use ts-node to execute typescript files.
     if (path.extname(this.manager.file) === '.ts') {
-      this.execArgv = ["-r", "ts-node/register"];
+      this.execArgv = ['-r', 'ts-node/register'];
     }
     if (this.manager.mode === 'process') {
       this.process = childProcess.fork(path.resolve(this.manager.file), this.args, {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I was constantly getting errors from node (cjs) while using the ShardManger with a typescript file. I solved this by adding the conditional to change the execArgv to use ts-node over node for executing the shard, given that the shard's extension is typescript.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
