### PR TITLE
fix(Guild): name acronym

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -465,7 +465,10 @@ class Guild extends Base {
    * @readonly
    */
   get nameAcronym() {
-    return this.name.replace(/\w+/g, name => name[0]).replace(/\s/g, '');
+    return this.name
+      .replace(/'s /g, ' ')
+      .replace(/\w+/g, e => e[0])
+      .replace(/\s/g, '');
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes the guild name acronym generation to be the same as the one the Discord app uses (taken from [DJScias/Discord-Datamining](https://raw.githubusercontent.com/DJScias/Discord-Datamining/master/2020/2020-04-18/40abc31adc473eefed44.js), search the page for `t.getAcronym = f` to find the definition).

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
