### PR TITLE
feat(REST): allow options.query as URLSearchParams

### DIFF
--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -18,7 +18,7 @@ class APIRequest {
 
     let queryString = '';
     if (options.query) {
-      let query = (options.query instanceof URLSearchParams ? [...options.query] : Object.entries(options.query))
+      const query = (options.query instanceof URLSearchParams ? [...options.query] : Object.entries(options.query))
         // Filter out undefined query options
         .filter(([, value]) => ![null, 'null', 'undefined'].includes(value) && typeof value !== 'undefined');
       queryString = new URLSearchParams(query).toString();

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -18,8 +18,10 @@ class APIRequest {
 
     let queryString = '';
     if (options.query) {
-      // Filter out undefined query options
-      const query = Object.entries(options.query).filter(([, value]) => value !== null && typeof value !== 'undefined');
+      // Support for the query as params, such as in GuildMemberManager#prune
+      let query = (options.query instanceof URLSearchParams ? [...options.query] : Object.entries(options.query))
+        // Filter out undefined query options
+        .filter(([, value]) => ![null, 'null', 'undefined'].includes(value) && typeof value !== 'undefined');
       queryString = new URLSearchParams(query).toString();
     }
     this.path = `${path}${queryString && `?${queryString}`}`;

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -18,7 +18,6 @@ class APIRequest {
 
     let queryString = '';
     if (options.query) {
-      // Support for the query as params, such as in GuildMemberManager#prune
       let query = (options.query instanceof URLSearchParams ? [...options.query] : Object.entries(options.query))
         // Filter out undefined query options
         .filter(([, value]) => ![null, 'null', 'undefined'].includes(value) && typeof value !== 'undefined');

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -18,9 +18,9 @@ class APIRequest {
 
     let queryString = '';
     if (options.query) {
-      const query = (options.query instanceof URLSearchParams ? [...options.query] : Object.entries(options.query))
-        // Filter out undefined query options
-        .filter(([, value]) => ![null, 'null', 'undefined'].includes(value) && typeof value !== 'undefined');
+      const query = Object.entries(options.query)
+        .filter(([, value]) => ![null, 'null', 'undefined'].includes(value) && typeof value !== 'undefined')
+        .flatMap(([key, value]) => (Array.isArray(value) ? value.map(v => [key, v]) : [[key, value]]));
       queryString = new URLSearchParams(query).toString();
     }
     this.path = `${path}${queryString && `?${queryString}`}`;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds support for a request's `query` option to be either an object or URLSearchParams.

This is necessary for https://github.com/discordjs/discord.js/pull/4142 to function. [thanks vlad](https://github.com/discordjs/discord.js/pull/4142#discussion_r418109277)
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
