### PR TITLE
typings(Guild): mark afkChannel* & applicationID as nullable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -666,10 +666,10 @@ declare module 'discord.js' {
 		private _sortedChannels(channel: Channel): Collection<Snowflake, GuildChannel>;
 		private _memberSpeakUpdate(user: Snowflake, speaking: boolean): void;
 
-		public readonly afkChannel: VoiceChannel;
-		public afkChannelID: Snowflake;
+		public readonly afkChannel: VoiceChannel | null;
+		public afkChannelID: Snowflake | null;
 		public afkTimeout: number;
-		public applicationID: Snowflake;
+		public applicationID: Snowflake | null;
 		public available: boolean;
 		public banner: string | null;
 		public channels: GuildChannelManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes #3804 by marking Guild#afkChannel* as nullable, also marks Guild#applicationID as nullable as its only present if the guild is owned by a bot

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
