### PR TITLE
docs(ReactionCollector): update remove and dispose events

### DIFF
--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -103,7 +103,7 @@ class ReactionCollector extends Collector {
    */
   dispose(reaction, user) {
     /**
-     * Emitted whenever a reaction is disposed of.
+     * Emitted whenever a reaction is disposed of. Only emitted when the `dispose` option is set to true.
      * @event ReactionCollector#dispose
      * @param {MessageReaction} reaction The reaction that was disposed of
      * @param {User} user The user that removed the reaction

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -111,7 +111,8 @@ class ReactionCollector extends Collector {
     if (reaction.message.id !== this.message.id) return null;
 
     /**
-     * Emitted whenever a reaction is removed from a message and the `dispose` option is set to true. Will emit on all reaction removals,
+     * Emitted whenever a reaction is removed from a message and the `dispose` option is set to true. 
+     * Emits on all reaction removal.
      * as opposed to {@link Collector#dispose} which will only be emitted when the entire reaction
      * is removed.
      * @event ReactionCollector#remove

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -111,10 +111,9 @@ class ReactionCollector extends Collector {
     if (reaction.message.id !== this.message.id) return null;
 
     /**
-     * Emitted whenever a reaction is removed from a message and the `dispose` option is set to true. 
-     * Emits on all reaction removal.
-     * as opposed to {@link Collector#dispose} which will only be emitted when the entire reaction
-     * is removed.
+     * Emitted whenever a reaction is removed from a message and the `dispose` option is set to true.
+     * Will emit on all reaction removals, as opposed to {@link Collector#dispose} which will only 
+     * be emitted when the entire reaction is removed.
      * @event ReactionCollector#remove
      * @param {MessageReaction} reaction The reaction that was removed
      * @param {User} user The user that removed the reaction

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -103,7 +103,7 @@ class ReactionCollector extends Collector {
    */
   dispose(reaction, user) {
     /**
-     * Emitted whenever a reaction is disposed of. Only emitted when the `dispose` option is set to true.
+     * Emitted whenever a reaction is disposed of and the `dispose` option is set to true.
      * @event ReactionCollector#dispose
      * @param {MessageReaction} reaction The reaction that was disposed of
      * @param {User} user The user that removed the reaction
@@ -111,9 +111,9 @@ class ReactionCollector extends Collector {
     if (reaction.message.id !== this.message.id) return null;
 
     /**
-     * Emitted whenever a reaction is removed from a message. Will emit on all reaction removals,
+     * Emitted whenever a reaction is removed from a message and the `dispose` option is set to true. Will emit on all reaction removals,
      * as opposed to {@link Collector#dispose} which will only be emitted when the entire reaction
-     * is removed. Only emitted when the `dispose` option is set to true.
+     * is removed.
      * @event ReactionCollector#remove
      * @param {MessageReaction} reaction The reaction that was removed
      * @param {User} user The user that removed the reaction

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -112,7 +112,7 @@ class ReactionCollector extends Collector {
 
     /**
      * Emitted whenever a reaction is removed from a message and the `dispose` option is set to true.
-     * Will emit on all reaction removals, as opposed to {@link Collector#dispose} which will only 
+     * Will emit on all reaction removals, as opposed to {@link Collector#dispose} which will only
      * be emitted when the entire reaction is removed.
      * @event ReactionCollector#remove
      * @param {MessageReaction} reaction The reaction that was removed

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -113,7 +113,7 @@ class ReactionCollector extends Collector {
     /**
      * Emitted whenever a reaction is removed from a message. Will emit on all reaction removals,
      * as opposed to {@link Collector#dispose} which will only be emitted when the entire reaction
-     * is removed.
+     * is removed. Only emitted when the `dispose` option is set to true.
      * @event ReactionCollector#remove
      * @param {MessageReaction} reaction The reaction that was removed
      * @param {User} user The user that removed the reaction


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The ReactionCollector#remove event is only emitted when the `dispose` option is true. The docs don't properly document this.
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
