### PR TITLE
feat(Integration): Add Integration#roles getter

### DIFF
--- a/src/structures/Integration.js
+++ b/src/structures/Integration.js
@@ -78,6 +78,16 @@ class Integration extends Base {
     this._patch(data);
   }
 
+  /**
+   * All roles that are managed by this integration
+   * @type {Collection<Snowflake, Role>}
+   * @readonly
+   */
+  get roles() {
+    const roles = this.guild.roles.cache;
+    return roles.filter(role => role.tags && role.tags.integrationID === this.id);
+  }
+
   _patch(data) {
     /**
      * The behavior of expiring subscribers

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -868,6 +868,7 @@ declare module 'discord.js' {
     public id: Snowflake;
     public name: string;
     public role: Role;
+    public readonly roles: Collection<Snowflake, Role>;
     public syncedAt: number;
     public syncing: boolean;
     public type: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Integration#role` currently only returns a single role, however an integration can manage multiple ones. This getter filters the guild's roles by their integration id to return all roles instead.

**Consideration**

Because the role's tags (see below) aren't guaranteed to be on the object, it's more reliable to use `Integration#role`. This could be shown in an info/warn tag if Discord is too lazy to fix it before documenting it.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating
- [x] Draft PR: This requires #4628 to be merged to make use of the `Role#tags` property

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
