### PR TITLE
docs(ReactionManager): clarify cache Collection keys type

### DIFF
--- a/src/managers/ReactionManager.js
+++ b/src/managers/ReactionManager.js
@@ -24,7 +24,7 @@ class ReactionManager extends BaseManager {
 
   /**
    * The reaction cache of this manager
-   * @type {Collection<Snowflake, MessageReaction>}
+   * @type {Collection<string|Snowflake, MessageReaction>}
    * @name ReactionManager#cache
    */
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1951,7 +1951,7 @@ declare module 'discord.js' {
     constructor(client: Client, iterable?: Iterable<any>);
   }
 
-  export class ReactionManager extends BaseManager<Snowflake, MessageReaction, MessageReactionResolvable> {
+  export class ReactionManager extends BaseManager<string | Snowflake, MessageReaction, MessageReactionResolvable> {
     constructor(message: Message, iterable?: Iterable<any>);
     public message: Message;
     public removeAll(): Promise<Message>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
[ReactionManager#cache](https://discord.js.org/#/docs/main/stable/class/ReactionManager?scrollTo=cache) returns a collection of [MessageReaction](https://discord.js.org/#/docs/main/stable/class/MessageReaction) mapped by either a `Snowflake` (for **custom emojis**) or a `string`(for **emojis**); but current type of [ReactionManager#cache](https://discord.js.org/#/docs/main/stable/class/ReactionManager?scrollTo=cache) is `Collection<Snowflake, MessageReaction>`.
Even if `Snowflake` is just a named typedef for `string`, it still seems a bit misleading and semantically incorrect.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
