### PR TITLE
types: add all types for GuildAuditLogsEntry#target

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -748,7 +748,18 @@ declare module 'discord.js' {
     public extra: object | Role | GuildMember | null;
     public id: Snowflake;
     public reason: string | null;
-    public target: Guild | User | Role | GuildEmoji | Invite | Webhook | Integration | null;
+    public target:
+      | Guild
+      | GuildChannel
+      | User
+      | Role
+      | GuildEmoji
+      | Invite
+      | Webhook
+      | Message
+      | Integration
+      | { id: string }
+      | null;
     public targetType: GuildAuditLogsTarget;
     public toJSON(): object;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -758,7 +758,7 @@ declare module 'discord.js' {
       | Webhook
       | Message
       | Integration
-      | { id: string }
+      | { id: Snowflake }
       | null;
     public targetType: GuildAuditLogsTarget;
     public toJSON(): object;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fix #4728 

Add `Message`, `GuildChannel` and `{ id: Snowflake }` as possible type for `GuildAuditLogsEntry#target`.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
