### PR TITLE
feat: bypass cache check with forceFetch param

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,34 +56,6 @@
     "tweetnacl": "^1.0.3",
     "ws": "^7.2.1"
   },
-  "peerDependencies": {
-    "bufferutil": "^4.0.1",
-    "erlpack": "discordapp/erlpack",
-    "libsodium-wrappers": "^0.7.6",
-    "sodium": "^3.0.2",
-    "utf-8-validate": "^5.0.2",
-    "zlib-sync": "^0.1.6"
-  },
-  "peerDependenciesMeta": {
-    "bufferutil": {
-      "optional": true
-    },
-    "erlpack": {
-      "optional": true
-    },
-    "libsodium-wrappers": {
-      "optional": true
-    },
-    "sodium": {
-      "optional": true
-    },
-    "utf-8-validate": {
-      "optional": true
-    },
-    "zlib-sync": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-angular": "^8.3.4",

--- a/src/managers/ChannelManager.js
+++ b/src/managers/ChannelManager.js
@@ -74,6 +74,7 @@ class ChannelManager extends BaseManager {
    * Obtains a channel from Discord, or the channel cache if it's already available.
    * @param {Snowflake} id ID of the channel
    * @param {boolean} [cache=true] Whether to cache the new channel object if it isn't already
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
    * @returns {Promise<Channel>}
    * @example
    * // Fetch a channel by its id
@@ -81,9 +82,11 @@ class ChannelManager extends BaseManager {
    *   .then(channel => console.log(channel.name))
    *   .catch(console.error);
    */
-  async fetch(id, cache = true) {
-    const existing = this.cache.get(id);
-    if (existing && !existing.partial) return existing;
+  async fetch(id, cache = true, forceFetch = false) {
+    if (!forceFetch) {
+      const existing = this.cache.get(id);
+      if (existing && !existing.partial) return existing;
+    }
 
     const data = await this.client.api.channels(id).get();
     return this.add(data, null, cache);

--- a/src/managers/ChannelManager.js
+++ b/src/managers/ChannelManager.js
@@ -74,7 +74,7 @@ class ChannelManager extends BaseManager {
    * Obtains a channel from Discord, or the channel cache if it's already available.
    * @param {Snowflake} id ID of the channel
    * @param {boolean} [cache=true] Whether to cache the new channel object if it isn't already
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<Channel>}
    * @example
    * // Fetch a channel by its id
@@ -82,8 +82,8 @@ class ChannelManager extends BaseManager {
    *   .then(channel => console.log(channel.name))
    *   .catch(console.error);
    */
-  async fetch(id, cache = true, forceFetch = false) {
-    if (!forceFetch) {
+  async fetch(id, cache = true, force = false) {
+    if (!force) {
       const existing = this.cache.get(id);
       if (existing && !existing.partial) return existing;
     }

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -67,7 +67,7 @@ class GuildMemberManager extends BaseManager {
    * @typedef {Object} FetchMemberOptions
    * @property {UserResolvable} user The user to fetch
    * @property {boolean} [cache=true] Whether or not to cache the fetched member
-   * @property {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @property {boolean} [force=false] Whether to skip the cache check and request the API
    */
 
   /**
@@ -79,7 +79,7 @@ class GuildMemberManager extends BaseManager {
    * @property {boolean} [withPresences=false] Whether or not to include the presences
    * @property {number} [time=120e3] Timeout for receipt of members
    * @property {?string} nonce Nonce for this request (32 characters max - default to base 16 now timestamp)
-   * @property {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @property {boolean} [force=false] Whether to skip the cache check and request the API
    */
 
   /**
@@ -100,7 +100,7 @@ class GuildMemberManager extends BaseManager {
    *   .catch(console.error);
    * @example
    * // Fetch a single member without checking cache
-   * guild.members.fetch({ user, forceFetch: true })
+   * guild.members.fetch({ user, force: true })
    *   .then(console.log)
    *   .catch(console.error)
    * @example
@@ -222,8 +222,8 @@ class GuildMemberManager extends BaseManager {
       .then(() => this.client.users.resolve(user));
   }
 
-  _fetchSingle({ user, cache, forceFetch = false }) {
-    if (!forceFetch) {
+  _fetchSingle({ user, cache, force = false }) {
+    if (!force) {
       const existing = this.cache.get(user);
       if (existing && !existing.partial) return Promise.resolve(existing);
     }
@@ -242,10 +242,10 @@ class GuildMemberManager extends BaseManager {
     query,
     time = 120e3,
     nonce = Date.now().toString(16),
-    forceFetch = false,
+    force = false,
   } = {}) {
     return new Promise((resolve, reject) => {
-      if (this.guild.memberCount === this.cache.size && !query && !limit && !presences && !user_ids && !forceFetch) {
+      if (this.guild.memberCount === this.cache.size && !query && !limit && !presences && !user_ids && !force) {
         resolve(this.cache);
         return;
       }

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -45,7 +45,7 @@ class MessageManager extends BaseManager {
    * Those need to be fetched separately in such a case.</info>
    * @param {Snowflake|ChannelLogsQueryOptions} [message] The ID of the message to fetch, or query parameters.
    * @param {boolean} [cache=true] Whether to cache the message(s)
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<Message>|Promise<Collection<Snowflake, Message>>}
    * @example
    * // Get message
@@ -63,8 +63,8 @@ class MessageManager extends BaseManager {
    *   .then(messages => console.log(`${messages.filter(m => m.author.id === '84484653687267328').size} messages`))
    *   .catch(console.error);
    */
-  fetch(message, cache = true, forceFetch = true) {
-    return typeof message === 'string' ? this._fetchId(message, cache, forceFetch) : this._fetchMany(message, cache);
+  fetch(message, cache = true, force = true) {
+    return typeof message === 'string' ? this._fetchId(message, cache, force) : this._fetchMany(message, cache);
   }
 
   /**
@@ -128,8 +128,8 @@ class MessageManager extends BaseManager {
     }
   }
 
-  async _fetchId(messageID, cache, forceFetch) {
-    if (!forceFetch) {
+  async _fetchId(messageID, cache, force) {
+    if (!force) {
       const existing = this.cache.get(messageID);
       if (existing && !existing.partial) return existing;
     }

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -63,7 +63,7 @@ class MessageManager extends BaseManager {
    *   .then(messages => console.log(`${messages.filter(m => m.author.id === '84484653687267328').size} messages`))
    *   .catch(console.error);
    */
-  fetch(message, cache = true, force = true) {
+  fetch(message, cache = true, force = false) {
     return typeof message === 'string' ? this._fetchId(message, cache, force) : this._fetchMany(message, cache);
   }
 

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -45,6 +45,7 @@ class MessageManager extends BaseManager {
    * Those need to be fetched separately in such a case.</info>
    * @param {Snowflake|ChannelLogsQueryOptions} [message] The ID of the message to fetch, or query parameters.
    * @param {boolean} [cache=true] Whether to cache the message(s)
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
    * @returns {Promise<Message>|Promise<Collection<Snowflake, Message>>}
    * @example
    * // Get message
@@ -62,8 +63,8 @@ class MessageManager extends BaseManager {
    *   .then(messages => console.log(`${messages.filter(m => m.author.id === '84484653687267328').size} messages`))
    *   .catch(console.error);
    */
-  fetch(message, cache = true) {
-    return typeof message === 'string' ? this._fetchId(message, cache) : this._fetchMany(message, cache);
+  fetch(message, cache = true, forceFetch = true) {
+    return typeof message === 'string' ? this._fetchId(message, cache, forceFetch) : this._fetchMany(message, cache);
   }
 
   /**
@@ -127,9 +128,12 @@ class MessageManager extends BaseManager {
     }
   }
 
-  async _fetchId(messageID, cache) {
-    const existing = this.cache.get(messageID);
-    if (existing && !existing.partial) return existing;
+  async _fetchId(messageID, cache, forceFetch) {
+    if (!forceFetch) {
+      const existing = this.cache.get(messageID);
+      if (existing && !existing.partial) return existing;
+    }
+
     const data = await this.client.api.channels[this.channel.id].messages[messageID].get();
     return this.add(data, cache);
   }

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -33,6 +33,7 @@ class RoleManager extends BaseManager {
    * Obtains one or more roles from Discord, or the role cache if they're already available.
    * @param {Snowflake} [id] ID or IDs of the role(s)
    * @param {boolean} [cache=true] Whether to cache the new roles objects if it weren't already
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
    * @returns {Promise<Role|RoleManager>}
    * @example
    * // Fetch all roles from the guild
@@ -45,8 +46,8 @@ class RoleManager extends BaseManager {
    *   .then(role => console.log(`The role color is: ${role.color}`))
    *   .catch(console.error);
    */
-  async fetch(id, cache = true) {
-    if (id) {
+  async fetch(id, cache = true, forceFetch = false) {
+    if (id && !forceFetch) {
       const existing = this.cache.get(id);
       if (existing) return existing;
     }

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -33,7 +33,7 @@ class RoleManager extends BaseManager {
    * Obtains one or more roles from Discord, or the role cache if they're already available.
    * @param {Snowflake} [id] ID or IDs of the role(s)
    * @param {boolean} [cache=true] Whether to cache the new roles objects if it weren't already
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<Role|RoleManager>}
    * @example
    * // Fetch all roles from the guild
@@ -46,8 +46,8 @@ class RoleManager extends BaseManager {
    *   .then(role => console.log(`The role color is: ${role.color}`))
    *   .catch(console.error);
    */
-  async fetch(id, cache = true, forceFetch = false) {
-    if (id && !forceFetch) {
+  async fetch(id, cache = true, force = false) {
+    if (id && !force) {
       const existing = this.cache.get(id);
       if (existing) return existing;
     }

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -55,11 +55,15 @@ class UserManager extends BaseManager {
    * Obtains a user from Discord, or the user cache if it's already available.
    * @param {Snowflake} id ID of the user
    * @param {boolean} [cache=true] Whether to cache the new user object if it isn't already
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
    * @returns {Promise<User>}
    */
-  async fetch(id, cache = true) {
-    const existing = this.cache.get(id);
-    if (existing && !existing.partial) return existing;
+  async fetch(id, cache = true, forceFetch = false) {
+    if (!forceFetch) {
+      const existing = this.cache.get(id);
+      if (existing && !existing.partial) return existing;
+    }
+
     const data = await this.client.api.users(id).get();
     return this.add(data, cache);
   }

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -55,11 +55,11 @@ class UserManager extends BaseManager {
    * Obtains a user from Discord, or the user cache if it's already available.
    * @param {Snowflake} id ID of the user
    * @param {boolean} [cache=true] Whether to cache the new user object if it isn't already
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<User>}
    */
-  async fetch(id, cache = true, forceFetch = false) {
-    if (!forceFetch) {
+  async fetch(id, cache = true, force = false) {
+    if (!force) {
       const existing = this.cache.get(id);
       if (existing && !existing.partial) return existing;
     }

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -90,10 +90,11 @@ class Channel extends Base {
 
   /**
    * Fetches this channel.
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
    * @returns {Promise<Channel>}
    */
-  fetch() {
-    return this.client.channels.fetch(this.id, true);
+  fetch(forceFetch = false) {
+    return this.client.channels.fetch(this.id, true, forceFetch);
   }
 
   static create(client, data, guild) {

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -90,11 +90,11 @@ class Channel extends Base {
 
   /**
    * Fetches this channel.
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<Channel>}
    */
-  fetch(forceFetch = false) {
-    return this.client.channels.fetch(this.id, true, forceFetch);
+  fetch(force = false) {
+    return this.client.channels.fetch(this.id, true, force);
   }
 
   static create(client, data, guild) {

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -61,11 +61,11 @@ class DMChannel extends Channel {
 
   /**
    * Fetch this DMChannel.
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<DMChannel>}
    */
-  fetch(forceFetch = false) {
-    return this.recipient.createDM(forceFetch);
+  fetch(force = false) {
+    return this.recipient.createDM(force);
   }
 
   /**

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -61,10 +61,11 @@ class DMChannel extends Channel {
 
   /**
    * Fetch this DMChannel.
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
    * @returns {Promise<DMChannel>}
    */
-  fetch() {
-    return this.recipient.createDM();
+  fetch(forceFetch = false) {
+    return this.recipient.createDM(forceFetch);
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -371,10 +371,11 @@ class GuildMember extends Base {
 
   /**
    * Fetches this GuildMember.
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
    * @returns {Promise<GuildMember>}
    */
-  fetch() {
-    return this.guild.members.fetch(this.id, true);
+  fetch(forceFetch = false) {
+    return this.guild.members.fetch({ user: this.id, cache: true, forceFetch });
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -371,11 +371,11 @@ class GuildMember extends Base {
 
   /**
    * Fetches this GuildMember.
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<GuildMember>}
    */
-  fetch(forceFetch = false) {
-    return this.guild.members.fetch({ user: this.id, cache: true, forceFetch });
+  fetch(force = false) {
+    return this.guild.members.fetch({ user: this.id, cache: true, force });
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -532,11 +532,11 @@ class Message extends Base {
 
   /**
    * Fetch this message.
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<Message>}
    */
-  fetch(forceFetch = false) {
-    return this.channel.messages.fetch(this.id, true, forceFetch);
+  fetch(force = false) {
+    return this.channel.messages.fetch(this.id, true, force);
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -532,10 +532,11 @@ class Message extends Base {
 
   /**
    * Fetch this message.
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
    * @returns {Promise<Message>}
    */
-  fetch() {
-    return this.channel.messages.fetch(this.id, true);
+  fetch(forceFetch = false) {
+    return this.channel.messages.fetch(this.id, true, forceFetch);
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -222,11 +222,15 @@ class User extends Base {
 
   /**
    * Creates a DM channel between the client and the user.
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
    * @returns {Promise<DMChannel>}
    */
-  async createDM() {
-    const { dmChannel } = this;
-    if (dmChannel && !dmChannel.partial) return dmChannel;
+  async createDM(forceFetch = false) {
+    if (!forceFetch) {
+      const { dmChannel } = this;
+      if (dmChannel && !dmChannel.partial) return dmChannel;
+    }
+
     const data = await this.client.api.users(this.client.user.id).channels.post({
       data: {
         recipient_id: this.id,
@@ -265,10 +269,11 @@ class User extends Base {
 
   /**
    * Fetches this user's flags.
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the AP
    * @returns {Promise<UserFlags>}
    */
-  async fetchFlags() {
-    if (this.flags) return this.flags;
+  async fetchFlags(forceFetch = false) {
+    if (this.flags && !forceFetch) return this.flags;
     const data = await this.client.api.users(this.id).get();
     this._patch(data);
     return this.flags;
@@ -276,10 +281,11 @@ class User extends Base {
 
   /**
    * Fetches this user.
+   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the AP
    * @returns {Promise<User>}
    */
-  fetch() {
-    return this.client.users.fetch(this.id, true);
+  fetch(forceFetch = false) {
+    return this.client.users.fetch(this.id, true, forceFetch);
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -222,11 +222,11 @@ class User extends Base {
 
   /**
    * Creates a DM channel between the client and the user.
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the API
+   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<DMChannel>}
    */
-  async createDM(forceFetch = false) {
-    if (!forceFetch) {
+  async createDM(force = false) {
+    if (!force) {
       const { dmChannel } = this;
       if (dmChannel && !dmChannel.partial) return dmChannel;
     }
@@ -269,11 +269,11 @@ class User extends Base {
 
   /**
    * Fetches this user's flags.
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the AP
+   * @param {boolean} [force=false] Whether to skip the cache check and request the AP
    * @returns {Promise<UserFlags>}
    */
-  async fetchFlags(forceFetch = false) {
-    if (this.flags && !forceFetch) return this.flags;
+  async fetchFlags(force = false) {
+    if (this.flags && !force) return this.flags;
     const data = await this.client.api.users(this.id).get();
     this._patch(data);
     return this.flags;
@@ -281,11 +281,11 @@ class User extends Base {
 
   /**
    * Fetches this user.
-   * @param {boolean} [forceFetch=false] Whether to skip the cache check and request the AP
+   * @param {boolean} [force=false] Whether to skip the cache check and request the AP
    * @returns {Promise<User>}
    */
-  fetch(forceFetch = false) {
-    return this.client.users.fetch(this.id, true, forceFetch);
+  fetch(force = false) {
+    return this.client.users.fetch(this.id, true, force);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -159,7 +159,7 @@ declare module 'discord.js' {
     public id: Snowflake;
     public type: keyof typeof ChannelType;
     public delete(reason?: string): Promise<this>;
-    public fetch(): Promise<this>;
+    public fetch(forceFetch?: boolean): Promise<this>;
     public toString(): string;
   }
 
@@ -563,7 +563,7 @@ declare module 'discord.js' {
     public recipient: User;
     public readonly partial: false;
     public type: 'dm';
-    public fetch(): Promise<this>;
+    public fetch(forceFetch?: boolean): Promise<this>;
   }
 
   export class Emoji extends Base {
@@ -808,8 +808,8 @@ declare module 'discord.js' {
     public user: User;
     public readonly voice: VoiceState;
     public ban(options?: BanOptions): Promise<GuildMember>;
-    public fetch(): Promise<GuildMember>;
-    public createDM(): Promise<DMChannel>;
+    public fetch(forceFetch?: boolean): Promise<GuildMember>;
+    public createDM(forceFetch?: boolean): Promise<DMChannel>;
     public deleteDM(): Promise<DMChannel>;
     public edit(data: GuildMemberEditData, reason?: string): Promise<GuildMember>;
     public hasPermission(
@@ -957,7 +957,7 @@ declare module 'discord.js' {
     public edit(options: MessageEditOptions | MessageEmbed | APIMessage): Promise<Message>;
     public equals(message: Message, rawData: object): boolean;
     public fetchWebhook(): Promise<Webhook>;
-    public fetch(): Promise<Message>;
+    public fetch(forceFetch?: boolean): Promise<Message>;
     public pin(): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public reply(
@@ -1492,8 +1492,8 @@ declare module 'discord.js' {
     public deleteDM(): Promise<DMChannel>;
     public displayAvatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string;
     public equals(user: User): boolean;
-    public fetch(): Promise<User>;
-    public fetchFlags(): Promise<UserFlags>;
+    public fetch(forceFetch?: boolean): Promise<User>;
+    public fetchFlags(forceFetch?: boolean): Promise<UserFlags>;
     public toString(): string;
     public typingDurationIn(channel: ChannelResolvable): number;
     public typingIn(channel: ChannelResolvable): boolean;
@@ -1826,7 +1826,7 @@ declare module 'discord.js' {
 
   export class ChannelManager extends BaseManager<Snowflake, Channel, ChannelResolvable> {
     constructor(client: Client, iterable: Iterable<any>);
-    public fetch(id: Snowflake, cache?: boolean): Promise<Channel>;
+    public fetch(id: Snowflake, cache?: boolean, forceFetch?: boolean): Promise<Channel>;
   }
 
   export abstract class BaseManager<K, Holds, R> {
@@ -1917,8 +1917,12 @@ declare module 'discord.js' {
     constructor(channel: TextChannel | DMChannel, iterable?: Iterable<any>);
     public channel: TextBasedChannelFields;
     public cache: Collection<Snowflake, Message>;
-    public fetch(message: Snowflake, cache?: boolean): Promise<Message>;
-    public fetch(options?: ChannelLogsQueryOptions, cache?: boolean): Promise<Collection<Snowflake, Message>>;
+    public fetch(message: Snowflake, cache?: boolean, forceFetch?: boolean): Promise<Message>;
+    public fetch(
+      options?: ChannelLogsQueryOptions,
+      cache?: boolean,
+      forceFetch?: boolean,
+    ): Promise<Collection<Snowflake, Message>>;
     public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;
     public delete(message: MessageResolvable, reason?: string): Promise<void>;
   }
@@ -1957,13 +1961,13 @@ declare module 'discord.js' {
     public guild: Guild;
 
     public create(options?: { data?: RoleData; reason?: string }): Promise<Role>;
-    public fetch(id: Snowflake, cache?: boolean): Promise<Role | null>;
-    public fetch(id?: Snowflake, cache?: boolean): Promise<this>;
+    public fetch(id: Snowflake, cache?: boolean, forceFetch?: boolean): Promise<Role | null>;
+    public fetch(id?: Snowflake, cache?: boolean, forceFetch?: boolean): Promise<this>;
   }
 
   export class UserManager extends BaseManager<Snowflake, User, UserResolvable> {
     constructor(client: Client, iterable?: Iterable<any>);
-    public fetch(id: Snowflake, cache?: boolean): Promise<User>;
+    public fetch(id: Snowflake, cache?: boolean, forceFetch?: boolean): Promise<User>;
   }
 
   export class VoiceStateManager extends BaseManager<Snowflake, VoiceState, typeof VoiceState> {
@@ -2391,6 +2395,7 @@ declare module 'discord.js' {
   interface FetchMemberOptions {
     user: UserResolvable;
     cache?: boolean;
+    forceFetch?: boolean;
   }
 
   interface FetchMembersOptions {
@@ -2400,6 +2405,7 @@ declare module 'discord.js' {
     withPresences?: boolean;
     time?: number;
     nonce?: string;
+    forceFetch?: boolean;
   }
 
   interface FileOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -158,8 +158,8 @@ declare module 'discord.js' {
     public deleted: boolean;
     public id: Snowflake;
     public type: keyof typeof ChannelType;
-    public delete(reason?: string): Promise<this>;
-    public fetch(force?: boolean): Promise<this>;
+    public delete(reason?: string): Promise<Channel>;
+    public fetch(force?: boolean): Promise<Channel>;
     public toString(): string;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -159,7 +159,7 @@ declare module 'discord.js' {
     public id: Snowflake;
     public type: keyof typeof ChannelType;
     public delete(reason?: string): Promise<this>;
-    public fetch(forceFetch?: boolean): Promise<this>;
+    public fetch(force?: boolean): Promise<this>;
     public toString(): string;
   }
 
@@ -563,7 +563,7 @@ declare module 'discord.js' {
     public recipient: User;
     public readonly partial: false;
     public type: 'dm';
-    public fetch(forceFetch?: boolean): Promise<this>;
+    public fetch(force?: boolean): Promise<this>;
   }
 
   export class Emoji extends Base {
@@ -808,8 +808,8 @@ declare module 'discord.js' {
     public user: User;
     public readonly voice: VoiceState;
     public ban(options?: BanOptions): Promise<GuildMember>;
-    public fetch(forceFetch?: boolean): Promise<GuildMember>;
-    public createDM(forceFetch?: boolean): Promise<DMChannel>;
+    public fetch(force?: boolean): Promise<GuildMember>;
+    public createDM(force?: boolean): Promise<DMChannel>;
     public deleteDM(): Promise<DMChannel>;
     public edit(data: GuildMemberEditData, reason?: string): Promise<GuildMember>;
     public hasPermission(
@@ -957,7 +957,7 @@ declare module 'discord.js' {
     public edit(options: MessageEditOptions | MessageEmbed | APIMessage): Promise<Message>;
     public equals(message: Message, rawData: object): boolean;
     public fetchWebhook(): Promise<Webhook>;
-    public fetch(forceFetch?: boolean): Promise<Message>;
+    public fetch(force?: boolean): Promise<Message>;
     public pin(): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public reply(
@@ -1492,8 +1492,8 @@ declare module 'discord.js' {
     public deleteDM(): Promise<DMChannel>;
     public displayAvatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string;
     public equals(user: User): boolean;
-    public fetch(forceFetch?: boolean): Promise<User>;
-    public fetchFlags(forceFetch?: boolean): Promise<UserFlags>;
+    public fetch(force?: boolean): Promise<User>;
+    public fetchFlags(force?: boolean): Promise<UserFlags>;
     public toString(): string;
     public typingDurationIn(channel: ChannelResolvable): number;
     public typingIn(channel: ChannelResolvable): boolean;
@@ -1826,7 +1826,7 @@ declare module 'discord.js' {
 
   export class ChannelManager extends BaseManager<Snowflake, Channel, ChannelResolvable> {
     constructor(client: Client, iterable: Iterable<any>);
-    public fetch(id: Snowflake, cache?: boolean, forceFetch?: boolean): Promise<Channel>;
+    public fetch(id: Snowflake, cache?: boolean, force?: boolean): Promise<Channel>;
   }
 
   export abstract class BaseManager<K, Holds, R> {
@@ -1917,11 +1917,11 @@ declare module 'discord.js' {
     constructor(channel: TextChannel | DMChannel, iterable?: Iterable<any>);
     public channel: TextBasedChannelFields;
     public cache: Collection<Snowflake, Message>;
-    public fetch(message: Snowflake, cache?: boolean, forceFetch?: boolean): Promise<Message>;
+    public fetch(message: Snowflake, cache?: boolean, force?: boolean): Promise<Message>;
     public fetch(
       options?: ChannelLogsQueryOptions,
       cache?: boolean,
-      forceFetch?: boolean,
+      force?: boolean,
     ): Promise<Collection<Snowflake, Message>>;
     public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;
     public delete(message: MessageResolvable, reason?: string): Promise<void>;
@@ -1961,13 +1961,13 @@ declare module 'discord.js' {
     public guild: Guild;
 
     public create(options?: { data?: RoleData; reason?: string }): Promise<Role>;
-    public fetch(id: Snowflake, cache?: boolean, forceFetch?: boolean): Promise<Role | null>;
-    public fetch(id?: Snowflake, cache?: boolean, forceFetch?: boolean): Promise<this>;
+    public fetch(id: Snowflake, cache?: boolean, force?: boolean): Promise<Role | null>;
+    public fetch(id?: Snowflake, cache?: boolean, force?: boolean): Promise<this>;
   }
 
   export class UserManager extends BaseManager<Snowflake, User, UserResolvable> {
     constructor(client: Client, iterable?: Iterable<any>);
-    public fetch(id: Snowflake, cache?: boolean, forceFetch?: boolean): Promise<User>;
+    public fetch(id: Snowflake, cache?: boolean, force?: boolean): Promise<User>;
   }
 
   export class VoiceStateManager extends BaseManager<Snowflake, VoiceState, typeof VoiceState> {
@@ -2395,7 +2395,7 @@ declare module 'discord.js' {
   interface FetchMemberOptions {
     user: UserResolvable;
     cache?: boolean;
-    forceFetch?: boolean;
+    force?: boolean;
   }
 
   interface FetchMembersOptions {
@@ -2405,7 +2405,7 @@ declare module 'discord.js' {
     withPresences?: boolean;
     time?: number;
     nonce?: string;
-    forceFetch?: boolean;
+    force?: boolean;
   }
 
   interface FileOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the parameter `forceFetch` on various functions that would check a manager's cache before falling back to requesting the API. If true, the cache check will be bypassed and hit the API. If undefined, the parameter will default to `false`.

Effected functions include:
- Managers
  - `ChannelManager#fetch`
  - `GuildMemberManager#fetch` (added to the options object)
  - `MessageManager#fetch`
  - `RoleManager#fetch`
  - `UserManager#fetch`
- Structures
  - `Channel#fetch`
  - `DMChannel#fetch` (relies on `User#createDM`)
  - `GuildMember#fetch`
  - `Message#fetch`
  - ~~`MessageReaction#fetch`~~ may not be necessary here
  - `User#fetchFlags`
  - `User#fetch`
  - `User#createDM` (underlying support for `DMChannel#fetch`)

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
