### PR TITLE
fix: consider #nsfw false if not present in data

### DIFF
--- a/src/structures/StoreChannel.js
+++ b/src/structures/StoreChannel.js
@@ -7,15 +7,25 @@ const GuildChannel = require('./GuildChannel');
  * @extends {GuildChannel}
  */
 class StoreChannel extends GuildChannel {
-  _patch(data) {
-    super._patch(data);
+  /**
+   * @param {*} guild The guild the store channel is part of
+   * @param {*} data The data for the store channel
+   */
+  constructor(guild, data) {
+    super(guild, data);
 
     /**
      * If the guild considers this channel NSFW
      * @type {boolean}
      * @readonly
      */
-    this.nsfw = data.nsfw;
+    this.nsfw = Boolean(data.nsfw);
+  }
+
+  _patch(data) {
+    super._patch(data);
+
+    if (typeof data.nsfw !== 'undefined') this.nsfw = Boolean(data.nsfw);
   }
 }
 

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -24,6 +24,13 @@ class TextChannel extends GuildChannel {
      * @type {MessageManager}
      */
     this.messages = new MessageManager(this);
+
+    /**
+     * If the guild considers this channel NSFW
+     * @type {boolean}
+     * @readonly
+     */
+    this.nsfw = Boolean(data.nsfw);
     this._typing = new Map();
   }
 
@@ -36,12 +43,7 @@ class TextChannel extends GuildChannel {
      */
     this.topic = data.topic;
 
-    /**
-     * If the guild considers this channel NSFW
-     * @type {boolean}
-     * @readonly
-     */
-    this.nsfw = data.nsfw;
+    if (typeof data.nsfw !== 'undefined') this.nsfw = Boolean(data.nsfw);
 
     /**
      * The ID of the last message sent in this channel, if one was sent


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- ⚠ closes #4296 

As #4296 brought up, discord.js has `text` type channels in cache where the `.nsfw` property returns `undefined`.

**Problem breakdown:**

- After some investigation the initial guess of this being caused by discord.js handling channel updates can be dismissed
- This is indeed caused by discord not sending `nsfw` in its channel data on initial guild payloads
- There are no updates sent after ready to provide these missing properties

This PR attempts to fix this inconsistency by considering the channel to not be nsfw if the `.nsfw` key is not present in the initial channel data.

<details>
<summary><b>Changes breakdown:</b></summary>

**TextChannel**

- assign `.nsfw` in the constructor with `this.nsfw = Boolean(data.nsfw);`
- patch `.nsfw` in `_patch` with `if (typeof data.nsfw !== 'undefined') this.nsfw = Boolean(data.nsfw);`
- move `.nsfw` docstring into the constructor call

**StoreChannel**

- assign `.nsfw` in the constructor with `this.nsfw = Boolean(data.nsfw);`
- patch `.nsfw` in `_patch` with `if (typeof data.nsfw !== 'undefined') this.nsfw = Boolean(data.nsfw);`
- move `.nsfw` docstring into the constructor call
- explicit constructor call due to above changes
- document constructor akin to TextChannel

</details>

<details>
<summary><b>Further considerations:</b></summary>

From my own tests (sample size: 237 channels out of which 44 are affected) i can say that after requesting said channels through the raw API endpoint `GET /channels/:id` none of the "pending" nsfw properties were `true`.

Sinister Rectus, dev of discordia could also reproduce this behavior and they seem to handle this the same way.

According to sinister this is also done on `user.bot` where we do handle this properly by assigning the `Boolean(data.bot)` in the constructor

https://github.com/discordjs/discord.js/blob/d827544fbd12e827fb4b6ff99d8894ecd79ede02/src/structures/User.js#L34

and only patching if the value is __not__ `undefined`

https://github.com/discordjs/discord.js/blob/d827544fbd12e827fb4b6ff99d8894ecd79ede02/src/structures/User.js#L61

I have applied this same reasoning to TextChannel and NewsChannel in this PR.

</details>

<details>
<summary><b>Typings considerations:</b></summary>

- Both TextChannel as well as NewsChannel are typed `boolean` instead of `?boolean` already, so this PR (fix) is consistent with the already applied typings.
- The constructor for NewsChannel has already been typed, but is now also documented accordingly

</details>

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
