### PR TITLE
feat(GuildMember): make GuildMember#setNickname first param nullable

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -319,7 +319,7 @@ class GuildMember extends Base {
 
   /**
    * Sets the nickname for this member.
-   * @param {string} nick The nickname for the guild member
+   * @param {string|null} nick The nickname for the guild member, or `null` if you want to reset their nickname
    * @param {string} [reason] Reason for setting the nickname
    * @returns {Promise<GuildMember>}
    */

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -274,7 +274,7 @@ class GuildMember extends Base {
   /**
    * The data for editing a guild member.
    * @typedef {Object} GuildMemberEditData
-   * @property {string} [nick] The nickname to set for the member
+   * @property {?string} [nick] The nickname to set for the member
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles or role IDs to apply
    * @property {boolean} [mute] Whether or not the member should be muted
    * @property {boolean} [deaf] Whether or not the member should be deafened

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -319,7 +319,7 @@ class GuildMember extends Base {
 
   /**
    * Sets the nickname for this member.
-   * @param {string|null} nick The nickname for the guild member, or `null` if you want to reset their nickname
+   * @param {?string} nick The nickname for the guild member, or `null` if you want to reset their nickname
    * @param {string} [reason] Reason for setting the nickname
    * @returns {Promise<GuildMember>}
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2648,7 +2648,7 @@ declare module 'discord.js' {
     | 'WELCOME_SCREEN_ENABLED';
 
   interface GuildMemberEditData {
-    nick?: string;
+    nick?: string | null;
     roles?: Collection<Snowflake, Role> | readonly RoleResolvable[];
     mute?: boolean;
     deaf?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -830,7 +830,7 @@ declare module 'discord.js' {
     ): boolean;
     public kick(reason?: string): Promise<GuildMember>;
     public permissionsIn(channel: ChannelResolvable): Readonly<Permissions>;
-    public setNickname(nickname: string, reason?: string): Promise<GuildMember>;
+    public setNickname(nickname: string | null, reason?: string): Promise<GuildMember>;
     public toJSON(): object;
     public toString(): string;
     public valueOf(): string;


### PR DESCRIPTION
Passing null into GuildMember#setNickname will reset the nickname. But neither the typings nor the jsdoc indicate that you can pass that in.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
