### PR TITLE
typings(StreamDispatcher): remove end event

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1504,7 +1504,7 @@ declare module 'discord.js' {
     public pause(silence?: boolean): void;
     public resume(): void;
 
-    public on(event: 'close' | 'drain' | 'end' | 'finish' | 'start', listener: () => void): this;
+    public on(event: 'close' | 'drain' | 'finish' | 'start', listener: () => void): this;
     public on(event: 'debug', listener: (info: string) => void): this;
     public on(event: 'error', listener: (err: Error) => void): this;
     public on(event: 'pipe' | 'unpipe', listener: (src: Readable) => void): this;
@@ -1512,7 +1512,7 @@ declare module 'discord.js' {
     public on(event: 'volumeChange', listener: (oldVolume: number, newVolume: number) => void): this;
     public on(event: string, listener: (...args: any[]) => void): this;
 
-    public once(event: 'close' | 'drain' | 'end' | 'finish' | 'start', listener: () => void): this;
+    public once(event: 'close' | 'drain' | 'finish' | 'start', listener: () => void): this;
     public once(event: 'debug', listener: (info: string) => void): this;
     public once(event: 'error', listener: (err: Error) => void): this;
     public once(event: 'pipe' | 'unpipe', listener: (src: Readable) => void): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Reflecting change from [this commit](https://github.com/discordjs/discord.js/commit/653784b56445b015a1584de1b693e57fc9069050#diff-690d90be1a8e0c08183fa630152b9258), which removes said event in typings.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
