### PR TITLE
fix: in/de-crement max listener for client events

### DIFF
--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -139,6 +139,26 @@ class BaseClient extends EventEmitter {
     this._immediates.delete(immediate);
   }
 
+  /**
+   * Increments max listeners by one, if they are not zero.
+   * @private
+   */
+  incrementMaxListeners() {
+    if (this.getMaxListeners() !== 0) {
+      this.setMaxListeners(this.getMaxListeners() + 1);
+    }
+  }
+
+  /**
+   * Decrements max listeners by one, if they are not zero.
+   * @private
+   */
+  decrementMaxListeners() {
+    if (this.getMaxListeners() !== 0) {
+      this.setMaxListeners(this.getMaxListeners() - 1);
+    }
+  }
+
   toJSON(...props) {
     return Util.flatten(this, { domain: false }, ...props);
   }

--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -144,8 +144,9 @@ class BaseClient extends EventEmitter {
    * @private
    */
   incrementMaxListeners() {
-    if (this.getMaxListeners() !== 0) {
-      this.setMaxListeners(this.getMaxListeners() + 1);
+    const maxListeners = this.getMaxListeners();
+    if (maxListeners !== 0) {
+      this.setMaxListeners(maxListeners + 1);
     }
   }
 
@@ -154,8 +155,9 @@ class BaseClient extends EventEmitter {
    * @private
    */
   decrementMaxListeners() {
-    if (this.getMaxListeners() !== 0) {
-      this.setMaxListeners(this.getMaxListeners() - 1);
+    const maxListeners = this.getMaxListeners();
+    if (maxListeners !== 0) {
+      this.setMaxListeners(maxListeners - 1);
     }
   }
 

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -196,15 +196,18 @@ class GuildManager extends BaseManager {
 
           const handleGuild = guild => {
             if (guild.id === data.id) {
-              this.client.removeListener(Events.GUILD_CREATE, handleGuild);
               this.client.clearTimeout(timeout);
+              this.client.removeListener(Events.GUILD_CREATE, handleGuild);
+              this.client.decrementMaxListeners();
               resolve(guild);
             }
           };
+          this.client.incrementMaxListeners();
           this.client.on(Events.GUILD_CREATE, handleGuild);
 
           const timeout = this.client.setTimeout(() => {
             this.client.removeListener(Events.GUILD_CREATE, handleGuild);
+            this.client.decrementMaxListeners();
             resolve(this.client.guilds.add(data));
           }, 10000);
           return undefined;

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -267,17 +267,21 @@ class GuildMemberManager extends BaseManager {
           (limit && fetchedMembers.size >= limit) ||
           i === chunk.count
         ) {
-          this.guild.client.removeListener(Events.GUILD_MEMBERS_CHUNK, handler);
+          this.client.clearTimeout(timeout);
+          this.client.removeListener(Events.GUILD_MEMBERS_CHUNK, handler);
+          this.client.decrementMaxListeners();
           let fetched = option ? fetchedMembers : this.cache;
           if (user_ids && !Array.isArray(user_ids) && fetched.size) fetched = fetched.first();
           resolve(fetched);
         }
       };
-      const timeout = this.guild.client.setTimeout(() => {
-        this.guild.client.removeListener(Events.GUILD_MEMBERS_CHUNK, handler);
+      const timeout = this.client.setTimeout(() => {
+        this.client.removeListener(Events.GUILD_MEMBERS_CHUNK, handler);
+        this.client.decrementMaxListeners();
         reject(new Error('GUILD_MEMBERS_TIMEOUT'));
       }, time);
-      this.guild.client.on(Events.GUILD_MEMBERS_CHUNK, handler);
+      this.client.incrementMaxListeners();
+      this.client.on(Events.GUILD_MEMBERS_CHUNK, handler);
     });
   }
 }

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -42,7 +42,7 @@ class MessageCollector extends Collector {
     this._handleChannelDeletion = this._handleChannelDeletion.bind(this);
     this._handleGuildDeletion = this._handleGuildDeletion.bind(this);
 
-    if (this.client.getMaxListeners() !== 0) this.client.setMaxListeners(this.client.getMaxListeners() + 1);
+    this.client.incrementMaxListeners();
     this.client.on(Events.MESSAGE_CREATE, this.handleCollect);
     this.client.on(Events.MESSAGE_DELETE, this.handleDispose);
     this.client.on(Events.MESSAGE_BULK_DELETE, bulkDeleteListener);
@@ -55,7 +55,7 @@ class MessageCollector extends Collector {
       this.client.removeListener(Events.MESSAGE_BULK_DELETE, bulkDeleteListener);
       this.client.removeListener(Events.CHANNEL_DELETE, this._handleChannelDeletion);
       this.client.removeListener(Events.GUILD_DELETE, this._handleGuildDeletion);
-      if (this.client.getMaxListeners() !== 0) this.client.setMaxListeners(this.client.getMaxListeners() - 1);
+      this.client.decrementMaxListeners();
     });
   }
 

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -49,7 +49,7 @@ class ReactionCollector extends Collector {
     this._handleGuildDeletion = this._handleGuildDeletion.bind(this);
     this._handleMessageDeletion = this._handleMessageDeletion.bind(this);
 
-    if (this.client.getMaxListeners() !== 0) this.client.setMaxListeners(this.client.getMaxListeners() + 1);
+    this.client.incrementMaxListeners();
     this.client.on(Events.MESSAGE_REACTION_ADD, this.handleCollect);
     this.client.on(Events.MESSAGE_REACTION_REMOVE, this.handleDispose);
     this.client.on(Events.MESSAGE_REACTION_REMOVE_ALL, this.empty);
@@ -64,7 +64,7 @@ class ReactionCollector extends Collector {
       this.client.removeListener(Events.MESSAGE_DELETE, this._handleMessageDeletion);
       this.client.removeListener(Events.CHANNEL_DELETE, this._handleChannelDeletion);
       this.client.removeListener(Events.GUILD_DELETE, this._handleGuildDeletion);
-      if (this.client.getMaxListeners() !== 0) this.client.setMaxListeners(this.client.getMaxListeners() - 1);
+      this.client.decrementMaxListeners();
     });
 
     this.on('collect', (reaction, user) => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -96,6 +96,8 @@ declare module 'discord.js' {
     private _immediates: Set<NodeJS.Immediate>;
     private readonly api: object;
     private rest: object;
+    private decrementMaxListeners(): void;
+    private incrementMaxListeners(): void;
 
     public options: ClientOptions;
     public clearInterval(interval: NodeJS.Timer): void;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #3943 by temporarily incrementing the max listener count when attaching a temporary listener.

I also moved the logic to in- and decrement into `BaseClient#incrementMaxListeners` and respectively `BaseClient#decrementMaxListeners`.


**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
