### PR TITLE
docs(MessageEmbed): document the constructor

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -7,6 +7,13 @@ const Util = require('../util/Util');
  * Represents an embed in a message (image/video preview, rich embed, etc.)
  */
 class MessageEmbed {
+  /**
+   * @name MessageEmbed
+   * @kind constructor
+   * @memberof MessageEmbed
+   * @param {MessageEmbed|Object} [data={}] MessageEmbed to clone or raw embed data
+   */
+
   constructor(data = {}, skipValidation = false) {
     this.setup(data, skipValidation);
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR documents the constructor of `MessageEmbed`, which somehow was not yet documented.
Resolves #4000?

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
