### PR TITLE
fix: correctly import extendable classes

### DIFF
--- a/src/managers/PresenceManager.js
+++ b/src/managers/PresenceManager.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BaseManager = require('./BaseManager');
-const { Presence } = require('../structures/Presence');
 
 /**
  * Manages API methods for Presences and holds their cache.
@@ -9,7 +8,7 @@ const { Presence } = require('../structures/Presence');
  */
 class PresenceManager extends BaseManager {
   constructor(client, iterable) {
-    super(client, iterable, Presence);
+    super(client, iterable, { name: 'Presence' });
   }
 
   /**

--- a/src/managers/PresenceManager.js
+++ b/src/managers/PresenceManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseManager = require('./BaseManager');
+const { Presence } = require('./Presence');
 
 /**
  * Manages API methods for Presences and holds their cache.
@@ -8,7 +9,7 @@ const BaseManager = require('./BaseManager');
  */
 class PresenceManager extends BaseManager {
   constructor(client, iterable) {
-    super(client, iterable, { name: 'Presence' });
+    super(client, iterable, Presence);
   }
 
   /**

--- a/src/managers/PresenceManager.js
+++ b/src/managers/PresenceManager.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const BaseManager = require('./BaseManager');
-const { Presence } = require('./Presence');
+const { Presence } = require('../structures/Presence');
 
 /**
  * Manages API methods for Presences and holds their cache.

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const Base = require('./Base');
-const { Presence } = require('./Presence');
 const Role = require('./Role');
-const VoiceState = require('./VoiceState');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { Error } = require('../errors');
 const GuildMemberRoleManager = require('../managers/GuildMemberRoleManager');
 const Permissions = require('../util/Permissions');
+const Structures = require('../util/Structures');
 
 /**
  * Represents a member of a guild on Discord.
@@ -126,6 +125,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get voice() {
+    const VoiceState = Structures.get('VoiceState');
     return this.guild.voiceStates.cache.get(this.id) || new VoiceState(this.guild, { user_id: this.id });
   }
 
@@ -153,6 +153,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get presence() {
+    const Presence = Structures.get('Presence');
     return (
       this.guild.presences.cache.get(this.id) ||
       new Presence(this.client, {

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -6,7 +6,7 @@ const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { Error } = require('../errors');
 const GuildMemberRoleManager = require('../managers/GuildMemberRoleManager');
 const Permissions = require('../util/Permissions');
-const Structures = require('../util/Structures');
+let Structures;
 
 /**
  * Represents a member of a guild on Discord.
@@ -125,6 +125,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get voice() {
+    if (!Structures) Structures = require('../util/Structures');
     const VoiceState = Structures.get('VoiceState');
     return this.guild.voiceStates.cache.get(this.id) || new VoiceState(this.guild, { user_id: this.id });
   }
@@ -153,6 +154,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get presence() {
+    if (!Structures) Structures = require('../util/Structures');
     const Presence = Structures.get('Presence');
     return (
       this.guild.presences.cache.get(this.id) ||

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -4,8 +4,9 @@ const Base = require('./Base');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { Error } = require('../errors');
 const Snowflake = require('../util/Snowflake');
-const Structures = require('../util/Structures');
 const UserFlags = require('../util/UserFlags');
+
+let Structures;
 
 /**
  * Represents a user on Discord.
@@ -156,6 +157,7 @@ class User extends Base {
     for (const guild of this.client.guilds.cache.values()) {
       if (guild.presences.cache.has(this.id)) return guild.presences.cache.get(this.id);
     }
+    if (!Structures) Structures = require('../util/Structures');
     const Presence = Structures.get('Presence');
     return new Presence(this.client, { user: { id: this.id } });
   }

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const Base = require('./Base');
-const { Presence } = require('./Presence');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { Error } = require('../errors');
 const Snowflake = require('../util/Snowflake');
+const Structures = require('../util/Structures');
 const UserFlags = require('../util/UserFlags');
 
 /**
@@ -156,6 +156,7 @@ class User extends Base {
     for (const guild of this.client.guilds.cache.values()) {
       if (guild.presences.cache.has(this.id)) return guild.presences.cache.get(this.id);
     }
+    const Presence = Structures.get('Presence');
     return new Presence(this.client, { user: { id: this.id } });
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fixes #4742 
This PR changes the `GuildMember` and `User` classes to import `Presence` (and `VoiceState` on `GuildMember`) using `Structures.get(...)` rather than a require import, to correct instantiate any custom extended class

Notes: the [`NewsChannel`](https://github.com/NotSugden/yeetcord.js/blob/patch-16/src/structures/NewsChannel.js#L3-L9) and [`ClientPresence`](https://github.com/NotSugden/yeetcord.js/blob/patch-16/src/structures/ClientPresence.js#L3-L8) classes seem to not extend `TextChannel` and `NewsChannel` respectively, but i wasn't sure the best way to go about fixing that, so i've left it for now

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
