### PR TITLE
 revert: channel unions (#3918 69d69f2) 

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -577,15 +577,6 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Whether this GuildChannel is a partial
-   * @type {boolean}
-   * @readonly
-   */
-  get partial() {
-    return false;
-  }
-
-  /**
    * Whether the channel is viewable by the client user
    * @type {boolean}
    * @readonly

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -132,7 +132,7 @@ declare module 'discord.js' {
   }
 
   export class CategoryChannel extends GuildChannel {
-    public readonly children: Collection<Snowflake, Exclude<GuildChannelTypes, CategoryChannel>>;
+    public readonly children: Collection<Snowflake, GuildChannel>;
     public type: 'category';
   }
 
@@ -143,8 +143,8 @@ declare module 'discord.js' {
     public deleted: boolean;
     public id: Snowflake;
     public type: keyof typeof ChannelType;
-    public delete(reason?: string): Promise<ChannelTypes>;
-    public fetch(): Promise<ChannelTypes>;
+    public delete(reason?: string): Promise<this>;
+    public fetch(): Promise<this>;
     public toString(): string;
   }
 
@@ -543,7 +543,7 @@ declare module 'discord.js' {
     public recipient: User;
     public readonly partial: false;
     public type: 'dm';
-    public fetch(): Promise<DMChannel>;
+    public fetch(): Promise<this>;
   }
 
   export class Emoji extends Base {
@@ -563,7 +563,7 @@ declare module 'discord.js' {
   export class Guild extends Base {
     constructor(client: Client, data: object);
     private _sortedRoles(): Collection<Snowflake, Role>;
-    private _sortedChannels(channel: Channel): Collection<Snowflake, GuildChannelTypes>;
+    private _sortedChannels(channel: Channel): Collection<Snowflake, GuildChannel>;
     private _memberSpeakUpdate(user: Snowflake, speaking: boolean): void;
 
     public readonly afkChannel: VoiceChannel | null;
@@ -578,7 +578,7 @@ declare module 'discord.js' {
     public defaultMessageNotifications: DefaultMessageNotifications | number;
     public deleted: boolean;
     public description: string | null;
-    public embedChannel: GuildChannelTypes | null;
+    public embedChannel: GuildChannel | null;
     public embedChannelID: Snowflake | null;
     public embedEnabled: boolean;
     public emojis: GuildEmojiManager;
@@ -710,7 +710,6 @@ declare module 'discord.js' {
     public readonly members: Collection<Snowflake, GuildMember>;
     public name: string;
     public readonly parent: CategoryChannel | null;
-    public readonly partial: false;
     public parentID: Snowflake | null;
     public permissionOverwrites: Collection<Snowflake, PermissionOverwrites>;
     public readonly permissionsLocked: boolean | null;
@@ -736,7 +735,7 @@ declare module 'discord.js' {
     public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
     public setName(name: string, reason?: string): Promise<this>;
     public setParent(
-      channel: CategoryChannel | Snowflake,
+      channel: GuildChannel | Snowflake,
       options?: { lockPermissions?: boolean; reason?: string },
     ): Promise<this>;
     public setPosition(position: number, options?: { relative?: boolean; reason?: string }): Promise<this>;
@@ -844,7 +843,7 @@ declare module 'discord.js' {
 
   export class Invite extends Base {
     constructor(client: Client, data: object);
-    public channel: GuildChannelTypes | PartialGroupDMChannel;
+    public channel: GuildChannel | PartialGroupDMChannel;
     public code: string;
     public readonly deletable: boolean;
     public readonly createdAt: Date | null;
@@ -961,11 +960,11 @@ declare module 'discord.js' {
   }
 
   export class MessageCollector extends Collector<Snowflake, Message> {
-    constructor(channel: TextBasedChannelTypes, filter: CollectorFilter, options?: MessageCollectorOptions);
-    private _handleChannelDeletion(channel: TextBasedChannelTypes): void;
+    constructor(channel: TextChannel | DMChannel, filter: CollectorFilter, options?: MessageCollectorOptions);
+    private _handleChannelDeletion(channel: GuildChannel): void;
     private _handleGuildDeletion(guild: Guild): void;
 
-    public channel: TextBasedChannelTypes;
+    public channel: Channel;
     public options: MessageCollectorOptions;
     public received: number;
 
@@ -1028,7 +1027,7 @@ declare module 'discord.js' {
       roles: Snowflake[] | Collection<Snowflake, Role>,
       everyone: boolean,
     );
-    private _channels: Collection<Snowflake, GuildChannelTypes> | null;
+    private _channels: Collection<Snowflake, GuildChannel> | null;
     private readonly _content: Message;
     private _members: Collection<Snowflake, GuildMember> | null;
 
@@ -1037,7 +1036,7 @@ declare module 'discord.js' {
     public everyone: boolean;
     public readonly guild: Guild;
     public has(
-      data: User | GuildMember | Role | GuildChannelTypes,
+      data: User | GuildMember | Role | GuildChannel,
       options?: {
         ignoreDirect?: boolean;
         ignoreRoles?: boolean;
@@ -1093,9 +1092,9 @@ declare module 'discord.js' {
   }
 
   export class PermissionOverwrites {
-    constructor(guildChannel: GuildChannelTypes, data?: object);
+    constructor(guildChannel: GuildChannel, data?: object);
     public allow: Readonly<Permissions>;
-    public readonly channel: GuildChannelTypes;
+    public readonly channel: GuildChannel;
     public deny: Readonly<Permissions>;
     public id: Snowflake;
     public type: OverwriteType;
@@ -1136,7 +1135,7 @@ declare module 'discord.js' {
 
   export class ReactionCollector extends Collector<Snowflake, MessageReaction> {
     constructor(message: Message, filter: CollectorFilter, options?: ReactionCollectorOptions);
-    private _handleChannelDeletion(channel: TextBasedChannelTypes): void;
+    private _handleChannelDeletion(channel: GuildChannel): void;
     private _handleGuildDeletion(guild: Guild): void;
     private _handleMessageDeletion(message: Message): void;
 
@@ -1775,9 +1774,9 @@ declare module 'discord.js' {
 
   //#region Managers
 
-  export class ChannelManager extends BaseManager<Snowflake, ChannelTypes, ChannelResolvable> {
+  export class ChannelManager extends BaseManager<Snowflake, Channel, ChannelResolvable> {
     constructor(client: Client, iterable: Iterable<any>);
-    public fetch(id: Snowflake, cache?: boolean): Promise<ChannelTypes>;
+    public fetch(id: Snowflake, cache?: boolean): Promise<Channel>;
   }
 
   export abstract class BaseManager<K, Holds, R> {
@@ -1792,7 +1791,7 @@ declare module 'discord.js' {
     public resolveID(resolvable: R): K | null;
   }
 
-  export class GuildChannelManager extends BaseManager<Snowflake, GuildChannelTypes, GuildChannelResolvable> {
+  export class GuildChannelManager extends BaseManager<Snowflake, GuildChannel, GuildChannelResolvable> {
     constructor(guild: Guild, iterable?: Iterable<any>);
     public guild: Guild;
     public create(name: string, options: GuildCreateChannelOptions & { type: 'voice' }): Promise<VoiceChannel>;
@@ -2124,10 +2123,6 @@ declare module 'discord.js' {
     channel: ChannelResolvable;
     position: number;
   }
-
-  type ChannelTypes = DMChannel | CategoryChannel | NewsChannel | StoreChannel | TextChannel | VoiceChannel;
-  type GuildChannelTypes = CategoryChannel | NewsChannel | StoreChannel | TextChannel | VoiceChannel;
-  type TextBasedChannelTypes = DMChannel | NewsChannel | TextChannel;
 
   type ChannelResolvable = Channel | Snowflake;
 
@@ -2784,19 +2779,14 @@ declare module 'discord.js' {
     [K in keyof Omit<
       T,
       'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch'
-    >]: // tslint:disable-next-line:ban-types
-    T[K] extends Function ? T[K] : T[K] | null;
+    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-next-line:ban-types
   };
 
-  interface PartialDMChannel extends Partialize<DMChannel,
-    'lastMessage' |
-    'lastMessageID' |
-    'messages' |
-    'recipient' |
-    'type' |
-    'typing' |
-    'typingCount'
-  > {
+  interface PartialDMChannel
+    extends Partialize<
+      DMChannel,
+      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+    > {
     lastMessage: null;
     lastMessageID: undefined;
     messages: MessageManager;
@@ -2820,16 +2810,11 @@ declare module 'discord.js' {
     }[];
   }
 
-  interface PartialGuildMember extends Partialize<GuildMember,
-    'bannable' |
-    'displayColor' |
-    'displayHexColor' |
-    'displayName' |
-    'guild' |
-    'kickable' |
-    'permissions' |
-    'roles'
-  > {
+  interface PartialGuildMember
+    extends Partialize<
+      GuildMember,
+      'bannable' | 'displayColor' | 'displayHexColor' | 'displayName' | 'guild' | 'kickable' | 'permissions' | 'roles'
+    > {
     readonly bannable: boolean;
     readonly displayColor: number;
     readonly displayHexColor: string;
@@ -2842,16 +2827,11 @@ declare module 'discord.js' {
     readonly roles: GuildMember['roles'];
   }
 
-  interface PartialMessage extends Partialize<Message,
-    'attachments' |
-    'channel' |
-    'deletable' |
-    'editable' |
-    'mentions' |
-    'pinnable' |
-    'system' |
-    'url'
-  > {
+  interface PartialMessage
+    extends Partialize<
+      Message,
+      'attachments' | 'channel' | 'deletable' | 'editable' | 'mentions' | 'pinnable' | 'system' | 'url'
+    > {
     attachments: Message['attachments'];
     channel: Message['channel'];
     readonly deletable: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2779,7 +2779,7 @@ declare module 'discord.js' {
     [K in keyof Omit<
       T,
       'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch'
-    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-next-line:ban-types
+    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-line:ban-types
   };
 
   interface PartialDMChannel

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -735,7 +735,7 @@ declare module 'discord.js' {
     public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
     public setName(name: string, reason?: string): Promise<this>;
     public setParent(
-      channel: GuildChannel | Snowflake,
+      channel: CategoryChannel | Snowflake,
       options?: { lockPermissions?: boolean; reason?: string },
     ): Promise<this>;
     public setPosition(position: number, options?: { relative?: boolean; reason?: string }): Promise<this>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR reverts #3918 / 69d69f25b964b6a2bb13bd086696abec17782ca3.
(Aside from StoreChannel#type and GuildChannel#setParent, as those are unrelated to this)

Taking the following example here:
```js
guild.channels.cache.get(someID).setName('foo').then(channel => {
  console.log(`New name: ${channel.name}`);
});
```
Results in an error like this:
```ts
This expression is not callable.
  Each member of the union type
(<TResult1 = CategoryChannel, TResult2 = never>(onfulfilled?:
(value: CategoryChannel) =>TResult1 | PromiseLike<TResult1>, onrejected?:
(reason: any) => TResult2 | PromiseLike<...>) => Promise<...>)
| (<TResult1 = NewsChannel, TResult2 = never>(onfulfilled?: (value: NewsChannel) =>
TResult1 | PromiseLike<...>, onre...
has signatures, but none of those signatures are compatible with each other.
```

However using `async` / `await`  seems to work fine:
```js
const channel = await guild.channels.cache.get(someID).setName('foo');
console.log(`New name: ${channel.name}`);
```

Considering that it works when using `async` / `await`, this feels like an issue with TS rather then our typings.

A d.js-free example of this error:
```ts
function a() {
	return Promise.resolve('a');
}

function b() {
	return Promise.resolve([1]);
}

function c() {
	if (Math.random() > 0.5) return a();
	return b();
}

c().then(thing => {
	console.log(`thing has a length of ${thing.length}`);
});
```

However there probably is nothing we can really do about this for now, except reverting.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
