### PR TITLE
fix(Message): include MessageEmbed type

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -400,7 +400,7 @@ class Message extends Base {
    * Options that can be passed into editMessage.
    * @typedef {Object} MessageEditOptions
    * @property {string} [content] Content to be edited
-   * @property {Object} [embed] An embed to be added/edited
+   * @property {MessageEmbed|Object} [embed] An embed to be added/edited
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2652,7 +2652,7 @@ declare module 'discord.js' {
 
   interface MessageEditOptions {
     content?: string;
-    embed?: MessageEmbedOptions | null;
+    embed?: MessageEmbed | MessageEmbedOptions | null;
     code?: string | boolean;
     flags?: BitFieldResolvable<MessageFlagsString>;
     allowedMentions?: MessageMentionOptions;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

[MessageEditOptions#embed](https://discord.js.org/#/docs/main/master/typedef/MessageEditOptions) allows a MessageEmbed structure to be passed. This is currently not reflected in documentation or typings which only allow the raw embed data (type: `MessageEmbedOptions`).

This PR adds the typings and documentation to rectify this.

```ts
import { MessageEmbed, MessageEditOptions } from 'discord.js';
const data: MessageEditOptions = {};
data.embed = new MessageEmbed();
```

```
(property) MessageEditOptions.embed?: MessageEmbedOptions | null | undefined
Type 'MessageEmbed' is not assignable to type 'MessageEmbedOptions'.
  Types of property 'timestamp' are incompatible.
    Type 'number | null' is not assignable to type 'number | Date | undefined'.
      Type 'null' is not assignable to type 'number | Date | undefined'.ts(2322)
```

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
