### PR TITLE
docs(Message): add timeout to Message#delete example

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -493,8 +493,8 @@ class Message extends Base {
    * @returns {Promise<Message>}
    * @example
    * // Delete a message
-   * message.delete()
-   *   .then(msg => console.log(`Deleted message from ${msg.author.username}`))
+   * message.delete({ timeout: 5000 })
+   *   .then(msg => console.log(`Deleted message from ${msg.author.username} after 5 seconds`))
    *   .catch(console.error);
    */
   delete(options = {}) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

People in our support channels are regularly confused about how to use Message#delete with a timeout after updating from v11, where it used to be `<Message>.delete(5000)`.

The documentation does not reflect this change through an example. This PR adds a timeout to the Message#delete example.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
