### PR TITLE
feat(ClientOptions): allow setting default allowedMentions

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -176,6 +176,11 @@ class APIMessage {
       flags = this.options.flags != null ? new MessageFlags(this.options.flags).bitfield : this.target.flags.bitfield;
     }
 
+    const allowed_mentions =
+      typeof this.options.allowedMentions === 'undefined'
+        ? this.target.client.options.allowedMentions
+        : this.options.allowedMentions;
+
     this.data = {
       content,
       tts,
@@ -184,7 +189,7 @@ class APIMessage {
       embeds,
       username,
       avatar_url: avatarURL,
-      allowed_mentions: this.options.allowedMentions,
+      allowed_mentions,
       flags,
     };
     return this;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -22,7 +22,7 @@ const browser = (exports.browser = typeof window !== 'undefined');
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
  * @property {DisableMentionType} [disableMentions='none'] Default value for {@link MessageOptions#disableMentions}
- * @property {MessageMentionOptions} [allowedMentions='none'] Default value for {@link MessageOptions#allowedMentions}
+ * @property {MessageMentionOptions} [allowedMentions] Default value for {@link MessageOptions#allowedMentions}
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
  * they're missing all the data for a particular structure. See the "Partials" topic listed in the sidebar for some
  * important usage information, as partials require you to put checks in place when handling data.
@@ -45,7 +45,6 @@ exports.DefaultOptions = {
   messageSweepInterval: 0,
   fetchAllMembers: false,
   disableMentions: 'none',
-  allowedMentions: {},
   partials: [],
   restWsBridgeTimeout: 5000,
   restRequestTimeout: 15000,

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -22,6 +22,7 @@ const browser = (exports.browser = typeof window !== 'undefined');
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
  * @property {DisableMentionType} [disableMentions='none'] Default value for {@link MessageOptions#disableMentions}
+ * @property {MessageMentionOptions} [allowedMentions='none'] Default value for {@link MessageOptions#allowedMentions}
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
  * they're missing all the data for a particular structure. See the "Partials" topic listed in the sidebar for some
  * important usage information, as partials require you to put checks in place when handling data.
@@ -44,6 +45,7 @@ exports.DefaultOptions = {
   messageSweepInterval: 0,
   fetchAllMembers: false,
   disableMentions: 'none',
+  allowedMentions: {},
   partials: [],
   restWsBridgeTimeout: 5000,
   restRequestTimeout: 15000,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2225,6 +2225,7 @@ declare module 'discord.js' {
     messageSweepInterval?: number;
     fetchAllMembers?: boolean;
     disableMentions?: 'none' | 'all' | 'everyone';
+    allowedMentions?: MessageMentionOptions;
     partials?: PartialTypes[];
     restWsBridgeTimeout?: number;
     restTimeOffset?: number;


### PR DESCRIPTION
This PR adds the ability to set `ClientOptions#allowedMentions` to be used as a default whenever `MessageOptions#allowedMentions` is not provided.

If not provided as an option, the default behaviour by Discord is to parse all mentions.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
