### PR TITLE
revert: 5047

### DIFF
--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -29,6 +29,12 @@ class MessageReaction {
     this.message = message;
 
     /**
+     * Whether the client has given this reaction
+     * @type {boolean}
+     */
+    this.me = data.me;
+
+    /**
      * A manager of the users that have given this reaction
      * @type {ReactionUserManager}
      */
@@ -48,12 +54,6 @@ class MessageReaction {
        */
       this.count = data.count;
     }
-
-    /**
-     * Whether the client has given this reaction
-     * @type {boolean}
-     */
-    this.me = data.me;
   }
 
   /**


### PR DESCRIPTION
Reverts #5047 because I think it introduced more bugs than it solved. 

There's still a very strange issue in here somewhere which results in `MessageReaction#me` being updated when you fetch it... but not until after fetch has returned... just in the cache.

![image](https://user-images.githubusercontent.com/5294381/100392447-b1b54880-308a-11eb-87c0-347d97add0f0.png)

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
