### PR TITLE
feat(typings): TypeScript support for changing $browser

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -193,25 +193,16 @@ declare module 'discord.js' {
     public toJSON(): object;
 
     public on<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
-    public on<S extends string | symbol>(
-      event: Exclude<S, keyof ClientEvents>,
-      listener: (...args: any[]) => void,
-    ): this;
+    public on<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
 
     public once<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
-    public once<S extends string | symbol>(
-      event: Exclude<S, keyof ClientEvents>,
-      listener: (...args: any[]) => void,
-    ): this;
+    public once<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
 
     public emit<K extends keyof ClientEvents>(event: K, ...args: ClientEvents[K]): boolean;
     public emit<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, ...args: any[]): boolean;
 
     public off<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
-    public off<S extends string | symbol>(
-      event: Exclude<S, keyof ClientEvents>,
-      listener: (...args: any[]) => void,
-    ): this;
+    public off<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
 
     public removeAllListeners<K extends keyof ClientEvents>(event?: K): this;
     public removeAllListeners<S extends string | symbol>(event?: Exclude<S, keyof ClientEvents>): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3065,7 +3065,7 @@ declare module 'discord.js' {
   }
 
   interface WebSocketProperties {
-    $browser: string;
+    $browser?: string;
   }
 
   type WSEventType =

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -193,16 +193,25 @@ declare module 'discord.js' {
     public toJSON(): object;
 
     public on<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
-    public on<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
+    public on<S extends string | symbol>(
+      event: Exclude<S, keyof ClientEvents>,
+      listener: (...args: any[]) => void,
+    ): this;
 
     public once<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
-    public once<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
+    public once<S extends string | symbol>(
+      event: Exclude<S, keyof ClientEvents>,
+      listener: (...args: any[]) => void,
+    ): this;
 
     public emit<K extends keyof ClientEvents>(event: K, ...args: ClientEvents[K]): boolean;
     public emit<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, ...args: any[]): boolean;
 
     public off<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => void): this;
-    public off<S extends string | symbol>(event: Exclude<S, keyof ClientEvents>, listener: (...args: any[]) => void): this;
+    public off<S extends string | symbol>(
+      event: Exclude<S, keyof ClientEvents>,
+      listener: (...args: any[]) => void,
+    ): this;
 
     public removeAllListeners<K extends keyof ClientEvents>(event?: K): this;
     public removeAllListeners<S extends string | symbol>(event?: Exclude<S, keyof ClientEvents>): this;
@@ -3061,6 +3070,11 @@ declare module 'discord.js' {
     large_threshold?: number;
     compress?: boolean;
     intents?: BitFieldResolvable<IntentsString> | number;
+    properties?: WebSocketProperties;
+  }
+
+  interface WebSocketProperties {
+    $browser: string;
   }
 
   type WSEventType =

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3065,7 +3065,9 @@ declare module 'discord.js' {
   }
 
   interface WebSocketProperties {
+    $os?: string;
     $browser?: string;
+    $device?: string;
   }
 
   type WSEventType =


### PR DESCRIPTION
This pull request provides support for changing the default ws#properties#$browser property for TypeScript. It can be done through vanilla JS without a problem, for example:
```js
const { Client } = require("discord.js");
const client = new Client({
  ws: {
    properties: {
      $browser: "Discord iOS" // <-- a popular value to change $browser to
    }
  }
});

client.once("ready", () => console.log("Ready")); // The bot will now show online on a mobile device
client.login("<TOKEN>");
```
whereas using TypeScript you would get compilation errors such as:
```
Type '{ properties: { $browser: string; }; }' is not assignable to type 'WebSocketOptions'.
  Object literal may only specify known properties, and 'properties' does not exist in type 'WebSocketOptions'.ts(2322)
index.d.ts(2208, 5): The expected type comes from property 'ws' which is declared here on type 'ClientOptions'
```

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
