### PR TITLE
fix(Util): cleanContent should remove mentions after formatting mentions

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -555,15 +555,6 @@ class Util {
    * @returns {string}
    */
   static cleanContent(str, message) {
-    if (message.client.options.disableMentions === 'everyone') {
-      str = str.replace(/@([^<>@ ]*)/gmsu, (match, target) => {
-        if (target.match(/^[&!]?\d+$/)) {
-          return `@${target}`;
-        } else {
-          return `@\u200b${target}`;
-        }
-      });
-    }
     str = str
       .replace(/<@!?[0-9]+>/g, input => {
         const id = input.replace(/<|!|>|@/g, '');
@@ -589,6 +580,15 @@ class Util {
         const role = message.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
         return role ? `@${role.name}` : input;
       });
+    if (message.client.options.disableMentions === 'everyone') {
+      str = str.replace(/@([^<>@ ]*)/gmsu, (match, target) => {
+        if (target.match(/^[&!]?\d+$/)) {
+          return `@${target}`;
+        } else {
+          return `@\u200b${target}`;
+        }
+      });
+    }
     if (message.client.options.disableMentions === 'all') {
       return Util.removeMentions(str);
     } else {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Util.cleanContent` currently removes possible everyone mentions then formats mentions, this could result in that being bypassed if a user had the username 'everyone' or a role had the name 'everyone'
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
