### PR TITLE
fix: correctly import VoiceState

### DIFF
--- a/src/client/actions/VoiceStateUpdate.js
+++ b/src/client/actions/VoiceStateUpdate.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Action = require('./Action');
-const VoiceState = require('../../structures/VoiceState');
+const Structures = require('../../util/Structures');
 const { Events } = require('../../util/Constants');
 
 class VoiceStateUpdate extends Action {
@@ -9,6 +9,7 @@ class VoiceStateUpdate extends Action {
     const client = this.client;
     const guild = client.guilds.cache.get(data.guild_id);
     if (guild) {
+      const VoiceState = Structures.get('VoiceState');
       // Update the state
       const oldState = guild.voiceStates.cache.has(data.user_id)
         ? guild.voiceStates.cache.get(data.user_id)._clone()

--- a/src/client/actions/VoiceStateUpdate.js
+++ b/src/client/actions/VoiceStateUpdate.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const Action = require('./Action');
-const Structures = require('../../util/Structures');
 const { Events } = require('../../util/Constants');
+const Structures = require('../../util/Structures');
 
 class VoiceStateUpdate extends Action {
   handle(data) {

--- a/src/managers/VoiceStateManager.js
+++ b/src/managers/VoiceStateManager.js
@@ -8,7 +8,7 @@ const BaseManager = require('./BaseManager');
  */
 class VoiceStateManager extends BaseManager {
   constructor(guild, iterable) {
-    super(guild.client, iterable, 'VoiceState');
+    super(guild.client, iterable, { name: 'VoiceState' });
     /**
      * The guild this manager belongs to
      * @type {Guild}

--- a/src/managers/VoiceStateManager.js
+++ b/src/managers/VoiceStateManager.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BaseManager = require('./BaseManager');
-const VoiceState = require('../structures/VoiceState');
 
 /**
  * Manages API methods for VoiceStates and stores their cache.
@@ -9,7 +8,7 @@ const VoiceState = require('../structures/VoiceState');
  */
 class VoiceStateManager extends BaseManager {
   constructor(guild, iterable) {
-    super(guild.client, iterable, VoiceState);
+    super(guild.client, iterable, 'VoiceState');
     /**
      * The guild this manager belongs to
      * @type {Guild}
@@ -27,7 +26,7 @@ class VoiceStateManager extends BaseManager {
     const existing = this.cache.get(data.user_id);
     if (existing) return existing._patch(data);
 
-    const entry = new VoiceState(this.guild, data);
+    const entry = new this.holds(this.guild, data);
     if (cache) this.cache.set(data.user_id, entry);
     return entry;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR properly imports the VoiceState class by using `Structures.get` rather than directly requiring it, as it is an extendable structure

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
