### PR TITLE
refactor(GuildChannel): change overwritePermisions to accept an array of overwrites

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -188,24 +188,28 @@ class GuildChannel extends Channel {
 
   /**
    * Replaces the permission overwrites in this channel.
-   * @param {Object} [options] Options
-   * @param {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [options.permissionOverwrites]
+   * @param {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} overwrites
    * Permission overwrites the channel gets updated with
-   * @param {string} [options.reason] Reason for updating the channel overwrites
+   * @param {string} [reason] Reason for updating the channel overwrites
    * @returns {Promise<GuildChannel>}
    * @example
-   * channel.overwritePermissions({
-   * permissionOverwrites: [
+   * channel.overwritePermissions([
    *   {
    *      id: message.author.id,
    *      deny: ['VIEW_CHANNEL'],
    *   },
-   * ],
-   *   reason: 'Needed to change permissions'
-   * });
+   * ], 'Needed to change permissions');
    */
-  overwritePermissions(options = {}) {
-    return this.edit(options).then(() => this);
+  overwritePermissions(overwrites, reason) {
+    if (!Array.isArray(overwrites)) {
+      return Promise.reject(new TypeError(
+        'INVALID_TYPE',
+        'overwrites',
+        'Array or Collection of Permission Overwrites',
+        true,
+      ));
+    }
+    return this.edit({ permissionOverwrites: overwrites, reason }).then(() => this);
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -201,7 +201,7 @@ class GuildChannel extends Channel {
    * ], 'Needed to change permissions');
    */
   overwritePermissions(overwrites, reason) {
-    if (!Array.isArray(overwrites)) {
+    if (!Array.isArray(overwrites) && !(overwrites instanceof Collection)) {
       return Promise.reject(new TypeError(
         'INVALID_TYPE',
         'overwrites',

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -785,7 +785,7 @@ declare module 'discord.js' {
 		public equals(channel: GuildChannel): boolean;
 		public fetchInvites(): Promise<Collection<string, Invite>>;
 		public lockPermissions(): Promise<this>;
-		public overwritePermissions(options?: { permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string; }): Promise<this>;
+		public overwritePermissions(overwrites: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>, reason?: string): Promise<this>;
 		public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
 		public setName(name: string, reason?: string): Promise<this>;
 		public setParent(channel: GuildChannel | Snowflake, options?: { lockPermissions?: boolean; reason?: string; }): Promise<this>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes GuildChannel.overwritePermissions to accept an array of Permission Overwrites instead of an object, which previously would accept ChannelData, and the function just acting as an alias for GuildChannel.edit

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
