### PR TITLE
fix(GuildMemberUpdate): cache incoming members & use partials if enabled

### DIFF
--- a/src/client/actions/ActionsManager.js
+++ b/src/client/actions/ActionsManager.js
@@ -20,6 +20,7 @@ class ActionsManager {
     this.register(require('./InviteCreate'));
     this.register(require('./InviteDelete'));
     this.register(require('./GuildMemberRemove'));
+    this.register(require('./GuildMemberUpdate'));
     this.register(require('./GuildBanRemove'));
     this.register(require('./GuildRoleCreate'));
     this.register(require('./GuildRoleDelete'));

--- a/src/client/actions/GuildMemberUpdate.js
+++ b/src/client/actions/GuildMemberUpdate.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const Action = require('./Action');
+const { Status, Events } = require('../../util/Constants');
+
+class GuildMemberUpdate extends Action {
+  handle(data, shard) {
+    const { client } = this;
+    const user = client.users.cache.get(data.user.id);
+    if (data.user.username) {
+      if (!user) {
+        client.users.add(data.user);
+      } else if (!user.equals(data.user)) {
+        client.actions.UserUpdate.handle(data.user);
+      }
+    }
+
+    const guild = client.guilds.cache.get(data.guild_id);
+    if (guild) {
+      const member = this.getMember({ user: data.user }, guild);
+      if (member) {
+        const old = member._update(data);
+        /**
+         * Emitted whenever a guild member changes - i.e. new role, removed role, nickname.
+         * Also emitted when the user's details (e.g. username) change.
+         * @event Client#guildMemberUpdate
+         * @param {GuildMember} oldMember The member before the update
+         * @param {GuildMember} newMember The member after the update
+         */
+        if (shard.status === Status.READY) client.emit(Events.GUILD_MEMBER_UPDATE, old, member);
+      } else {
+        const newMember = guild.members.add(data);
+        /**
+         * Emitted whenever a member becomes available in a large guild.
+         * @event Client#guildMemberAvailable
+         * @param {GuildMember} member The member that became available
+         */
+        this.client.emit(Events.GUILD_MEMBER_AVAILABLE, newMember);
+      }
+    }
+  }
+}
+
+module.exports = GuildMemberUpdate;

--- a/src/client/actions/GuildMemberUpdate.js
+++ b/src/client/actions/GuildMemberUpdate.js
@@ -3,7 +3,7 @@
 const Action = require('./Action');
 const { Status, Events } = require('../../util/Constants');
 
-class GuildMemberUpdate extends Action {
+class GuildMemberUpdateAction extends Action {
   handle(data, shard) {
     const { client } = this;
     if (data.user.username) {
@@ -41,4 +41,4 @@ class GuildMemberUpdate extends Action {
   }
 }
 
-module.exports = GuildMemberUpdate;
+module.exports = GuildMemberUpdateAction;

--- a/src/client/actions/GuildMemberUpdate.js
+++ b/src/client/actions/GuildMemberUpdate.js
@@ -6,8 +6,8 @@ const { Status, Events } = require('../../util/Constants');
 class GuildMemberUpdate extends Action {
   handle(data, shard) {
     const { client } = this;
-    const user = client.users.cache.get(data.user.id);
     if (data.user.username) {
+      const user = client.users.cache.get(data.user.id);
       if (!user) {
         client.users.add(data.user);
       } else if (!user.equals(data.user)) {

--- a/src/client/websocket/handlers/GUILD_MEMBER_UPDATE.js
+++ b/src/client/websocket/handlers/GUILD_MEMBER_UPDATE.js
@@ -1,29 +1,5 @@
 'use strict';
 
-const { Status, Events } = require('../../../util/Constants');
-
-module.exports = (client, { d: data }, shard) => {
-  let user = client.users.cache.get(data.user.id);
-  if (!user && data.user.username) user = client.users.add(data.user);
-  if (user && data.user && data.user.username) {
-    if (!user.equals(data.user)) client.actions.UserUpdate.handle(data.user);
-  }
-
-  const guild = client.guilds.cache.get(data.guild_id);
-  if (guild) {
-    const member = guild.members.cache.get(data.user.id);
-    if (member) {
-      const old = member._update(data);
-      if (shard.status === Status.READY) {
-        /**
-         * Emitted whenever a guild member changes - i.e. new role, removed role, nickname.
-         * Also emitted when the user's details (e.g. username) change.
-         * @event Client#guildMemberUpdate
-         * @param {GuildMember} oldMember The member before the update
-         * @param {GuildMember} newMember The member after the update
-         */
-        client.emit(Events.GUILD_MEMBER_UPDATE, old, member);
-      }
-    }
-  }
+module.exports = (client, packet, shard) => {
+  client.actions.GuildMemberUpdate.handle(packet.d, shard);
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR ensures that the incoming member (update) data is always cached, even if the member was not cached.

If using partials, the guildMemberUpdate event will be emitted with a partial 'old' member.
If not using partials, the guildMemberAvailable event will be emitted.

I also added the guildMemberAvailable event doc string back, which was erroneously removed from the documentation some time ago. (See: f3cad81f5314a3997ac188277e2471ba84cbd771 )

**This is not tested yet.**

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
