### PR TITLE
refactor(ReactionUserManager): use client property

### DIFF
--- a/src/managers/ReactionUserManager.js
+++ b/src/managers/ReactionUserManager.js
@@ -48,16 +48,16 @@ class ReactionUserManager extends BaseManager {
 
   /**
    * Removes a user from this reaction.
-   * @param {UserResolvable} [user=this.reaction.message.client.user] The user to remove the reaction of
+   * @param {UserResolvable} [user=this.client.user] The user to remove the reaction of
    * @returns {Promise<MessageReaction>}
    */
-  remove(user = this.reaction.message.client.user) {
-    const message = this.reaction.message;
-    const userID = message.client.users.resolveID(user);
+  remove(user = this.client.user) {
+    const userID = this.client.users.resolveID(user);
     if (!userID) return Promise.reject(new Error('REACTION_RESOLVE_USER'));
-    return message.client.api.channels[message.channel.id].messages[message.id].reactions[
-      this.reaction.emoji.identifier
-    ][userID === message.client.user.id ? '@me' : userID]
+    const message = this.reaction.message;
+    return this.client.api.channels[message.channel.id].messages[message.id].reactions[this.reaction.emoji.identifier][
+      userID === message.client.user.id ? '@me' : userID
+    ]
       .delete()
       .then(() => this.reaction);
   }

--- a/src/managers/ReactionUserManager.js
+++ b/src/managers/ReactionUserManager.js
@@ -56,7 +56,7 @@ class ReactionUserManager extends BaseManager {
     if (!userID) return Promise.reject(new Error('REACTION_RESOLVE_USER'));
     const message = this.reaction.message;
     return this.client.api.channels[message.channel.id].messages[message.id].reactions[this.reaction.emoji.identifier][
-      userID === message.client.user.id ? '@me' : userID
+      userID === this.client.user.id ? '@me' : userID
     ]
       .delete()
       .then(() => this.reaction);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`ReactionUserManager` has a `.client` property, so why not use it?

**Status**

- [x] Code changes have been tested against the Discord API
- [x] Typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
