### PR TITLE
fix(playinterface): lazy require VoiceBroadcast to avoid circular

### DIFF
--- a/src/client/voice/util/PlayInterface.js
+++ b/src/client/voice/util/PlayInterface.js
@@ -60,7 +60,8 @@ class PlayInterface {
    * @returns {StreamDispatcher}
    */
   play(resource, options = {}) {
-    if (resource instanceof Broadcast) {
+    const VoiceBroadcast = require('../VoiceBroadcast');
+    if (resource instanceof VoiceBroadcast) {
       if (!this.player.playBroadcast) throw new Error('VOICE_PLAY_INTERFACE_NO_BROADCAST');
       return this.player.playBroadcast(resource, options);
     }
@@ -91,6 +92,3 @@ class PlayInterface {
 }
 
 module.exports = PlayInterface;
-
-// eslint-disable-next-line import/order
-const Broadcast = require('../VoiceBroadcast');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #3859 by lazily requiring `VoiceBroadcast` from within `PlayInterface#play`.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
