### PR TITLE
fix(User): only assign to bot initially or if info is actually present

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -45,11 +45,13 @@ class User extends Base {
       this.username = null;
     }
 
-    /**
-     * Whether or not the user is a bot
-     * @type {boolean}
-     */
-    this.bot = Boolean(data.bot);
+    if ('bot' in data || typeof this.bot !== 'boolean') {
+      /**
+       * Whether or not the user is a bot
+       * @type {boolean}
+       */
+      this.bot = Boolean(data.bot);
+    }
 
     if ('discriminator' in data) {
       /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #4985 and fixes #4943.

This PR fixes the bot property of a bot to erroneously changing into `false` when the USER partial was enabled and their partial is requested through something like `Action#getUser` or explicitly through `UserStore#add` with just an `id` property.

This is solved by only initially setting the property, or updating it if the payload actually includes a `bot` property

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
