### PR TITLE
feat(GuildEmoji): cache the author

### DIFF
--- a/src/structures/BaseGuildEmoji.js
+++ b/src/structures/BaseGuildEmoji.js
@@ -51,8 +51,6 @@ class BaseGuildEmoji extends Emoji {
      */
     if (typeof data.available !== 'undefined') this.available = data.available;
 
-    if (typeof data.user !== 'undefined') this.author = this.client.users.add(data.user);
-
     if (data.roles) this._roles = data.roles;
   }
 }

--- a/src/structures/BaseGuildEmoji.js
+++ b/src/structures/BaseGuildEmoji.js
@@ -51,6 +51,8 @@ class BaseGuildEmoji extends Emoji {
      */
     if (typeof data.available !== 'undefined') this.available = data.available;
 
+    if (typeof data.user !== 'undefined') this.author = this.client.users.add(data.user);
+
     if (data.roles) this._roles = data.roles;
   }
 }

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -15,7 +15,7 @@ class GuildEmoji extends BaseGuildEmoji {
 
     /**
      * The user who created this emoji
-     * @type {User|null}
+     * @type {?User}
      */
     this.author = null;
   }

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -10,14 +10,15 @@ const Permissions = require('../util/Permissions');
  * @extends {BaseGuildEmoji}
  */
 class GuildEmoji extends BaseGuildEmoji {
-  /**
-   * @name GuildEmoji
-   * @kind constructor
-   * @memberof GuildEmoji
-   * @param {Client} client The instantiating client
-   * @param {Object} data The data for the guild emoji
-   * @param {Guild} guild The guild the guild emoji is part of
-   */
+  constructor(client, data, guild) {
+    super(client, data, guild);
+
+    /**
+     * The user who created this emoji
+     * @type {User|null}
+     */
+    this.author = null;
+  }
 
   /**
    * The guild this emoji is part of
@@ -67,7 +68,7 @@ class GuildEmoji extends BaseGuildEmoji {
       .guilds(this.guild.id)
       .emojis(this.id)
       .get()
-      .then(emoji => this.client.users.add(emoji.user));
+      .then(emoji => this._patch(emoji) || this.author);
   }
 
   /**

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -10,6 +10,11 @@ const Permissions = require('../util/Permissions');
  * @extends {BaseGuildEmoji}
  */
 class GuildEmoji extends BaseGuildEmoji {
+  /**
+   * @param {Client} client The instantiating client
+   * @param {Object} data The data for the guild emoji
+   * @param {Guild} guild The guild the guild emoji is part of
+   */
   constructor(client, data, guild) {
     super(client, data, guild);
 
@@ -30,6 +35,11 @@ class GuildEmoji extends BaseGuildEmoji {
     const clone = super._clone();
     clone._roles = this._roles.slice();
     return clone;
+  }
+
+  _patch(data) {
+    super._patch(data);
+    if (typeof data.user !== 'undefined') this.author = this.client.users.add(data.user);
   }
 
   /**
@@ -55,20 +65,21 @@ class GuildEmoji extends BaseGuildEmoji {
    * Fetches the author for this emoji
    * @returns {Promise<User>}
    */
-  fetchAuthor() {
+  async fetchAuthor() {
     if (this.managed) {
-      return Promise.reject(new Error('EMOJI_MANAGED'));
+      throw new Error('EMOJI_MANAGED');
     } else {
-      if (!this.guild.me) return Promise.reject(new Error('GUILD_UNCACHED_ME'));
+      if (!this.guild.me) throw new Error('GUILD_UNCACHED_ME');
       if (!this.guild.me.permissions.has(Permissions.FLAGS.MANAGE_EMOJIS)) {
-        return Promise.reject(new Error('MISSING_MANAGE_EMOJIS_PERMISSION', this.guild));
+        throw new Error('MISSING_MANAGE_EMOJIS_PERMISSION', this.guild);
       }
     }
-    return this.client.api
+    const data = await this.client.api
       .guilds(this.guild.id)
       .emojis(this.id)
-      .get()
-      .then(emoji => this._patch(emoji) || this.author);
+      .get();
+    this._patch(data);
+    return this.author;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -773,6 +773,7 @@ declare module 'discord.js' {
   export class GuildEmoji extends BaseGuildEmoji {
     public readonly deletable: boolean;
     public guild: Guild;
+    public author: User | null;
     public readonly roles: GuildEmojiRoleManager;
     public readonly url: string;
     public delete(reason?: string): Promise<GuildEmoji>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`GuildEmoji#fetchAuthor` fetches the emoji's author by fetching the entire emoji via `GET /guilds/:id/emojis/:id` and returns `.user`, but only adds it to `Client#users#cache`. This PR also assigns it to `GuildEmoji#author` to reduce API calls.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
