### PR TITLE
feat(Message): support pin and unpin with reason

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -428,13 +428,15 @@ class Message extends Base {
 
   /**
    * Pins this message to the channel's pinned messages.
+   * @param {Object} [options] Options for pinning
+   * @param {string} [options.reason] Reason for pinning
    * @returns {Promise<Message>}
    */
-  pin() {
+  pin(options) {
     return this.client.api
       .channels(this.channel.id)
       .pins(this.id)
-      .put()
+      .put(options)
       .then(() => this);
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -433,7 +433,7 @@ class Message extends Base {
    * @returns {Promise<Message>}
    * @example
    * // Pin a message with a reason
-   * message.pin({ reason: 'important'})
+   * message.pin({ reason: 'important' })
    *   .then(console.log)
    *   .catch(console.error)
    */
@@ -452,7 +452,7 @@ class Message extends Base {
    * @returns {Promise<Message>}
    * @example
    * // Unpin a message with a reason
-   * message.unpin({ reason: 'no longer relevant'})
+   * message.unpin({ reason: 'no longer relevant' })
    *   .then(console.log)
    *   .catch(console.error)
    */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -431,6 +431,11 @@ class Message extends Base {
    * @param {Object} [options] Options for pinning
    * @param {string} [options.reason] Reason for pinning
    * @returns {Promise<Message>}
+   * @example
+   * // Pin a message with a reason
+   * message.pin({ reason: 'important'})
+   *   .then(console.log)
+   *   .catch(console.error)
    */
   pin(options) {
     return this.client.api
@@ -445,6 +450,11 @@ class Message extends Base {
    * @param {Object} [options] Options for unpinning
    * @param {string} [options.reason] Reason for unpinning
    * @returns {Promise<Message>}
+   * @example
+   * // Unpin a message with a reason
+   * message.unpin({ reason: 'no longer relevant'})
+   *   .then(console.log)
+   *   .catch(console.error)
    */
   unpin(options) {
     return this.client.api

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -442,13 +442,15 @@ class Message extends Base {
 
   /**
    * Unpins this message from the channel's pinned messages.
+   * @param {Object} [options] Options for unpinning
+   * @param {string} [options.reason] Reason for unpinning
    * @returns {Promise<Message>}
    */
-  unpin() {
+  unpin(options) {
     return this.client.api
       .channels(this.channel.id)
       .pins(this.id)
-      .delete()
+      .delete(options)
       .then(() => this);
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -958,7 +958,7 @@ declare module 'discord.js' {
     public equals(message: Message, rawData: object): boolean;
     public fetchWebhook(): Promise<Webhook>;
     public fetch(): Promise<Message>;
-    public pin(): Promise<Message>;
+    public pin(options?: { reason?: string }): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public reply(
       content?: StringResolvable,
@@ -983,7 +983,7 @@ declare module 'discord.js' {
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): object;
     public toString(): string;
-    public unpin(): Promise<Message>;
+    public unpin(options?: { reason?: string }): Promise<Message>;
   }
 
   export class MessageAttachment {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- ⚠ closes #4359 

Message#pin and Message#unpin support reasons to be set as detailed in #4359 

<details>
<summary>
ℹ Note: The UI displays the reason for pin, not for unpin!</summary>

![image](https://user-images.githubusercontent.com/26532370/85924231-1f1d3d00-b891-11ea-8252-9e4be9e4e524.png)

However it is still available in the audit log data returned from the API

![image](https://user-images.githubusercontent.com/26532370/85924255-55f35300-b891-11ea-9c5c-797752483e43.png)

</details>

<details>
<summary>Test code</summary>

```js
message.pin({ reason: 'pintest' })
			.then(msg => {
				msg.unpin({ reason: 'unpintest' });
			})
			.catch(console.error);
```

</details>


**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
