### PR TITLE
fix: Client#sweepMessages should throw an INVALID_TYPE error

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -64,7 +64,7 @@ class Client extends BaseClient {
 
     if (Array.isArray(this.options.shards)) {
       this.options.shards = [...new Set(
-        this.options.shards.filter(item => !isNaN(item) && item >= 0 && item < Infinity && item === (item | 0))
+        this.options.shards.filter(item => !isNaN(item) && item >= 0 && item < Infinity && item === (item | 0)),
       )];
     }
 
@@ -199,7 +199,7 @@ class Client extends BaseClient {
     if (!token || typeof token !== 'string') throw new Error('TOKEN_INVALID');
     this.token = token = token.replace(/^(Bot|Bearer)\s*/i, '');
     this.emit(Events.DEBUG,
-      `Provided token: ${token.split('.').map((val, i) => i > 1 ? val.replace(/./g, '*') : val).join('.')}`
+      `Provided token: ${token.split('.').map((val, i) => i > 1 ? val.replace(/./g, '*') : val).join('.')}`,
     );
 
     if (this.options.presence) {
@@ -303,7 +303,7 @@ class Client extends BaseClient {
       channels++;
 
       messages += channel.messages.cache.sweep(
-        message => now - (message.editedTimestamp || message.createdTimestamp) > lifetimeMs
+        message => now - (message.editedTimestamp || message.createdTimestamp) > lifetimeMs,
       );
     }
 

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -286,7 +286,7 @@ class Client extends BaseClient {
    */
   sweepMessages(lifetime = this.options.messageCacheLifetime) {
     if (typeof lifetime !== 'number' || isNaN(lifetime)) {
-      throw new TypeError('CLIENT_INVALID_OPTION', 'Lifetime', 'a number');
+      throw new TypeError('INVALID_TYPE', 'lifetime', 'number');
     }
     if (lifetime <= 0) {
       this.emit(Events.DEBUG, 'Didn\'t sweep messages - lifetime is unlimited');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes Client#sweepMessages to throw an INVALID_TYPE error instead of an CLIENT_INVALID_OPTION error if the `lifetime` parameter is not the correct type

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
