### PR TITLE
feat(Message): allow custom emoji format for react

### DIFF
--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -123,11 +123,10 @@ class GuildEmojiManager extends BaseManager {
     if (typeof emoji === 'string') {
       const res = parseEmoji(emoji);
       if (res && res.name.length) {
-        return `${res.animated ? 'a:' : ''}${res.name}${res.id ? `:${res.id}` : ''}`;
+        emoji = `${res.animated ? 'a:' : ''}${res.name}${res.id ? `:${res.id}` : ''}`;
       }
-      if (!emoji.includes('%')) {
-        return encodeURIComponent(emoji);
-      }
+      if (!emoji.includes('%')) return encodeURIComponent(emoji);
+      else return emoji;
     }
     return null;
   }

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -6,6 +6,7 @@ const GuildEmoji = require('../structures/GuildEmoji');
 const ReactionEmoji = require('../structures/ReactionEmoji');
 const Collection = require('../util/Collection');
 const DataResolver = require('../util/DataResolver');
+const { parseEmoji } = require('../util/Util');
 
 /**
  * Manages API methods for GuildEmojis and stores their cache.
@@ -105,6 +106,7 @@ class GuildEmojiManager extends BaseManager {
   /**
    * Data that can be resolved to give an emoji identifier. This can be:
    * * The unicode representation of an emoji
+   * * The `<a:name:id>`, `<:name:id>`, `:name:id` or `a:name:id` emoji identifier string of an emoji
    * * An EmojiResolvable
    * @typedef {string|EmojiResolvable} EmojiIdentifierResolvable
    */
@@ -119,6 +121,10 @@ class GuildEmojiManager extends BaseManager {
     if (emojiResolvable) return emojiResolvable.identifier;
     if (emoji instanceof ReactionEmoji) return emoji.identifier;
     if (typeof emoji === 'string') {
+      const res = parseEmoji(emoji);
+      if (res.name.length) {
+        emoji = `${res.animated ? 'a:' : ''}${res.name}${res.id ? `:${res.id}` : ''}`;
+      }
       if (!emoji.includes('%')) return encodeURIComponent(emoji);
       else return emoji;
     }

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -123,10 +123,11 @@ class GuildEmojiManager extends BaseManager {
     if (typeof emoji === 'string') {
       const res = parseEmoji(emoji);
       if (res.name.length) {
-        emoji = `${res.animated ? 'a:' : ''}${res.name}${res.id ? `:${res.id}` : ''}`;
+        return `${res.animated ? 'a:' : ''}${res.name}${res.id ? `:${res.id}` : ''}`;
       }
-      if (!emoji.includes('%')) return encodeURIComponent(emoji);
-      else return emoji;
+      if (!emoji.includes('%')) {
+        return encodeURIComponent(emoji);
+      }
     }
     return null;
   }

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -122,7 +122,7 @@ class GuildEmojiManager extends BaseManager {
     if (emoji instanceof ReactionEmoji) return emoji.identifier;
     if (typeof emoji === 'string') {
       const res = parseEmoji(emoji);
-      if (res.name.length) {
+      if (res && res.name.length) {
         return `${res.animated ? 'a:' : ''}${res.name}${res.id ? `:${res.id}` : ''}`;
       }
       if (!emoji.includes('%')) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- ⚠resolves #4006

Currently the `"<:name:id>"` and `"<a:name:id>"` emoji "mention" format strings are not valid input to Message#react, as #4006 brought up. This PR aims to support this input by utilizing the libraries [Util.parseEmoji](https://discord.js.org/#/docs/main/stable/class/Util?scrollTo=s-parseEmoji) method.

The length check is required as the parseEmoji function also returns a valid object with nonsensical input. A name will always be present, if the emoji is valid - either by the custom emoji name or the unicode representation.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
