### PR TITLE
fix(Action): Don't crash when partials are disabled

### DIFF
--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -93,7 +93,8 @@ class GenericAction {
     if (data.guild_id) {
       const guild = this.client.guilds.cache.get(data.guild_id);
       if (guild) {
-        return this.getMember(data.member, guild).user;
+        const member = this.getMember(data.member, guild);
+        return member ? member.user : undefined;
       }
     }
     return this.getUser(data);

--- a/src/client/actions/TypingStart.js
+++ b/src/client/actions/TypingStart.js
@@ -7,7 +7,7 @@ const textBasedChannelTypes = ['dm', 'text', 'news'];
 class TypingStart extends Action {
   handle(data) {
     const channel = this.getChannel(data);
-    if (!textBasedChannelTypes.includes(channel.type)) {
+    if (channel && !textBasedChannelTypes.includes(channel.type)) {
       this.client.emit(Events.WARN, `Discord sent a typing packet to a ${channel.type} channel ${channel.id}`);
       return;
     }

--- a/src/client/actions/TypingStart.js
+++ b/src/client/actions/TypingStart.js
@@ -7,7 +7,10 @@ const textBasedChannelTypes = ['dm', 'text', 'news'];
 class TypingStart extends Action {
   handle(data) {
     const channel = this.getChannel(data);
-    if (channel && !textBasedChannelTypes.includes(channel.type)) {
+    if (!channel) {
+      return;
+    }
+    if (!textBasedChannelTypes.includes(channel.type)) {
       this.client.emit(Events.WARN, `Discord sent a typing packet to a ${channel.type} channel ${channel.id}`);
       return;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #4821
this.getMember() returns undefined if there is no cached member and partials are disabled for members.

Also only checks for the correct channel type in TypingStart if there actually is a known channel, I've missed this in my previous PR.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
