### PR TITLE
fix(GuildMember): properly check permissions for hasPermissions

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -265,7 +265,7 @@ class GuildMember extends Base {
    */
   hasPermission(permission, { checkAdmin = true, checkOwner = true } = {}) {
     if (checkOwner && this.user.id === this.guild.ownerID) return true;
-    return this.roles.cache.some(r => r.permissions.has(permission, checkAdmin));
+    return this.permissions.has(permission, checkAdmin);
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -265,7 +265,8 @@ class GuildMember extends Base {
    */
   hasPermission(permission, { checkAdmin = true, checkOwner = true } = {}) {
     if (checkOwner && this.user.id === this.guild.ownerID) return true;
-    return this.permissions.has(permission, checkAdmin);
+    const permissions = new Permissions(this.roles.cache.map(role => role.permissions));
+    return permissions.has(permission, checkAdmin);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a bug to do with `GuildMember.hasPermission`, to explain:
if a server had 2 roles, `@everyone` and `Role A`, if `@everyone` only had `SEND_MESSAGES`, and `Role A` only had `VIEW_CHANNEL`, `GuildMember.hasPermission(['SEND_MESSAGES', 'VIEW_CHANNEL'])` would inaccurately return `false`, this is because `GuildMember.hasPermission` checks if any of the members roles has the provided permissions, instead of combining all the permissions the member has, and then checking that
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
