### PR TITLE
fix(DataResolver): resolveInviteCode to support new domain

### DIFF
--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -30,7 +30,7 @@ class DataResolver {
    * @returns {string}
    */
   static resolveInviteCode(data) {
-    const inviteRegex = /discord(?:app\.com\/invite|\.gg(?:\/invite)?)\/([\w-]{2,255})/i;
+    const inviteRegex = /discord(?:(?:app)?\.com\/invite|\.gg(?:\/invite)?)\/([\w-]{2,255})/i;
     const match = inviteRegex.exec(data);
     if (match && match[1]) return match[1];
     return data;


### PR DESCRIPTION
Update resolveInviteCode method to support "discord.com/invite" links.

**Please describe the changes this PR makes and why it should be merged:**
Will support the new discord.com domain for resolving link invites.
Only changed regex, nothing else. Theres probably a butt load of other things to do, but I figured this would help.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes

- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
