### PR TITLE
fix(Action): Sanity-Check if Discord includes all required data

### DIFF
--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -90,7 +90,7 @@ class GenericAction {
   }
 
   getUserFromMember(data) {
-    if (data.guild_id) {
+    if (data.guild_id && data.member && data.member.user) {
       const guild = this.client.guilds.cache.get(data.guild_id);
       if (guild) {
         const member = this.getMember(data.member, guild);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #4840
I would've expected Discord to _alyways_ include _both_ a `guild_id` and a `member` if the event came from a guild but - guess not.
Make sure that the fields we are interested in are actually present in the payload.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
