### PR TITLE
typings(WebhookClient): client is not a Client

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -303,13 +303,6 @@ declare module 'discord.js' {
 		public toString(): string;
 	}
 
-	export interface ActivityOptions {
-		name?: string;
-		url?: string;
-		type?: ActivityType | number;
-		shardID?: number | number[];
-	}
-
 	export class ClientUser extends User {
 		public mfaEnabled: boolean;
 		public verified: boolean;
@@ -1630,6 +1623,7 @@ declare module 'discord.js' {
 	export class WebhookClient extends WebhookMixin(BaseClient) {
 		constructor(id: string, token: string, options?: ClientOptions);
 		public token: string;
+		public readonly client: this;
 	}
 
 	export class WebSocketManager extends EventEmitter {
@@ -1923,11 +1917,18 @@ declare module 'discord.js' {
 		| 'SYNC'
 		| 'PLAY';
 
+	interface ActivityOptions {
+		name?: string;
+		url?: string;
+		type?: ActivityType | number;
+		shardID?: number | number[];
+	}
+
 	type ActivityType = 'PLAYING'
 		| 'STREAMING'
 		| 'LISTENING'
 		| 'WATCHING'
-		| 'CUSTOM_STATUS';
+    | 'CUSTOM_STATUS';
 
 	type MessageFlagsString = 'CROSSPOSTED'
 		| 'IS_CROSSPOST'

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1928,7 +1928,7 @@ declare module 'discord.js' {
 		| 'STREAMING'
 		| 'LISTENING'
 		| 'WATCHING'
-    | 'CUSTOM_STATUS';
+		| 'CUSTOM_STATUS';
 
 	type MessageFlagsString = 'CROSSPOSTED'
 		| 'IS_CROSSPOST'


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the typings for WebhookClient#client to be `this` instead of being a `Client` from the WebhookMixin, (as constructing a new WebhhokClient has no Client parameter, and defines it as `this`, see [here](https://github.com/discordjs/discord.js/blob/91a025caaaadb49a4f6610ef1ff2f06d69784987/src/client/WebhookClient.js#L23))

(also moves an Interface from the classes regionto the typedefs region)

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
