### PR TITLE
fix(typings): correct spelling of APIError

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2085,7 +2085,7 @@ declare module 'discord.js' {
     deaf?: boolean;
   }
 
-  interface APIErrror {
+  interface APIError {
     UNKNOWN_ACCOUNT: number;
     UNKNOWN_APPLICATION: number;
     UNKNOWN_CHANNEL: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

APIErrror has been changed by APIError

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
