### PR TITLE
docs(GuildManager): resolve returns a GuildChannel

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -46,7 +46,7 @@ class GuildChannelManager extends BaseManager {
    * @memberof GuildChannelManager
    * @instance
    * @param {GuildChannelResolvable} channel The GuildChannel resolvable to resolve
-   * @returns {?Channel}
+   * @returns {?GuildChannel}
    */
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR corrects the docs for `GuildChannelManager` for resolve to return a `GuildChannel
**Status**
fixes #4332 
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)` rather than a `Channel`
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
