### PR TITLE
feat(Guild#fetch): withCount param

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -306,6 +306,26 @@ class Guild extends Base {
     if (typeof data.max_presences !== 'undefined') this.maximumPresences = data.max_presences || 25000;
 
     /**
+     * The approximate amount of members the guild has
+     * <info>You will need to fetch the guild using {@link Guild#fetch} if you want to receive this parameter</info>
+     * @type {?number}
+     * @name Guild#approximateMemberCount
+     */
+    if (typeof data.approximate_member_count !== 'undefined') {
+      this.approximateMemberCount = data.approximate_member_count || null;
+    }
+
+    /**
+     * The approximate amount of presences the guild has
+     * <info>You will need to fetch the guild using {@link Guild#fetch} if you want to receive this parameter</info>
+     * @type {?number}
+     * @name Guild#approximatePresenceCount
+     */
+    if (typeof data.approximate_presence_count !== 'undefined') {
+      this.approximatePresenceCount = data.approximate_presence_count || null;
+    }
+
+    /**
      * The vanity URL code of the guild, if any
      * @type {?string}
      */
@@ -585,12 +605,13 @@ class Guild extends Base {
 
   /**
    * Fetches this guild.
+   * @param {boolean} [withCounts=false] Wether or not to fetch the approximate member and presence count
    * @returns {Promise<Guild>}
    */
-  fetch() {
+  fetch(withCounts = false) {
     return this.client.api
       .guilds(this.id)
-      .get()
+      .get({ query: { with_counts: withCounts } })
       .then(data => {
         this._patch(data);
         return this;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -605,13 +605,12 @@ class Guild extends Base {
 
   /**
    * Fetches this guild.
-   * @param {boolean} [withCounts=false] Wether or not to fetch the approximate member and presence count
    * @returns {Promise<Guild>}
    */
-  fetch(withCounts = false) {
+  fetch() {
     return this.client.api
       .guilds(this.id)
-      .get({ query: { with_counts: withCounts } })
+      .get({ query: { with_counts: true } })
       .then(data => {
         this._patch(data);
         return this;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -312,7 +312,7 @@ class Guild extends Base {
      * @name Guild#approximateMemberCount
      */
     if (typeof data.approximate_member_count !== 'undefined') {
-      this.approximateMemberCount = data.approximate_member_count || null;
+      this.approximateMemberCount = data.approximate_member_count;
     }
 
     /**
@@ -322,7 +322,7 @@ class Guild extends Base {
      * @name Guild#approximatePresenceCount
      */
     if (typeof data.approximate_presence_count !== 'undefined') {
-      this.approximatePresenceCount = data.approximate_presence_count || null;
+      this.approximatePresenceCount = data.approximate_presence_count;
     }
 
     /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -649,7 +649,7 @@ declare module 'discord.js' {
     public delete(): Promise<Guild>;
     public edit(data: GuildEditData, reason?: string): Promise<Guild>;
     public equals(guild: Guild): boolean;
-    public fetch(withCounts?: boolean): Promise<Guild>;
+    public fetch(): Promise<Guild>;
     public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
     public fetchBan(user: UserResolvable): Promise<{ user: User; reason: string }>;
     public fetchBans(): Promise<Collection<Snowflake, { user: User; reason: string }>>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -588,6 +588,8 @@ declare module 'discord.js' {
     public afkChannelID: Snowflake | null;
     public afkTimeout: number;
     public applicationID: Snowflake | null;
+    public approximateMemberCount: number | null;
+    public approximatePresenceCount: number | null;
     public available: boolean;
     public banner: string | null;
     public channels: GuildChannelManager;
@@ -647,7 +649,7 @@ declare module 'discord.js' {
     public delete(): Promise<Guild>;
     public edit(data: GuildEditData, reason?: string): Promise<Guild>;
     public equals(guild: Guild): boolean;
-    public fetch(): Promise<Guild>;
+    public fetch(withCounts?: boolean): Promise<Guild>;
     public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
     public fetchBan(user: UserResolvable): Promise<{ user: User; reason: string }>;
     public fetchBans(): Promise<Collection<Snowflake, { user: User; reason: string }>>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -588,8 +588,8 @@ declare module 'discord.js' {
     public afkChannelID: Snowflake | null;
     public afkTimeout: number;
     public applicationID: Snowflake | null;
-    public approximateMemberCount: number | null;
-    public approximatePresenceCount: number | null;
+    public approximateMemberCount?: number;
+    public approximatePresenceCount?: number;
     public available: boolean;
     public banner: string | null;
     public channels: GuildChannelManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds support for the new **`GET`** `guilds/:id` query parameter `with_counts` per https://github.com/discord/discord-api-docs/pull/1528. This includes two new properties: `approximate_member_count` and `approximate_presence_count` both assigned to `Guild#approximateMemberCount` and `Guild#approximatePresenceCount` respectively. 

I can add support for the `with_counts` query param for `GuildManager#fetch` once #4086 is merged.

This PR will be a draft until the feature is deployed. ~~I am still [yet to test this](https://discordapp.com/channels/613425648685547541/697489244649816084/701861149112664064).~~

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
