### PR TITLE
feat(*): enforce strings

### DIFF
--- a/esm/discord.mjs
+++ b/esm/discord.mjs
@@ -49,7 +49,7 @@ export const {
   escapeMarkdown,
   fetchRecommendedShards,
   resolveColor,
-  resolveString,
+  verifyString,
   splitMessage,
   Application,
   ApplicationCommand,

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -37,6 +37,13 @@ const Messages = {
   COLOR_RANGE: 'Color must be within the range 0 - 16777215 (0xFFFFFF).',
   COLOR_CONVERT: 'Unable to convert color to a number.',
 
+  EMBED_TITLE: 'MessageEmbed title must be a string',
+  EMBED_FIELD_NAME: 'MessageEmbed field names must be non-empty strings.',
+  EMBED_FIELD_VALUE: 'MessageEmbed field values must be non-empty strings.',
+  EMBED_FOOTER_TEXT: 'MessageEmbed footer text must be a string.',
+  EMBED_DESCRIPTION: 'MessageEmbed description must be a string.',
+  EMBED_AUTHOR_NAME: 'MessageEmbed author name must be a string.',
+
   FILE_NOT_FOUND: file => `File could not be found: ${file}`,
 
   USER_NO_DMCHANNEL: 'No DM Channel exists!',
@@ -71,7 +78,8 @@ const Messages = {
   IMAGE_SIZE: size => `Invalid image size: ${size}`,
 
   MESSAGE_BULK_DELETE_TYPE: 'The messages must be an Array, Collection, or number.',
-  MESSAGE_NONCE_TYPE: 'Message nonce must be an integer or a string.',
+  MESSAGE_NONCE_TYPE: 'Message nonce must fit in an unsigned 64-bit integer.',
+  MESSAGE_CONTENT_TYPE: 'Message content must be a non-empty string.',
 
   TYPING_COUNT: 'Count must be at least 1',
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -78,7 +78,7 @@ const Messages = {
   IMAGE_SIZE: size => `Invalid image size: ${size}`,
 
   MESSAGE_BULK_DELETE_TYPE: 'The messages must be an Array, Collection, or number.',
-  MESSAGE_NONCE_TYPE: 'Message nonce must fit in an unsigned 64-bit integer.',
+  MESSAGE_NONCE_TYPE: 'Message nonce must be an integer or a string.',
   MESSAGE_CONTENT_TYPE: 'Message content must be a non-empty string.',
 
   TYPING_COUNT: 'Count must be at least 1',

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -37,7 +37,7 @@ const Messages = {
   COLOR_RANGE: 'Color must be within the range 0 - 16777215 (0xFFFFFF).',
   COLOR_CONVERT: 'Unable to convert color to a number.',
 
-  EMBED_TITLE: 'MessageEmbed title must be a string',
+  EMBED_TITLE: 'MessageEmbed title must be a string.',
   EMBED_FIELD_NAME: 'MessageEmbed field names must be non-empty strings.',
   EMBED_FIELD_VALUE: 'MessageEmbed field values must be non-empty strings.',
   EMBED_FOOTER_TEXT: 'MessageEmbed footer text must be a string.',

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ module.exports = {
   escapeMarkdown: Util.escapeMarkdown,
   fetchRecommendedShards: Util.fetchRecommendedShards,
   resolveColor: Util.resolveColor,
-  resolveString: Util.resolveString,
+  verifyString: Util.verifyString,
   splitMessage: Util.splitMessage,
 
   // Structures

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -92,7 +92,7 @@ class APIMessage {
     if (this.options.content === null) {
       content = '';
     } else if (typeof this.options.content !== 'undefined') {
-      content = Util.resolveString(this.options.content);
+      content = Util.verifyString(this.options.content, new RangeError('MESSAGE_CONTENT_TYPE'), false);
     }
 
     if (typeof content !== 'string') return content;
@@ -322,7 +322,7 @@ class APIMessage {
   /**
    * Transforms the user-level arguments into a final options object. Passing a transformed options object alone into
    * this method will keep it the same, allowing for the reuse of the final options object.
-   * @param {StringResolvable} [content] Content to send
+   * @param {string} [content] Content to send
    * @param {MessageOptions|WebhookMessageOptions|MessageAdditions} [options={}] Options to use
    * @param {MessageOptions|WebhookMessageOptions} [extra={}] Extra options to add onto transformed options
    * @param {boolean} [isWebhook=false] Whether or not to use WebhookMessageOptions as the result
@@ -358,7 +358,7 @@ class APIMessage {
   /**
    * Creates an `APIMessage` from user-level arguments.
    * @param {MessageTarget} target Target to send to
-   * @param {StringResolvable} [content] Content to send
+   * @param {string} [content] Content to send
    * @param {MessageOptions|WebhookMessageOptions|MessageAdditions} [options={}] Options to use
    * @param {MessageOptions|WebhookMessageOptions} [extra={}] - Extra options to add onto transformed options
    * @returns {MessageOptions|WebhookMessageOptions}

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -92,7 +92,7 @@ class APIMessage {
     if (this.options.content === null) {
       content = '';
     } else if (typeof this.options.content !== 'undefined') {
-      content = Util.verifyString(this.options.content, new RangeError('MESSAGE_CONTENT_TYPE'));
+      content = Util.verifyString(this.options.content, RangeError, 'MESSAGE_CONTENT_TYPE');
     }
 
     if (typeof content !== 'string') return content;

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -92,7 +92,7 @@ class APIMessage {
     if (this.options.content === null) {
       content = '';
     } else if (typeof this.options.content !== 'undefined') {
-      content = Util.verifyString(this.options.content, new RangeError('MESSAGE_CONTENT_TYPE'), false);
+      content = Util.verifyString(this.options.content, new RangeError('MESSAGE_CONTENT_TYPE'));
     }
 
     if (typeof content !== 'string') return content;

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -92,7 +92,7 @@ class APIMessage {
     if (this.options.content === null) {
       content = '';
     } else if (typeof this.options.content !== 'undefined') {
-      content = Util.verifyString(this.options.content, RangeError, 'MESSAGE_CONTENT_TYPE');
+      content = Util.verifyString(this.options.content, RangeError, 'MESSAGE_CONTENT_TYPE', false);
     }
 
     if (typeof content !== 'string') return content;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -486,7 +486,7 @@ class Message extends Base {
 
   /**
    * Edits the content of the message.
-   * @param {StringResolvable|APIMessage} [content] The new content for the message
+   * @param {string|APIMessage} [content] The new content for the message
    * @param {MessageEditOptions|MessageEmbed} [options] The options to provide
    * @returns {Promise<Message>}
    * @example

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -335,8 +335,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   setDescription(description) {
-    description = Util.verifyString(description, new RangeError('EMBED_DESCRIPTION'));
-    this.description = description;
+    this.description = Util.verifyString(description, new RangeError('EMBED_DESCRIPTION'));
     return this;
   }
 
@@ -347,8 +346,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   setFooter(text, iconURL) {
-    text = Util.verifyString(text, new RangeError('EMBED_FOOTER_TEXT'));
-    this.footer = { text, iconURL };
+    this.footer = { text: Util.verifyString(text, new RangeError('EMBED_FOOTER_TEXT')), iconURL };
     return this;
   }
 
@@ -389,8 +387,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   setTitle(title) {
-    title = Util.verifyString(title, new RangeError('EMBED_TITLE'));
-    this.title = title;
+    this.title = Util.verifyString(title, new RangeError('EMBED_TITLE'));
     return this;
   }
 
@@ -443,9 +440,11 @@ class MessageEmbed {
    * @returns {EmbedField}
    */
   static normalizeField(name, value, inline = false) {
-    name = Util.verifyString(name, new RangeError('EMBED_FIELD_NAME'), false);
-    value = Util.verifyString(value, new RangeError('EMBED_FIELD_VALUE'), false);
-    return { name, value, inline };
+    return {
+      name: Util.verifyString(name, new RangeError('EMBED_FIELD_NAME'), false),
+      value: Util.verifyString(value, new RangeError('EMBED_FIELD_VALUE'), false),
+      inline,
+    };
   }
 
   /**

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -315,7 +315,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   setAuthor(name, iconURL, url) {
-    this.author = { name: Util.verifyString(name, new RangeError('EMBED_AUTHOR_NAME')), iconURL, url };
+    this.author = { name: Util.verifyString(name, RangeError, 'EMBED_AUTHOR_NAME'), iconURL, url };
     return this;
   }
 
@@ -335,7 +335,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   setDescription(description) {
-    this.description = Util.verifyString(description, new RangeError('EMBED_DESCRIPTION'));
+    this.description = Util.verifyString(description, RangeError, 'EMBED_DESCRIPTION');
     return this;
   }
 
@@ -346,7 +346,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   setFooter(text, iconURL) {
-    this.footer = { text: Util.verifyString(text, new RangeError('EMBED_FOOTER_TEXT')), iconURL };
+    this.footer = { text: Util.verifyString(text, RangeError, 'EMBED_FOOTER_TEXT'), iconURL };
     return this;
   }
 
@@ -387,7 +387,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   setTitle(title) {
-    this.title = Util.verifyString(title, new RangeError('EMBED_TITLE'));
+    this.title = Util.verifyString(title, RangeError, 'EMBED_TITLE');
     return this;
   }
 
@@ -441,8 +441,8 @@ class MessageEmbed {
    */
   static normalizeField(name, value, inline = false) {
     return {
-      name: Util.verifyString(name, new RangeError('EMBED_FIELD_NAME'), false),
-      value: Util.verifyString(value, new RangeError('EMBED_FIELD_VALUE'), false),
+      name: Util.verifyString(name, RangeError, 'EMBED_FIELD_NAME', false),
+      value: Util.verifyString(value, RangeError, 'EMBED_FIELD_VALUE', false),
       inline,
     };
   }

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -265,8 +265,8 @@ class MessageEmbed {
 
   /**
    * Adds a field to the embed (max 25).
-   * @param {StringResolvable} name The name of this field
-   * @param {StringResolvable} value The value of this field
+   * @param {string} name The name of this field
+   * @param {string} value The value of this field
    * @param {boolean} [inline=false] If this field will be displayed inline
    * @returns {MessageEmbed}
    */
@@ -309,13 +309,13 @@ class MessageEmbed {
 
   /**
    * Sets the author of this embed.
-   * @param {StringResolvable} name The name of the author
+   * @param {string} name The name of the author
    * @param {string} [iconURL] The icon URL of the author
    * @param {string} [url] The URL of the author
    * @returns {MessageEmbed}
    */
   setAuthor(name, iconURL, url) {
-    this.author = { name: Util.resolveString(name), iconURL, url };
+    this.author = { name: Util.verifyString(name, new RangeError('EMBED_AUTHOR_NAME')), iconURL, url };
     return this;
   }
 
@@ -331,23 +331,23 @@ class MessageEmbed {
 
   /**
    * Sets the description of this embed.
-   * @param {StringResolvable} description The description
+   * @param {string} description The description
    * @returns {MessageEmbed}
    */
   setDescription(description) {
-    description = Util.resolveString(description);
+    description = Util.verifyString(description, new RangeError('EMBED_DESCRIPTION'));
     this.description = description;
     return this;
   }
 
   /**
    * Sets the footer of this embed.
-   * @param {StringResolvable} text The text of the footer
+   * @param {string} text The text of the footer
    * @param {string} [iconURL] The icon URL of the footer
    * @returns {MessageEmbed}
    */
   setFooter(text, iconURL) {
-    text = Util.resolveString(text);
+    text = Util.verifyString(text, new RangeError('EMBED_FOOTER_TEXT'));
     this.footer = { text, iconURL };
     return this;
   }
@@ -385,11 +385,11 @@ class MessageEmbed {
 
   /**
    * Sets the title of this embed.
-   * @param {StringResolvable} title The title
+   * @param {string} title The title
    * @returns {MessageEmbed}
    */
   setTitle(title) {
-    title = Util.resolveString(title);
+    title = Util.verifyString(title, new RangeError('EMBED_TITLE'));
     this.title = title;
     return this;
   }
@@ -437,21 +437,21 @@ class MessageEmbed {
 
   /**
    * Normalizes field input and resolves strings.
-   * @param {StringResolvable} name The name of the field
-   * @param {StringResolvable} value The value of the field
+   * @param {string} name The name of the field
+   * @param {string} value The value of the field
    * @param {boolean} [inline=false] Set the field to display inline
    * @returns {EmbedField}
    */
   static normalizeField(name, value, inline = false) {
-    name = Util.resolveString(name);
-    value = Util.resolveString(value);
+    name = Util.verifyString(name, new RangeError('EMBED_FIELD_NAME'), false);
+    value = Util.verifyString(value, new RangeError('EMBED_FIELD_VALUE'), false);
     return { name, value, inline };
   }
 
   /**
    * @typedef {Object} EmbedFieldData
-   * @property {StringResolvable} name The name of this field
-   * @property {StringResolvable} value The value of this field
+   * @property {string} name The name of this field
+   * @property {string} value The value of this field
    * @property {boolean} [inline] If this field will be displayed inline
    */
 

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -105,7 +105,7 @@ class Webhook {
 
   /**
    * Sends a message with this webhook.
-   * @param {StringResolvable|APIMessage} [content=''] The content to send
+   * @param {string|APIMessage} [content=''] The content to send
    * @param {WebhookMessageOptions|MessageAdditions} [options={}] The options to provide
    * @returns {Promise<Message|Object>}
    * @example

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -335,10 +335,7 @@ class TextBasedChannel {
       }
       if (messageIDs.length === 0) return new Collection();
       if (messageIDs.length === 1) {
-        await this.client.api
-          .channels(this.id)
-          .messages(messageIDs[0])
-          .delete();
+        await this.client.api.channels(this.id).messages(messageIDs[0]).delete();
         const message = this.client.actions.MessageDelete.getMessage(
           {
             message_id: messageIDs[0],

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -114,7 +114,7 @@ class TextBasedChannel {
 
   /**
    * Sends a message to this channel.
-   * @param {StringResolvable|APIMessage} [content=''] The content to send
+   * @param {string|APIMessage} [content=''] The content to send
    * @param {MessageOptions|MessageAdditions} [options={}] The options to provide
    * @returns {Promise<Message|Message[]>}
    * @example
@@ -335,7 +335,10 @@ class TextBasedChannel {
       }
       if (messageIDs.length === 0) return new Collection();
       if (messageIDs.length === 1) {
-        await this.client.api.channels(this.id).messages(messageIDs[0]).delete();
+        await this.client.api
+          .channels(this.id)
+          .messages(messageIDs[0])
+          .delete();
         const message = this.client.actions.MessageDelete.getMessage(
           {
             message_id: messageIDs[0],

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -353,7 +353,7 @@ class Util {
    * @param {boolean} [allowEmpty=true] Wether an empty string should be allowed
    * @returns {string}
    */
-  static verifyString(data, error = new Error(), allowEmpty = true) {
+  static verifyString(data, error = new Error(`Expected a string, got ${data} instead`), allowEmpty = true) {
     if (typeof data !== 'string') throw error;
     if (!allowEmpty && data.length === 0) throw error;
     return data;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -62,7 +62,7 @@ class Util {
    * @returns {string[]}
    */
   static splitMessage(text, { maxLength = 2000, char = '\n', prepend = '', append = '' } = {}) {
-    text = Util.verifyString(text, new RangeError('MESSAGE_CONTENT_TYPE'), false);
+    text = Util.verifyString(text, RangeError, 'MESSAGE_CONTENT_TYPE', false);
     if (text.length <= maxLength) return [text];
     const splitText = text.split(char);
     if (splitText.some(chunk => chunk.length > maxLength)) throw new RangeError('SPLIT_MAX_LEN');

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -349,13 +349,19 @@ class Util {
   /**
    * Verifies the provided data is a string, otherwise throws provided error.
    * @param {string} data The string resolvable to resolve
-   * @param {Error} [error=Error] The error to throw, should the validation fail
-   * @param {boolean} [allowEmpty=true] Wether an empty string should be allowed
+   * @param {Function} [error] The Error constructor to instantiate. Defaults to Error
+   * @param {string} [errorMessage] The error message to throw with. Defaults to "Expected string, got <data> instead."
+   * @param {boolean} [allowEmpty=true] Whether an empty string should be allowed
    * @returns {string}
    */
-  static verifyString(data, error = new Error(`Expected a string, got ${data} instead`), allowEmpty = true) {
-    if (typeof data !== 'string') throw error;
-    if (!allowEmpty && data.length === 0) throw error;
+  static verifyString(
+    data,
+    error = Error,
+    errorMessage = `Expected a string, got ${data} instead.`,
+    allowEmpty = true,
+  ) {
+    if (typeof data !== 'string') throw new error(errorMessage);
+    if (!allowEmpty && data.length === 0) throw new error(errorMessage);
     return data;
   }
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -57,12 +57,12 @@ class Util {
 
   /**
    * Splits a string into multiple chunks at a designated character that do not exceed a specific length.
-   * @param {StringResolvable} text Content to split
+   * @param {string} text Content to split
    * @param {SplitOptions} [options] Options controlling the behavior of the split
    * @returns {string[]}
    */
   static splitMessage(text, { maxLength = 2000, char = '\n', prepend = '', append = '' } = {}) {
-    text = Util.resolveString(text);
+    text = Util.verifyString(text, new RangeError('MESSAGE_CONTENT_TYPE'), false);
     if (text.length <= maxLength) return [text];
     const splitText = text.split(char);
     if (splitText.some(chunk => chunk.length > maxLength)) throw new RangeError('SPLIT_MAX_LEN');
@@ -347,22 +347,16 @@ class Util {
   }
 
   /**
-   * Data that can be resolved to give a string. This can be:
-   * * A string
-   * * An array (joined with a new line delimiter to give a string)
-   * * Any value
-   * @typedef {string|Array|*} StringResolvable
-   */
-
-  /**
-   * Resolves a StringResolvable to a string.
-   * @param {StringResolvable} data The string resolvable to resolve
+   * Verifies the provided data is a string, otherwise throws provided error.
+   * @param {string} data The string resolvable to resolve
+   * @param {Error} [error=Error] The error to throw, should the validation fail
+   * @param {boolean} [allowEmpty=true] Wether an empty string should be allowed
    * @returns {string}
    */
-  static resolveString(data) {
-    if (typeof data === 'string') return data;
-    if (Array.isArray(data)) return data.join('\n');
-    return String(data);
+  static verifyString(data, error = new Error(), allowEmpty = true) {
+    if (typeof data !== 'string') throw error;
+    if (!allowEmpty && data.length === 0) throw error;
+    return data;
   }
 
   /**

--- a/test/sendtest.js
+++ b/test/sendtest.js
@@ -9,7 +9,6 @@ const { Client, Intents, MessageAttachment, MessageEmbed } = require('../src');
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 
-const fill = c => Array(4).fill(c.repeat(1000));
 const buffer = l => fetch(l).then(res => res.buffer());
 const read = util.promisify(fs.readFile);
 const readStream = fs.createReadStream;
@@ -24,15 +23,10 @@ const attach = (attachment, name) => new MessageAttachment(attachment, name);
 
 const tests = [
   m => m.channel.send('x'),
-  m => m.channel.send(['x', 'y']),
 
   m => m.channel.send('x', { code: true }),
   m => m.channel.send('1', { code: 'js' }),
   m => m.channel.send('x', { code: '' }),
-
-  m => m.channel.send(fill('x'), { split: true }),
-  m => m.channel.send(fill('1'), { code: 'js', split: true }),
-  m => m.channel.send(fill('xyz '), { split: { char: ' ' } }),
 
   m => m.channel.send('x', { embed: { description: 'a' } }),
   m => m.channel.send({ embed: { description: 'a' } }),
@@ -68,8 +62,8 @@ const tests = [
   m => m.channel.send({ embed: { description: 'a' } }).then(m2 => m2.edit({ embed: null })),
   m => m.channel.send(embed().setDescription('a')).then(m2 => m2.edit({ embed: null })),
 
-  m => m.channel.send(['x', 'y'], [embed().setDescription('a'), attach(linkB)]),
-  m => m.channel.send(['x', 'y'], [attach(linkA), attach(linkB)]),
+  m => m.channel.send('x', [embed().setDescription('a'), attach(linkB)]),
+  m => m.channel.send('x', [attach(linkA), attach(linkB)]),
 
   m => m.channel.send([embed().setDescription('a'), attach(linkB)]),
   m =>
@@ -83,37 +77,14 @@ const tests = [
         .setImage('attachment://two.png')
         .attachFiles([attach(linkB, 'two.png')]),
     }),
-  async m =>
-    m.channel.send(['x', 'y', 'z'], {
-      code: 'js',
-      embed: embed()
-        .setImage('attachment://two.png')
-        .attachFiles([attach(linkB, 'two.png')]),
-      files: [{ attachment: await buffer(linkA) }],
-    }),
-
   m => m.channel.send('x', attach(fileA)),
   m => m.channel.send({ files: [fileA] }),
   m => m.channel.send(attach(fileA)),
   async m => m.channel.send({ files: [await read(fileA)] }),
-  async m =>
-    m.channel.send(fill('x'), {
-      code: 'js',
-      split: true,
-      embed: embed().setImage('attachment://zero.png'),
-      files: [attach(await buffer(linkA), 'zero.png')],
-    }),
 
   m => m.channel.send('x', attach(readStream(fileA))),
   m => m.channel.send({ files: [readStream(fileA)] }),
   m => m.channel.send({ files: [{ attachment: readStream(fileA) }] }),
-  async m =>
-    m.channel.send(fill('xyz '), {
-      code: 'js',
-      split: { char: ' ', prepend: 'hello! ', append: '!!!' },
-      embed: embed().setImage('attachment://zero.png'),
-      files: [linkB, attach(await buffer(linkA), 'zero.png'), readStream(fileA)],
-    }),
 
   m => m.channel.send('Done!'),
 ];

--- a/test/voice.js
+++ b/test/voice.js
@@ -58,7 +58,7 @@ client.on('message', m => {
       m.channel.send(com, { code: true });
     } catch (e) {
       console.log(e);
-      m.channel.send(e, { code: true });
+      m.channel.send(String(e), { code: true });
     }
   }
 });

--- a/test/webhooktest.js
+++ b/test/webhooktest.js
@@ -9,7 +9,6 @@ const { Client, Intents, MessageAttachment, MessageEmbed, WebhookClient } = requ
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 
-const fill = c => Array(4).fill(c.repeat(1000));
 const buffer = l => fetch(l).then(res => res.buffer());
 const read = util.promisify(fs.readFile);
 const readStream = fs.createReadStream;
@@ -24,15 +23,9 @@ const attach = (attachment, name) => new MessageAttachment(attachment, name);
 
 const tests = [
   (m, hook) => hook.send('x'),
-  (m, hook) => hook.send(['x', 'y']),
-
   (m, hook) => hook.send('x', { code: true }),
   (m, hook) => hook.send('1', { code: 'js' }),
   (m, hook) => hook.send('x', { code: '' }),
-
-  (m, hook) => hook.send(fill('x'), { split: true }),
-  (m, hook) => hook.send(fill('1'), { code: 'js', split: true }),
-  (m, hook) => hook.send(fill('xyz '), { split: { char: ' ' } }),
 
   (m, hook) => hook.send({ embeds: [{ description: 'a' }] }),
   (m, hook) => hook.send({ files: [{ attachment: linkA }] }),
@@ -61,8 +54,8 @@ const tests = [
   (m, hook) => hook.send({ embeds: [{ description: 'a' }] }),
   (m, hook) => hook.send(embed().setDescription('a')),
 
-  (m, hook) => hook.send(['x', 'y'], [embed().setDescription('a'), attach(linkB)]),
-  (m, hook) => hook.send(['x', 'y'], [attach(linkA), attach(linkB)]),
+  (m, hook) => hook.send('x', [embed().setDescription('a'), attach(linkB)]),
+  (m, hook) => hook.send('x', [attach(linkA), attach(linkB)]),
 
   (m, hook) => hook.send([embed().setDescription('a'), attach(linkB)]),
   (m, hook) =>
@@ -93,25 +86,10 @@ const tests = [
   (m, hook) => hook.send({ files: [fileA] }),
   (m, hook) => hook.send(attach(fileA)),
   async (m, hook) => hook.send({ files: [await read(fileA)] }),
-  async (m, hook) =>
-    hook.send(fill('x'), {
-      code: 'js',
-      split: true,
-      embeds: [embed().setImage('attachment://zero.png')],
-      files: [attach(await buffer(linkA), 'zero.png')],
-    }),
 
   (m, hook) => hook.send('x', attach(readStream(fileA))),
   (m, hook) => hook.send({ files: [readStream(fileA)] }),
   (m, hook) => hook.send({ files: [{ attachment: readStream(fileA) }] }),
-  async (m, hook) =>
-    hook.send(fill('xyz '), {
-      code: 'js',
-      split: { char: ' ', prepend: 'hello! ', append: '!!!' },
-      embeds: [embed().setImage('attachment://zero.png')],
-      files: [linkB, attach(await buffer(linkA), 'zero.png'), readStream(fileA)],
-    }),
-
   (m, hook) => hook.send('Done!'),
 ];
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1966,7 +1966,7 @@ declare module 'discord.js' {
     public token: string;
     public editMessage(
       message: MessageResolvable,
-      content: string | APIMessage | MessageEmbed | MessageEmbed[],
+      content: string | null | APIMessage | MessageEmbed | MessageEmbed[],
       options?: WebhookEditMessageOptions,
     ): Promise<RawMessage>;
     public editMessage(message: MessageResolvable, options: WebhookEditMessageOptions): Promise<RawMessage>;
@@ -2362,7 +2362,7 @@ declare module 'discord.js' {
     edit(options: WebhookEditData): Promise<Webhook>;
     editMessage(
       message: MessageResolvable | '@original',
-      content: string | APIMessage | MessageAdditions,
+      content: string | null | APIMessage | MessageAdditions,
       options?: WebhookEditMessageOptions,
     ): Promise<Message | RawMessage>;
     editMessage(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -135,7 +135,7 @@ declare module 'discord.js' {
     ): APIMessage;
     public static create(
       target: MessageTarget,
-      content: string,
+      content: string | null,
       options: MessageOptions | WebhookMessageOptions | MessageAdditions,
       extra?: MessageOptions | WebhookMessageOptions,
     ): APIMessage;
@@ -144,13 +144,13 @@ declare module 'discord.js' {
     ): [MessageEmbed[], MessageAttachment[]];
     public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | MessageAttachment): Promise<unknown>;
     public static transformOptions(
-      content: string,
+      content: string | null,
       options?: undefined,
       extra?: MessageOptions | WebhookMessageOptions,
       isWebhook?: boolean,
     ): MessageOptions | WebhookMessageOptions;
     public static transformOptions(
-      content: string,
+      content: string | null,
       options: MessageOptions | WebhookMessageOptions | MessageAdditions,
       extra?: MessageOptions | WebhookMessageOptions,
       isWebhook?: boolean,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1791,7 +1791,6 @@ declare module 'discord.js' {
       reason?: string,
     ): Promise<{ id: Snowflake; position: number }[]>;
     public static splitMessage(text: string, options?: SplitOptions): string[];
-    public static str2ab(str: string): ArrayBuffer;
   }
 
   class VoiceBroadcast extends EventEmitter {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1184,7 +1184,9 @@ declare module 'discord.js' {
       options?: ReactionCollectorOptions,
     ): ReactionCollector;
     public delete(): Promise<Message>;
-    public edit(content: APIMessageContentResolvable | MessageEditOptions | MessageEmbed | APIMessage): Promise<Message>;
+    public edit(
+      content: APIMessageContentResolvable | MessageEditOptions | MessageEmbed | APIMessage,
+    ): Promise<Message>;
     public edit(content: string, options: MessageEditOptions | MessageEmbed): Promise<Message>;
     public equals(message: Message, rawData: unknown): boolean;
     public fetchReference(): Promise<Message>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1977,14 +1977,14 @@ declare module 'discord.js' {
     public send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<RawMessage[]>;
     public send(options: WebhookMessageOptions | APIMessage): Promise<RawMessage | RawMessage[]>;
     public send(
-      content: string,
+      content: string | null,
       options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<RawMessage>;
     public send(
-      content: string,
+      content: string | null,
       options: WebhookMessageOptions & { split: true | SplitOptions },
     ): Promise<RawMessage[]>;
-    public send(content: string, options: WebhookMessageOptions): Promise<RawMessage | RawMessage[]>;
+    public send(content: string | null, options: WebhookMessageOptions): Promise<RawMessage | RawMessage[]>;
   }
 
   export class WebSocketManager extends EventEmitter {
@@ -2324,9 +2324,9 @@ declare module 'discord.js' {
     send(content: string | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
     send(options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
     send(options: MessageOptions | APIMessage): Promise<Message | Message[]>;
-    send(content: string, options: (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-    send(content: string, options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    send(content: string, options: MessageOptions): Promise<Message | Message[]>;
+    send(content: string | null, options: (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+    send(content: string | null, options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+    send(content: string | null, options: MessageOptions): Promise<Message | Message[]>;
   }
 
   interface TextBasedChannelFields extends PartialTextBasedChannelFields {
@@ -2384,7 +2384,7 @@ declare module 'discord.js' {
       options: WebhookMessageOptions & { split: true | SplitOptions },
     ): Promise<(Message | RawMessage)[]>;
     send(
-      content: string,
+      content: string | null,
       options: WebhookMessageOptions,
     ): Promise<Message | RawMessage | (Message | RawMessage)[]>;
     sendSlackMessage(body: unknown): Promise<boolean>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2376,11 +2376,11 @@ declare module 'discord.js' {
     send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<(Message | RawMessage)[]>;
     send(options: WebhookMessageOptions | APIMessage): Promise<Message | RawMessage | (Message | RawMessage)[]>;
     send(
-      content: string,
+      content: string | null,
       options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message | RawMessage>;
     send(
-      content: string,
+      content: string | null,
       options: WebhookMessageOptions & { split: true | SplitOptions },
     ): Promise<(Message | RawMessage)[]>;
     send(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2486,7 +2486,7 @@ declare module 'discord.js' {
     RESOURCE_OVERLOADED: 130000;
   }
 
-  type APIMessageContentResolvable = string | number | boolean | bigint | symbol | readonly string[];
+  type APIMessageContentResolvable = string | number | boolean | bigint | readonly string[];
 
   interface ApplicationAsset {
     name: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1781,7 +1781,7 @@ declare module 'discord.js' {
     public static moveElementInArray(array: any[], element: any, newIndex: number, offset?: boolean): number;
     public static parseEmoji(text: string): { animated: boolean; name: string; id: string | null } | null;
     public static resolveColor(color: ColorResolvable): number;
-    public static verifyString(data: string, error?: Error, allowEmpty?: boolean): string;
+    public static verifyString(data: string, error?: typeof Error, errorMessage?: string, allowEmpty?: boolean): string;
     public static setPosition<T extends Channel | Role>(
       item: T,
       position: number,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -448,16 +448,16 @@ declare module 'discord.js' {
     public defer(options?: InteractionDeferOptions): Promise<void>;
     public deleteReply(): Promise<void>;
     public editReply(
-      content: string | APIMessage | WebhookEditMessageOptions | MessageAdditions,
+      content: string | null | APIMessage | WebhookEditMessageOptions | MessageAdditions,
     ): Promise<Message | RawMessage>;
-    public editReply(content: string, options?: WebhookEditMessageOptions): Promise<Message | RawMessage>;
+    public editReply(content: string | null, options?: WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
     public followUp(
       content: string | APIMessage | InteractionReplyOptions | MessageAdditions,
     ): Promise<Message | RawMessage>;
-    public followUp(content: string, options?: InteractionReplyOptions): Promise<Message | RawMessage>;
-    public reply(content: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
-    public reply(content: string, options?: InteractionReplyOptions): Promise<void>;
+    public followUp(content: string | null, options?: InteractionReplyOptions): Promise<Message | RawMessage>;
+    public reply(content: string | null | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
+    public reply(content: string | null, options?: InteractionReplyOptions): Promise<void>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
   }
 
@@ -1185,7 +1185,7 @@ declare module 'discord.js' {
     ): ReactionCollector;
     public delete(): Promise<Message>;
     public edit(
-      content: string | MessageEditOptions | MessageEmbed | APIMessage,
+      content: string | null | MessageEditOptions | MessageEmbed | APIMessage,
     ): Promise<Message>;
     public edit(content: string | null, options: MessageEditOptions | MessageEmbed): Promise<Message>;
     public equals(message: Message, rawData: unknown): boolean;
@@ -1197,19 +1197,19 @@ declare module 'discord.js' {
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public removeAttachments(): Promise<Message>;
     public reply(
-      content: string | (ReplyMessageOptions & { split?: false }) | MessageAdditions,
+      content: string | null | (ReplyMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     public reply(options: ReplyMessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
     public reply(options: ReplyMessageOptions | APIMessage): Promise<Message | Message[]>;
     public reply(
-      content: string,
+      content: string | null,
       options: (ReplyMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     public reply(
-      content: string,
+      content: string | null,
       options: ReplyMessageOptions & { split: true | SplitOptions },
     ): Promise<Message[]>;
-    public reply(content: string, options: ReplyMessageOptions): Promise<Message | Message[]>;
+    public reply(content: string | null, options: ReplyMessageOptions): Promise<Message | Message[]>;
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): unknown;
     public toString(): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -129,13 +129,13 @@ declare module 'discord.js' {
 
     public static create(
       target: MessageTarget,
-      content: APIMessageContentResolvable,
+      content: string,
       options?: undefined,
       extra?: MessageOptions | WebhookMessageOptions,
     ): APIMessage;
     public static create(
       target: MessageTarget,
-      content: StringResolvable,
+      content: string,
       options: MessageOptions | WebhookMessageOptions | MessageAdditions,
       extra?: MessageOptions | WebhookMessageOptions,
     ): APIMessage;
@@ -144,13 +144,13 @@ declare module 'discord.js' {
     ): [MessageEmbed[], MessageAttachment[]];
     public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | MessageAttachment): Promise<unknown>;
     public static transformOptions(
-      content: APIMessageContentResolvable,
+      content: string,
       options?: undefined,
       extra?: MessageOptions | WebhookMessageOptions,
       isWebhook?: boolean,
     ): MessageOptions | WebhookMessageOptions;
     public static transformOptions(
-      content: StringResolvable,
+      content: string,
       options: MessageOptions | WebhookMessageOptions | MessageAdditions,
       extra?: MessageOptions | WebhookMessageOptions,
       isWebhook?: boolean,
@@ -1184,10 +1184,8 @@ declare module 'discord.js' {
       options?: ReactionCollectorOptions,
     ): ReactionCollector;
     public delete(): Promise<Message>;
-    public edit(
-      content: APIMessageContentResolvable | MessageEditOptions | MessageEmbed | APIMessage,
-    ): Promise<Message>;
-    public edit(content: StringResolvable, options: MessageEditOptions | MessageEmbed): Promise<Message>;
+    public edit(content: APIMessageContentResolvable | MessageEditOptions | MessageEmbed | APIMessage): Promise<Message>;
+    public edit(content: string, options: MessageEditOptions | MessageEmbed): Promise<Message>;
     public equals(message: Message, rawData: unknown): boolean;
     public fetchReference(): Promise<Message>;
     public fetchWebhook(): Promise<Webhook>;
@@ -1202,14 +1200,14 @@ declare module 'discord.js' {
     public reply(options: ReplyMessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
     public reply(options: ReplyMessageOptions | APIMessage): Promise<Message | Message[]>;
     public reply(
-      content: StringResolvable,
+      content: string,
       options: (ReplyMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     public reply(
-      content: StringResolvable,
+      content: string,
       options: ReplyMessageOptions & { split: true | SplitOptions },
     ): Promise<Message[]>;
-    public reply(content: StringResolvable, options: ReplyMessageOptions): Promise<Message | Message[]>;
+    public reply(content: string, options: ReplyMessageOptions): Promise<Message | Message[]>;
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): unknown;
     public toString(): string;
@@ -1271,26 +1269,22 @@ declare module 'discord.js' {
     public type: string;
     public url: string | null;
     public readonly video: MessageEmbedVideo | null;
-    public addField(name: StringResolvable, value: StringResolvable, inline?: boolean): this;
+    public addField(name: string, value: string, inline?: boolean): this;
     public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
     public attachFiles(file: (MessageAttachment | FileOptions | string)[]): this;
-    public setAuthor(name: StringResolvable, iconURL?: string, url?: string): this;
+    public setAuthor(name: string, iconURL?: string, url?: string): this;
     public setColor(color: ColorResolvable): this;
-    public setDescription(description: StringResolvable): this;
-    public setFooter(text: StringResolvable, iconURL?: string): this;
+    public setDescription(description: string): this;
+    public setFooter(text: string, iconURL?: string): this;
     public setImage(url: string): this;
     public setThumbnail(url: string): this;
     public setTimestamp(timestamp?: Date | number): this;
-    public setTitle(title: StringResolvable): this;
+    public setTitle(title: string): this;
     public setURL(url: string): this;
     public spliceFields(index: number, deleteCount: number, ...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
     public toJSON(): unknown;
 
-    public static normalizeField(
-      name: StringResolvable,
-      value: StringResolvable,
-      inline?: boolean,
-    ): Required<EmbedFieldData>;
+    public static normalizeField(name: string, value: string, inline?: boolean): Required<EmbedFieldData>;
     public static normalizeFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): Required<EmbedFieldData>[];
   }
 
@@ -1785,7 +1779,7 @@ declare module 'discord.js' {
     public static moveElementInArray(array: any[], element: any, newIndex: number, offset?: boolean): number;
     public static parseEmoji(text: string): { animated: boolean; name: string; id: string | null } | null;
     public static resolveColor(color: ColorResolvable): number;
-    public static resolveString(data: StringResolvable): string;
+    public static verifyString(data: string, error?: Error, allowEmpty?: boolean): string;
     public static setPosition<T extends Channel | Role>(
       item: T,
       position: number,
@@ -1794,7 +1788,8 @@ declare module 'discord.js' {
       route: unknown,
       reason?: string,
     ): Promise<{ id: Snowflake; position: number }[]>;
-    public static splitMessage(text: StringResolvable, options?: SplitOptions): string[];
+    public static splitMessage(text: string, options?: SplitOptions): string[];
+    public static str2ab(str: string): ArrayBuffer;
   }
 
   class VoiceBroadcast extends EventEmitter {
@@ -1981,14 +1976,17 @@ declare module 'discord.js' {
     public send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<RawMessage[]>;
     public send(options: WebhookMessageOptions | APIMessage): Promise<RawMessage | RawMessage[]>;
     public send(
-      content: StringResolvable,
+      content: string,
       options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<RawMessage>;
     public send(
-      content: StringResolvable,
+      content: string,
       options: WebhookMessageOptions & { split: true | SplitOptions },
     ): Promise<RawMessage[]>;
-    public send(content: StringResolvable, options: WebhookMessageOptions): Promise<RawMessage | RawMessage[]>;
+    public send(
+      content: string,
+      options: WebhookMessageOptions,
+    ): Promise<RawMessage | RawMessage[]>;
   }
 
   export class WebSocketManager extends EventEmitter {
@@ -2325,14 +2323,12 @@ declare module 'discord.js' {
   interface PartialTextBasedChannelFields {
     lastMessageID: Snowflake | null;
     readonly lastMessage: Message | null;
-    send(
-      content: APIMessageContentResolvable | (MessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message>;
+    send(content: string | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
     send(options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
     send(options: MessageOptions | APIMessage): Promise<Message | Message[]>;
-    send(content: StringResolvable, options: (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-    send(content: StringResolvable, options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    send(content: StringResolvable, options: MessageOptions): Promise<Message | Message[]>;
+    send(content: string, options: (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+    send(content: string, options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
+    send(content: string, options: MessageOptions): Promise<Message | Message[]>;
   }
 
   interface TextBasedChannelFields extends PartialTextBasedChannelFields {
@@ -2382,15 +2378,15 @@ declare module 'discord.js' {
     send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<(Message | RawMessage)[]>;
     send(options: WebhookMessageOptions | APIMessage): Promise<Message | RawMessage | (Message | RawMessage)[]>;
     send(
-      content: StringResolvable,
+      content: string,
       options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message | RawMessage>;
     send(
-      content: StringResolvable,
+      content: string,
       options: WebhookMessageOptions & { split: true | SplitOptions },
     ): Promise<(Message | RawMessage)[]>;
     send(
-      content: StringResolvable,
+      content: string,
       options: WebhookMessageOptions,
     ): Promise<Message | RawMessage | (Message | RawMessage)[]>;
     sendSlackMessage(body: unknown): Promise<boolean>;
@@ -2491,7 +2487,7 @@ declare module 'discord.js' {
     RESOURCE_OVERLOADED: 130000;
   }
 
-  type APIMessageContentResolvable = string | number | boolean | bigint | symbol | readonly StringResolvable[];
+  type APIMessageContentResolvable = string | number | boolean | bigint | symbol | readonly string[];
 
   interface ApplicationAsset {
     name: string;
@@ -2801,8 +2797,8 @@ declare module 'discord.js' {
   }
 
   interface EmbedFieldData {
-    name: StringResolvable;
-    value: StringResolvable;
+    name: string;
+    value: string;
     inline?: boolean;
   }
 
@@ -3207,7 +3203,7 @@ declare module 'discord.js' {
 
   interface MessageEditOptions {
     attachments?: MessageAttachment[];
-    content?: StringResolvable;
+    content?: string;
     embed?: MessageEmbed | MessageEmbedOptions | null;
     code?: string | boolean;
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
@@ -3216,14 +3212,14 @@ declare module 'discord.js' {
   }
 
   interface MessageEmbedAuthor {
-    name?: string;
+    name: string;
     url?: string;
     iconURL?: string;
     proxyIconURL?: string;
   }
 
   interface MessageEmbedFooter {
-    text?: string;
+    text: string;
     iconURL?: string;
     proxyIconURL?: string;
   }
@@ -3303,7 +3299,7 @@ declare module 'discord.js' {
   interface MessageOptions {
     tts?: boolean;
     nonce?: string | number;
-    content?: StringResolvable;
+    content?: string;
     embed?: MessageEmbed | MessageEmbedOptions;
     allowedMentions?: MessageMentionOptions;
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
@@ -3651,8 +3647,6 @@ declare module 'discord.js' {
   type SpeakingString = 'SPEAKING' | 'SOUNDSHARE' | 'PRIORITY_SPEAKING';
 
   type StreamType = 'unknown' | 'converted' | 'opus' | 'ogg/opus' | 'webm/opus';
-
-  type StringResolvable = string | string[] | any;
 
   type SystemChannelFlagsString =
     | 'SUPPRESS_JOIN_NOTIFICATIONS'

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -129,7 +129,7 @@ declare module 'discord.js' {
 
     public static create(
       target: MessageTarget,
-      content: string,
+      content: string | null,
       options?: undefined,
       extra?: MessageOptions | WebhookMessageOptions,
     ): APIMessage;
@@ -1187,7 +1187,7 @@ declare module 'discord.js' {
     public edit(
       content: APIMessageContentResolvable | MessageEditOptions | MessageEmbed | APIMessage,
     ): Promise<Message>;
-    public edit(content: string, options: MessageEditOptions | MessageEmbed): Promise<Message>;
+    public edit(content: string | null, options: MessageEditOptions | MessageEmbed): Promise<Message>;
     public equals(message: Message, rawData: unknown): boolean;
     public fetchReference(): Promise<Message>;
     public fetchWebhook(): Promise<Webhook>;
@@ -1985,10 +1985,7 @@ declare module 'discord.js' {
       content: string,
       options: WebhookMessageOptions & { split: true | SplitOptions },
     ): Promise<RawMessage[]>;
-    public send(
-      content: string,
-      options: WebhookMessageOptions,
-    ): Promise<RawMessage | RawMessage[]>;
+    public send(content: string, options: WebhookMessageOptions): Promise<RawMessage | RawMessage[]>;
   }
 
   export class WebSocketManager extends EventEmitter {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3211,14 +3211,14 @@ declare module 'discord.js' {
   }
 
   interface MessageEmbedAuthor {
-    name: string;
+    name?: string;
     url?: string;
     iconURL?: string;
     proxyIconURL?: string;
   }
 
   interface MessageEmbedFooter {
-    text: string;
+    text?: string;
     iconURL?: string;
     proxyIconURL?: string;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1185,7 +1185,7 @@ declare module 'discord.js' {
     ): ReactionCollector;
     public delete(): Promise<Message>;
     public edit(
-      content: APIMessageContentResolvable | MessageEditOptions | MessageEmbed | APIMessage,
+      content: string | MessageEditOptions | MessageEmbed | APIMessage,
     ): Promise<Message>;
     public edit(content: string | null, options: MessageEditOptions | MessageEmbed): Promise<Message>;
     public equals(message: Message, rawData: unknown): boolean;
@@ -1197,7 +1197,7 @@ declare module 'discord.js' {
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public removeAttachments(): Promise<Message>;
     public reply(
-      content: APIMessageContentResolvable | (ReplyMessageOptions & { split?: false }) | MessageAdditions,
+      content: string | (ReplyMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
     public reply(options: ReplyMessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
     public reply(options: ReplyMessageOptions | APIMessage): Promise<Message | Message[]>;
@@ -1966,13 +1966,13 @@ declare module 'discord.js' {
     public token: string;
     public editMessage(
       message: MessageResolvable,
-      content: APIMessageContentResolvable | APIMessage | MessageEmbed | MessageEmbed[],
+      content: string | APIMessage | MessageEmbed | MessageEmbed[],
       options?: WebhookEditMessageOptions,
     ): Promise<RawMessage>;
     public editMessage(message: MessageResolvable, options: WebhookEditMessageOptions): Promise<RawMessage>;
     public fetchMessage(message: Snowflake, cache?: boolean): Promise<RawMessage>;
     public send(
-      content: APIMessageContentResolvable | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
+      content: string | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<RawMessage>;
     public send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<RawMessage[]>;
     public send(options: WebhookMessageOptions | APIMessage): Promise<RawMessage | RawMessage[]>;
@@ -2362,7 +2362,7 @@ declare module 'discord.js' {
     edit(options: WebhookEditData): Promise<Webhook>;
     editMessage(
       message: MessageResolvable | '@original',
-      content: APIMessageContentResolvable | APIMessage | MessageAdditions,
+      content: string | APIMessage | MessageAdditions,
       options?: WebhookEditMessageOptions,
     ): Promise<Message | RawMessage>;
     editMessage(
@@ -2371,7 +2371,7 @@ declare module 'discord.js' {
     ): Promise<Message | RawMessage>;
     fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | RawMessage>;
     send(
-      content: APIMessageContentResolvable | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
+      content: string | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message | RawMessage>;
     send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<(Message | RawMessage)[]>;
     send(options: WebhookMessageOptions | APIMessage): Promise<Message | RawMessage | (Message | RawMessage)[]>;
@@ -2484,8 +2484,6 @@ declare module 'discord.js' {
     REACTION_BLOCKED: 90001;
     RESOURCE_OVERLOADED: 130000;
   }
-
-  type APIMessageContentResolvable = string | number | boolean | bigint | readonly string[];
 
   interface ApplicationAsset {
     name: string;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -35,7 +35,6 @@ client.on('message', ({ channel }) => {
   assertIsMessage(channel.send('string'));
   assertIsMessage(channel.send({}));
   assertIsMessage(channel.send({ embed: {} }));
-  assertIsMessage(channel.send({ another: 'property' }, {}));
 
   const attachment = new MessageAttachment('file.png');
   const embed = new MessageEmbed();
@@ -43,7 +42,6 @@ client.on('message', ({ channel }) => {
   assertIsMessage(channel.send(embed));
   assertIsMessage(channel.send([attachment, embed]));
 
-  assertIsMessageArray(channel.send(Symbol('another primitive'), { split: true }));
   assertIsMessageArray(channel.send({ split: true }));
 
   // @ts-expect-error


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes StringResolvable (which was just a nice naming scheme for "any" anyways) and enforces and tests for strings to be passed where before any could be resolved to strings.

We have a lot of issues in support regarding people wondering why certain parts of a message or embed may show "undefined" or "null" due to unexpectedly resolving them to strings ([despite it being documented](https://discord.js.org/#/docs/main/stable/typedef/StringResolvable), as space has pointed out).

This is majorly opinionated and I personally believe we should hand the responsibility of providing message content as a string (and how it might be composed from the respective structures) up to the developer. While I do see that resolving anything to a string has its benefits (especially with structures that do have proper #toString implementations resulting in useful content), I also feel like this change will ultimately result in more verbose and explicit code for users as well as more useful pointers (as the previously resolved `undefined` -> `"undefined"`, to name one example, would now throw with a useful error pointing clearly to the issue)

To achieve this I replaced the `resolveString` method with `verifyString` and let the context provide the error to be thrown in order to provide useful information (which embed or message attribute caused this error) utilizing `RangeError` and the existing error message constant system.

**Input/Feedback requested**

| ❓  For now this only throws with empty string where the API rejects. However while empty strings are valid (the API accepts and processes the request instead of throwing) in several positions in embed structures they do cause unexpected behavior. For example providing `""` as embed author name or footer text will hide the respective icon, despite technically being valid (a zero-width space can circumvent this behavior). We could decide to be opinionated here and generally enforce a non-empty string to be passed where strings are expected in embeds. |
| --- |

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
