### PR TITLE
fix(Typings): use Channel instead of *ChannelTypes in ClientEvents

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2168,10 +2168,10 @@ declare module 'discord.js' {
   }
 
   interface ClientEvents {
-    channelCreate: [ChannelTypes];
-    channelDelete: [ChannelTypes | PartialDMChannel];
-    channelPinsUpdate: [TextBasedChannelTypes | PartialDMChannel, Date];
-    channelUpdate: [ChannelTypes, ChannelTypes];
+    channelCreate: [Channel];
+    channelDelete: [Channel | PartialDMChannel];
+    channelPinsUpdate: [Channel | PartialDMChannel, Date];
+    channelUpdate: [Channel, Channel];
     debug: [string];
     warn: [string];
     disconnect: [any, number];
@@ -2209,7 +2209,7 @@ declare module 'discord.js' {
     roleCreate: [Role];
     roleDelete: [Role];
     roleUpdate: [Role, Role];
-    typingStart: [TextBasedChannelTypes | PartialDMChannel, User | PartialUser];
+    typingStart: [Channel | PartialDMChannel, User | PartialUser];
     userUpdate: [User | PartialUser, User | PartialUser];
     voiceStateUpdate: [VoiceState, VoiceState];
     webhookUpdate: [TextChannel];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes the references to the removed channel union types.

I seem to somehow have missed those in #3978.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
