### PR TITLE
docs(Guild): Guild.setName() example

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1106,7 +1106,7 @@ class Guild extends Base {
    * @example
    * // Edit the guild name
    * guild.setName('Discord Guild')
-   *  .then(updated => console.log(`Updated guild name to ${guild}`))
+   *  .then(updated => console.log(`Updated guild name to ${updated.name}`))
    *  .catch(console.error);
    */
   setName(name, reason) {


### PR DESCRIPTION
The docs example was incorrect, as the parameter is called `updated` but was later referenced as `guild`.  This PR fixes that by changing it to `updated` to match other examples, such as `setRegion()`

**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
