### PR TITLE
fix(Message): use Promise#reject instead of Throw on Message#delete

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -550,7 +550,7 @@ class Message extends Base {
    *   .catch(console.error);
    */
   delete(options = {}) {
-    if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
+    if (typeof options !== 'object') return Promise.reject(new TypeError('INVALID_TYPE', 'options', 'object', true));
     const { timeout = 0, reason } = options;
     if (timeout <= 0) {
       return this.channel.messages.delete(this.id, reason).then(() => this);


### PR DESCRIPTION
ty to @NotSugden for drawing to my attention that this should be a Promise rejection.

I don't believe this one is breaking because it only addresses one method by which the previously thrown error could not be handled (Promise.catch) with no impact to try/catch.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
