### PR TITLE
feat(types): BitFieldResolvable use ReadonlyArray

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2138,7 +2138,7 @@ declare module 'discord.js' {
   type Base64String = string;
 
   type BitFieldResolvable<T extends string> =
-    | RecursiveArray<T | number | Readonly<BitField<T>>>
+    | RecursiveReadonlyArray<T | number | Readonly<BitField<T>>>
     | T
     | number
     | Readonly<BitField<T>>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2806,6 +2806,8 @@ declare module 'discord.js' {
 
   interface RecursiveArray<T> extends Array<T | RecursiveArray<T>> {}
 
+  type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray<T>>;
+
   interface PermissionOverwriteOptions {
     allow: PermissionResolvable;
     deny: PermissionResolvable;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolve #4601 
Change `BitFieldResolvable` subtype `RecursiveArray` into `RecursiveReadonlyArray`.
A resolvable's purpose is to be resolved, so its data don't need to be changed, that's why a read only version of array is more suitable.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
