### PR TITLE
fix(Guild): change wrong description & call fetchVanityData internally

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -336,7 +336,7 @@ class Guild extends Base {
     /* eslint-disable max-len */
     /**
      * The use count of the vanity URL code of the guild, if any
-     * <info>You will need to fetch the guild using {@link Guild#fetchVanityCode} if you want to receive this parameter</info>
+     * <info>You will need to fetch the guild using {@link Guild#fetchVanityData} if you want to receive this parameter</info>
      * @type {?number}
      */
     this.vanityURLUses = null;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -771,13 +771,7 @@ class Guild extends Base {
    *   .catch(console.error);
    */
   fetchVanityCode() {
-    if (!this.features.includes('VANITY_URL')) {
-      return Promise.reject(new Error('VANITY_URL'));
-    }
-    return this.client.api
-      .guilds(this.id, 'vanity-url')
-      .get()
-      .then(res => res.code);
+    return this.fetchVanityData().then(vanity => vanity.code);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -336,7 +336,7 @@ class Guild extends Base {
     /* eslint-disable max-len */
     /**
      * The use count of the vanity URL code of the guild, if any
-     * <info>You will need to fetch the guild using {@link Guild#fetchVanityData} if you want to receive this parameter</info>
+     * <info>You will need to fetch this parameter using {@link Guild#fetchVanityData} if you want to receive it</info>
      * @type {?number}
      */
     this.vanityURLUses = null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The docs for vanityURLUses mention the need to use `Guild#fetchVanityCode` (and not `Guild#fetchVanityData`), which is wrong.
Also, this PR makes it that even when only calling fetchVanityCode, it will internally call fetchVanityData, so the users would be set anyway.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
**This PR includes internal code changes as well as documentation changes.**