### PR TITLE
types(Activity): move flags from Presence to Activity

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,6 +29,7 @@ declare module 'discord.js' {
     public createdTimestamp: number;
     public details: string | null;
     public emoji: Emoji | null;
+    public flags: Readonly<ActivityFlags>;
     public name: string;
     public party: {
       id: string | null;
@@ -1230,7 +1231,6 @@ declare module 'discord.js' {
     constructor(client: Client, data?: object);
     public activities: Activity[];
     public clientStatus: ClientPresenceStatusData | null;
-    public flags: Readonly<ActivityFlags>;
     public guild: Guild | null;
     public readonly member: GuildMember | null;
     public status: PresenceStatus;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR moves the `flags` property from `Presence` to `Activity` in the typings. There is no `Presence#flags` but there is [`Activity#flags`](https://discord.js.org/#/docs/main/stable/class/Activity?scrollTo=flags).

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
