### PR TITLE
refactor: remove unused error in catch statements

### DIFF
--- a/src/client/voice/receiver/PacketHandler.js
+++ b/src/client/voice/receiver/PacketHandler.js
@@ -90,7 +90,7 @@ class PacketHandler extends EventEmitter {
           this.connection.onSpeaking({ user_id: userStat.userID, ssrc: ssrc, speaking: 0 });
           this.receiver.connection.client.clearTimeout(speakingTimeout);
           this.speakingTimeouts.delete(ssrc);
-        } catch (ex) {
+        } catch {
           // Connection already closed, ignore
         }
       }, DISCORD_SPEAKING_DELAY);

--- a/src/client/voice/util/Secretbox.js
+++ b/src/client/voice/util/Secretbox.js
@@ -27,6 +27,6 @@ exports.methods = {};
       if (libName === 'libsodium-wrappers' && lib.ready) await lib.ready; // eslint-disable-line no-await-in-loop
       exports.methods = libs[libName](lib);
       break;
-    } catch (err) {} // eslint-disable-line no-empty
+    } catch {} // eslint-disable-line no-empty
   }
 })();

--- a/src/client/websocket/handlers/index.js
+++ b/src/client/websocket/handlers/index.js
@@ -7,7 +7,7 @@ const handlers = {};
 for (const name of Object.keys(WSEvents)) {
   try {
     handlers[name] = require(`./${name}.js`);
-  } catch (err) {} // eslint-disable-line no-empty
+  } catch {} // eslint-disable-line no-empty
 }
 
 module.exports = handlers;

--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -39,7 +39,7 @@ class ClientPresence extends Presence {
         try {
           const a = await this.client.api.oauth2.applications(applicationID).assets.get();
           for (const asset of a) assets.set(asset.name, asset.id);
-        } catch { } // eslint-disable-line no-empty
+        } catch {} // eslint-disable-line no-empty
       }
     }
 

--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -39,7 +39,7 @@ class ClientPresence extends Presence {
         try {
           const a = await this.client.api.oauth2.applications(applicationID).assets.get();
           for (const asset of a) assets.set(asset.name, asset.id);
-        } catch (err) { } // eslint-disable-line no-empty
+        } catch { } // eslint-disable-line no-empty
       }
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR just removes an unused error variable, to keep it consistent with other places that do the same thing

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
