### PR TITLE
docs(MessageMentionTypes): move possible values to description

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -86,8 +86,8 @@ class Webhook {
    * @property {Object[]} [embeds] An array of embeds for the message
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {'none' | 'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not
-   * all mentions or everyone/here mentions should be sanitized to prevent unexpected mentions
+   * @property {DisableMentionType} [disableMentions=this.client.options.disableMentions] Whether or not all mentions or
+   * everyone/here mentions should be sanitized to prevent unexpected mentions
    * @property {FileOptions[]|string[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -78,7 +78,7 @@ class TextBasedChannel {
 
   /**
    * Types of mentions to enable in MessageMentionOptions. It can be one of the following strings:
-   * - `role`
+   * - `roles`
    * - `users`
    * - `everyone`
    * @typedef {string} MessageMentionTypes

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -77,8 +77,11 @@ class TextBasedChannel {
    */
 
   /**
-   * Types of mentions to enable in MessageMentionOptions
-   * @typedef {'role' | 'users' | 'everyone'} MessageMentionTypes
+   * Types of mentions to enable in MessageMentionOptions. It can be one of the following strings:
+   * - `role`
+   * - `users`
+   * - `everyone`
+   * @typedef {string} MessageMentionTypes
    */
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -77,7 +77,7 @@ class TextBasedChannel {
    */
 
   /**
-   * Types of mentions to enable in MessageMentionOptions. Here are the available strings:
+   * Types of mentions to enable in MessageMentionOptions.
    * - `roles`
    * - `users`
    * - `everyone`

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -77,7 +77,7 @@ class TextBasedChannel {
    */
 
   /**
-   * Types of mentions to enable in MessageMentionOptions. It can be one of the following strings:
+   * Types of mentions to enable in MessageMentionOptions. Here are the available strings:
    * - `roles`
    * - `users`
    * - `everyone`

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -59,8 +59,8 @@ class TextBasedChannel {
    * @property {MessageEmbed|Object} [embed] An embed for the message
    * (see [here](https://discordapp.com/developers/docs/resources/channel#embed-object) for more details)
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
-   * @property {'none' | 'all' | 'everyone'} [disableMentions=this.client.options.disableMentions] Whether or not
-   * all mentions or everyone/here mentions should be sanitized to prevent unexpected mentions
+   * @property {DisableMentionType} [disableMentions=this.client.options.disableMentions] Whether or not all mentions or
+   * everyone/here mentions should be sanitized to prevent unexpected mentions
    * @property {FileOptions[]|BufferResolvable[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
@@ -82,6 +82,14 @@ class TextBasedChannel {
    * - `users`
    * - `everyone`
    * @typedef {string} MessageMentionTypes
+   */
+
+  /**
+   * The type of mentions to disable.
+   * - `none`
+   * - `all`
+   * - `everyone`
+   * @typedef {string} DisableMentionType
    */
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -21,8 +21,7 @@ const browser = (exports.browser = typeof window !== 'undefined');
  * the message cache lifetime (in seconds, 0 for never)
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
- * @property {'none' | 'all' | 'everyone'} [disableMentions='none'] Default value
- * for {@link MessageOptions#disableMentions}
+ * @property {DisableMentionType} [disableMentions='none'] Default value for {@link MessageOptions#disableMentions}
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
  * they're missing all the data for a particular structure. See the "Partials" topic listed in the sidebar for some
  * important usage information, as partials require you to put checks in place when handling data.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR corrects the JSDoc of `MessageMentionTypes` by moving the possible string values to the description and having `string` as the type. It also corrects the word `role` to `roles`, as specified in the [Discord API docs](https://discordapp.com/developers/docs/resources/channel#allowed-mentions-object-allowed-mention-types) and [typings](https://github.com/discordjs/discord.js/blob/f2fdb9331895da59546107efe245a2e0137ef2e7/typings/index.d.ts#L2656).

It also adds a new typedef `DisableMentionType` to avoid using literal string types in various instances for `MessageOptions#disableMentions`.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
