### PR TITLE
fix(MessageManager): throw if delete param is not MessageResolvable

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseManager = require('./BaseManager');
+const { TypeError } = require('../errors');
 const Message = require('../structures/Message');
 const Collection = require('../util/Collection');
 const LimitedCollection = require('../util/LimitedCollection');
@@ -120,9 +121,9 @@ class MessageManager extends BaseManager {
    */
   async delete(message, reason) {
     message = this.resolveID(message);
-    if (message) {
-      await this.client.api.channels(this.channel.id).messages(message).delete({ reason });
-    }
+    if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
+
+    await this.client.api.channels(this.channel.id).messages(message).delete({ reason });
   }
 
   async _fetchId(messageID, cache, force) {


### PR DESCRIPTION
The `MessageManager#delete` method could silently resolve without making any API call if the supplied param was not MessageResolvable.

```js
message.channel.messages.delete("755203620831756368") // successfully deletes message
message.channel.messages.delete("1") // throws DiscordAPIError: Unknown Message
message.channel.messages.delete() // would silently resolve
message.channel.messages.delete({ foo: "bar" }) // would silently resolve
```

This addresses case 3 and 4 above by throwing a TypeError for params which are not `MessageResolvable`

semver:major

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
