### PR TITLE
fix(ReactionCollector): only modify users and total on collect

### DIFF
--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -41,6 +41,11 @@ class ReactionCollector extends Collector {
 
     if (this.client.getMaxListeners() !== 0) this.client.setMaxListeners(this.client.getMaxListeners() + 1);
     this.client.on('messageReactionAdd', this.listener);
+
+    this.on('fullCollect', (reaction, user) => {
+      this.users.set(user.id, user);
+      this.total++;
+    });
   }
 
   /**
@@ -64,9 +69,8 @@ class ReactionCollector extends Collector {
    * @returns {?string} Reason to end the collector, if any
    * @private
    */
-  postCheck(reaction, user) {
-    this.users.set(user.id, user);
-    if (this.options.max && ++this.total >= this.options.max) return 'limit';
+  postCheck() {
+    if (this.options.max && this.total >= this.options.max) return 'limit';
     if (this.options.maxEmojis && this.collected.size >= this.options.maxEmojis) return 'emojiLimit';
     if (this.options.maxUsers && this.users.size >= this.options.maxUsers) return 'userLimit';
     return null;

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -99,6 +99,14 @@ class Collector extends EventEmitter {
        */
       this.emit('collect', collect.value, this);
 
+      /**
+       * Emitted whenever an element is collected.
+       * @event Collector#fullCollect
+       * @param {...*} args The arguments emitted by the listener
+       * @private
+       */
+      this.emit('fullCollect', ...args, this);
+
       if (this._idletimeout) {
         this.client.clearTimeout(this._idletimeout);
         this._idletimeout = this.client.setTimeout(() => this.stop('idle'), this.options.idle);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes that `ReactionCollector`s increment the `total` property and add the relevant user to `users` on _every_ reaction received.

Maybe there is a better solution than adding a new event to `Collector`, but I could not find a way to get the relevant user otherwise.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
