### PR TITLE
fix(BaseManager): properly type valueOf

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1838,6 +1838,7 @@ declare module 'discord.js' {
     public add(data: any, cache?: boolean, { id, extras }?: { id: K; extras: any[] }): Holds;
     public resolve(resolvable: R): Holds | null;
     public resolveID(resolvable: R): K | null;
+    public valueOf(): Collection<K, Holds>;
   }
 
   export class GuildChannelManager extends BaseManager<Snowflake, GuildChannel, GuildChannelResolvable> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

BaseManager#valueOf returns its cache collection, but the return is currently typed as `:Object`. This PR documents types the return value based on key and holdings.

**Further considerations:**

Whether or not valueOf should even return a Collection in the first place is another topic, which should be discussed for the next semver major. This is (according to @Monbrey) the case due to Util#toJSON expecting to find Collections there to extract the appropriate data for use cases like broadcast evaluations.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
