### PR TITLE
fix(Typings): GuildPreview#features and Integration#type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -822,7 +822,7 @@ declare module 'discord.js' {
     public description?: string;
     public discoverySplash: string | null;
     public emojis: Collection<Snowflake, GuildPreviewEmoji>;
-    public features: GuildFeatures;
+    public features: GuildFeatures[];
     public icon: string | null;
     public id: string;
     public name: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -861,7 +861,7 @@ declare module 'discord.js' {
     public role: Role;
     public syncedAt: number;
     public syncing: boolean;
-    public type: number;
+    public type: string;
     public user: User;
     public delete(reason?: string): Promise<Integration>;
     public edit(data: IntegrationEditData, reason?: string): Promise<Integration>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
* GuildPreview#features is `GuildFeatures[]` instead of `GuildFeatures`
* Integration#type is `string` instead of `number`
This is what the types should be and what they are in the documentation.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.