### PR TITLE
docs: clarify which checks GuildMember#manageable does

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -212,7 +212,8 @@ class GuildMember extends Base {
   }
 
   /**
-   * Whether this member is manageable in terms of role hierarchy by the client user
+   * Whether the client user is above this user in the hierarchy, according to role position and guild ownership.
+   * This is a prerequisite for many moderative actions.
    * @type {boolean}
    * @readonly
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

After a users confusion we discussed on the server about how we could be more semantic on what GuildMember#manageable does internally and what it is used for:

- Check for role hierarchy
- Guild ownership overrides (from either side)
- The client user can not manage itself
- basis for moderative actions

This PR is the conclusion of this conversation and proposes its outcome:

> Whether the client user is above this user in the hierarchy, according to role position and guild ownership.
> This is a prerequisite for many moderative actions.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
