### PR TITLE
feature: added safeSend to DMChannel

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -78,6 +78,40 @@ class DMChannel extends Channel {
   toString() {
     return this.recipient.toString();
   }
+  
+  /**
+   * Callback for handling a DM error
+   *
+   * @callback onError
+   * @param {Error} error - The error that gets caught
+   */
+
+  /**
+   * Send a message safely to a user, without worrying about using catch if the user disabled DMs.
+   * Generally used for confirmation messages and unimportant notes.
+   * @param {StringResolvable|APIMessage} [content=''] The content to send
+   * @param {MessageOptions|MessageAdditions} [options={}] The options to provide
+   * @param {onError} [onError] The callback to call if an error occures
+   * @returns {Promise<Message|Message[]|undefined>}
+   * @example
+   * // Send a basic message
+   * user.send('hello!');
+   * // Will not error if user has disabled DMs
+   * @example
+   * // Send a basic message and catch the error
+   * user.send('hello!', (err) => {
+   *  console.log(err); // Will print the error if there is any
+   * });
+   */
+  safeSend(content, options, onError) {
+    try {
+      return this.send(content, options);
+    } catch(err) {
+      if (typeof onError === 'function') {
+        onError(err);
+      }
+    }
+  }
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel
   /* eslint-disable no-empty-function */

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -78,7 +78,7 @@ class DMChannel extends Channel {
   toString() {
     return this.recipient.toString();
   }
-  
+
   /**
    * Callback for handling a DM error
    *
@@ -91,7 +91,7 @@ class DMChannel extends Channel {
    * Generally used for confirmation messages and unimportant notes.
    * @param {StringResolvable|APIMessage} [content=''] The content to send
    * @param {MessageOptions|MessageAdditions} [options={}] The options to provide
-   * @param {onError} [onError] The callback to call if an error occures
+   * @param {onError} [onError] The callback to call if an error occurs
    * @returns {Promise<Message|Message[]|undefined>}
    * @example
    * // Send a basic message
@@ -103,13 +103,14 @@ class DMChannel extends Channel {
    *  console.log(err); // Will print the error if there is any
    * });
    */
-  safeSend(content, options, onError) {
+  async safeSend(content, options, onError) {
     try {
-      return this.send(content, options);
-    } catch(err) {
+      return await this.send(content, options);
+    } catch (err) {
       if (typeof onError === 'function') {
         onError(err);
       }
+      return undefined;
     }
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -544,7 +544,20 @@ declare module 'discord.js' {
     public readonly partial: false;
     public type: 'dm';
     public fetch(): Promise<DMChannel>;
-    public safeSend(): Promise<Message | undefined>;
+    public safeSend(
+      options: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions | APIMessage,
+    ): Promise<Message>;
+    public safeSend(
+      options: (MessageOptions & { split: true | SplitOptions; content: StringResolvable }) | APIMessage,
+    ): Promise<Message[]>;
+    public safeSend(
+      content: StringResolvable,
+      options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions,
+    ): Promise<Message>;
+    public safeSend(
+      content: StringResolvable,
+      options?: MessageOptions & { split: true | SplitOptions },
+    ): Promise<Message[]>;
   }
 
   export class Emoji extends Base {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -544,6 +544,7 @@ declare module 'discord.js' {
     public readonly partial: false;
     public type: 'dm';
     public fetch(): Promise<DMChannel>;
+    public safeSend(): Promise<Message | undefined>;
   }
 
   export class Emoji extends Base {
@@ -2780,26 +2781,17 @@ declare module 'discord.js' {
     partial: true;
     fetch(): Promise<T>;
   } & {
-    [K in keyof Omit<T,
-      'client' |
-      'createdAt' |
-      'createdTimestamp' |
-      'id' |
-      'partial' |
-      'fetch' | O>
-      // tslint:disable-next-line:ban-types
-    ]: T[K] extends Function ? T[K] : T[K] | null;
+    [K in keyof Omit<
+      T,
+      'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | O
+    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-next-line:ban-types
   };
 
-  interface PartialDMChannel extends Partialize<DMChannel,
-    'lastMessage' |
-    'lastMessageID' |
-    'messages' |
-    'recipient' |
-    'type' |
-    'typing' |
-    'typingCount'
-  > {
+  interface PartialDMChannel
+    extends Partialize<
+      DMChannel,
+      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+    > {
     lastMessage: null;
     lastMessageID: undefined;
     messages: MessageManager;
@@ -2823,16 +2815,11 @@ declare module 'discord.js' {
     }[];
   }
 
-  interface PartialGuildMember extends Partialize<GuildMember,
-    'bannable' |
-    'displayColor' |
-    'displayHexColor' |
-    'displayName' |
-    'guild' |
-    'kickable' |
-    'permissions' |
-    'roles'
-  > {
+  interface PartialGuildMember
+    extends Partialize<
+      GuildMember,
+      'bannable' | 'displayColor' | 'displayHexColor' | 'displayName' | 'guild' | 'kickable' | 'permissions' | 'roles'
+    > {
     readonly bannable: boolean;
     readonly displayColor: number;
     readonly displayHexColor: string;
@@ -2845,16 +2832,11 @@ declare module 'discord.js' {
     readonly roles: GuildMember['roles'];
   }
 
-  interface PartialMessage extends Partialize<Message,
-    'attachments' |
-    'channel' |
-    'deletable' |
-    'editable' |
-    'mentions' |
-    'pinnable' |
-    'system' |
-    'url'
-  > {
+  interface PartialMessage
+    extends Partialize<
+      Message,
+      'attachments' | 'channel' | 'deletable' | 'editable' | 'mentions' | 'pinnable' | 'system' | 'url'
+    > {
     attachments: Message['attachments'];
     channel: Message['channel'];
     readonly deletable: boolean;


### PR DESCRIPTION
safeSend automatically catches the error if a user has disabled their DMs when trying to send them a DM.
This method is useful for sending confirmation messages or any unimportant private messages that don't have to be sent.

**Please describe the changes this PR makes and why it should be merged:**
This PR eases on developers that don't want to mess with catching every DM they send.
As specifies before, this method should only be used when sending confirmation messages or unimportant private messages that don't have to be sent, e.x. when closing a ticket channel, or when warning a user.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
