### PR TITLE
fix?(typings): add a catch-all to ClientEvents

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2218,6 +2218,7 @@ declare module 'discord.js' {
     shardReady: [number];
     shardReconnecting: [number];
     shardResume: [number, number];
+    [event: string | symbol]: any[];
   }
 
   interface ClientOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allows users to have `client.on('eventNotInTheDocs', (...args) => {});`, with TypeScript not yelling at them, [context](https://discordapp.com/channels/222078108977594368/682166281826598932/694107302264963112).
**Note: That "lock" was intentional, check this [comment](https://github.com/discordjs/discord.js/pull/3944#discussion_r393221258) on the original pull request. Also, it can be [augmented](https://discordapp.com/channels/222078108977594368/682166281826598932/694108543816826920), so intellisense can still autocomplete event names, and `ClientEvents` should be extended by the user. Aaaaaand... @SpaceEEC also said it should not be reverted, [here](https://discordapp.com/channels/222078108977594368/682166281826598932/694109876653260812), so this is here, waiting for your feedback.**

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
