### PR TITLE
fix(typings): allow custom events

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -198,6 +198,12 @@ declare module 'discord.js' {
 
     public emit<K extends keyof ClientEvents>(event: K, ...args: ClientEvents[K]): boolean;
     public emit<S extends string>(event: Exclude<S, keyof ClientEvents>, ...args: any[]): boolean;
+
+    public off<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
+    public off<S extends string>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
+
+    public removeAllListeners<K extends keyof ClientEvents>(event?: K): this;
+    public removeAllListeners<S extends string | symbol>(event?: Exclude<S, keyof ClientEvents>): this;
   }
 
   export class ClientApplication extends Base {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -191,16 +191,16 @@ declare module 'discord.js' {
     public toJSON(): object;
 
     public on<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
-    public on<S extends string>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
+    public on<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
 
     public once<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
-    public once<S extends string>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
+    public once<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
 
     public emit<K extends keyof ClientEvents>(event: K, ...args: ClientEvents[K]): boolean;
-    public emit<S extends string>(event: Exclude<S, keyof ClientEvents>, ...args: any[]): boolean;
+    public emit<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, ...args: any[]): boolean;
 
     public off<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
-    public off<S extends string>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
+    public off<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
 
     public removeAllListeners<K extends keyof ClientEvents>(event?: K): this;
     public removeAllListeners<S extends string | symbol>(event?: Exclude<S, keyof ClientEvents>): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -190,11 +190,14 @@ declare module 'discord.js' {
     public sweepMessages(lifetime?: number): number;
     public toJSON(): object;
 
-    public on<K extends keyof ClientEvents, S extends K | string>(event: S, listener: (...args: S extends K ? ClientEvents[K] : any[]) => void): this;
+    public on<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
+    public on<S extends string>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
 
-    public once<K extends keyof ClientEvents, S extends K | string>(event: S, listener: (...args: S extends K ? ClientEvents[K] : any[]) => void): this;
+    public once<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
+    public once<S extends string>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
 
-    public emit<K extends keyof ClientEvents, S extends K | string>(event: S, ...args: S extends K ? ClientEvents[K] : any[]): boolean;
+    public emit<K extends keyof ClientEvents>(event: K, ...args: ClientEvents[K]): boolean;
+    public emit<S extends string>(event: Exclude<S, keyof ClientEvents>, ...args: any[]): boolean;
   }
 
   export class ClientApplication extends Base {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -190,11 +190,11 @@ declare module 'discord.js' {
     public sweepMessages(lifetime?: number): number;
     public toJSON(): object;
 
-    public on<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
+    public on<K extends keyof ClientEvents, S extends K | string>(event: S, listener: (...args: S extends K ? ClientEvents[K] : any[]) => void): this;
 
-    public once<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
+    public once<K extends keyof ClientEvents, S extends K | string>(event: S, listener: (...args: S extends K ? ClientEvents[K] : any[]) => void): this;
 
-    public emit<K extends keyof ClientEvents>(event: K, ...args: ClientEvents[K]): boolean;
+    public emit<K extends keyof ClientEvents, S extends K | string>(event: S, ...args: S extends K ? ClientEvents[K] : any[]): boolean;
   }
 
   export class ClientApplication extends Base {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently, you are only allowed to emit and listen to discord.js events. However, this is not correct, you should be able to create and emit custom events (since the methods come from the Node.js EventEmitter).

This can be easily done by adding a method overload in the typings. I also included the `off()` and `removeAllListeners()` methods, because I thought it was weird that they were left out. 

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
