### PR TITLE
feat(MessageManager): extend API coverage

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -115,7 +115,7 @@ class MessageManager extends BaseManager {
 
   /**
    * Edits a message, even if it's not cached.
-   * @param {MessageResolvable} message The message to delete
+   * @param {MessageResolvable} message The message to edit
    * @param {StringResolvable|APIMessage} [content] The new content for the message
    * @param {MessageEditOptions|MessageEmbed} [options] The options to provide
    * @returns {Promise<void>}
@@ -131,6 +131,18 @@ class MessageManager extends BaseManager {
           clone._patch(d);
         }
       });
+    }
+  }
+
+  /**
+   * Publishes a message in an announcement channel to all channels following it, even if it's not cached.
+   * @param {MessageResolvable} message The message to publish
+   * @returns {Promise<void>}
+   */
+  async crosspost(message) {
+    message = this.resolveID(message);
+    if (message) {
+      await this.client.api.channels(this.channel.id).messages(message).crosspost.post();
     }
   }
 

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -123,16 +123,15 @@ class MessageManager extends BaseManager {
    */
   async edit(message, content, options) {
     message = this.resolveID(message);
-    if (message) {
-      const { data } =
-        content instanceof APIMessage ? content.resolveData() : APIMessage.create(this, content, options).resolveData();
-      await this.client.api.channels[this.channel.id].messages[message].patch({ data }).then(d => {
-        if (this.cache.has(message)) {
-          const clone = this.cache.get(message)._clone();
-          clone._patch(d);
-        }
-      });
-    }
+    if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
+    const { data } =
+      content instanceof APIMessage ? content.resolveData() : APIMessage.create(this, content, options).resolveData();
+    await this.client.api.channels[this.channel.id].messages[message].patch({ data }).then(d => {
+      if (this.cache.has(message)) {
+        const clone = this.cache.get(message)._clone();
+        clone._patch(d);
+      }
+    });
   }
 
   /**
@@ -142,9 +141,9 @@ class MessageManager extends BaseManager {
    */
   async crosspost(message) {
     message = this.resolveID(message);
-    if (message) {
-      await this.client.api.channels(this.channel.id).messages(message).crosspost.post();
-    }
+    if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
+
+    await this.client.api.channels(this.channel.id).messages(message).crosspost.post();
   }
 
   /**
@@ -156,13 +155,13 @@ class MessageManager extends BaseManager {
    */
   async pin(message, options) {
     message = this.resolveID(message);
-    if (message) {
-      await this.client.api
-        .channels(this.channel.id)
-        .pins(message)
-        .put(options)
-        .then(() => this);
-    }
+    if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
+
+    await this.client.api
+      .channels(this.channel.id)
+      .pins(message)
+      .put(options)
+      .then(() => this);
   }
 
   /**
@@ -174,13 +173,13 @@ class MessageManager extends BaseManager {
    */
   async unpin(message, options) {
     message = this.resolveID(message);
-    if (message) {
-      await this.client.api
-        .channels(this.channel.id)
-        .pins(message)
-        .delete(options)
-        .then(() => this);
-    }
+    if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
+
+    await this.client.api
+      .channels(this.channel.id)
+      .pins(message)
+      .delete(options)
+      .then(() => this);
   }
 
   /**
@@ -208,9 +207,9 @@ class MessageManager extends BaseManager {
    */
   async delete(message, reason) {
     message = this.resolveID(message);
-    if (message) {
-      await this.client.api.channels(this.channel.id).messages(message).delete({ reason });
-    }
+    if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
+
+    await this.client.api.channels(this.channel.id).messages(message).delete({ reason });
   }
 
   async _fetchId(messageID, cache, force) {

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -165,6 +165,24 @@ class MessageManager extends BaseManager {
   }
 
   /**
+   * Unins a message from the channel's pinned messages, even if it's not cached.
+   * @param {MessageResolvable} message The message to unpin
+   * @param {Object} [options] Options for unpinning
+   * @param {string} [options.reason] Reason for unpinning
+   * @returns {Promise<void>}
+   */
+  async unpin(message, options) {
+    message = this.resolveID(message);
+    if (message) {
+      await this.client.api
+        .channels(this.channel.id)
+        .pins(message)
+        .delete(options)
+        .then(() => this);
+    }
+  }
+
+  /**
    * Deletes a message, even if it's not cached.
    * @param {MessageResolvable} message The message to delete
    * @param {string} [reason] Reason for deleting this message, if it does not belong to the client user

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -147,6 +147,24 @@ class MessageManager extends BaseManager {
   }
 
   /**
+   * Pins a message to the channel's pinned messages, even if it's not cached.
+   * @param {MessageResolvable} message The message to pin
+   * @param {Object} [options] Options for pinning
+   * @param {string} [options.reason] Reason for pinning
+   * @returns {Promise<void>}
+   */
+  async pin(message, options) {
+    message = this.resolveID(message);
+    if (message) {
+      await this.client.api
+        .channels(this.channel.id)
+        .pins(message)
+        .put(options)
+        .then(() => this);
+    }
+  }
+
+  /**
    * Deletes a message, even if it's not cached.
    * @param {MessageResolvable} message The message to delete
    * @param {string} [reason] Reason for deleting this message, if it does not belong to the client user

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseManager = require('./BaseManager');
+const { TypeError } = require('../errors');
 const APIMessage = require('../structures/APIMessage');
 const Message = require('../structures/Message');
 const Collection = require('../util/Collection');
@@ -180,6 +181,23 @@ class MessageManager extends BaseManager {
         .delete(options)
         .then(() => this);
     }
+  }
+
+  /**
+   * Adds a reaction to the message, even if it's not cached.
+   * @param {MessageResolvable} message The messag to react to
+   * @param {EmojiIdentifierResolvable} emoji The emoji to react with
+   * @returns {Promise<void>}
+   */
+  async react(message, emoji) {
+    message = this.resolveID(message);
+    if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
+
+    emoji = this.client.emojis.resolveIdentifier(emoji);
+    if (!emoji) throw new TypeError('EMOJI_TYPE', 'emoji', 'EmojiIdentifierResolvable');
+
+    // eslint-disable-next-line newline-per-chained-call
+    await this.client.api.channels(this.channel.id).messages(message).reactions(emoji, '@me').put();
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -503,23 +503,15 @@ class Message extends Base {
    *   .catch(console.error);
    */
   react(emoji) {
-    emoji = this.client.emojis.resolveIdentifier(emoji);
-    if (!emoji) throw new TypeError('EMOJI_TYPE');
-
-    return this.client.api
-      .channels(this.channel.id)
-      .messages(this.id)
-      .reactions(emoji, '@me')
-      .put()
-      .then(
-        () =>
-          this.client.actions.MessageReactionAdd.handle({
-            user: this.client.user,
-            channel: this.channel,
-            message: this,
-            emoji: Util.parseEmoji(emoji),
-          }).reaction,
-      );
+    return this.channel.messages.react(this.id, emoji).then(
+      () =>
+        this.client.actions.MessageReactionAdd.handle({
+          user: this.client.user,
+          channel: this.channel,
+          message: this,
+          emoji: Util.parseEmoji(emoji),
+        }).reaction,
+    );
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -439,13 +439,7 @@ class Message extends Base {
    *   .catch(console.error);
    */
   edit(content, options) {
-    const { data } =
-      content instanceof APIMessage ? content.resolveData() : APIMessage.create(this, content, options).resolveData();
-    return this.client.api.channels[this.channel.id].messages[this.id].patch({ data }).then(d => {
-      const clone = this._clone();
-      clone._patch(d);
-      return clone;
-    });
+    return this.channel.messages.edit(this.id, content, options).then(() => this);
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -469,11 +469,7 @@ class Message extends Base {
    *   .catch(console.error)
    */
   pin(options) {
-    return this.client.api
-      .channels(this.channel.id)
-      .pins(this.id)
-      .put(options)
-      .then(() => this);
+    return this.channel.messages.pin(this.id, options).then(() => this);
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -453,9 +453,8 @@ class Message extends Base {
    *     .catch(console.error);
    * }
    */
-  async crosspost() {
-    await this.client.api.channels(this.channel.id).messages(this.id).crosspost.post();
-    return this;
+  crosspost() {
+    return this.channel.messages.crosspost(this.id).then(() => this);
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -419,7 +419,7 @@ class Message extends Base {
   }
 
   /**
-   * Options that can be passed into editMessage.
+   * Options that can be passed into Message#edit.
    * @typedef {Object} MessageEditOptions
    * @property {string} [content] Content to be edited
    * @property {MessageEmbed|Object} [embed] An embed to be added/edited

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -484,11 +484,7 @@ class Message extends Base {
    *   .catch(console.error)
    */
   unpin(options) {
-    return this.client.api
-      .channels(this.channel.id)
-      .pins(this.id)
-      .delete(options)
-      .then(() => this);
+    return this.channel.messages.unpin(this.id, options).then(() => this);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1984,6 +1984,17 @@ declare module 'discord.js' {
     constructor(channel: TextChannel | DMChannel, iterable?: Iterable<any>);
     public channel: TextBasedChannelFields;
     public cache: Collection<Snowflake, Message>;
+    public crosspost(message: MessageResolvable): Promise<void>;
+    public delete(message: MessageResolvable, reason?: string): Promise<void>;
+    public edit(
+      message: MessageResolvable,
+      content: APIMessageContentResolvable | MessageEditOptions | MessageEmbed | APIMessage,
+    ): Promise<void>;
+    public edit(
+      message: MessageResolvable,
+      content: StringResolvable,
+      options: MessageEditOptions | MessageEmbed,
+    ): Promise<void>;
     public fetch(message: Snowflake, cache?: boolean, force?: boolean): Promise<Message>;
     public fetch(
       options?: ChannelLogsQueryOptions,
@@ -1991,7 +2002,9 @@ declare module 'discord.js' {
       force?: boolean,
     ): Promise<Collection<Snowflake, Message>>;
     public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;
-    public delete(message: MessageResolvable, reason?: string): Promise<void>;
+    public react(message: MessageResolvable, emoji: EmojiIdentifierResolvable): Promise<void>;
+    public pin(message: MessageResolvable, options?: { reason?: string }): Promise<void>;
+    public unpin(message: MessageResolvable, options?: { reason?: string }): Promise<void>;
   }
 
   // Hacky workaround because changing the signature of an overridden method errors


### PR DESCRIPTION
This is to be the first of a few PRs I plan to make which adds additional methods to the Manager classes. Open to discussion and feedback (and additional testing please!) before I start submitting others.

This allows users to directly handle not only creating and fetching Messages from the Manager, but also editing, crossposting, reacting to, pinning and unpinning messages by ID, allowing management of uncached messages.

MessageManager seemed like the logical place to start with this given it already provided support for deleting by ID, and is one of the two most common areas a structure is likely to be uncached.

Like the existing delete method, these all return Promise<void> rather than returning the updated cached structure, as they're designed to compatible with uncached Messages.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
