### PR TITLE
docs(Guild): description of Guild#premiumSubscriptionCount

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -223,7 +223,7 @@ class Guild extends Base {
     this.premiumTier = data.premium_tier;
 
     /**
-     * The total number of users currently boosting this server
+     * The total number of boosts for this server
      * @type {?number}
      * @name Guild#premiumSubscriptionCount
      */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Guild#premiumSubscriptionCount returns the amount of boosts, not the amount of boosters which applied them (this metric is not available)

since discord now allows multiple boosts per person the current description is no longer applicable

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
