### PR TITLE
feat(GuildChannel): support conversion between text and news 

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -370,9 +370,7 @@ class GuildChannel extends Channel {
       reason,
     });
 
-    const clone = this._clone();
-    clone._patch(newData);
-    return clone;
+    return this.client.actions.ChannelUpdate.handle(newData).updated;
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -6,6 +6,7 @@ const PermissionOverwrites = require('./PermissionOverwrites');
 const Role = require('./Role');
 const { Error, TypeError } = require('../errors');
 const Collection = require('../util/Collection');
+const { ChannelTypes } = require('../util/Constants');
 const Permissions = require('../util/Permissions');
 const Util = require('../util/Util');
 
@@ -294,6 +295,7 @@ class GuildChannel extends Channel {
    * The data for a guild channel.
    * @typedef {Object} ChannelData
    * @property {string} [name] The name of the channel
+   * @property {string} [type] The type of the the channel (only conversion between text and news is supported)
    * @property {number} [position] The position of the channel
    * @property {string} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW
@@ -355,6 +357,7 @@ class GuildChannel extends Channel {
     const newData = await this.client.api.channels(this.id).patch({
       data: {
         name: (data.name || this.name).trim(),
+        type: data.type ? ChannelTypes[data.type.toUpperCase()] : this.type,
         topic: data.topic,
         nsfw: data.nsfw,
         bitrate: data.bitrate || this.bitrate,

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -87,6 +87,16 @@ class TextChannel extends GuildChannel {
   }
 
   /**
+   * Sets the type of this channel (only conversion between text and news is supported)
+   * @param {string} type The new channel type
+   * @param {string} reason Reason for changing the channel's type
+   * @returns {Promise<GuildChannel>}
+   */
+  setType(type, reason) {
+    return this.edit({ type }, reason);
+  }
+
+  /**
    * Fetches all webhooks for the channel.
    * @returns {Promise<Collection<Snowflake, Webhook>>}
    * @example

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1188,6 +1188,7 @@ declare module 'discord.js' {
       options?: { avatar?: BufferResolvable | Base64Resolvable; reason?: string },
     ): Promise<Webhook>;
     public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
+    public setType(type: string, reason?: string): Promise<GuildChannel>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
     public addFollower(channel: GuildChannelResolvable, reason?: string): Promise<NewsChannel>;
   }
@@ -1529,6 +1530,7 @@ declare module 'discord.js' {
     ): Promise<Webhook>;
     public setNSFW(nsfw: boolean, reason?: string): Promise<TextChannel>;
     public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
+    public setType(type: string, reason?: string): Promise<GuildChannel>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2232,7 +2232,10 @@ declare module 'discord.js' {
 
   interface ChannelData {
     name?: string;
-    type?: string;
+    type?: Exclude<
+      keyof typeof ChannelType | ChannelType,
+      'dm' | 'group' | 'unknown' | ChannelType.dm | ChannelType.group | ChannelType.unknown
+    >;
     position?: number;
     topic?: string;
     nsfw?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1188,7 +1188,10 @@ declare module 'discord.js' {
       options?: { avatar?: BufferResolvable | Base64Resolvable; reason?: string },
     ): Promise<Webhook>;
     public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
-    public setType(type: string, reason?: string): Promise<GuildChannel>;
+    public setType(
+      type: Exclude<keyof typeof ChannelType, 'dm' | 'group' | 'unknown' | 'category' | 'voice' | 'store'>,
+      reason?: string,
+    ): Promise<GuildChannel>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
     public addFollower(channel: GuildChannelResolvable, reason?: string): Promise<NewsChannel>;
   }
@@ -1530,7 +1533,10 @@ declare module 'discord.js' {
     ): Promise<Webhook>;
     public setNSFW(nsfw: boolean, reason?: string): Promise<TextChannel>;
     public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
-    public setType(type: string, reason?: string): Promise<GuildChannel>;
+    public setType(
+      type: Exclude<keyof typeof ChannelType, 'dm' | 'group' | 'unknown' | 'category' | 'voice' | 'store'>,
+      reason?: string,
+    ): Promise<GuildChannel>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
   }
 
@@ -2232,10 +2238,7 @@ declare module 'discord.js' {
 
   interface ChannelData {
     name?: string;
-    type?: Exclude<
-      keyof typeof ChannelType | ChannelType,
-      'dm' | 'group' | 'unknown' | ChannelType.dm | ChannelType.group | ChannelType.unknown
-    >;
+    type?: Exclude<keyof typeof ChannelType, 'dm' | 'group' | 'unknown' | 'category' | 'voice' | 'store'>;
     position?: number;
     topic?: string;
     nsfw?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1188,10 +1188,7 @@ declare module 'discord.js' {
       options?: { avatar?: BufferResolvable | Base64Resolvable; reason?: string },
     ): Promise<Webhook>;
     public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
-    public setType(
-      type: Exclude<keyof typeof ChannelType, 'dm' | 'group' | 'unknown' | 'category' | 'voice' | 'store'>,
-      reason?: string,
-    ): Promise<GuildChannel>;
+    public setType(type: Pick<typeof ChannelType, 'text' | 'news'>, reason?: string): Promise<GuildChannel>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
     public addFollower(channel: GuildChannelResolvable, reason?: string): Promise<NewsChannel>;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2232,6 +2232,7 @@ declare module 'discord.js' {
 
   interface ChannelData {
     name?: string;
+    type?: string;
     position?: number;
     topic?: string;
     nsfw?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1530,10 +1530,7 @@ declare module 'discord.js' {
     ): Promise<Webhook>;
     public setNSFW(nsfw: boolean, reason?: string): Promise<TextChannel>;
     public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
-    public setType(
-      type: Exclude<keyof typeof ChannelType, 'dm' | 'group' | 'unknown' | 'category' | 'voice' | 'store'>,
-      reason?: string,
-    ): Promise<GuildChannel>;
+    public setType(type: Pick<typeof ChannelType, 'text' | 'news'>, reason?: string): Promise<GuildChannel>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
   }
 
@@ -2235,7 +2232,7 @@ declare module 'discord.js' {
 
   interface ChannelData {
     name?: string;
-    type?: Exclude<keyof typeof ChannelType, 'dm' | 'group' | 'unknown' | 'category' | 'voice' | 'store'>;
+    type?: Pick<typeof ChannelType, 'text' | 'news'>;
     position?: number;
     topic?: string;
     nsfw?: boolean;


### PR DESCRIPTION
Discord.js did not support providing `type` in the GuildChannel#edit payload, this adds support for that and a `setType` helper method on TextChannel and NewsChannel.

The API will throw an error if attempting to convert to anything other than Text or News.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
