### PR TITLE
typings: Refactor how channel types are done

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,12 +1,12 @@
 declare enum ChannelType {
-	text,
-	dm,
-	voice,
-	group,
-	category,
-	news,
-	store,
-	unknown
+	TEXT = 'text',
+	DM = 'dm',
+	VOICE = 'voice',
+	GROUP = 'group',
+	CATEGORY = 'category',
+	NEWS = 'news',
+	STORE = 'store',
+	UNKNOWN = 'unknown'
 }
 
 declare module 'discord.js' {
@@ -131,6 +131,7 @@ declare module 'discord.js' {
 
 	export class CategoryChannel extends GuildChannel {
 		public readonly children: Collection<Snowflake, GuildChannel>;
+		public type: ChannelType.CATEGORY;
 	}
 
 	export class Channel extends Base {
@@ -139,7 +140,7 @@ declare module 'discord.js' {
 		public readonly createdTimestamp: number;
 		public deleted: boolean;
 		public id: Snowflake;
-		public type: keyof typeof ChannelType;
+		public type: ChannelType;
 		public delete(reason?: string): Promise<Channel>;
 		public fetch(): Promise<Channel>;
 		public toString(): string;
@@ -643,6 +644,7 @@ declare module 'discord.js' {
 		public messages: MessageManager;
 		public recipient: User;
 		public readonly partial: false;
+		public type: ChannelType.DM;
 		public fetch(): Promise<DMChannel>;
 	}
 
@@ -807,6 +809,7 @@ declare module 'discord.js' {
 		public readonly permissionsLocked: boolean | null;
 		public readonly position: number;
 		public rawPosition: number;
+		public type: Exclude<ChannelType, ChannelType.DM | ChannelType.GROUP | ChannelType.UNKNOWN>;
 		public readonly viewable: boolean;
 		public clone(options?: GuildChannelCloneOptions): Promise<this>;
 		public createInvite(options?: InviteOptions): Promise<Invite>;
@@ -1392,6 +1395,7 @@ declare module 'discord.js' {
 		constructor(guild: Guild, data?: object);
 		public messages: MessageManager;
 		public nsfw: boolean;
+		public type: ChannelType.TEXT;
 		public rateLimitPerUser: number;
 		public topic: string | null;
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable, reason?: string }): Promise<Webhook>;
@@ -1404,6 +1408,7 @@ declare module 'discord.js' {
 		constructor(guild: Guild, data?: object);
 		public messages: MessageManager;
 		public nsfw: boolean;
+		public type: ChannelType.NEWS;
 		public topic: string | null;
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable, reason?: string }): Promise<Webhook>;
 		public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
@@ -1506,6 +1511,7 @@ declare module 'discord.js' {
 		public readonly full: boolean;
 		public readonly joinable: boolean;
 		public readonly speakable: boolean;
+		public type: ChannelType.VOICE;
 		public userLimit: number;
 		public join(): Promise<VoiceConnection>;
 		public leave(): void;
@@ -2291,7 +2297,7 @@ declare module 'discord.js' {
 	interface GuildCreateChannelOptions {
 		permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
 		topic?: string;
-		type?: Exclude<keyof typeof ChannelType, 'dm' | 'group' | 'unknown'>;
+		type?: Exclude<ChannelType, ChannelType.DM | ChannelType.GROUP | ChannelType.UNKNOWN>;
 		nsfw?: boolean;
 		parent?: ChannelResolvable;
 		bitrate?: number;
@@ -2731,7 +2737,7 @@ declare module 'discord.js' {
 	interface CrosspostedChannel {
 		channelID: Snowflake;
 		guildID: Snowflake;
-		type: keyof typeof ChannelType;
+		type: ChannelType;
 		name: string;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2518,10 +2518,10 @@ declare module 'discord.js' {
   interface GuildCreateChannelOptions {
     permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
     topic?: string;
-		type?: Exclude<
-			keyof typeof ChannelType | ChannelType,
-			'dm' | 'group' | 'unknown' | ChannelType.dm | ChannelType.group | ChannelType.unknown
-		>;
+    type?: Exclude<
+        keyof typeof ChannelType | ChannelType,
+        'dm' | 'group' | 'unknown' | ChannelType.dm | ChannelType.group | ChannelType.unknown
+    >;
     nsfw?: boolean;
     parent?: ChannelResolvable;
     bitrate?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1769,7 +1769,8 @@ declare module 'discord.js' {
 
 //#region Managers
 
-	export class ChannelManager extends BaseManager<Snowflake, Channel, ChannelResolvable> {
+	type Channels = TextChannel | DMChannel | VoiceChannel | CategoryChannel | NewsChannel | StoreChannel;
+	export class ChannelManager extends BaseManager<Snowflake, Channels, ChannelResolvable> {
 		constructor(client: Client, iterable: Iterable<any>);
 		public fetch(id: Snowflake, cache?: boolean): Promise<Channel>;
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1769,8 +1769,7 @@ declare module 'discord.js' {
 
 //#region Managers
 
-	type Channels = TextChannel | DMChannel | VoiceChannel | CategoryChannel | NewsChannel | StoreChannel;
-	export class ChannelManager extends BaseManager<Snowflake, Channels, ChannelResolvable> {
+	export class ChannelManager extends BaseManager<Snowflake, Channel, ChannelResolvable> {
 		constructor(client: Client, iterable: Iterable<any>);
 		public fetch(id: Snowflake, cache?: boolean): Promise<Channel>;
 	}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1082,7 +1082,7 @@ declare module 'discord.js' {
 		public messages: MessageManager;
 		public nsfw: boolean;
 		public topic: string | null;
-    public type: ChannelType.NEWS;
+		public type: ChannelType.NEWS;
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable; reason?: string; }): Promise<Webhook>;
 		public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
@@ -2135,7 +2135,7 @@ declare module 'discord.js' {
 	interface CrosspostedChannel {
 		channelID: Snowflake;
 		guildID: Snowflake;
-    type: ChannelType;
+		type: ChannelType;
 		name: string;
 	}
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,12 +1,12 @@
 declare enum ChannelType {
-	TEXT = 'text',
-	DM = 'dm',
-	VOICE = 'voice',
-	GROUP = 'group',
-	CATEGORY = 'category',
-	NEWS = 'news',
-	STORE = 'store',
-	UNKNOWN = 'unknown'
+	text = 0,
+	dm = 1,
+	voice = 2,
+	group = 3,
+	category = 4,
+	news = 5,
+	store = 6,
+	unknown = 7
 }
 
 declare module 'discord.js' {
@@ -131,7 +131,7 @@ declare module 'discord.js' {
 
 	export class CategoryChannel extends GuildChannel {
 		public readonly children: Collection<Snowflake, GuildChannel>;
-		public type: ChannelType.CATEGORY;
+		public type: 'category';
 	}
 
 	export class Channel extends Base {
@@ -140,7 +140,7 @@ declare module 'discord.js' {
 		public readonly createdTimestamp: number;
 		public deleted: boolean;
 		public id: Snowflake;
-		public type: ChannelType;
+		public type: keyof typeof ChannelType;
 		public delete(reason?: string): Promise<Channel>;
 		public fetch(): Promise<Channel>;
 		public toString(): string;
@@ -609,7 +609,7 @@ declare module 'discord.js' {
 		public messages: MessageManager;
 		public recipient: User;
 		public readonly partial: false;
-		public type: ChannelType.DM;
+		public type: 'dm';
 		public fetch(): Promise<DMChannel>;
 	}
 
@@ -779,7 +779,7 @@ declare module 'discord.js' {
 		public readonly permissionsLocked: boolean | null;
 		public readonly position: number;
 		public rawPosition: number;
-		public type: Exclude<ChannelType, ChannelType.DM | ChannelType.GROUP | ChannelType.UNKNOWN>;
+		public type: Exclude<keyof typeof ChannelType, 'dm' | 'group' | 'unknown'>;
 		public readonly viewable: boolean;
 		public clone(options?: GuildChannelCloneOptions): Promise<this>;
 		public createInvite(options?: InviteOptions): Promise<Invite>;
@@ -1082,7 +1082,7 @@ declare module 'discord.js' {
 		public messages: MessageManager;
 		public nsfw: boolean;
 		public topic: string | null;
-		public type: ChannelType.NEWS;
+		public type: 'news';
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable; reason?: string; }): Promise<Webhook>;
 		public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
 		public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
@@ -1390,7 +1390,7 @@ declare module 'discord.js' {
 		constructor(guild: Guild, data?: object);
 		public messages: MessageManager;
 		public nsfw: boolean;
-		public type: ChannelType.TEXT;
+		public type: 'text';
 		public rateLimitPerUser: number;
 		public topic: string | null;
 		public createWebhook(name: string, options?: { avatar?: BufferResolvable | Base64Resolvable; reason?: string; }): Promise<Webhook>;
@@ -1494,7 +1494,7 @@ declare module 'discord.js' {
 		public readonly full: boolean;
 		public readonly joinable: boolean;
 		public readonly speakable: boolean;
-		public type: ChannelType.VOICE;
+		public type: 'voice';
 		public userLimit: number;
 		public join(): Promise<VoiceConnection>;
 		public leave(): void;
@@ -2135,7 +2135,7 @@ declare module 'discord.js' {
 	interface CrosspostedChannel {
 		channelID: Snowflake;
 		guildID: Snowflake;
-		type: ChannelType;
+		type: keyof typeof ChannelType;
 		name: string;
 	}
 
@@ -2292,7 +2292,10 @@ declare module 'discord.js' {
 	interface GuildCreateChannelOptions {
 		permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
 		topic?: string;
-		type?: Exclude<ChannelType, ChannelType.DM | ChannelType.GROUP | ChannelType.UNKNOWN>;
+		type?: Exclude<
+			keyof typeof ChannelType | ChannelType,
+			'dm' | 'group' | 'unknown' | ChannelType.dm | ChannelType.group | ChannelType.unknown
+		>;
 		nsfw?: boolean;
 		parent?: ChannelResolvable;
 		bitrate?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,12 +1,12 @@
 declare enum ChannelType {
-	text = 0,
-	dm = 1,
-	voice = 2,
-	group = 3,
-	category = 4,
-	news = 5,
-	store = 6,
-	unknown = 7
+	text,
+	dm,
+	voice,
+	group,
+	category,
+	news,
+	store,
+	unknown
 }
 
 declare module 'discord.js' {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Inspired by #3807, originally going for a different solution but ultimately becoming a copy due to certain issues I ran into

Changes made:
- Each Channel class now has a corresponding type property
- GuildCreateChannelOptions#type now actually takes numbers

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
