### PR TITLE
types(GuildPreview): Make description nullable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -887,7 +887,7 @@ declare module 'discord.js' {
     constructor(client: Client, data: object);
     public approximateMemberCount: number;
     public approximatePresenceCount: number;
-    public description?: string;
+    public description?: string | null;
     public discoverySplash: string | null;
     public emojis: Collection<Snowflake, GuildPreviewEmoji>;
     public features: GuildFeatures[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -887,7 +887,7 @@ declare module 'discord.js' {
     constructor(client: Client, data: object);
     public approximateMemberCount: number;
     public approximatePresenceCount: number;
-    public description?: string | null;
+    public description: string | null;
     public discoverySplash: string | null;
     public emojis: Collection<Snowflake, GuildPreviewEmoji>;
     public features: GuildFeatures[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The typings don't state that the description of a `GuildPreview` can be null. It can be null if a guild has never set a description before for which this pull request addresses.
**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
