### PR TITLE
docs(faq): ffmpeg-binaries -> ffmpeg-static

### DIFF
--- a/docs/general/faq.md
+++ b/docs/general/faq.md
@@ -14,10 +14,10 @@ Update to Node.js 12.0.0 or newer.
 
 ## How do I install FFMPEG?
 
-- **npm:** `npm install ffmpeg-binaries`
+- **npm:** `npm install ffmpeg-static`
 - **Ubuntu 16.04:** `sudo apt install ffmpeg`
 - **Ubuntu 14.04:** `sudo apt-get install libav-tools`
-- **Windows:** `npm install ffmpeg-binaries` or see the [FFMPEG section of AoDude's guide](https://github.com/bdistin/OhGodMusicBot/blob/master/README.md#download-ffmpeg).
+- **Windows:** `npm install ffmpeg-static` or see the [FFMPEG section of AoDude's guide](https://github.com/bdistin/OhGodMusicBot/blob/master/README.md#download-ffmpeg).
 
 ## How do I set up @discordjs/opus?
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`ffmpeg-binaries` has been deprecated, its deprecation message as well as [topics/voice](https://discord.js.org/#/docs/main/master/topics/voice) and [prism-media](https://npm.im/prism-media) say to use ffmpeg-static, but looks like the FAQ wasn't updated.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
