### PR TITLE
fix(APIRequest): group all reactions into the same route per channel

### DIFF
--- a/src/client/rest/APIRequest.js
+++ b/src/client/rest/APIRequest.js
@@ -15,7 +15,7 @@ class APIRequest {
   }
 
   getRoute(url) {
-    let route = url.split('?')[0].split('/');
+    const route = url.split('?')[0].split('/');
     const routeBucket = [];
     for (let i = 0; i < route.length; i++) {
       // Reactions routes and sub-routes all share the same bucket

--- a/src/client/rest/APIRequest.js
+++ b/src/client/rest/APIRequest.js
@@ -15,13 +15,17 @@ class APIRequest {
   }
 
   getRoute(url) {
-    let route = url.split('?')[0];
-    if (route.includes('/channels/') || route.includes('/guilds/')) {
-      const startInd = route.includes('/channels/') ? route.indexOf('/channels/') : route.indexOf('/guilds/');
-      const majorID = route.substring(startInd).split('/')[2];
-      route = route.replace(/(\d{8,})/g, ':id').replace(':id', majorID);
+    let route = url.split('?')[0].split('/');
+    const routeBucket = [];
+    for (let i = 0; i < route.length; i++) {
+      // Reactions routes and sub-routes all share the same bucket
+      if (route[i - 1] === 'reactions') break;
+      // Literal IDs should only be taken account if they are the Major ID (the Channel/Guild ID)
+      if (/\d{16,19}/g.test(route[i]) && !/channels|guilds/.test(route[i - 1])) routeBucket.push(':id');
+      // All other parts of the route should be considered as part of the bucket identifier
+      else routeBucket.push(route[i]);
     }
-    return route;
+    return routeBucket.join('/');
   }
 
   getAuth() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR groups all reaction routes into one handler per channel.

All reactions in a channel share the same bucket when adding or removing them.

For example:
- `/channels/123/messages/:id/reactions/emoji:123/@me`
- `/channels/123/messages/:id/reactions/emoji2:456/@me`
- `/channels/123/messages/:id/reactions/emoji2:456/789`

Would be grouped together under:
- `/channels/123/messaages/:id/reactions`

This is a backport from our current release, where this has been fixed already:
https://github.com/discordjs/discord.js/blob/0e44ecd420ba94b490c2cba1f7a30d1fa5878183/src/rest/APIRouter.js#L20-L28


**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
