### PR TITLE
docs(ShardClientUtil): link Shard#message from send method

### DIFF
--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -76,9 +76,10 @@ class ShardClientUtil {
   }
 
   /**
-   * Sends a message to the master process, see {@link Shard#message}.
+   * Sends a message to the master process.
    * @param {*} message Message to send
    * @returns {Promise<void>}
+   * @emits Shard#message
    */
   send(message) {
     return new Promise((resolve, reject) => {

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -76,7 +76,7 @@ class ShardClientUtil {
   }
 
   /**
-   * Sends a message to the master process.
+   * Sends a message to the master process, see {@link Shard#message}.
    * @param {*} message Message to send
    * @returns {Promise<void>}
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR links `Shard#message` from `ShardClientUtil#send`'s documentation, since it's not immediately obvious where the message gets send to.


**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
