### PR TITLE
fix(Voice): correctly set speaking data in the voice ssrcMap

### DIFF
--- a/src/client/voice/networking/VoiceWebSocket.js
+++ b/src/client/voice/networking/VoiceWebSocket.js
@@ -189,7 +189,7 @@ class VoiceWebSocket extends EventEmitter {
         this.emit('sessionDescription', packet.d);
         break;
       case VoiceOPCodes.CLIENT_CONNECT:
-        this.connection.ssrcMap.set(+packet.d.audio_ssrc, packet.d.user_id);
+        this.connection.ssrcMap.set(+packet.d.audio_ssrc, { userID: packet.d.user_id, speaking: 0 });
         break;
       case VoiceOPCodes.CLIENT_DISCONNECT:
         const streamInfo = this.connection.receiver && this.connection.receiver.packets.streams.get(packet.d.user_id);

--- a/src/client/voice/receiver/PacketHandler.js
+++ b/src/client/voice/receiver/PacketHandler.js
@@ -86,6 +86,11 @@ class PacketHandler extends EventEmitter {
 
     let speakingTimeout = this.speakingTimeouts.get(ssrc);
     if (typeof speakingTimeout === 'undefined') {
+      // Ensure at least the speaking bit is set.
+      // As the object is by reference, it's only needed once per client re-connect.
+      if (userStat.speaking === 0) {
+        userStat.speaking = 1;
+      }
       this.connection.onSpeaking({ user_id: userStat.userID, ssrc: ssrc, speaking: userStat.speaking });
       speakingTimeout = this.receiver.connection.client.setTimeout(() => {
         try {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Addresses an issue where if a voice event was fired on the WebSocket connection, the value written to the ssrcMap was incorrect (just an ID, not an object). The WebSocket connection fires voice events when changing from voice to video and vice-versa.

Also addresses a knock on issue where the speaking state was assumed to already be at least a`1` (it's a bitmask), but because the WebSocket event is fired on the reconnect, it starts as `0`, and needs to be updated on the first Voice packet.

This also addresses an issue where the first `speaking` event for a users session would have the wrong bitmask.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
