### PR TITLE
typings(Client): remove typingStop event

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -239,7 +239,7 @@ declare module 'discord.js' {
     public on(event: 'roleCreate' | 'roleDelete', listener: (role: Role) => void): this;
     public on(event: 'roleUpdate', listener: (oldRole: Role, newRole: Role) => void): this;
     public on(
-      event: 'typingStart' | 'typingStop',
+      event: 'typingStart',
       listener: (channel: Channel | PartialChannel, user: User | PartialUser) => void,
     ): this;
     public on(event: 'userUpdate', listener: (oldUser: User | PartialUser, newUser: User | PartialUser) => void): this;
@@ -312,7 +312,7 @@ declare module 'discord.js' {
     public once(event: 'roleCreate' | 'roleDelete', listener: (role: Role) => void): this;
     public once(event: 'roleUpdate', listener: (oldRole: Role, newRole: Role) => void): this;
     public once(
-      event: 'typingStart' | 'typingStop',
+      event: 'typingStart',
       listener: (channel: Channel | PartialChannel, user: User | PartialUser) => void,
     ): this;
     public once(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `Client#typingStop` event was removed in v12, and thus shouldn't be in the typings

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
