### PR TITLE
fix(Typing): change NodeJS.Timer into NodeJS.Timeout

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -121,7 +121,7 @@ class WebSocketShard extends EventEmitter {
     /**
      * The HELLO timeout
      * @name WebSocketShard#helloTimeout
-     * @type {?NodeJS.Timer}
+     * @type {?NodeJS.Timeout}
      * @private
      */
     Object.defineProperty(this, 'helloTimeout', { value: undefined, writable: true });
@@ -145,7 +145,7 @@ class WebSocketShard extends EventEmitter {
     /**
      * The ready timeout
      * @name WebSocketShard#readyTimeout
-     * @type {?NodeJS.Timer}
+     * @type {?NodeJS.Timeout}
      * @private
      */
     Object.defineProperty(this, 'readyTimeout', { value: undefined, writable: true });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -91,8 +91,8 @@ declare module 'discord.js' {
 
   export class BaseClient extends EventEmitter {
     constructor(options?: ClientOptions);
-    private _timeouts: Set<NodeJS.Timer>;
-    private _intervals: Set<NodeJS.Timer>;
+    private _timeouts: Set<NodeJS.Timeout>;
+    private _intervals: Set<NodeJS.Timeout>;
     private _immediates: Set<NodeJS.Immediate>;
     private readonly api: object;
     private rest: object;
@@ -100,12 +100,12 @@ declare module 'discord.js' {
     private incrementMaxListeners(): void;
 
     public options: ClientOptions;
-    public clearInterval(interval: NodeJS.Timer): void;
-    public clearTimeout(timeout: NodeJS.Timer): void;
+    public clearInterval(interval: NodeJS.Timeout): void;
+    public clearTimeout(timeout: NodeJS.Timeout): void;
     public clearImmediate(timeout: NodeJS.Immediate): void;
     public destroy(): void;
-    public setInterval(fn: (...args: any[]) => void, delay: number, ...args: any[]): NodeJS.Timer;
-    public setTimeout(fn: (...args: any[]) => void, delay: number, ...args: any[]): NodeJS.Timer;
+    public setInterval(fn: (...args: any[]) => void, delay: number, ...args: any[]): NodeJS.Timeout;
+    public setTimeout(fn: (...args: any[]) => void, delay: number, ...args: any[]): NodeJS.Timeout;
     public setImmediate(fn: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
     public toJSON(...props: { [key: string]: boolean | string }[]): object;
   }
@@ -262,8 +262,8 @@ declare module 'discord.js' {
 
   export abstract class Collector<K, V> extends EventEmitter {
     constructor(client: Client, filter: CollectorFilter, options?: CollectorOptions);
-    private _timeout: NodeJS.Timer | null;
-    private _idletimeout: NodeJS.Timer | null;
+    private _timeout: NodeJS.Timeout | null;
+    private _idletimeout: NodeJS.Timeout | null;
 
     public readonly client: Client;
     public collected: Collection<K, V>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fix #4754 

Using `NodeJS.Timeout` is more relevant than `NodeJS.Timer`.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
