### PR TITLE
feat: trigger userUpdate on GUILD_MEMBER_UPDATE

### DIFF
--- a/src/client/actions/UserUpdate.js
+++ b/src/client/actions/UserUpdate.js
@@ -13,6 +13,7 @@ class UserUpdateAction extends Action {
     if (!oldUser.equals(newUser)) {
       /**
        * Emitted whenever a user's details (e.g. username) are changed.
+       * Triggered by the Discord gateway events USER_UPDATE, GUILD_MEMBER_UPDATE, and PRESENCE_UPDATE.
        * @event Client#userUpdate
        * @param {User} oldUser The user before the update
        * @param {User} newUser The user after the update

--- a/src/client/websocket/handlers/GUILD_MEMBER_UPDATE.js
+++ b/src/client/websocket/handlers/GUILD_MEMBER_UPDATE.js
@@ -3,6 +3,12 @@
 const { Status, Events } = require('../../../util/Constants');
 
 module.exports = (client, { d: data }, shard) => {
+  let user = client.users.cache.get(data.user.id);
+  if (!user && data.user.username) user = client.users.add(data.user);
+  if (user && data.user && data.user.username) {
+    if (!user.equals(data.user)) client.actions.UserUpdate.handle(data.user);
+  }
+
   const guild = client.guilds.cache.get(data.guild_id);
   if (guild) {
     const member = guild.members.cache.get(data.user.id);
@@ -11,6 +17,7 @@ module.exports = (client, { d: data }, shard) => {
       if (shard.status === Status.READY) {
         /**
          * Emitted whenever a guild member changes - i.e. new role, removed role, nickname.
+         * Also emitted when the user's details (e.g. username) change.
          * @event Client#guildMemberUpdate
          * @param {GuildMember} oldMember The member before the update
          * @param {GuildMember} newMember The member after the update


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `USER_UPDATE` gateway event only triggers when the bot's user itself is updated, but discord.js's userUpdate event triggers when any user known user is updated.

Currently, the userUpdate event triggers on the `USER_UPDATE` gateway event as well as the `PRESENCE_UPDATE` event. 
However, due to the addition of Intents, Discord now also sends user updates in the `GUILD_MEMBER_UPDATE` event:
> `GUILD_MEMBER_UDPATE` will now fire when a user changes so that bots that want to opt out of presence can still receive updated user attributes.

(from https://github.com/discord/discord-api-docs/pull/1307#issuecomment-581561519)

This PR updates discord.js to also trigger the userUpdate event on the `GUILD_MEMBER_UPDATE` events, for users who are using the `GUILD_MEMBERS` intent but not the `GUILD_PRESENCES` event. I copied the relevant code from the `PresenceUpdate` action to the `GUILD_MEMBER_UPDATE` handler.
It also updates documentation to clarify which events trigger userUpdate.

resolves #4279, related to #4169

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
