### PR TITLE
fix try catch block in Client.js

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -37,7 +37,7 @@ class Client extends BaseClient {
     try {
       // Test if worker threads module is present and used
       data = require('worker_threads').workerData || data;
-    } catch {
+    } catch (e) {
       // Do nothing
     }
 


### PR DESCRIPTION
catch requires the error object to be caught- this is causing errors in the wild.