### PR TITLE
typings(PartialTextBasedChannelFields): fix send overload

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2100,6 +2100,7 @@ declare module 'discord.js' {
     readonly lastPinAt: Date;
     send(
       options:
+      MessageOptions |
       MessageOptions & { split?: false } |
       MessageAdditions |
       APIMessage,
@@ -2111,7 +2112,7 @@ declare module 'discord.js' {
     ): Promise<Message[]>;
     send(
       content: StringResolvable,
-      options?: (MessageOptions & { split?: false }) | MessageAdditions,
+      options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     send(
       content: StringResolvable,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR (partially-ish) reverts one part of my PR #3935, specifically the duplicate `MessageOptions`, as apperently TS throws an error if you try to cast the object as `MessageOptions`, since it isnt assignable to `MessageOptions & { split?: false }`

bit of an oopsies on my part, i didn't try casting the options object when testing the overloads

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
