### PR TITLE
Remove permissions note from setChannel

### DIFF
--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -154,7 +154,7 @@ class VoiceState extends Base {
   /**
    * Moves the member to a different channel, or disconnects them from the one they're in.
    * @param {ChannelResolvable|null} [channel] Channel to move the member to, or `null` if you want to disconnect them
-   * from voice. Requires the `MOVE_MEMBERS` permission.
+   * from voice.
    * @param {string} [reason] Reason for moving member to another channel or disconnecting
    * @returns {Promise<GuildMember>}
    */


### PR DESCRIPTION
The docs on other methods do not reference permissions that are needed to perform them.  This removes the line from `voiceState#setChannel` to be consistent with the rest of the docs.

**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
