### PR TITLE
fix: Remove setTopic from GuildChannel and apply to TextChannel

### DIFF
--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -7,6 +7,14 @@ const GuildChannel = require('./GuildChannel');
  * @extends {GuildChannel}
  */
 class CategoryChannel extends GuildChannel {
+  _patch(data) {
+    super._patch(data);
+
+    // Category Channels cannot have invites
+    this.createInvite = undefined;
+    this.fetchInvites = undefined;
+  }
+
   /**
    * Channels that are a part of this category
    * @type {Collection<Snowflake, GuildChannel>}

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -7,8 +7,8 @@ const GuildChannel = require('./GuildChannel');
  * @extends {GuildChannel}
  */
 class CategoryChannel extends GuildChannel {
-  _patch(data) {
-    super._patch(data);
+  constructor(guild, data) {
+    super(guild, data);
 
     // Category Channels cannot have invites
     this.createInvite = undefined;

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -411,21 +411,6 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Sets a new topic for the guild channel.
-   * @param {string} topic The new topic for the guild channel
-   * @param {string} [reason] Reason for changing the guild channel's topic
-   * @returns {Promise<GuildChannel>}
-   * @example
-   * // Set a new channel topic
-   * channel.setTopic('needs more rate limiting')
-   *   .then(newChannel => console.log(`Channel's new topic is ${newChannel.topic}`))
-   *   .catch(console.error);
-   */
-  setTopic(topic, reason) {
-    return this.edit({ topic }, reason);
-  }
-
-  /**
    * Sets a new position for the guild channel.
    * @param {number} position The new position for the guild channel
    * @param {Object} [options] Options for setting position

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -90,7 +90,7 @@ class TextChannel extends GuildChannel {
    * Sets a new topic for the channel.
    * @param {string} topic The new topic for the channel
    * @param {string} [reason] Reason for changing the channel's topic
-   * @returns {Promise<TextChannel>}
+   * @returns {Promise<this>}
    * @example
    * // Set a new channel topic
    * channel.setTopic('needs more rate limiting')
@@ -98,11 +98,14 @@ class TextChannel extends GuildChannel {
    *   .catch(console.error);
    */
   setTopic(topic, reason) {
-    return this.edit({
-      topic
-    }, reason);
+    return this.edit(
+      {
+        topic,
+      },
+      reason,
+    );
   }
-  
+
   /**
    * Fetches all webhooks for the channel.
    * @returns {Promise<Collection<Snowflake, Webhook>>}

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -38,7 +38,7 @@ class TextChannel extends GuildChannel {
     super._patch(data);
 
     /**
-     * The topic of the text channel
+     * The topic of the channel
      * @type {?string}
      */
     this.topic = data.topic;
@@ -87,13 +87,13 @@ class TextChannel extends GuildChannel {
   }
 
   /**
-   * Sets a new topic for the Text Channel.
-   * @param {string} topic The new topic for the Text channel
-   * @param {string} [reason] Reason for changing the Text channel's topic
+   * Sets a new topic for the channel.
+   * @param {string} topic The new topic for the channel
+   * @param {string} [reason] Reason for changing the channel's topic
    * @returns {Promise<TextChannel>}
    * @example
    * // Set a new channel topic
-   * TextChannel.setTopic('needs more rate limiting')
+   * channel.setTopic('needs more rate limiting')
    *   .then(newChannel => console.log(`Channel's new topic is ${newChannel.topic}`))
    *   .catch(console.error);
    */

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -87,6 +87,23 @@ class TextChannel extends GuildChannel {
   }
 
   /**
+   * Sets a new topic for the Text Channel.
+   * @param {string} topic The new topic for the Text channel
+   * @param {string} [reason] Reason for changing the Text channel's topic
+   * @returns {Promise<TextChannel>}
+   * @example
+   * // Set a new channel topic
+   * TextChannel.setTopic('needs more rate limiting')
+   *   .then(newChannel => console.log(`Channel's new topic is ${newChannel.topic}`))
+   *   .catch(console.error);
+   */
+  setTopic(topic, reason) {
+    return this.edit({
+      topic
+    }, reason);
+  }
+  
+  /**
    * Fetches all webhooks for the channel.
    * @returns {Promise<Collection<Snowflake, Webhook>>}
    * @example

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -821,7 +821,6 @@ declare module 'discord.js' {
       options?: { lockPermissions?: boolean; reason?: string },
     ): Promise<this>;
     public setPosition(position: number, options?: { relative?: boolean; reason?: string }): Promise<this>;
-    public setTopic(topic: string, reason?: string): Promise<this>;
     public updateOverwrite(
       userOrRole: RoleResolvable | UserResolvable,
       options: PermissionOverwriteOption,
@@ -1527,6 +1526,7 @@ declare module 'discord.js' {
     ): Promise<Webhook>;
     public setNSFW(nsfw: boolean, reason?: string): Promise<TextChannel>;
     public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
+    public setTopic(topic: string, reason?: string): Promise<TextChannel>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1526,7 +1526,7 @@ declare module 'discord.js' {
     ): Promise<Webhook>;
     public setNSFW(nsfw: boolean, reason?: string): Promise<TextChannel>;
     public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
-    public setTopic(topic: string, reason?: string): Promise<TextChannel>;
+    public setTopic(topic: string, reason?: string): Promise<this>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
   }
 


### PR DESCRIPTION
#4831 
Remove setTopic from GuildChannel
Add it to TextChannel ~~(or TextBasedChannel??)~~
NewsChannel inherits it from TextChannel.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
- [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
