### PR TITLE
feat(MessageEmbed): re-introduce MessageEmbed#addField

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -218,7 +218,7 @@ class MessageEmbed {
    * Adds a field to the embed (max 25).
    * @param {StringResolvable} name The name of this field
    * @param {StringResolvable} value The value of this field
-   * @param {boolean} [inline] If this field will be displayed inline
+   * @param {boolean} [inline=false] If this field will be displayed inline
    * @returns {MessageEmbed}
    */
   addField(name, value, inline) {
@@ -401,7 +401,7 @@ class MessageEmbed {
     * @typedef {Object} EmbedFieldData
     * @property {StringResolvable} name The name of this field
     * @property {StringResolvable} value The value of this field
-    * @property {boolean} [inline] If this field will be displayed inline
+    * @property {boolean} [inline=false] If this field will be displayed inline
     */
 
   /**

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -225,6 +225,17 @@ class MessageEmbed {
   }
 
   /**
+   * Adds a field to the embed (max 25).
+   * @param {StringResolvable} name The name of this field
+   * @param {StringResolvable} value The value of this field
+   * @param {boolean} [inline] If this field will be displayed inline
+   * @returns {MessageEmbed}
+   */
+  addField(name, value, inline) {
+    return this.addFields({ name, value, inline });
+  }
+
+  /**
    * Removes, replaces, and inserts fields in the embed (max 25).
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of fields to remove

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -215,16 +215,6 @@ class MessageEmbed {
   }
 
   /**
-   * Adds fields to the embed (max 25).
-   * @param {...EmbedFieldData|EmbedFieldData[]} fields The fields to add
-   * @returns {MessageEmbed}
-   */
-  addFields(...fields) {
-    this.fields.push(...this.constructor.normalizeFields(fields));
-    return this;
-  }
-
-  /**
    * Adds a field to the embed (max 25).
    * @param {StringResolvable} name The name of this field
    * @param {StringResolvable} value The value of this field
@@ -233,6 +223,16 @@ class MessageEmbed {
    */
   addField(name, value, inline) {
     return this.addFields({ name, value, inline });
+  }
+
+  /**
+   * Adds fields to the embed (max 25).
+   * @param {...EmbedFieldData|EmbedFieldData[]} fields The fields to add
+   * @returns {MessageEmbed}
+   */
+  addFields(...fields) {
+    this.fields.push(...this.constructor.normalizeFields(fields));
+    return this;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1053,8 +1053,8 @@ declare module 'discord.js' {
 		public type: string;
 		public url?: string;
 		public readonly video: MessageEmbedVideo | null;
-		public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
 		public addField(name: StringResolvable, value: StringResolvable, inline?: boolean): this;
+		public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
 		public attachFiles(file: (MessageAttachment | FileOptions | string)[]): this;
 		public setAuthor(name: StringResolvable, iconURL?: string, url?: string): this;
 		public setColor(color: ColorResolvable): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1054,6 +1054,7 @@ declare module 'discord.js' {
 		public url?: string;
 		public readonly video: MessageEmbedVideo | null;
 		public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
+		public addField(name: StringResolvable, value: StringResolvable, inline?: boolean): this;
 		public attachFiles(file: (MessageAttachment | FileOptions | string)[]): this;
 		public setAuthor(name: StringResolvable, iconURL?: string, url?: string): this;
 		public setColor(color: ColorResolvable): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Re-introduces MessageEmbed#addField as convenience wrapper to MessageEmbed#addFields to not have to provide a field data object.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
