### PR TITLE
feat(Shard): shard-specific broadcastEval/fetchClientValues + shard Id util

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,10 +2,10 @@
   "extends": ["eslint:recommended", "plugin:prettier/recommended"],
   "plugins": ["import"],
   "parserOptions": {
-    "ecmaVersion": 2019
+    "ecmaVersion": 2020
   },
   "env": {
-    "es6": true,
+    "es2020": true,
     "node": true
   },
   "overrides": [{ "files": ["*.browser.js"], "env": { "browser": true } }],

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -21,6 +21,7 @@ const Messages = {
   DISALLOWED_INTENTS: 'Privileged intent provided is not enabled or whitelisted.',
   SHARDING_NO_SHARDS: 'No shards have been spawned.',
   SHARDING_IN_PROCESS: 'Shards are still being spawned.',
+  SHARDING_SHARD_NOT_FOUND: id => `Shard ${id} could not be found.`,
   SHARDING_ALREADY_SPAWNED: count => `Already spawned ${count} shards.`,
   SHARDING_PROCESS_EXISTS: id => `Shard ${id} already has an active process.`,
   SHARDING_WORKER_EXISTS: id => `Shard ${id} already has an active worker.`,

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -29,6 +29,8 @@ const Messages = {
   SHARDING_READY_DISCONNECTED: id => `Shard ${id}'s Client disconnected before becoming ready.`,
   SHARDING_READY_DIED: id => `Shard ${id}'s process exited before its Client became ready.`,
   SHARDING_NO_CHILD_EXISTS: id => `Shard ${id} has no active process or worker.`,
+  SHARDING_SHARD_MISCALCULATION: (shard, guild, count) =>
+    `Calculated invalid shard ${shard} for guild ${guild} with ${count} shards.`,
 
   COLOR_RANGE: 'Color must be within the range 0 - 16777215 (0xFFFFFF).',
   COLOR_CONVERT: 'Unable to convert color to a number.',

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -343,9 +343,10 @@ class Shard extends EventEmitter {
 
       // Shard is requesting an eval broadcast
       if (message._sEval) {
-        this.manager.broadcastEval(message._sEval).then(
-          results => this.send({ _sEval: message._sEval, _result: results }),
-          err => this.send({ _sEval: message._sEval, _error: Util.makePlainError(err) }),
+        this.manager.broadcastEval(message._sEval, message._sEvalShard).then(
+          results => this.send({ _sEval: message._sEval, _sEvalShard: message._sEvalShard, _result: results }),
+          err =>
+            this.send({ _sEval: message._sEval, _sEvalShard: message._sEvalShard, _error: Util.makePlainError(err) }),
         );
         return;
       }

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -334,19 +334,20 @@ class Shard extends EventEmitter {
 
       // Shard is requesting a property fetch
       if (message._sFetchProp) {
-        this.manager.fetchClientValues(message._sFetchProp).then(
-          results => this.send({ _sFetchProp: message._sFetchProp, _result: results }),
-          err => this.send({ _sFetchProp: message._sFetchProp, _error: Util.makePlainError(err) }),
+        const resp = { _sFetchProp: message._sFetchProp, _sFetchPropShard: message._sFetchPropShard };
+        this.manager.fetchClientValues(message._sFetchProp, message._sFetchPropShard).then(
+          results => this.send({ ...resp, _result: results }),
+          err => this.send({ ...resp, _error: Util.makePlainError(err) }),
         );
         return;
       }
 
       // Shard is requesting an eval broadcast
       if (message._sEval) {
+        const resp = { _sEval: message._sEval, _sEvalShard: message._sEvalShard };
         this.manager.broadcastEval(message._sEval, message._sEvalShard).then(
-          results => this.send({ _sEval: message._sEval, _sEvalShard: message._sEvalShard, _result: results }),
-          err =>
-            this.send({ _sEval: message._sEval, _sEvalShard: message._sEvalShard, _error: Util.makePlainError(err) }),
+          results => this.send({ ...resp, _result: results }),
+          err => this.send({ ...resp, _error: Util.makePlainError(err) }),
         );
         return;
       }

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -228,14 +228,14 @@ class ShardClientUtil {
   }
 
   /**
-   * Get the shard Id for a given guild Id.
-   * @param {Snowflake} guildId Snowflake guild Id to get shard Id for
+   * Get the shard ID for a given guild ID.
+   * @param {Snowflake} guildID Snowflake guild ID to get shard ID for
    * @param {number} shardCount Number of shards
    * @returns {number}
    */
-  static shardIdForGuildId(guildId, shardCount) {
-    const shard = Number(BigInt(guildId) >> 22n) % shardCount;
-    if (shard < 0) throw new Error('SHARDING_SHARD_MISCALCULATION', shard, guildId, shardCount);
+  static shardIDForGuildID(guildID, shardCount) {
+    const shard = Number(BigInt(guildID) >> 22n) % shardCount;
+    if (shard < 0) throw new Error('SHARDING_SHARD_MISCALCULATION', shard, guildID, shardCount);
     return shard;
   }
 }

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -125,8 +125,9 @@ class ShardClientUtil {
   }
 
   /**
-   * Evaluates a script or function on all shards, in the context of the {@link Client}s.
+   * Evaluates a script or function on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {string|Function} script JavaScript to run on each shard
+   * @param {number} [shard] Shard to run script on, all if undefined
    * @returns {Promise<Array<*>>} Results of the script execution
    * @example
    * client.shard.broadcastEval('this.guilds.cache.size')
@@ -134,20 +135,20 @@ class ShardClientUtil {
    *   .catch(console.error);
    * @see {@link ShardingManager#broadcastEval}
    */
-  broadcastEval(script) {
+  broadcastEval(script, shard) {
     return new Promise((resolve, reject) => {
       const parent = this.parentPort || process;
       script = typeof script === 'function' ? `(${script})(this)` : script;
 
       const listener = message => {
-        if (!message || message._sEval !== script) return;
+        if (!message || message._sEval !== script || message._sEvalShard !== shard) return;
         parent.removeListener('message', listener);
         if (!message._error) resolve(message._result);
         else reject(Util.makeError(message._error));
       };
       parent.on('message', listener);
 
-      this.send({ _sEval: script }).catch(err => {
+      this.send({ _sEval: script, _sEvalShard: shard }).catch(err => {
         parent.removeListener('message', listener);
         reject(err);
       });

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -100,7 +100,7 @@ class ShardClientUtil {
    * Fetches a client property value of each shard, or a given shard.
    * @param {string} prop Name of the client property to get, using periods for nesting
    * @param {number} [shard] Shard to fetch property from, all if undefined
-   * @returns {Promise<Array<*>>}
+   * @returns {Promise<*>|Promise<Array<*>>}
    * @example
    * client.shard.fetchClientValues('guilds.cache.size')
    *   .then(results => console.log(`${results.reduce((prev, val) => prev + val, 0)} total guilds`))
@@ -130,7 +130,7 @@ class ShardClientUtil {
    * Evaluates a script or function on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {string|Function} script JavaScript to run on each shard
    * @param {number} [shard] Shard to run script on, all if undefined
-   * @returns {Promise<Array<*>>} Results of the script execution
+   * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    * @example
    * client.shard.broadcastEval('this.guilds.cache.size')
    *   .then(results => console.log(`${results.reduce((prev, val) => prev + val, 0)} total guilds`))

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Events } = require('../util/Constants');
+const Snowflake = require('../util/Snowflake');
 const Util = require('../util/Util');
 
 /**
@@ -225,6 +226,18 @@ class ShardClientUtil {
       );
     }
     return this._singleton;
+  }
+
+  /**
+   * Get the shard Id for a given guild Id.
+   * @param {Snowflake} guildId Snowflake guild Id to get shard Id for
+   * @param {number} shardCount Number of shards
+   * @returns {number}
+   */
+  static shardIdForGuildId(guildId, shardCount) {
+    // This performs (guild_id >> 22) % num_shards, but with a string Snowflake
+    const timestamp = Snowflake.deconstruct(guildId).timestamp;
+    return (timestamp - Snowflake.epoch) % shardCount;
   }
 }
 

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { Events } = require('../util/Constants');
-const Snowflake = require('../util/Snowflake');
 const Util = require('../util/Util');
 
 /**
@@ -235,9 +234,9 @@ class ShardClientUtil {
    * @returns {number}
    */
   static shardIdForGuildId(guildId, shardCount) {
-    // This performs (guild_id >> 22) % num_shards, but with a string Snowflake
-    const timestamp = Snowflake.deconstruct(guildId).timestamp;
-    return (timestamp - Snowflake.epoch) % shardCount;
+    const shard = Number(BigInt(guildId) >> 22n) % shardCount;
+    if (shard < 0) throw new Error('SHARDING_SHARD_MISCALCULATION', shard, guildId, shardCount);
+    return shard;
   }
 }
 

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -228,6 +228,9 @@ class ShardingManager extends EventEmitter {
    * @returns {Promise<Array<*>>} Results of the script execution
    */
   broadcastEval(script, shard) {
+    if (this.shards.size === 0) return Promise.reject(new Error('SHARDING_NO_SHARDS'));
+    if (this.shards.size !== this.shardList.length) return Promise.reject(new Error('SHARDING_IN_PROCESS'));
+
     if (shard !== undefined) {
       if (this.shards.has(shard)) return Promise.all([this.shards.get(shard).eval(script)]);
       return Promise.reject(new Error('SHARDING_SHARD_NOT_FOUND', shard));

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -222,13 +222,19 @@ class ShardingManager extends EventEmitter {
   }
 
   /**
-   * Evaluates a script on all shards, in the context of the {@link Client}s.
+   * Evaluates a script on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {string} script JavaScript to run on each shard
+   * @param {number} [shard] Shard to run on, all if undefined
    * @returns {Promise<Array<*>>} Results of the script execution
    */
-  broadcastEval(script) {
+  broadcastEval(script, shard) {
+    if (shard !== undefined) {
+      if (this.shards.has(shard)) return Promise.all([this.shards.get(shard).eval(script)]);
+      return Promise.reject(new Error('SHARDING_SHARD_NOT_FOUND', shard));
+    }
+
     const promises = [];
-    for (const shard of this.shards.values()) promises.push(shard.eval(script));
+    for (const sh of this.shards.values()) promises.push(sh.eval(script));
     return Promise.all(promises);
   }
 

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -225,7 +225,7 @@ class ShardingManager extends EventEmitter {
    * Evaluates a script on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {string} script JavaScript to run on each shard
    * @param {number} [shard] Shard to run on, all if undefined
-   * @returns {Promise<Array<*>>} Results of the script execution
+   * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    */
   broadcastEval(script, shard) {
     return this._performOnShards('eval', [script], shard);
@@ -235,7 +235,7 @@ class ShardingManager extends EventEmitter {
    * Fetches a client property value of each shard, or a given shard.
    * @param {string} prop Name of the client property to get, using periods for nesting
    * @param {number} [shard] Shard to fetch property from, all if undefined
-   * @returns {Promise<Array<*>>}
+   * @returns {Promise<*>|Promise<Array<*>>}
    * @example
    * manager.fetchClientValues('guilds.cache.size')
    *   .then(results => console.log(`${results.reduce((prev, val) => prev + val, 0)} total guilds`))
@@ -250,15 +250,15 @@ class ShardingManager extends EventEmitter {
    * @param {string} method Method name to run on each shard
    * @param {Array<*>} args Arguments to pass through to the method call
    * @param {number} [shard] Shard to run on, all if undefined
-   * @returns {Promise<Array<*>>} Results of the method execution
+   * @returns {Promise<*>|Promise<Array<*>>} Results of the method execution
    * @private
    */
   _performOnShards(method, args, shard) {
     if (this.shards.size === 0) return Promise.reject(new Error('SHARDING_NO_SHARDS'));
     if (this.shards.size !== this.shardList.length) return Promise.reject(new Error('SHARDING_IN_PROCESS'));
 
-    if (shard !== undefined) {
-      if (this.shards.has(shard)) return Promise.all([this.shards.get(shard)[method](...args)]);
+    if (typeof shard === 'number') {
+      if (this.shards.has(shard)) return this.shards.get(shard)[method](...args);
       return Promise.reject(new Error('SHARDING_SHARD_NOT_FOUND', shard));
     }
 

--- a/src/util/Snowflake.js
+++ b/src/util/Snowflake.js
@@ -79,6 +79,15 @@ class SnowflakeUtil {
     });
     return res;
   }
+
+  /**
+   * Discord's epoch value (2015-01-01T00:00:00.000Z).
+   * @type {number}
+   * @readonly
+   */
+  static get EPOCH() {
+    return EPOCH;
+  }
 }
 
 module.exports = SnowflakeUtil;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1381,6 +1381,7 @@ declare module 'discord.js' {
     public send(message: any): Promise<void>;
 
     public static singleton(client: Client, mode: ShardingManagerMode): ShardClientUtil;
+    public static shardIdForGuildId(guildId: Snowflake, shardCount: number): number;
   }
 
   export class ShardingManager extends EventEmitter {
@@ -1423,6 +1424,7 @@ declare module 'discord.js' {
   export class SnowflakeUtil {
     public static deconstruct(snowflake: Snowflake): DeconstructedSnowflake;
     public static generate(timestamp?: number | Date): Snowflake;
+    public static readonly EPOCH: number;
   }
 
   export class Speaking extends BitField<SpeakingString> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1374,9 +1374,9 @@ declare module 'discord.js' {
     public readonly ids: number[];
     public mode: ShardingManagerMode;
     public parentPort: any | null;
-    public broadcastEval(script: string, shard?: number): Promise<any[]>;
-    public broadcastEval<T>(fn: (client: Client) => T, shard?: number): Promise<T[]>;
-    public fetchClientValues(prop: string, shard?: number): Promise<any[]>;
+    public broadcastEval(script: string, shard?: number): Promise<any> | Promise<any[]>;
+    public broadcastEval<T>(fn: (client: Client) => T, shard?: number): Promise<T> | Promise<T[]>;
+    public fetchClientValues(prop: string, shard?: number): Promise<any> | Promise<any[]>;
     public respawnAll(shardDelay?: number, respawnDelay?: number, spawnTimeout?: number): Promise<void>;
     public send(message: any): Promise<void>;
 
@@ -1397,7 +1397,7 @@ declare module 'discord.js' {
         execArgv?: string[];
       },
     );
-    private _performOnShards(method: string, args: any[], shard?: number): Promise<any[]>;
+    private _performOnShards(method: string, args: any[], shard?: number): Promise<any> | Promise<any[]>;
 
     public file: string;
     public respawn: boolean;
@@ -1406,9 +1406,9 @@ declare module 'discord.js' {
     public token: string | null;
     public totalShards: number | 'auto';
     public broadcast(message: any): Promise<Shard[]>;
-    public broadcastEval(script: string, shard?: number): Promise<any[]>;
+    public broadcastEval(script: string, shard?: number): Promise<any> | Promise<any[]>;
     public createShard(id: number): Shard;
-    public fetchClientValues(prop: string, shard?: number): Promise<any[]>;
+    public fetchClientValues(prop: string, shard?: number): Promise<any> | Promise<any[]>;
     public respawnAll(
       shardDelay?: number,
       respawnDelay?: number,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1374,9 +1374,9 @@ declare module 'discord.js' {
     public readonly ids: number[];
     public mode: ShardingManagerMode;
     public parentPort: any | null;
-    public broadcastEval(script: string): Promise<any[]>;
-    public broadcastEval<T>(fn: (client: Client) => T): Promise<T[]>;
-    public fetchClientValues(prop: string): Promise<any[]>;
+    public broadcastEval(script: string, shard?: number): Promise<any[]>;
+    public broadcastEval<T>(fn: (client: Client) => T, shard?: number): Promise<T[]>;
+    public fetchClientValues(prop: string, shard?: number): Promise<any[]>;
     public respawnAll(shardDelay?: number, respawnDelay?: number, spawnTimeout?: number): Promise<void>;
     public send(message: any): Promise<void>;
 
@@ -1404,9 +1404,9 @@ declare module 'discord.js' {
     public token: string | null;
     public totalShards: number | 'auto';
     public broadcast(message: any): Promise<Shard[]>;
-    public broadcastEval(script: string): Promise<any[]>;
+    public broadcastEval(script: string, shard?: number): Promise<any[]>;
     public createShard(id: number): Shard;
-    public fetchClientValues(prop: string): Promise<any[]>;
+    public fetchClientValues(prop: string, shard?: number): Promise<any[]>;
     public respawnAll(
       shardDelay?: number,
       respawnDelay?: number,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1374,9 +1374,12 @@ declare module 'discord.js' {
     public readonly ids: number[];
     public mode: ShardingManagerMode;
     public parentPort: any | null;
-    public broadcastEval(script: string, shard?: number): Promise<any> | Promise<any[]>;
-    public broadcastEval<T>(fn: (client: Client) => T, shard?: number): Promise<T> | Promise<T[]>;
-    public fetchClientValues(prop: string, shard?: number): Promise<any> | Promise<any[]>;
+    public broadcastEval(script: string): Promise<any[]>;
+    public broadcastEval(script: string, shard: number): Promise<any>;
+    public broadcastEval<T>(fn: (client: Client) => T): Promise<T[]>;
+    public broadcastEval<T>(fn: (client: Client) => T, shard: number): Promise<T>;
+    public fetchClientValues(prop: string): Promise<any[]>;
+    public fetchClientValues(prop: string, shard: number): Promise<any>;
     public respawnAll(shardDelay?: number, respawnDelay?: number, spawnTimeout?: number): Promise<void>;
     public send(message: any): Promise<void>;
 
@@ -1397,7 +1400,8 @@ declare module 'discord.js' {
         execArgv?: string[];
       },
     );
-    private _performOnShards(method: string, args: any[], shard?: number): Promise<any> | Promise<any[]>;
+    private _performOnShards(method: string, args: any[]): Promise<any[]>;
+    private _performOnShards(method: string, args: any[], shard: number): Promise<any>;
 
     public file: string;
     public respawn: boolean;
@@ -1406,9 +1410,11 @@ declare module 'discord.js' {
     public token: string | null;
     public totalShards: number | 'auto';
     public broadcast(message: any): Promise<Shard[]>;
-    public broadcastEval(script: string, shard?: number): Promise<any> | Promise<any[]>;
+    public broadcastEval(script: string): Promise<any[]>;
+    public broadcastEval(script: string, shard: number): Promise<any>;
     public createShard(id: number): Shard;
-    public fetchClientValues(prop: string, shard?: number): Promise<any> | Promise<any[]>;
+    public fetchClientValues(prop: string): Promise<any[]>;
+    public fetchClientValues(prop: string, shard: number): Promise<any>;
     public respawnAll(
       shardDelay?: number,
       respawnDelay?: number,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1384,7 +1384,7 @@ declare module 'discord.js' {
     public send(message: any): Promise<void>;
 
     public static singleton(client: Client, mode: ShardingManagerMode): ShardClientUtil;
-    public static shardIdForGuildId(guildId: Snowflake, shardCount: number): number;
+    public static shardIDForGuildID(guildID: Snowflake, shardCount: number): number;
   }
 
   export class ShardingManager extends EventEmitter {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1396,6 +1396,7 @@ declare module 'discord.js' {
         execArgv?: string[];
       },
     );
+    private _performOnShards(method: string, args: any[], shard?: number): Promise<any[]>;
 
     public file: string;
     public respawn: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds the ability to call `broadcastEval` and `fetchClientValues` from a shard to run on different target shard, instead of broadcasting to all and using an `if` in the given script to filter by shard.

Now you can target a shard directly:

```javascript
const { ShardClientUtil } = require('discord.js');
const guild = '433980600391696384';

// Get the shard Id -- `client.shard.constructor.shardIdForGuildId` could also be used
const shard = ShardClientUtil.shardIdForGuildId(guild, 2);

// Get the guild from that shard only
const name = await client.shard.broadcastEval(`this.guilds.cache.get('${guild}').name`, shard);

return [name, shard, client.shardId];
```

We get back `[JetBrains Community, 1, 0]`, so we can see it correctly went to the target shard and found the guild there.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
