### PR TITLE
fix(Voice*): filter out silent audio from video users

### DIFF
--- a/src/client/voice/VoiceConnection.js
+++ b/src/client/voice/VoiceConnection.js
@@ -473,7 +473,11 @@ class VoiceConnection extends EventEmitter {
   }
 
   onStartSpeaking({ user_id, ssrc, speaking }) {
-    this.ssrcMap.set(+ssrc, { userID: user_id, speaking: speaking });
+    this.ssrcMap.set(+ssrc, {
+      ...(this.ssrcMap.get(+ssrc) || {}),
+      userID: user_id,
+      speaking: speaking,
+    });
   }
 
   /**

--- a/src/client/voice/networking/VoiceWebSocket.js
+++ b/src/client/voice/networking/VoiceWebSocket.js
@@ -189,7 +189,11 @@ class VoiceWebSocket extends EventEmitter {
         this.emit('sessionDescription', packet.d);
         break;
       case VoiceOPCodes.CLIENT_CONNECT:
-        this.connection.ssrcMap.set(+packet.d.audio_ssrc, { userID: packet.d.user_id, speaking: 0 });
+        this.connection.ssrcMap.set(+packet.d.audio_ssrc, {
+          userID: packet.d.user_id,
+          speaking: 0,
+          hasVideo: Boolean(packet.d.video_ssrc),
+        });
         break;
       case VoiceOPCodes.CLIENT_DISCONNECT:
         const streamInfo = this.connection.receiver && this.connection.receiver.packets.streams.get(packet.d.user_id);

--- a/src/client/voice/receiver/PacketHandler.js
+++ b/src/client/voice/receiver/PacketHandler.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('events');
 const Speaking = require('../../../util/Speaking');
 const secretbox = require('../util/Secretbox');
+const { SILENCE_FRAME } = require('../util/Silence');
 
 // The delay between packets when a user is considered to have stopped speaking
 // https://github.com/discordjs/discord.js/issues/3524#issuecomment-540373200
@@ -85,6 +86,24 @@ class PacketHandler extends EventEmitter {
     const userStat = this.connection.ssrcMap.get(ssrc);
     if (!userStat) return;
 
+    let opusPacket;
+    const streamInfo = this.streams.get(userStat.userID);
+    // If the user is in video, we need to check if the packet is just silence
+    if (userStat.hasVideo) {
+      opusPacket = this.parseBuffer(buffer);
+      if (opusPacket instanceof Error) {
+        // Only emit an error if we were actively receiving packets from this user
+        if (streamInfo) {
+          this.emit('error', opusPacket);
+          return;
+        }
+      }
+      if (SILENCE_FRAME.equals(opusPacket)) {
+        // If this is a silence frame, pretend we never received it
+        return;
+      }
+    }
+
     let speakingTimeout = this.speakingTimeouts.get(ssrc);
     if (typeof speakingTimeout === 'undefined') {
       // Ensure at least the speaking bit is set.
@@ -107,15 +126,17 @@ class PacketHandler extends EventEmitter {
       speakingTimeout.refresh();
     }
 
-    let stream = this.streams.get(userStat.userID);
-    if (!stream) return;
-    stream = stream.stream;
-    const opusPacket = this.parseBuffer(buffer);
-    if (opusPacket instanceof Error) {
-      this.emit('error', opusPacket);
-      return;
+    if (streamInfo) {
+      const { stream } = streamInfo;
+      if (!opusPacket) {
+        opusPacket = this.parseBuffer(buffer);
+        if (opusPacket instanceof Error) {
+          this.emit('error', opusPacket);
+          return;
+        }
+      }
+      stream.push(opusPacket);
     }
-    stream.push(opusPacket);
   }
 }
 

--- a/src/client/voice/receiver/PacketHandler.js
+++ b/src/client/voice/receiver/PacketHandler.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EventEmitter = require('events');
+const Speaking = require('../../../util/Speaking');
 const secretbox = require('../util/Secretbox');
 
 // The delay between packets when a user is considered to have stopped speaking
@@ -89,7 +90,7 @@ class PacketHandler extends EventEmitter {
       // Ensure at least the speaking bit is set.
       // As the object is by reference, it's only needed once per client re-connect.
       if (userStat.speaking === 0) {
-        userStat.speaking = 1;
+        userStat.speaking = Speaking.FLAGS.SPEAKING;
       }
       this.connection.onSpeaking({ user_id: userStat.userID, ssrc: ssrc, speaking: userStat.speaking });
       speakingTimeout = this.receiver.connection.client.setTimeout(() => {

--- a/src/client/voice/util/Silence.js
+++ b/src/client/voice/util/Silence.js
@@ -10,4 +10,6 @@ class Silence extends Readable {
   }
 }
 
+Silence.SILENCE_FRAME = SILENCE_FRAME;
+
 module.exports = Silence;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Problem:**
This resolves #5019. When a user has video enabled, they send silent audio frames continually even if they are not speaking. Discord.js didn't check whether a received audio packet was silence or not for performance reasons. This shortcut is no longer applicable since it causes the incorrect behaviour described in the issue above.

**Fix:**
Instead of decoding all the received packets, we only decode the packets from users with video enabled (which is where the issue occurs). If a packet is received from such a user and it turns out to be silent audio, the packet is ignored which is a graceful fix for this issue. This means performance will only degrade (and even then, I doubt it will be by a lot) in cases where a bot is in the same voice channel as users with video enabled, and the bot is actively receiving audio.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
