### PR TITLE
docs(VoiceState): improve phrasing of setChannel method

### DIFF
--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -153,8 +153,8 @@ class VoiceState extends Base {
 
   /**
    * Moves the member to a different channel, or disconnects them from the one they're in.
-   * @param {ChannelResolvable|null} [channel] Channel to move the member to, or `null` if you want to disconnect them from
-   * voice. Requires the `MOVE_MEMBERS` permission.
+   * @param {ChannelResolvable|null} [channel] Channel to move the member to, or `null` if you want to disconnect them
+   * from voice. Requires the `MOVE_MEMBERS` permission.
    * @param {string} [reason] Reason for moving member to another channel or disconnecting
    * @returns {Promise<GuildMember>}
    */

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -152,10 +152,10 @@ class VoiceState extends Base {
   }
 
   /**
-   * Moves the member to a different channel, or kick them from the one they're in.
-   * @param {ChannelResolvable|null} [channel] Channel to move the member to, or `null` if you want to kick them from
-   * voice
-   * @param {string} [reason] Reason for moving member to another channel or kicking
+   * Moves the member to a different channel, or disconnects them from the one they're in.
+   * @param {ChannelResolvable|null} [channel] Channel to move the member to, or `null` if you want to disconnect them from
+   * voice. Requires the `MOVE_MEMBERS` permission.
+   * @param {string} [reason] Reason for moving member to another channel or disconnecting
    * @returns {Promise<GuildMember>}
    */
   setChannel(channel, reason) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Added permission needed to edit a member's voice state and adjusted docs to say **"Disconnect"** instead of **"Kicking"** the member.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
