### PR TITLE
refactor(Guild)/fix(Util): use resolveID and regex for cleanCodeBlockContent

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -861,7 +861,7 @@ class Guild extends Base {
     }
     if (data.afkTimeout) _data.afk_timeout = Number(data.afkTimeout);
     if (typeof data.icon !== 'undefined') _data.icon = data.icon;
-    if (data.owner) _data.owner_id = this.client.users.resolve(data.owner).id;
+    if (data.owner) _data.owner_id = this.client.users.resolveID(data.owner);
     if (data.splash) _data.splash = data.splash;
     if (data.banner) _data.banner = data.banner;
     if (typeof data.explicitContentFilter !== 'undefined') {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -559,7 +559,7 @@ class Util {
    * @returns {string}
    */
   static cleanCodeBlockContent(text) {
-    return text.replace('```', '`\u200b``');
+    return text.replace(/```/g, '`\u200b``');
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR refactors the Guild#edit function to use `this.client.users.resolveID` instead of `this.client.users.resolve(...).id`, also uses a regex for `Util#cleanCodeBlockContent` as its meant to replace all codeblocks and not just the first

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
