### PR TITLE
fix(RequestHandler): a global timeout implies limited

### DIFF
--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -48,7 +48,7 @@ class RequestHandler {
   }
 
   get limited() {
-    return (this.manager.globalTimeout || this.remaining <= 0) && Date.now() < this.reset;
+    return Boolean(this.manager.globalTimeout) || (this.remaining <= 0 && Date.now() < this.reset);
   }
 
   get _inactive() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR modifies the `RequestHandler#limited` getter in that way, that an existing `globalTimeout` alone limits a handler regardless of their `reset` time.

This is necessary because hitting a global ratelimit with one handler should _always_ limit _all_ handlers until further requests may be made.

This did not apply to handlers before due to invalid parentheses in said getter:
`(global or no_requests_left) and (now < reset)`

Which should have been:
`global or (no_requests_left and now < reset)`

This issue can be reproduced by doing the following steps:
- Manually set a global timeout `client.rest.globalTimeout = somePromise;`
- Optionally test any existing `RequestHandler`; It will have a `limited` of `false` (if not limited per route already)
- Make any request, if the `RequestHandler` is idle (or did not exist before) a request will be made.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
(Manually set a global timeout, didn't actually hit it)
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
