### PR TITLE
feat(Message): add allowedMentions to MessageEditOptions

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -402,6 +402,7 @@ class Message extends Base {
    * @property {string} [content] Content to be edited
    * @property {Object} [embed] An embed to be added/edited
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
+   * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2613,6 +2613,7 @@ declare module 'discord.js' {
     embed?: MessageEmbedOptions | null;
     code?: string | boolean;
     flags?: BitFieldResolvable<MessageFlagsString>;
+    allowedMentions?: MessageMentionOptions;
   }
 
   interface MessageEmbedAuthor {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR documents the `allowedMentions` part of `MessageEditOptions` as bots are now able to edit those too.

Relevant upstream PR: https://github.com/discord/discord-api-docs/pull/1483

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
