### PR TITLE
fix(MessageReactionAdd): prevent double messageReactionAdd triggering

### DIFF
--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -28,7 +28,7 @@ class MessageReactionAdd extends Action {
 
     // Verify reaction
     if (message.partial && !this.client.options.partials.includes(PartialTypes.REACTION)) return false;
-    const existing = message.reactions.cache.get(data.emoji.id || data.emoji.name)
+    const existing = message.reactions.cache.get(data.emoji.id || data.emoji.name);
     if (existing && existing.users.cache.has(user.id)) return { message, reaction: existing, user };
     const reaction = message.reactions.add({
       emoji: data.emoji,

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -29,10 +29,8 @@ class MessageReactionAdd extends Action {
     // Verify reaction
     if (message.partial && !this.client.options.partials.includes(PartialTypes.REACTION)) return false;
     const existing =
-      (message.reactions.cache.has(data.emoji.id) &&
-        message.reactions.cache.get(data.emoji.id).users.cache.get(user.id)) ||
-      (message.reactions.cache.has(data.emoji.name) &&
-        message.reactions.cache.get(data.emoji.name).users.cache.get(user.id));
+      message.reactions.cache.has(data.emoji.id || data.emoji.name) &&
+      message.reactions.cache.get(data.emoji.id || data.emoji.name).users.cache.get(user.id);
     if (existing) return { message, reaction: existing, user };
     const reaction = message.reactions.add({
       emoji: data.emoji,

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -29,8 +29,10 @@ class MessageReactionAdd extends Action {
     // Verify reaction
     if (message.partial && !this.client.options.partials.includes(PartialTypes.REACTION)) return false;
     const existing =
-      message.reactions.cache.has(data.emoji.name) &&
-      message.reactions.cache.get(data.emoji.name).users.cache.get(user.id);
+      (message.reactions.cache.has(data.emoji.id) &&
+        message.reactions.cache.get(data.emoji.id).users.cache.get(user.id)) ||
+      (message.reactions.cache.has(data.emoji.name) &&
+        message.reactions.cache.get(data.emoji.name).users.cache.get(user.id));
     if (existing) return { message, reaction: existing, user };
     const reaction = message.reactions.add({
       emoji: data.emoji,

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -28,6 +28,10 @@ class MessageReactionAdd extends Action {
 
     // Verify reaction
     if (message.partial && !this.client.options.partials.includes(PartialTypes.REACTION)) return false;
+    const existing =
+      message.reactions.cache.has(data.emoji.name) &&
+      message.reactions.cache.get(data.emoji.name).users.cache.get(user.id);
+    if (existing) return { message, reaction: existing, user };
     const reaction = message.reactions.add({
       emoji: data.emoji,
       count: message.partial ? null : 0,

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -28,10 +28,8 @@ class MessageReactionAdd extends Action {
 
     // Verify reaction
     if (message.partial && !this.client.options.partials.includes(PartialTypes.REACTION)) return false;
-    const existing =
-      message.reactions.cache.has(data.emoji.id || data.emoji.name) &&
-      message.reactions.cache.get(data.emoji.id || data.emoji.name).users.cache.get(user.id);
-    if (existing) return { message, reaction: existing, user };
+    const existing = message.reactions.cache.get(data.emoji.id || data.emoji.name)
+    if (existing && existing.users.cache.has(user.id)) return { message, reaction: existing, user };
     const reaction = message.reactions.add({
       emoji: data.emoji,
       count: message.partial ? null : 0,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes #4284.
The method [Message#react()](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=react) calls MessageReactionAdd#handle() (`this.client.actions.MessageReactionAdd.handle()`, [line 493 at Message.js](https://github.com/discordjs/discord.js/blob/master/src/structures/Message.js#L493)). So, if the user is listening for the `messageReactionAdd` event and the bot client react using [Message#react()](https://discord.js.org/#/docs/main/stable/class/Message?scrollTo=react), MessageReactionAdd#handle() method is called twice (second time when data is received from the API and handled at [WebSocketManager#handlePacket()](https://github.com/discordjs/discord.js/blob/master/src/client/websocket/WebSocketManager.js#L370) which calls again MessageReactionAdd#handle()) and so the event` messageReactionAdd` is emitted twice (see bellow the output before PR).

I tried to fix that by doing something similar to what has been done in [MessageCreateAction#handle()](https://github.com/discordjs/discord.js/blob/master/src/client/actions/MessageCreate.js#L7).

__Example code:__
```js
require('dotenv').config()
const Discord = require('discord.js');

const client = new Discord.Client();

client.once('ready', () => console.log(`Logged in as ${client.user.tag}.`));

client.on('message', async (message) => {
  console.log('Someone said something.');
  const reaction = await message.react('🤔');
});

client.on('messageReactionAdd', (reaction, user) => {
  console.log(`${user.tag} reacted ${reaction.emoji.name} on message ${reaction.message.id}.`);
});

client.login(process.env.TOKEN);
```

__Output before PR:__
```
Logged in as Somebot#8206.
Someone said something.
Somebot#8206 reacted 🤔 on message 740631539108544752.
Somebot#8206 reacted 🤔 on message 740631539108544752.
```

__Ouput after PR:__
```
Logged in as Somebot#8206.
Someone said something.
Somebot#8206 reacted 🤔 on message 740631816695709708.
```

I also tested with partials enabled, me and the bot reacting to new and old messages, it's working.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
