### PR TITLE
fix(BaseGuildEmoji): typo in requiresColons

### DIFF
--- a/src/structures/BaseGuildEmoji.js
+++ b/src/structures/BaseGuildEmoji.js
@@ -17,7 +17,7 @@ class BaseGuildEmoji extends Emoji {
      */
     this.guild = guild;
 
-    this.requireColons = null;
+    this.requiresColons = null;
     this.managed = null;
     this.available = null;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes a typo in the BaseGuildEmoji#requiresColons property which was missing the "s" in requires.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
