### PR TITLE
docs(PartialRoleData): id is optional

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -46,7 +46,7 @@ class GuildManager extends BaseManager {
   /**
    * Partial data for a Role.
    * @typedef {Object} PartialRoleData
-   * @property {number} id The ID for this role, used to set channel overrides,
+   * @property {number} [id] The ID for this role, used to set channel overrides,
    * this is a placeholder and will be replaced by the API after consumption
    * @property {string} [name] The name of the role
    * @property {ColorResolvable} [color] The color of the role, either a hex string or a base 10 number


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR marks the `id` property of PartialRoleData as optional, since it is optional

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
