### PR TITLE
fix(Webpack): add Buffer polyfill in browser

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
     __dirname: true,
     process: true,
     path: 'empty',
-    Buffer: false,
+    Buffer: true,
     zlib: 'empty',
   },
   optimization: {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Theres no reason to not have this polyfill as I can spot right now.
Our bundle-size with this increases by 1KB.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
