### PR TITLE
fix(Guild): resolve role id and call existing handler

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1169,7 +1169,7 @@ class Guild extends Base {
   setRolePositions(rolePositions) {
     // Make sure rolePositions are prepared for API
     rolePositions = rolePositions.map(o => ({
-      id: o.role,
+      id: this.roles.resolveID(o.role),
       position: o.position,
     }));
 
@@ -1181,7 +1181,7 @@ class Guild extends Base {
       })
       .then(
         () =>
-          this.client.actions.GuildRolePositionUpdate.handle({
+          this.client.actions.GuildRolesPositionUpdate.handle({
             guild_id: this.id,
             roles: rolePositions,
           }).guild,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes two bugs in `Guild#setRolePositions`:
- Roles weren't resolved to ids
- A non existing handler was called resulting in an error:
  `TypeError: Cannot read property 'handle' of undefined`

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
