### PR TITLE
fix(MessageReaction): set MessageReaction#me in patch method

### DIFF
--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -29,12 +29,6 @@ class MessageReaction {
     this.message = message;
 
     /**
-     * Whether the client has given this reaction
-     * @type {boolean}
-     */
-    this.me = data.me;
-
-    /**
      * A manager of the users that have given this reaction
      * @type {ReactionUserManager}
      */
@@ -54,6 +48,12 @@ class MessageReaction {
        */
       this.count = data.count;
     }
+
+    /**
+     * Whether the client has given this reaction
+     * @type {boolean}
+     */
+    this.me = data.me;
   }
 
   /**


### PR DESCRIPTION
Fixes #5046 by setting `MessageReaction#me` in `MessageReaction#_patch` ensuring it gets updated when fetching partials.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
