### PR TITLE
docs(Permissions): Permissions Name Update

### DIFF
--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -57,7 +57,7 @@ class Permissions extends BitField {
  * * `ADD_REACTIONS` (add new reactions to messages)
  * * `VIEW_AUDIT_LOG`
  * * `PRIORITY_SPEAKER`
- * * `STREAM`
+ * * `VIDEO` (allows go live and video calls)
  * * `VIEW_CHANNEL`
  * * `SEND_MESSAGES`
  * * `SEND_TTS_MESSAGES`

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -58,6 +58,7 @@ class Permissions extends BitField {
  * * `VIEW_AUDIT_LOG`
  * * `PRIORITY_SPEAKER`
  * * `VIDEO` (allows go live and video calls)
+ * * `STREAM` (deprecated, use `VIDEO` instead)
  * * `VIEW_CHANNEL`
  * * `SEND_MESSAGES`
  * * `SEND_TTS_MESSAGES`
@@ -93,6 +94,7 @@ Permissions.FLAGS = {
   VIEW_AUDIT_LOG: 1 << 7,
   PRIORITY_SPEAKER: 1 << 8,
   VIDEO: 1 << 9,
+  STREAM: 1 << 9,
   VIEW_CHANNEL: 1 << 10,
   SEND_MESSAGES: 1 << 11,
   SEND_TTS_MESSAGES: 1 << 12,

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -57,7 +57,7 @@ class Permissions extends BitField {
  * * `ADD_REACTIONS` (add new reactions to messages)
  * * `VIEW_AUDIT_LOG`
  * * `PRIORITY_SPEAKER`
- * * `VIDEO` (allows go live and video calls)
+ * * `VIDEO`
  * * `STREAM` (deprecated, use `VIDEO` instead)
  * * `VIEW_CHANNEL`
  * * `SEND_MESSAGES`

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -92,7 +92,7 @@ Permissions.FLAGS = {
   ADD_REACTIONS: 1 << 6,
   VIEW_AUDIT_LOG: 1 << 7,
   PRIORITY_SPEAKER: 1 << 8,
-  STREAM: 1 << 9,
+  VIDEO: 1 << 9,
   VIEW_CHANNEL: 1 << 10,
   SEND_MESSAGES: 1 << 11,
   SEND_TTS_MESSAGES: 1 << 12,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2754,6 +2754,7 @@ declare module 'discord.js' {
     | 'VIEW_AUDIT_LOG'
     | 'PRIORITY_SPEAKER'
     | 'VIDEO'
+    | 'STREAM'
     | 'VIEW_CHANNEL'
     | 'SEND_MESSAGES'
     | 'SEND_TTS_MESSAGES'

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2753,7 +2753,7 @@ declare module 'discord.js' {
     | 'ADD_REACTIONS'
     | 'VIEW_AUDIT_LOG'
     | 'PRIORITY_SPEAKER'
-    | 'STREAM'
+    | 'VIDEO'
     | 'VIEW_CHANNEL'
     | 'SEND_MESSAGES'
     | 'SEND_TTS_MESSAGES'


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This update is for Discords new video call rollout on servers, changing the `STREAM` permission to `VIDEO` which allows both. This might be temporary as Discord is currently deciding whether to use 1 or both permissions. I recommend this PR hold off for a little while discord makes the necessary changes to accompany this rollout.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
