### PR TITLE
add default options for intents

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -3,7 +3,7 @@
 const Package = (exports.Package = require('../../package.json'));
 const { Error, RangeError } = require('../errors');
 const browser = (exports.browser = typeof window !== 'undefined');
-
+const Intents = require('./Intents');
 /**
  * Options for a client.
  * @typedef {Object} ClientOptions
@@ -69,6 +69,7 @@ exports.DefaultOptions = {
       $device: 'discord.js',
     },
     version: 6,
+    intents: Intents.NON_PRIVILEGED
   },
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

If intents are not provided in the clientOptions, it'll default to Intents.NON_PRIVILEDGED

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [ x ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
