### PR TITLE
fix(MessageEmbed): prevent possible destructuring error

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -411,7 +411,13 @@ class MessageEmbed {
    * @returns {EmbedField[]}
    */
   static normalizeFields(...fields) {
-    return fields.flat(2).map(({ name, value, inline }) => this.normalizeField(name, value, inline));
+    return fields.flat(2).map(field =>
+      this.normalizeField(
+        field && field.name,
+        field && field.value,
+        field && typeof field.inline === 'boolean' ? field.inline : false,
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If `undefined` or `null` was passed as an array element to MessageEmbed.normalizeFields, it would throw an error because of destructuring null/undefined. This change prevents it.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**  
- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
