### PR TITLE
fix(MessageEmbed): Skip validation of field when inside a message

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -98,7 +98,7 @@ class Message extends Base {
      * A list of embeds in the message - e.g. YouTube Player
      * @type {MessageEmbed[]}
      */
-    this.embeds = (data.embeds || []).map(e => new Embed(e));
+    this.embeds = (data.embeds || []).map(e => new Embed(e, true));
 
     /**
      * A collection of attachments in the message - e.g. Pictures - mapped by their ID
@@ -225,7 +225,7 @@ class Message extends Base {
     if ('content' in data) this.content = data.content;
     if ('pinned' in data) this.pinned = data.pinned;
     if ('tts' in data) this.tts = data.tts;
-    if ('embeds' in data) this.embeds = data.embeds.map(e => new Embed(e));
+    if ('embeds' in data) this.embeds = data.embeds.map(e => new Embed(e, true));
     else this.embeds = this.embeds.slice();
 
     if ('attachments' in data) {

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -257,7 +257,7 @@ class MessageEmbed {
    */
   addFields(...fields) {
     const preparedFields = this.skipValiation
-      ? fields.map(Util.cloneObject)
+      ? fields.flat(2).map(Util.cloneObject)
       : this.constructor.normalizeFields(...fields);
     this.fields.push(...preparedFields);
     return this;
@@ -272,7 +272,7 @@ class MessageEmbed {
    */
   spliceFields(index, deleteCount, ...fields) {
     const preparedFields = this.skipValiation
-      ? fields.map(Util.cloneObject)
+      ? fields.flat(2).map(Util.cloneObject)
       : this.constructor.normalizeFields(...fields);
     this.fields.splice(index, deleteCount, ...preparedFields);
     return this;

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -73,7 +73,7 @@ class MessageEmbed {
      * The fields of this embed
      * @type {EmbedField[]}
      */
-    this.fields = data.fields ? this.normalizeFields(data.fields) : [];
+    this.fields = data.fields ? this.constructor._normalizeFields(this.skipValidation, data.fields) : [];
 
     /**
      * @typedef {Object} MessageEmbedThumbnail
@@ -260,7 +260,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   addFields(...fields) {
-    this.fields.push(...this.normalizeFields(fields));
+    this.fields.push(...this.constructor._normalizeFields(this.skipValidation, fields));
     return this;
   }
 
@@ -272,7 +272,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   spliceFields(index, deleteCount, ...fields) {
-    this.fields.splice(index, deleteCount, ...this.normalizeFields(...fields));
+    this.fields.splice(index, deleteCount, ...this.constructor._normalizeFields(this.skipValidation, ...fields));
     return this;
   }
 
@@ -420,13 +420,14 @@ class MessageEmbed {
    * @param {StringResolvable} name The name of the field
    * @param {StringResolvable} value The value of the field
    * @param {boolean} [inline=false] Set the field to display inline
+   * @param {boolean} [skipValidation=false] Skips the validation of the name and value
    * @returns {EmbedField}
    */
-  normalizeField(name, value, inline = false) {
+  static normalizeField(name, value, inline = false, skipValidation = false) {
     name = Util.resolveString(name);
-    if (!this.skipValidation && !name) throw new RangeError('EMBED_FIELD_NAME');
+    if (!skipValidation && !name) throw new RangeError('EMBED_FIELD_NAME');
     value = Util.resolveString(value);
-    if (!this.skipValidation && !value) throw new RangeError('EMBED_FIELD_VALUE');
+    if (!skipValidation && !value) throw new RangeError('EMBED_FIELD_VALUE');
     return { name, value, inline };
   }
 
@@ -439,10 +440,11 @@ class MessageEmbed {
 
   /**
    * Normalizes field input and resolves strings.
+   * @param {boolean} skipValidation Skips the validation of the name and value in fields
    * @param  {...EmbedFieldData|EmbedFieldData[]} fields Fields to normalize
    * @returns {EmbedField[]}
    */
-  normalizeFields(...fields) {
+  static _normalizeFields(skipValidation, ...fields) {
     return fields
       .flat(2)
       .map(field =>
@@ -450,8 +452,18 @@ class MessageEmbed {
           field && field.name,
           field && field.value,
           field && typeof field.inline === 'boolean' ? field.inline : false,
+          skipValidation,
         ),
       );
+  }
+
+  /**
+   * Normalizes field input and resolves strings.
+   * @param  {...EmbedFieldData|EmbedFieldData[]} fields Fields to normalize
+   * @returns {EmbedField[]}
+   */
+  static normalizeFields(...fields) {
+    return this._normalizeFields(false, ...fields);
   }
 }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -196,13 +196,6 @@ class MessageEmbed {
      * @type {Array<FileOptions|string|MessageAttachment>}
      */
     this.files = data.files || [];
-
-    /**
-     * If this embed should skip validation of fields
-     * @type {boolean}
-     * @private
-     */
-    this.skipValiation = skipValidation;
   }
 
   /**
@@ -256,10 +249,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   addFields(...fields) {
-    const preparedFields = this.skipValiation
-      ? fields.flat(2).map(Util.cloneObject)
-      : this.constructor.normalizeFields(...fields);
-    this.fields.push(...preparedFields);
+    this.fields.push(...this.constructor.normalizeFields(fields));
     return this;
   }
 
@@ -271,10 +261,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   spliceFields(index, deleteCount, ...fields) {
-    const preparedFields = this.skipValiation
-      ? fields.flat(2).map(Util.cloneObject)
-      : this.constructor.normalizeFields(...fields);
-    this.fields.splice(index, deleteCount, ...preparedFields);
+    this.fields.splice(index, deleteCount, ...this.constructor.normalizeFields(...fields));
     return this;
   }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -65,7 +65,7 @@ class MessageEmbed {
      * The fields of this embed
      * @type {EmbedField[]}
      */
-    this.fields = data.fields ? this.constructor._normalizeFields(this.skipValidation, data.fields) : [];
+    this.fields = data.fields ? this.constructor._normalizeFields(skipValidation, data.fields) : [];
 
     /**
      * @typedef {Object} MessageEmbedThumbnail
@@ -193,12 +193,6 @@ class MessageEmbed {
      * @type {Array<FileOptions|string|MessageAttachment>}
      */
     this.files = data.files || [];
-
-    /**
-     * If this embed should skip validation of its data
-     * @type {boolean}
-     */
-    this.skipValidation = skipValidation;
   }
 
   /**

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -8,8 +8,8 @@ const Util = require('../util/Util');
  */
 class MessageEmbed {
   /**
-   * @param {Object} data The data to build the embed from
-   * @param {boolean} skipValidation A flag to skip field validations
+   * @param {Object} [data={}] The data to build the embed from
+   * @param {boolean} [skipValidation=false] A flag to skip field validations
    */
   constructor(data = {}, skipValidation = false) {
     this.setup(data, skipValidation);

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -7,11 +7,19 @@ const Util = require('../util/Util');
  * Represents an embed in a message (image/video preview, rich embed, etc.)
  */
 class MessageEmbed {
-  constructor(data = {}) {
-    this.setup(data);
+  /**
+   * @param {Object} data The data to build the embed from
+   * @param {boolean} skipValidation A flag to skip field validations
+   */
+  constructor(data = {}, skipValidation = false) {
+    this.setup(data, skipValidation);
   }
 
-  setup(data) {
+  /**
+   * @param {Object} data The data to build the embed from
+   * @param {boolean} skipValidation A flag to skip field validations
+   */
+  setup(data, skipValidation) {
     /**
      * The type of this embed, either:
      * * `rich` - a rich embed
@@ -65,7 +73,7 @@ class MessageEmbed {
      * The fields of this embed
      * @type {EmbedField[]}
      */
-    this.fields = data.fields ? this.constructor.normalizeFields(data.fields) : [];
+    this.fields = data.fields ? this.normalizeFields(data.fields) : [];
 
     /**
      * @typedef {Object} MessageEmbedThumbnail
@@ -193,6 +201,12 @@ class MessageEmbed {
      * @type {Array<FileOptions|string|MessageAttachment>}
      */
     this.files = data.files || [];
+
+    /**
+     * If this embed should skip validation of its data
+     * @type {boolean}
+     */
+    this.skipValidation = skipValidation;
   }
 
   /**
@@ -246,7 +260,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   addFields(...fields) {
-    this.fields.push(...this.constructor.normalizeFields(fields));
+    this.fields.push(...this.normalizeFields(fields));
     return this;
   }
 
@@ -258,7 +272,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   spliceFields(index, deleteCount, ...fields) {
-    this.fields.splice(index, deleteCount, ...this.constructor.normalizeFields(...fields));
+    this.fields.splice(index, deleteCount, ...this.normalizeFields(...fields));
     return this;
   }
 
@@ -408,11 +422,11 @@ class MessageEmbed {
    * @param {boolean} [inline=false] Set the field to display inline
    * @returns {EmbedField}
    */
-  static normalizeField(name, value, inline = false) {
+  normalizeField(name, value, inline = false) {
     name = Util.resolveString(name);
-    if (!name) throw new RangeError('EMBED_FIELD_NAME');
+    if (!this.skipValidation && !name) throw new RangeError('EMBED_FIELD_NAME');
     value = Util.resolveString(value);
-    if (!value) throw new RangeError('EMBED_FIELD_VALUE');
+    if (!this.skipValidation && !value) throw new RangeError('EMBED_FIELD_VALUE');
     return { name, value, inline };
   }
 
@@ -428,7 +442,7 @@ class MessageEmbed {
    * @param  {...EmbedFieldData|EmbedFieldData[]} fields Fields to normalize
    * @returns {EmbedField[]}
    */
-  static normalizeFields(...fields) {
+  normalizeFields(...fields) {
     return fields
       .flat(2)
       .map(field =>

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -7,18 +7,10 @@ const Util = require('../util/Util');
  * Represents an embed in a message (image/video preview, rich embed, etc.)
  */
 class MessageEmbed {
-  /**
-   * @param {Object} [data={}] The data to build the embed from
-   * @param {boolean} [skipValidation=false] A flag to skip field validations
-   */
   constructor(data = {}, skipValidation = false) {
     this.setup(data, skipValidation);
   }
 
-  /**
-   * @param {Object} data The data to build the embed from
-   * @param {boolean} skipValidation A flag to skip field validations
-   */
   setup(data, skipValidation) {
     /**
      * The type of this embed, either:

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1157,12 +1157,7 @@ declare module 'discord.js' {
         name: StringResolvable,
         value: StringResolvable,
         inline?: boolean,
-        skipValidation?: boolean
     ): Required<EmbedFieldData>;
-    public static _normalizeFields(
-        skipValidation: boolean,
-        ...fields: EmbedFieldData[] | EmbedFieldData[][]
-    ): Required<EmbedFieldData>[];
     public static normalizeFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): Required<EmbedFieldData>[];
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1152,13 +1152,8 @@ declare module 'discord.js' {
     public setURL(url: string): this;
     public spliceFields(index: number, deleteCount: number, ...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
     public toJSON(): object;
-
-    public static normalizeField(
-      name: StringResolvable,
-      value: StringResolvable,
-      inline?: boolean,
-    ): Required<EmbedFieldData>;
-    public static normalizeFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): Required<EmbedFieldData>[];
+    public normalizeField(name: StringResolvable, value: StringResolvable, inline?: boolean): Required<EmbedFieldData>;
+    public normalizeFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): Required<EmbedFieldData>[];
   }
 
   export class MessageFlags extends BitField<MessageFlagsString> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1120,7 +1120,7 @@ declare module 'discord.js' {
   }
 
   export class MessageEmbed {
-    constructor(data?: MessageEmbed | MessageEmbedOptions, skipValidation?: boolean);
+    constructor(data?: MessageEmbed | MessageEmbedOptions);
     public author: MessageEmbedAuthor | null;
     public color?: number;
     public readonly createdAt: Date | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1152,8 +1152,18 @@ declare module 'discord.js' {
     public setURL(url: string): this;
     public spliceFields(index: number, deleteCount: number, ...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
     public toJSON(): object;
-    public normalizeField(name: StringResolvable, value: StringResolvable, inline?: boolean): Required<EmbedFieldData>;
-    public normalizeFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): Required<EmbedFieldData>[];
+
+    public static normalizeField(
+        name: StringResolvable,
+        value: StringResolvable,
+        inline?: boolean,
+        skipValidation?: boolean
+    ): Required<EmbedFieldData>;
+    public static _normalizeFields(
+        skipValidation: boolean,
+        ...fields: EmbedFieldData[] | EmbedFieldData[][]
+    ): Required<EmbedFieldData>[];
+    public static normalizeFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): Required<EmbedFieldData>[];
   }
 
   export class MessageFlags extends BitField<MessageFlagsString> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1154,9 +1154,9 @@ declare module 'discord.js' {
     public toJSON(): object;
 
     public static normalizeField(
-        name: StringResolvable,
-        value: StringResolvable,
-        inline?: boolean,
+      name: StringResolvable,
+      value: StringResolvable,
+      inline?: boolean,
     ): Required<EmbedFieldData>;
     public static normalizeFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): Required<EmbedFieldData>[];
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1120,7 +1120,7 @@ declare module 'discord.js' {
   }
 
   export class MessageEmbed {
-    constructor(data?: MessageEmbed | MessageEmbedOptions);
+    constructor(data?: MessageEmbed | MessageEmbedOptions, skipValidation?: boolean);
     public author: MessageEmbedAuthor | null;
     public color?: number;
     public readonly createdAt: Date | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This should fix #3892 by skipping validation on embeds when they are part of a parent message.

The library works fine with this change, but per discussion in #library-discussion, we can't actually reproduce the buggy embed to test this. One should be able to assume this will work though (assuming I've added the flag in the right places) as it is disabling the validation that was throwing the error.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
