### PR TITLE
feat(Guild): add includeApplications option for fetchIntegrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
       ]
     }
   },
-  "prettier":{
+  "prettier": {
     "singleQuote": true,
     "printWidth": 120,
     "trailingComma": "all",

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,7 @@ module.exports = {
   splitMessage: Util.splitMessage,
 
   // Structures
+  Application: require('./structures/interfaces/Application'),
   Base: require('./structures/Base'),
   Activity: require('./structures/Presence').Activity,
   APIMessage: require('./structures/APIMessage'),

--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -5,7 +5,7 @@ const Application = require('./interfaces/Application');
 
 /**
  * Represents a Client OAuth2 Application.
- * @extends {Base}
+ * @extends {Application}
  */
 class ClientApplication extends Application {
   _patch(data) {

--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -71,6 +71,16 @@ class ClientApplication extends Base {
      * @type {?User|Team}
      */
     this.owner = data.team ? new Team(this.client, data.team) : data.owner ? this.client.users.add(data.owner) : null;
+
+    if (typeof data.bot !== 'undefined') {
+      /**
+       * The bot {@link User user} for this application
+       * @type {?User}
+       */
+      this.bot = this.client.users.add(data.bot);
+    } else if (!this.bot) {
+      this.bot = null;
+    }
   }
 
   /**

--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -1,46 +1,15 @@
 'use strict';
 
-const Base = require('./Base');
 const Team = require('./Team');
-const { ClientApplicationAssetTypes, Endpoints } = require('../util/Constants');
-const Snowflake = require('../util/Snowflake');
-
-const AssetTypes = Object.keys(ClientApplicationAssetTypes);
+const Application = require('./interfaces/Application');
 
 /**
  * Represents a Client OAuth2 Application.
  * @extends {Base}
  */
-class ClientApplication extends Base {
-  constructor(client, data) {
-    super(client);
-    this._patch(data);
-  }
-
+class ClientApplication extends Application {
   _patch(data) {
-    /**
-     * The ID of the app
-     * @type {Snowflake}
-     */
-    this.id = data.id;
-
-    /**
-     * The name of the app
-     * @type {string}
-     */
-    this.name = data.name;
-
-    /**
-     * The app's description
-     * @type {string}
-     */
-    this.description = data.description;
-
-    /**
-     * The app's icon hash
-     * @type {string}
-     */
-    this.icon = data.icon;
+    super._patch(data);
 
     /**
      * The app's cover image
@@ -71,95 +40,6 @@ class ClientApplication extends Base {
      * @type {?User|Team}
      */
     this.owner = data.team ? new Team(this.client, data.team) : data.owner ? this.client.users.add(data.owner) : null;
-
-    if (typeof data.bot !== 'undefined') {
-      /**
-       * The bot {@link User user} for this application
-       * @type {?User}
-       */
-      this.bot = this.client.users.add(data.bot);
-    } else if (!this.bot) {
-      this.bot = null;
-    }
-  }
-
-  /**
-   * The timestamp the app was created at
-   * @type {number}
-   * @readonly
-   */
-  get createdTimestamp() {
-    return Snowflake.deconstruct(this.id).timestamp;
-  }
-
-  /**
-   * The time the app was created at
-   * @type {Date}
-   * @readonly
-   */
-  get createdAt() {
-    return new Date(this.createdTimestamp);
-  }
-
-  /**
-   * A link to the application's icon.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
-   * @returns {?string} URL to the icon
-   */
-  iconURL({ format, size } = {}) {
-    if (!this.icon) return null;
-    return this.client.rest.cdn.AppIcon(this.id, this.icon, { format, size });
-  }
-
-  /**
-   * A link to this application's cover image.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
-   * @returns {?string} URL to the cover image
-   */
-  coverImage({ format, size } = {}) {
-    if (!this.cover) return null;
-    return Endpoints.CDN(this.client.options.http.cdn).AppIcon(this.id, this.cover, { format, size });
-  }
-
-  /**
-   * Asset data.
-   * @typedef {Object} ClientAsset
-   * @property {Snowflake} id The asset ID
-   * @property {string} name The asset name
-   * @property {string} type The asset type
-   */
-
-  /**
-   * Gets the clients rich presence assets.
-   * @returns {Promise<Array<ClientAsset>>}
-   */
-  fetchAssets() {
-    return this.client.api.oauth2
-      .applications(this.id)
-      .assets.get()
-      .then(assets =>
-        assets.map(a => ({
-          id: a.id,
-          name: a.name,
-          type: AssetTypes[a.type - 1],
-        })),
-      );
-  }
-
-  /**
-   * When concatenated with a string, this automatically returns the application's name instead of the
-   * ClientApplication object.
-   * @returns {string}
-   * @example
-   * // Logs: Application name: My App
-   * console.log(`Application name: ${application}`);
-   */
-  toString() {
-    return this.name;
-  }
-
-  toJSON() {
-    return super.toJSON({ createdTimestamp: true });
   }
 }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -698,6 +698,8 @@ class Guild extends Base {
   /**
    * Fetches a collection of integrations to this guild.
    * Resolves with a collection mapping integrations by their ids.
+   * @param {Object} [options] Options for fetching integrations
+   * @param {boolean} [options.includeApplications] Whether to include bot and Oauth2 webhook integrations
    * @returns {Promise<Collection<string, Integration>>}
    * @example
    * // Fetch integrations
@@ -705,10 +707,14 @@ class Guild extends Base {
    *   .then(integrations => console.log(`Fetched ${integrations.size} integrations`))
    *   .catch(console.error);
    */
-  fetchIntegrations() {
+  fetchIntegrations({ includeApplications = false } = {}) {
     return this.client.api
       .guilds(this.id)
-      .integrations.get()
+      .integrations.get({
+        query: {
+          include_applications: includeApplications,
+        },
+      })
       .then(data =>
         data.reduce(
           (collection, integration) => collection.set(integration.id, new Integration(this.client, integration, this)),

--- a/src/structures/Integration.js
+++ b/src/structures/Integration.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Base = require('./Base');
+const ClientApplication = require('./ClientApplication');
 
 /**
  * The information account for an integration
@@ -92,6 +93,20 @@ class Integration extends Base {
      * @type {number}
      */
     this.expireGracePeriod = data.expire_grace_period;
+
+    if ('application' in data) {
+      if (this.application) {
+        this.application._patch(data.application);
+      } else {
+        /**
+         * The application for this integration
+         * @type {?ClientApplication}
+         */
+        this.application = new ClientApplication(this.client, data.application);
+      }
+    } else if (!this.application) {
+      this.application = null;
+    }
   }
 
   /**

--- a/src/structures/Integration.js
+++ b/src/structures/Integration.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Base = require('./Base');
-const ClientApplication = require('./ClientApplication');
+const IntegrationApplication = require('./IntegrationApplication');
 
 /**
  * The information account for an integration
@@ -100,9 +100,9 @@ class Integration extends Base {
       } else {
         /**
          * The application for this integration
-         * @type {?ClientApplication}
+         * @type {?IntegrationApplication}
          */
-        this.application = new ClientApplication(this.client, data.application);
+        this.application = new IntegrationApplication(this.client, data.application);
       }
     } else if (!this.application) {
       this.application = null;

--- a/src/structures/IntegrationApplication.js
+++ b/src/structures/IntegrationApplication.js
@@ -4,7 +4,7 @@ const Application = require('./interfaces/Application');
 
 /**
  * Represents an Integration's OAuth2 Application.
- * @extends {Base}
+ * @extends {Application}
  */
 class IntegrationApplication extends Application {
   _patch(data) {

--- a/src/structures/IntegrationApplication.js
+++ b/src/structures/IntegrationApplication.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const Application = require('./interfaces/Application');
+
+/**
+ * Represents an Integration's OAuth2 Application.
+ * @extends {Base}
+ */
+class IntegrationApplication extends Application {
+  _patch(data) {
+    super._patch(data);
+
+    if (typeof data.bot !== 'undefined') {
+      /**
+       * The bot {@link User user} for this application
+       * @type {?User}
+       */
+      this.bot = this.client.users.add(data.bot);
+    } else if (!this.bot) {
+      this.bot = null;
+    }
+  }
+}
+
+module.exports = IntegrationApplication;

--- a/src/structures/interfaces/Application.js
+++ b/src/structures/interfaces/Application.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Base = require('./Base');
-const { ClientApplicationAssetTypes, Endpoints } = require('../util/Constants');
-const Snowflake = require('../util/Snowflake');
+const { ClientApplicationAssetTypes, Endpoints } = require('../../util/Constants');
+const Snowflake = require('../../util/Snowflake');
+const Base = require('../Base');
 
 const AssetTypes = Object.keys(ClientApplicationAssetTypes);
 

--- a/src/structures/interfaces/Application.js
+++ b/src/structures/interfaces/Application.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const Base = require('./Base');
+const { ClientApplicationAssetTypes, Endpoints } = require('../util/Constants');
+const Snowflake = require('../util/Snowflake');
+
+const AssetTypes = Object.keys(ClientApplicationAssetTypes);
+
+/**
+ * Represents an OAuth2 Application.
+ * @abstract
+ */
+class Oauth2Application extends Base {
+  constructor(client, data) {
+    super(client);
+    this._patch(data);
+  }
+
+  _patch(data) {
+    /**
+     * The ID of the app
+     * @type {Snowflake}
+     */
+    this.id = data.id;
+
+    /**
+     * The name of the app
+     * @type {string}
+     */
+    this.name = data.name;
+
+    /**
+     * The app's description
+     * @type {string}
+     */
+    this.description = data.description;
+
+    /**
+     * The app's icon hash
+     * @type {string}
+     */
+    this.icon = data.icon;
+  }
+
+  /**
+   * The timestamp the app was created at
+   * @type {number}
+   * @readonly
+   */
+  get createdTimestamp() {
+    return Snowflake.deconstruct(this.id).timestamp;
+  }
+
+  /**
+   * The time the app was created at
+   * @type {Date}
+   * @readonly
+   */
+  get createdAt() {
+    return new Date(this.createdTimestamp);
+  }
+
+  /**
+   * A link to the application's icon.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string} URL to the icon
+   */
+  iconURL({ format, size } = {}) {
+    if (!this.icon) return null;
+    return this.client.rest.cdn.AppIcon(this.id, this.icon, { format, size });
+  }
+
+  /**
+   * A link to this application's cover image.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string} URL to the cover image
+   */
+  coverImage({ format, size } = {}) {
+    if (!this.cover) return null;
+    return Endpoints.CDN(this.client.options.http.cdn).AppIcon(this.id, this.cover, { format, size });
+  }
+
+  /**
+   * Asset data.
+   * @typedef {Object} ApplicationAsset
+   * @property {Snowflake} id The asset ID
+   * @property {string} name The asset name
+   * @property {string} type The asset type
+   */
+
+  /**
+   * Gets the clients rich presence assets.
+   * @returns {Promise<Array<ApplicationAsset>>}
+   */
+  fetchAssets() {
+    return this.client.api.oauth2
+      .applications(this.id)
+      .assets.get()
+      .then(assets =>
+        assets.map(a => ({
+          id: a.id,
+          name: a.name,
+          type: AssetTypes[a.type - 1],
+        })),
+      );
+  }
+
+  /**
+   * When concatenated with a string, this automatically returns the application's name instead of the
+   * Oauth2Application object.
+   * @returns {string}
+   * @example
+   * // Logs: Application name: My App
+   * console.log(`Application name: ${application}`);
+   */
+  toString() {
+    return this.name;
+  }
+
+  toJSON() {
+    return super.toJSON({ createdTimestamp: true });
+  }
+}
+
+module.exports = Oauth2Application;

--- a/src/structures/interfaces/Application.js
+++ b/src/structures/interfaces/Application.js
@@ -10,7 +10,7 @@ const AssetTypes = Object.keys(ClientApplicationAssetTypes);
  * Represents an OAuth2 Application.
  * @abstract
  */
-class Oauth2Application extends Base {
+class Application extends Base {
   constructor(client, data) {
     super(client);
     this._patch(data);
@@ -122,4 +122,4 @@ class Oauth2Application extends Base {
   }
 }
 
-module.exports = Oauth2Application;
+module.exports = Application;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -231,6 +231,7 @@ declare module 'discord.js' {
 
   export class ClientApplication extends Base {
     constructor(client: Client, data: object);
+    public bot: User | null;
     public botPublic: boolean | null;
     public botRequireCodeGrant: boolean | null;
     public cover: string | null;
@@ -915,6 +916,7 @@ declare module 'discord.js' {
   export class Integration extends Base {
     constructor(client: Client, data: object, guild: Guild);
     public account: IntegrationAccount;
+    public application: ClientApplication | null;
     public enabled: boolean;
     public expireBehavior: number;
     public expireGracePeriod: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -693,7 +693,7 @@ declare module 'discord.js' {
     public fetchBan(user: UserResolvable): Promise<{ user: User; reason: string }>;
     public fetchBans(): Promise<Collection<Snowflake, { user: User; reason: string }>>;
     public fetchEmbed(): Promise<GuildWidget>;
-    public fetchIntegrations(): Promise<Collection<string, Integration>>;
+    public fetchIntegrations(options?: FetchIntegrationsOptions): Promise<Collection<string, Integration>>;
     public fetchInvites(): Promise<Collection<string, Invite>>;
     public fetchPreview(): Promise<GuildPreview>;
     public fetchVanityCode(): Promise<string>;
@@ -2459,6 +2459,10 @@ declare module 'discord.js' {
     VoiceState: typeof VoiceState;
     Role: typeof Role;
     User: typeof User;
+  }
+
+  interface FetchIntegrationsOptions {
+    includeApplications?: boolean;
   }
 
   interface FetchMemberOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -94,6 +94,21 @@ declare module 'discord.js' {
     public split(): APIMessage[];
   }
 
+  export abstract class Application {
+    constructor(client: Client, data: object);
+    public readonly createdAt: Date;
+    public readonly createdTimestamp: number;
+    public description: string;
+    public icon: string;
+    public id: Snowflake;
+    public name: string;
+    public coverImage(options?: ImageURLOptions): string;
+    public fetchAssets(): Promise<ApplicationAsset[]>;
+    public iconURL(options?: ImageURLOptions): string;
+    public toJSON(): object;
+    public toString(): string;
+  }
+
   export class Base {
     constructor(client: Client);
     public readonly client: Client;
@@ -229,25 +244,12 @@ declare module 'discord.js' {
     public removeAllListeners<S extends string | symbol>(event?: Exclude<S, keyof ClientEvents>): this;
   }
 
-  export class ClientApplication extends Base {
-    constructor(client: Client, data: object);
-    public bot: User | null;
+  export class ClientApplication extends Application {
     public botPublic: boolean | null;
     public botRequireCodeGrant: boolean | null;
     public cover: string | null;
-    public readonly createdAt: Date;
-    public readonly createdTimestamp: number;
-    public description: string;
-    public icon: string;
-    public id: Snowflake;
-    public name: string;
     public owner: User | Team | null;
     public rpcOrigins: string[];
-    public coverImage(options?: ImageURLOptions): string;
-    public fetchAssets(): Promise<ClientApplicationAsset[]>;
-    public iconURL(options?: ImageURLOptions): string;
-    public toJSON(): object;
-    public toString(): string;
   }
 
   export class ClientUser extends User {
@@ -931,6 +933,10 @@ declare module 'discord.js' {
     public delete(reason?: string): Promise<Integration>;
     public edit(data: IntegrationEditData, reason?: string): Promise<Integration>;
     public sync(): Promise<Integration>;
+  }
+
+  export class IntegrationApplication extends Application {
+    public bot: User | null;
   }
 
   export class Intents extends BitField<IntentsString> {
@@ -2177,6 +2183,12 @@ declare module 'discord.js' {
 
   type APIMessageContentResolvable = string | number | boolean | bigint | symbol | readonly StringResolvable[];
 
+  interface ApplicationAsset {
+    name: string;
+    id: Snowflake;
+    type: 'BIG' | 'SMALL';
+  }
+
   interface AuditLogChange {
     key: string;
     old?: any;
@@ -2240,12 +2252,6 @@ declare module 'discord.js' {
   }
 
   type ChannelResolvable = Channel | Snowflake;
-
-  interface ClientApplicationAsset {
-    name: string;
-    id: Snowflake;
-    type: 'BIG' | 'SMALL';
-  }
 
   interface ClientEvents {
     channelCreate: [Channel];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -918,7 +918,7 @@ declare module 'discord.js' {
   export class Integration extends Base {
     constructor(client: Client, data: object, guild: Guild);
     public account: IntegrationAccount;
-    public application: ClientApplication | null;
+    public application: IntegrationApplication | null;
     public enabled: boolean;
     public expireBehavior: number;
     public expireGracePeriod: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
api docs ref: https://github.com/discord/discord-api-docs/pull/1886/files
this PR (was meant to initially) adds `Integration#application`, and `IntegrationApplication#bot`

due to adding the new `IntegrationApplication` class, i opted to make an abstract `Application` class as its very similar to `ClientApplication`, except missing a few properties, and one of its own, and so wouldn't be duplicating 90% of a class

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
    - Tried to avoid that obviously but comment if I broke something
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
