### PR TITLE
fix(User): set User#bot to false if not partial

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -46,7 +46,7 @@ class User extends Base {
      * @type {?boolean}
      * @name User#bot
      */
-    this.bot = !this.partial ? Boolean(data.bot) : null;
+    this.bot = Boolean(data.bot);
 
     if ('discriminator' in data) {
       /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -30,15 +30,6 @@ class User extends Base {
   }
 
   _patch(data) {
-    if (typeof this.bot !== 'boolean') {
-      /**
-       * Whether or not the user is a bot
-       * @type {?boolean}
-       * @name User#bot
-       */
-      this.bot = 'bot' in data ? Boolean(data.bot) : null;
-    }
-
     if ('username' in data) {
       /**
        * The username of the user
@@ -49,6 +40,13 @@ class User extends Base {
     } else if (typeof this.username !== 'string') {
       this.username = null;
     }
+
+    /**
+     * Whether or not the user is a bot
+     * @type {?boolean}
+     * @name User#bot
+     */
+    this.bot = !this.partial ? Boolean(data.bot) : null;
 
     if ('discriminator' in data) {
       /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Closes #4702 

#4636 recently introduced a bug where `User#bot` was set to `null` instead of `false`. This is the case because it checked if the bot property was present in the data to see if it was a partial or not, however this property also does not exist for a regular user. This has been fixed by using `User#partial` which checks if the username property exists instead.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
