### PR TITLE
docs(Role): Update various Role method descriptions

### DIFF
--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -232,7 +232,7 @@ class Role extends Base {
    * @example
    * // Set the name of the role
    * role.setName('new role')
-   *   .then(updated => console.log(`Edited name of role to ${updated.name}`))
+   *   .then(updated => console.log(`Updated role name to ${updated.name}`))
    *   .catch(console.error);
    */
   setName(name, reason) {

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -173,7 +173,7 @@ class Role extends Base {
    * @example
    * // Edit a role
    * role.edit({ name: 'new role' })
-   *   .then(updated => console.log(`Edited role ${updated.name} name to ${updated.name}`))
+   *   .then(updated => console.log(`Edited role name to ${updated.name}`))
    *   .catch(console.error);
    */
   async edit(data, reason) {

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -232,7 +232,7 @@ class Role extends Base {
    * @example
    * // Set the name of the role
    * role.setName('new role')
-   *   .then(updated => console.log(`Edited name of role ${role.name} to ${updated.name}`))
+   *   .then(updated => console.log(`Edited name of role to ${updated.name}`))
    *   .catch(console.error);
    */
   setName(name, reason) {

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -262,7 +262,7 @@ class Role extends Base {
    * @example
    * // Set the hoist of the role
    * role.setHoist(true)
-   *   .then(r => console.log(`Role hoisted: ${r.hoist}`))
+   *   .then(updated => console.log(`Role hoisted: ${updated.hoist}`))
    *   .catch(console.error);
    */
   setHoist(hoist, reason) {


### PR DESCRIPTION
The setName example is incorrect and will display the wrong data for the name before the method is called.  Additionally, it's inconsistent with other examples, such as `GuildChannel#setName`

**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
