### PR TITLE
fix(MessageReaction): defines the client property in the type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1165,6 +1165,7 @@ declare module 'discord.js' {
     constructor(client: Client, data: object, message: Message);
     private _emoji: GuildEmoji | ReactionEmoji;
 
+    public readonly client: Client;
     public count: number | null;
     public readonly emoji: GuildEmoji | ReactionEmoji;
     public me: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I created an issue #5002 this is the PR to resolve it.  I wasn't 100% sure i've followed the contribution guidelines.

This solves the missing `client` property from the `MessageReaction` typing

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [ ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
- [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
