### PR TITLE
feat(GuildMemberManager): customisable timeout for _fetchMany

### DIFF
--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -76,6 +76,7 @@ class GuildMemberManager extends BaseManager {
    * @property {?string} query Limit fetch to members with similar usernames
    * @property {number} [limit=0] Maximum number of members to request
    * @property {boolean} [withPresences=false] Whether or not to include the presences
+   * @property {number} [time=120e3] Timeout for receipt of members
    */
 
   /**
@@ -223,7 +224,7 @@ class GuildMemberManager extends BaseManager {
       .then(data => this.add(data, cache));
   }
 
-  _fetchMany({ limit = 0, withPresences: presences = false, user: user_ids, query } = {}) {
+  _fetchMany({ limit = 0, withPresences: presences = false, user: user_ids, query, time = 120e3 } = {}) {
     return new Promise((resolve, reject) => {
       if (this.guild.memberCount === this.cache.size && !query && !limit && !presences && !user_ids) {
         resolve(this.cache);
@@ -262,7 +263,7 @@ class GuildMemberManager extends BaseManager {
       const timeout = this.guild.client.setTimeout(() => {
         this.guild.client.removeListener(Events.GUILD_MEMBERS_CHUNK, handler);
         reject(new Error('GUILD_MEMBERS_TIMEOUT'));
-      }, 120e3);
+      }, time);
       this.guild.client.on(Events.GUILD_MEMBERS_CHUNK, handler);
     });
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2373,6 +2373,7 @@ declare module 'discord.js' {
     query?: string;
     limit?: number;
     withPresences?: boolean;
+    time?: number;
   }
 
   interface FileOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a `time` parameter to `FetchMembersOptions` in order to allow customisation of the timeout for receipt of members.
Many use cases do not require 120 seconds of timeout, also this can be a good workaround until https://github.com/discordjs/discord.js/issues/4018 gets fixed in Discord API itself.

https://i.imgur.com/DTw2QLh.png

An example of use case that would benefit from this feat can be found in the issue itself (or directly from the image that should tell enough of what's the issue behind this).

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
