### PR TITLE
feat(MessageEmbed): change toJSON method to return an api-compatible object

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -152,7 +152,7 @@ class APIMessage {
     } else if (this.options.embed) {
       embedLikes.push(this.options.embed);
     }
-    const embeds = embedLikes.map(e => new MessageEmbed(e)._apiTransform());
+    const embeds = embedLikes.map(e => new MessageEmbed(e).toJSON());
 
     let username;
     let avatarURL;

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -337,16 +337,11 @@ class MessageEmbed {
     return this;
   }
 
-  toJSON() {
-    return Util.flatten(this, { hexColor: true });
-  }
-
   /**
-   * Transforms the embed object to be processed.
+   * Transforms the embed to a plain object.
    * @returns {Object} The raw data of this embed
-   * @private
    */
-  _apiTransform() {
+  toJSON() {
     return {
       title: this.title,
       type: 'rich',

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1051,8 +1051,6 @@ declare module 'discord.js' {
 
 	export class MessageEmbed {
 		constructor(data?: MessageEmbed | MessageEmbedOptions);
-		private _apiTransform(): MessageEmbedOptions;
-
 		public author: { name?: string; url?: string; iconURL?: string; proxyIconURL?: string } | null;
 		public color: number;
 		public readonly createdAt: Date | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes and documents `MessageEmbed#toJSON` to return what `_apiTransform` used to return and removes `_apiTransform`.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
