### PR TITLE
fix: always emit guildUnavailable if a guild became unavailable

### DIFF
--- a/src/client/actions/GuildDelete.js
+++ b/src/client/actions/GuildDelete.js
@@ -18,7 +18,7 @@ class GuildDeleteAction extends Action {
         if (channel.type === 'text') channel.stopTyping(true);
       }
 
-      if (guild.available && data.unavailable) {
+      if (data.unavailable) {
         // Guild is unavailable
         guild.available = false;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently when an unavailable guild "becomes" unavailable it will be treated as a regular `guildDelete` instead.
- Removal from cache
- Emitting `guildDelete`
- etc.

This is because we only allow "available" guilds to become unavailable:
https://github.com/discordjs/discord.js/blob/df324e2c21171aa17bc4e43f4a36f78c2f0eaec1/src/client/actions/GuildDelete.js#L21
While this assumption seems sound, Discord seems to still emit such packets during outages (maybe for guilds that hit a presence limit too).

This PR will always treat guilds that became unavailable as such instead of treating them as "deleted" guilds.

This _might_ also fix unexpected guildCreate events during / after outages as those guilds are still kept cached (as intended).

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
  I do not happen to have an outage to test this at hand.
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
