### PR TITLE
feat(typings): add number type for setExplicitContentFilter method

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2537,7 +2537,7 @@ declare module 'discord.js' {
     name?: string;
     region?: string;
     verificationLevel?: VerificationLevel;
-    explicitContentFilter?: ExplicitContentFilterLevel;
+    explicitContentFilter?: ExplicitContentFilterLevel | number;
     defaultMessageNotifications?: DefaultMessageNotifications | number;
     afkChannel?: ChannelResolvable;
     systemChannel?: ChannelResolvable;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -699,7 +699,7 @@ declare module 'discord.js' {
     ): Promise<Guild>;
     public setDiscoverySplash(discoverySplash: Base64Resolvable | null, reason?: string): Promise<Guild>;
     public setEmbed(embed: GuildWidgetData, reason?: string): Promise<Guild>;
-    public setExplicitContentFilter(explicitContentFilter: ExplicitContentFilterLevel, reason?: string): Promise<Guild>;
+    public setExplicitContentFilter(explicitContentFilter: ExplicitContentFilterLevel|number, reason?: string): Promise<Guild>;
     public setIcon(icon: Base64Resolvable | null, reason?: string): Promise<Guild>;
     public setName(name: string, reason?: string): Promise<Guild>;
     public setOwner(owner: GuildMemberResolvable, reason?: string): Promise<Guild>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -711,7 +711,7 @@ declare module 'discord.js' {
     public setSplash(splash: Base64Resolvable | null, reason?: string): Promise<Guild>;
     public setSystemChannel(systemChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
     public setSystemChannelFlags(systemChannelFlags: SystemChannelFlagsResolvable, reason?: string): Promise<Guild>;
-    public setVerificationLevel(verificationLevel: VerificationLevel, reason?: string): Promise<Guild>;
+    public setVerificationLevel(verificationLevel: VerificationLevel | number, reason?: string): Promise<Guild>;
     public setWidget(widget: GuildWidgetData, reason?: string): Promise<Guild>;
     public splashURL(options?: ImageURLOptions): string | null;
     public toJSON(): object;
@@ -2536,7 +2536,7 @@ declare module 'discord.js' {
   interface GuildEditData {
     name?: string;
     region?: string;
-    verificationLevel?: VerificationLevel;
+    verificationLevel?: VerificationLevel | number;
     explicitContentFilter?: ExplicitContentFilterLevel | number;
     defaultMessageNotifications?: DefaultMessageNotifications | number;
     afkChannel?: ChannelResolvable;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -699,7 +699,7 @@ declare module 'discord.js' {
     ): Promise<Guild>;
     public setDiscoverySplash(discoverySplash: Base64Resolvable | null, reason?: string): Promise<Guild>;
     public setEmbed(embed: GuildWidgetData, reason?: string): Promise<Guild>;
-    public setExplicitContentFilter(explicitContentFilter: ExplicitContentFilterLevel|number, reason?: string): Promise<Guild>;
+    public setExplicitContentFilter(explicitContentFilter: ExplicitContentFilterLevel | number, reason?: string): Promise<Guild>;
     public setIcon(icon: Base64Resolvable | null, reason?: string): Promise<Guild>;
     public setName(name: string, reason?: string): Promise<Guild>;
     public setOwner(owner: GuildMemberResolvable, reason?: string): Promise<Guild>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

the `setExplicitContentFilter()` does accept number for the level and it doesn't work using typescript.

![Capture d’écran 2020-08-12 à 12 26 42](https://user-images.githubusercontent.com/42497995/90012918-94f43100-dca4-11ea-8e29-3bb37c413b69.png)

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.