### PR TITLE
fix(Message): update getters to take null permissions into account

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -180,9 +180,9 @@ class Message extends Base {
      */
     this.activity = data.activity
       ? {
-        partyID: data.activity.party_id,
-        type: data.activity.type,
-      }
+          partyID: data.activity.party_id,
+          type: data.activity.type,
+        }
       : null;
 
     /**
@@ -218,10 +218,10 @@ class Message extends Base {
      */
     this.reference = data.message_reference
       ? {
-        channelID: data.message_reference.channel_id,
-        guildID: data.message_reference.guild_id,
-        messageID: data.message_reference.message_id,
-      }
+          channelID: data.message_reference.channel_id,
+          guildID: data.message_reference.guild_id,
+          messageID: data.message_reference.message_id,
+        }
       : null;
   }
 
@@ -409,8 +409,8 @@ class Message extends Base {
     return (
       !this.deleted &&
       (this.author.id === this.client.user.id ||
-        ((this.guild && this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
-      ));
+        (this.guild && this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
+    );
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -409,7 +409,9 @@ class Message extends Base {
     return (
       !this.deleted &&
       (this.author.id === this.client.user.id ||
-        (this.guild && this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
+        (this.guild &&
+          this.channel.permissionsFor(this.client.user) &&
+          this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
     );
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -406,12 +406,11 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
+    const permissions = this.guild && this.channel.permissionsFor(this.client.user);
     return (
       !this.deleted &&
       (this.author.id === this.client.user.id ||
-        (this.guild &&
-          this.channel.permissionsFor(this.client.user) &&
-          this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
+        (permissions && permissions.has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
     );
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -406,11 +406,10 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
-    const permissions = this.guild && this.channel.permissionsFor(this.client.user);
     return (
       !this.deleted &&
       (this.author.id === this.client.user.id ||
-        (permissions && permissions.has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
+        ((this.guild && this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
     );
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -406,7 +406,7 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
-    return (
+    return Boolean(
       !this.deleted &&
       (this.author.id === this.client.user.id ||
         (this.guild && this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false)))

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -408,8 +408,8 @@ class Message extends Base {
   get deletable() {
     return Boolean(
       !this.deleted &&
-      (this.author.id === this.client.user.id ||
-        (this.guild && this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
+        (this.author.id === this.client.user.id ||
+          (this.guild && this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false))),
     );
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -180,9 +180,9 @@ class Message extends Base {
      */
     this.activity = data.activity
       ? {
-          partyID: data.activity.party_id,
-          type: data.activity.type,
-        }
+        partyID: data.activity.party_id,
+        type: data.activity.type,
+      }
       : null;
 
     /**
@@ -218,10 +218,10 @@ class Message extends Base {
      */
     this.reference = data.message_reference
       ? {
-          channelID: data.message_reference.channel_id,
-          guildID: data.message_reference.guild_id,
-          messageID: data.message_reference.message_id,
-        }
+        channelID: data.message_reference.channel_id,
+        guildID: data.message_reference.guild_id,
+        messageID: data.message_reference.message_id,
+      }
       : null;
   }
 
@@ -410,7 +410,7 @@ class Message extends Base {
       !this.deleted &&
       (this.author.id === this.client.user.id ||
         ((this.guild && this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
-    );
+      ));
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -409,7 +409,7 @@ class Message extends Base {
     return Boolean(
       !this.deleted &&
         (this.author.id === this.client.user.id ||
-          (this.guild && this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false))),
+          this.channel.permissionsFor?.(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES)),
     );
   }
 


### PR DESCRIPTION
#5056, check to make sure return from channel#permissionsFor isn't null before calling .has on it. Open to refactoring to avoid duplicate permissionsFor calls

closes #5056 

**Status**

- [] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
