### PR TITLE
fix(PacketHandler): guild members chunk packet handler should…

### DIFF
--- a/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
+++ b/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
@@ -10,7 +10,7 @@ module.exports = (client, { d: data }) => {
 
   for (const member of data.members) members.set(member.user.id, guild.members.add(member));
   if (data.presences) {
-    for (const presence of data.presences) guild.presences.cache.add(Object.assign(presence, { guild }));
+    for (const presence of data.presences) guild.presences.add(Object.assign(presence, { guild }));
   }
   /**
    * Emitted whenever a chunk of guild members is received (all members come from the same guild).


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#3562 added the `withPresences` option to the guild members manager's fetch method, however it incorrectly calls 
`guild.presences.cache.add(...)`
it should be calling 
`guild.presences.add(...)`
This pr fixes that which fixes #4091
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
