### PR TITLE
fix(Shard): cleanup after settling spawn promise

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -131,10 +131,13 @@ class Shard extends EventEmitter {
 
     if (spawnTimeout === -1 || spawnTimeout === Infinity) return this.process || this.worker;
     await new Promise((resolve, reject) => {
-      this.once('ready', resolve);
+      const timeout = setTimeout(() => reject(new Error('SHARDING_READY_TIMEOUT', this.id)), spawnTimeout);
+        this.once('ready', () => {
+        clearTimeout(timeout);
+        resolve();
+      });
       this.once('disconnect', () => reject(new Error('SHARDING_READY_DISCONNECTED', this.id)));
       this.once('death', () => reject(new Error('SHARDING_READY_DIED', this.id)));
-      setTimeout(() => reject(new Error('SHARDING_READY_TIMEOUT', this.id)), spawnTimeout);
     });
     return this.process || this.worker;
   }

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -131,13 +131,37 @@ class Shard extends EventEmitter {
 
     if (spawnTimeout === -1 || spawnTimeout === Infinity) return this.process || this.worker;
     await new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error('SHARDING_READY_TIMEOUT', this.id)), spawnTimeout);
-      this.once('ready', () => {
-        clearTimeout(timeout);
+      const cleanup = () => {
+        clearTimeout(spawnTimeoutTimer);
+        this.off('ready', onReady);
+        this.off('disconnect', onDisconnect);
+        this.off('death', onDeath);
+      };
+
+      const onReady = () => {
+        cleanup();
         resolve();
-      });
-      this.once('disconnect', () => reject(new Error('SHARDING_READY_DISCONNECTED', this.id)));
-      this.once('death', () => reject(new Error('SHARDING_READY_DIED', this.id)));
+      };
+
+      const onDisconnect = () => {
+        cleanup();
+        reject(new Error('SHARDING_READY_DISCONNECTED', this.id));
+      };
+
+      const onDeath = () => {
+        cleanup();
+        reject(new Error('SHARDING_READY_DIED', this.id));
+      };
+
+      const onTimeout = () => {
+        cleanup();
+        reject(new Error('SHARDING_READY_TIMEOUT', this.id));
+      };
+
+      const spawnTimeoutTimer = setTimeout(onTimeout, spawnTimeout);
+      this.once('ready', onReady);
+      this.once('disconnect', onDisconnect);
+      this.once('death', onDeath);
     });
     return this.process || this.worker;
   }

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -132,7 +132,7 @@ class Shard extends EventEmitter {
     if (spawnTimeout === -1 || spawnTimeout === Infinity) return this.process || this.worker;
     await new Promise((resolve, reject) => {
       const timeout = setTimeout(() => reject(new Error('SHARDING_READY_TIMEOUT', this.id)), spawnTimeout);
-        this.once('ready', () => {
+      this.once('ready', () => {
         clearTimeout(timeout);
         resolve();
       });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -703,8 +703,12 @@ declare module 'discord.js' {
 		public premiumSubscriptionCount: number | null;
 		public premiumTier: PremiumTier;
 		public presences: PresenceManager;
+		public readonly publicUpdatesChannel: TextChannel | null;
+		public publicUpdatesChannelID: Snowflake | null;
 		public region: string;
 		public roles: RoleManager;
+		public readonly rulesChannel: TextChannel | null;
+		public rulesChannelID: Snowflake | null;
 		public readonly shard: WebSocketShard;
 		public shardID: number;
 		public splash: string | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -703,12 +703,8 @@ declare module 'discord.js' {
 		public premiumSubscriptionCount: number | null;
 		public premiumTier: PremiumTier;
 		public presences: PresenceManager;
-		public readonly publicUpdatesChannel: TextChannel | null;
-		public publicUpdatesChannelID: Snowflake | null;
 		public region: string;
 		public roles: RoleManager;
-		public readonly rulesChannel: TextChannel | null;
-		public rulesChannelID: Snowflake | null;
 		public readonly shard: WebSocketShard;
 		public shardID: number;
 		public splash: string | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR clears the ready timeout on a Shard, as to not reject the promise after it's already been resolved / rejected

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
