### PR TITLE
feat(GuildMemberManager): nonce and chunk_count for _fetchMany

### DIFF
--- a/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
+++ b/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
@@ -17,6 +17,14 @@ module.exports = (client, { d: data }) => {
    * @event Client#guildMembersChunk
    * @param {Collection<Snowflake, GuildMember>} members The members in the chunk
    * @param {Guild} guild The guild related to the member chunk
+   * @param {object} chunk Properties of the received chunk
+   * @param {number} chunk.index Index of the received chunk
+   * @param {number} chunk.count Number of chunks the client should receive
+   * @param {?string} chunk.nonce Nonce for this chunk
    */
-  client.emit(Events.GUILD_MEMBERS_CHUNK, members, guild);
+  client.emit(Events.GUILD_MEMBERS_CHUNK, members, guild, {
+    count: data.chunk_count,
+    index: data.chunk_index,
+    nonce: data.nonce,
+  });
 };

--- a/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
+++ b/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
@@ -17,7 +17,7 @@ module.exports = (client, { d: data }) => {
    * @event Client#guildMembersChunk
    * @param {Collection<Snowflake, GuildMember>} members The members in the chunk
    * @param {Guild} guild The guild related to the member chunk
-   * @param {object} chunk Properties of the received chunk
+   * @param {Object} chunk Properties of the received chunk
    * @param {number} chunk.index Index of the received chunk
    * @param {number} chunk.count Number of chunks the client should receive
    * @param {?string} chunk.nonce Nonce for this chunk

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -100,7 +100,7 @@ const Messages = {
   DELETE_GROUP_DM_CHANNEL: "Bots don't have access to Group DM Channels and cannot delete them",
   FETCH_GROUP_DM_CHANNEL: "Bots don't have access to Group DM Channels and cannot fetch them",
 
-  MEMBER_FETCH_NONCE_LENGTH: `Nonce length must not exceed 32 characters.`,
+  MEMBER_FETCH_NONCE_LENGTH: 'Nonce length must not exceed 32 characters.',
 };
 
 for (const [name, message] of Object.entries(Messages)) register(name, message);

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -99,6 +99,8 @@ const Messages = {
 
   DELETE_GROUP_DM_CHANNEL: "Bots don't have access to Group DM Channels and cannot delete them",
   FETCH_GROUP_DM_CHANNEL: "Bots don't have access to Group DM Channels and cannot fetch them",
+
+  FETCH_NONCE_LENGTH: length => `Nonce length must not exceed ${length} characters.`,
 };
 
 for (const [name, message] of Object.entries(Messages)) register(name, message);

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -100,7 +100,7 @@ const Messages = {
   DELETE_GROUP_DM_CHANNEL: "Bots don't have access to Group DM Channels and cannot delete them",
   FETCH_GROUP_DM_CHANNEL: "Bots don't have access to Group DM Channels and cannot fetch them",
 
-  FETCH_NONCE_LENGTH: length => `Nonce length must not exceed ${length} characters.`,
+  MEMBER_FETCH_NONCE_LENGTH: `Nonce length must not exceed 32 characters.`,
 };
 
 for (const [name, message] of Object.entries(Messages)) register(name, message);

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -232,6 +232,7 @@ class GuildMemberManager extends BaseManager {
         return;
       }
       if (!query && !user_ids) query = '';
+      if (!nonce) nonce = this.guild.id;
       this.guild.shard.send({
         op: OPCodes.REQUEST_GUILD_MEMBERS,
         d: {
@@ -239,7 +240,7 @@ class GuildMemberManager extends BaseManager {
           presences,
           user_ids,
           query,
-          nonce: nonce || this.guild.id,
+          nonce,
           limit,
         },
       });

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const BaseManager = require('./BaseManager');
-const { Error, TypeError } = require('../errors');
+const { Error, TypeError, RangeError } = require('../errors');
 const GuildMember = require('../structures/GuildMember');
 const Collection = require('../util/Collection');
 const { Events, OPCodes } = require('../util/Constants');
@@ -231,7 +231,7 @@ class GuildMemberManager extends BaseManager {
     user: user_ids,
     query,
     time = 120e3,
-    nonce = this.guild.id,
+    nonce = Date.now().toString(16),
   } = {}) {
     return new Promise((resolve, reject) => {
       if (this.guild.memberCount === this.cache.size && !query && !limit && !presences && !user_ids) {
@@ -239,6 +239,7 @@ class GuildMemberManager extends BaseManager {
         return;
       }
       if (!query && !user_ids) query = '';
+      if (nonce.length > 32) throw new RangeError('FETCH_NONCE_LENGTH', 32);
       this.guild.shard.send({
         op: OPCodes.REQUEST_GUILD_MEMBERS,
         d: {
@@ -246,7 +247,7 @@ class GuildMemberManager extends BaseManager {
           presences,
           user_ids,
           query,
-          nonce: nonce.substring(0, 32),
+          nonce,
           limit,
         },
       });

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -225,14 +225,20 @@ class GuildMemberManager extends BaseManager {
       .then(data => this.add(data, cache));
   }
 
-  _fetchMany({ limit = 0, withPresences: presences = false, user: user_ids, query, time = 120e3, nonce } = {}) {
+  _fetchMany({
+    limit = 0,
+    withPresences: presences = false,
+    user: user_ids,
+    query,
+    time = 120e3,
+    nonce = this.guild.id,
+  } = {}) {
     return new Promise((resolve, reject) => {
       if (this.guild.memberCount === this.cache.size && !query && !limit && !presences && !user_ids) {
         resolve(this.cache);
         return;
       }
       if (!query && !user_ids) query = '';
-      if (!nonce) nonce = this.guild.id;
       this.guild.shard.send({
         op: OPCodes.REQUEST_GUILD_MEMBERS,
         d: {
@@ -240,7 +246,7 @@ class GuildMemberManager extends BaseManager {
           presences,
           user_ids,
           query,
-          nonce,
+          nonce: nonce.substring(0, 32),
           limit,
         },
       });

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -77,7 +77,7 @@ class GuildMemberManager extends BaseManager {
    * @property {number} [limit=0] Maximum number of members to request
    * @property {boolean} [withPresences=false] Whether or not to include the presences
    * @property {number} [time=120e3] Timeout for receipt of members
-   * @property {?string} nonce Nonce for this request (default to guild ID)
+   * @property {?string} nonce Nonce for this request (32 characters max - default to base 16 now timestamp)
    */
 
   /**

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -248,8 +248,8 @@ class GuildMemberManager extends BaseManager {
       const option = query || limit || presences || user_ids;
       let i = 0;
       const handler = (members, _, chunk) => {
-        if (chunk.nonce !== nonce) return;
         timeout.refresh();
+        if (chunk.nonce !== nonce) return;
         i++;
         for (const member of members.values()) {
           if (option) fetchedMembers.set(member.id, member);

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -258,7 +258,7 @@ class GuildMemberManager extends BaseManager {
           this.guild.memberCount <= this.cache.size ||
           (option && members.size < 1000) ||
           (limit && fetchedMembers.size >= limit) ||
-          i === chunk.count - 1
+          i === chunk.count
         ) {
           this.guild.client.removeListener(Events.GUILD_MEMBERS_CHUNK, handler);
           let fetched = option ? fetchedMembers : this.cache;

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -239,7 +239,7 @@ class GuildMemberManager extends BaseManager {
         return;
       }
       if (!query && !user_ids) query = '';
-      if (nonce.length > 32) throw new RangeError('FETCH_NONCE_LENGTH', 32);
+      if (nonce.length > 32) throw new RangeError('MEMBER_FETCH_NONCE_LENGTH');
       this.guild.shard.send({
         op: OPCodes.REQUEST_GUILD_MEMBERS,
         d: {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2391,6 +2391,7 @@ declare module 'discord.js' {
     limit?: number;
     withPresences?: boolean;
     time?: number;
+    nonce?: string;
   }
 
   interface FileOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2197,7 +2197,11 @@ declare module 'discord.js' {
     guildMemberAdd: [GuildMember | PartialGuildMember];
     guildMemberAvailable: [GuildMember | PartialGuildMember];
     guildMemberRemove: [GuildMember | PartialGuildMember];
-    guildMembersChunk: [Collection<Snowflake, GuildMember | PartialGuildMember>, Guild];
+    guildMembersChunk: [
+      Collection<Snowflake, GuildMember | PartialGuildMember>,
+      Guild,
+      { count: number; index: number; nonce: string | undefined },
+    ];
     guildMemberSpeaking: [GuildMember | PartialGuildMember, Readonly<Speaking>];
     guildMemberUpdate: [GuildMember | PartialGuildMember, GuildMember | PartialGuildMember];
     guildUpdate: [Guild, Guild];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR exposes `chunk_index`, `chunk_count` and `nonce` (if provided) properties in the `guildMembersChunk` event.
As a result, `GuildMemberManager#_fetchMany` was slightly redesigned to use these values :
- `nonce` is set to the guild ID unless a custom one was provided (this will allow several fetches at the same time)
- `count` is compared to a counter incremented on each chunk received (see below why I have chosen to not use `index`)

I have made the choice to use a counter that I increment on each chunk because I haven't seen anywhere the chunks are sent in the right order all the time. However, if the chunks are sent in order I'll make it use `index`.

I have also kept timeout because I believe, even if I can't find any use case, this might be useful in some cases (I don't even know which ones but well). If you feel like this isn't justified anymore, let me know so I can remove it.

This will definitely fix https://github.com/discordjs/discord.js/issues/4018 by the way.

Upstream PR for `chunk_index` and `chunk_count`: https://github.com/discord/discord-api-docs/pull/1545
Upstream PR for `nonce`: https://github.com/discord/discord-api-docs/pull/1549

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
