### PR TITLE
fix(message_mentions): lazy require GuildMember to avoid circular

### DIFF
--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const GuildMember = require('./GuildMember');
 const Collection = require('../util/Collection');
 const { ChannelTypes } = require('../util/Constants');
 const Util = require('../util/Util');
@@ -174,6 +173,7 @@ class MessageMentions {
    */
   has(data, { ignoreDirect = false, ignoreRoles = false, ignoreEveryone = false } = {}) {
     if (!ignoreEveryone && this.everyone) return true;
+    const GuildMember = require('./GuildMember');
     if (!ignoreRoles && data instanceof GuildMember) {
       for (const role of this.roles.values()) if (data.roles.cache.has(role.id)) return true;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes an error being thrown when using `MessageMentions#has` by lazily requiring `GuildMember`.

```js
TypeError: Right-hand side of 'instanceof' is not callable
    at MessageMentions.has (<snip>\discord.js\src\structures\MessageMentions.js:177:30)
```

The error was caused by a circular require, see:
Client
-> GuildManager
-> Guild
-> GuildMemberManager
-> **`GuildMember`**
-> TextBasedChannel
-> MessageManager
-> Message
-> MessageMentions
-> **`GuildMember`**

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
