### PR TITLE
chore(Release): version upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord.js",
-  "version": "12.5.0",
+  "version": "12.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord.js",
-  "version": "12.5.0",
+  "version": "12.5.1",
   "description": "A powerful library for interacting with the Discord API",
   "main": "./src/index",
   "types": "./typings/index.d.ts",


### PR DESCRIPTION
This change was only applied to the stable branch, not master.

*Side note: stable still has the version set to `12.5.0` in `package-lock.json` FWIW*