### PR TITLE
feat(DataResolver): prefer streams over buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "unpkg": "./webpack/discord.min.js",
   "dependencies": {
     "@discordjs/collection": "^0.1.5",
+    "@discordjs/form-data": "^3.0.1",
     "abort-controller": "^3.0.0",
-    "form-data": "^3.0.0",
     "node-fetch": "^2.6.0",
     "prism-media": "^1.2.0",
     "setimmediate": "^1.0.5",

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const https = require('https');
+const FormData = require('@discordjs/form-data');
 const AbortController = require('abort-controller');
-const FormData = require('form-data');
 const fetch = require('node-fetch');
 const { browser, UserAgent } = require('../util/Constants');
 

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -118,12 +118,9 @@ class DataResolver {
     const file = await this.resolveFile(resource);
     if (Buffer.isBuffer(file)) return file;
 
-    return new Promise((resolve, reject) => {
-      const buffers = [];
-      file.once('error', reject);
-      file.on('data', data => buffers.push(data));
-      file.once('end', () => resolve(Buffer.concat(buffers)));
-    });
+    const buffers = [];
+    for await (const data of file) buffers.push(data);
+    return Buffer.concat(buffers);
   }
 }
 

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -85,14 +85,15 @@ class DataResolver {
    * @param {BufferResolvable|Stream} resource The buffer or stream resolvable to resolve
    * @returns {Promise<Buffer|Stream>}
    */
-  static resolveFile(resource) {
-    if (!browser && Buffer.isBuffer(resource)) return Promise.resolve(resource);
-    if (browser && resource instanceof ArrayBuffer) return Promise.resolve(Util.convertToBuffer(resource));
+  static async resolveFile(resource) {
+    if (!browser && Buffer.isBuffer(resource)) return resource;
+    if (browser && resource instanceof ArrayBuffer) return Util.convertToBuffer(resource);
     if (resource instanceof stream.Readable) return resource;
 
     if (typeof resource === 'string') {
       if (/^https?:\/\//.test(resource)) {
-        return fetch(resource).then(res => (browser ? res.blob() : res.body));
+        const res = await fetch(resource);
+        return browser ? res.blob() : res.body;
       } else if (!browser) {
         return new Promise((resolve, reject) => {
           const file = path.resolve(resource);
@@ -105,7 +106,7 @@ class DataResolver {
       }
     }
 
-    return Promise.reject(new TypeError('REQ_RESOURCE_TYPE'));
+    throw new TypeError('REQ_RESOURCE_TYPE');
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -538,6 +538,7 @@ declare module 'discord.js' {
   export class DataResolver {
     public static resolveBase64(data: Base64Resolvable): string;
     public static resolveFile(resource: BufferResolvable | Stream): Promise<Buffer | Stream>;
+    public static resolveFileAsBuffer(resource: BufferResolvable | Stream): Promise<Buffer>;
     public static resolveImage(resource: BufferResolvable | Base64Resolvable): Promise<string>;
     public static resolveInviteCode(data: InviteResolvable): string;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -11,10 +11,10 @@ declare enum ChannelType {
 
 declare module 'discord.js' {
   import BaseCollection from '@discordjs/collection';
-  import { EventEmitter } from 'events';
-  import { Stream, Readable, Writable } from 'stream';
   import { ChildProcess } from 'child_process';
+  import { EventEmitter } from 'events';
   import { PathLike } from 'fs';
+  import { Readable, Stream, Writable } from 'stream';
   import * as WebSocket from 'ws';
 
   export const version: string;
@@ -537,7 +537,7 @@ declare module 'discord.js' {
 
   export class DataResolver {
     public static resolveBase64(data: Base64Resolvable): string;
-    public static resolveFile(resource: BufferResolvable | Stream): Promise<Buffer>;
+    public static resolveFile(resource: BufferResolvable | Stream): Promise<Buffer | Stream>;
     public static resolveImage(resource: BufferResolvable | Base64Resolvable): Promise<string>;
     public static resolveInviteCode(data: InviteResolvable): string;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I've noticed high memory usage when tried to send a few ~100mb files as message attachments so I went to the source code and discovered that, indeed, everything is being converted to Buffers for some reason. Since discord.js uses node-fetch under the hood, which accepts Streams, the fix seems to be pretty simple.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.