### PR TITLE
fix(MessageEmbed): Throw RangeError if name or value is undefined or null

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -409,10 +409,10 @@ class MessageEmbed {
    * @returns {EmbedField}
    */
   static normalizeField(name, value, inline = false) {
-    name = Util.resolveString(name);	
+    name = Util.resolveString(name);
     if (!name || name === 'undefined' || name === 'null') throw new RangeError('EMBED_FIELD_NAME');
-    value = Util.resolveString(value);	
-    if (!value || value === 'undefined' ||name === 'null') throw new RangeError('EMBED_FIELD_VALUE');
+    value = Util.resolveString(value);
+    if (!value || value === 'undefined' || name === 'null') throw new RangeError('EMBED_FIELD_VALUE');
     return { name, value, inline };
   }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -409,10 +409,10 @@ class MessageEmbed {
    * @returns {EmbedField}
    */
   static normalizeField(name, value, inline = false) {
-    name = Util.resolveString(name);
     if (!name) throw new RangeError('EMBED_FIELD_NAME');
-    value = Util.resolveString(value);
     if (!value) throw new RangeError('EMBED_FIELD_VALUE');
+    name = Util.resolveString(name);
+    value = Util.resolveString(value);
     return { name, value, inline };
   }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -409,10 +409,10 @@ class MessageEmbed {
    * @returns {EmbedField}
    */
   static normalizeField(name, value, inline = false) {
-    if (!name) throw new RangeError('EMBED_FIELD_NAME');
-    if (!value) throw new RangeError('EMBED_FIELD_VALUE');
-    name = Util.resolveString(name);
-    value = Util.resolveString(value);
+    name = Util.resolveString(name);	
+    if (!name || name === 'undefined' || name === 'null') throw new RangeError('EMBED_FIELD_NAME');
+    value = Util.resolveString(value);	
+    if (!value || value === 'undefined' ||name === 'null') throw new RangeError('EMBED_FIELD_VALUE');
     return { name, value, inline };
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changed MessageEmbed to throw RangeErrors for undefined values and names before resolving the string
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
   - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
 - [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
