### PR TITLE
feat(Message): add messageEditHistoryMaxSize to limit stored msg edits

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -432,6 +432,13 @@ class Client extends BaseClient {
     if (typeof options.messageSweepInterval !== 'number' || isNaN(options.messageSweepInterval)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'messageSweepInterval', 'a number');
     }
+    if (
+      typeof options.messageEditHistoryMaxSize !== 'number' ||
+      isNaN(options.messageEditHistoryMaxSize) ||
+      options.messageEditHistoryMaxSize < -1
+    ) {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'messageEditHistoryMaxSize', 'a number greater than or equal to -1');
+    }
     if (typeof options.fetchAllMembers !== 'boolean') {
       throw new TypeError('CLIENT_INVALID_OPTION', 'fetchAllMembers', 'a boolean');
     }

--- a/src/client/actions/MessageUpdate.js
+++ b/src/client/actions/MessageUpdate.js
@@ -9,9 +9,9 @@ class MessageUpdateAction extends Action {
       const { id, channel_id, guild_id, author, timestamp, type } = data;
       const message = this.getMessage({ id, channel_id, guild_id, author, timestamp, type }, channel);
       if (message) {
-        message.patch(data);
+        const old = message.patch(data);
         return {
-          old: message._edits[0],
+          old,
           updated: message,
         };
       }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -240,8 +240,11 @@ class Message extends Base {
    * @private
    */
   patch(data) {
-    const clone = this._clone();
-    this._edits.unshift(clone);
+    const { messageEditHistoryMaxSize } = this.client.options;
+    if (messageEditHistoryMaxSize !== 0) {
+      const editsLimit = messageEditHistoryMaxSize === -1 ? Infinity : messageEditHistoryMaxSize;
+      if (this._edits.unshift(this._clone()) > editsLimit) this._edits.pop();
+    }
 
     if ('edited_timestamp' in data) this.editedTimestamp = new Date(data.edited_timestamp).getTime();
     if ('content' in data) this.content = data.content;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -235,15 +235,17 @@ class Message extends Base {
   }
 
   /**
-   * Updates the message.
+   * Updates the message and returns the old message.
    * @param {Object} data Raw Discord message update data
+   * @returns {Message}
    * @private
    */
   patch(data) {
+    const clone = this._clone();
     const { messageEditHistoryMaxSize } = this.client.options;
     if (messageEditHistoryMaxSize !== 0) {
       const editsLimit = messageEditHistoryMaxSize === -1 ? Infinity : messageEditHistoryMaxSize;
-      if (this._edits.unshift(this._clone()) > editsLimit) this._edits.pop();
+      if (this._edits.unshift(clone) > editsLimit) this._edits.pop();
     }
 
     if ('edited_timestamp' in data) this.editedTimestamp = new Date(data.edited_timestamp).getTime();
@@ -271,6 +273,8 @@ class Message extends Base {
     );
 
     this.flags = new MessageFlags('flags' in data ? data.flags : 0).freeze();
+
+    return clone;
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -19,6 +19,9 @@ const browser = (exports.browser = typeof window !== 'undefined');
  * sweepable (in seconds, 0 for forever)
  * @property {number} [messageSweepInterval=0] How frequently to remove messages from the cache that are older than
  * the message cache lifetime (in seconds, 0 for never)
+ * @property {number} [messageEditHistoryMaxSize=-1] Maximum number of previous versions to hold for an edited message
+ * (-1 or Infinity for unlimited - don't do this without message sweeping, otherwise memory usage will climb
+ * indefinitely. Setting this to 0 may have undesired effects such as messageUpdate not firing)
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
  * @property {DisableMentionType} [disableMentions='none'] Default value for {@link MessageOptions#disableMentions}
@@ -43,6 +46,7 @@ exports.DefaultOptions = {
   messageCacheMaxSize: 200,
   messageCacheLifetime: 0,
   messageSweepInterval: 0,
+  messageEditHistoryMaxSize: -1,
   fetchAllMembers: false,
   disableMentions: 'none',
   partials: [],

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -20,8 +20,7 @@ const browser = (exports.browser = typeof window !== 'undefined');
  * @property {number} [messageSweepInterval=0] How frequently to remove messages from the cache that are older than
  * the message cache lifetime (in seconds, 0 for never)
  * @property {number} [messageEditHistoryMaxSize=-1] Maximum number of previous versions to hold for an edited message
- * (-1 or Infinity for unlimited - don't do this without message sweeping, otherwise memory usage will climb
- * indefinitely. Setting this to 0 may have undesired effects such as messageUpdate not firing)
+ * (-1 or Infinity for unlimited - don't do this without sweeping, otherwise memory usage may climb indefinitely.)
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
  * @property {DisableMentionType} [disableMentions='none'] Default value for {@link MessageOptions#disableMentions}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -977,7 +977,7 @@ declare module 'discord.js' {
   export class Message extends Base {
     constructor(client: Client, data: object, channel: TextChannel | DMChannel | NewsChannel);
     private _edits: Message[];
-    private patch(data: object): void;
+    private patch(data: object): Message;
 
     public activity: MessageActivity | null;
     public application: ClientApplication | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2317,6 +2317,7 @@ declare module 'discord.js' {
     messageCacheMaxSize?: number;
     messageCacheLifetime?: number;
     messageSweepInterval?: number;
+    messageEditHistoryMaxSize?: number;
     fetchAllMembers?: boolean;
     disableMentions?: 'none' | 'all' | 'everyone';
     allowedMentions?: MessageMentionOptions;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes #4826 by adding a new client option to set a fixed limit on the edit history stored for each message in the client cache.

This has been tested in production on my bot (where the original memory issue was observed) for roughly a month and seems to be fine.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
