### PR TITLE
typings(PartialTextBasedChannelFields): fix send overloads

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2085,16 +2085,16 @@ declare module 'discord.js' {
     lastPinTimestamp: number | null;
     readonly lastPinAt: Date;
     send(
-      options: 
+      options:
       MessageOptions & { split?: false } |
       MessageAdditions |
       APIMessage,
-    ): Promise<Message>
+    ): Promise<Message>;
     send(
       options:
       MessageOptions & { split: true | SplitOptions; content: StringResolvable } |
       APIMessage,
-    ): Promise<Message[]>
+    ): Promise<Message[]>;
     send(
       content: StringResolvable,
       options?: (MessageOptions & { split?: false }) | MessageAdditions,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2085,22 +2085,23 @@ declare module 'discord.js' {
     lastPinTimestamp: number | null;
     readonly lastPinAt: Date;
     send(
-      content?: StringResolvable,
-      options?: MessageOptions | MessageAdditions | (MessageOptions & { split?: false }),
+      options: 
+      MessageOptions & { split?: false } |
+      MessageAdditions |
+      APIMessage,
+    ): Promise<Message>
+    send(
+      options:
+      MessageOptions & { split: true | SplitOptions; content: StringResolvable } |
+      APIMessage,
+    ): Promise<Message[]>
+    send(
+      content: StringResolvable,
+      options?: (MessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     send(
-      content?: StringResolvable,
-      options?: (MessageOptions & { split: true | SplitOptions }),
-    ): Promise<Message[]>;
-    send(
-      options?:
-        | MessageOptions
-        | MessageAdditions
-        | APIMessage
-        | (MessageOptions & { split?: false }),
-    ): Promise<Message>;
-    send(
-      options?: (MessageOptions & { split: true | SplitOptions }) | MessageAdditions | APIMessage,
+      content: StringResolvable,
+      options?: MessageOptions & { split: true | SplitOptions },
     ): Promise<Message[]>;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2086,20 +2086,18 @@ declare module 'discord.js' {
     readonly lastPinAt: Date;
     send(
       content?: StringResolvable,
-      options?: MessageOptions | MessageAdditions | (MessageOptions & { split?: false }) | MessageAdditions,
+      options?: MessageOptions | MessageAdditions | (MessageOptions & { split?: false }),
     ): Promise<Message>;
     send(
       content?: StringResolvable,
-      options?: (MessageOptions & { split: true | SplitOptions }) | MessageAdditions,
+      options?: (MessageOptions & { split: true | SplitOptions }),
     ): Promise<Message[]>;
     send(
       options?:
         | MessageOptions
         | MessageAdditions
         | APIMessage
-        | (MessageOptions & { split?: false })
-        | MessageAdditions
-        | APIMessage,
+        | (MessageOptions & { split?: false }),
     ): Promise<Message>;
     send(
       options?: (MessageOptions & { split: true | SplitOptions }) | MessageAdditions | APIMessage,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the overloads for the `send` method on `PartialTextBasedChannelFields`, before it seemed not possible to have the resulting `Message` be an array of `Message`s, (seemingly because of the order the overloads where defined, changing that order seemed to have fixed the issue), and also makes the first parameter of the method required, as trying to send with no parameters will always result in an error, 

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
