### PR TITLE
cleanup(Message): remove options for Message#delete

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -116,14 +116,13 @@ class MessageManager extends BaseManager {
   /**
    * Deletes a message, even if it's not cached.
    * @param {MessageResolvable} message The message to delete
-   * @param {string} [reason] Reason for deleting this message, if it does not belong to the client user
    * @returns {Promise<void>}
    */
-  async delete(message, reason) {
+  async delete(message) {
     message = this.resolveID(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
-    await this.client.api.channels(this.channel.id).messages(message).delete({ reason });
+    await this.client.api.channels(this.channel.id).messages(message).delete();
   }
 
   async _fetchId(messageID, cache, force) {

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -563,28 +563,16 @@ class Message extends Base {
 
   /**
    * Deletes the message.
-   * @param {Object} [options] Options
-   * @param {number} [options.timeout=0] How long to wait to delete the message in milliseconds
-   * @param {string} [options.reason] Reason for deleting this message, if it does not belong to the client user
    * @returns {Promise<Message>}
    * @example
    * // Delete a message
-   * message.delete({ timeout: 5000 })
-   *   .then(msg => console.log(`Deleted message from ${msg.author.username} after 5 seconds`))
+   * message.delete()
+   *   .then(msg => console.log(`Deleted message from ${msg.author.username}`))
    *   .catch(console.error);
    */
-  delete(options = {}) {
-    if (typeof options !== 'object') return Promise.reject(new TypeError('INVALID_TYPE', 'options', 'object', true));
-    const { timeout = 0, reason } = options;
-    if (timeout <= 0) {
-      return this.channel.messages.delete(this.id, reason).then(() => this);
-    } else {
-      return new Promise(resolve => {
-        this.client.setTimeout(() => {
-          resolve(this.delete({ reason }));
-        }, timeout);
-      });
-    }
+  async delete() {
+    await this.channel.messages.delete(this.id);
+    return this;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1017,7 +1017,7 @@ declare module 'discord.js' {
       options?: AwaitReactionsOptions,
     ): Promise<Collection<Snowflake, MessageReaction>>;
     public createReactionCollector(filter: CollectorFilter, options?: ReactionCollectorOptions): ReactionCollector;
-    public delete(options?: { timeout?: number; reason?: string }): Promise<Message>;
+    public delete(): Promise<Message>;
     public edit(
       content: APIMessageContentResolvable | MessageEditOptions | MessageEmbed | APIMessage,
     ): Promise<Message>;
@@ -1989,7 +1989,7 @@ declare module 'discord.js' {
       force?: boolean,
     ): Promise<Collection<Snowflake, Message>>;
     public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;
-    public delete(message: MessageResolvable, reason?: string): Promise<void>;
+    public delete(message: MessageResolvable): Promise<void>;
   }
 
   // Hacky workaround because changing the signature of an overridden method errors


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removes options for `Message#delete` (and `MessageManager#delete`):
- `timeout` because that implementation is prone to errors (see e.g. #4916) and inconsistent with others, being the only method which takes a timeout value
- `reason` because messages deleted by bot users won't create audit log entries

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
