### PR TITLE
revert "chore(docs): example for timeout in message.delete()"

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -496,11 +496,6 @@ class Message extends Base {
    * message.delete({ timeout: 5000 })
    *   .then(msg => console.log(`Deleted message from ${msg.author.username} after 5 seconds`))
    *   .catch(console.error);
-   * @example
-   * // Delete a message after a short delay
-   * message.delete({ timeout: 5000 })
-   *   .then(msg => console.log(`Deleted message from ${msg.author.username} after a delay`))
-   *   .catch(console.error)
    */
   delete(options = {}) {
     if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);


### PR DESCRIPTION
This PR reverts #4165 as it is a somewhat duplicate of #4090.

This went unnoticed because #4165 (or rather its branch) did not include the change of #4090, so it looked like the above example was not using an options object.


