### PR TITLE
feat: removed ClientUser.setActivity .setAFK and .setStatus

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -126,21 +126,6 @@ class ClientUser extends Structures.get('User') {
    */
 
   /**
-   * Sets the status of the client user.
-   * @param {PresenceStatusData} status Status to change to
-   * @param {?number|number[]} [shardID] Shard ID(s) to have the activity set on
-   * @returns {Promise<Presence>}
-   * @example
-   * // Set the client user's status
-   * client.user.setStatus('idle')
-   *   .then(console.log)
-   *   .catch(console.error);
-   */
-  setStatus(status, shardID) {
-    return this.setPresence({ status, shardID });
-  }
-
-  /**
    * Options for setting an activity
    * @typedef ActivityOptions
    * @type {Object}
@@ -148,33 +133,6 @@ class ClientUser extends Structures.get('User') {
    * @property {ActivityType|number} [type] Type of the activity
    * @property {?number|number[]} [shardID] Shard Id(s) to have the activity set on
    */
-
-  /**
-   * Sets the activity the client user is playing.
-   * @param {string|ActivityOptions} [name] Activity being played, or options for setting the activity
-   * @param {ActivityOptions} [options] Options for setting the activity
-   * @returns {Promise<Presence>}
-   * @example
-   * // Set the client user's activity
-   * client.user.setActivity('discord.js', { type: 'WATCHING' })
-   *   .then(presence => console.log(`Activity set to ${presence.activities[0].name}`))
-   *   .catch(console.error);
-   */
-  setActivity(name, options = {}) {
-    if (!name) return this.setPresence({ activity: null, shardID: options.shardID });
-
-    const activity = Object.assign({}, options, typeof name === 'object' ? name : { name });
-    return this.setPresence({ activity, shardID: activity.shardID });
-  }
-
-  /**
-   * Sets/removes the AFK flag for the client user.
-   * @param {boolean} afk Whether or not the user is AFK
-   * @returns {Promise<Presence>}
-   */
-  setAFK(afk) {
-    return this.setPresence({ afk });
-  }
 }
 
 module.exports = ClientUser;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -222,12 +222,8 @@ declare module 'discord.js' {
   export class ClientUser extends User {
     public mfaEnabled: boolean;
     public verified: boolean;
-    public setActivity(options?: ActivityOptions): Promise<Presence>;
-    public setActivity(name: string, options?: ActivityOptions): Promise<Presence>;
-    public setAFK(afk: boolean): Promise<Presence>;
     public setAvatar(avatar: BufferResolvable | Base64Resolvable): Promise<ClientUser>;
     public setPresence(data: PresenceData): Promise<Presence>;
-    public setStatus(status: PresenceStatusData, shardID?: number | number[]): Promise<Presence>;
     public setUsername(username: string): Promise<ClientUser>;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

In favor of ClientUser.setPresence, removed ClientUser.setActivity .setAFK and .setStatus since they are merged in one method

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
