### PR TITLE
fix(Partials): Use more user objects available from the gateway

### DIFF
--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -81,15 +81,13 @@ class GenericAction {
   }
 
   getMember(data, guild) {
-    const id = data.user.id;
+    const user = data.user;
     return this.getPayload(
       {
-        user: {
-          id,
-        },
+        user,
       },
       guild.members,
-      id,
+      user.id,
       PartialTypes.GUILD_MEMBER,
     );
   }

--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -81,15 +81,7 @@ class GenericAction {
   }
 
   getMember(data, guild) {
-    const user = data.user;
-    return this.getPayload(
-      {
-        user,
-      },
-      guild.members,
-      user.id,
-      PartialTypes.GUILD_MEMBER,
-    );
+    return this.getPayload(data, guild.members, data.user.id, PartialTypes.GUILD_MEMBER);
   }
 
   getUser(data) {

--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -88,6 +88,16 @@ class GenericAction {
     const id = data.user_id;
     return data.user || this.getPayload({ id }, this.client.users, id, PartialTypes.USER);
   }
+
+  getUserFromMember(data) {
+    if (data.guild_id) {
+      const guild = this.client.guilds.cache.get(data.guild_id);
+      if (guild) {
+        return this.getMember(data.member, guild).user;
+      }
+    }
+    return this.getUser(data);
+  }
 }
 
 module.exports = GenericAction;

