### PR TITLE
fix(BaseGuildEmoji): account for optional properties

### DIFF
--- a/src/structures/BaseGuildEmoji.js
+++ b/src/structures/BaseGuildEmoji.js
@@ -49,7 +49,7 @@ class BaseGuildEmoji extends Emoji {
      * @type {boolean}
      * @name GuildEmoji#available
      */
-    if (typeof data.available !== 'undefined') this.available = data.available;
+    this.available = Boolean(data.available);
 
     if (data.roles) this._roles = data.roles;
   }

--- a/src/structures/BaseGuildEmoji.js
+++ b/src/structures/BaseGuildEmoji.js
@@ -35,14 +35,14 @@ class BaseGuildEmoji extends Emoji {
      * @type {boolean}
      * @name GuildEmoji#requiresColons
      */
-    if (typeof data.require_colons !== 'undefined') this.requiresColons = data.require_colons;
+    this.requiresColons = Boolean(data.require_colons);
 
     /**
      * Whether this emoji is managed by an external service
      * @type {boolean}
      * @name GuildEmoji#managed
      */
-    if (typeof data.managed !== 'undefined') this.managed = data.managed;
+    this.managed = Boolean(data.managed);
 
     /**
      * Whether this emoji is available


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `available` property of an Emoji is optional according to Discord API docs [here](https://discord.com/developers/docs/resources/emoji#emoji-object-emoji-structure). This PR accounts for this by setting `<GuildEmoji>.available` to consistently be a boolean value..

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
