### PR TITLE
issue when providing a lowercase color name

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -436,7 +436,7 @@ class Util {
     if (typeof color === 'string') {
       if (color === 'RANDOM') return Math.floor(Math.random() * (0xffffff + 1));
       if (color === 'DEFAULT') return 0;
-      color = Colors[color] || parseInt(color.replace('#', ''), 16);
+      color = Colors[color.toUpperCase()] || parseInt(color.replace('#', ''), 16);
     } else if (Array.isArray(color)) {
       color = (color[0] << 16) + (color[1] << 8) + color[2];
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The changes made are to change the color string to upper case since that's how they are written in the Constants file to fix an issue that when trying to use lower case names it will output NaN instead of the color.

An example of what I mean
![image](https://user-images.githubusercontent.com/11788894/91683367-70141080-eb22-11ea-8849-b3df7675403d.png)


**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
