### PR TITLE
fix(GuildChannel): Default `parentID` to `null`

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -52,7 +52,7 @@ class GuildChannel extends Channel {
      * The ID of the category parent of this channel
      * @type {?Snowflake}
      */
-    this.parentID = data.parent_id;
+    this.parentID = data.parent_id || null;
 
     /**
      * A map of permission overwrites in this channel for roles and users


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #4868
This issue did not just affect CategoryChannels, it affected any channel type.
This seems to be the only place where `parentID` is being set, so make sure that it defaults to null there. The API documentation also actually states that `channel_id` may be unset unstead of null.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
