### PR TITLE
Better user input sanitization: replace disableEveryone with disableMentions

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -386,8 +386,8 @@ class Client extends BaseClient {
     if (typeof options.fetchAllMembers !== 'boolean') {
       throw new TypeError('CLIENT_INVALID_OPTION', 'fetchAllMembers', 'a boolean');
     }
-    if (typeof options.disableEveryone !== 'boolean') {
-      throw new TypeError('CLIENT_INVALID_OPTION', 'disableEveryone', 'a boolean');
+    if (typeof options.disableMentions !== 'boolean') {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'disableMentions', 'a boolean');
     }
     if (!Array.isArray(options.partials)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'partials', 'an Array');

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -89,8 +89,8 @@ class APIMessage {
     }
 
     const disableMentions = typeof this.options.disableMentions === 'undefined' ?
-        this.target.client.options.disableMentions :
-        this.options.disableMentions;
+      this.target.client.options.disableMentions :
+      this.options.disableMentions;
     if (disableMentions) {
       content = (content || '').replace(/@/g, '@\u200b');
     }

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -113,11 +113,11 @@ class APIMessage {
         content = `${mentionPart}${content || ''}`;
       }
 
-      const disableEveryone = typeof this.options.disableEveryone === 'undefined' ?
-        this.target.client.options.disableEveryone :
-        this.options.disableEveryone;
-      if (disableEveryone) {
-        content = (content || '').replace(/@(everyone|here)/g, '@\u200b$1');
+      const disableMentions = typeof this.options.disableMentions === 'undefined' ?
+        this.target.client.options.disableMentions :
+        this.options.disableMentions;
+      if (disableMentions) {
+        content = (content || '').replace(/@/g, '@\u200b');
       }
 
       if (isSplit) {

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -88,6 +88,13 @@ class APIMessage {
       content = Util.resolveString(this.options.content);
     }
 
+    const disableMentions = typeof this.options.disableMentions === 'undefined' ?
+        this.target.client.options.disableMentions :
+        this.options.disableMentions;
+    if (disableMentions) {
+      content = (content || '').replace(/@/g, '@\u200b');
+    }
+
     const isSplit = typeof this.options.split !== 'undefined' && this.options.split !== false;
     const isCode = typeof this.options.code !== 'undefined' && this.options.code !== false;
     const splitOptions = isSplit ? { ...this.options.split } : undefined;
@@ -111,13 +118,6 @@ class APIMessage {
         }
       } else if (mentionPart) {
         content = `${mentionPart}${content || ''}`;
-      }
-
-      const disableMentions = typeof this.options.disableMentions === 'undefined' ?
-        this.target.client.options.disableMentions :
-        this.options.disableMentions;
-      if (disableMentions) {
-        content = (content || '').replace(/@/g, '@\u200b');
       }
 
       if (isSplit) {

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -92,7 +92,7 @@ class APIMessage {
       this.target.client.options.disableMentions :
       this.options.disableMentions;
     if (disableMentions) {
-      content = (content || '').replace(/@/g, '@\u200b');
+      content = Util.removeMentions(content || '');
     }
 
     const isSplit = typeof this.options.split !== 'undefined' && this.options.split !== false;

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -85,8 +85,8 @@ class Webhook {
    * @property {string} [nonce=''] The nonce for the message
    * @property {Object[]} [embeds] An array of embeds for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {boolean} [disableEveryone=this.client.options.disableEveryone] Whether or not @everyone and @here
-   * should be replaced with plain-text
+   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not mentions
+   * should be replaced with plain-text (this includes: role, user and everyone/here mentions)
    * @property {FileOptions[]|string[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -85,8 +85,8 @@ class Webhook {
    * @property {string} [nonce=''] The nonce for the message
    * @property {Object[]} [embeds] An array of embeds for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not a zero width space should be placed
-   * after every @ character to prevent unexpected mentions
+   * @property {boolean} [disableMentions=this.client.options.disableMentions]  Whether or not a zero width space
+   * should be placed after every @ character to prevent unexpected mentions
    * @property {FileOptions[]|string[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -85,7 +85,7 @@ class Webhook {
    * @property {string} [nonce=''] The nonce for the message
    * @property {Object[]} [embeds] An array of embeds for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {boolean} [disableMentions=this.client.options.disableMentions]  Whether or not a zero width space
+   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not a zero width space
    * should be placed after every @ character to prevent unexpected mentions
    * @property {FileOptions[]|string[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -85,8 +85,8 @@ class Webhook {
    * @property {string} [nonce=''] The nonce for the message
    * @property {Object[]} [embeds] An array of embeds for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not mentions
-   * should be replaced with plain-text (this includes: role, user and everyone/here mentions)
+   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not a zero width space should be placed
+   * after every @ character to prevent unexpected mentions
    * @property {FileOptions[]|string[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -57,8 +57,8 @@ class TextBasedChannel {
    * @property {string} [content=''] The content for the message
    * @property {MessageEmbed|Object} [embed] An embed for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {boolean} [disableEveryone=this.client.options.disableEveryone] Whether or not @everyone and @here
-   * should be replaced with plain-text
+   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not mentions
+   * should be replaced with plain-text (this includes: role, user and everyone/here mentions)
    * @property {FileOptions[]|BufferResolvable[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -57,8 +57,8 @@ class TextBasedChannel {
    * @property {string} [content=''] The content for the message
    * @property {MessageEmbed|Object} [embed] An embed for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not mentions
-   * should be replaced with plain-text (this includes: role, user and everyone/here mentions)
+   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not a zero width space should be placed
+   * after every @ character to prevent unexpected mentions
    * @property {FileOptions[]|BufferResolvable[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -57,8 +57,8 @@ class TextBasedChannel {
    * @property {string} [content=''] The content for the message
    * @property {MessageEmbed|Object} [embed] An embed for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not a zero width space should be placed
-   * after every @ character to prevent unexpected mentions
+   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not a zero width space
+   * should be placed after every @ character to prevent unexpected mentions
    * @property {FileOptions[]|BufferResolvable[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -21,7 +21,7 @@ const browser = exports.browser = typeof window !== 'undefined';
  * the message cache lifetime (in seconds, 0 for never)
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
- * @property {boolean} [disableEveryone=false] Default value for {@link MessageOptions#disableEveryone}
+ * @property {boolean} [disableMentions=false] Default value for {@link MessageOptions#disableMentions}
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
  * they're missing all the data for a particular structure. See the "Partials" topic listed in the sidebar for some
  * important usage information, as partials require you to put checks in place when handling data.
@@ -47,7 +47,7 @@ exports.DefaultOptions = {
   messageCacheLifetime: 0,
   messageSweepInterval: 0,
   fetchAllMembers: false,
-  disableEveryone: false,
+  disableMentions: false,
   partials: [],
   restWsBridgeTimeout: 5000,
   disabledEvents: [],

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -519,38 +519,52 @@ class Util {
   }
 
   /**
+   * Breaks user, role and everyone/here mentions by adding a zero width space after every @ character
+   * @param {string} str The string to sanitize
+   * @returns {string}
+   */
+  static removeMentions(str) {
+    return str
+      .replace(/@/g, '@\u200b');
+  }
+
+  /**
    * The content to have all mentions replaced by the equivalent text.
    * @param {string} str The string to be converted
    * @param {Message} message The message object to reference
    * @returns {string}
    */
   static cleanContent(str, message) {
-    return str
-      .replace(/@/g, '@\u200b')
-      .replace(/<@!?[0-9]+>/g, input => {
-        const id = input.replace(/<|!|>|@/g, '');
-        if (message.channel.type === 'dm') {
-          const user = message.client.users.cache.get(id);
-          return user ? `@${user.username}` : input;
-        }
+    if (message.client.options.disableMentions) {
+      return Util.removeMentions(str);
+    } else {
+      return str
+        .replace(/@/g, '@\u200b')
+        .replace(/<@!?[0-9]+>/g, input => {
+          const id = input.replace(/<|!|>|@/g, '');
+          if (message.channel.type === 'dm') {
+            const user = message.client.users.cache.get(id);
+            return user ? `@${user.username}` : input;
+          }
 
-        const member = message.channel.guild.members.cache.get(id);
-        if (member) {
-          return `@${member.displayName}`;
-        } else {
-          const user = message.client.users.cache.get(id);
-          return user ? `@${user.username}` : input;
-        }
-      })
-      .replace(/<#[0-9]+>/g, input => {
-        const channel = message.client.channels.cache.get(input.replace(/<|#|>/g, ''));
-        return channel ? `#${channel.name}` : input;
-      })
-      .replace(/<@&[0-9]+>/g, input => {
-        if (message.channel.type === 'dm') return input;
-        const role = message.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
-        return role ? `@${role.name}` : input;
-      });
+          const member = message.channel.guild.members.cache.get(id);
+          if (member) {
+            return `@${member.displayName}`;
+          } else {
+            const user = message.client.users.cache.get(id);
+            return user ? `@${user.username}` : input;
+          }
+        })
+        .replace(/<#[0-9]+>/g, input => {
+          const channel = message.client.channels.cache.get(input.replace(/<|#|>/g, ''));
+          return channel ? `#${channel.name}` : input;
+        })
+        .replace(/<@&[0-9]+>/g, input => {
+          if (message.channel.type === 'dm') return input;
+          const role = message.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
+          return role ? `@${role.name}` : input;
+        });
+    }
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -524,8 +524,7 @@ class Util {
    * @returns {string}
    */
   static removeMentions(str) {
-    return str
-      .replace(/@/g, '@\u200b');
+    return str.replace(/@/g, '@\u200b');
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -526,7 +526,7 @@ class Util {
    */
   static cleanContent(str, message) {
     return str
-      .replace(/@(everyone|here)/g, '@\u200b$1')
+      .replace(/@/g, '@\u200b')
       .replace(/<@!?[0-9]+>/g, input => {
         const id = input.replace(/<|!|>|@/g, '');
         if (message.channel.type === 'dm') {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -534,7 +534,7 @@ class Util {
    * @returns {string}
    */
   static cleanContent(str, message) {
-    return str
+    return Util.removeMentions(str
       .replace(/<@!?[0-9]+>/g, input => {
         const id = input.replace(/<|!|>|@/g, '');
         if (message.channel.type === 'dm') {
@@ -558,8 +558,7 @@ class Util {
         if (message.channel.type === 'dm') return input;
         const role = message.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
         return role ? `@${role.name}` : input;
-      })
-      .replace(/@/g, '@\u200b');
+      }));
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -535,36 +535,32 @@ class Util {
    * @returns {string}
    */
   static cleanContent(str, message) {
-    if (message.client.options.disableMentions) {
-      return Util.removeMentions(str);
-    } else {
-      return str
-        .replace(/@/g, '@\u200b')
-        .replace(/<@!?[0-9]+>/g, input => {
-          const id = input.replace(/<|!|>|@/g, '');
-          if (message.channel.type === 'dm') {
-            const user = message.client.users.cache.get(id);
-            return user ? `@${user.username}` : input;
-          }
+    return str
+      .replace(/<@!?[0-9]+>/g, input => {
+        const id = input.replace(/<|!|>|@/g, '');
+        if (message.channel.type === 'dm') {
+          const user = message.client.users.cache.get(id);
+          return user ? `@${user.username}` : input;
+        }
 
-          const member = message.channel.guild.members.cache.get(id);
-          if (member) {
-            return `@${member.displayName}`;
-          } else {
-            const user = message.client.users.cache.get(id);
-            return user ? `@${user.username}` : input;
-          }
-        })
-        .replace(/<#[0-9]+>/g, input => {
-          const channel = message.client.channels.cache.get(input.replace(/<|#|>/g, ''));
-          return channel ? `#${channel.name}` : input;
-        })
-        .replace(/<@&[0-9]+>/g, input => {
-          if (message.channel.type === 'dm') return input;
-          const role = message.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
-          return role ? `@${role.name}` : input;
-        });
-    }
+        const member = message.channel.guild.members.cache.get(id);
+        if (member) {
+          return `@${member.displayName}`;
+        } else {
+          const user = message.client.users.cache.get(id);
+          return user ? `@${user.username}` : input;
+        }
+      })
+      .replace(/<#[0-9]+>/g, input => {
+        const channel = message.client.channels.cache.get(input.replace(/<|#|>/g, ''));
+        return channel ? `#${channel.name}` : input;
+      })
+      .replace(/<@&[0-9]+>/g, input => {
+        if (message.channel.type === 'dm') return input;
+        const role = message.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
+        return role ? `@${role.name}` : input;
+      })
+      .replace(/@/g, '@\u200b');
   }
 
   /**

--- a/test/disableMentions.js
+++ b/test/disableMentions.js
@@ -11,16 +11,16 @@ const client = new Discord.Client({
 const tests = [
     // Test 1
     // See https://github.com/discordapp/discord-api-docs/issues/1189
-    '@\u202eeveryone',
+    '@\u202eeveryone @\u202ehere',
 
     // Test 2
     // See https://github.com/discordapp/discord-api-docs/issues/1241
     // TL;DR: Characters like \u0300 will only be stripped if more than 299 are present
-    '\u0300@'.repeat(150) + '@\u0300everyone',
+    '\u0300@'.repeat(150) + '@\u0300everyone @\u0300here',
 
     // Test 3
-    // Normal @everyone mention
-    '@everyone',
+    // Normal @everyone/@here mention
+    '@everyone @here',
 ];
 
 

--- a/test/disableMentions.js
+++ b/test/disableMentions.js
@@ -1,0 +1,41 @@
+const Discord = require('../src');
+const { token, prefix } = require('./auth');
+
+const client = new Discord.Client({
+    // To see a difference, comment out disableMentions and run the same tests using disableEveryone
+    // You will notice that all messages will mention @everyone
+    //disableEveryone: true
+    disableMentions: true
+});
+
+const tests = [
+    // Test 1
+    // See https://github.com/discordapp/discord-api-docs/issues/1189
+    '@\u202eeveryone',
+
+    // Test 2
+    // See https://github.com/discordapp/discord-api-docs/issues/1241
+    // TL;DR: Characters like \u0300 will only be stripped if more than 299 are present
+    '\u0300@'.repeat(150) + '@\u0300everyone',
+
+    // Test 3
+    // Normal @everyone mention
+    '@everyone',
+];
+
+
+
+client.on('ready', () => console.log('Ready!'));
+
+client.on('message', message => {
+    const command = message.content.substr(prefix.length);
+    
+    if (command === 'test1')
+        message.reply(tests[0]);
+    else if (command === 'test2')
+        message.reply(tests[1]);
+    else if (command === 'test3')
+        message.reply(tests[2]);
+});
+
+client.login(token).catch(console.error);

--- a/test/disableMentions.js
+++ b/test/disableMentions.js
@@ -34,8 +34,6 @@ client.on('message', message => {
     const [command, ...args] = message.content.substr(prefix.length).split(' ');
     
     // Clean content and log each character
-    // If message includes a mention and disableMentions option is set, this breaks all mentions
-    // As a test, send `!test1 @here`
     console.log(Util.cleanContent(args.join(' '), message).split(''));
 
     if (command === 'test1')

--- a/test/disableMentions.js
+++ b/test/disableMentions.js
@@ -1,4 +1,5 @@
 const Discord = require('../src');
+const { Util } = Discord;
 const { token, prefix } = require('./auth');
 
 const client = new Discord.Client({
@@ -28,8 +29,15 @@ const tests = [
 client.on('ready', () => console.log('Ready!'));
 
 client.on('message', message => {
-    const command = message.content.substr(prefix.length);
+    // Check if message starts with prefix
+    if (!message.content.startsWith(prefix)) return;
+    const [command, ...args] = message.content.substr(prefix.length).split(' ');
     
+    // Clean content and log each character
+    // If message includes a mention and disableMentions option is set, this breaks all mentions
+    // As a test, send `!test1 @here`
+    console.log(Util.cleanContent(args.join(' '), message).split(''));
+
     if (command === 'test1')
         message.reply(tests[0]);
     else if (command === 'test2')

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1434,6 +1434,7 @@ declare module 'discord.js' {
 		public static basename(path: string, ext?: string): string;
 		public static binaryToID(num: string): Snowflake;
 		public static cleanContent(str: string, message: Message): string;
+		public static removeMentions(str: string): string;
 		public static cloneObject(obj: object): object;
 		public static convertToBuffer(ab: ArrayBuffer | string): Buffer;
 		public static delayFor(ms: number): Promise<void>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2068,7 +2068,7 @@ declare module 'discord.js' {
 		messageCacheLifetime?: number;
 		messageSweepInterval?: number;
 		fetchAllMembers?: boolean;
-		disableEveryone?: boolean;
+		disableMentions?: boolean;
 		partials?: PartialTypes[];
 		restWsBridgeTimeout?: number;
 		restTimeOffset?: number;
@@ -2464,7 +2464,7 @@ declare module 'discord.js' {
 		nonce?: string;
 		content?: string;
 		embed?: MessageEmbed | MessageEmbedOptions;
-		disableEveryone?: boolean;
+		disableMentions?: boolean;
 		files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
 		code?: string | boolean;
 		split?: boolean | SplitOptions;
@@ -2693,7 +2693,7 @@ declare module 'discord.js' {
 		tts?: boolean;
 		nonce?: string;
 		embeds?: (MessageEmbed | object)[];
-		disableEveryone?: boolean;
+		disableMentions?: boolean;
 		files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
 		code?: string | boolean;
 		split?: boolean | SplitOptions;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In an [earlier Pull Request](https://github.com/discordjs/discord.js/pull/3606), I tried fixing a bug where `disableEveryone` would not work if certain characters were in between the mention. At the time I was not aware that the RTL character (\u202e) can appear anywhere in the mention, which makes the Pull Request useless as it only works with `@\u202e?everyone`. Additionally, the Right to Left override character is not the only character that Discord strips.
A few months ago a [warning](https://discordapp.com/developers/docs/resources/channel#create-message) regarding message sanitization has been added to the API documentation:
> Discord may strip certain characters from message content, like invalid unicode characters or characters which cause unexpected message formatting. If you are passing user-generated strings into message content, consider sanitizing the data to prevent unexpected behavior. For example, to prevent unexpected mentions you could consider stripping @ characters or placing a zero-width space (U-200B) after them.

As it is unclear *what* characters specifically are stripped, it's rather hard to write a proper `disableEveryone` option (while still allowing other mentions such as user and role mentions). 
This Pull Request **removes** the ClientOption/MessageOption `disableEveryone` and adds `disableMentions`, which breaks **any** type of mention (except for channel mentions) instead of just `@everyone`/`@here` by adding a zero width space after every `@` character (as recommended by the API documentation).
Controlled mentions (such as user mentions at the beginning of message content in Message#reply) will not be affected by this change.

For clarification, I added tests that can be found in `test/disableMentions.js`. It shows that it is no longer possible to bypass the replacement using "certain characters":
__Using `disableMentions`:__
![image](https://user-images.githubusercontent.com/30553356/75184905-75dd0380-5745-11ea-8f86-07b88a3c21b7.png)
__Using `disableEveryone`:__
![image](https://user-images.githubusercontent.com/30553356/75185054-bdfc2600-5745-11ea-9d37-4c5b8cecb383.png)



**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