--- a/src/client/actions/ActionsManager.js
+++ b/src/client/actions/ActionsManager.js
@@ -35,6 +35,7 @@ class ActionsManager {
     this.register(require('./GuildChannelsPositionUpdate'));
     this.register(require('./GuildIntegrationsUpdate'));
     this.register(require('./WebhooksUpdate'));
+    this.register(require('./TypingStart'));
   }
 
   register(Action) {

--- a/src/client/actions/GuildMemberRemove.js
+++ b/src/client/actions/GuildMemberRemove.js
@@ -9,7 +9,7 @@ class GuildMemberRemoveAction extends Action {
     const guild = client.guilds.cache.get(data.guild_id);
     let member = null;
     if (guild) {
-      member = this.getMember(data, guild);
+      member = this.getMember({ user: data.user }, guild);
       guild.memberCount--;
       if (member) {
         member.deleted = true;

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -15,7 +15,15 @@ class MessageReactionAdd extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const user = data.member ? this.client.users.add(data.member.user) : this.getUser(data);
+    let user;
+    if (data.guild_id) {
+      const guild = this.client.guilds.cache.get(data.guild_id);
+      if (guild) {
+        user = this.getMember(data.member, guild).user;
+      }
+    } else {
+      user = this.getUser(data);
+    }
     if (!user) return false;
 
     // Verify channel

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -15,7 +15,7 @@ class MessageReactionAdd extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const user = this.getUser(data);
+    const user = data.member ? this.client.users.add(data.member.user) : this.getUser(data);
     if (!user) return false;
 
     // Verify channel

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -15,7 +15,7 @@ class MessageReactionAdd extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const user = this.getUserFromMember();
+    const user = this.getUserFromMember(data);
     if (!user) return false;
 
     // Verify channel

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -15,15 +15,7 @@ class MessageReactionAdd extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    let user;
-    if (data.guild_id) {
-      const guild = this.client.guilds.cache.get(data.guild_id);
-      if (guild) {
-        user = this.getMember(data.member, guild).user;
-      }
-    } else {
-      user = this.getUser(data);
-    }
+    const user = this.getUserFromMember();
     if (!user) return false;
 
     // Verify channel

--- a/src/client/actions/TypingStart.js
+++ b/src/client/actions/TypingStart.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const Action = require('./Action');
+const { Events } = require('../../util/Constants');
+const textBasedChannelTypes = ['dm', 'text', 'news'];
+
+class TypingStart extends Action {
+  handle(data) {
+    const channel = this.getChannel(data);
+    let user;
+    if (data.guild_id) {
+      const guild = this.client.guilds.cache.get(data.guild_id);
+      if (guild) {
+        user = this.getMember(data.member, guild).user;
+      }
+    } else {
+      user = this.getUser(data);
+    }
+    const timestamp = new Date(data.timestamp * 1000);
+
+    if (channel && user) {
+      if (!textBasedChannelTypes.includes(channel.type)) {
+        this.client.emit(Events.WARN, `Discord sent a typing packet to a ${channel.type} channel ${channel.id}`);
+        return;
+      }
+
+      if (channel._typing.has(user.id)) {
+        const typing = channel._typing.get(user.id);
+
+        typing.lastTimestamp = timestamp;
+        typing.elapsedTime = Date.now() - typing.since;
+        this.client.clearTimeout(typing.timeout);
+        typing.timeout = this.tooLate(channel, user);
+      } else {
+        const since = new Date();
+        const lastTimestamp = new Date();
+        channel._typing.set(user.id, {
+          user,
+          since,
+          lastTimestamp,
+          elapsedTime: Date.now() - since,
+          timeout: this.tooLate(channel, user),
+        });
+
+        /**
+         * Emitted whenever a user starts typing in a channel.
+         * @event Client#typingStart
+         * @param {Channel} channel The channel the user started typing in
+         * @param {User} user The user that started typing
+         */
+        this.client.emit(Events.TYPING_START, channel, user);
+      }
+    }
+  }
+
+  tooLate(channel, user) {
+    return channel.client.setTimeout(() => {
+      channel._typing.delete(user.id);
+    }, 10000);
+  }
+}
+
+module.exports = TypingStart;

--- a/src/client/actions/TypingStart.js
+++ b/src/client/actions/TypingStart.js
@@ -12,7 +12,7 @@ class TypingStart extends Action {
       return;
     }
 
-    const user = this.getUserFromMember();
+    const user = this.getUserFromMember(data);
     const timestamp = new Date(data.timestamp * 1000);
 
     if (channel && user) {

--- a/src/client/actions/TypingStart.js
+++ b/src/client/actions/TypingStart.js
@@ -7,23 +7,15 @@ const textBasedChannelTypes = ['dm', 'text', 'news'];
 class TypingStart extends Action {
   handle(data) {
     const channel = this.getChannel(data);
-    let user;
-    if (data.guild_id) {
-      const guild = this.client.guilds.cache.get(data.guild_id);
-      if (guild) {
-        user = this.getMember(data.member, guild).user;
-      }
-    } else {
-      user = this.getUser(data);
+    if (!textBasedChannelTypes.includes(channel.type)) {
+      this.client.emit(Events.WARN, `Discord sent a typing packet to a ${channel.type} channel ${channel.id}`);
+      return;
     }
+
+    const user = this.getUserFromMember();
     const timestamp = new Date(data.timestamp * 1000);
 
     if (channel && user) {
-      if (!textBasedChannelTypes.includes(channel.type)) {
-        this.client.emit(Events.WARN, `Discord sent a typing packet to a ${channel.type} channel ${channel.id}`);
-        return;
-      }
-
       if (channel._typing.has(user.id)) {
         const typing = channel._typing.get(user.id);
 

--- a/src/client/websocket/handlers/TYPING_START.js
+++ b/src/client/websocket/handlers/TYPING_START.js
@@ -5,7 +5,7 @@ const textBasedChannelTypes = ['dm', 'text', 'news'];
 
 module.exports = (client, { d: data }) => {
   const channel = client.channels.cache.get(data.channel_id);
-  const user = client.users.cache.get(data.user_id);
+  const user = data.member ? client.users.add(data.member.user) : client.users.cache.get(data.user_id);
   const timestamp = new Date(data.timestamp * 1000);
 
   if (channel && user) {

--- a/src/client/websocket/handlers/TYPING_START.js
+++ b/src/client/websocket/handlers/TYPING_START.js
@@ -1,50 +1,5 @@
 'use strict';
 
-const { Events } = require('../../../util/Constants');
-const textBasedChannelTypes = ['dm', 'text', 'news'];
-
-module.exports = (client, { d: data }) => {
-  const channel = client.channels.cache.get(data.channel_id);
-  const user = data.member ? client.users.add(data.member.user) : client.users.cache.get(data.user_id);
-  const timestamp = new Date(data.timestamp * 1000);
-
-  if (channel && user) {
-    if (!textBasedChannelTypes.includes(channel.type)) {
-      client.emit(Events.WARN, `Discord sent a typing packet to a ${channel.type} channel ${channel.id}`);
-      return;
-    }
-
-    if (channel._typing.has(user.id)) {
-      const typing = channel._typing.get(user.id);
-
-      typing.lastTimestamp = timestamp;
-      typing.elapsedTime = Date.now() - typing.since;
-      client.clearTimeout(typing.timeout);
-      typing.timeout = tooLate(channel, user);
-    } else {
-      const since = new Date();
-      const lastTimestamp = new Date();
-      channel._typing.set(user.id, {
-        user,
-        since,
-        lastTimestamp,
-        elapsedTime: Date.now() - since,
-        timeout: tooLate(channel, user),
-      });
-
-      /**
-       * Emitted whenever a user starts typing in a channel.
-       * @event Client#typingStart
-       * @param {Channel} channel The channel the user started typing in
-       * @param {User} user The user that started typing
-       */
-      client.emit(Events.TYPING_START, channel, user);
-    }
-  }
+module.exports = (client, packet) => {
+  client.actions.TypingStart.handle(packet.d);
 };
-
-function tooLate(channel, user) {
-  return channel.client.setTimeout(() => {
-    channel._typing.delete(user.id);
-  }, 10000);
-}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The Gateway includes a member object wrapping a user object in `MESSAGE_REACTION_ADD` and `TYPING_START` events, if those events originated from a guild. Those were previously ignored. If available, that data is now used.
Similar story for `GUILD_MEMBER_REMOVE`, it includes a full `user` object. Use that instead of just the ID.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
