### PR TITLE
refactor(GuildChannel): rework setting parent and permission locking

### DIFF
--- a/src/client/actions/GuildChannelsPositionUpdate.js
+++ b/src/client/actions/GuildChannelsPositionUpdate.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-depth */
 'use strict';
 
 const Action = require('./Action');
@@ -10,7 +11,26 @@ class GuildChannelsPositionUpdate extends Action {
     if (guild) {
       for (const partialChannel of data.channels) {
         const channel = guild.channels.cache.get(partialChannel.id);
-        if (channel) channel.rawPosition = partialChannel.position;
+        if (channel) {
+          const { position, parent_id, lock_permissions } = partialChannel;
+          if (position) {
+            channel.rawPosition = position;
+          }
+          if (parent_id) {
+            const newParent = guild.channels.cache.get(parent_id);
+            if (newParent) {
+              channel.parentID = parent_id;
+            }
+          }
+          if (lock_permissions) {
+            const newParent = guild.channels.cache.get(parent_id);
+            if (newParent) {
+              channel.permissionOverwrites = newParent.permissionOverwrites.clone();
+            } else if (channel.parent) {
+              channel.permissionOverwrites = channel.parent.permissionOverwrites.clone();
+            }
+          }
+        }
       }
     }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1192,7 +1192,9 @@ class Guild extends Base {
    * The data needed for updating a channel's position.
    * @typedef {Object} ChannelPosition
    * @property {ChannelResolvable} channel Channel to update
-   * @property {number} position New position for the channel
+   * @property {number} [position] New position for the channel
+   * @property {?CategoryChannel|Snowflake} [parent] Parent channel
+   * @property {boolean} [lockPermissions] If the permissions should be locked to the parent
    */
 
   /**
@@ -1208,6 +1210,8 @@ class Guild extends Base {
     const updatedChannels = channelPositions.map(r => ({
       id: this.client.channels.resolveID(r.channel),
       position: r.position,
+      parent_id: r.parent !== null ? this.client.channels.resolveID(r.parent) || undefined : null,
+      lock_permissions: r.lockPermissions,
     }));
 
     return this.client.api

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2173,7 +2173,9 @@ declare module 'discord.js' {
 
   interface ChannelPosition {
     channel: ChannelResolvable;
-    position: number;
+    position?: number;
+    parent?: GuildChannel | Snowflake;
+    lockPermissions?: boolean;
   }
 
   type ChannelResolvable = Channel | Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- 🌊 **upstream:** DAPI documentation `lock_permissions`,  `set_parent` in (https://github.com/discord/discord-api-docs/pull/1776)
- 🌊 **upstream:** DAPI feature request `lock_permissions` in `PATCH/channels/{channel.id}` (https://github.com/discord/discord-api-docs/discussions/3264)
- ✏ **draft:** subject to change
---

After some more digging brought up after #4144 this has turned out to be much more of an issue and less of an easy fix as originally assumed. I'll submit this as a draft PR so it can be referenced.

**⚠This PR will be subject to heavy changes as more information is acquired!**

**Current checklist/required information:**

- [x] Make #setChannelPositions accept parent and lock options
- [ ] Figure out how to efficiently set role data for all necessary roles when positions or parent properties are modified
- [ ] use [modify channel positions endpoint](https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions) for #setParent and permission locking
- [ ] use [modify channel positions endpoint](https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions) for Role#setPosition
- [ ] use [modify channel positions endpoint](https://discord.com/developers/docs/resources/guild#modify-guild-channel-positions) for Role#edit, if a position is modified
- [ ] 🌊 DAPI documentation `lock_permissions` in above endpoint (https://github.com/discord/discord-api-docs/pull/1776)
- [ ] 🌊 DAPI documentation `set_parent` in above endpoint (https://github.com/discord/discord-api-docs/pull/1776)
- [ ] 🌊 DAPI feature `lock_permissions` in PATCH/channels/{channel.id} (https://github.com/discord/discord-api-docs/issues/1796)

**Changes:**

- [`Guild#setChannelPositions`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=setChannelPositions) allow and properly handle parent and lock options
- [`Guild#setChannelPositions`](https://discord.js.org/#/docs/main/stable/class/Guild?scrollTo=setChannelPositions) make position optional (while this could be argued as major, it really just fixes the behavior to reflect the actual behavior of the API)

**Alternatives:**
- split #setChannelPositions support into own PR
- split #setParent allowing overwrites into own PR, should https://github.com/discord/discord-api-docs/issues/1796 be granted

**Original Issue**

The original hacky fix has been moved into #4627 to allow acting faster than the above linked documentation request, should the need arise.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
