### PR TITLE
ci: use npm ci instead of npm install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build and deploy documentation
         uses: discordjs/action-docs@v1
@@ -41,7 +41,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build and deploy webpack
         uses: discordjs/action-webpack@v1

--- a/.github/workflows/test-cron.yml
+++ b/.github/workflows/test-cron.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run ESLint
         uses: icrawl/action-eslint@v1
@@ -34,7 +34,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run TSLint
         run: npm run lint:typings
@@ -52,7 +52,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Register Problem Matcher
         run: echo "##[add-matcher].github/tsc.json"
@@ -73,7 +73,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Test documentation
         run: npm run docs:test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run ESLint
         uses: icrawl/action-eslint@v1
@@ -32,7 +32,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run TSLint
         run: npm run lint:typings
@@ -50,7 +50,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Register Problem Matcher
         run: echo "##[add-matcher].github/tsc.json"
@@ -71,7 +71,7 @@ jobs:
           node-version: 12
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Test documentation
         run: npm run docs:test


### PR DESCRIPTION
Use npm ci instead of npm install when installing dependencies in CI.

**Please describe the changes this PR makes and why it should be merged:**

This PR makes changes to CI workflows, more particularly, the `Install dependencies` steps in workflows. It replaces all instances of `npm install` with `npm ci`, which is a better way of installing npm dependencies in a CI enviroment. You may read more about `npm ci`, it's differences with `npm install` why it's better to use it in this case by looking at [the npm CLI documentation for `npm ci` here.](https://docs.npmjs.com/cli/ci.html)

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
