### PR TITLE
Remove Guild#member

### DIFF
--- a/docs/examples/moderation.md
+++ b/docs/examples/moderation.md
@@ -33,7 +33,7 @@ client.on('message', message => {
     // If we have a user mentioned
     if (user) {
       // Now we get the member from the user
-      const member = message.guild.member(user);
+      const member = message.guild.members.resolve(user);
       // If the member is in the guild
       if (member) {
         /**
@@ -105,7 +105,7 @@ client.on('message', message => {
     // If we have a user mentioned
     if (user) {
       // Now we get the member from the user
-      const member = message.guild.member(user);
+      const member = message.guild.members.resolve(user);
       // If the member is in the guild
       if (member) {
         /**

--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -501,7 +501,7 @@ class VoiceConnection extends EventEmitter {
     }
 
     if (guild && user && !speaking.equals(old)) {
-      const member = guild.member(user);
+      const member = guild.members.resolve(user);
       if (member) {
         /**
          * Emitted once a guild member changes speaking state.

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -627,18 +627,6 @@ class Guild extends Base {
   }
 
   /**
-   * Returns the GuildMember form of a User object, if the user is present in the guild.
-   * @param {UserResolvable} user The user that you want to obtain the GuildMember of
-   * @returns {?GuildMember}
-   * @example
-   * // Get the guild member of a user
-   * const member = guild.member(message.author);
-   */
-  member(user) {
-    return this.members.resolve(user);
-  }
-
-  /**
    * Fetches this guild.
    * @returns {Promise<Guild>}
    */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -277,7 +277,7 @@ class Message extends Base {
    * @readonly
    */
   get member() {
-    return this.guild ? this.guild.member(this.author) || null : null;
+    return this.guild ? this.guild.members.resolve(this.author) || null : null;
   }
 
   /**

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -138,7 +138,7 @@ class MessageMentions {
     if (!this.guild) return null;
     this._members = new Collection();
     this.users.forEach(user => {
-      const member = this.guild.member(user);
+      const member = this.guild.members.resolve(user);
       if (member) this._members.set(member.user.id, member);
     });
     return this._members;

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -127,7 +127,7 @@ class Role extends Base {
    */
   get editable() {
     if (this.managed) return false;
-    const clientMember = this.guild.member(this.client.user);
+    const clientMember = this.guild.members.resolve(this.client.user);
     if (!clientMember.permissions.has(Permissions.FLAGS.MANAGE_ROLES)) return false;
     return clientMember.roles.highest.comparePositionTo(this) > 0;
   }

--- a/test/random.js
+++ b/test/random.js
@@ -116,7 +116,8 @@ client.on('message', message => {
 
     if (message.content.startsWith('kick')) {
       message.guild
-        .member(message.mentions.users.first())
+        .members
+        .resolve(message.mentions.users.first())
         .kick()
         .then(member => {
           console.log(member);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -704,7 +704,6 @@ declare module 'discord.js' {
     public fetchWidget(): Promise<GuildWidget>;
     public iconURL(options?: ImageURLOptions & { dynamic?: boolean }): string | null;
     public leave(): Promise<Guild>;
-    public member(user: UserResolvable): GuildMember | null;
     public setAFKChannel(afkChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
     public setAFKTimeout(afkTimeout: number, reason?: string): Promise<Guild>;
     public setBanner(banner: Base64Resolvable | null, reason?: string): Promise<Guild>;


### PR DESCRIPTION
Remove `Guild#member` as it's a poorly-named helper method for `Guild#members#resolve` (although not a 1-to-1, I do understand).

Fixes #4888

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
