### PR TITLE
docs(setSpeaking): BitFieldResolvable -> Speaking

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -143,7 +143,7 @@ class VoiceConnection extends EventEmitter {
 
   /**
    * Sets whether the voice connection should display as "speaking", "soundshare" or "none".
-   * @param {BitFieldResolvable} value The new speaking state
+   * @param {Speaking} value The new speaking state
    */
   setSpeaking(value) {
     if (this.speaking.equals(value)) return;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Changed `BitFieldResolvable` to `Speaking` for specificity

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
