### PR TITLE
refactor(WebhookClient): initialization from url

### DIFF
--- a/src/client/WebhookClient.js
+++ b/src/client/WebhookClient.js
@@ -2,6 +2,7 @@
 
 const Webhook = require('../structures/Webhook');
 const BaseClient = require('./BaseClient');
+const DataResolver = require('../util/DataResolver');
 
 /**
  * The webhook client.
@@ -10,19 +11,29 @@ const BaseClient = require('./BaseClient');
  */
 class WebhookClient extends BaseClient {
   /**
-   * @param {Snowflake} id ID of the webhook
-   * @param {string} token Token of the webhook
-   * @param {ClientOptions} [options] Options for the client
+   * @param {WebhookClientOptions} options Options for the client
    * @example
-   * // Create a new webhook and send a message
-   * const hook = new Discord.WebhookClient('1234', 'abcdef');
+   * // Create a new webhook from ID and token and send a message
+   * const hook = new Discord.WebhookClient({ id: '1234', token: 'abcdef' });
+   * hook.send('This will send a message').catch(console.error);
+   * @example
+   * // Create a new webhook from URL and send a message
+   * const hook = new Discord.WebhookClient({ url: 'https://discordapp.com/api/webhooks/1234/abcdef' });
    * hook.send('This will send a message').catch(console.error);
    */
-  constructor(id, token, options) {
+  constructor(options) {
     super(options);
-    Object.defineProperty(this, 'client', { value: this });
-    this.id = id;
-    Object.defineProperty(this, 'token', { value: token, writable: true, configurable: true });
+
+    const buildFromURL = options.url ? DataResolver.resolveWebhookURL(options.url) : false;
+    if (buildFromURL) {
+      Object.defineProperty(this, 'client', { value: this });
+      this.id = buildFromURL[0];
+      Object.defineProperty(this, 'token', { value: buildFromURL[1], writable: true, configurable: true });
+    } else {
+      Object.defineProperty(this, 'client', { value: this });
+      this.id = options.id;
+      Object.defineProperty(this, 'token', { value: options.token, writable: true, configurable: true });
+    }
   }
 }
 

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -36,6 +36,18 @@ class DataResolver {
   }
 
   /**
+   * Resolves a Discord webhook URL into an id and token tuple
+   * @param {string} data The webhookURL to resolve
+   * @returns {?Array<string>}
+   */
+  static resolveWebhookURL(data) {
+    const webhookRegex = /discordapp\.com\/api\/webhooks\/([0-9]+)\/([a-zA-Z0-9_-]+)/i;
+    const match = webhookRegex.exec(data);
+    if (match && match[1] && match[2]) return [match[1], match[2]];
+    return null;
+  }
+
+  /**
    * Resolves a Base64Resolvable, a string, or a BufferResolvable to a Base 64 image.
    * @param {BufferResolvable|Base64Resolvable} image The image to be resolved
    * @returns {Promise<?string>}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -626,6 +626,7 @@ declare module 'discord.js' {
 		public static resolveFile(resource: BufferResolvable | Stream): Promise<Buffer>;
 		public static resolveImage(resource: BufferResolvable | Base64Resolvable): Promise<string>;
 		public static resolveInviteCode(data: InviteResolvable): string;
+		public static resolveWebhookURL(data: string): [string, string] | null;
 	}
 
 	export class DiscordAPIError extends Error {
@@ -1650,7 +1651,8 @@ declare module 'discord.js' {
 	}
 
 	export class WebhookClient extends WebhookMixin(BaseClient) {
-		constructor(id: string, token: string, options?: ClientOptions);
+		constructor(options: WebhookClientOptions & { id: string; token: string });
+		constructor(options: WebhookClientOptions & { url: string });
 		public token: string;
 	}
 
@@ -2733,6 +2735,12 @@ declare module 'discord.js' {
 		guildID: Snowflake;
 		type: keyof typeof ChannelType;
 		name: string;
+	}
+
+	interface WebhookClientOptions extends ClientOptions {
+		id?: string;
+		token?: string;
+		url?: string;
 	}
 
 //#endregion


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the ability to initialize a `WebhookClient` from a webhook URL and reactors the way `WebhookClient`s are initialized as a whole.

Previously, they would be initialized as:
```js
new WebhookClient('id', 'token')
```
This PR changes initilization into a more object-oriented manner:
```js
new WebhookClient({ id: '', token '' });
// or
new WebhookClient({ url: '' });
```

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
