### PR TITLE
feat(Client): allow options for generateInvite

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -367,7 +367,7 @@ class Client extends BaseClient {
     if (Array.isArray(options) || ['string', 'number'].includes(typeof options) || options instanceof Permissions) {
       process.emitWarning(
         'Client#generateInvite: Generate invite with an options object instead of a PermissionResolvable',
-        'DeprecationWarning'
+        'DeprecationWarning',
       );
       options = { permissions: options };
     }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -359,7 +359,9 @@ class Client extends BaseClient {
    * @param {InviteGenerationOptions|PermissionResolvable} [options] Permissions to request
    * @returns {Promise<string>}
    * @example
-   * client.generateInvite(['SEND_MESSAGES', 'MANAGE_GUILD', 'MENTION_EVERYONE'])
+   * client.generateInvite({
+   *   permissions: ['SEND_MESSAGES', 'MANAGE_GUILD', 'MENTION_EVERYONE'],
+   * })
    *   .then(link => console.log(`Generated bot invite link: ${link}`))
    *   .catch(console.error);
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2663,7 +2663,7 @@ declare module 'discord.js' {
     | 'DIRECT_MESSAGES'
     | 'DIRECT_MESSAGE_REACTIONS'
     | 'DIRECT_MESSAGE_TYPING';
-                                                             
+
   interface InviteGenerationOptions {
     permissions?: PermissionResolvable;
     guild?: GuildResolvable;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -187,7 +187,7 @@ declare module 'discord.js' {
     public fetchInvite(invite: InviteResolvable): Promise<Invite>;
     public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
     public fetchWebhook(id: Snowflake, token?: string): Promise<Webhook>;
-    public generateInvite(permissions?: PermissionResolvable): Promise<string>;
+    public generateInvite(options?: InviteGenerationOptions | PermissionResolvable): Promise<string>;
     public login(token?: string): Promise<string>;
     public sweepMessages(lifetime?: number): number;
     public toJSON(): object;
@@ -2663,6 +2663,12 @@ declare module 'discord.js' {
     | 'DIRECT_MESSAGES'
     | 'DIRECT_MESSAGE_REACTIONS'
     | 'DIRECT_MESSAGE_TYPING';
+                                                             
+  interface InviteGenerationOptions {
+    permissions?: PermissionResolvable;
+    guild?: GuildResolvable;
+    disableGuildSelect?: boolean;
+  }
 
   interface InviteOptions {
     temporary?: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR deprecates the old method of passing a `PermissionResolvable` into `Client#generateInvite` and instead allows an object of options to be provided consisting of `permissions`, `guild`, and `disableGuildSelect`, ([API Docs reference](https://discord.com/developers/docs/topics/oauth2#bot-authorization-flow))

Wasn't sure about adding `redirect_uri` seeing as its not apart of the bot authorisation flow
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [  ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
