### PR TITLE
fix(Rest): resolved a regression, added retried AbortError

### DIFF
--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -90,7 +90,7 @@ class RequestHandler {
     } catch (error) {
       // Retry the specified number of times for request abortions
       if (request.retries === this.manager.client.options.retryLimit) {
-        throw new HTTPError(res.statusText, res.constructor.name, res.status, request.method, request.path);
+        throw new HTTPError(error.message, error.constructor.name, error.status, request.method, request.path);
       }
 
       request.retries++;

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -88,8 +88,13 @@ class RequestHandler {
     try {
       res = await request.make();
     } catch (error) {
-      // NodeFetch error expected for all "operational" errors, such as 500 status code
-      throw new HTTPError(error.message, error.constructor.name, error.status, request.method, request.path);
+      // Retry the specified number of times for request abortions
+      if (request.retries === this.manager.client.options.retryLimit) {
+        throw new HTTPError(res.statusText, res.constructor.name, res.status, request.method, request.path);
+      }
+
+      request.retries++;
+      return this.execute(request);
     }
 
     if (res && res.headers) {
@@ -122,20 +127,34 @@ class RequestHandler {
       }
     }
 
+    // Handle 2xx and 3xx responses
     if (res.ok) {
       // Nothing wrong with the request, proceed with the next one
       return parseResponse(res);
     }
 
-    // Handle ratelimited requests
-    if (res.status === 429) {
-      // A ratelimit was hit - this should never happen
-      this.manager.client.emit('debug', `429 hit on route ${request.route}`);
-      await Util.delayFor(this.retryAfter);
-      return this.execute(request);
+    // Handle 4xx responses
+    if (res.status >= 400 && res.status < 500) {
+      // Handle ratelimited requests
+      if (res.status === 429) {
+        // A ratelimit was hit - this should never happen
+        this.manager.client.emit('debug', `429 hit on route ${request.route}`);
+        await Util.delayFor(this.retryAfter);
+        return this.execute(request);
+      }
+
+      // Handle possible malformed requests
+      let data;
+      try {
+        data = await parseResponse(res);
+      } catch (err) {
+        throw new HTTPError(err.message, err.constructor.name, err.status, request.method, request.path);
+      }
+
+      throw new DiscordAPIError(request.path, data, request.method, res.status);
     }
 
-    // Handle server errors
+    // Handle 5xx responses
     if (res.status >= 500 && res.status < 600) {
       // Retry the specified number of times for possible serverside issues
       if (request.retries === this.manager.client.options.retryLimit) {
@@ -146,16 +165,8 @@ class RequestHandler {
       return this.execute(request);
     }
 
-    // Handle possible malformed requests
-    try {
-      const data = await parseResponse(res);
-      if (res.status >= 400 && res.status < 500) {
-        throw new DiscordAPIError(request.path, data, request.method, res.status);
-      }
-      return null;
-    } catch (err) {
-      throw new HTTPError(err.message, err.constructor.name, err.status, request.method, request.path);
-    }
+    // Fallback in the rare case a status code outside the range 200..=599 is returned
+    return null;
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

#4835 introduced a regression in 4xx errors, the following chunks of code are not identical - the old one rejected with DiscordAPIError if there was a 4xx error, but the new one throws, and then re-throws but as a HTTPError:

https://github.com/discordjs/discord.js/blob/7b38f46caf9790357eed5b24c118123a00c867fd/src/rest/RequestHandler.js#L167-L175

https://github.com/discordjs/discord.js/blob/169d4c3bff75858d84ed91d1a92b0c1f3bedbc02/src/rest/RequestHandler.js#L150-L158

My apologies for anyone affected, even though nobody reported this issue (yet) since the names and properties are nearly identical for error handlers that don't check for `instanceof`. But the good news, retried AbortErrors!

<details>
  <summary>Stack Traces and Types</summary>

  Running the following code, and using [`@klasa/type`](https://www.npmjs.com/package/@klasa/type) to retrieve the output's type in eval:

  ```javascript
  message.channel.send('a'.repeat(2001));
  ```
  
  ### Before this patch:

  ```
  DiscordAPIError: Invalid Form Body
  content: Must be 2000 or fewer in length.
      at RequestHandler.execute (.../node_modules/discord.js/src/rest/RequestHandler.js:157:13)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
      at async RequestHandler.push (.../node_modules/discord.js/src/rest/RequestHandler.js:39:14)
      at async Object.eval (.../dist/commands/System/Admin/eval.js:74:26)
      at async Object.run (.../dist/commands/System/Admin/eval.js:19:49)
      at async default_1.runCommand (.../dist/monitors/commandHandler.js:58:38)
      ...
  ```

  Type:

  ```typescript
  Promise<HTTPError>
  ```

  **The type is incorrect, the error thrown must be an instance of DiscordAPIError if it's related to an error thrown from the API.**
  
  ### After this patch:

  ```
  DiscordAPIError: Invalid Form Body
  content: Must be 2000 or fewer in length.
      at RequestHandler.execute (.../node_modules/discord.js/src/rest/RequestHandler.js:154:13)
      at processTicksAndRejections (internal/process/task_queues.js:93:5)
      at async RequestHandler.push (.../node_modules/discord.js/src/rest/RequestHandler.js:39:14)
      at async Object.eval (.../dist/commands/System/Admin/eval.js:74:26)
      at async Object.run (.../dist/commands/System/Admin/eval.js:19:49)
      at async default_1.runCommand (.../dist/monitors/commandHandler.js:58:38)
      ...
  ```

  Type:

  ```typescript
  Promise<DiscordAPIError>
  ```

  **With this patch, the error's type is the correct one.**

  ---
  
</details>

Fixes #3471

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
