### PR TITLE
feat(GuildManager): add AFK and system channel options in create

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -8,6 +8,7 @@ const GuildMember = require('../structures/GuildMember');
 const Invite = require('../structures/Invite');
 const Role = require('../structures/Role');
 const {
+  ChannelTypes,
   Events,
   VerificationLevels,
   DefaultMessageNotifications,
@@ -129,6 +130,8 @@ class GuildManager extends BaseManager {
    * <warn>This is only available to bots in fewer than 10 guilds.</warn>
    * @param {string} name The name of the guild
    * @param {Object} [options] Options for the creating
+   * @param {number} [options.afkChannelID] The ID of the AFK channel
+   * @param {number} [options.afkTimeout] The AFK timeout in seconds
    * @param {PartialChannelData[]} [options.channels] The channels for this guild
    * @param {DefaultMessageNotifications} [options.defaultMessageNotifications] The default message notifications
    * for the guild
@@ -137,18 +140,22 @@ class GuildManager extends BaseManager {
    * @param {string} [options.region] The region for the server, defaults to the closest one available
    * @param {PartialRoleData[]} [options.roles] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.
+   * @param {number} [options.systemChannelID] The ID of the system channel
    * @param {VerificationLevel} [options.verificationLevel] The verification level for the guild
    * @returns {Promise<Guild>} The guild that was created
    */
   async create(
     name,
     {
+      afkChannelID,
+      afkTimeout,
       channels = [],
       defaultMessageNotifications,
       explicitContentFilter,
       icon = null,
       region,
       roles = [],
+      systemChannelID,
       verificationLevel,
     } = {},
   ) {
@@ -163,6 +170,7 @@ class GuildManager extends BaseManager {
       explicitContentFilter = ExplicitContentFilterLevels.indexOf(explicitContentFilter);
     }
     for (const channel of channels) {
+      if (channel.type) channel.type = ChannelTypes[channel.type.toUpperCase()];
       channel.parent_id = channel.parentID;
       delete channel.parentID;
       if (!channel.permissionOverwrites) continue;
@@ -187,8 +195,11 @@ class GuildManager extends BaseManager {
             verification_level: verificationLevel,
             default_message_notifications: defaultMessageNotifications,
             explicit_content_filter: explicitContentFilter,
-            channels,
             roles,
+            channels,
+            afk_channel_id: afkChannelID,
+            afk_timeout: afkTimeout,
+            system_channel_id: systemChannelID,
           },
         })
         .then(data => {

--- a/test/createGuild.js
+++ b/test/createGuild.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const assert = require('assert');
+const { token } = require('./auth');
+const { Client } = require('../src');
+
+const client = new Client();
+
+client.on('ready', async () => {
+  try {
+    const guild = await client.guilds.create('testing', {
+      channels: [
+        { name: 'afk channel', type: 'voice', id: 0 },
+        { name: 'system-channel', id: 1 },
+      ],
+      afkChannelID: 0,
+      afkTimeout: 60,
+      systemChannelID: 1,
+    });
+    console.log(guild.id);
+    assert.strictEqual(guild.afkChannel.name, 'afk channel');
+    assert.strictEqual(guild.afkTimeout, 60);
+    assert.strictEqual(guild.systemChannel.name, 'system-channel');
+    await guild.delete();
+    client.destroy();
+  } catch (error) {
+    console.error(error);
+  }
+});
+
+client.login(token).catch(console.error);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1941,10 +1941,7 @@ declare module 'discord.js' {
 
   export class GuildManager extends BaseManager<Snowflake, Guild, GuildResolvable> {
     constructor(client: Client, iterable?: Iterable<any>);
-    public create(
-      name: string,
-      options?: { region?: string; icon: BufferResolvable | Base64Resolvable | null },
-    ): Promise<Guild>;
+    public create(name: string, options?: GuildCreateOptions): Promise<Guild>;
     public fetch(id: Snowflake, cache?: boolean, force?: boolean): Promise<Guild>;
   }
 
@@ -2575,6 +2572,19 @@ declare module 'discord.js' {
 
   interface GuildChannelCloneOptions extends GuildCreateChannelOptions {
     name?: string;
+  }
+
+  interface GuildCreateOptions {
+    afkChannelID?: number;
+    afkTimeout?: number;
+    channels?: PartialChannelData[];
+    defaultMessageNotifications?: DefaultMessageNotifications | number;
+    explicitContentFilter?: ExplicitContentFilterLevel | number;
+    icon?: BufferResolvable | Base64Resolvable | null;
+    region?: string;
+    roles?: PartialRoleData[];
+    systemChannelID?: number;
+    verificationLevel?: VerificationLevel | number;
   }
 
   interface GuildWidget {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds support for the `afk_channel_id`, `afk_timeout`, and `system_channel_id` parameters in the [create guild](https://discord.com/developers/docs/resources/guild#create-guild-json-params) endpoint by adding the `afkChannelID`, `afkTimeout`, and `systemChannelID` options in `GuildManager#create`.

This PR also fixes a minor bug in `create` when specifying types for the channels due to the channel types not being changed from `'text'`, `'voice'` etc to the corresponding numbers, so Discord would return an error.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
