### PR TITLE
typings(AddGuildMemberOptions): change accessToken from String to string

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2031,7 +2031,7 @@ declare module 'discord.js' {
 	}
 
 	interface AddGuildMemberOptions {
-		accessToken: String;
+		accessToken: string;
 		nick?: string;
 		roles?: Collection<Snowflake, Role> | RoleResolvable[];
 		mute?: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes 'String' to 'string' in the AddGuildMemberOptions interface definition in the typings

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
