### PR TITLE
fix(PresenceStatus): include invisible in typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2915,9 +2915,9 @@ declare module 'discord.js' {
     readonly tag: null;
   }
 
-  type PresenceStatus = ClientPresenceStatus | 'offline';
-
   type PresenceStatusData = ClientPresenceStatus | 'invisible';
+
+  type PresenceStatus = PresenceStatusData | 'offline';
 
   interface RateLimitData {
     timeout: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- ⚠ closes #4371

This PR creates needed overlap "invisible" for the PresenceStatus type by changing the base typing from ClientPresenceStatus  to PresenceStatusData, serving as additive hierarchy. The naming of these properties is rather confusing, hence i'll explain the change in some more detail:

```ts
/**
 * baseline, returned as value to the respective platform keys of <GuildMember>.presence.clientStatus
 * thus can only be online, idle, dnd
 */
type ClientPresenceStatus = 'online' | 'idle' | 'dnd';

/**
 * Acts as option for setting the client users presence via <Client>.user.setPresence (or derivatives)
 * This can also include "invisible", this can not include "offline"
 */
type PresenceStatusData = ClientPresenceStatus | 'invisible';

/**
 * return value of <GuildMember>.presence.status
 * This needs to include "offline" for non-client members
 * This also still needs to include "invisible" for the client member
 */
type PresenceStatus = PresenceStatusData | 'offline';
```

Before this change both `PresenceStatus` as well as `PresenceStatusData` were extensions based on `ClientPresenceStatus` with either `'offline'` or `'invisible'` added, which caused unexpected behavior as detailed in #4371 

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
