### PR TITLE
fix(Shard): avoid caching null child in eval/fetchClientValue

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -23,9 +23,11 @@ const Messages = {
   SHARDING_IN_PROCESS: 'Shards are still being spawned.',
   SHARDING_ALREADY_SPAWNED: count => `Already spawned ${count} shards.`,
   SHARDING_PROCESS_EXISTS: id => `Shard ${id} already has an active process.`,
+  SHARDING_WORKER_EXISTS: id => `Shard ${id} already has an active worker.`,
   SHARDING_READY_TIMEOUT: id => `Shard ${id}'s Client took too long to become ready.`,
   SHARDING_READY_DISCONNECTED: id => `Shard ${id}'s Client disconnected before becoming ready.`,
   SHARDING_READY_DIED: id => `Shard ${id}'s process exited before its Client became ready.`,
+  SHARDING_NO_CHILD_EXISTS: id => `Shard ${id} has no active process or worker.`,
 
   COLOR_RANGE: 'Color must be within the range 0 - 16777215 (0xFFFFFF).',
   COLOR_CONVERT: 'Unable to convert color to a number.',

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -124,6 +124,9 @@ class Shard extends EventEmitter {
         .on('exit', this._exitListener);
     }
 
+    this._evals.clear();
+    this._fetches.clear();
+
     /**
      * Emitted upon the creation of the shard's child process/worker.
      * @event Shard#spawn

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -225,6 +225,10 @@ class Shard extends EventEmitter {
    *   .catch(console.error);
    */
   fetchClientValue(prop) {
+    // Shard is dead (maybe respawning), don't cache anything and error immediately
+    if (!this.process && !this.worker) return Promise.reject(new Error('SHARDING_NO_CHILD_EXISTS', this.id));
+
+    // Cached promise from previous call
     if (this._fetches.has(prop)) return this._fetches.get(prop);
 
     const promise = new Promise((resolve, reject) => {
@@ -255,6 +259,10 @@ class Shard extends EventEmitter {
    * @returns {Promise<*>} Result of the script execution
    */
   eval(script) {
+    // Shard is dead (maybe respawning), don't cache anything and error immediately
+    if (!this.process && !this.worker) return Promise.reject(new Error('SHARDING_NO_CHILD_EXISTS', this.id));
+
+    // Cached promise from previous call
     if (this._evals.has(script)) return this._evals.get(script);
 
     const promise = new Promise((resolve, reject) => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes #4286 by ensuring that a cached call to `eval/fetchClientValue` will never exist where both `process` and `worker` are `null` in a shard.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
