### PR TITLE
Fix reconnection loop on 4013 and 4014 close codes

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -18,7 +18,7 @@ const Messages = {
   SHARDING_INVALID: 'Invalid shard settings were provided.',
   SHARDING_REQUIRED: 'This session would have handled too many guilds - Sharding is required.',
   INVALID_INTENTS: 'Invalid intent provided for WebSocket intents.',
-  DISALLOWED_INTENTS: 'You included a WebSocket intent that you do not have permissions to use.',
+  DISALLOWED_INTENTS: 'Privileged intent provided is not enabled or whitelisted.',
   SHARDING_NO_SHARDS: 'No shards have been spawned.',
   SHARDING_IN_PROCESS: 'Shards are still being spawned.',
   SHARDING_ALREADY_SPAWNED: count => `Already spawned ${count} shards.`,

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -17,8 +17,8 @@ const Messages = {
 
   SHARDING_INVALID: 'Invalid shard settings were provided.',
   SHARDING_REQUIRED: 'This session would have handled too many guilds - Sharding is required.',
-  INVALID_INTENTS: 'There is an invalid intent for websocket intents.',
-  DISALLOWED_INTENTS: 'You included an intent on your websocket intents which you do not have privilege on.',
+  INVALID_INTENTS: 'Invalid intent provided for WebSocket intents.',
+  DISALLOWED_INTENTS: 'You included a WebSocket intent that you do not have permissions to use.',
   SHARDING_NO_SHARDS: 'No shards have been spawned.',
   SHARDING_IN_PROCESS: 'Shards are still being spawned.',
   SHARDING_ALREADY_SPAWNED: count => `Already spawned ${count} shards.`,

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -17,6 +17,8 @@ const Messages = {
 
   SHARDING_INVALID: 'Invalid shard settings were provided.',
   SHARDING_REQUIRED: 'This session would have handled too many guilds - Sharding is required.',
+  INVALID_INTENTS: 'There is an invalid intent for websocket intents.',
+  DISALLOWED_INTENTS: 'You included an intent on your websocket intents which you do not have privilege on.',
   SHARDING_NO_SHARDS: 'No shards have been spawned.',
   SHARDING_IN_PROCESS: 'Shards are still being spawned.',
   SHARDING_ALREADY_SPAWNED: count => `Already spawned ${count} shards.`,

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -95,6 +95,7 @@ exports.WSCodes = {
   4004: 'TOKEN_INVALID',
   4010: 'SHARDING_INVALID',
   4011: 'SHARDING_REQUIRED',
+  4013: 'INVALID_INTENTS'
 };
 
 const AllowedImageFormats = ['webp', 'png', 'jpg', 'gif'];

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -95,7 +95,8 @@ exports.WSCodes = {
   4004: 'TOKEN_INVALID',
   4010: 'SHARDING_INVALID',
   4011: 'SHARDING_REQUIRED',
-  4013: 'INVALID_INTENTS'
+  4013: 'INVALID_INTENTS',
+  4014: 'DISALLOWED INTENTS',
 };
 
 const AllowedImageFormats = ['webp', 'png', 'jpg', 'gif'];

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -96,7 +96,7 @@ exports.WSCodes = {
   4010: 'SHARDING_INVALID',
   4011: 'SHARDING_REQUIRED',
   4013: 'INVALID_INTENTS',
-  4014: 'DISALLOWED INTENTS',
+  4014: 'DISALLOWED_INTENTS',
 };
 
 const AllowedImageFormats = ['webp', 'png', 'jpg', 'gif'];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As per: https://discordapp.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes
Discord added 4013 and 4014 which are invalid intent sent & no privileges on the privileged intent. This adds this codes on ws unrecoverable list, hence fixing the re-connection loop experienced for this code.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
