### PR TITLE
feat(Message): added replies

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -208,7 +208,11 @@ class APIMessage {
       avatar_url: avatarURL,
       allowed_mentions: typeof content === 'undefined' ? undefined : allowedMentions,
       flags,
-      message_reference: this.options.message_reference,
+      message_reference: this.options.refer ? {
+        message_id: this.options.refer.message,
+        guild_id: this.options.refer.guild,
+        channel_id: this.options.refer.channel
+      } : null,
     };
     return this;
   }

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -208,6 +208,7 @@ class APIMessage {
       avatar_url: avatarURL,
       allowed_mentions: typeof content === 'undefined' ? undefined : allowedMentions,
       flags,
+      message_reference: this.options.message_reference,
     };
     return this;
   }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -599,7 +599,7 @@ class Message extends Base {
    *   .catch(console.error);
    */
   reply(content, options) {
-    if(options && options.refer) {
+    if(options && options.refer && !options.message_reference) {
       return this.channel.send(
         content instanceof APIMessage
           ? content

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -599,7 +599,7 @@ class Message extends Base {
    *   .catch(console.error);
    */
   reply(content, options) {
-    if(options && options.new) {
+    if(options && options.refer) {
       return this.channel.send(
         content instanceof APIMessage
           ? content

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -599,11 +599,19 @@ class Message extends Base {
    *   .catch(console.error);
    */
   reply(content, options) {
-    return this.channel.send(
-      content instanceof APIMessage
-        ? content
-        : APIMessage.transformOptions(content, options, { reply: this.member || this.author }),
-    );
+    if(options && options.new) {
+      return this.channel.send(
+        content instanceof APIMessage
+          ? content
+          : APIMessage.transformOptions(content, options, { message_reference: { message_id: this.id, guild_id: this.guild ? this.guild.id : null } }),
+      );
+    } else {
+      return this.channel.send(
+        content instanceof APIMessage
+          ? content
+          : APIMessage.transformOptions(content, options, { reply: this.member || this.author }),
+      );
+    }
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -599,11 +599,11 @@ class Message extends Base {
    *   .catch(console.error);
    */
   reply(content, options) {
-    if(options && options.refer && !options.message_reference) {
+    if(options && options.refer instanceof Boolean && options.refer) {
       return this.channel.send(
         content instanceof APIMessage
           ? content
-          : APIMessage.transformOptions(content, options, { message_reference: { message_id: this.id, guild_id: this.guild ? this.guild.id : null } }),
+          : APIMessage.transformOptions(content, options, { refer: { message: this.id, guild: this.guild ? this.guild.id : null } }),
       );
     } else {
       return this.channel.send(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds option for `Message#reply` and `TextBasedChannel#send`:
- `refer` is an object and has the options `message`, `guild` and `channel` corresponding to the ids for the `message_reference` object.

Adds option for `Message#reply`:
- `refer` as a boolean is used to make the reply refer to the original message.

**Status**
- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
