### PR TITLE
fix(lint): RESTManager warning

### DIFF
--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -61,7 +61,7 @@ class RESTManager {
   }
 
   get endpoint() {
-    return this.client.options.api;
+    return this.client.options.http.api;
   }
 
   set endpoint(endpoint) {

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -60,6 +60,10 @@ class RESTManager {
     return this.push(handler, apiRequest);
   }
 
+  get endpoint() {
+    return this.client.options.api;
+  }
+
   set endpoint(endpoint) {
     this.client.options.http.api = endpoint;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes the following warning on every pull request:
![image](https://user-images.githubusercontent.com/43409674/92304509-45451480-ef87-11ea-93fa-e40622242847.png)

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
