### PR TITLE
fix(Shard): don't pass event arguments to exit handler

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -96,7 +96,7 @@ class Shard extends EventEmitter {
      * @type {Function}
      * @private
      */
-    this._exitListener = this._handleExit.bind(this);
+    this._exitListener = this._handleExit.bind(this, undefined);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a regression from https://github.com/discordjs/discord.js/pull/4845/files#diff-75a4f785c550209a707697c399a87938fad288bbd1c571614808ed8c08edbd04L99 that currently means shards don't restart when their process exits.

This fixes #4927.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
