### PR TITLE
fix(User): set User#system to a boolean value only

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -70,14 +70,12 @@ class User extends Base {
       this.avatar = null;
     }
 
-    if ('system' in data) {
-      /**
-       * Whether the user is an Official Discord System user (part of the urgent message system)
-       * @type {?boolean}
-       * @name User#system
-       */
-      this.system = Boolean(data.system);
-    }
+    /**
+     * Whether the user is an Official Discord System user (part of the urgent message system)
+     * @type {boolean}
+     * @name User#system
+     */
+    this.system = Boolean(data.system);
 
     if ('locale' in data) {
       /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1515,7 +1515,7 @@ declare module 'discord.js' {
     public locale?: string;
     public readonly partial: false;
     public readonly presence: Presence;
-    public system?: boolean;
+    public system: boolean;
     public readonly tag: string;
     public username: string;
     public avatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

#4706 recently updated User#bot to always be represented with a boolean value. As User#system is received in the exact same way as User#bot from the API, it makes sense to update it also for consistency. This PR ensures that User#system is always defined as a boolean value.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
