### PR TITLE
chore(Typings): stricter def for Client#emit

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -193,6 +193,8 @@ declare module 'discord.js' {
     public on<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
 
     public once<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
+
+    public emit<K extends keyof ClientEvents>(event: K, ...args: ClientEvents[K]): boolean;
   }
 
   export class ClientApplication extends Base {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I overrode the `ClientEvents` typings in my project so I could emit my own event on `Client` and noticed there's only the basic `@types/node` typings for `Client#emit`, and this PR fixes that.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
