### PR TITLE
perf(VoiceConnection): skip redundant volume transformer on join

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -468,7 +468,7 @@ class VoiceConnection extends EventEmitter {
       ready();
     } else {
       // This serves to provide support for voice receive, sending audio is required to receive it.
-      const dispatcher = this.play(new SingleSilence(), { type: 'opus' });
+      const dispatcher = this.play(new SingleSilence(), { type: 'opus', volume: false });
       dispatcher.once('finish', ready);
     }
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR skips redundant decoding, volume transforming (by the factor 1), and encoding of the single silence frame being sent on join to enable audio receive.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
