### PR TITLE
fix: prevent errors in older versions of Node

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -38,7 +38,7 @@ class Client extends BaseClient {
     try {
       // Test if worker threads module is present and used
       data = require('worker_threads').workerData || data;
-    } catch {
+    } catch (e) {
       // Do nothing
     }
 


### PR DESCRIPTION
Fixes error in older versions of Node as seen in Stack Overflow questions [62624941](https://stackoverflow.com/questions/62624941/discord-js-ubuntu-catch-syntaxerror-unexpected-token) and [62819245](https://stackoverflow.com/questions/62819245/my-discord-bot-works-on-my-windows-machine-but-not-on-the-vps-any-ideas). Please edit as needed. 

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
