### PR TITLE
fix(GuildChannel): parentID shouldn't be set in the constructor

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -32,8 +32,6 @@ class GuildChannel extends Channel {
      * @type {Guild}
      */
     this.guild = guild;
-
-    this.parentID = null;
   }
 
   _patch(data) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fixes #4918 
fixes an issue that my PR #4845 introduced - setting `GuildChannel#parentID` to null in the constructor

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
  - untested but i will test it later to make sure
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
