### PR TITLE
fix(Channel): ensure partial DMChannels get created

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -100,17 +100,12 @@ class Channel extends Base {
     const Structures = require('../util/Structures');
     let channel;
     if (!data.guild_id && !guild) {
-      switch (data.type) {
-        case ChannelTypes.DM: {
-          const DMChannel = Structures.get('DMChannel');
-          channel = new DMChannel(client, data);
-          break;
-        }
-        case ChannelTypes.GROUP: {
-          const PartialGroupDMChannel = require('./PartialGroupDMChannel');
-          channel = new PartialGroupDMChannel(client, data);
-          break;
-        }
+      if ((data.recipients && data.type !== ChannelTypes.GROUP) || data.type === ChannelTypes.DM) {
+        const DMChannel = Structures.get('DMChannel');
+        channel = new DMChannel(client, data);
+      } else if (data.type === ChannelTypes.GROUP) {
+        const PartialGroupDMChannel = require('./PartialGroupDMChannel');
+        channel = new PartialGroupDMChannel(client, data);
       }
     } else {
       guild = guild || client.guilds.cache.get(data.guild_id);


### PR DESCRIPTION
Partial DMChannels were never getting initiated after 161f90761aa357f17066f4171a5f43f76a552eb7. It expected a [`data.type` to compare](https://github.com/discordjs/discord.js/blob/master/src/structures/Channel.js#L103-L104), but that couldn't be determined within a partial dm's ["payload"](https://github.com/discordjs/discord.js/blob/master/src/client/actions/Action.js#L39-L43). This resulted in the DMChannel not getting initiated which made `PartialTypes.CHANNEL` useless as you would never receive events for uncached dms due to `Action#getChannel()` always returning [`null`](https://github.com/discordjs/discord.js/blob/master/src/managers/ChannelManager.js#L34).

This PR fixes this by not explicitly comparing the `data.type`, but instead checks for the `recipients` field which is only present within DMChannels and PartialGroupDMChannels.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
