### PR TITLE
fix(Typing): setSpeaking public

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -144,7 +144,6 @@ class VoiceConnection extends EventEmitter {
   /**
    * Sets whether the voice connection should display as "speaking", "soundshare" or "none".
    * @param {BitFieldResolvable} value The new speaking state
-   * @private
    */
   setSpeaking(value) {
     if (this.speaking.equals(value)) return;

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -81,10 +81,11 @@ class ReactionCollector extends Collector {
   /**
    * Handles an incoming reaction for possible collection.
    * @param {MessageReaction} reaction The reaction to possibly collect
+   * @param {User} user The user that added the reaction
    * @returns {?Snowflake|string}
    * @private
    */
-  collect(reaction) {
+  collect(reaction, user) {
     /**
      * Emitted whenever a reaction is collected.
      * @event ReactionCollector#collect
@@ -92,6 +93,19 @@ class ReactionCollector extends Collector {
      * @param {User} user The user that added the reaction
      */
     if (reaction.message.id !== this.message.id) return null;
+
+    /**
+     * Emitted whenever a reaction is newly created on a message. Will emit only when a new reaction is
+     * added to the message, as opposed to {@link Collector#collect} which which will
+     * be emitted even when a reaction has already been added to the message.
+     * @event ReactionCollector#create
+     * @param {MessageReaction} reaction The reaction that was added
+     * @param {User} user The user that added the reaction
+     */
+    if (reaction.count === 1 && this.filter(reaction, user, this.collected)) {
+      this.emit('create', reaction, user);
+    }
+
     return ReactionCollector.key(reaction);
   }
 

--- a/test/reactionCollectorCreated.test.js
+++ b/test/reactionCollectorCreated.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const { token, guildId, channelId, messageId } = require('./auth.js');
+const { Client, ReactionCollector } = require('../src');
+
+const client = new Client();
+
+client.on('ready', async () => {
+  const guild = client.guilds.cache.get(guildId);
+
+  const channel = guild.channels.cache.get(channelId);
+
+  const message = await channel.messages.fetch(messageId);
+
+  await message.react('🔔');
+  // Await message.reactions.removeAll();
+
+  const collector = new ReactionCollector(message, () => true, { dispose: true });
+
+  collector.on('collect', () => {
+    console.log('collected');
+  });
+
+  collector.on('create', () => {
+    console.log('created');
+  });
+
+  collector.on('remove', () => {
+    console.log('removed');
+  });
+
+  collector.on('dispose', () => {
+    console.log('disposed');
+  });
+});
+
+client.login(token);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1590,7 +1590,6 @@ declare module 'discord.js' {
     private reconnect(token: string, endpoint: string): void;
     private sendVoiceStateUpdate(options: object): Promise<Shard>;
     private setSessionID(sessionID: string): void;
-    private setSpeaking(value: BitFieldResolvable<SpeakingString>): void;
     private setTokenAndEndpoint(token: string, endpoint: string): void;
     private updateChannel(channel: VoiceChannel): void;
 
@@ -1605,6 +1604,7 @@ declare module 'discord.js' {
     public voiceManager: ClientVoiceManager;
     public disconnect(): void;
     public play(input: VoiceBroadcast | Readable | string, options?: StreamOptions): StreamDispatcher;
+    public setSpeaking(value: BitFieldResolvable<SpeakingString>): void;
 
     public on(event: 'authenticated' | 'closing' | 'newSession' | 'ready' | 'reconnecting', listener: () => void): this;
     public on(event: 'debug', listener: (message: string) => void): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`VoiceConnection#setSpeaking` has been declared as private, when its only usage was by an external method calling it, therefore ruining its declaration.

This PR fixes #4074 

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
