### PR TITLE
fix(Actions): Avoid crash in InviteCreate with unknown channel

### DIFF
--- a/src/client/actions/InviteCreate.js
+++ b/src/client/actions/InviteCreate.js
@@ -9,7 +9,7 @@ class InviteCreateAction extends Action {
     const client = this.client;
     const channel = client.channels.cache.get(data.channel_id);
     const guild = client.guilds.cache.get(data.guild_id);
-    if (!channel && !guild) return false;
+    if (!channel) return false;
 
     const inviteData = Object.assign(data, { channel, guild });
     const invite = new Invite(client, inviteData);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #4851
Previously the code was only checking for either of channel and guild to be present, and only exited early if _neither_ was present. However in a scenario where the client receives an invite with a known guild but an unknown channel, this would have crashed further down the line because of `channel` being undefined.
I don't really see a reason to keep the guild check so I've just removed it alltogether.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
