### PR TITLE
types(TextBasedChannel): make lastPinAt nullable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2073,7 +2073,7 @@ declare module 'discord.js' {
   interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     _typing: Map<string, TypingData>;
     lastPinTimestamp: number | null;
-    readonly lastPinAt: Date;
+    readonly lastPinAt: Date | null;
     typing: boolean;
     typingCount: number;
     awaitMessages(filter: CollectorFilter, options?: AwaitMessagesOptions): Promise<Collection<Snowflake, Message>>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR makes `TextBasedChannel#lastPinAt` nullable in the typings, like it is [documented](https://discord.js.org/#/docs/main/stable/class/TextBasedChannel?scrollTo=lastPinAt).

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
