### PR TITLE
cleanup(Client): improve generateInvite()

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -383,18 +383,20 @@ class Client extends BaseClient {
   /**
    * Generates a link that can be used to invite the bot to a guild.
    * @param {InviteGenerationOptions} [options={}] Options for the invite
-   * @returns {string}
+   * @returns {Promise<string>}
    * @example
-   * const link = client.generateInvite({
+   * client.generateInvite({
    *   permissions: ['SEND_MESSAGES', 'MANAGE_GUILD', 'MENTION_EVERYONE'],
-   * });
-   * console.log(`Generated bot invite link: ${link}`);
+   * })
+   *   .then(link => console.log(`Generated bot invite link: ${link}`))
+   *   .catch(console.error);
    */
-  generateInvite(options = {}) {
+  async generateInvite(options = {}) {
     if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
 
+    const application = await this.fetchApplication();
     const query = new URLSearchParams({
-      client_id: this.user.id,
+      client_id: application.id,
       scope: 'bot',
     });
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -217,7 +217,7 @@ declare module 'discord.js' {
     public fetchGuildTemplate(template: GuildTemplateResolvable): Promise<GuildTemplate>;
     public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
     public fetchWebhook(id: Snowflake, token?: string): Promise<Webhook>;
-    public generateInvite(options?: InviteGenerationOptions): string;
+    public generateInvite(options?: InviteGenerationOptions): Promise<string>;
     public login(token?: string): Promise<string>;
     public sweepMessages(lifetime?: number): number;
     public toJSON(): object;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -217,7 +217,7 @@ declare module 'discord.js' {
     public fetchGuildTemplate(template: GuildTemplateResolvable): Promise<GuildTemplate>;
     public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
     public fetchWebhook(id: Snowflake, token?: string): Promise<Webhook>;
-    public generateInvite(options?: InviteGenerationOptions | PermissionResolvable): Promise<string>;
+    public generateInvite(options?: InviteGenerationOptions): string;
     public login(token?: string): Promise<string>;
     public sweepMessages(lifetime?: number): number;
     public toJSON(): object;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Move `InviteGenerationOptions` typedef from below the class to above the method (consistency)
- Passing a `PermissionResolvable` is deprecated, so it now throws an error if the passed options are not an object
- ~Fetching the application doesn't seem required, so the method doesn't return a promise anymore~
- Only add permissions to the query if they aren't `0`

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
