### PR TITLE
fix(GuildEmojiManager): check for guild in methods that use it

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -103,6 +103,8 @@ const Messages = {
   FETCH_GROUP_DM_CHANNEL: "Bots don't have access to Group DM Channels and cannot fetch them",
 
   MEMBER_FETCH_NONCE_LENGTH: 'Nonce length must not exceed 32 characters.',
+
+  GUILDEMOJIMANAGER_NO_GUILD: 'Method cannot be called from a Client instance.',
 };
 
 for (const [name, message] of Object.entries(Messages)) register(name, message);

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -2,7 +2,6 @@
 
 const BaseManager = require('./BaseManager');
 const { Error, TypeError } = require('../errors');
-const Guild = require('../structures/Guild');
 const GuildEmoji = require('../structures/GuildEmoji');
 const ReactionEmoji = require('../structures/ReactionEmoji');
 const Collection = require('../util/Collection');
@@ -19,7 +18,7 @@ class GuildEmojiManager extends BaseManager {
      * The guild this manager belongs to
      * @type {?Guild}
      */
-    this.guild = guild instanceof Guild ? guild : null;
+    this.guild = 'name' in guild ? guild : null;
   }
 
   /**

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const BaseManager = require('./BaseManager');
-const { TypeError } = require('../errors');
+const { Error, TypeError } = require('../errors');
+const Guild = require('../structures/Guild');
 const GuildEmoji = require('../structures/GuildEmoji');
 const ReactionEmoji = require('../structures/ReactionEmoji');
 const Collection = require('../util/Collection');
@@ -16,9 +17,9 @@ class GuildEmojiManager extends BaseManager {
     super(guild.client, iterable, GuildEmoji);
     /**
      * The guild this manager belongs to
-     * @type {Guild}
+     * @type {?Guild}
      */
-    this.guild = guild;
+    this.guild = guild instanceof Guild ? guild : null;
   }
 
   /**
@@ -28,6 +29,7 @@ class GuildEmojiManager extends BaseManager {
    */
 
   add(data, cache) {
+    if (!this.guild) throw new Error('GUILDEMOJIMANAGER_NO_GUILD');
     return super.add(data, cache, { extras: [this.guild] });
   }
 
@@ -51,6 +53,7 @@ class GuildEmojiManager extends BaseManager {
    *   .catch(console.error);
    */
   async create(attachment, name, { roles, reason } = {}) {
+    if (!this.guild) throw new Error('GUILDEMOJIMANAGER_NO_GUILD');
     attachment = await DataResolver.resolveImage(attachment);
     if (!attachment) throw new TypeError('REQ_RESOURCE_TYPE');
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1917,7 +1917,7 @@ declare module 'discord.js' {
 
   export class GuildEmojiManager extends BaseManager<Snowflake, GuildEmoji, EmojiResolvable> {
     constructor(guild: Guild, iterable?: Iterable<any>);
-    public guild: Guild;
+    public guild: Guild | null;
     public create(
       attachment: BufferResolvable | Base64Resolvable,
       name: string,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Client#emojis` and `Guild#emojis` both return a `GuildEmojiManager`, however the current code base does not account for former not having a valid guild property. `client.emojis.create(...)` before resulted in `DiscordAPIError: 405: Method Not Allowed`, this PR aims to fix that by checking if a guild is present before using it for methods and throwing a custom error.

**Consideration**

There's also the option to create two separate classes for `Client#emojis` and `Guild#emojis`, I've decided to take this approach for now but I'm open to suggestions.

**Status**

- [x] Code changes have been tested against the Discord API
- [x] I know how to update typings and have done so

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
