### PR TITLE
fix(GuildChannel): make lockPermissions use parent overwrites

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -334,8 +334,22 @@ class GuildChannel extends Channel {
       });
     }
 
-    const permission_overwrites =
-      data.permissionOverwrites && data.permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
+    let permission_overwrites = false;
+
+    if (data.permissionOverwrites) {
+      permission_overwrites = data.permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
+    }
+
+    if (data.lockPermissions) {
+      if (data.parentID) {
+        const newParent = this.guild.channels.resolve(data.parentID);
+        if (newParent && newParent.type === 'category') {
+          permission_overwrites = newParent.permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
+        }
+      } else if (this.parent) {
+        permission_overwrites = this.parent.permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
+      }
+    }
 
     const newData = await this.client.api.channels(this.id).patch({
       data: {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -334,7 +334,7 @@ class GuildChannel extends Channel {
       });
     }
 
-    let permission_overwrites = false;
+    let permission_overwrites = undefined;
 
     if (data.permissionOverwrites) {
       permission_overwrites = data.permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -334,7 +334,7 @@ class GuildChannel extends Channel {
       });
     }
 
-    let permission_overwrites = undefined;
+    let permission_overwrites;
 
     if (data.permissionOverwrites) {
       permission_overwrites = data.permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- ⚠closes #4144

I decided to make this (original) PR separate from #4598 since it allows a quick fix of the issue at hand in case the required Discord API documentation takes more time than anticipated. The client handles this situation differently, however. After documentation on the API documentation this will be applied as a feature in #4598.

Should #4598 me merged before this issue will auto-close as it is obsolete.

as #4144 has brought to light the `lockPermissions` option in GuildChannel#setParent (and as direct cause GuildChannel#edit) does currently not lock permissions.

I tracked this down due to the API no longer accepting a `lock_permissions` field when patching a channel as per <https://discord.com/developers/docs/resources/channel#modify-channel>, which is how the feature is currently implemented as of #1727

https://github.com/discordjs/discord.js/blob/ae716872b9d9f711c0f7240a9dbd951d99a9c0ee/src/structures/GuildChannel.js#L340-L353

Since locking permissions really just means replacing the channels overwrites with its parents (or future parents) overwrites this proposed solution resolves these overwrites based on the current state and provides them (if applicable along with the new parent) in the patch data.

**Considerations/Assumptions made:**

- If both overwrites and the lock option are provided: the overwrites are overwritten
- If a new parent and lock option are provided: use the overwrites of the to-be parent
- If lock is supplied without a parent: use the overwrites of `this.parent`
- If the new parent is not a category channel or can not be resolved: ignore the lock option

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
