### PR TITLE
revert(Shard): "fix missing child_process silent option of Shard to allow listening to output"

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -115,7 +115,6 @@ class Shard extends EventEmitter {
         .fork(path.resolve(this.manager.file), this.args, {
           env: this.env,
           execArgv: this.execArgv,
-          silent: true,
         })
         .on('message', this._handleMessage.bind(this))
         .on('exit', this._exitListener);


### PR DESCRIPTION
Reverts discordjs/discord.js#4308

This was a breaking change which required you to listen to `stdout`, `stderr`, etc manually.
Needs to be reworked if it should land in any minor version to let users control the way of doing it.