### PR TITLE
fix: fetch channel if not cached

### DIFF
--- a/src/client/websocket/handlers/TYPING_START.js
+++ b/src/client/websocket/handlers/TYPING_START.js
@@ -4,8 +4,23 @@ const { Events } = require('../../../util/Constants');
 const textBasedChannelTypes = ['dm', 'text', 'news'];
 
 module.exports = (client, { d: data }) => {
-  const channel = client.channels.cache.get(data.channel_id);
-  const user = client.users.cache.get(data.user_id);
+  let channel = client.channels.cache.get(data.channel_id);
+  let user = client.channels.cache.get(data.user_id);
+
+  if (!channel || !user) {
+    client.channels.fetch(data.channel_id).then(rChannel => {
+      channel = rChannel;
+      client.users.fetch(data.user_id).then(rUser => {
+        user = rUser;
+        triggerEvent(channel, user, data, client);
+      });
+    });
+  } else {
+    triggerEvent(channel, user, data, client);
+  }
+};
+
+function triggerEvent(channel, user, data, client) {
   const timestamp = new Date(data.timestamp * 1000);
 
   if (channel && user) {
@@ -41,7 +56,7 @@ module.exports = (client, { d: data }) => {
       client.emit(Events.TYPING_START, channel, user);
     }
   }
-};
+}
 
 function tooLate(channel, user) {
   return channel.client.setTimeout(() => {


### PR DESCRIPTION
This is fetching the channel and the user if it's not cached

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
