### PR TITLE
docs(MessageManager): document return type of delete

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -115,7 +115,7 @@ class MessageManager extends BaseManager {
    * Deletes a message, even if it's not cached.
    * @param {MessageResolvable} message The message to delete
    * @param {string} [reason] Reason for deleting this message, if it does not belong to the client user
-   * @returns {Promise}
+   * @returns {Promise<void>}
    */
   async delete(message, reason) {
     message = this.resolveID(message);

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -115,6 +115,7 @@ class MessageManager extends BaseManager {
    * Deletes a message, even if it's not cached.
    * @param {MessageResolvable} message The message to delete
    * @param {string} [reason] Reason for deleting this message, if it does not belong to the client user
+   * @returns {Promise}
    */
   async delete(message, reason) {
     message = this.resolveID(message);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR documents the return type of `MessageManager#delete`.

The [documentation](https://discord.js.org/#/docs/main/stable/class/MessageManager?scrollTo=delete) currently states the return type of `void`, however it should be `Promise`.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
