### PR TITLE
feat(Rest): better handling of global rate limit and invalid request tracking

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -487,6 +487,9 @@ class Client extends BaseClient {
     if (typeof options.restRequestTimeout !== 'number' || isNaN(options.restRequestTimeout)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'restRequestTimeout', 'a number');
     }
+    if (typeof options.restGlobalRateLimit !== 'number' || isNaN(options.restGlobalRateLimit)) {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'restGlobalRateLimit', 'a number');
+    }
     if (typeof options.restSweepInterval !== 'number' || isNaN(options.restSweepInterval)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'restSweepInterval', 'a number');
     }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -478,6 +478,9 @@ class Client extends BaseClient {
     if (typeof options.messageSweepInterval !== 'number' || isNaN(options.messageSweepInterval)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'messageSweepInterval', 'a number');
     }
+    if (typeof options.invalidRequestWarningInterval !== 'number' || isNaN(options.invalidRequestWarningInterval)) {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'invalidRequestWarningInterval', 'a number');
+    }
     if (!Array.isArray(options.partials)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'partials', 'an Array');
     }

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -13,7 +13,10 @@ class RESTManager {
     this.handlers = new Collection();
     this.tokenPrefix = tokenPrefix;
     this.versioned = true;
-    this.globalTimeout = null;
+    this.globalLimit = client.options.restGlobalRateLimit > 0 ? client.options.restGlobalRateLimit : Infinity;
+    this.globalRemaining = this.globalLimit;
+    this.globalReset = null;
+    this.globalDelay = null;
     if (client.options.restSweepInterval > 0) {
       client.setInterval(() => {
         this.handlers.sweep(handler => handler._inactive);

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -28,7 +28,6 @@ class RequestHandler {
     this.reset = -1;
     this.remaining = -1;
     this.limit = -1;
-    this.retryAfter = -1;
   }
 
   async push(request) {
@@ -40,18 +39,61 @@ class RequestHandler {
     }
   }
 
+  get globalLimited() {
+    return this.manager.globalRemaining <= 0 && Date.now() < this.manager.globalReset;
+  }
+
+  get localLimited() {
+    return this.remaining <= 0 && Date.now() < this.reset;
+  }
+
   get limited() {
-    return Boolean(this.manager.globalTimeout) || (this.remaining <= 0 && Date.now() < this.reset);
+    return this.globalLimited || this.localLimited;
   }
 
   get _inactive() {
     return this.queue.remaining === 0 && !this.limited;
   }
 
+  globalDelayFor(ms) {
+    return new Promise(resolve => {
+      setTimeout(
+        manager => {
+          manager.globalDelay = null;
+          resolve();
+        },
+        ms,
+        this.manager,
+      );
+    });
+  }
+
   async execute(request) {
-    // After calculations and requests have been done, pre-emptively stop further requests
-    if (this.limited) {
-      const timeout = this.reset + this.manager.client.options.restTimeOffset - Date.now();
+    /*
+     * After calculations have been done, pre-emptively stop further requests
+     * Potentially loop until this task can run if e.g. the global rate limit is hit twice
+     */
+    while (this.limited) {
+      let global, limit, timeout, delayPromise;
+
+      if (this.globalLimited) {
+        // Set the variables based on the global rate limit
+        global = true;
+        limit = this.manager.globalLimit;
+        timeout = this.manager.globalReset + this.manager.client.options.restTimeOffset - Date.now();
+        // If this is the first task to reach the global timeout, set the global delay
+        if (!this.manager.globalDelay) {
+          // The global delay function should clear the global delay state when it is resolved
+          this.manager.globalDelay = this.globalDelayFor(timeout);
+        }
+        delayPromise = this.manager.globalDelay;
+      } else {
+        // Set the variables based on the route-specific rate limit
+        global = false;
+        limit = this.limit;
+        timeout = this.reset + this.manager.client.options.restTimeOffset - Date.now();
+        delayPromise = Util.delayFor(timeout);
+      }
 
       if (this.manager.client.listenerCount(RATE_LIMIT)) {
         /**
@@ -63,23 +105,28 @@ class RequestHandler {
          * @param {string} rateLimitInfo.method HTTP method used for request that triggered this event
          * @param {string} rateLimitInfo.path Path used for request that triggered this event
          * @param {string} rateLimitInfo.route Route used for request that triggered this event
+         * @param {boolean} rateLimitInfo.global Whether the rate limit that was reached was the global limit
          */
         this.manager.client.emit(RATE_LIMIT, {
           timeout,
-          limit: this.limit,
+          limit: limit,
           method: request.method,
           path: request.path,
           route: request.route,
+          global: global,
         });
       }
 
-      if (this.manager.globalTimeout) {
-        await this.manager.globalTimeout;
-      } else {
-        // Wait for the timeout to expire in order to avoid an actual 429
-        await Util.delayFor(timeout);
-      }
+      // Wait for the timeout to expire in order to avoid an actual 429
+      await delayPromise; // eslint-disable-line no-await-in-loop
     }
+
+    // As the request goes out, update the global usage information
+    if (!this.manager.globalReset || this.manager.globalReset < Date.now()) {
+      this.manager.globalReset = Date.now() + 1000;
+      this.manager.globalRemaining = this.manager.globalLimit;
+    }
+    this.manager.globalRemaining--;
 
     // Perform the request
     let res;
@@ -100,28 +147,31 @@ class RequestHandler {
       const limit = res.headers.get('x-ratelimit-limit');
       const remaining = res.headers.get('x-ratelimit-remaining');
       const reset = res.headers.get('x-ratelimit-reset');
-      const retryAfter = res.headers.get('retry-after');
-
       this.limit = limit ? Number(limit) : Infinity;
       this.remaining = remaining ? Number(remaining) : 1;
       this.reset = reset ? calculateReset(reset, serverDate) : Date.now();
-      this.retryAfter = retryAfter ? Number(retryAfter) * 1000 : -1;
 
       // https://github.com/discordapp/discord-api-docs/issues/182
       if (request.route.includes('reactions')) {
         this.reset = new Date(serverDate).getTime() - getAPIOffset(serverDate) + 250;
       }
 
-      // Handle global ratelimit
-      if (res.headers.get('x-ratelimit-global')) {
-        // Set the manager's global timeout as the promise for other requests to "wait"
-        this.manager.globalTimeout = Util.delayFor(this.retryAfter);
-
-        // Wait for the global timeout to resolve before continuing
-        await this.manager.globalTimeout;
-
-        // Clean up global timeout
-        this.manager.globalTimeout = null;
+      // Handle retryAfter, which means we have actually hit a rate limit
+      var retryAfter = res.headers.get('retry-after');
+      retryAfter = retryAfter ? Number(retryAfter) * 1000 : -1;
+      if (retryAfter > 0) {
+        // If the global ratelimit header is set, that means we hit the global rate limit
+        if (res.headers.get('x-ratelimit-global')) {
+          this.manager.globalRemaining = 0;
+          this.manager.globalReset = Date.now() + retryAfter;
+        } else if (!this.localLimited) {
+          /*
+           * This is a sublimit (e.g. 2 channel name changes/10 minutes) since the headers don't indicate a
+           * route-wide rate limit. Don't update remaining or reset to avoid rate limiting the whole
+           * endpoint, just set a reset time on the request itself to avoid retrying too soon.
+           */
+          res.sublimit = retryAfter;
+        }
       }
     }
 
@@ -136,8 +186,12 @@ class RequestHandler {
       // Handle ratelimited requests
       if (res.status === 429) {
         // A ratelimit was hit - this should never happen
-        this.manager.client.emit('debug', `429 hit on route ${request.route}`);
-        await Util.delayFor(this.retryAfter);
+        this.manager.client.emit('debug', `429 hit on route ${request.route}${res.sublimit ? ' for sublimit' : ''}`);
+        // If caused by a sublimit, wait it out here so other requests on the route can be handled
+        if (res.sublimit) {
+          await Util.delayFor(res.sublimit);
+          delete res.sublimit;
+        }
         return this.execute(request);
       }
 

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -66,7 +66,7 @@ class RequestHandler {
 
   globalDelayFor(ms) {
     return new Promise(resolve => {
-      setTimeout(
+      this.manager.client.setTimeout(
         manager => {
           manager.globalDelay = null;
           resolve();

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -83,11 +83,11 @@ class RequestHandler {
      * Potentially loop until this task can run if e.g. the global rate limit is hit twice
      */
     while (this.limited) {
-      let global, limit, timeout, delayPromise;
+      let isGlobal, limit, timeout, delayPromise;
 
       if (this.globalLimited) {
         // Set the variables based on the global rate limit
-        global = true;
+        isGlobal = true;
         limit = this.manager.globalLimit;
         timeout = this.manager.globalReset + this.manager.client.options.restTimeOffset - Date.now();
         // If this is the first task to reach the global timeout, set the global delay
@@ -98,7 +98,7 @@ class RequestHandler {
         delayPromise = this.manager.globalDelay;
       } else {
         // Set the variables based on the route-specific rate limit
-        global = false;
+        isGlobal = false;
         limit = this.limit;
         timeout = this.reset + this.manager.client.options.restTimeOffset - Date.now();
         delayPromise = Util.delayFor(timeout);
@@ -122,7 +122,7 @@ class RequestHandler {
           method: request.method,
           path: request.path,
           route: request.route,
-          global: global,
+          global: isGlobal,
         });
       }
 

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -66,14 +66,10 @@ class RequestHandler {
 
   globalDelayFor(ms) {
     return new Promise(resolve => {
-      this.manager.client.setTimeout(
-        manager => {
-          manager.globalDelay = null;
-          resolve();
-        },
-        ms,
-        this.manager,
-      );
+      this.manager.client.setTimeout(() => {
+        this.manager.globalDelay = null;
+        resolve();
+      }, ms);
     });
   }
 

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -27,8 +27,8 @@ function calculateReset(reset, serverDate) {
  * Therefore, store these at file scope here rather than in the client's
  * RESTManager object.
  */
-var invalidCount = 0;
-var invalidCountResetTime = null;
+let invalidCount = 0;
+let invalidCountResetTime = null;
 
 class RequestHandler {
   constructor(manager) {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -19,6 +19,9 @@ const { Error, RangeError } = require('../errors');
  * @property {number} [messageSweepInterval=0] How frequently to remove messages from the cache that are older than
  * the message cache lifetime (in seconds, 0 for never)
  * @property {MessageMentionOptions} [allowedMentions] Default value for {@link MessageOptions#allowedMentions}
+ * @property {number} [invalidRequestWarningInterval=0] The number of invalid REST requests (those that return
+ * 401, 403, or 429) in a 10 minute window between emitted warnings (0 for no warnings). That is, if set to 500,
+ * warnings will be emitted at invalid request number 500, 1000, 1500, and so on.
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
  * they're missing all the data for a particular structure. See the "Partials" topic listed in the sidebar for some
  * important usage information, as partials require you to put checks in place when handling data.
@@ -42,6 +45,7 @@ exports.DefaultOptions = {
   messageCacheMaxSize: 200,
   messageCacheLifetime: 0,
   messageSweepInterval: 0,
+  invalidRequestWarningInterval: 0,
   partials: [],
   restWsBridgeTimeout: 5000,
   restRequestTimeout: 15000,
@@ -221,6 +225,7 @@ exports.VoiceOPCodes = {
 
 exports.Events = {
   RATE_LIMIT: 'rateLimit',
+  INVALID_REQUEST_WARNING: 'invalidRequestWarning',
   CLIENT_READY: 'ready',
   GUILD_CREATE: 'guildCreate',
   GUILD_DELETE: 'guildDelete',

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -32,7 +32,7 @@ const { Error, RangeError } = require('../errors');
  * @property {number} [restRequestTimeout=15000] Time to wait before cancelling a REST request, in milliseconds
  * @property {number} [restSweepInterval=60] How frequently to delete inactive request buckets, in seconds
  * (or 0 for never)
- * @property {number} [restGlobalRateLimit=0] How many messages to allow sending per second (0 for unlimited, 50 for
+ * @property {number} [restGlobalRateLimit=0] How many requests to allow sending per second (0 for unlimited, 50 for
  * the standard global limit used by Discord)
  * @property {number} [retryLimit=1] How many times to retry on 5XX errors (Infinity for indefinite amount of retries)
  * @property {PresenceData} [presence={}] Presence data to use upon login

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -29,6 +29,8 @@ const { Error, RangeError } = require('../errors');
  * @property {number} [restRequestTimeout=15000] Time to wait before cancelling a REST request, in milliseconds
  * @property {number} [restSweepInterval=60] How frequently to delete inactive request buckets, in seconds
  * (or 0 for never)
+ * @property {number} [restGlobalRateLimit=0] How many messages to allow sending per second (0 for unlimited, 50 for
+ * the standard global limit used by Discord)
  * @property {number} [retryLimit=1] How many times to retry on 5XX errors (Infinity for indefinite amount of retries)
  * @property {PresenceData} [presence={}] Presence data to use upon login
  * @property {IntentsResolvable} intents Intents to enable for this connection
@@ -43,6 +45,7 @@ exports.DefaultOptions = {
   partials: [],
   restWsBridgeTimeout: 5000,
   restRequestTimeout: 15000,
+  restGlobalRateLimit: 0,
   retryLimit: 1,
   restTimeOffset: 500,
   restSweepInterval: 60,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2438,6 +2438,7 @@ declare module 'discord.js' {
     restWsBridgeTimeout?: number;
     restTimeOffset?: number;
     restRequestTimeout?: number;
+    restGlobalRateLimit?: number;
     restSweepInterval?: number;
     retryLimit?: number;
     presence?: PresenceData;
@@ -3196,6 +3197,7 @@ declare module 'discord.js' {
     method: string;
     path: string;
     route: string;
+    global: boolean;
   }
 
   interface RawOverwriteData {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -368,6 +368,7 @@ declare module 'discord.js' {
     };
     Events: {
       RATE_LIMIT: 'rateLimit';
+      INVALID_REQUEST_WARNING: 'invalidRequestWarning';
       CLIENT_READY: 'ready';
       RESUMED: 'resumed';
       GUILD_CREATE: 'guildCreate';
@@ -2411,6 +2412,7 @@ declare module 'discord.js' {
     messageUpdate: [oldMessage: Message | PartialMessage, newMessage: Message | PartialMessage];
     presenceUpdate: [oldPresence: Presence | undefined, newPresence: Presence];
     rateLimit: [rateLimitData: RateLimitData];
+    invalidRequestWarning: [invalidRequestWarningData: InvalidRequestWarningData];
     ready: [];
     invalidated: [];
     roleCreate: [role: Role];
@@ -2434,6 +2436,7 @@ declare module 'discord.js' {
     messageCacheLifetime?: number;
     messageSweepInterval?: number;
     allowedMentions?: MessageMentionOptions;
+    invalidRequestWarningInterval?: number;
     partials?: PartialTypes[];
     restWsBridgeTimeout?: number;
     restTimeOffset?: number;
@@ -3198,6 +3201,11 @@ declare module 'discord.js' {
     path: string;
     route: string;
     global: boolean;
+  }
+
+  interface InvalidRequestWarningData {
+    count: number;
+    remainingTime: number;
   }
 
   interface RawOverwriteData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently, there is no support for preemptively avoiding the global rate limit - any requests in-flight to Discord at the time the limit is reached will simply result in 429s. This PR adds a configurable preemptive global rate limit option `restGlobalRateLimit` (defaulting to zero, which maintains the current behavior). Additionally, it makes the following related enhancements:
- Report the real timeout when the global rate limit is hit
- Handle rate sublimits for individual requests more cleanly
- Remove unnecessary double wait from some rate limit handling code paths

This PR also adds tracking for the number of invalid REST requests (those that result in a 401, 403, or 429 status code) to aid in avoiding the 10k invalid requests in 10 minutes temporary ban. The library user can configure a warning period to through the new option `invalidRequestWarningInterval` (defaulting to zero, which emits no warnings), which causes an `INVALID_REQUEST_WARNING` event to be emitted with the number of invalid requests made in the 10 minute period and the amount of time left in the period. That is, if `invalidRequestWarningInterval = 500`, then an event will be emitted at the 500th, 1000th, 1500th, and so on invalid request in the 10 minute period.


**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
