### PR TITLE
fix(Typings): add optional Set<Snowflake> to shardReady event

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2221,7 +2221,7 @@ declare module 'discord.js' {
     webhookUpdate: [TextChannel];
     shardDisconnect: [CloseEvent, number];
     shardError: [Error, number];
-    shardReady: [number];
+    shardReady: [number, Set<Snowflake> | undefined];
     shardReconnecting: [number];
     shardResume: [number, number];
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds the optional `unavailableGuilds` parameter to the argument list of the `shardReady` event in the typings.

For reference: <https://discord.js.org/#/docs/main/stable/class/Client?scrollTo=e-shardReady>

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
