### PR TITLE
feat(Message): replace reply functionality with inline replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ client.on('ready', () => {
 
 client.on('message', msg => {
   if (msg.content === 'ping') {
-    msg.reply('pong');
+    msg.channel.send('pong');
   }
 });
 

--- a/docs/examples/avatars.js
+++ b/docs/examples/avatars.js
@@ -23,7 +23,7 @@ client.on('message', message => {
   // If the message is "what is my avatar"
   if (message.content === 'what is my avatar') {
     // Send the user's avatar URL
-    message.reply(message.author.displayAvatarURL());
+    message.channel.send(message.author.displayAvatarURL());
   }
 });
 

--- a/docs/examples/moderation.md
+++ b/docs/examples/moderation.md
@@ -45,23 +45,23 @@ client.on('message', message => {
           .kick('Optional reason that will display in the audit logs')
           .then(() => {
             // We let the message author know we were able to kick the person
-            message.reply(`Successfully kicked ${user.tag}`);
+            message.channel.send(`Successfully kicked ${user.tag}`);
           })
           .catch(err => {
             // An error happened
             // This is generally due to the bot not being able to kick the member,
             // either due to missing permissions or role hierarchy
-            message.reply('I was unable to kick the member');
+            message.channel.send('I was unable to kick the member');
             // Log the error
             console.error(err);
           });
       } else {
         // The mentioned user isn't in this guild
-        message.reply("That user isn't in this guild!");
+        message.channel.send("That user isn't in this guild!");
       }
       // Otherwise, if no user was mentioned
     } else {
-      message.reply("You didn't mention the user to kick!");
+      message.channel.send("You didn't mention the user to kick!");
     }
   }
 });
@@ -121,23 +121,23 @@ client.on('message', message => {
           })
           .then(() => {
             // We let the message author know we were able to ban the person
-            message.reply(`Successfully banned ${user.tag}`);
+            message.channel.send(`Successfully banned ${user.tag}`);
           })
           .catch(err => {
             // An error happened
             // This is generally due to the bot not being able to ban the member,
             // either due to missing permissions or role hierarchy
-            message.reply('I was unable to ban the member');
+            message.channel.send('I was unable to ban the member');
             // Log the error
             console.error(err);
           });
       } else {
         // The mentioned user isn't in this guild
-        message.reply("That user isn't in this guild!");
+        message.channel.send("That user isn't in this guild!");
       }
     } else {
       // Otherwise, if no user was mentioned
-      message.reply("You didn't mention the user to ban!");
+      message.channel.send("You didn't mention the user to ban!");
     }
   }
 });

