### PR TITLE
remove User#locale

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -28,7 +28,6 @@ class User extends Base {
     this.id = data.id;
 
     this.system = null;
-    this.locale = null;
     this.flags = null;
 
     this._patch(data);
@@ -77,14 +76,6 @@ class User extends Base {
        * @type {?boolean}
        */
       this.system = Boolean(data.system);
-    }
-
-    if ('locale' in data) {
-      /**
-       * The locale of the user's client (ISO 639-1)
-       * @type {?string}
-       */
-      this.locale = data.locale;
     }
 
     if ('public_flags' in data) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1543,7 +1543,6 @@ declare module 'discord.js' {
     public flags: Readonly<UserFlags> | null;
     public id: Snowflake;
     public lastMessageID: Snowflake | null;
-    public locale: string | null;
     public readonly partial: false;
     public readonly presence: Presence;
     public system: boolean | null;
@@ -3045,11 +3044,9 @@ declare module 'discord.js' {
 
   type PartialTypes = 'USER' | 'CHANNEL' | 'GUILD_MEMBER' | 'MESSAGE' | 'REACTION';
 
-  interface PartialUser
-    extends Omit<Partialize<User, 'bot' | 'flags' | 'locale' | 'system' | 'tag' | 'username'>, 'deleted'> {
+  interface PartialUser extends Omit<Partialize<User, 'bot' | 'flags' | 'system' | 'tag' | 'username'>, 'deleted'> {
     bot: User['bot'];
     flags: User['flags'];
-    locale: User['locale'];
     system: User['system'];
     readonly tag: null;
     username: null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

User#locale is currently a useless property as Discord does not expose the locale property to bots (can only be accessed via the Get Current User endpoint), and it is always `null` or `undefined` in d.js (depending on the exact version).

This breaking PR removes it.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
