### PR TITLE
fix(Util): throw token invalid for fetching rec. shard amount

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -245,7 +245,8 @@ class Util {
     })
       .then(res => {
         if (res.ok) return res.json();
-        throw new DiscordError('TOKEN_INVALID');
+        if (res.status === 401) throw new DiscordError('TOKEN_INVALID');
+        throw res;
       })
       .then(data => data.shards * (1000 / guildsPerShard));
   }

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -245,7 +245,7 @@ class Util {
     })
       .then(res => {
         if (res.ok) return res.json();
-        throw res;
+        throw new DiscordError('TOKEN_INVALID');
       })
       .then(data => data.shards * (1000 / guildsPerShard));
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- ⚠fixes #4778

As #4778 has brough to light we currently throw the response if an invalid token is provided when fetching the recommended amount of shards from the API.

While changing the kind of error to throw here could be framed as major i am so bold to say that this can not be deliberate design (as it results in the rather unhelpful ` #<Response>` being thrown) and thus will tag it as patch and consider it a fix rather than a feature.

https://github.com/discordjs/discord.js/blob/b0ab37ddc0614910e032ccf423816e106c3804e5/src/util/Util.js#L246-L247

Seeing that providing an invalid token will result in a 401 response adding a line to throw TOKEN_INVALID instead if that's the case provides more context to the user but still enables other faults to be propagated.


**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
