### PR TITLE
typings(MessageEmbed): mark properties as able to be undefined

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1052,21 +1052,21 @@ declare module 'discord.js' {
 	export class MessageEmbed {
 		constructor(data?: MessageEmbed | MessageEmbedOptions);
 		public author: { name?: string; url?: string; iconURL?: string; proxyIconURL?: string } | null;
-		public color: number;
+		public color?: number;
 		public readonly createdAt: Date | null;
-		public description: string;
+		public description?: string;
 		public fields: EmbedField[];
 		public files: (MessageAttachment | string | FileOptions)[];
 		public footer: { text?: string; iconURL?: string; proxyIconURL?: string } | null;
 		public readonly hexColor: string | null;
 		public image: { url: string; proxyURL?: string; height?: number; width?: number; } | null;
 		public readonly length: number;
-		public provider: { name: string; url: string; };
+		public provider?: { name: string; url: string; };
 		public thumbnail: { url: string; proxyURL?: string; height?: number; width?: number; } | null;
 		public timestamp: number | null;
-		public title: string;
+		public title?: string;
 		public type: string;
-		public url: string;
+		public url?: string;
 		public readonly video: { url?: string; proxyURL?: string; height?: number; width?: number } | null;
 		public addFields(...fields: EmbedField[] | EmbedField[][]): this;
 		public attachFiles(file: (MessageAttachment | FileOptions | string)[]): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR marks the color, description, provider, title, and url properties as able to be undefined, since they are able to be undefined

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [] This PR **only** includes non-code changes, like changes to documentation, README, etc.
