### PR TITLE
fix(Guild): cache fetched widget data

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -896,8 +896,7 @@ class Guild extends Base {
    *   .catch(console.error);
    */
   async fetchWidget() {
-    const data = await this.client.api.guilds(this.id)
-      .widget.get();
+    const data = await this.client.api.guilds(this.id).widget.get();
     this.widgetEnabled = this.embedEnabled = data.enabled;
     this.widgetChannelID = this.embedChannelID = data.channel_id;
     return {

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -883,13 +883,7 @@ class Guild extends Base {
    *   .catch(console.error);
    */
   fetchEmbed() {
-    return this.client.api
-      .guilds(this.id)
-      .embed.get()
-      .then(data => ({
-        enabled: data.enabled,
-        channel: data.channel_id ? this.channels.cache.get(data.channel_id) : null,
-      }));
+    return this.fetchWidget();
   }
 
   /**
@@ -901,14 +895,16 @@ class Guild extends Base {
    *   .then(widget => console.log(`The widget is ${widget.enabled ? 'enabled' : 'disabled'}`))
    *   .catch(console.error);
    */
-  fetchWidget() {
-    return this.client.api
+  async fetchWidget() {
+    const data = await this.client.api
       .guilds(this.id)
-      .widget.get()
-      .then(data => ({
-        enabled: data.enabled,
-        channel: data.channel_id ? this.channels.cache.get(data.channel_id) : null,
-      }));
+      .widget.get();
+    this.widgetEnabled = this.embedEnabled = data.enabled;
+    this.widgetChannelID = this.embedChannelID = data.channel_id;
+    return {
+      enabled: data.enabled,
+      channel: data.channel_id ? this.channels.cache.get(data.channel_id) : null,
+    };
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -896,8 +896,7 @@ class Guild extends Base {
    *   .catch(console.error);
    */
   async fetchWidget() {
-    const data = await this.client.api
-      .guilds(this.id)
+    const data = await this.client.api.guilds(this.id)
       .widget.get();
     this.widgetEnabled = this.embedEnabled = data.enabled;
     this.widgetChannelID = this.embedChannelID = data.channel_id;
@@ -1383,16 +1382,7 @@ class Guild extends Base {
    * @deprecated
    */
   setEmbed(embed, reason) {
-    return this.client.api
-      .guilds(this.id)
-      .embed.patch({
-        data: {
-          enabled: embed.enabled,
-          channel_id: this.channels.resolveID(embed.channel),
-        },
-        reason,
-      })
-      .then(() => this);
+    return this.setWidget(embed, reason);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR modifies the `Guild#fetchWidget` function to cache the data received as it is not sent in the initial `GUILD_CREATE` packets ([API Docs ref](https://github.com/discord/discord-api-docs/issues/1102))

this PR also changes `setEmbed` and `fetchEmbed` to instead return the respective widget function,
this was to avoid duplicated code - both methods do technically call a different endpoint but they yield the same result
**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
