### PR TITLE
fix(Message): Message#createdTimestamp uses deconstructed message id to get timestamp

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -13,8 +13,8 @@ const Collection = require('../util/Collection');
 const { MessageTypes } = require('../util/Constants');
 const MessageFlags = require('../util/MessageFlags');
 const Permissions = require('../util/Permissions');
+const SnowflakeUtil = require('../util/Snowflake');
 const Util = require('../util/Util');
-const SnowflakeUtil = require('../util/Snowflake')
 
 /**
  * Represents a message on Discord.

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -14,8 +14,7 @@ const { MessageTypes } = require('../util/Constants');
 const MessageFlags = require('../util/MessageFlags');
 const Permissions = require('../util/Permissions');
 const Util = require('../util/Util');
-const Snowflake = require('../util/Snowflake');
-const SnowflakeUtil = require('../util/Snowflake');
+const SnowflakeUtil = require('../util/Snowflake')
 
 /**
  * Represents a message on Discord.
@@ -117,7 +116,7 @@ class Message extends Base {
      * The timestamp the message was sent at
      * @type {number}
      */
-    this.createdTimestamp = data.timestamp ? new Date(data.timestamp).getTime() : new Date(SnowflakeUtil.deconstruct(this.id).timestamp);
+    this.createdTimestamp = data.timestamp ? new Date(data.timestamp).getTime() : SnowflakeUtil.deconstruct(this.id).timestamp;
 
     /**
      * The timestamp the message was last edited at (if applicable)

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -14,6 +14,8 @@ const { MessageTypes } = require('../util/Constants');
 const MessageFlags = require('../util/MessageFlags');
 const Permissions = require('../util/Permissions');
 const Util = require('../util/Util');
+const Snowflake = require('../util/Snowflake');
+const SnowflakeUtil = require('../util/Snowflake');
 
 /**
  * Represents a message on Discord.
@@ -115,7 +117,7 @@ class Message extends Base {
      * The timestamp the message was sent at
      * @type {number}
      */
-    this.createdTimestamp = new Date(data.timestamp).getTime();
+    this.createdTimestamp = data.timestamp ? new Date(data.timestamp).getTime() : new Date(SnowflakeUtil.deconstruct(this.id).timestamp);
 
     /**
      * The timestamp the message was last edited at (if applicable)

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -116,7 +116,7 @@ class Message extends Base {
      * The timestamp the message was sent at
      * @type {number}
      */
-    this.createdTimestamp = data.timestamp ? new Date(data.timestamp).getTime() : SnowflakeUtil.deconstruct(this.id).timestamp;
+    this.createdTimestamp = SnowflakeUtil.deconstruct(this.id).timestamp;
 
     /**
      * The timestamp the message was last edited at (if applicable)


### PR DESCRIPTION
https://i.imgur.com/6RlLWOW.png

First PR yeet

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
