### PR TITLE
Make sure data.name doesn't become type "number"

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -339,7 +339,7 @@ class GuildChannel extends Channel {
 
     const newData = await this.client.api.channels(this.id).patch({
       data: {
-        name: (data.name || this.name).trim(),
+        name: (data.name.toString() || this.name).trim(),
         topic: data.topic,
         nsfw: data.nsfw,
         bitrate: data.bitrate || this.bitrate,


### PR DESCRIPTION
if you pass Math.random() to GuildChannel#setName, It will error out with the error `TypeError: (data.name || this.name).trim is not a function`. This should've fixed it at least for me.

**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
