### PR TITLE
Add message.publishable and message.publish()

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -397,6 +397,21 @@ class Message extends Base {
   }
 
   /**
+   * Whether the message is publishable by the client user
+   * @type {boolean}
+   * @readonly
+   */
+  get publishable() {
+    return (
+      this.type === 'DEFAULT' &&
+      this.guild &&
+      !this.flags.has(MessageFlags.FLAGS.CROSSPOSTED) &&
+      this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false) &&
+      this.channel.type === 'news'
+    );
+  }
+
+  /**
    * Options that can be passed into editMessage.
    * @typedef {Object} MessageEditOptions
    * @property {string} [content] Content to be edited
@@ -461,6 +476,24 @@ class Message extends Base {
       .channels(this.channel.id)
       .pins(this.id)
       .delete(options)
+      .then(() => this);
+  }
+
+  /**
+   * Publish this message in the news channel to subscribers.
+   * @returns {Promise<Message>}
+   * @example
+   * // Publish a message
+   * message.publish()
+   *   .then(console.log)
+   *   .catch(console.error)
+   */
+  publish() {
+    return this.client.api
+      .channels(this.channel.id)
+      .messages(this.id)
+      .crosspost()
+      .post()
       .then(() => this);
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -956,6 +956,7 @@ declare module 'discord.js' {
     public nonce: string | null;
     public readonly partial: false;
     public readonly pinnable: boolean;
+    public readonly publishable: boolean;
     public pinned: boolean;
     public reactions: ReactionManager;
     public system: boolean;
@@ -977,6 +978,7 @@ declare module 'discord.js' {
     public fetchWebhook(): Promise<Webhook>;
     public fetch(): Promise<Message>;
     public pin(options?: { reason?: string }): Promise<Message>;
+    public publish(): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public reply(
       content?: StringResolvable,


### PR DESCRIPTION
I added the property message.publishable and the function message.publish()

**Status**

- [x] Code changes have been tested against the Discord API
- [x] I know how to update typings and have done so

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
