### PR TITLE
fix: adapt #manageable to check for CONNECT for VoiceChannel

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -566,7 +566,13 @@ class GuildChannel extends Channel {
    */
   get manageable() {
     if (this.client.user.id === this.guild.ownerID) return true;
-    if (!this.viewable) return false;
+    if (this.type === 'voice') {
+      if (!this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false)) {
+        return false;
+      }
+    } else if (!this.viewable) {
+      return false;
+    }
     return this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Discord implicitly denies any interaction on channels if the actor does not have their respective gatekeeper permission. For VoiceChannel this is actually `CONNECT` (exclusively, checked that) while for Category- and TextChannel `VIEW_CHANNEL`.

This PR aims to fix the behavior of GuildChannel#manageable based on its more specific type to properly reflect the state in terms of manageability.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
