### PR TITLE
fix(User): type dmChannel as nullable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1477,7 +1477,7 @@ declare module 'discord.js' {
     public readonly createdTimestamp: number;
     public discriminator: string;
     public readonly defaultAvatarURL: string;
-    public readonly dmChannel: DMChannel;
+    public readonly dmChannel: DMChannel | null;
     public flags?: Readonly<UserFlags>;
     public id: Snowflake;
     public lastMessageID: Snowflake | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- ⚠closes #4608

As #4608 pointed out User#dmChannel is wrongly typed. The DM channel can be uncached, in which case the getter returns `null`.

https://github.com/discordjs/discord.js/blob/d827544fbd12e827fb4b6ff99d8894ecd79ede02/src/structures/User.js#L213-L220
https://github.com/discordjs/discord.js/blob/d827544fbd12e827fb4b6ff99d8894ecd79ede02/typings/index.d.ts#L1474

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
