### PR TITLE
fix(MessageReaction): fetching a removed partial custom emoji 

### DIFF
--- a/src/managers/ReactionManager.js
+++ b/src/managers/ReactionManager.js
@@ -64,32 +64,6 @@ class ReactionManager extends BaseManager {
       .reactions.delete()
       .then(() => this.message);
   }
-
-  _partial(emoji) {
-    const id = emoji.id || emoji.name;
-    const existing = this.cache.get(id);
-    return !existing || existing.partial;
-  }
-
-  async _fetchReaction(reactionEmoji, cache) {
-    const id = reactionEmoji.id || reactionEmoji.name;
-    const existing = this.cache.get(id);
-    if (!this._partial(reactionEmoji)) return existing;
-    const data = await this.client.api
-      .channels(this.message.channel.id)
-      .messages(this.message.id)
-      .get();
-    if (this.message.partial) this.message._patch(data);
-    if (!data.reactions || !data.reactions.some(r => (r.emoji.id || r.emoji.name) === id)) {
-      reactionEmoji.reaction._patch({ count: 0 });
-      this.message.reactions.cache.delete(id);
-      return existing;
-    }
-    for (const reaction of data.reactions) {
-      if (this._partial(reaction.emoji)) this.add(reaction, cache);
-    }
-    return existing;
-  }
 }
 
 module.exports = ReactionManager;

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -102,33 +102,15 @@ class MessageReaction {
    * @returns {Promise<MessageReaction>}
    */
   async fetch() {
-    const emojiID = this.emoji.id || this.emoji.name;
-    const reactionManager = this.message.reactions;
-    if (!this.partial) return this;
-    const data = await this.client.api
-      .channels(this.message.channel.id)
-      .messages(this.message.id)
-      .get();
-    if (this.message.partial) this.message._patch(data);
-    // The reactions field won't be present when the message doesn't have any reactions
-    if (!data.reactions || !data.reactions.some(r => (r.emoji.id || r.emoji.name) === emojiID)) {
-      this._patch({ count: 0 });
-      reactionManager.cache.delete(emojiID);
-      return this;
-    }
-    data.reactions
-      .filter(({ emoji: { id, name } }) => this._isPartial(id || name))
-      .forEach(reaction => reactionManager.add(reaction));
+    const message = await this.message.fetch();
+    const existing = message.reactions.cache.get(this.emoji.id || this.emoji.name);
+    // The reaction won't get set when it has been completely removed
+    this._patch(existing || { count: 0 });
     return this;
   }
 
   toJSON() {
     return Util.flatten(this, { emoji: 'emojiID', message: 'messageID' });
-  }
-
-  _isPartial(emojiID) {
-    const existing = this.message.reactions.cache.get(emojiID);
-    return !existing || existing.partial;
   }
 
   _add(user) {


### PR DESCRIPTION
Fixes #3946

After a "partial" MessageReaction (being a custom emoji) was completely removed, the `emoji` getter would [return an instance of GuildEmoji](https://github.com/discordjs/discord.js/blob/master/src/structures/MessageReaction.js#L83-L85) which was being [passed](https://github.com/discordjs/discord.js/blob/master/src/structures/MessageReaction.js#L105) into `ReactionManager#_fetchReaction()`. Since `GuildEmoji#reaction` will always return `undefined` it would end up throwing an error since `_patch()` was trying to be called on that
https://github.com/discordjs/discord.js/blob/7994b5612a8d791c02503648c954ca38072433b9/src/managers/ReactionManager.js#L84
And as for why this doesn't occur within the `messageReactionAdd` event (which was [asked](https://canary.discordapp.com/channels/222078108977594368/682166281826598932/689375862365093889) on `#library-discussion` channel is because that line will only execute when a reaction emoji has been completely removed and/or when all reactions which is [checked](https://github.com/discordjs/discord.js/blob/master/src/managers/ReactionManager.js#L83) beforehand.

To fix this issue: instead of manually fetching the message and handling the fetched message to update the reactions [`Message#fetch()`](https://github.com/discordjs/discord.js/blob/master/src/structures/Message.js#L532-L538) will be used to indirectly update the reaction, which is much simpler to how it was before so it can be done directly within `MessageReaction#fetch()` to avoid having trouble finding a reference externally to get access to the _patch method. It somewhat does the same by fetching the message and then updating `Message#reactions` ([`Message#fetch()`](https://github.com/discordjs/discord.js/blob/master/src/structures/Message.js#L537) → [`MessageManager#fetchId()`](https://github.com/discordjs/discord.js/blob/master/src/managers/MessageManager.js#L66) → [`MessageManager#add()`](https://github.com/discordjs/discord.js/blob/master/src/managers/MessageManager.js#L133) → [`Message#_patch()`](https://github.com/discordjs/discord.js/blob/master/src/managers/BaseManager.js#L46) → [`ReactionManager#add()`](https://github.com/discordjs/discord.js/blob/master/src/structures/Message.js#L133) → ... [`MessageReaction#_patch()`](https://github.com/discordjs/discord.js/blob/master/src/structures/MessageReaction.js#L54)). When an emoji / all reactions has been completely removed it wouldn't be present within `Message#reactions`, so `MessageReaction#count` should obviously be set to `0`
which is [handled](https://github.com/izexi/discord.js/blob/7546075b3b1b4196f736362384a420f36be642fd/src/structures/MessageReaction.js#L107-L108).

<details>
<summary>Here's a snippet of how I tested these changes</summary>

```ts
import { Client, DMChannel, ClientUser, Message } from 'discord.js';

interface MockEmoji {
  name: string;
  id: string | null;
}

const mockClient = new Client({ partials: ['MESSAGE', 'REACTION', 'CHANNEL'] });
const mockCustomEmoji: MockEmoji = { name: 'POGGERS', id: '4' };
const mockUnicodeEmoji: MockEmoji = { name: '😩', id: null };
const mockFetch = (reactions: { emoji: MockEmoji; count: number }[] = []) =>
  jest
    .spyOn(Message.prototype, 'fetch')
    .mockImplementation(async function(this: Message) {
      // @ts-ignore
      this._patch({
        reactions,
        id: this.id
      });
      return this;
    });

beforeAll(() => {
  // Add a mock ClientUser
  mockClient.user = new ClientUser(mockClient, { user: { id: '0' } });
  // Add a mock me
  mockClient.users.add({
    username: 'Havoc',
    id: '191615925336670208',
    discriminator: '7078',
    avatar: 'a_dde53f5afa943f4a2628d47045ef92c3'
  });
  // Add a mock channel
  mockClient.channels.add({
    id: '2',
    type: 1
  });
  // Add a partial message to the channel
  (mockClient.channels.cache.first() as DMChannel).messages.add({
    id: '3',
    channel_id: '2'
  });
});

describe('messageReactionAdd', () => {
  it('should fetch the custom reaction', done => {
    mockClient.once('messageReactionAdd', async reaction => {
      expect(reaction.partial).toBe(true);
      await reaction.fetch();
      expect(reaction.partial).toBe(false);
      expect(reaction.count).toBe(1);
      done();
    });
    mockFetch([{ emoji: mockCustomEmoji, count: 1 }]);
    // Mock a "partial" reaction being added to the message
    // @ts-ignore
    mockClient.actions.MessageReactionAdd.handle({
      user_id: '191615925336670208',
      emoji: mockCustomEmoji,
      message_id: '3',
      channel_id: '2'
    });
  });

  it('should fetch the unicode reaction', done => {
    mockClient.once('messageReactionAdd', async reaction => {
      expect(reaction.partial).toBe(true);
      await reaction.fetch();
      expect(reaction.partial).toBe(false);
      expect(reaction.count).toBe(1);
      done();
    });
    mockFetch([{ emoji: mockUnicodeEmoji, count: 1 }]);
    // Mock a "partial" reaction being added to the message
    // @ts-ignore
    mockClient.actions.MessageReactionAdd.handle({
      user_id: '191615925336670208',
      emoji: mockUnicodeEmoji,
      message_id: '3',
      channel_id: '2'
    });
  });
});

describe('messageReactionRemove', () => {
  it('should fetch the custom cleared reaction', done => {
    mockClient.once('messageReactionRemove', async reaction => {
      expect(reaction.partial).toBe(true);
      await reaction.fetch();
      expect(reaction.partial).toBe(false);
      expect(reaction.count).toBe(0);
      done();
    });
    mockFetch();
    // Mock a "partial" reaction being removed from the message
    // @ts-ignore
    mockClient.actions.MessageReactionRemove.handle({
      user_id: '191615925336670208',
      emoji: mockCustomEmoji,
      message_id: '3',
      channel_id: '2'
    });
  });

  it('should fetch the cleared reaction', done => {
    mockClient.once('messageReactionRemove', async reaction => {
      expect(reaction.partial).toBe(true);
      await reaction.fetch();
      expect(reaction.partial).toBe(false);
      expect(reaction.count).toBe(0);
      done();
    });
    mockFetch();
    // Mock a "partial" reaction being removed from the message
    // @ts-ignore
    mockClient.actions.MessageReactionRemove.handle({
      user_id: '191615925336670208',
      emoji: mockUnicodeEmoji,
      message_id: '3',
      channel_id: '2'
    });
  });
});

afterEach(() =>
  (mockClient.channels.cache.first() as DMChannel).messages.cache
    .first()
    ?.reactions.cache.clear()
);
```

</details>


**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
