### PR TITLE
feat(GuildMember): add 'resetNickname' method

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -328,6 +328,15 @@ class GuildMember extends Base {
   }
 
   /**
+   * Resets the nickname for this member.
+   * @param {string} [reason] Reason for resetting the nickname
+   * @returns {Promise<GuildMember>}
+   */
+  resetNickname(reason) {
+    return this.edit({ nick: '' }, reason);
+  }
+
+  /**
    * Creates a DM channel between the client and this member.
    * @returns {Promise<DMChannel>}
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -831,6 +831,7 @@ declare module 'discord.js' {
     public kick(reason?: string): Promise<GuildMember>;
     public permissionsIn(channel: ChannelResolvable): Readonly<Permissions>;
     public setNickname(nickname: string, reason?: string): Promise<GuildMember>;
+    public resetNickname(reason?: string): Promise<GuildMember>;
     public toJSON(): object;
     public toString(): string;
     public valueOf(): string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

We know that there are alternatives to reset a nicknames, like:
```js
<GuildMember>.setNickname('');
// or
<GuildMember>.setNickname(<GuildMember>.user.username) // not recommended
```
however, not many of us know this and it may take some time for some to realize it, as has been my case. That's why I decided to create this alias.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
