### PR TITLE
fix(Guild): default max presences value

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -300,7 +300,7 @@ class Guild extends Base {
      * @type {?number}
      * @name Guild#maximumPresences
      */
-    if (typeof data.max_presences !== 'undefined') this.maximumPresences = data.max_presences || 5000;
+    if (typeof data.max_presences !== 'undefined') this.maximumPresences = data.max_presences || 25000;
 
     /**
      * The vanity URL code of the guild, if any


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Update the default value of maximum presences from 5,000 to 25,000 per discordapp/discord-api-docs#1428

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
