### PR TITLE
fix(MessageEmbed): explicitly mark `proxyIconURL` as undefined

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -324,7 +324,7 @@ class MessageEmbed {
    */
   setFooter(text, iconURL) {
     text = Util.resolveString(text);
-    this.footer = { text, iconURL };
+    this.footer = { text, iconURL, proxyIconURL: undefined };
     return this;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR explicitly adds the `proxyIconURL` property as `unfined` when calling `.setFooter()`.
This change may seem futile but it allows an exhaustive comparison between two MessageEmbed with the same properties.

```ts
import assert from 'assert';

let a = new discord.MessageEmbed({ footer: { text: "test" } })
let b = new discord.MessageEmbed().setFooter("test")

assert.deepStrictEqual(a, b) // => throw because of the missing `proxyIconURL`
```

https://nodejs.org/api/assert.html#assert_assert_deepstrictequal_actual_expected_message

This kind of behaviour is very widely used in unit tests to check the proper functioning of the system.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [] This PR **only** includes non-code changes, like changes to documentation, README, etc.
