### PR TITLE
docs(ShardingManager): remove experimental status of Worker threads

### DIFF
--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -20,9 +20,7 @@ const Util = require('../util/Util');
 class ShardingManager extends EventEmitter {
   /**
    * The mode to spawn shards with for a {@link ShardingManager}: either "process" to use child processes, or
-   * "worker" to use workers. The "worker" mode relies on the experimental
-   * [Worker threads](https://nodejs.org/api/worker_threads.html) functionality that is present in Node v10.5.0 or
-   * newer. Node must be started with the `--experimental-worker` flag to expose it.
+   * "worker" to use [Worker threads][Worker threads](https://nodejs.org/api/worker_threads.html).
    * @typedef {Object} ShardingManagerMode
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This changes the JSDoc for `ShardingManagerMode` to remove mention of Worker threads being experimental. Node 12+ is required for the master branch, and Worker threads are stable since Node 12, so it makes sense.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
