### PR TITLE
typings(Guild): mark nullable properties as nullable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -667,9 +667,9 @@ declare module 'discord.js' {
 		private _memberSpeakUpdate(user: Snowflake, speaking: boolean): void;
 
 		public readonly afkChannel: VoiceChannel;
-		public afkChannelID: Snowflake;
+		public afkChannelID: Snowflake | null;
 		public afkTimeout: number;
-		public applicationID: Snowflake;
+		public applicationID: Snowflake | null;
 		public available: boolean;
 		public banner: string | null;
 		public channels: GuildChannelManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Both properties are marked as nullable form the API and correctly so in the docsstrings, applies this to the typings as well<https://discordapp.com/developers/docs/resources/guild>

* resolves #3804

Properties:
* #afkChannelID
* #applicationID

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ x I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
