### PR TITLE
feat(UserFlags): add renamed UserFlags

### DIFF
--- a/src/util/UserFlags.js
+++ b/src/util/UserFlags.js
@@ -17,7 +17,8 @@ class UserFlags extends BitField {}
 /**
  * Numeric user flags. All available properties:
  * * `DISCORD_EMPLOYEE`
- * * `DISCORD_PARTNER`
+ * * `PARTNERED_SERVER_OWNER`
+ * * `DISCORD_PARTNER` **(deprecated)**
  * * `HYPESQUAD_EVENTS`
  * * `BUGHUNTER_LEVEL_1`
  * * `HOUSE_BRAVERY`
@@ -28,12 +29,14 @@ class UserFlags extends BitField {}
  * * `SYSTEM`
  * * `BUGHUNTER_LEVEL_2`
  * * `VERIFIED_BOT`
- * * `VERIFIED_DEVELOPER`
+ * * `EARLY_VERIFIED_BOT_DEVELOPER`
+ * * `VERIFIED_DEVELOPER` **(deprecated)**
  * @type {Object}
  * @see {@link https://discord.com/developers/docs/resources/user#user-object-user-flags}
  */
 UserFlags.FLAGS = {
   DISCORD_EMPLOYEE: 1 << 0,
+  PARTNERED_SERVER_OWNER: 1 << 1,
   DISCORD_PARTNER: 1 << 1,
   HYPESQUAD_EVENTS: 1 << 2,
   BUGHUNTER_LEVEL_1: 1 << 3,
@@ -45,6 +48,7 @@ UserFlags.FLAGS = {
   SYSTEM: 1 << 12,
   BUGHUNTER_LEVEL_2: 1 << 14,
   VERIFIED_BOT: 1 << 16,
+  EARLY_VERIFIED_DEVELOPER: 1 << 17,
   VERIFIED_DEVELOPER: 1 << 17,
 };
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3130,7 +3130,7 @@ declare module 'discord.js' {
     | 'SYSTEM'
     | 'BUGHUNTER_LEVEL_2'
     | 'VERIFIED_BOT'
-    | 'EARLY_VERIFIED_BOT_DEVELOPER'
+    | 'EARLY_VERIFIED_DEVELOPER'
     | 'VERIFIED_DEVELOPER';
 
   type UserResolvable = User | Snowflake | Message | GuildMember;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3118,6 +3118,7 @@ declare module 'discord.js' {
 
   type UserFlagsString =
     | 'DISCORD_EMPLOYEE'
+    | 'PARTNERED_SERVER_OWNER'
     | 'DISCORD_PARTNER'
     | 'HYPESQUAD_EVENTS'
     | 'BUGHUNTER_LEVEL_1'
@@ -3129,6 +3130,7 @@ declare module 'discord.js' {
     | 'SYSTEM'
     | 'BUGHUNTER_LEVEL_2'
     | 'VERIFIED_BOT'
+    | 'EARLY_VERIFIED_BOT_DEVELOPER'
     | 'VERIFIED_DEVELOPER';
 
   type UserResolvable = User | Snowflake | Message | GuildMember;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
user flags `DISCORD_PARTNER` and `VERIFIED_DEVELOPER` have been renamed, this PR reflects those changes by deprecating the old names, and adding the renamed flags

see https://github.com/discord/discord-api-docs/pull/2011
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
