### PR TITLE
fix: implement valueOf on pseudo managers

### DIFF
--- a/src/managers/GuildEmojiRoleManager.js
+++ b/src/managers/GuildEmojiRoleManager.js
@@ -114,6 +114,10 @@ class GuildEmojiRoleManager {
   _patch(roles) {
     this.emoji._roles = roles;
   }
+
+  valueOf() {
+    return this.cache;
+  }
 }
 
 module.exports = GuildEmojiRoleManager;

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -156,6 +156,10 @@ class GuildMemberRoleManager {
     clone.member._roles = [...this._roles.keyArray()];
     return clone;
   }
+
+  valueOf() {
+    return this.cache;
+  }
 }
 
 module.exports = GuildMemberRoleManager;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1871,6 +1871,7 @@ declare module 'discord.js' {
     public add(roleOrRoles: RoleResolvable | RoleResolvable[] | Collection<Snowflake, Role>): Promise<GuildEmoji>;
     public set(roles: RoleResolvable[] | Collection<Snowflake, Role>): Promise<GuildEmoji>;
     public remove(roleOrRoles: RoleResolvable | RoleResolvable[] | Collection<Snowflake, Role>): Promise<GuildEmoji>;
+    public valueOf(): Collection<Snowflake, Role>;
   }
 
   export class GuildManager extends BaseManager<Snowflake, Guild, GuildResolvable> {
@@ -1911,6 +1912,7 @@ declare module 'discord.js' {
       roleOrRoles: RoleResolvable | RoleResolvable[] | Collection<Snowflake, Role>,
       reason?: string,
     ): Promise<GuildMember>;
+    public valueOf(): Collection<Snowflake, Role>;
   }
 
   export class MessageManager extends BaseManager<Snowflake, Message, MessageResolvable> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently BaseManager#valueOf returns the cache collection, while this is not the case for the pseudo managers GuildEmojiRoleManager and GuildMemberRolemanager. 

This PR brings the needed consistency and implements the pseudo managers #valueOf method akin to the BaseManager.

**Versioning considerations:**

- This could be seen as semver **major** as it changes the behavior of the public facing API #valueOf to be consistent with BaseManager
- This could be seen as **patch** since it fixes inconsistent behavior, which appeared due to an oversight (as already briefly mentioned in #4594 the return value for BaseManager was picked to properly allow passing the structure through broadcast evaluation without loosing all its data)
-  "This PR changes the library's interface" is not ticked due to #valueOf already being inherited from the Object base
- "This PR includes breaking changes" is not ticked due to above unclear considerations

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
