### PR TITLE
fix(ApiMessage): respect allowedMentions with split

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -191,7 +191,7 @@ class APIMessage {
       embeds,
       username,
       avatar_url: avatarURL,
-      allowed_mentions: typeof content === 'string' ? allowedMentions : undefined,
+      allowed_mentions: typeof content === 'undefined' ? undefined : allowedMentions,
       flags,
     };
     return this;
@@ -246,8 +246,8 @@ class APIMessage {
         data = { ...this.data, content: this.data.content[i] };
         opt = { ...this.options, content: this.data.content[i] };
       } else {
-        data = { content: this.data.content[i], tts: this.data.tts };
-        opt = { content: this.data.content[i], tts: this.data.tts };
+        data = { content: this.data.content[i], tts: this.data.tts, allowed_mentions: this.options.allowedMentions };
+        opt = { content: this.data.content[i], tts: this.data.tts, allowedMentions: this.options.allowedMentions };
       }
 
       const apiMessage = new APIMessage(this.target, opt);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- ⚠closes #4300

An oversight in two positions leads to `allowedMentions` being ignored when `splitOptions` are present.

<details>
<summary>Breakdown of changes</summary>

- https://github.com/discordjs/discord.js/pull/4588/files#diff-3916ea503ae839d34e6dd447ef035977R194 : required to not pass undefined if `content` is an array (which is the case when split options are passed)
- https://github.com/discordjs/discord.js/pull/4588/files#diff-3916ea503ae839d34e6dd447ef035977R249-R250 : allowed_mentions/allowedMentions need to be passed to split messages that are not the last message as well. `allowed_mentions` is used in `data` since it represents the data sent to the API. `allowedMentions` is used in `opt` since it represents [APIMessage#options](https://discord.js.org/#/docs/main/stable/class/APIMessage?scrollTo=options) and thus needs to follow library spec.

</details>

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
