### PR TITLE
docs(ShardingManager): fix typo in JSDoc

### DIFF
--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -20,7 +20,7 @@ const Util = require('../util/Util');
 class ShardingManager extends EventEmitter {
   /**
    * The mode to spawn shards with for a {@link ShardingManager}: either "process" to use child processes, or
-   * "worker" to use [Worker threads][Worker threads](https://nodejs.org/api/worker_threads.html).
+   * "worker" to use [Worker threads](https://nodejs.org/api/worker_threads.html).
    * @typedef {Object} ShardingManagerMode
    */
 


### PR DESCRIPTION
Fix typo introduced in PR #4157 in the link to Node docs

**Please describe the changes this PR makes and why it should be merged:**

Mea culpa, I botched the markdown on my previous PR.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
