### PR TITLE
typings(MessageEmebd): fix typings for addFields

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -390,7 +390,7 @@ class MessageEmbed {
     * @typedef {Object} EmbedFieldData
     * @property {StringResolvable} name The name of this field
     * @property {StringResolvable} value The value of this field
-    * @property {?boolean} inline If this field will be displayed inline
+    * @property {boolean} [inline] If this field will be displayed inline
     */
 
   /**

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -189,7 +189,7 @@ class MessageEmbed {
 
   /**
    * Adds a fields to the embed (max 25).
-   * @param {...EmbedField|EmbedField[]} fields The fields to add
+   * @param {...EmbedFieldData|EmbedFieldData[]} fields The fields to add
    * @returns {MessageEmbed}
    */
   addFields(...fields) {
@@ -201,7 +201,7 @@ class MessageEmbed {
    * Removes, replaces, and inserts fields in the embed (max 25).
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of fields to remove
-   * @param {...EmbedField|EmbedField[]} [fields] The replacing field objects
+   * @param {...EmbedFieldData|EmbedFieldData[]} [fields] The replacing field objects
    * @returns {MessageEmbed}
    */
   spliceFields(index, deleteCount, ...fields) {
@@ -360,8 +360,15 @@ class MessageEmbed {
   }
 
   /**
+    * @typedef {Object} EmbedFieldData
+    * @property {StringResolvable} name The name of this field
+    * @property {StringResolvable} value The value of this field
+    * @property {?boolean} inline If this field will be displayed inline
+    */
+
+  /**
    * Check for valid field input and resolves strings
-   * @param  {...EmbedField|EmbedField[]} fields Fields to normalize
+   * @param  {...EmbedFieldData|EmbedFieldData[]} fields Fields to normalize
    * @returns {EmbedField[]}
    */
   static normalizeFields(...fields) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2190,7 +2190,7 @@ declare module 'discord.js' {
 	interface EmbedFieldData {
 		name: StringResolvable;
 		value: StringResolvable;
-		inline?: boolean
+		inline?: boolean;
 	}
 
 	type EmojiIdentifierResolvable = string | EmojiResolvable;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1068,7 +1068,7 @@ declare module 'discord.js' {
 		public type: string;
 		public url: string;
 		public readonly video: { url?: string; proxyURL?: string; height?: number; width?: number } | null;
-		public addFields(...fields: EmbedField[] | EmbedField[][]): this;
+		public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
 		public attachFiles(file: (MessageAttachment | FileOptions | string)[]): this;
 		public setAuthor(name: StringResolvable, iconURL?: string, url?: string): this;
 		public setColor(color: ColorResolvable): this;
@@ -1079,11 +1079,11 @@ declare module 'discord.js' {
 		public setTimestamp(timestamp?: Date | number): this;
 		public setTitle(title: StringResolvable): this;
 		public setURL(url: string): this;
-		public spliceFields(index: number, deleteCount: number, ...fields: EmbedField[] | EmbedField[][]): this;
+		public spliceFields(index: number, deleteCount: number, ...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
 		public toJSON(): object;
 
-		public static normalizeField(name: StringResolvable, value: StringResolvable, inline?: boolean): Required<EmbedField>;
-		public static normalizeFields(...fields: EmbedField[] | EmbedField[][]): Required<EmbedField>[];
+		public static normalizeField(name: StringResolvable, value: StringResolvable, inline?: boolean): Required<EmbedFieldData>;
+		public static normalizeFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): Required<EmbedFieldData>[];
 	}
 
 	export class MessageMentions {
@@ -2184,7 +2184,13 @@ declare module 'discord.js' {
 	interface EmbedField {
 		name: string;
 		value: string;
-		inline?: boolean;
+		inline: boolean;
+	}
+
+	interface EmbedFieldData {
+		name: StringResolvable;
+		value: StringResolvable;
+		inline?: boolean
 	}
 
 	type EmojiIdentifierResolvable = string | EmojiResolvable;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fix typings for `addFields `and `spliceFields `as well as the underlying `normalizeFields `call by introducing a second typing, **EmbedFieldData** alongside EmbedField to enable passing of **StringResolvable** to the builder methods while keeping the certain string for the accessor through the field structure e.g. `embed.fields[0].name` as well as a certain boolean for the inline accessor - as inline is defaulted to `false` in the normalizeField call

⚠ I have tested this with all possible inputs and accessors I could think of, however please let somebody proficient in typings review this before merging

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
