### PR TITLE
docs(examples): fix example img

### DIFF
--- a/docs/examples/attachments.md
+++ b/docs/examples/attachments.md
@@ -111,7 +111,7 @@ client.login('your token here');
 
 The results are the same as the URL examples:
 
-![Image showing result](/static/attachment-example1.png)
+![Image showing result](/static/attachment-example2.png)
 
 But what if you have a buffer from an image? Or a text document? Well, it's the same as sending a local file or a URL!
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes **"The results are the same as the URL examples:"** image in **"Sending a local file or buffer"** Portion of **attachments.md**, looks like the result is different than that of Example Code.
![Screenshot from 2020-08-03 18-12-41](https://user-images.githubusercontent.com/34993200/89185847-85942a00-d5b8-11ea-80e7-0473048ce087.png)

**It should be :**
![Screenshot from 2020-08-03 18-14-56](https://user-images.githubusercontent.com/34993200/89187308-bbd2a900-d5ba-11ea-9655-dabca4c2101d.png)


**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
