### PR TITLE
fix(GuildMemberManager): options.roles on 'prune'

### DIFF
--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -161,19 +161,22 @@ class GuildMemberManager extends BaseManager {
    *    .then(pruned => console.log(`I just pruned ${pruned} people!`))
    *    .catch(console.error);
    */
-  prune({ days = 7, dry = false, count = true, roles = [], reason } = {}) {
+  prune({ days = 7, dry = false, count: compute_prune_count = true, roles = [], reason } = {}) {
     if (typeof days !== 'number') throw new TypeError('PRUNE_DAYS_TYPE');
 
-    const query = new URLSearchParams();
-    query.set('days', days);
-    query.set('compute_prune_count', count);
+    const query = { days };
+    const resolvedRoles = [];
 
     for (const role of roles) {
       const resolvedRole = this.guild.roles.resolveID(role);
       if (!resolvedRole) {
         return Promise.reject(new TypeError('INVALID_TYPE', 'roles', 'Array of Roles or Snowflakes', true));
       }
-      query.append('include_roles', role);
+      resolvedRoles.push(resolvedRole);
+    }
+
+    if (resolvedRoles.length) {
+      query.include_roles = dry ? resolvedRoles.join(',') : resolvedRoles;
     }
 
     const endpoint = this.client.api.guilds(this.guild.id).prune;
@@ -182,13 +185,12 @@ class GuildMemberManager extends BaseManager {
       return endpoint.get({ query, reason }).then(data => data.pruned);
     }
 
-    const body = [...query.entries()].reduce((acc, [k, v]) => {
-      if (k === 'include_roles') v = (acc[k] || []).concat(v);
-      acc[k] = v;
-      return acc;
-    }, {});
-
-    return endpoint.post({ data: body, reason }).then(data => data.pruned);
+    return endpoint
+      .post({
+        data: { ...query, compute_prune_count },
+        reason,
+      })
+      .then(data => data.pruned);
   }
 
   /**


### PR DESCRIPTION
Since https://github.com/discordjs/discord.js/commit/257371da288d5ac0d796de6802b951fa30245c0d was merged, it allowed an array of values to be passed through a query's value (as explained [here](https://github.com/discordjs/discord.js/pull/4143#pullrequestreview-405182638)). https://github.com/discordjs/discord.js/commit/f1194afd7c046a0ac3a89036f917187e4e95b4ec did not accommodate for these changes that were committed beforehand to make `include_roles=foo&include_roles=bar` possible. 

As of https://github.com/discord/discord-api-docs/commit/b9edace323c9df64c79f104d85984690ae4e2977#diff-c4e1390fca89ecc96b01a093f988fa1cR720 Discord now accepts a "comma-delimited array of snowflakes"... but the old `key=value&key=value` still works (and is even being used in the client). This PR changes the prune method to pass comma-delimited array of role IDs for `options.roles` since that is what is currently documented. The code within the `APIRequest` class hasn't been changed for more compatibility (incase Discord decides to add or change another query that accepts the `key=value&key=value` format). `compute_prune_count` is also excluded from the GET request for the prune in this PR, since that isn't being [used](https://discord.com/developers/docs/resources/guild#get-guild-prune-count).

Fixes #4834 

<details>
<summary>Here's a snippet of how I tested these changes</summary>

```ts
import { once } from 'events';
import { Client } from 'discord.js';
import { TEST_GUILD_ID, TEST_ROLE_IDS, TOKEN } from './constants';

const client = new Client();
// verified through the client
const EXPECTED_NUMBER = 6;

client.login(TOKEN);

test('GuildMemberManager#prune() with options.roles', async () => {
  await once(client, 'ready');

  const { members } = client.guilds.cache.get(TEST_GUILD_ID);

  // GET
  expect(
    members.prune({
      days: 30,
      roles: TEST_ROLE_IDS,
      dry: true,
    })
  ).resolves.toBe(EXPECTED_NUMBER);

  // POST
  expect(
    members.prune({
      days: 30,
      roles: TEST_ROLE_IDS,
    })
  ).resolves.toBe(EXPECTED_NUMBER);
});
```

</details>


**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
