### PR TITLE
fix(Typings): Channel#delete returns bad type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -156,8 +156,8 @@ declare module 'discord.js' {
     public deleted: boolean;
     public id: Snowflake;
     public type: keyof typeof ChannelType;
-    public delete(reason?: string): Promise<this>;
-    public fetch(): Promise<this>;
+    public delete(reason?: string): Promise<Channel>;
+    public fetch(): Promise<Channel>;
     public toString(): string;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**



So I found a typings issues. With the following code: 
```ts
channel.delete().catch()
```
where `channel` is `TextChannel | DMChannel | NewsChannel` and the statement fails with
```
TS2349: This expression is not callable.
  Each member of the union type '(<TResult = never>(onrejected?: (reason: any) => TResult | PromiseLike<TResult>) => Promise<DMChannel | TResult>) | (<TResult = never>(onrejected?: (reason: any) => TResult | PromiseLike<...>) => Promise<...>) | (<TResult = never>(onrejected?: (reason: any) => TResult | PromiseLike<...>) => Promise<...>)' has signatures, but none of those signatures are compatible with each other.
```

Seems to be an issue introduced with v12 as the Channel typings changed from `public delete(): Promise<Channel>;` to `public delete(reason?: string): Promise<this>;`. This change generally makes a lot of sense if `channel` was `TextChannel` for example, because the return of `TextChannel#delete` would be `Promise<TextChannel>` then. However, there are the shown issues with multiple types.

Granted this would be an easy fix if you cast a type like `(msg.channel as TextChannel).delete().catch()` but I thought that this issue shouldn't appear in the first place. Returning `Promise<Channel>` is not optimal and would be the v11 revert but there is no other good fix for this other than the PR + casting to the specific type with the resolved promise.

Introducing types on the top level classes like `TextChannel` would introduce the same issue.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
