### PR TITLE
feat: add includeDefault option to User#avatarURL

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { deprecate } = require('util');
 const Base = require('./Base');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { Error } = require('../errors');
@@ -342,5 +343,10 @@ class User extends Base {
 }
 
 TextBasedChannel.applyToClass(User);
+
+User.prototype.displayAvatarURL = deprecate(
+  User.prototype.displayAvatarURL,
+  'User#displayAvatarURL is deprecated! Use User#avatarURL with the option includeDefault instead.',
+);
 
 module.exports = User;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -163,12 +163,13 @@ class User extends Base {
   }
 
   /**
-   * A link to the user's avatar.
+   * A link to the user's avatar. If they don't have one and
+   * includeDefault is true, a link to their default avatar is returned.
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
-  avatarURL({ format, size, dynamic } = {}) {
-    if (!this.avatar) return null;
+  avatarURL({ format, size, dynamic, includeDefault } = {}) {
+    if (!this.avatar) return includeDefault ? this.defaultAvatarURL : null;
     return this.client.rest.cdn.Avatar(this.id, this.avatar, format, size, dynamic);
   }
 
@@ -186,6 +187,7 @@ class User extends Base {
    * Otherwise a link to their default avatar will be returned.
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {string}
+   * @deprecated Use avatarURL() with includeDefault set to true instead.
    */
   displayAvatarURL(options) {
     return this.avatarURL(options) || this.defaultAvatarURL;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -165,12 +165,12 @@ class User extends Base {
 
   /**
    * A link to the user's avatar. If they don't have one and
-   * includeDefault is true, a link to their default avatar is returned.
+   * display is true, a link to their default avatar is returned.
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
-  avatarURL({ format, size, dynamic, includeDefault } = {}) {
-    if (!this.avatar) return includeDefault ? this.defaultAvatarURL : null;
+  avatarURL({ format, size, dynamic, display } = {}) {
+    if (!this.avatar) return display ? this.defaultAvatarURL : null;
     return this.client.rest.cdn.Avatar(this.id, this.avatar, format, size, dynamic);
   }
 
@@ -188,7 +188,7 @@ class User extends Base {
    * Otherwise a link to their default avatar will be returned.
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {string}
-   * @deprecated Use avatarURL() with includeDefault set to true instead.
+   * @deprecated
    */
   displayAvatarURL(options) {
     return this.avatarURL(options) || this.defaultAvatarURL;
@@ -346,7 +346,7 @@ TextBasedChannel.applyToClass(User);
 
 User.prototype.displayAvatarURL = deprecate(
   User.prototype.displayAvatarURL,
-  'User#displayAvatarURL is deprecated! Use User#avatarURL with the option includeDefault instead.',
+  'User#displayAvatarURL is deprecated: Use User#avatarURL with the display option instead',
 );
 
 module.exports = User;

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -165,12 +165,12 @@ class User extends Base {
 
   /**
    * A link to the user's avatar. If they don't have one and
-   * display is true, a link to their default avatar is returned.
+   * includeDefault is true, a link to their default avatar is returned.
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
-  avatarURL({ format, size, dynamic, display } = {}) {
-    if (!this.avatar) return display ? this.defaultAvatarURL : null;
+  avatarURL({ format, size, dynamic, includeDefault } = {}) {
+    if (!this.avatar) return includeDefault ? this.defaultAvatarURL : null;
     return this.client.rest.cdn.Avatar(this.id, this.avatar, format, size, dynamic);
   }
 
@@ -346,7 +346,7 @@ TextBasedChannel.applyToClass(User);
 
 User.prototype.displayAvatarURL = deprecate(
   User.prototype.displayAvatarURL,
-  'User#displayAvatarURL is deprecated: Use User#avatarURL with the display option instead',
+  'User#displayAvatarURL is deprecated: Use User#avatarURL with the includeDefault option instead',
 );
 
 module.exports = User;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -117,7 +117,7 @@ function makeImageUrl(root, { format = 'webp', size } = {}) {
  * @property {boolean} [dynamic] If true, the format will dynamically change to `gif` for
  * animated avatars; the default is false.
  * @property {number} [size] One of `16`, `32`, `64`, `128`, `256`, `512`, `1024`, `2048`, `4096`
- * @property {boolean} [display] If true, the default avatar is returned when a user doesn't have one.
+ * @property {boolean} [includeDefault] If true, the default avatar is returned when a user doesn't have one.
  */
 
 exports.Endpoints = {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -117,6 +117,7 @@ function makeImageUrl(root, { format = 'webp', size } = {}) {
  * @property {boolean} [dynamic] If true, the format will dynamically change to `gif` for
  * animated avatars; the default is false.
  * @property {number} [size] One of `16`, `32`, `64`, `128`, `256`, `512`, `1024`, `2048`, `4096`
+ * @property {boolean} [includeDefault] If true, the default avatar is returned when a user doesn't have one.
  */
 
 exports.Endpoints = {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -117,7 +117,7 @@ function makeImageUrl(root, { format = 'webp', size } = {}) {
  * @property {boolean} [dynamic] If true, the format will dynamically change to `gif` for
  * animated avatars; the default is false.
  * @property {number} [size] One of `16`, `32`, `64`, `128`, `256`, `512`, `1024`, `2048`, `4096`
- * @property {boolean} [includeDefault] If true, the default avatar is returned when a user doesn't have one.
+ * @property {boolean} [display] If true, the default avatar is returned when a user doesn't have one.
  */
 
 exports.Endpoints = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1547,8 +1547,8 @@ declare module 'discord.js' {
     public system?: boolean;
     public readonly tag: string;
     public username: string;
-    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; display?: false }): string | null;
-    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; display: true }): string;
+    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; includeDefault?: false }): string | null;
+    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; includeDefault: true }): string;
     public createDM(): Promise<DMChannel>;
     public deleteDM(): Promise<DMChannel>;
     public displayAvatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1547,8 +1547,8 @@ declare module 'discord.js' {
     public system?: boolean;
     public readonly tag: string;
     public username: string;
-    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; includeDefault?: false }): string | null;
-    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; includeDefault: true }): string;
+    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; display?: false }): string | null;
+    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; display: true }): string;
     public createDM(): Promise<DMChannel>;
     public deleteDM(): Promise<DMChannel>;
     public displayAvatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1547,7 +1547,8 @@ declare module 'discord.js' {
     public system?: boolean;
     public readonly tag: string;
     public username: string;
-    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string | null;
+    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; includeDefault?: boolean }): string | null;
+    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; includeDefault: true }): string;
     public createDM(): Promise<DMChannel>;
     public deleteDM(): Promise<DMChannel>;
     public displayAvatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1547,7 +1547,7 @@ declare module 'discord.js' {
     public system?: boolean;
     public readonly tag: string;
     public username: string;
-    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; includeDefault?: boolean }): string | null;
+    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; includeDefault?: false }): string | null;
     public avatarURL(options?: ImageURLOptions & { dynamic?: boolean; includeDefault: true }): string;
     public createDM(): Promise<DMChannel>;
     public deleteDM(): Promise<DMChannel>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR implements one of the ideas from #4767. It merges the functionality of User#displayAvatarURL into User#avatarURL with the option `includeDefault`, which when set to true will return a link to a user's default avatar if they don't have one.
```ts
user.avatarURL({includeDefault: true}) // equals user.displayAvatarURL()
```
It deprecates the method User#displayAvatarURL, which could be removed in the next major version.

The main point of this is to remove the confusion of having two separate avatarURL methods. I also think that it's more consistent with the rest of the methods, because there is `guild.iconURL()` but not `guild.displayIconURL()` for example. 

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