--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -68,7 +68,7 @@ client.on('ready', () => {
 
 client.on('message', msg => {
   if (msg.content === 'ping') {
-    msg.reply('pong');
+    msg.channel.send('pong');
   }
 });
 

--- a/docs/topics/voice.md
+++ b/docs/topics/voice.md
@@ -37,7 +37,7 @@ client.on('message', async message => {
     if (message.member.voice.channel) {
       const connection = await message.member.voice.channel.join();
     } else {
-      message.reply('You need to join a voice channel first!');
+      message.channel.send('You need to join a voice channel first!');
     }
   }
 });

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -79,8 +79,6 @@ class APIMessage {
    * @returns {?(string|string[])}
    */
   makeContent() {
-    const GuildMember = require('./GuildMember');
-
     let content;
     if (this.options.content === null) {
       content = '';
@@ -110,25 +108,14 @@ class APIMessage {
     const isCode = typeof this.options.code !== 'undefined' && this.options.code !== false;
     const splitOptions = isSplit ? { ...this.options.split } : undefined;
 
-    let mentionPart = '';
-    if (this.options.reply && !this.isUser && this.target.type !== 'dm') {
-      const id = this.target.client.users.resolveID(this.options.reply);
-      mentionPart = `<@${this.options.reply instanceof GuildMember && this.options.reply.nickname ? '!' : ''}${id}>, `;
-      if (isSplit) {
-        splitOptions.prepend = `${mentionPart}${splitOptions.prepend || ''}`;
-      }
-    }
-
-    if (content || mentionPart) {
+    if (content) {
       if (isCode) {
         const codeName = typeof this.options.code === 'string' ? this.options.code : '';
-        content = `${mentionPart}\`\`\`${codeName}\n${Util.cleanCodeBlockContent(content)}\n\`\`\``;
+        content = `\`\`\`${codeName}\n${Util.cleanCodeBlockContent(content)}\n\`\`\``;
         if (isSplit) {
           splitOptions.prepend = `${splitOptions.prepend || ''}\`\`\`${codeName}\n`;
           splitOptions.append = `\n\`\`\`${splitOptions.append || ''}`;
         }
-      } else if (mentionPart) {
-        content = `${mentionPart}${content}`;
       }
 
       if (isSplit) {
@@ -182,21 +169,6 @@ class APIMessage {
       typeof this.options.allowedMentions === 'undefined'
         ? this.target.client.options.allowedMentions
         : this.options.allowedMentions;
-    if (this.options.reply) {
-      const id = this.target.client.users.resolveID(this.options.reply);
-      if (allowedMentions) {
-        // Clone the object as not to alter the ClientOptions object
-        allowedMentions = Util.cloneObject(allowedMentions);
-        const parsed = allowedMentions.parse && allowedMentions.parse.includes('users');
-        // Check if the mention won't be parsed, and isn't supplied in `users`
-        if (!parsed && !(allowedMentions.users && allowedMentions.users.includes(id))) {
-          if (!allowedMentions.users) allowedMentions.users = [];
-          allowedMentions.users.push(id);
-        }
-      } else {
-        allowedMentions = { users: [id] };
-      }
-    }
 
     this.data = {
       content,

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -82,7 +82,7 @@ class Emoji extends Base {
    * @example
    * // Send a custom emoji from a guild:
    * const emoji = guild.emojis.cache.first();
-   * msg.reply(`Hello! ${emoji}`);
+   * msg.channel.send(`Hello! ${emoji}`);
    * @example
    * // Send the emoji used in a reaction to the channel the reaction is part of
    * reaction.message.channel.send(`The emoji used was: ${reaction.emoji}`);

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -460,7 +460,10 @@ class Message extends Base {
    * }
    */
   async crosspost() {
-    await this.client.api.channels(this.channel.id).messages(this.id).crosspost.post();
+    await this.client.api
+      .channels(this.channel.id)
+      .messages(this.id)
+      .crosspost.post();
     return this;
   }
 
@@ -561,25 +564,6 @@ class Message extends Base {
         }, timeout);
       });
     }
-  }
-
-  /**
-   * Replies to the message.
-   * @param {StringResolvable|APIMessage} [content=''] The content for the message
-   * @param {MessageOptions|MessageAdditions} [options={}] The options to provide
-   * @returns {Promise<Message|Message[]>}
-   * @example
-   * // Reply to a message
-   * message.reply('Hey, I\'m a reply!')
-   *   .then(() => console.log(`Sent a reply to ${message.author.username}`))
-   *   .catch(console.error);
-   */
-  reply(content, options) {
-    return this.channel.send(
-      content instanceof APIMessage
-        ? content
-        : APIMessage.transformOptions(content, options, { reply: this.member || this.author }),
-    );
   }
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -65,7 +65,6 @@ class TextBasedChannel {
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message
-   * @property {UserResolvable} [reply] User to reply to (prefixes the message with a mention, except in DMs)
    */
 
   /**
@@ -330,7 +329,10 @@ class TextBasedChannel {
       }
       if (messageIDs.length === 0) return new Collection();
       if (messageIDs.length === 1) {
-        await this.client.api.channels(this.id).messages(messageIDs[0]).delete();
+        await this.client.api
+          .channels(this.id)
+          .messages(messageIDs[0])
+          .delete();
         const message = this.client.actions.MessageDelete.getMessage(
           {
             message_id: messageIDs[0],

--- a/test/disableMentions.js
+++ b/test/disableMentions.js
@@ -36,9 +36,9 @@ client.on('message', message => {
   // Clean content and log each character
   console.log(Util.cleanContent(args.join(' '), message).split(''));
 
-  if (command === 'test1') message.reply(tests[0]);
-  else if (command === 'test2') message.reply(tests[1]);
-  else if (command === 'test3') message.reply(tests[2]);
+  if (command === 'test1') message.channel.send(tests[0]);
+  else if (command === 'test2') message.channel.send(tests[1]);
+  else if (command === 'test3') message.channel.send(tests[2]);
 });
 
 client.login(token).catch(console.error);

--- a/test/random.js
+++ b/test/random.js
@@ -134,7 +134,7 @@ client.on('message', message => {
       }
       message.channel.send('last one...').then(m => {
         const diff = Date.now() - start;
-        m.reply(`Each message took ${diff / 21}ms to send`);
+        m.channel.send(`Each message took ${diff / 21}ms to send`);
       });
     }
 
@@ -205,7 +205,7 @@ client.on('message', msg => {
       .join()
       .then(conn => {
         con = conn;
-        msg.reply('done');
+        msg.channel.send('done');
         const s = ytdl(song, { filter: 'audioonly' }, { passes: 3 });
         s.on('error', e => console.log(`e w stream 2 ${e}`));
         disp = conn.playStream(s);

--- a/test/sendtest.js
+++ b/test/sendtest.js
@@ -32,7 +32,6 @@ const tests = [
 
   m => m.channel.send(fill('x'), { split: true }),
   m => m.channel.send(fill('1'), { code: 'js', split: true }),
-  m => m.channel.send(fill('x'), { reply: m.author, code: 'js', split: true }),
   m => m.channel.send(fill('xyz '), { split: { char: ' ' } }),
 
   m => m.channel.send('x', { embed: { description: 'a' } }),
@@ -99,7 +98,6 @@ const tests = [
   async m => m.channel.send({ files: [await read(fileA)] }),
   async m =>
     m.channel.send(fill('x'), {
-      reply: m.author,
       code: 'js',
       split: true,
       embed: embed().setImage('attachment://zero.png'),
@@ -111,7 +109,6 @@ const tests = [
   m => m.channel.send({ files: [{ attachment: readStream(fileA) }] }),
   async m =>
     m.channel.send(fill('xyz '), {
-      reply: m.author,
       code: 'js',
       split: { char: ' ', prepend: 'hello! ', append: '!!!' },
       embed: embed().setImage('attachment://zero.png'),

--- a/test/tester1000.js
+++ b/test/tester1000.js
@@ -31,7 +31,7 @@ const commands = {
     }
     message.channel.send(res, { code: 'js' });
   },
-  ping: message => message.reply('pong'),
+  ping: message => message.channel.send('pong'),
 };
 
 client.on('message', message => {

--- a/test/voice.js
+++ b/test/voice.js
@@ -43,11 +43,11 @@ client.on('message', m => {
         conn.receiver.createStream(m.author, true).on('data', b => console.log(b.toString()));
         conn.player.on('error', (...e) => console.log('player', ...e));
         if (!connections.has(m.guild.id)) connections.set(m.guild.id, { conn, queue: [] });
-        m.reply('ok!');
+        m.channel.send('ok!');
         conn.play(ytdl('https://www.youtube.com/watch?v=_XXOSf0s2nk', { filter: 'audioonly' }, { passes: 3 }));
       });
     } else {
-      m.reply('Specify a voice channel!');
+      m.channel.send('Specify a voice channel!');
     }
   } else if (m.content.startsWith('#eval') && m.author.id === '66564597481480192') {
     try {

--- a/test/webhooktest.js
+++ b/test/webhooktest.js
@@ -32,7 +32,6 @@ const tests = [
 
   (m, hook) => hook.send(fill('x'), { split: true }),
   (m, hook) => hook.send(fill('1'), { code: 'js', split: true }),
-  (m, hook) => hook.send(fill('x'), { reply: m.author, code: 'js', split: true }),
   (m, hook) => hook.send(fill('xyz '), { split: { char: ' ' } }),
 
   (m, hook) => hook.send({ embeds: [{ description: 'a' }] }),
@@ -96,7 +95,6 @@ const tests = [
   async (m, hook) => hook.send({ files: [await read(fileA)] }),
   async (m, hook) =>
     hook.send(fill('x'), {
-      reply: m.author,
       code: 'js',
       split: true,
       embeds: [embed().setImage('attachment://zero.png')],
@@ -108,7 +106,6 @@ const tests = [
   (m, hook) => hook.send({ files: [{ attachment: readStream(fileA) }] }),
   async (m, hook) =>
     hook.send(fill('xyz '), {
-      reply: m.author,
       code: 'js',
       split: { char: ' ', prepend: 'hello! ', append: '!!!' },
       embeds: [embed().setImage('attachment://zero.png')],

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1027,20 +1027,6 @@ declare module 'discord.js' {
     public fetch(force?: boolean): Promise<Message>;
     public pin(options?: { reason?: string }): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
-    public reply(
-      content: APIMessageContentResolvable | (MessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message>;
-    public reply(options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    public reply(options: MessageOptions | APIMessage): Promise<Message | Message[]>;
-    public reply(
-      content: StringResolvable,
-      options: (MessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message>;
-    public reply(
-      content: StringResolvable,
-      options: MessageOptions & { split: true | SplitOptions },
-    ): Promise<Message[]>;
-    public reply(content: StringResolvable, options: MessageOptions): Promise<Message | Message[]>;
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): object;
     public toString(): string;
@@ -2829,7 +2815,6 @@ declare module 'discord.js' {
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
     code?: string | boolean;
     split?: boolean | SplitOptions;
-    reply?: UserResolvable;
   }
 
   type MessageReactionResolvable = MessageReaction | Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

| ⛔ on hold, waiting for implementation of Message#inlineReply. Will move the implementation to Message#reply while also removing Message#inlineReply after merge|
| --- |

<details>
<summary>original:</summary>

This PR removes Message#reply from the library as it is just a convenience shortcut for
```js
<Message>.channel.send(`${<Message>.author}`, content)
```

Before it was argued that the added benefit of adding the reply recipient as parsed mention to the respective options was indeed a considerable ease of use compared to the #send call with all required options to make this work, however Discord has recently had previews for inline replies in development client and rumors of a new message type (19) being the proper implementation after the initial tests have reached us.

While this is not yet officially confirmed in any discord API documentation cleaning the namespace to provide actual reply functionality (should it be available for bots in the first place) or keeping it clear due to the associated meaning of the term "reply" brought forward by aforementioned functionality.

The implementation of the feature itself can then take place in a minor release, while the clearing of the name space (this PR) obviously requires a semver: major, thus me making this PR now, aiming it for v13 together with using the new API versions.

- remove the method from the code base
- remove from APIMessage options
- remove from typings
- remove from boilerplate
- remove from examples
- remove from test files

Should I have missed any caveat please do let me know!

</details>

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
