### PR TITLE
fix(Guild): sort text, news, and store channels together

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1335,7 +1335,13 @@ class Guild extends Base {
   _sortedChannels(channel) {
     const category = channel.type === ChannelTypes.CATEGORY;
     return Util.discordSort(
-      this.channels.cache.filter(c => c.type === channel.type && (category || c.parent === channel.parent)),
+      this.channels.cache.filter(
+        c =>
+          (['text', 'news', 'store'].includes(channel.type)
+            ? ['text', 'news', 'store'].includes(c.type)
+            : c.type === channel.type) &&
+          (category || c.parent === channel.parent),
+      ),
     );
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR sorts text, news, and store channels together, and fixes the `position`s of those channels. Fixes #3963.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
