### PR TITLE
docs(RoleManager): everyone role can't be null

### DIFF
--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -125,7 +125,7 @@ class RoleManager extends BaseManager {
 
   /**
    * The `@everyone` role of the guild
-   * @type {?Role}
+   * @type {Role}
    * @readonly
    */
   get everyone() {

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -129,7 +129,7 @@ class RoleManager extends BaseManager {
    * @readonly
    */
   get everyone() {
-    return this.cache.get(this.guild.id) || null;
+    return this.cache.get(this.guild.id);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1904,7 +1904,7 @@ declare module 'discord.js' {
 
   export class RoleManager extends BaseManager<Snowflake, Role, RoleResolvable> {
     constructor(guild: Guild, iterable?: Iterable<any>);
-    public readonly everyone: Role | null;
+    public readonly everyone: Role;
     public readonly highest: Role;
     public guild: Guild;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the jsdoc of RoleManager ; the everyone role can't be null

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
