### PR TITLE
fix(RoleManager): fix ID return value, change return type to collection

### DIFF
--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -2,6 +2,7 @@
 
 const BaseManager = require('./BaseManager');
 const Role = require('../structures/Role');
+const Collection = require('../util/Collection');
 const Permissions = require('../util/Permissions');
 const { resolveColor } = require('../util/Util');
 
@@ -53,9 +54,10 @@ class RoleManager extends BaseManager {
     }
 
     // We cannot fetch a single role, as of this commit's date, Discord API throws with 405
-    const roles = await this.client.api.guilds(this.guild.id).roles.get();
-    for (const role of roles) this.add(role, cache);
-    return id ? this.cache.get(id) || null : this;
+    const data = await this.client.api.guilds(this.guild.id).roles.get();
+    const roles = new Collection();
+    for (const role of data) roles.set(role.id, this.add(role, cache));
+    return id ? roles.get(id) || null : roles;
   }
 
   /**

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -35,7 +35,7 @@ class RoleManager extends BaseManager {
    * @param {Snowflake} [id] ID or IDs of the role(s)
    * @param {boolean} [cache=true] Whether to cache the new roles objects if it weren't already
    * @param {boolean} [force=false] Whether to skip the cache check and request the API
-   * @returns {Promise<Role|RoleManager>}
+   * @returns {Promise<Role|Collection<Snowflake, Role>>}
    * @example
    * // Fetch all roles from the guild
    * message.guild.roles.fetch()

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -32,8 +32,8 @@ class RoleManager extends BaseManager {
 
   /**
    * Obtains one or more roles from Discord, or the role cache if they're already available.
-   * @param {Snowflake} [id] ID or IDs of the role(s)
-   * @param {boolean} [cache=true] Whether to cache the new roles objects if it weren't already
+   * @param {Snowflake} [id] ID of the role to fetch
+   * @param {boolean} [cache=true] Whether to cache the new role object(s) if they weren't already
    * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<?Role|Collection<Snowflake, Role>>}
    * @example

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -35,7 +35,7 @@ class RoleManager extends BaseManager {
    * @param {Snowflake} [id] ID or IDs of the role(s)
    * @param {boolean} [cache=true] Whether to cache the new roles objects if it weren't already
    * @param {boolean} [force=false] Whether to skip the cache check and request the API
-   * @returns {Promise<Role|Collection<Snowflake, Role>>}
+   * @returns {Promise<?Role|Collection<Snowflake, Role>>}
    * @example
    * // Fetch all roles from the guild
    * message.guild.roles.fetch()

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2027,7 +2027,7 @@ declare module 'discord.js' {
 
     public create(options?: { data?: RoleData; reason?: string }): Promise<Role>;
     public fetch(id: Snowflake, cache?: boolean, force?: boolean): Promise<Role | null>;
-    public fetch(id?: Snowflake, cache?: boolean, force?: boolean): Promise<this>;
+    public fetch(id?: Snowflake, cache?: boolean, force?: boolean): Promise<Collection<Snowflake, Role>>;
   }
 
   export class UserManager extends BaseManager<Snowflake, User, UserResolvable> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

1. When using `RoleManager#fetch` with a single ID, [it tries to get the role from `this.cache`](https://github.com/discordjs/discord.js/blob/master/src/managers/RoleManager.js#L58), however that won't work when `cache` is set to `false` and it will return `null` even when the role was fetched correctly. This has ben fixed by getting the role from the collection instead.

2. Unlike any other manager, fetching without passing an ID returns the manager instead of the fetched collection, this has been changed for consistency.

**Status**

- [x] Code changes have been tested against the Discord API
- [x] I know how to update typings and have done so

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
