### PR TITLE
feat(Channel): add isText() type guard

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -97,6 +97,14 @@ class Channel extends Base {
     return this.client.channels.fetch(this.id, true, force);
   }
 
+  /**
+   * Whether this channel is text-based
+   * @returns {boolean}
+   */
+  isText() {
+    return ['text', 'dm', 'news'].includes(this.type);
+  }
+
   static create(client, data, guild) {
     const Structures = require('../util/Structures');
     let channel;

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -98,7 +98,7 @@ class Channel extends Base {
   }
 
   /**
-   * Whether this channel is text-based
+   * Indicates whether this channel is text-based.
    * @returns {boolean}
    */
   isText() {

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -102,7 +102,7 @@ class Channel extends Base {
    * @returns {boolean}
    */
   isText() {
-    return ['text', 'dm', 'news'].includes(this.type);
+    return 'messages' in this;
   }
 
   static create(client, data, guild) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -160,6 +160,7 @@ declare module 'discord.js' {
     public type: keyof typeof ChannelType;
     public delete(reason?: string): Promise<Channel>;
     public fetch(force?: boolean): Promise<Channel>;
+    public isText(): this is TextChannel | DMChannel | NewsChannel;
     public toString(): string;
   }
 
@@ -800,6 +801,7 @@ declare module 'discord.js' {
       options: PermissionOverwriteOption,
       reason?: string,
     ): Promise<this>;
+    public isText(): this is TextChannel | NewsChannel;
   }
 
   export class GuildEmoji extends BaseGuildEmoji {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently, there is no easy way in TypeScript to find out if a channel is text-based or not.

```ts
['text', 'dm', 'news'].includes(channel.type)
channel.type === 'text' || channel.type === 'dm' || channel.type === 'news'
```
Both of these examples work fine during runtime, but don't act as a type guard; If `channel` had the type `Channel` before the check, it will also keep it afterwards.

```ts
channel instanceof TextChannel || channel instanceof DMChannel || channel instanceof NewsChannel
channel as TextChannel
```
These two would actually narrow the type down to only text-based channels, but both aren't really optimal. The former option is too long and the latter doesn't actually check the type, it just tells the compiler that it will be a `TextChannel` even if it may not be one.

I generally think that checks like this should be able without having to either import the classes and doing multiple `instanceof` checks or casting its type which may lead to side effects.

**Status**

- [x] Code changes have been tested against the Discord API
- [x] I know how to update typings and have done so

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
