### PR TITLE
updating stuff on v11 DiscordJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,5 @@ See [the contribution guide](https://github.com/discordjs/discord.js/blob/master
 ## Help
 If you don't understand something in the documentation, you are experiencing problems, or you just need a gentle
 nudge in the right direction, please don't hesitate to join our official [Discord.js Server](https://discord.gg/bRCvFy9).
+
+EDIT THIS WHEN DONE! this for V11 DiscordJS that still supported some bots.

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ discord.js is a powerful [node.js](https://nodejs.org) module that allows you to
 **Node.js 6.0.0 or newer is required.**  
 Ignore any warnings about unmet peer dependencies, as they're all optional.
 
-Without voice support: `npm install discord.js`  
-With voice support ([@discordjs/opus](https://www.npmjs.com/package/@discordjs/opus)): `npm install discord.js @discordjs/opus`  
-With voice support ([opusscript](https://www.npmjs.com/package/opusscript)): `npm install discord.js opusscript`
+Without voice support: `npm install discord.js@11.6.2`  
+With voice support ([@discordjs/opus](https://www.npmjs.com/package/@discordjs/opus)): `npm install discord.js@11.6.2 @discordjs/opus`  
+With voice support ([opusscript](https://www.npmjs.com/package/opusscript)): `npm install discord.js@11.6.2 opusscript`
 
 ### Audio engines
 The preferred audio engine is @discordjs/opus, as it performs significantly better than opusscript. When both are available, discord.js will automatically choose @discordjs/opus.

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -420,7 +420,7 @@ class Client extends EventEmitter {
   generateInvite(permissions) {
     permissions = Permissions.resolve(permissions);
     return this.fetchApplication().then(application =>
-      `https://discordapp.com/oauth2/authorize?client_id=${application.id}&permissions=${permissions}&scope=bot`
+      `https://discord.com/oauth2/authorize?client_id=${application.id}&permissions=${permissions}&scope=bot`
     );
   }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -78,7 +78,7 @@ exports.DefaultOptions = {
    */
   http: {
     version: 7,
-    host: 'https://discordapp.com',
+    host: 'https://discord.com',
     cdn: 'https://cdn.discordapp.com',
   },
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Discord Devs are planning change discordapp.com to discord.com on they API in eta 7th november 2020

some my codes still runs on v11 DiscordJS and i know its bit outdated but v11 needs a hard push out updating domain keep some v11 bots going.

i dont have eta when starting but message been post by discord dev team today and my bot still on v11 DiscordJS that cant be upgrading at this moment.

i don't know if i got all http correct push changes but double check for me if can.

Screenshot they message:

![Discord_Rx7acPgu0V](https://user-images.githubusercontent.com/18028479/87761686-ce529180-c809-11ea-94b3-d280db9f00e0.png)


**Status**

Updating discordapp.com to discord.com on planning working on moving API Domain.

**Semantic versioning classification:**

this only for V11 Discord.JS nothing else.
