### PR TITLE
feat(Types): support type-guarding using Channel#type string literal

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -577,6 +577,15 @@ class GuildChannel extends Channel {
   }
 
   /**
+   * Whether this GuildChannel is a partial
+   * @type {boolean}
+   * @readonly
+   */
+  get partial() {
+    return false;
+  }
+
+  /**
    * Whether the channel is viewable by the client user
    * @type {boolean}
    * @readonly

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -132,7 +132,7 @@ declare module 'discord.js' {
   }
 
   export class CategoryChannel extends GuildChannel {
-    public readonly children: Collection<Snowflake, GuildChannelTypes>;
+    public readonly children: Collection<Snowflake, Exclude<GuildChannelTypes, CategoryChannel>>;
     public type: 'category';
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1471,6 +1471,7 @@ declare module 'discord.js' {
   export class StoreChannel extends GuildChannel {
     constructor(guild: Guild, data?: object);
     public nsfw: boolean;
+    public type: 'store';
   }
 
   class StreamDispatcher extends VolumeMixin(Writable) {
@@ -2276,6 +2277,9 @@ declare module 'discord.js' {
     channel: ChannelResolvable;
     position: number;
   }
+
+  type ChannelTypes = DMChannel | CategoryChannel | NewsChannel | StoreChannel | TextChannel | VoiceChannel;
+  type GuildChannelTypes = CategoryChannel | NewsChannel | StoreChannel | TextChannel | VoiceChannel;
 
   type ChannelResolvable = Channel | Snowflake;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1250,7 +1250,7 @@ declare module 'discord.js' {
   }
 
   export class PermissionOverwrites {
-    constructor(guildChannel: GuildChannel, data?: object);
+    constructor(guildChannel: GuildChannelTypes, data?: object);
     public allow: Readonly<Permissions>;
     public readonly channel: GuildChannelTypes;
     public deny: Readonly<Permissions>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2280,6 +2280,7 @@ declare module 'discord.js' {
 
   type ChannelTypes = DMChannel | CategoryChannel | NewsChannel | StoreChannel | TextChannel | VoiceChannel;
   type GuildChannelTypes = CategoryChannel | NewsChannel | StoreChannel | TextChannel | VoiceChannel;
+  type TextBasedChannelTypes = DMChannel | NewsChannel | TextChannel;
 
   type ChannelResolvable = Channel | Snowflake;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -132,7 +132,7 @@ declare module 'discord.js' {
   }
 
   export class CategoryChannel extends GuildChannel {
-    public readonly children: Collection<Snowflake, GuildChannel>;
+    public readonly children: Collection<Snowflake, GuildChannelTypes>;
     public type: 'category';
   }
 
@@ -143,8 +143,8 @@ declare module 'discord.js' {
     public deleted: boolean;
     public id: Snowflake;
     public type: keyof typeof ChannelType;
-    public delete(reason?: string): Promise<Channel>;
-    public fetch(): Promise<Channel>;
+    public delete(reason?: string): Promise<ChannelTypes>;
+    public fetch(): Promise<ChannelTypes>;
     public toString(): string;
   }
 
@@ -176,11 +176,17 @@ declare module 'discord.js' {
     public sweepMessages(lifetime?: number): number;
     public toJSON(): object;
 
-    public on(event: 'channelCreate' | 'channelDelete', listener: (channel: Channel | PartialChannel) => void): this;
-    public on(event: 'channelPinsUpdate', listener: (channel: Channel | PartialChannel, time: Date) => void): this;
+    public on(
+      event: 'channelCreate' | 'channelDelete',
+      listener: (channel: ChannelTypes | PartialChannel) => void,
+    ): this;
+    public on(
+      event: 'channelPinsUpdate',
+      listener: (channel: TextBasedChannelTypes | PartialChannel, time: Date) => void,
+    ): this;
     public on(
       event: 'channelUpdate',
-      listener: (oldChannel: Channel | PartialChannel, newChannel: Channel | PartialChannel) => void,
+      listener: (oldChannel: ChannelTypes | PartialChannel, newChannel: ChannelTypes | PartialChannel) => void,
     ): this;
     public on(event: 'debug' | 'warn', listener: (info: string) => void): this;
     public on(event: 'disconnect', listener: (event: any, shardID: number) => void): this;
@@ -240,7 +246,7 @@ declare module 'discord.js' {
     public on(event: 'roleUpdate', listener: (oldRole: Role, newRole: Role) => void): this;
     public on(
       event: 'typingStart' | 'typingStop',
-      listener: (channel: Channel | PartialChannel, user: User | PartialUser) => void,
+      listener: (channel: TextBasedChannelTypes | PartialChannel, user: User | PartialUser) => void,
     ): this;
     public on(event: 'userUpdate', listener: (oldUser: User | PartialUser, newUser: User | PartialUser) => void): this;
     public on(event: 'voiceStateUpdate', listener: (oldState: VoiceState, newState: VoiceState) => void): this;
@@ -251,11 +257,17 @@ declare module 'discord.js' {
     public on(event: 'shardResume', listener: (id: number, replayed: number) => void): this;
     public on(event: string, listener: (...args: any[]) => void): this;
 
-    public once(event: 'channelCreate' | 'channelDelete', listener: (channel: Channel | PartialChannel) => void): this;
-    public once(event: 'channelPinsUpdate', listener: (channel: Channel | PartialChannel, time: Date) => void): this;
+    public once(
+      event: 'channelCreate' | 'channelDelete',
+      listener: (channel: ChannelTypes | PartialChannel) => void,
+    ): this;
+    public once(
+      event: 'channelPinsUpdate',
+      listener: (channel: TextBasedChannelTypes | PartialChannel, time: Date) => void,
+    ): this;
     public once(
       event: 'channelUpdate',
-      listener: (oldChannel: Channel | PartialChannel, newChannel: Channel | PartialChannel) => void,
+      listener: (oldChannel: ChannelTypes | PartialChannel, newChannel: ChannelTypes | PartialChannel) => void,
     ): this;
     public once(event: 'debug' | 'warn', listener: (info: string) => void): this;
     public once(event: 'disconnect', listener: (event: any, shardID: number) => void): this;
@@ -313,7 +325,7 @@ declare module 'discord.js' {
     public once(event: 'roleUpdate', listener: (oldRole: Role, newRole: Role) => void): this;
     public once(
       event: 'typingStart' | 'typingStop',
-      listener: (channel: Channel | PartialChannel, user: User | PartialUser) => void,
+      listener: (channel: TextBasedChannelTypes | PartialChannel, user: User | PartialUser) => void,
     ): this;
     public once(
       event: 'userUpdate',
@@ -710,7 +722,7 @@ declare module 'discord.js' {
   export class Guild extends Base {
     constructor(client: Client, data: object);
     private _sortedRoles(): Collection<Snowflake, Role>;
-    private _sortedChannels(channel: Channel): Collection<Snowflake, GuildChannel>;
+    private _sortedChannels(channel: Channel): Collection<Snowflake, GuildChannelTypes>;
     private _memberSpeakUpdate(user: Snowflake, speaking: boolean): void;
 
     public readonly afkChannel: VoiceChannel | null;
@@ -725,7 +737,7 @@ declare module 'discord.js' {
     public defaultMessageNotifications: DefaultMessageNotifications | number;
     public deleted: boolean;
     public description: string | null;
-    public embedChannel: GuildChannel | null;
+    public embedChannel: GuildChannelTypes | null;
     public embedChannelID: Snowflake | null;
     public embedEnabled: boolean;
     public emojis: GuildEmojiManager;
@@ -882,7 +894,7 @@ declare module 'discord.js' {
     public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
     public setName(name: string, reason?: string): Promise<this>;
     public setParent(
-      channel: GuildChannel | Snowflake,
+      channel: CategoryChannel | Snowflake,
       options?: { lockPermissions?: boolean; reason?: string },
     ): Promise<this>;
     public setPosition(position: number, options?: { relative?: boolean; reason?: string }): Promise<this>;
@@ -989,7 +1001,7 @@ declare module 'discord.js' {
 
   export class Invite extends Base {
     constructor(client: Client, data: object);
-    public channel: GuildChannel | PartialGroupDMChannel;
+    public channel: GuildChannelTypes | PartialGroupDMChannel;
     public code: string;
     public readonly deletable: boolean;
     public readonly createdAt: Date | null;
@@ -1106,11 +1118,11 @@ declare module 'discord.js' {
   }
 
   export class MessageCollector extends Collector<Snowflake, Message> {
-    constructor(channel: TextChannel | DMChannel, filter: CollectorFilter, options?: MessageCollectorOptions);
+    constructor(channel: TextBasedChannelTypes, filter: CollectorFilter, options?: MessageCollectorOptions);
     private _handleChannelDeletion(channel: GuildChannel): void;
     private _handleGuildDeletion(guild: Guild): void;
 
-    public channel: Channel;
+    public channel: TextBasedChannelTypes;
     public options: MessageCollectorOptions;
     public received: number;
 
@@ -1173,7 +1185,7 @@ declare module 'discord.js' {
       roles: Snowflake[] | Collection<Snowflake, Role>,
       everyone: boolean,
     );
-    private _channels: Collection<Snowflake, GuildChannel> | null;
+    private _channels: Collection<Snowflake, GuildChannelTypes> | null;
     private readonly _content: Message;
     private _members: Collection<Snowflake, GuildMember> | null;
 
@@ -1182,7 +1194,7 @@ declare module 'discord.js' {
     public everyone: boolean;
     public readonly guild: Guild;
     public has(
-      data: User | GuildMember | Role | GuildChannel,
+      data: User | GuildMember | Role | GuildChannelTypes,
       options?: {
         ignoreDirect?: boolean;
         ignoreRoles?: boolean;
@@ -1240,7 +1252,7 @@ declare module 'discord.js' {
   export class PermissionOverwrites {
     constructor(guildChannel: GuildChannel, data?: object);
     public allow: Readonly<Permissions>;
-    public readonly channel: GuildChannel;
+    public readonly channel: GuildChannelTypes;
     public deny: Readonly<Permissions>;
     public id: Snowflake;
     public type: OverwriteType;
@@ -1919,9 +1931,9 @@ declare module 'discord.js' {
 
   //#region Managers
 
-  export class ChannelManager extends BaseManager<Snowflake, Channel, ChannelResolvable> {
+  export class ChannelManager extends BaseManager<Snowflake, ChannelTypes, ChannelResolvable> {
     constructor(client: Client, iterable: Iterable<any>);
-    public fetch(id: Snowflake, cache?: boolean): Promise<Channel>;
+    public fetch(id: Snowflake, cache?: boolean): Promise<ChannelTypes>;
   }
 
   export abstract class BaseManager<K, Holds, R> {
@@ -1936,7 +1948,7 @@ declare module 'discord.js' {
     public resolveID(resolvable: R): K | null;
   }
 
-  export class GuildChannelManager extends BaseManager<Snowflake, GuildChannel, GuildChannelResolvable> {
+  export class GuildChannelManager extends BaseManager<Snowflake, GuildChannelTypes, GuildChannelResolvable> {
     constructor(guild: Guild, iterable?: Iterable<any>);
     public guild: Guild;
     public create(name: string, options: GuildCreateChannelOptions & { type: 'voice' }): Promise<VoiceChannel>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -133,6 +133,7 @@ declare module 'discord.js' {
 
   export class CategoryChannel extends GuildChannel {
     public readonly children: Collection<Snowflake, Exclude<GuildChannelTypes, CategoryChannel>>;
+    public readonly partial: false;
     public type: 'category';
   }
 
@@ -142,6 +143,7 @@ declare module 'discord.js' {
     public readonly createdTimestamp: number;
     public deleted: boolean;
     public id: Snowflake;
+    public readonly partial: false;
     public type: keyof typeof ChannelType;
     public delete(reason?: string): Promise<ChannelTypes>;
     public fetch(): Promise<ChannelTypes>;
@@ -870,6 +872,7 @@ declare module 'discord.js' {
     public name: string;
     public readonly parent: CategoryChannel | null;
     public parentID: Snowflake | null;
+    public readonly partial: false;
     public permissionOverwrites: Collection<Snowflake, PermissionOverwrites>;
     public readonly permissionsLocked: boolean | null;
     public readonly position: number;
@@ -1119,7 +1122,7 @@ declare module 'discord.js' {
 
   export class MessageCollector extends Collector<Snowflake, Message> {
     constructor(channel: TextBasedChannelTypes, filter: CollectorFilter, options?: MessageCollectorOptions);
-    private _handleChannelDeletion(channel: GuildChannel): void;
+    private _handleChannelDeletion(channel: TextBasedChannelTypes): void;
     private _handleGuildDeletion(guild: Guild): void;
 
     public channel: TextBasedChannelTypes;
@@ -1293,7 +1296,7 @@ declare module 'discord.js' {
 
   export class ReactionCollector extends Collector<Snowflake, MessageReaction> {
     constructor(message: Message, filter: CollectorFilter, options?: ReactionCollectorOptions);
-    private _handleChannelDeletion(channel: GuildChannel): void;
+    private _handleChannelDeletion(channel: TextBasedChannelTypes): void;
     private _handleGuildDeletion(guild: Guild): void;
     private _handleMessageDeletion(message: Message): void;
 
@@ -1483,6 +1486,7 @@ declare module 'discord.js' {
   export class StoreChannel extends GuildChannel {
     constructor(guild: Guild, data?: object);
     public nsfw: boolean;
+    public readonly partial: false;
     public type: 'store';
   }
 
@@ -1678,6 +1682,7 @@ declare module 'discord.js' {
     public readonly editable: boolean;
     public readonly full: boolean;
     public readonly joinable: boolean;
+    public readonly partial: false;
     public readonly speakable: boolean;
     public type: 'voice';
     public userLimit: number;
@@ -2882,7 +2887,7 @@ declare module 'discord.js' {
     [K in keyof Omit<T, 'id' | 'partial'>]: T[K] | null;
   };
 
-  interface PartialChannel extends Partialize<Channel> {}
+  interface PartialChannel extends Partialize<ChannelTypes> {}
 
   interface PartialChannelData {
     id?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -133,7 +133,6 @@ declare module 'discord.js' {
 
   export class CategoryChannel extends GuildChannel {
     public readonly children: Collection<Snowflake, Exclude<GuildChannelTypes, CategoryChannel>>;
-    public readonly partial: false;
     public type: 'category';
   }
 
@@ -143,7 +142,6 @@ declare module 'discord.js' {
     public readonly createdTimestamp: number;
     public deleted: boolean;
     public id: Snowflake;
-    public readonly partial: false;
     public type: keyof typeof ChannelType;
     public delete(reason?: string): Promise<ChannelTypes>;
     public fetch(): Promise<ChannelTypes>;
@@ -871,8 +869,8 @@ declare module 'discord.js' {
     public readonly members: Collection<Snowflake, GuildMember>;
     public name: string;
     public readonly parent: CategoryChannel | null;
-    public parentID: Snowflake | null;
     public readonly partial: false;
+    public parentID: Snowflake | null;
     public permissionOverwrites: Collection<Snowflake, PermissionOverwrites>;
     public readonly permissionsLocked: boolean | null;
     public readonly position: number;
@@ -1486,7 +1484,6 @@ declare module 'discord.js' {
   export class StoreChannel extends GuildChannel {
     constructor(guild: Guild, data?: object);
     public nsfw: boolean;
-    public readonly partial: false;
     public type: 'store';
   }
 
@@ -1682,7 +1679,6 @@ declare module 'discord.js' {
     public readonly editable: boolean;
     public readonly full: boolean;
     public readonly joinable: boolean;
-    public readonly partial: false;
     public readonly speakable: boolean;
     public type: 'voice';
     public userLimit: number;


### PR DESCRIPTION
This PR adds three new union types to better define the return types of methods that return Channels, rather than having them all return the abstract classes `Channel` or `GuildChannel`.

By doing so, `channel.type` can be used as a type-guard in TS projects.

There are also a couple of other types improvements:
 - `StoreChannel#type` was missing, added
 - `GuildChannel#setParent` should accept `CategoryChannel`, not abstract `GuildChannel`

I haven't changed the type of function parameters being passed in as class extension is sufficient in these areas - open to discussion if this should also be done.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
