### PR TITLE
chore(WebSocketShard): Log Discord requested reconnects

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -407,6 +407,7 @@ class WebSocketShard extends EventEmitter {
         this.identify();
         break;
       case OPCodes.RECONNECT:
+        this.debug('[RECONNECT] Discord asked us to reconnect');
         this.destroy({ closeCode: 4000 });
         break;
       case OPCodes.INVALID_SESSION:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

If anyone wants to know if Discord asks us to reconnect, here you go. Simple debug message that just says "hey, Discord wants us to reconnect, so we will, and we'll attempt to resume too!"

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
