### PR TITLE
feat(VoiceReceiver): createStream add channels and rate params

### DIFF
--- a/src/client/voice/receiver/Receiver.js
+++ b/src/client/voice/receiver/Receiver.js
@@ -31,6 +31,8 @@ class VoiceReceiver extends EventEmitter {
    * @property {string} [mode='opus'] The mode for audio output. This defaults to opus, meaning discord.js won't decode
    * the packets for you. You can set this to 'pcm' so that the stream's output will be 16-bit little-endian stereo
    * audio
+   * @property {number} [channels=2] The number of channels in the output stream for pcm mode. Defaults to 2 for stereo.
+   * @property {number} [rate=48000] The audio sample rate (in Hz) of the output stream for pcm mode. Defaults to 48000.
    * @property {string} [end='silence'] When the stream should be destroyed. If `silence`, this will be when the user
    * stops talking. Otherwise, if `manual`, this should be handled by you.
    */
@@ -42,12 +44,12 @@ class VoiceReceiver extends EventEmitter {
    * @param {ReceiveStreamOptions} options Options.
    * @returns {ReadableStream}
    */
-  createStream(user, { mode = 'opus', end = 'silence' } = {}) {
+  createStream(user, { mode = 'opus', end = 'silence', channels = 2, rate = 48000 } = {}) {
     user = this.connection.client.users.resolve(user);
     if (!user) throw new Error('VOICE_USER_MISSING');
     const stream = this.packets.makeStream(user.id, end);
     if (mode === 'pcm') {
-      const decoder = new prism.opus.Decoder({ channels: 2, rate: 48000, frameSize: 960 });
+      const decoder = new prism.opus.Decoder({ channels: channels, rate: rate, frameSize: 960 });
       stream.pipe(decoder);
       return decoder;
     }

--- a/src/client/voice/receiver/Receiver.js
+++ b/src/client/voice/receiver/Receiver.js
@@ -49,7 +49,7 @@ class VoiceReceiver extends EventEmitter {
     if (!user) throw new Error('VOICE_USER_MISSING');
     const stream = this.packets.makeStream(user.id, end);
     if (mode === 'pcm') {
-      const decoder = new prism.opus.Decoder({ channels: channels, rate: rate, frameSize: 960 });
+      const decoder = new prism.opus.Decoder({ channels, rate, frameSize: 960 });
       stream.pipe(decoder);
       return decoder;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1633,7 +1633,7 @@ declare module 'discord.js' {
     constructor(connection: VoiceConnection);
     public createStream(
       user: UserResolvable,
-      options?: { mode?: 'opus' | 'pcm'; end?: 'silence' | 'manual' },
+      options?: { mode?: 'opus' | 'pcm'; channels?: number; rate?: number; end?: 'silence' | 'manual' },
     ): Readable;
 
     public on(event: 'debug', listener: (error: Error | string) => void): this;


### PR DESCRIPTION
Allow setting the number of channels and sample rate for receiver stream

**Please describe the changes this PR makes and why it should be merged:**
Adds the option to set the number of channels and sample rate when creating a voice receiver stream. 

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
