### PR TITLE
fix(ClientPresence): add presence to ClientPresence from ClientOptions

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -131,7 +131,7 @@ class Client extends BaseClient {
      * @private
      * @type {ClientPresence}
      */
-    this.presence = new ClientPresence(this);
+    this.presence = new ClientPresence(this, options.presence);
 
     Object.defineProperty(this, 'token', { writable: true });
     if (!browser && !this.token && 'DISCORD_TOKEN' in process.env) {

--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -11,7 +11,7 @@ class ClientPresence extends Presence {
    * @param {Object} [data={}] The data for the client presence
    */
   constructor(client, data = {}) {
-    super(client, Object.assign(data, { status: 'online', user: { id: null } }));
+    super(client, Object.assign(data, { status: data.status || 'online', user: { id: null } }));
   }
 
   async set(presence) {

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -155,7 +155,7 @@ class Activity {
      * The type of the activity status
      * @type {ActivityType}
      */
-    this.type = ActivityTypes[data.type];
+    this.type = ActivityTypes[data.type] || ActivityTypes[ActivityTypes.indexOf(data.type)];
 
     /**
      * If the activity is being streamed, a link to the stream


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
this PR adds data about the client's presence to the ClientPresence class from the options that were passed in the client constructor. without this PR, the client cannot display its status or activity in any way, because by default, ClientPresence is changed only using the setStatus, setActivity, and setPresence methods. so if these methods are not used, the ClientPresence class always contains only standard values, although in fact the values may differ from those displayed in the Discord. 
this PR also fixes an issue where the setStatus and setActivity methods overwritten values for each other. that is, if I set the idle status to the client via setStatus, and then use setActivity to set the activity, the idle status will simply disappear. similarly, in the opposite direction.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
