### PR TITLE
fix(GuildMemberRolesManager): type error should mention Role and Snowflake too

### DIFF
--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -90,7 +90,7 @@ class GuildMemberRoleManager {
     } else {
       roleOrRoles = this.guild.roles.resolve(roleOrRoles);
       if (roleOrRoles === null) {
-        throw new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true);
+        throw new TypeError('INVALID_TYPE', 'roles', 'Role or Snowflake or Array or Collection of Roles or Snowflakes', true);
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put({ reason });

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -90,7 +90,12 @@ class GuildMemberRoleManager {
     } else {
       roleOrRoles = this.guild.roles.resolve(roleOrRoles);
       if (roleOrRoles === null) {
-        throw new TypeError('INVALID_TYPE', 'roles', 'Role, Snowflake or Array or Collection of Roles or Snowflakes', true);
+        throw new TypeError(
+          'INVALID_TYPE',
+          'roles',
+          'Role, Snowflake or Array or Collection of Roles or Snowflakes',
+          true,
+        );
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put({ reason });

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -90,7 +90,7 @@ class GuildMemberRoleManager {
     } else {
       roleOrRoles = this.guild.roles.resolve(roleOrRoles);
       if (roleOrRoles === null) {
-        throw new TypeError('INVALID_TYPE', 'roles', 'Role or Snowflake or Array or Collection of Roles or Snowflakes', true);
+        throw new TypeError('INVALID_TYPE', 'roles', 'Role, Snowflake or Array or Collection of Roles or Snowflakes', true);
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put({ reason });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When passing an invalid object to `GuildMemberRolesManager#add` that is not an Array or Collection the error will mislead people into thinking the method *only* accepts Arrays or Collections of Roles, not single Roles as well.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
