### PR TITLE
docs(sharding): ShardingManager#createShard doesn't spawn the shard

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -15,7 +15,7 @@ let Worker = null;
  */
 class Shard extends EventEmitter {
   /**
-   * @param {ShardingManager} manager Manager that is spawning this shard
+   * @param {ShardingManager} manager Manager that is creating this shard
    * @param {number} id ID of this shard
    */
   constructor(manager, id) {

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -155,6 +155,8 @@ class ShardingManager extends EventEmitter {
      * Emitted upon creating a shard.
      * @event ShardingManager#shardCreate
      * @param {Shard} shard Shard that was created
+     * @example
+     * manager.createShard(3).spawn();
      */
     this.emit('shardCreate', shard);
     return shard;

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -143,10 +143,11 @@ class ShardingManager extends EventEmitter {
   }
 
   /**
-   * Spawns a single shard.
-   * @param {number} [id=this.shards.size] ID of the shard to spawn -
+   * Creates a single shard.
+   * <warn>Using this method is usually not necessary if you use the spawn method.</warn>
+   * @param {number} [id=this.shards.size] ID of the shard to create -
    * **This is usually not necessary to manually specify.**
-   * @returns {Shard}
+   * @returns {Shard} Note that the created shard needs to be explicitly spawned using its spawn method.
    */
   createShard(id = this.shards.size) {
     const shard = new Shard(this, id);
@@ -155,8 +156,6 @@ class ShardingManager extends EventEmitter {
      * Emitted upon creating a shard.
      * @event ShardingManager#shardCreate
      * @param {Shard} shard Shard that was created
-     * @example
-     * manager.createShard(3).spawn();
      */
     this.emit('shardCreate', shard);
     return shard;

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -145,8 +145,8 @@ class ShardingManager extends EventEmitter {
   /**
    * Creates a single shard.
    * <warn>Using this method is usually not necessary if you use the spawn method.</warn>
-   * @param {number} [id=this.shards.size] ID of the shard to create -
-   * **This is usually not necessary to manually specify.**
+   * @param {number} [id=this.shards.size] ID of the shard to create
+   * <info>This is usually not necessary to manually specify.</info>
    * @returns {Shard} Note that the created shard needs to be explicitly spawned using its spawn method.
    */
   createShard(id = this.shards.size) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR clarifies that `ShardingManager#createShard` does not actually _spawn_ the created shard and that this has to be done manually.

Resolves #3874 

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
