### PR TITLE
fix(Util): Fix cleanContent mention exploit

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -560,15 +560,15 @@ class Util {
         const id = input.replace(/<|!|>|@/g, '');
         if (message.channel.type === 'dm') {
           const user = message.client.users.cache.get(id);
-          return user ? `@${user.username}` : input;
+          return user ? Util.removeMentions(`@${user.username}`) : input;
         }
 
         const member = message.channel.guild.members.cache.get(id);
         if (member) {
-          return `@${member.displayName}`;
+          return Util.removeMentions(`@${member.displayName}`);
         } else {
           const user = message.client.users.cache.get(id);
-          return user ? `@${user.username}` : input;
+          return user ? Util.removeMentions(`@${user.username}`) : input;
         }
       })
       .replace(/<#[0-9]+>/g, input => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

People figured out a new exploit to mention roles using bots, although users can be mentioned using that too.
(https://github.com/abalabahaha/eris/pull/990)
this issue also realized this one too.

It can username canbe mention exploit.
ex) if User set nickname/displayname `!236696896658341888` or `&566992616319877121` and insert a pair of `<>`
it can be role/user get pinged.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
