### PR TITLE
docs: Bump version to 11.6.0

### DIFF
--- a/docs/general/updating.md
+++ b/docs/general/updating.md
@@ -1,3 +1,7 @@
+# Version 11.6.0
+v11.6.0 backports new features from the in-development v12, and fixes bugs in the v11.5.x releases.
+See [the changelog](https://github.com/discordjs/discord.js/releases/tag/11.6.0) for a full list of changes, including information about deprecations.
+
 # Version 11.5.0
 v11.5.0 backports new features from the in-development v12, and fixes bugs in the v11.4.x releases.
 See [the changelog](https://github.com/discordjs/discord.js/releases/tag/11.5.0) for a full list of changes, including information about deprecations.

--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -19,7 +19,7 @@
 
 # Welcome!
 Welcome to the discord.js v11.6 documentation.
-The v11.6 release contains bugfixes from v11.4 and backports features from the in-development v12.
+The v11.6 release contains bugfixes from v11.5 and backports features from the in-development v12.
 
 v12 is still very much a work-in-progress, as we're aiming to make it the best it can possibly be before releasing.
 If you are fond of living life on the bleeding-edge, check out the master branch.

--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -18,8 +18,8 @@
 </div>
 
 # Welcome!
-Welcome to the discord.js v11.5 documentation.
-The v11.5 release contains bugfixes from v11.4 and backports features from the in-development v12.
+Welcome to the discord.js v11.6 documentation.
+The v11.6 release contains bugfixes from v11.4 and backports features from the in-development v12.
 
 v12 is still very much a work-in-progress, as we're aiming to make it the best it can possibly be before releasing.
 If you are fond of living life on the bleeding-edge, check out the master branch.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Bump's the version in the docs to the new stable version, i.e is 11.6.0
**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
