### PR TITLE
fix(Collector): throw an error if a non-function was provided as filter

### DIFF
--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EventEmitter = require('events');
+const { TypeError } = require('../../errors');
 const Collection = require('../../util/Collection');
 const Util = require('../../util/Util');
 
@@ -73,6 +74,10 @@ class Collector extends EventEmitter {
      * @private
      */
     this._idletimeout = null;
+
+    if (typeof filter !== 'function') {
+      throw new TypeError('INVALID_TYPE', 'filter', 'function');
+    }
 
     this.handleCollect = this.handleCollect.bind(this);
     this.handleDispose = this.handleDispose.bind(this);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR asserts that the provided filter-function is actually a function, if that fails, an error indicating such is thrown.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
