### PR TITLE
docs(BitField): document constructors of deriving classes

### DIFF
--- a/src/util/ActivityFlags.js
+++ b/src/util/ActivityFlags.js
@@ -9,6 +9,13 @@ const BitField = require('./BitField');
 class ActivityFlags extends BitField {}
 
 /**
+ * @name ActivityFlags
+ * @kind constructor
+ * @memberof ActivityFlags
+ * @param {BitFieldResolvable} [bits=0] Bit(s) to read from
+ */
+
+/**
  * Numeric activity flags. All available properties:
  * * `INSTANCE`
  * * `JOIN`

--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -7,7 +7,7 @@ const { RangeError } = require('../errors');
  */
 class BitField {
   /**
-   * @param {BitFieldResolvable} [bits=0] Bits(s) to read from
+   * @param {BitFieldResolvable} [bits=0] Bit(s) to read from
    */
   constructor(bits) {
     /**
@@ -48,7 +48,7 @@ class BitField {
 
   /**
    * Gets all given bits that are missing from the bitfield.
-   * @param {BitFieldResolvable} bits Bits(s) to check for
+   * @param {BitFieldResolvable} bits Bit(s) to check for
    * @param {...*} hasParams Additional parameters for the has method, if any
    * @returns {string[]}
    */

--- a/src/util/Intents.js
+++ b/src/util/Intents.js
@@ -8,6 +8,13 @@ const BitField = require('./BitField');
 class Intents extends BitField {}
 
 /**
+ * @name Intents
+ * @kind constructor
+ * @memberof Intents
+ * @param {IntentsResolvable} [bits=0] Bit(s) to read from
+ */
+
+/**
  * Data that can be resolved to give a permission number. This can be:
  * * A string (see {@link Intents.FLAGS})
  * * An intents flag

--- a/src/util/MessageFlags.js
+++ b/src/util/MessageFlags.js
@@ -9,6 +9,13 @@ const BitField = require('./BitField');
 class MessageFlags extends BitField {}
 
 /**
+ * @name MessageFlags
+ * @kind constructor
+ * @memberof MessageFlags
+ * @param {BitFieldResolvable} [bits=0] Bit(s) to read from
+ */
+
+/**
  * Numeric message flags. All available properties:
  * * `CROSSPOSTED`
  * * `IS_CROSSPOST`

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -10,6 +10,13 @@ const BitField = require('./BitField');
  */
 class Permissions extends BitField {
   /**
+   * @name Permissions
+   * @kind constructor
+   * @memberof Permissions
+   * @param {PermissionResolvable} [bits=0] Bit(s) to read from
+   */
+
+  /**
    * Data that can be resolved to give a permission number. This can be:
    * * A string (see {@link Permissions.FLAGS})
    * * A permission number

--- a/src/util/Speaking.js
+++ b/src/util/Speaking.js
@@ -10,6 +10,13 @@ const BitField = require('./BitField');
 class Speaking extends BitField {}
 
 /**
+ * @name Speaking
+ * @kind constructor
+ * @memberof Speaking
+ * @param {BitFieldResolvable} [bits=0] Bit(s) to read from
+ */
+
+/**
  * Numeric speaking flags. All available properties:
  * * `SPEAKING`
  * * `SOUNDSHARE`

--- a/src/util/SystemChannelFlags.js
+++ b/src/util/SystemChannelFlags.js
@@ -11,6 +11,13 @@ const BitField = require('./BitField');
 class SystemChannelFlags extends BitField {}
 
 /**
+ * @name SystemChannelFlags
+ * @kind constructor
+ * @memberof SystemChannelFlags
+ * @param {SystemChannelFlagsResolvable} [bits=0] Bit(s) to read from
+ */
+
+/**
  * Data that can be resolved to give a sytem channel flag bitfield. This can be:
  * * A string (see {@link SystemChannelFlags.FLAGS})
  * * A sytem channel flag


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR documents the constructors of all classes deriving `BitField`:
- ActivityFlags 
- Intents 
- MessageFlags 
- Permissions
- Speaking 
- SystemChannelFlags 

Before:
![image](https://user-images.githubusercontent.com/24881032/76082554-f6a0c880-5fab-11ea-95a6-5580034de028.png)

After:
![image](https://user-images.githubusercontent.com/24881032/76082925-b3932500-5fac-11ea-9861-ae7a3132ed0f.png)

(Also fixed a typo: `Bits(s)` -> `Bit(s)`)
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
