### PR TITLE
fix(GuildEmojiCreate): Prevent double fire from emoji creation

### DIFF
--- a/src/client/actions/GuildEmojiCreate.js
+++ b/src/client/actions/GuildEmojiCreate.js
@@ -5,13 +5,14 @@ const { Events } = require('../../util/Constants');
 
 class GuildEmojiCreateAction extends Action {
   handle(guild, createdEmoji) {
+    const already = guild.emojis.cache.has(createdEmoji.id);
     const emoji = guild.emojis.add(createdEmoji);
     /**
      * Emitted whenever a custom emoji is created in a guild.
      * @event Client#emojiCreate
      * @param {GuildEmoji} emoji The emoji that was created
      */
-    this.client.emit(Events.GUILD_EMOJI_CREATE, emoji);
+    if (!already) this.client.emit(Events.GUILD_EMOJI_CREATE, emoji);
     return { emoji };
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pull request addresses the issue where creating emojis via the application would fire the `emojiUpdate` event twice. A simple check has been added which will prevent this.

This pull request will resolve issue #4857.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
