### PR TITLE
fix(Collector): support async

### DIFF
--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -9,7 +9,7 @@ const Util = require('../../util/Util');
  * @typedef {Function} CollectorFilter
  * @param {...*} args Any arguments received by the listener
  * @param {Collection} collection The items collected by this collector
- * @returns {boolean}
+ * @returns {boolean|Promise<boolean>}
  */
 
 /**
@@ -86,10 +86,10 @@ class Collector extends EventEmitter {
    * @param {...*} args The arguments emitted by the listener
    * @emits Collector#collect
    */
-  handleCollect(...args) {
+  async handleCollect(...args) {
     const collect = this.collect(...args);
 
-    if (collect && this.filter(...args, this.collected)) {
+    if (collect && (await this.filter(...args, this.collected))) {
       this.collected.set(collect, args[0]);
 
       /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2261,7 +2261,7 @@ declare module 'discord.js' {
     target: WebSocket;
   }
 
-  type CollectorFilter = (...args: any[]) => boolean;
+  type CollectorFilter = (...args: any[]) => boolean | Promise<boolean>;
 
   interface CollectorOptions {
     time?: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Previously, collectors (such as awaitMessages or awaitReactions) did not support an async filter. Instead, they would return true always leading to unexpected behaviour.

```js
let message = await channel.send("React with :thumbsup: to confirm");
message.react("👍");
// Async is not required here, but it may be for more complex filters
await message.awaitReactions(async (reaction, user) => !user.bot && reaction.emoji.name == "👍", {max: 1, time: 30000});
// Previously, this would continue instantly since the bot reacted. (Despite !user.bot filter)
console.log("Done");
```

This PR will not break compatibility

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
