### PR TITLE
Make the token read only

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -202,7 +202,11 @@ class Client extends BaseClient {
    */
   async login(token = this.token) {
     if (!token || typeof token !== 'string') throw new Error('TOKEN_INVALID');
-    this.token = token = token.replace(/^(Bot|Bearer)\s*/i, '');
+    Object.defineProperty(this, "token", {
+      value: token.replace(/^(Bot|Bearer)\s*/i, ''),
+      writable: false
+    });
+    token = this.token
     this.emit(
       Events.DEBUG,
       `Provided token: ${token
@@ -210,7 +214,7 @@ class Client extends BaseClient {
         .map((val, i) => (i > 1 ? val.replace(/./g, '*') : val))
         .join('.')}`,
     );
-
+    
     if (this.options.presence) {
       this.options.ws.presence = await this.presence._parse(this.options.presence);
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
We can change the token while a client is running and that can create error
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added) 
Just change a property
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.