### PR TITLE
fix: typing start event emitting on non text based channels

### DIFF
--- a/src/client/websocket/handlers/TYPING_START.js
+++ b/src/client/websocket/handlers/TYPING_START.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const { Events } = require('../../../util/Constants');
 const textBasedChannelTypes = ['dm', 'text', 'news'];
 

--- a/src/client/websocket/handlers/TYPING_START.js
+++ b/src/client/websocket/handlers/TYPING_START.js
@@ -9,10 +9,7 @@ module.exports = (client, { d: data }) => {
 
   if (channel && user) {
     if (!textBasedChannelTypes.includes(channel.type)) {
-      client.emit(
-        Events.WARN,
-        `Discord sent a typing packet to a non text based channel (id: ${channel.id}, type: ${channel.type}).`,
-      );
+      client.emit(Events.WARN, `Discord sent a typing packet to a ${channel.type} channel ${channel.id}`);
       return;
     }
 

--- a/src/client/websocket/handlers/TYPING_START.js
+++ b/src/client/websocket/handlers/TYPING_START.js
@@ -1,11 +1,11 @@
 'use strict';
 const { Events } = require('../../../util/Constants');
+const textBasedChannelTypes = ['dm', 'text', 'news'];
 
 module.exports = (client, { d: data }) => {
   const channel = client.channels.cache.get(data.channel_id);
   const user = client.users.cache.get(data.user_id);
   const timestamp = new Date(data.timestamp * 1000);
-  const textBasedChannelTypes = ['dm', 'text', 'news'];
 
   if (channel && user) {
     if (!textBasedChannelTypes.includes(channel.type)) {

--- a/src/client/websocket/handlers/TYPING_START.js
+++ b/src/client/websocket/handlers/TYPING_START.js
@@ -1,15 +1,18 @@
 'use strict';
-
 const { Events } = require('../../../util/Constants');
 
 module.exports = (client, { d: data }) => {
   const channel = client.channels.cache.get(data.channel_id);
   const user = client.users.cache.get(data.user_id);
   const timestamp = new Date(data.timestamp * 1000);
+  const textBasedChannelTypes = ['dm', 'text', 'news'];
 
   if (channel && user) {
-    if (channel.type === 'voice') {
-      client.emit(Events.WARN, `Discord sent a typing packet to a voice channel ${channel.id}`);
+    if (!textBasedChannelTypes.includes(channel.type)) {
+      client.emit(
+        Events.WARN,
+        `Discord sent a typing packet to a non text based channel (id: ${channel.id}, type: ${channel.type}).`,
+      );
       return;
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

A user has recently reported the following error:

<details><summary>Stacktrace</summary>

```
node_modules\discord.js\src\client\websocket\handlers\TYPING_START.js:16    if (channel._typing.has(user.id)) {
                        ^

TypeError: Cannot read property 'has' of undefined
    at Object.module.exports [as TYPING_START] (C:\Users\--snip--\Desktop\bot\node_modules\discord.js\src\client\websocket\handlers\TYPING_START.js:16:25)
    at WebSocketManager.handlePacket (C:\Users\--snip--\Desktop\bot\node_modules\discord.js\src\client\websocket\WebSocketManager.js:386:31)
    at WebSocketShard.onPacket (C:\Users\--snip--\Desktop\bot\node_modules\discord.js\src\client\websocket\WebSocketShard.js:436:22)
    at WebSocketShard.onMessage (C:\Users\--snip--\Desktop\bot\node_modules\discord.js\src\client\websocket\WebSocketShard.js:293:10)
    at WebSocket.onMessage (C:\Users\--snip--\Desktop\bot\node_modules\ws\lib\event-target.js:125:16)
    at WebSocket.emit (events.js:310:20)
    at Receiver.receiverOnMessage (C:\Users\--snip--\Desktop\bot\node_modules\ws\lib\websocket.js:800:20)
    at Receiver.emit (events.js:310:20)
    at Receiver.dataMessage (C:\Users\--snip--\Desktop\bot\node_modules\ws\lib\receiver.js:436:14)
    at Receiver.getData (C:\Users\--snip--\Desktop\bot\node_modules\ws\lib\receiver.js:366:17)
```
</details>

After some digging this seems to have occurred by a TYPING_START event being emitted on a non text based channel (thus not having a `_typing` Map to call #has on), which the library currently does not exhaustively exclude.

After some further investigation on the discord API discord typing can apparently be accepted for any channel and the library needs to handle this.

I have attempted to do so in this PR by:
- returning if the exhaustive check for text based channels is not satisfied.
- enhancing the WARN line with more information (channel type) ⚠*

_⚠* If warn values are considered part of the public facing API this is a semver minor, else patch could be applicable._

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
