### PR TITLE
typings(StreamDispatcher): correct property types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1366,14 +1366,14 @@ declare module 'discord.js' {
 
   class StreamDispatcher extends VolumeMixin(Writable) {
     constructor(player: object, options?: StreamOptions, streams?: object);
-    public player: object;
-    public pausedSince: number;
+    public readonly bitrateEditable: boolean;
     public broadcast: VoiceBroadcast | null;
     public readonly paused: boolean;
-    public readonly pausedTime: boolean | null;
+    public pausedSince: number | null;
+    public readonly pausedTime: number;
+    public player: object;
     public readonly streamTime: number;
     public readonly totalStreamTime: number;
-    public readonly bitrateEditable: boolean;
 
     public setBitrate(value: number | 'auto'): boolean;
     public setPLP(value: number): boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1375,11 +1375,11 @@ declare module 'discord.js' {
     public readonly streamTime: number;
     public readonly totalStreamTime: number;
 
-    public setBitrate(value: number | 'auto'): boolean;
-    public setPLP(value: number): boolean;
-    public setFEC(enabled: boolean): boolean;
     public pause(silence?: boolean): void;
     public resume(): void;
+    public setBitrate(value: number | 'auto'): boolean;
+    public setFEC(enabled: boolean): boolean;
+    public setPLP(value: number): boolean;
 
     public on(event: 'close' | 'drain' | 'finish' | 'start', listener: () => void): this;
     public on(event: 'debug', listener: (info: string) => void): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #4057. It also sorts the properties & methods in alphabetical order. To be specific:

- Marked `StreamDispatcher#pausedSince` as nullable
- `StreamDispatcher#pausedTime` is a number, not a boolean (also not nullable)

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
