### PR TITLE
feat(voiceState): add self_video property

### DIFF
--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -60,6 +60,7 @@ class VoiceState extends Base {
     this.streaming = data.self_stream || false;
     /**
      * Whether this member's camera is enabled
+     * @type {boolean}
      */
     this.video = data.self_video;
     /**

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -49,6 +49,11 @@ class VoiceState extends Base {
      */
     this.selfMute = data.self_mute;
     /**
+     * Whether this member's camera is enabled
+     * @type {boolean}
+     */
+    this.selfVideo = data.self_video;
+    /**
      * The session ID of this member's connection
      * @type {?string}
      */
@@ -58,11 +63,6 @@ class VoiceState extends Base {
      * @type {boolean}
      */
     this.streaming = data.self_stream || false;
-    /**
-     * Whether this member's camera is enabled
-     * @type {boolean}
-     */
-    this.video = data.self_video;
     /**
      * The ID of the voice channel that this member is in
      * @type {?Snowflake}

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -59,6 +59,10 @@ class VoiceState extends Base {
      */
     this.streaming = data.self_stream || false;
     /**
+     * Whether this member's camera is enabled
+     */
+    this.video = data.self_video;
+    /**
      * The ID of the voice channel that this member is in
      * @type {?Snowflake}
      */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1672,7 +1672,7 @@ declare module 'discord.js' {
     public serverMute?: boolean;
     public sessionID?: string;
     public streaming: boolean;
-    public video: boolean;
+    public selfVideo: boolean;
     public readonly speaking: boolean | null;
 
     public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1672,6 +1672,7 @@ declare module 'discord.js' {
     public serverMute?: boolean;
     public sessionID?: string;
     public streaming: boolean;
+    public video: boolean;
     public readonly speaking: boolean | null;
 
     public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add the documented [self_video](https://discord.com/developers/docs/resources/voice#voice-state-object-voice-state-structure) property to the voiceState.

Per #4340 and [#1729](https://github.com/discord/discord-api-docs/pull/1729)

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
