### PR TITLE
docs(WebSocketManager): fix type of status

### DIFF
--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -76,7 +76,7 @@ class WebSocketManager extends EventEmitter {
 
     /**
      * The current status of this WebSocketManager
-     * @type {number}
+     * @type {Status}
      */
     this.status = Status.IDLE;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

[`WebSocketManager`](https://discord.js.org/#/docs/main/master/class/WebSocketManager?scrollTo=status) has a type of `number`, but [`Status`](https://discord.js.org/#/docs/main/master/typedef/Status) is more descriptive.

The type is already `Status` in the typings, just not in the docs.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
