### PR TITLE
fix(GuildEmojiManager): throw an error if image resolving fails

### DIFF
--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -50,29 +50,30 @@ class GuildEmojiManager extends BaseManager {
    *   .then(emoji => console.log(`Created new emoji with name ${emoji.name}!`))
    *   .catch(console.error);
    */
-  create(attachment, name, { roles, reason } = {}) {
-    if (typeof attachment === 'string' && attachment.startsWith('data:')) {
-      const data = { image: attachment, name };
-      if (roles) {
-        data.roles = [];
-        for (let role of roles instanceof Collection ? roles.values() : roles) {
-          role = this.guild.roles.resolve(role);
-          if (!role) {
-            return Promise.reject(
-              new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true),
-            );
-          }
-          data.roles.push(role.id);
-        }
-      }
+  async create(attachment, name, { roles, reason } = {}) {
+    if (typeof attachment !== 'string' || !attachment.startsWith('data:')) {
+      attachment = await DataResolver.resolveImage(attachment);
+    }
+    if (!attachment) throw new TypeError('REQ_RESOURCE_TYPE');
 
-      return this.client.api
-        .guilds(this.guild.id)
-        .emojis.post({ data, reason })
-        .then(emoji => this.client.actions.GuildEmojiCreate.handle(this.guild, emoji).emoji);
+    const data = { image: attachment, name };
+    if (roles) {
+      data.roles = [];
+      for (let role of roles instanceof Collection ? roles.values() : roles) {
+        role = this.guild.roles.resolve(role);
+        if (!role) {
+          return Promise.reject(
+            new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true),
+          );
+        }
+        data.roles.push(role.id);
+      }
     }
 
-    return DataResolver.resolveImage(attachment).then(image => this.create(image, name, { roles, reason }));
+    return this.client.api
+      .guilds(this.guild.id)
+      .emojis.post({ data, reason })
+      .then(emoji => this.client.actions.GuildEmojiCreate.handle(this.guild, emoji).emoji);
   }
 
   /**

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -51,9 +51,7 @@ class GuildEmojiManager extends BaseManager {
    *   .catch(console.error);
    */
   async create(attachment, name, { roles, reason } = {}) {
-    if (typeof attachment !== 'string' || !attachment.startsWith('data:')) {
-      attachment = await DataResolver.resolveImage(attachment);
-    }
+    attachment = await DataResolver.resolveImage(attachment);
     if (!attachment) throw new TypeError('REQ_RESOURCE_TYPE');
 
     const data = { image: attachment, name };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #3933. 

The method was recursing endlessly if anything falsy (such as omitting the parameter) was passed as attachment.

I moved the `DataResolver#resolveImage` call to the top of the method and made the method throw an error (`REQ_RESOURCE_TYPE`) if resolving failed.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
