### PR TITLE
fix(typings): return types for 'Webhook(Client)#send()'

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2193,7 +2193,7 @@ declare module 'discord.js' {
     content: string;
     channel_id: Snowflake;
     author: {
-      bot: true;
+      bot: boolean;
       id: Snowflake;
       username: string;
       avatar: string | null;
@@ -2266,7 +2266,7 @@ declare module 'discord.js' {
       public_flags?: number;
       member?: {
         nick: string | null;
-        roles: string[];
+        roles: Snowflake[];
         joined_at: string;
         premium_since?: string | null;
         deaf: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2193,7 +2193,7 @@ declare module 'discord.js' {
     content: string;
     channel_id: Snowflake;
     author: {
-      bot: boolean;
+      bot?: true;
       id: Snowflake;
       username: string;
       avatar: string | null;
@@ -2255,14 +2255,7 @@ declare module 'discord.js' {
       username: string;
       discriminator: string;
       avatar: string | null;
-      bot?: boolean;
-      system?: boolean;
-      mfa_enabled?: boolean;
-      locale?: string;
-      verified?: boolean;
-      email?: string | null;
-      flags?: number;
-      premium_type?: number;
+      bot?: true;
       public_flags?: number;
       member?: {
         nick: string | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2097,18 +2097,21 @@ declare module 'discord.js' {
     edit(options: WebhookEditData): Promise<Webhook>;
     send(
       content: APIMessageContentResolvable | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message>;
-    send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    send(options: WebhookMessageOptions | APIMessage): Promise<Message | Message[]>;
+    ): Promise<Message | APIRawMessage>;
+    send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<(Message | APIRawMessage)[]>;
+    send(options: WebhookMessageOptions | APIMessage): Promise<Message | APIRawMessage | (Message | APIRawMessage)[]>;
     send(
       content: StringResolvable,
       options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message>;
+    ): Promise<Message | APIRawMessage>;
     send(
       content: StringResolvable,
       options: WebhookMessageOptions & { split: true | SplitOptions },
-    ): Promise<Message[]>;
-    send(content: StringResolvable, options: WebhookMessageOptions): Promise<Message | Message[]>;
+    ): Promise<(Message | APIRawMessage)[]>;
+    send(
+      content: StringResolvable,
+      options: WebhookMessageOptions,
+    ): Promise<Message | APIRawMessage | (Message | APIRawMessage)[]>;
     sendSlackMessage(body: object): Promise<boolean>;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2184,6 +2184,102 @@ declare module 'discord.js' {
 
   type APIMessageContentResolvable = string | number | boolean | bigint | symbol | readonly StringResolvable[];
 
+  interface APIRawMessage {
+    id: Snowflake;
+    type: number;
+    content: string;
+    channel_id: Snowflake;
+    author: {
+      bot: true;
+      id: Snowflake;
+      username: string;
+      avatar: string | null;
+      discriminator: string;
+    };
+    attachments: {
+      id: Snowflake;
+      filename: string;
+      size: number;
+      url: string;
+      proxy_url: string;
+      height: number | null;
+      width: number | null;
+    }[];
+    embeds: {
+      title?: string;
+      type?: 'rich' | 'image' | 'video' | 'gifv' | 'article' | 'link';
+      description?: string;
+      url?: string;
+      timestamp?: string;
+      color?: number;
+      footer?: {
+        text: string;
+        icon_url?: string;
+        proxy_icon_url?: string;
+      };
+      image?: {
+        url?: string;
+        proxy_url?: string;
+        height?: number;
+        width?: number;
+      };
+      thumbnail?: {
+        url?: string;
+        proxy_url?: string;
+        height?: number;
+        width?: number;
+      };
+      video?: {
+        url?: string;
+        height?: number;
+        width?: number;
+      };
+      provider?: { name?: string; url?: string };
+      author?: {
+        name?: string;
+        url?: string;
+        icon_url?: string;
+        proxy_icon_url?: string;
+      };
+      fields?: {
+        name: string;
+        value: string;
+        inline?: boolean;
+      }[];
+    }[];
+    mentions: {
+      id: Snowflake;
+      username: string;
+      discriminator: string;
+      avatar: string | null;
+      bot?: boolean;
+      system?: boolean;
+      mfa_enabled?: boolean;
+      locale?: string;
+      verified?: boolean;
+      email?: string | null;
+      flags?: number;
+      premium_type?: number;
+      public_flags?: number;
+      member?: {
+        nick: string | null;
+        roles: string[];
+        joined_at: string;
+        premium_since?: string | null;
+        deaf: boolean;
+        mute: boolean;
+      };
+    }[];
+    mention_roles: Snowflake[];
+    pinned: boolean;
+    mention_everyone: boolean;
+    tts: boolean;
+    timestamp: string;
+    edited_timestamp: string | null;
+    flags: number;
+    webhook_id: Snowflake;
+  }
+
   interface ApplicationAsset {
     name: string;
     id: Snowflake;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2097,21 +2097,25 @@ declare module 'discord.js' {
     edit(options: WebhookEditData): Promise<Webhook>;
     send(
       content: APIMessageContentResolvable | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message | APIRawMessage>;
-    send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<(Message | APIRawMessage)[]>;
-    send(options: WebhookMessageOptions | APIMessage): Promise<Message | APIRawMessage | (Message | APIRawMessage)[]>;
+    ): Promise<Message | WebhookRawMessageResponse>;
+    send(
+      options: WebhookMessageOptions & { split: true | SplitOptions },
+    ): Promise<(Message | WebhookRawMessageResponse)[]>;
+    send(
+      options: WebhookMessageOptions | APIMessage,
+    ): Promise<Message | WebhookRawMessageResponse | (Message | WebhookRawMessageResponse)[]>;
     send(
       content: StringResolvable,
       options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message | APIRawMessage>;
+    ): Promise<Message | WebhookRawMessageResponse>;
     send(
       content: StringResolvable,
       options: WebhookMessageOptions & { split: true | SplitOptions },
-    ): Promise<(Message | APIRawMessage)[]>;
+    ): Promise<(Message | WebhookRawMessageResponse)[]>;
     send(
       content: StringResolvable,
       options: WebhookMessageOptions,
-    ): Promise<Message | APIRawMessage | (Message | APIRawMessage)[]>;
+    ): Promise<Message | WebhookRawMessageResponse | (Message | WebhookRawMessageResponse)[]>;
     sendSlackMessage(body: object): Promise<boolean>;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3279,6 +3279,16 @@ declare module 'discord.js' {
     split?: boolean | SplitOptions;
   }
 
+  type WebhookRawMessageResponse = Omit<APIRawMessage, 'author'> & {
+    author: {
+      bot: true;
+      id: Snowflake;
+      username: string;
+      avatar: string | null;
+      discriminator: '0000';
+    };
+  };
+
   type WebhookTypes = 'Incoming' | 'Channel Follower';
 
   interface WebSocketOptions {


### PR DESCRIPTION
As shown below, [`Webhook(Client)#send()`](https://discord.js.org/#/docs/main/stable/class/Webhook?scrollTo=send) would either return a Message (if the client was initiated and the channel was cached) or it would return the raw message response from the API (which has been added as a `APIRawMessage` interface in this PR).
https://github.com/discordjs/discord.js/blob/d2341654fe6ef87c6048bb5bf74c394062f3f618/src/structures/Webhook.js#L162-L164

Cuurently the typings do not reflect this behaviour, this PR fixes that.

I did consider making use of the [`APIMessage`](https://github.com/discordjs/discord-api-types/blob/main/v6/payloads/channel.ts#L53-L81) over on [`discord-api-types`](https://github.com/discordjs/discord-api-types) but that would mean introducing another dependency which be a breaking change for all Typescript developers.

| :warning: This change is breaking for Typescript developers that make use of properties or methods exclusive to a Message and not within the APIRawMessage from the resolved returned value of `Webhook(Client)#send()`. |
| --- |

<details>
<summary>Here's a snippet of how I tested these changes</summary>

```ts
import { expectType } from 'tsd';
import { WebhookRawMessageResponse, Message, WebhookClient } from 'discord.js';

const webhookClient = new WebhookClient('', '');

expectType<Message | WebhookRawMessageResponse>(
  await webhookClient.send('foo')
);

expectType<(Message | WebhookRawMessageResponse)[]>(
  await webhookClient.send('foo', { split: true })
);

expectType<
  Message | WebhookRawMessageResponse | (Message | WebhookRawMessageResponse)[]
>(await webhookClient.send({ embeds: [] }, { split: true }));

expectType<Message | WebhookRawMessageResponse>(
  await webhookClient.send('foo', { embeds: [] })
);

expectType<
  Message | WebhookRawMessageResponse | (Message | WebhookRawMessageResponse)[]
>(await webhookClient.send('foo', { embeds: [], split: true }));
```
</details>

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
