### PR TITLE
fix(APIMessage): add reply user to allowedMentions

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -185,8 +185,10 @@ class APIMessage {
     if (this.options.reply) {
       const id = this.target.client.users.resolveID(this.options.reply);
       if (allowedMentions) {
+        // clone the object as to alter the ClientOptions object
         allowedMentions = Util.cloneObject(allowedMentions);
         const parsed = allowedMentions.parse && allowedMentions.parse.includes('users');
+        // check if the mention won't be parsed, and isn't supplied in `users`
         if (!parsed && !(allowedMentions.users && allowedMentions.users.includes(id))) {
           if (!allowedMentions.users) allowedMentions.users = [];
           allowedMentions.users.push(id);

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -184,7 +184,7 @@ class APIMessage {
         : this.options.allowedMentions;
     if (this.options.reply && allowedMentions) {
       const id = this.target.client.users.resolveID(this.options.reply);
-      const parsed = allowedMentions.parse && allowedMentions.parse.includes('user');
+      const parsed = allowedMentions.parse && allowedMentions.parse.includes('users');
       if (!parsed && !(allowedMentions.users && allowedMentions.users.includes(id))) {
         if (!allowedMentions.users) allowedMentions.users = [];
         allowedMentions.users.push(id);

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -178,16 +178,21 @@ class APIMessage {
       flags = this.options.flags != null ? new MessageFlags(this.options.flags).bitfield : this.target.flags.bitfield;
     }
 
-    const allowedMentions =
-      Util.cloneObject(typeof this.options.allowedMentions === 'undefined'
+    let allowedMentions =
+      typeof this.options.allowedMentions === 'undefined'
         ? this.target.client.options.allowedMentions
-        : this.options.allowedMentions);
-    if (this.options.reply && allowedMentions) {
+        : this.options.allowedMentions;
+    if (this.options.reply) {
       const id = this.target.client.users.resolveID(this.options.reply);
-      const parsed = allowedMentions.parse && allowedMentions.parse.includes('users');
-      if (!parsed && !(allowedMentions.users && allowedMentions.users.includes(id))) {
-        if (!allowedMentions.users) allowedMentions.users = [];
-        allowedMentions.users.push(id);
+      if (allowedMentions) {
+        allowedMentions = Util.cloneObject(allowedMentions);
+        const parsed = allowedMentions.parse && allowedMentions.parse.includes('users');
+        if (!parsed && !(allowedMentions.users && allowedMentions.users.includes(id))) {
+          if (!allowedMentions.users) allowedMentions.users = [];
+          allowedMentions.users.push(id);
+        }
+      } else {
+        allowedMentions = { users: [id] };
       }
     }
 

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -185,10 +185,10 @@ class APIMessage {
     if (this.options.reply) {
       const id = this.target.client.users.resolveID(this.options.reply);
       if (allowedMentions) {
-        // clone the object as to alter the ClientOptions object
+        // Clone the object as to alter the ClientOptions object
         allowedMentions = Util.cloneObject(allowedMentions);
         const parsed = allowedMentions.parse && allowedMentions.parse.includes('users');
-        // check if the mention won't be parsed, and isn't supplied in `users`
+        // Check if the mention won't be parsed, and isn't supplied in `users`
         if (!parsed && !(allowedMentions.users && allowedMentions.users.includes(id))) {
           if (!allowedMentions.users) allowedMentions.users = [];
           allowedMentions.users.push(id);

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -179,9 +179,9 @@ class APIMessage {
     }
 
     const allowedMentions =
-      typeof this.options.allowedMentions === 'undefined'
+      Util.cloneObject(typeof this.options.allowedMentions === 'undefined'
         ? this.target.client.options.allowedMentions
-        : this.options.allowedMentions;
+        : this.options.allowedMentions);
     if (this.options.reply && allowedMentions) {
       const id = this.target.client.users.resolveID(this.options.reply);
       const parsed = allowedMentions.parse && allowedMentions.parse.includes('users');

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -182,6 +182,14 @@ class APIMessage {
       typeof this.options.allowedMentions === 'undefined'
         ? this.target.client.options.allowedMentions
         : this.options.allowedMentions;
+    if (this.options.reply && allowedMentions) {
+      const id = this.target.client.users.resolveID(this.options.reply);
+      const parsed = allowedMentions.parse && allowedMentions.parse.includes('user');
+      if (!parsed && !(allowedMentions.users && allowedMentions.users.includes(id))) {
+        if (!allowedMentions.users) allowedMentions.users = [];
+        allowedMentions.users.push(id);
+      }
+    }
 
     this.data = {
       content,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes `APIMessage#resolveData` to add the specified `reply` user to allowedMentions

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
