### PR TITLE
feat: add Blob support for browser

### DIFF
--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -88,6 +88,7 @@ class DataResolver {
   static async resolveFile(resource) {
     if (!browser && Buffer.isBuffer(resource)) return resource;
     if (browser && resource instanceof ArrayBuffer) return Util.convertToBuffer(resource);
+    if (browser && resource instanceof Blob) return resource;
     if (resource instanceof stream.Readable) return resource;
 
     if (typeof resource === 'string') {

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -89,7 +89,6 @@ class DataResolver {
     if (!browser && Buffer.isBuffer(resource)) return resource;
     if (browser && resource instanceof ArrayBuffer) return Util.convertToBuffer(resource);
     // eslint-disable-next-line no-undef
-    // eslint-disable-next-line no-undef
     if (browser && resource instanceof Blob) return resource;
     if (resource instanceof stream.Readable) return resource;
 

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -89,6 +89,7 @@ class DataResolver {
     if (!browser && Buffer.isBuffer(resource)) return resource;
     if (browser && resource instanceof ArrayBuffer) return Util.convertToBuffer(resource);
     // eslint-disable-next-line no-undef
+    // eslint-disable-next-line no-undef
     if (browser && resource instanceof Blob) return resource;
     if (resource instanceof stream.Readable) return resource;
 

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -88,6 +88,7 @@ class DataResolver {
   static async resolveFile(resource) {
     if (!browser && Buffer.isBuffer(resource)) return resource;
     if (browser && resource instanceof ArrayBuffer) return Util.convertToBuffer(resource);
+    // eslint-disable-next-line no-undef
     if (browser && resource instanceof Blob) return resource;
     if (resource instanceof stream.Readable) return resource;
 


### PR DESCRIPTION
I could not get browser based discord.js file attachments working with dynamic content (string).

I tried the different methods BufferResolvable/Stream.

Using a TextEncoder, I can convert the string into an ArrayBuffer. After some tinkering, the main issue is that FormData.append() expects a Blob instead of an ArrayBuffer. The Blob was rejected in resolveFile. I patched one line to pass through Blobs and now it works for my use case.

At least with Google Chrome Version 83.0.4103.97 (Official Build) (32-bit) and Firefox.

One problem is that stream in the documentation refers to discord.js audio streams instead of std stream, but I am not sure about that. Anyway, it rejected my File stream as File Attachment.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
