### PR TITLE
fix(APIMessage): only pass allowedMentions if content is defined

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -191,7 +191,7 @@ class APIMessage {
       embeds,
       username,
       avatar_url: avatarURL,
-      allowed_mentions: typeof content === 'string' ? allowedMentions : null,
+      allowed_mentions: typeof content === 'string' ? allowedMentions : undefined,
       flags,
     };
     return this;

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -88,14 +88,16 @@ class APIMessage {
       content = Util.resolveString(this.options.content);
     }
 
+    if (typeof content !== 'string') return;
+
     const disableMentions =
       typeof this.options.disableMentions === 'undefined'
         ? this.target.client.options.disableMentions
         : this.options.disableMentions;
     if (disableMentions === 'all') {
-      content = Util.removeMentions(content || '');
+      content = Util.removeMentions(content);
     } else if (disableMentions === 'everyone') {
-      content = (content || '').replace(/@([^<>@ ]*)/gmsu, (match, target) => {
+      content = (content).replace(/@([^<>@ ]*)/gmsu, (match, target) => {
         if (target.match(/^[&!]?\d+$/)) {
           return `@${target}`;
         } else {
@@ -120,17 +122,17 @@ class APIMessage {
     if (content || mentionPart) {
       if (isCode) {
         const codeName = typeof this.options.code === 'string' ? this.options.code : '';
-        content = `${mentionPart}\`\`\`${codeName}\n${Util.cleanCodeBlockContent(content || '')}\n\`\`\``;
+        content = `${mentionPart}\`\`\`${codeName}\n${Util.cleanCodeBlockContent(content)}\n\`\`\``;
         if (isSplit) {
           splitOptions.prepend = `${splitOptions.prepend || ''}\`\`\`${codeName}\n`;
           splitOptions.append = `\n\`\`\`${splitOptions.append || ''}`;
         }
       } else if (mentionPart) {
-        content = `${mentionPart}${content || ''}`;
+        content = `${mentionPart}${content}`;
       }
 
       if (isSplit) {
-        content = Util.splitMessage(content || '', splitOptions);
+        content = Util.splitMessage(content, splitOptions);
       }
     }
 
@@ -189,7 +191,7 @@ class APIMessage {
       embeds,
       username,
       avatar_url: avatarURL,
-      allowed_mentions: allowedMentions,
+      allowed_mentions: typeof content === 'string' ? allowedMentions : null,
       flags,
     };
     return this;

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -88,7 +88,7 @@ class APIMessage {
       content = Util.resolveString(this.options.content);
     }
 
-    if (typeof content !== 'string') return;
+    if (typeof content !== 'string') return content;
 
     const disableMentions =
       typeof this.options.disableMentions === 'undefined'
@@ -97,7 +97,7 @@ class APIMessage {
     if (disableMentions === 'all') {
       content = Util.removeMentions(content);
     } else if (disableMentions === 'everyone') {
-      content = (content).replace(/@([^<>@ ]*)/gmsu, (match, target) => {
+      content = content.replace(/@([^<>@ ]*)/gmsu, (match, target) => {
         if (target.match(/^[&!]?\d+$/)) {
           return `@${target}`;
         } else {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #4170 this PR changes `APIMessage#makeContent` to return undefined if the content passed is undefined, like its supposed to, as previously having the `disableMentions` client option enabled would pass an empty string, removing content on methods such as `Message#suppressEmbeds`, it also only passes `allowedMentions` if there is content, this fixes a bug to do with using `Message#suppressEmbeds` on a message authored by another user while the `allowedMentions` client option is enabled (API would throw an error, because flags and allowed_mentions were passed and only flags should have been)

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
