### PR TITLE
typings(Invite): channel can be a PartialGroupDMChannel

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -931,7 +931,7 @@ declare module 'discord.js' {
 
 	export class Invite extends Base {
 		constructor(client: Client, data: object);
-		public channel: GuildChannel;
+		public channel: GuildChannel | PartialGroupDMChannel;
 		public code: string;
 		public readonly deletable: boolean;
 		public readonly createdAt: Date | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the typings for Invite#channel from being only a GuildChannel to a GuildChannel or a PartialGroupDMChannel

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
