### PR TITLE
feat(GuildMemberManager): throw TypeError on incorrect GuildMemberManager#ban params

### DIFF
--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -207,7 +207,7 @@ class GuildMemberManager extends BaseManager {
    *   .catch(console.error);
    */
   ban(user, options = { days: 0 }) {
-    if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
+    if (typeof options !== 'object') return Promise.reject(new TypeError('INVALID_TYPE', 'options', 'object', true));
     if (options.days) options.delete_message_days = options.days;
     const id = this.client.users.resolveID(user);
     if (!id) return Promise.reject(new Error('BAN_RESOLVE_ID', true));

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -207,6 +207,7 @@ class GuildMemberManager extends BaseManager {
    *   .catch(console.error);
    */
   ban(user, options = { days: 0 }) {
+    if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
     if (options.days) options.delete_message_days = options.days;
     const id = this.client.users.resolveID(user);
     if (!id) return Promise.reject(new Error('BAN_RESOLVE_ID', true));


### PR DESCRIPTION
Consistent with the error thrown by `Message#delete()` when passing a number instead of an object, implements the same TypeError to `GuildMemberManager#ban()` and subsequently `GuildMember#ban()` to catch people passing a string instead of an object.

Not sure how to semantically version this.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
