### PR TITLE
Remove filtering of string forms of null and undefined

### DIFF
--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -20,7 +20,7 @@ class APIRequest {
     let queryString = '';
     if (options.query) {
       const query = Object.entries(options.query)
-        .filter(([, value]) => ![null, 'null', 'undefined'].includes(value) && typeof value !== 'undefined')
+        .filter(([, value]) => value !== null && typeof value !== 'undefined')
         .flatMap(([key, value]) => (Array.isArray(value) ? value.map(v => [key, v]) : [[key, value]]));
       queryString = new URLSearchParams(query).toString();
     }


### PR DESCRIPTION
Removed null and undefined being filtered out in string forms which caused issues in `Client#api`, closes issue: https://github.com/discordjs/discord.js/issues/5072

**Please describe the changes this PR makes and why it should be merged:**
This PR is meant to remove the filtering of string forms of null and undefined to prevent `DiscordAPIError` being thrown when given them as a string in the query of the `Client#api`
**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
