### PR TITLE
feat(Guild): discovery splash

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -131,10 +131,16 @@ class Guild extends Base {
     this.icon = data.icon;
 
     /**
-     * The hash of the guild splash image (VIP only)
+     * The hash of the guild invite splash image
      * @type {?string}
      */
     this.splash = data.splash;
+
+    /**
+     * The hash of the guild discovery splash image
+     * @type {?string}
+     */
+    this.discoverySplash = data.discovery_splash;
 
     /**
      * The region the guild is located in
@@ -503,13 +509,23 @@ class Guild extends Base {
   }
 
   /**
-   * The URL to this guild's splash.
+   * The URL to this guild's invite splash image.
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   splashURL({ format, size } = {}) {
     if (!this.splash) return null;
     return this.client.rest.cdn.Splash(this.id, this.splash, format, size);
+  }
+
+  /**
+   * The URL to this guild's discovery splash image.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string}
+   */
+  discoverySplashURL({ format, size } = {}) {
+    if (!this.discoverySplash) return null;
+    return this.client.rest.cdn.DiscoverySplash(this.id, this.discoverySplash, format, size);
   }
 
   /**
@@ -945,7 +961,8 @@ class Guild extends Base {
    * @property {number} [afkTimeout] The AFK timeout of the guild
    * @property {Base64Resolvable} [icon] The icon of the guild
    * @property {GuildMemberResolvable} [owner] The owner of the guild
-   * @property {Base64Resolvable} [splash] The splash screen of the guild
+   * @property {Base64Resolvable} [splash] The invite splash image of the guild
+   * @property {Base64Resolvable} [discoverySplash] The discovery splash image of the guild
    * @property {Base64Resolvable} [banner] The banner of the guild
    * @property {DefaultMessageNotifications|number} [defaultMessageNotifications] The default message notifications
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The system channel flags of the guild
@@ -985,6 +1002,7 @@ class Guild extends Base {
     if (typeof data.icon !== 'undefined') _data.icon = data.icon;
     if (data.owner) _data.owner_id = this.client.users.resolveID(data.owner);
     if (data.splash) _data.splash = data.splash;
+    if (data.discoverySplash) _data.discovery_splash = data.discoverySplash;
     if (data.banner) _data.banner = data.banner;
     if (typeof data.explicitContentFilter !== 'undefined') {
       _data.explicit_content_filter =
@@ -1160,9 +1178,9 @@ class Guild extends Base {
   }
 
   /**
-   * Sets a new guild splash screen.
-   * @param {Base64Resolvable|BufferResolvable} splash The new splash screen of the guild
-   * @param {string} [reason] Reason for changing the guild's splash screen
+   * Sets a new guild invite splash image.
+   * @param {Base64Resolvable|BufferResolvable} splash The new invite splash image of the guild
+   * @param {string} [reason] Reason for changing the guild's invite splash image
    * @returns {Promise<Guild>}
    * @example
    * // Edit the guild splash
@@ -1172,6 +1190,21 @@ class Guild extends Base {
    */
   async setSplash(splash, reason) {
     return this.edit({ splash: await DataResolver.resolveImage(splash), reason });
+  }
+
+  /**
+   * Sets a new guild discovery splash image.
+   * @param {Base64Resolvable|BufferResolvable} discoverySplash The new discovery splash image of the guild
+   * @param {string} [reason] Reason for changing the guild's discovery splash image
+   * @returns {Promise<Guild>}
+   * @example
+   * // Edit the guild discovery splash
+   * guild.setDiscoverySplash('./discoverysplash.png')
+   *  .then(updated => console.log('Updated the guild discovery splash'))
+   *  .catch(console.error);
+   */
+  async setDiscoverySplash(discoverySplash, reason) {
+    return this.edit({ discoverySplash: await DataResolver.resolveImage(discoverySplash), reason });
   }
 
   /**
@@ -1327,6 +1360,7 @@ class Guild extends Base {
       this.id === guild.id &&
       this.available === guild.available &&
       this.splash === guild.splash &&
+      this.discoverySplash === guild.discoverySplash &&
       this.region === guild.region &&
       this.name === guild.name &&
       this.memberCount === guild.memberCount &&
@@ -1371,6 +1405,7 @@ class Guild extends Base {
     });
     json.iconURL = this.iconURL();
     json.splashURL = this.splashURL();
+    json.discoverySplashURL = this.discoverySplashURL();
     json.bannerURL = this.bannerURL();
     return json;
   }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1230,8 +1230,8 @@ class Guild extends Base {
    * @example
    * // Edit the guild discovery splash
    * guild.setDiscoverySplash('./discoverysplash.png')
-   *  .then(updated => console.log('Updated the guild discovery splash'))
-   *  .catch(console.error);
+   *   .then(updated => console.log('Updated the guild discovery splash'))
+   *   .catch(console.error);
    */
   async setDiscoverySplash(discoverySplash, reason) {
     return this.edit({ discoverySplash: await DataResolver.resolveImage(discoverySplash), reason });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -600,6 +600,7 @@ declare module 'discord.js' {
     public defaultMessageNotifications: DefaultMessageNotifications | number;
     public deleted: boolean;
     public description: string | null;
+    public discoverySplash: string | null;
     public embedChannel: GuildChannel | null;
     public embedChannelID: Snowflake | null;
     public embedEnabled: boolean;
@@ -650,6 +651,7 @@ declare module 'discord.js' {
     public bannerURL(options?: ImageURLOptions): string | null;
     public createIntegration(data: IntegrationData, reason?: string): Promise<Guild>;
     public delete(): Promise<Guild>;
+    public discoverySplashURL(options?: ImageURLOptions): string | null;
     public edit(data: GuildEditData, reason?: string): Promise<Guild>;
     public equals(guild: Guild): boolean;
     public fetch(): Promise<Guild>;
@@ -675,6 +677,7 @@ declare module 'discord.js' {
       defaultMessageNotifications: DefaultMessageNotifications | number,
       reason?: string,
     ): Promise<Guild>;
+    public setDiscoverySplash(discoverySplash: Base64Resolvable | null, reason?: string): Promise<Guild>;
     public setEmbed(embed: GuildEmbedData, reason?: string): Promise<Guild>;
     public setExplicitContentFilter(explicitContentFilter: ExplicitContentFilterLevel, reason?: string): Promise<Guild>;
     public setIcon(icon: Base64Resolvable | null, reason?: string): Promise<Guild>;
@@ -2508,6 +2511,7 @@ declare module 'discord.js' {
     icon?: Base64Resolvable;
     owner?: GuildMemberResolvable;
     splash?: Base64Resolvable;
+    discoverySplash?: Base64Resolvable;
     banner?: Base64Resolvable;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds support for reading and setting a guild's Discovery splash
Looks like it got into GuildPreview but was never added to Guild
The CDN stuff was added in #3965

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
