### PR TITLE
feat: reimplement disableEveryone into disableMentions

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -386,8 +386,8 @@ class Client extends BaseClient {
     if (typeof options.fetchAllMembers !== 'boolean') {
       throw new TypeError('CLIENT_INVALID_OPTION', 'fetchAllMembers', 'a boolean');
     }
-    if (typeof options.disableMentions !== 'boolean') {
-      throw new TypeError('CLIENT_INVALID_OPTION', 'disableMentions', 'a boolean');
+    if (options.disableMentions && typeof options.disableMentions !== 'string') {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'disableMentions', 'a string');
     }
     if (!Array.isArray(options.partials)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'partials', 'an Array');

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -386,7 +386,7 @@ class Client extends BaseClient {
     if (typeof options.fetchAllMembers !== 'boolean') {
       throw new TypeError('CLIENT_INVALID_OPTION', 'fetchAllMembers', 'a boolean');
     }
-    if (options.disableMentions && typeof options.disableMentions !== 'string') {
+    if (typeof options.disableMentions !== 'string') {
       throw new TypeError('CLIENT_INVALID_OPTION', 'disableMentions', 'a string');
     }
     if (!Array.isArray(options.partials)) {

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -91,8 +91,16 @@ class APIMessage {
     const disableMentions = typeof this.options.disableMentions === 'undefined' ?
       this.target.client.options.disableMentions :
       this.options.disableMentions;
-    if (disableMentions) {
+    if (disableMentions === 'all') {
       content = Util.removeMentions(content || '');
+    } else if (disableMentions === 'everyone') {
+      content = (content || '').replace(/@([^<>@ ]*)/gsmu, (match, target) => {
+        if (target.match(/^[&!]?\d+$/)) {
+          return `@${target}`;
+        } else {
+          return `@\u200b${target}`;
+        }
+      });
     }
 
     const isSplit = typeof this.options.split !== 'undefined' && this.options.split !== false;

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -85,7 +85,7 @@ class Webhook {
    * @property {string} [nonce=''] The nonce for the message
    * @property {Object[]} [embeds] An array of embeds for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not all mentions
+   * @property {'none' | 'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not all mentions
    * or everyone/here mentions should be sanitized to prevent unexpected mentions
    * @property {FileOptions[]|string[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -85,8 +85,8 @@ class Webhook {
    * @property {string} [nonce=''] The nonce for the message
    * @property {Object[]} [embeds] An array of embeds for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not a zero width space
-   * should be placed after every @ character to prevent unexpected mentions
+   * @property {'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not all mentions
+   * or everyone/here mentions should be sanitized to prevent unexpected mentions
    * @property {FileOptions[]|string[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -85,8 +85,8 @@ class Webhook {
    * @property {string} [nonce=''] The nonce for the message
    * @property {Object[]} [embeds] An array of embeds for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {'none' | 'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not all mentions
-   * or everyone/here mentions should be sanitized to prevent unexpected mentions
+   * @property {'none' | 'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not
+   * all mentions or everyone/here mentions should be sanitized to prevent unexpected mentions
    * @property {FileOptions[]|string[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -57,7 +57,7 @@ class TextBasedChannel {
    * @property {string} [content=''] The content for the message
    * @property {MessageEmbed|Object} [embed] An embed for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not all mentions
+   * @property {'none' | 'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not all mentions
    * or everyone/here mentions should be sanitized to prevent unexpected mentions
    * @property {FileOptions[]|BufferResolvable[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -57,8 +57,8 @@ class TextBasedChannel {
    * @property {string} [content=''] The content for the message
    * @property {MessageEmbed|Object} [embed] An embed for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {boolean} [disableMentions=this.client.options.disableMentions] Whether or not a zero width space
-   * should be placed after every @ character to prevent unexpected mentions
+   * @property {'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not all mentions
+   * or everyone/here mentions should be sanitized to prevent unexpected mentions
    * @property {FileOptions[]|BufferResolvable[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -57,8 +57,8 @@ class TextBasedChannel {
    * @property {string} [content=''] The content for the message
    * @property {MessageEmbed|Object} [embed] An embed for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {'none' | 'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not all mentions
-   * or everyone/here mentions should be sanitized to prevent unexpected mentions
+   * @property {'none' | 'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not
+   * all mentionsor everyone/here mentions should be sanitized to prevent unexpected mentions
    * @property {FileOptions[]|BufferResolvable[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -21,7 +21,7 @@ const browser = exports.browser = typeof window !== 'undefined';
  * the message cache lifetime (in seconds, 0 for never)
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
- * @property {boolean} [disableMentions=false] Default value for {@link MessageOptions#disableMentions}
+ * @property {'all' | 'everyone'} [disableMentions=undefined] Default value for {@link MessageOptions#disableMentions}
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
  * they're missing all the data for a particular structure. See the "Partials" topic listed in the sidebar for some
  * important usage information, as partials require you to put checks in place when handling data.
@@ -47,7 +47,7 @@ exports.DefaultOptions = {
   messageCacheLifetime: 0,
   messageSweepInterval: 0,
   fetchAllMembers: false,
-  disableMentions: false,
+  disableMentions: undefined,
   partials: [],
   restWsBridgeTimeout: 5000,
   disabledEvents: [],

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -21,7 +21,7 @@ const browser = exports.browser = typeof window !== 'undefined';
  * the message cache lifetime (in seconds, 0 for never)
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
- * @property {'all' | 'everyone'} [disableMentions=undefined] Default value for {@link MessageOptions#disableMentions}
+ * @property {'all' | 'everyone'} [disableMentions='none'] Default value for {@link MessageOptions#disableMentions}
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
  * they're missing all the data for a particular structure. See the "Partials" topic listed in the sidebar for some
  * important usage information, as partials require you to put checks in place when handling data.
@@ -47,7 +47,7 @@ exports.DefaultOptions = {
   messageCacheLifetime: 0,
   messageSweepInterval: 0,
   fetchAllMembers: false,
-  disableMentions: undefined,
+  disableMentions: 'none',
   partials: [],
   restWsBridgeTimeout: 5000,
   disabledEvents: [],

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -21,7 +21,8 @@ const browser = exports.browser = typeof window !== 'undefined';
  * the message cache lifetime (in seconds, 0 for never)
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
- * @property {'none' | 'all' | 'everyone'} [disableMentions='none'] Default value for {@link MessageOptions#disableMentions}
+ * @property {'none' | 'all' | 'everyone'} [disableMentions='none'] Default value
+ * for {@link MessageOptions#disableMentions}
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
  * they're missing all the data for a particular structure. See the "Partials" topic listed in the sidebar for some
  * important usage information, as partials require you to put checks in place when handling data.

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -21,7 +21,7 @@ const browser = exports.browser = typeof window !== 'undefined';
  * the message cache lifetime (in seconds, 0 for never)
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
- * @property {'all' | 'everyone'} [disableMentions='none'] Default value for {@link MessageOptions#disableMentions}
+ * @property {'none' | 'all' | 'everyone'} [disableMentions='none'] Default value for {@link MessageOptions#disableMentions}
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
  * they're missing all the data for a particular structure. See the "Partials" topic listed in the sidebar for some
  * important usage information, as partials require you to put checks in place when handling data.

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -534,22 +534,30 @@ class Util {
    * @returns {string}
    */
   static cleanContent(str, message) {
-    return Util.removeMentions(str
-      .replace(/<@!?[0-9]+>/g, input => {
-        const id = input.replace(/<|!|>|@/g, '');
-        if (message.channel.type === 'dm') {
-          const user = message.client.users.cache.get(id);
-          return user ? `@${user.username}` : input;
-        }
-
-        const member = message.channel.guild.members.cache.get(id);
-        if (member) {
-          return `@${member.displayName}`;
+    if (message.client.options.disableMentions === 'everyone') {
+      str = str.replace(/@([^<>@ ]*)/gsmu, (match, target) => {
+        if (target.match(/^[&!]?\d+$/)) {
+          return `@${target}`;
         } else {
-          const user = message.client.users.cache.get(id);
-          return user ? `@${user.username}` : input;
+          return `@\u200b${target}`;
         }
-      })
+      });
+    }
+    str = str.replace(/<@!?[0-9]+>/g, input => {
+      const id = input.replace(/<|!|>|@/g, '');
+      if (message.channel.type === 'dm') {
+        const user = message.client.users.cache.get(id);
+        return user ? `@${user.username}` : input;
+      }
+
+      const member = message.channel.guild.members.cache.get(id);
+      if (member) {
+        return `@${member.displayName}`;
+      } else {
+        const user = message.client.users.cache.get(id);
+        return user ? `@${user.username}` : input;
+      }
+    })
       .replace(/<#[0-9]+>/g, input => {
         const channel = message.client.channels.cache.get(input.replace(/<|#|>/g, ''));
         return channel ? `#${channel.name}` : input;
@@ -558,7 +566,12 @@ class Util {
         if (message.channel.type === 'dm') return input;
         const role = message.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
         return role ? `@${role.name}` : input;
-      }));
+      });
+    if (message.client.options.disableMentions === 'all') {
+      return Util.removeMentions(str);
+    } else {
+      return str;
+    }
   }
 
   /**

--- a/test/disableMentions.js
+++ b/test/disableMentions.js
@@ -6,7 +6,7 @@ const client = new Discord.Client({
     // To see a difference, comment out disableMentions and run the same tests using disableEveryone
     // You will notice that all messages will mention @everyone
     //disableEveryone: true
-    disableMentions: true
+    disableMentions: "everyone"
 });
 
 const tests = [

--- a/test/disableMentions.js
+++ b/test/disableMentions.js
@@ -6,7 +6,7 @@ const client = new Discord.Client({
     // To see a difference, comment out disableMentions and run the same tests using disableEveryone
     // You will notice that all messages will mention @everyone
     //disableEveryone: true
-    disableMentions: "everyone"
+    disableMentions: 'everyone'
 });
 
 const tests = [

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2069,7 +2069,7 @@ declare module 'discord.js' {
 		messageCacheLifetime?: number;
 		messageSweepInterval?: number;
 		fetchAllMembers?: boolean;
-		disableMentions?: boolean;
+		disableMentions?: 'all' | 'everyone';
 		partials?: PartialTypes[];
 		restWsBridgeTimeout?: number;
 		restTimeOffset?: number;
@@ -2465,7 +2465,7 @@ declare module 'discord.js' {
 		nonce?: string;
 		content?: string;
 		embed?: MessageEmbed | MessageEmbedOptions;
-		disableMentions?: boolean;
+		disableMentions?: 'all' | 'everyone';
 		files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
 		code?: string | boolean;
 		split?: boolean | SplitOptions;
@@ -2694,7 +2694,7 @@ declare module 'discord.js' {
 		tts?: boolean;
 		nonce?: string;
 		embeds?: (MessageEmbed | object)[];
-		disableMentions?: boolean;
+		disableMentions?: 'all' | 'everyone';
 		files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
 		code?: string | boolean;
 		split?: boolean | SplitOptions;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2069,7 +2069,7 @@ declare module 'discord.js' {
 		messageCacheLifetime?: number;
 		messageSweepInterval?: number;
 		fetchAllMembers?: boolean;
-		disableMentions?: 'all' | 'everyone';
+		disableMentions?: 'none' | 'all' | 'everyone';
 		partials?: PartialTypes[];
 		restWsBridgeTimeout?: number;
 		restTimeOffset?: number;
@@ -2465,7 +2465,7 @@ declare module 'discord.js' {
 		nonce?: string;
 		content?: string;
 		embed?: MessageEmbed | MessageEmbedOptions;
-		disableMentions?: 'all' | 'everyone';
+		disableMentions?: 'none' | 'all' | 'everyone';
 		files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
 		code?: string | boolean;
 		split?: boolean | SplitOptions;
@@ -2694,7 +2694,7 @@ declare module 'discord.js' {
 		tts?: boolean;
 		nonce?: string;
 		embeds?: (MessageEmbed | object)[];
-		disableMentions?: 'all' | 'everyone';
+		disableMentions?: 'none' | 'all' | 'everyone';
 		files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
 		code?: string | boolean;
 		split?: boolean | SplitOptions;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In PR  [3830](https://github.com/discordjs/discord.js/pull/3830), disableEveryone was removed and replaced with disableMentions which sanitized all mentions and "broke" all mentions even if unintentional. Although, the client option was a good idea, giving more power to the user. Although it took away what most users may have been using which was them not wanting to mention everyone. This PR keeps the ClientOptions#disableMentions but splits it's functionality into two expected values; "all" or "everyone". "all" being the behavior of  #3830 and "everyone" being an improved version of disableEveryone which _should_ not be subject to special characters.

I have tested this extensively with test/disableMentions.js and all tests have passed. However, there were other issues such as injecting the special characters anywhere in the strings "everyone" or "here". This caused the fix to change a lot and I have written my own tests which can be found [here](https://github.com/PapiOphidian/discord-everyone-abuse)
All of tests found at the link have passed and function as intended.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
