### PR TITLE
docs: use npm ci instead of npm install

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,7 +11,7 @@ is a great boon to your development process.
 To get ready to work on the codebase, please do the following:
 
 1. Fork & clone the repository, and make sure you're on the **master** branch
-2. Run `npm install`
+2. Run `npm ci`
 3. If you're working on voice, also run `npm install @discordjs/opus` or `npm install opusscript`
 4. Code your heart out!
 5. Run `npm test` to run ESLint and ensure any JSDoc changes are valid


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Use `npm ci` instead of `npm install` after cloning the repository. When running on my (old) machine, `npm ci` finished in about 26 seconds after a fresh clone where `npm install` took about 42 seconds to finish. Since you already have a `package-lock.json` file, `npm ci` will also make sure that everyone uses the same package versions consistently.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
