### PR TITLE
fix(Typings): client message event should not emit PartialMessage

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2164,7 +2164,7 @@ declare module 'discord.js' {
     guildUpdate: [Guild, Guild];
     inviteCreate: [Invite];
     inviteDelete: [Invite];
-    message: [Message | PartialMessage];
+    message: [Message];
     messageDelete: [Message | PartialMessage];
     messageReactionRemoveAll: [Message | PartialMessage];
     messageReactionRemoveEmoji: [MessageReaction];
@@ -2784,19 +2784,14 @@ declare module 'discord.js' {
     [K in keyof Omit<
       T,
       'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch'
-    >]: // tslint:disable-next-line:ban-types
-    T[K] extends Function ? T[K] : T[K] | null;
+    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-next-line:ban-types
   };
 
-  interface PartialDMChannel extends Partialize<DMChannel,
-    'lastMessage' |
-    'lastMessageID' |
-    'messages' |
-    'recipient' |
-    'type' |
-    'typing' |
-    'typingCount'
-  > {
+  interface PartialDMChannel
+    extends Partialize<
+      DMChannel,
+      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+    > {
     lastMessage: null;
     lastMessageID: undefined;
     messages: MessageManager;
@@ -2820,16 +2815,11 @@ declare module 'discord.js' {
     }[];
   }
 
-  interface PartialGuildMember extends Partialize<GuildMember,
-    'bannable' |
-    'displayColor' |
-    'displayHexColor' |
-    'displayName' |
-    'guild' |
-    'kickable' |
-    'permissions' |
-    'roles'
-  > {
+  interface PartialGuildMember
+    extends Partialize<
+      GuildMember,
+      'bannable' | 'displayColor' | 'displayHexColor' | 'displayName' | 'guild' | 'kickable' | 'permissions' | 'roles'
+    > {
     readonly bannable: boolean;
     readonly displayColor: number;
     readonly displayHexColor: string;
@@ -2842,16 +2832,11 @@ declare module 'discord.js' {
     readonly roles: GuildMember['roles'];
   }
 
-  interface PartialMessage extends Partialize<Message,
-    'attachments' |
-    'channel' |
-    'deletable' |
-    'editable' |
-    'mentions' |
-    'pinnable' |
-    'system' |
-    'url'
-  > {
+  interface PartialMessage
+    extends Partialize<
+      Message,
+      'attachments' | 'channel' | 'deletable' | 'editable' | 'mentions' | 'pinnable' | 'system' | 'url'
+    > {
     attachments: Message['attachments'];
     channel: Message['channel'];
     readonly deletable: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2784,7 +2784,7 @@ declare module 'discord.js' {
     [K in keyof Omit<
       T,
       'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch'
-    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-next-line:ban-types
+    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-line:ban-types
   };
 
   interface PartialDMChannel


### PR DESCRIPTION
I can't think of a reason why the `Client#message` event would ever emit a PartialMessage.
If anyone else can, lets close this PR.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
