### PR TITLE
refactor: make LimitedCollection an implementation detail

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ module.exports = {
   Collection: require('./util/Collection'),
   Constants: require('./util/Constants'),
   DataResolver: require('./util/DataResolver'),
-  LimitedCollection: require('./util/LimitedCollection'),
   BaseManager: require('./managers/BaseManager'),
   DiscordAPIError: require('./rest/DiscordAPIError'),
   HTTPError: require('./rest/HTTPError'),

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -21,7 +21,7 @@ class MessageManager extends BaseManager {
 
   /**
    * The cache of Messages
-   * @type {LimitedCollection<Snowflake, Message>}
+   * @type {Collection<Snowflake, Message>}
    * @name MessageManager#cache
    */
 

--- a/src/util/LimitedCollection.js
+++ b/src/util/LimitedCollection.js
@@ -8,6 +8,7 @@ const Collection = require('./Collection.js');
  * @extends {Collection}
  * @param {number} [maxSize=0] The maximum size of the Collection
  * @param {Iterable} [iterable=null] Optional entries passed to the Map constructor.
+ * @private
  */
 class LimitedCollection extends Collection {
   constructor(maxSize = 0, iterable = null) {
@@ -23,6 +24,10 @@ class LimitedCollection extends Collection {
     if (this.maxSize === 0) return this;
     if (this.size >= this.maxSize && !this.has(key)) this.delete(this.firstKey());
     return super.set(key, value);
+  }
+
+  static get [Symbol.species]() {
+    return Collection;
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1914,11 +1914,6 @@ declare module 'discord.js' {
     public toJSON(): object;
   }
 
-  export class LimitedCollection<K, V> extends Collection<K, V> {
-    public constructor(maxSize: number, iterable: Iterable<any>);
-    public maxSize: number;
-  }
-
   //#endregion
 
   //#region Managers
@@ -2016,7 +2011,7 @@ declare module 'discord.js' {
   export class MessageManager extends BaseManager<Snowflake, Message, MessageResolvable> {
     constructor(channel: TextChannel | DMChannel, iterable?: Iterable<any>);
     public channel: TextBasedChannelFields;
-    public cache: LimitedCollection<Snowflake, Message>;
+    public cache: Collection<Snowflake, Message>;
     public fetch(message: Snowflake, cache?: boolean): Promise<Message>;
     public fetch(options?: ChannelLogsQueryOptions, cache?: boolean): Promise<Collection<Snowflake, Message>>;
     public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR documents `LimitedCollection` as a private implementation detail of `MessageManger` and adds `get[@@species]` to it.

This is in order to fix cloning of the then `Collection`.

So `message.channel.messages.cache.clone()` returns a collection actually including the cached messages unlike currently always returning an empty `LimitedCollection`.
The same applies to all other methods creating a new instance of this class. (filter, map, etc.)

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
