### PR TITLE
Add intents to the DefaultOptions

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -55,6 +55,7 @@ exports.DefaultOptions = {
   restTimeOffset: 500,
   restSweepInterval: 60,
   presence: {},
+  intents: undefined,
 
   /**
    * WebSocket options (these are left as snake_case to match the API)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the intents key to DefaultOptions in order to be able to access it (if set) through client.options.ws.intents.

undefined was chosen as a value since neither souji nor I were sure what to set it at and "it works". If a better value is needed, that can evidently be changed.

I also state typings do not need to be changed as it seems like this ends up being more of a fix than a modification, `intents` is already present in the wsoptions typings.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
