### PR TITLE
typings(PartialUser): fix PartialUser remove `deleted` property

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3031,11 +3031,13 @@ declare module 'discord.js' {
 
   type PartialTypes = 'USER' | 'CHANNEL' | 'GUILD_MEMBER' | 'MESSAGE' | 'REACTION';
 
-  interface PartialUser extends Omit<Partialize<User, 'bot' | 'flags' | 'locale' | 'system'>, "deleted"> {
+  interface PartialUser extends Omit<Partialize<User, 'bot' | 'flags' | 'locale' | 'system' | 'tag' | 'username'>, "deleted"> {
     bot: User['bot'];
     flags: User['flags'];
     locale: User['locale'];
     system: User['system'];
+    readonly tag: null;
+    username: null;
   }
 
   type PresenceStatusData = ClientPresenceStatus | 'invisible';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3031,7 +3031,7 @@ declare module 'discord.js' {
 
   type PartialTypes = 'USER' | 'CHANNEL' | 'GUILD_MEMBER' | 'MESSAGE' | 'REACTION';
 
-  interface PartialUser extends Omit<Partialize<User, 'bot' | 'flags' | 'locale' | 'system' | 'tag' | 'username'>, "deleted"> {
+  interface PartialUser extends Omit<Partialize<User, 'bot' | 'flags' | 'locale' | 'system' | 'tag' | 'username'>, 'deleted'> {
     bot: User['bot'];
     flags: User['flags'];
     locale: User['locale'];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3031,13 +3031,11 @@ declare module 'discord.js' {
 
   type PartialTypes = 'USER' | 'CHANNEL' | 'GUILD_MEMBER' | 'MESSAGE' | 'REACTION';
 
-  interface PartialUser extends Partialize<User, 'bot' | 'flags' | 'locale' | 'system' | 'tag' | 'username'> {
+  interface PartialUser extends Omit<Partialize<User, 'bot' | 'flags' | 'locale' | 'system'>, "deleted"> {
     bot: User['bot'];
     flags: User['flags'];
     locale: User['locale'];
     system: User['system'];
-    readonly tag: null;
-    username: null;
   }
 
   type PresenceStatusData = ClientPresenceStatus | 'invisible';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently `Partialize` is adding the `deleted` property to all partial types using it, including `PartialUser`, which is wrong as a `User` can't have the `deleted` property.
Additionally, `Partialize` is already making all properties nullable, so explicitly setting `username` to null isn't required - even on a partial user it can be populated after e.g. a `USER_UPDATE` event.

Fixes #4615

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
