### PR TITLE
types: don't allow any object in the first parameter if second parameter is not given in TextBasedChannel#send

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1009,7 +1009,7 @@ declare module 'discord.js' {
       content: APIMessageContentResolvable | (MessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     public reply(options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    public reply(options: MessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
+    public reply(options: MessageOptions | APIMessage): Promise<Message | Message[]>;
     public reply(
       content: StringResolvable,
       options: (MessageOptions & { split?: false }) | MessageAdditions,
@@ -1018,7 +1018,7 @@ declare module 'discord.js' {
       content: StringResolvable,
       options: MessageOptions & { split: true | SplitOptions },
     ): Promise<Message[]>;
-    public reply(content: StringResolvable, options: MessageOptions | MessageAdditions): Promise<Message | Message[]>;
+    public reply(content: StringResolvable, options: MessageOptions): Promise<Message | Message[]>;
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): object;
     public toString(): string;
@@ -2042,10 +2042,10 @@ declare module 'discord.js' {
       content: APIMessageContentResolvable | (MessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     send(options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    send(options: MessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
+    send(options: MessageOptions | APIMessage): Promise<Message | Message[]>;
     send(content: StringResolvable, options: (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
     send(content: StringResolvable, options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    send(content: StringResolvable, options: MessageOptions | MessageAdditions): Promise<Message | Message[]>;
+    send(content: StringResolvable, options: MessageOptions): Promise<Message | Message[]>;
   }
 
   interface TextBasedChannelFields extends PartialTextBasedChannelFields {
@@ -2079,7 +2079,7 @@ declare module 'discord.js' {
       content: APIMessageContentResolvable | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    send(options: WebhookMessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
+    send(options: WebhookMessageOptions | APIMessage): Promise<Message | Message[]>;
     send(
       content: StringResolvable,
       options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
@@ -2088,7 +2088,7 @@ declare module 'discord.js' {
       content: StringResolvable,
       options: WebhookMessageOptions & { split: true | SplitOptions },
     ): Promise<Message[]>;
-    send(content: StringResolvable, options: WebhookMessageOptions | MessageAdditions): Promise<Message | Message[]>;
+    send(content: StringResolvable, options: WebhookMessageOptions): Promise<Message | Message[]>;
     sendSlackMessage(body: object): Promise<boolean>;
   }
 
@@ -2162,7 +2162,7 @@ declare module 'discord.js' {
     REACTION_BLOCKED: number;
   }
 
-  type APIMessageContentResolvable = string | number | boolean | bigint | symbol | any[];
+  type APIMessageContentResolvable = string | number | boolean | bigint | symbol | readonly StringResolvable[];
 
   interface AuditLogChange {
     key: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -60,14 +60,26 @@ declare module 'discord.js' {
 
     public static create(
       target: MessageTarget,
-      content?: StringResolvable,
-      options?: MessageOptions | WebhookMessageOptions | MessageAdditions,
+      content: APIMessageContentResolvable,
+      options?: undefined,
+      extra?: MessageOptions | WebhookMessageOptions,
+    ): APIMessage;
+    public static create(
+      target: MessageTarget,
+      content: StringResolvable,
+      options: MessageOptions | WebhookMessageOptions | MessageAdditions,
       extra?: MessageOptions | WebhookMessageOptions,
     ): APIMessage;
     public static partitionMessageAdditions(
       items: readonly (MessageEmbed | MessageAttachment)[],
     ): [MessageEmbed[], MessageAttachment[]];
     public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | MessageAttachment): Promise<object>;
+    public static transformOptions(
+      content: APIMessageContentResolvable,
+      options?: undefined,
+      extra?: MessageOptions | WebhookMessageOptions,
+      isWebhook?: boolean,
+    ): MessageOptions | WebhookMessageOptions;
     public static transformOptions(
       content: StringResolvable,
       options: MessageOptions | WebhookMessageOptions | MessageAdditions,
@@ -984,33 +996,29 @@ declare module 'discord.js' {
     ): Promise<Collection<Snowflake, MessageReaction>>;
     public createReactionCollector(filter: CollectorFilter, options?: ReactionCollectorOptions): ReactionCollector;
     public delete(options?: { timeout?: number; reason?: string }): Promise<Message>;
-    public edit(content: StringResolvable, options?: MessageEditOptions | MessageEmbed): Promise<Message>;
-    public edit(options: MessageEditOptions | MessageEmbed | APIMessage): Promise<Message>;
+    public edit(
+      content: APIMessageContentResolvable | MessageEditOptions | MessageEmbed | APIMessage,
+    ): Promise<Message>;
+    public edit(content: StringResolvable, options: MessageEditOptions | MessageEmbed): Promise<Message>;
     public equals(message: Message, rawData: object): boolean;
     public fetchWebhook(): Promise<Webhook>;
     public fetch(force?: boolean): Promise<Message>;
     public pin(options?: { reason?: string }): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public reply(
-      content?: StringResolvable,
-      options?: MessageOptions | MessageAdditions | (MessageOptions & { split?: false }) | MessageAdditions,
+      content: APIMessageContentResolvable | (MessageOptions & { split?: false }) | MessageAdditions,
+    ): Promise<Message>;
+    public reply(options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+    public reply(options: MessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
+    public reply(
+      content: StringResolvable,
+      options: (MessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     public reply(
-      content?: StringResolvable,
-      options?: (MessageOptions & { split: true | SplitOptions }) | MessageAdditions,
+      content: StringResolvable,
+      options: MessageOptions & { split: true | SplitOptions },
     ): Promise<Message[]>;
-    public reply(
-      options?:
-        | MessageOptions
-        | MessageAdditions
-        | APIMessage
-        | (MessageOptions & { split?: false })
-        | MessageAdditions
-        | APIMessage,
-    ): Promise<Message>;
-    public reply(
-      options?: (MessageOptions & { split: true | SplitOptions }) | MessageAdditions | APIMessage,
-    ): Promise<Message[]>;
+    public reply(content: StringResolvable, options: MessageOptions | MessageAdditions): Promise<Message | Message[]>;
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): object;
     public toString(): string;
@@ -2031,16 +2039,13 @@ declare module 'discord.js' {
     lastMessageID: Snowflake | null;
     readonly lastMessage: Message | null;
     send(
-      options: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions | APIMessage,
+      content: APIMessageContentResolvable | (MessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
-    send(
-      options: (MessageOptions & { split: true | SplitOptions; content: StringResolvable }) | APIMessage,
-    ): Promise<Message[]>;
-    send(
-      content: StringResolvable,
-      options?: MessageOptions | (MessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message>;
-    send(content: StringResolvable, options?: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+    send(options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+    send(options: MessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
+    send(content: StringResolvable, options: (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+    send(content: StringResolvable, options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+    send(content: StringResolvable, options: MessageOptions | MessageAdditions): Promise<Message | Message[]>;
   }
 
   interface TextBasedChannelFields extends PartialTextBasedChannelFields {
@@ -2071,17 +2076,19 @@ declare module 'discord.js' {
     delete(reason?: string): Promise<void>;
     edit(options: WebhookEditData): Promise<Webhook>;
     send(
-      content?: StringResolvable,
-      options?: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
+      content: APIMessageContentResolvable | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
+    ): Promise<Message>;
+    send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+    send(options: WebhookMessageOptions | MessageAdditions | APIMessage): Promise<Message | Message[]>;
+    send(
+      content: StringResolvable,
+      options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     send(
-      content?: StringResolvable,
-      options?: (WebhookMessageOptions & { split: true | SplitOptions }) | MessageAdditions,
+      content: StringResolvable,
+      options: WebhookMessageOptions & { split: true | SplitOptions },
     ): Promise<Message[]>;
-    send(options?: (WebhookMessageOptions & { split?: false }) | MessageAdditions | APIMessage): Promise<Message>;
-    send(
-      options?: (WebhookMessageOptions & { split: true | SplitOptions }) | MessageAdditions | APIMessage,
-    ): Promise<Message[]>;
+    send(content: StringResolvable, options: WebhookMessageOptions | MessageAdditions): Promise<Message | Message[]>;
     sendSlackMessage(body: object): Promise<boolean>;
   }
 
@@ -2154,6 +2161,8 @@ declare module 'discord.js' {
     INVITE_ACCEPTED_TO_GUILD_NOT_CONTAINING_BOT: number;
     REACTION_BLOCKED: number;
   }
+
+  type APIMessageContentResolvable = string | number | boolean | bigint | symbol | any[];
 
   interface AuditLogChange {
     key: string;
@@ -2689,7 +2698,7 @@ declare module 'discord.js' {
   }
 
   interface MessageEditOptions {
-    content?: string;
+    content?: StringResolvable;
     embed?: MessageEmbed | MessageEmbedOptions | null;
     code?: string | boolean;
     flags?: BitFieldResolvable<MessageFlagsString>;
@@ -2769,7 +2778,7 @@ declare module 'discord.js' {
   interface MessageOptions {
     tts?: boolean;
     nonce?: string;
-    content?: string;
+    content?: StringResolvable;
     embed?: MessageEmbed | MessageEmbedOptions;
     disableMentions?: 'none' | 'all' | 'everyone';
     allowedMentions?: MessageMentionOptions;
@@ -2789,7 +2798,7 @@ declare module 'discord.js' {
 
   type MessageResolvable = Message | Snowflake;
 
-  type MessageTarget = TextChannel | DMChannel | User | GuildMember | Webhook | WebhookClient;
+  type MessageTarget = TextChannel | NewsChannel | DMChannel | User | GuildMember | Webhook | WebhookClient;
 
   type MessageType =
     | 'DEFAULT'

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,6 +1,6 @@
 /// <reference path="index.d.ts" />
 
-import { Client } from 'discord.js';
+import { Client, Message } from 'discord.js';
 
 const client: Client = new Client();
 
@@ -23,6 +23,24 @@ client.on('messageReactionRemoveAll', async message => {
   if (message.partial) message = await message.fetch();
 
   console.log(`messageReactionRemoveAll - content: ${message.content}`);
+});
+
+// These are to check that stuff is the right type
+declare const assertIsMessage: (m: Promise<Message>) => void;
+declare const assertIsMessageArray: (m: Promise<Message[]>) => void;
+
+client.on('message', ({ channel }) => {
+  assertIsMessage(channel.send('string'));
+  assertIsMessage(channel.send({}));
+  assertIsMessage(channel.send({ embed: {} }));
+  assertIsMessage(channel.send({ another: 'property' }, {}));
+  assertIsMessageArray(channel.send(Symbol('another primitive'), { split: true }));
+  assertIsMessageArray(channel.send({ split: true }));
+
+  // @ts-expect-error
+  channel.send();
+  // @ts-expect-error
+  channel.send({ another: 'property' });
 });
 
 client.login('absolutely-valid-token');

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,6 +1,6 @@
 /// <reference path="index.d.ts" />
 
-import { Client, Message } from 'discord.js';
+import { Client, Message, MessageAttachment, MessageEmbed } from 'discord.js';
 
 const client: Client = new Client();
 
@@ -34,6 +34,13 @@ client.on('message', ({ channel }) => {
   assertIsMessage(channel.send({}));
   assertIsMessage(channel.send({ embed: {} }));
   assertIsMessage(channel.send({ another: 'property' }, {}));
+
+  const attachment = new MessageAttachment('file.png');
+  const embed = new MessageEmbed();
+  assertIsMessage(channel.send(attachment));
+  assertIsMessage(channel.send(embed));
+  assertIsMessage(channel.send([attachment, embed]));
+
   assertIsMessageArray(channel.send(Symbol('another primitive'), { split: true }));
   assertIsMessageArray(channel.send({ split: true }));
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously, this was allowed:

```ts
channel.send({embed: {tilte: 'meant to be title'}})
```

This commit fixes this for `TextBasedChannel#send`, `Message#reply` etc. so that TS would emit an error.

This PR also changes `Message(Edit)Options.content` from `string` to `StringResolvable` and includes `NewsChannel` in `MessageTarget`.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
