### PR TITLE
Change permission overwrite methods descriptions

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -213,7 +213,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Updates permission overwrites for a user or role in this channel, or creates an entry if not already present
+   * Updates permission overwrites for a user or role in this channel, or creates an entry if not already present.
    * @param {RoleResolvable|UserResolvable} userOrRole The user or role to update
    * @param {PermissionOverwriteOptions} options The options for the update
    * @param {string} [reason] Reason for creating/editing this overwrite

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -213,7 +213,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Updates Overwrites for a user or role in this channel. (creates if non-existent)
+   * Updates permission overwrites for a user or role in this channel, or creates an entry if not already present
    * @param {RoleResolvable|UserResolvable} userOrRole The user or role to update
    * @param {PermissionOverwriteOptions} options The options for the update
    * @param {string} [reason] Reason for creating/editing this overwrite
@@ -236,13 +236,13 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Overwrites the permissions for a user or role in this channel. (replaces if existent)
+   * Creates permission overwrites for a user or role in this channel, or updates them if already present
    * @param {RoleResolvable|UserResolvable} userOrRole The user or role to update
    * @param {PermissionOverwriteOptions} options The options for the update
    * @param {string} [reason] Reason for creating/editing this overwrite
    * @returns {Promise<GuildChannel>}
    * @example
-   * // Create or Replace permissions overwrites for a message author
+   * // Create or Replace permission overwrites for a message author
    * message.channel.createOverwrite(message.author, {
    *   SEND_MESSAGES: false
    * })

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -236,7 +236,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Creates permission overwrites for a user or role in this channel, or updates them if already present
+   * Creates permission overwrites for a user or role in this channel, or replaces them if already present
    * @param {RoleResolvable|UserResolvable} userOrRole The user or role to update
    * @param {PermissionOverwriteOptions} options The options for the update
    * @param {string} [reason] Reason for creating/editing this overwrite

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -236,7 +236,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Creates permission overwrites for a user or role in this channel, or replaces them if already present
+   * Creates permission overwrites for a user or role in this channel, or replaces them if already present.
    * @param {RoleResolvable|UserResolvable} userOrRole The user or role to update
    * @param {PermissionOverwriteOptions} options The options for the update
    * @param {string} [reason] Reason for creating/editing this overwrite


### PR DESCRIPTION
The methods `GuildChannel#updateOverwrite` and `#createOverwrite` had some awkward wording in the description: `. (...)` does not look good.  This PR cleans up the descriptions to be one sentence that's clearer in meaning.  There's also changes to make `permission overwrite/s` consistent - some lines had `permissions overwrite/s`.

**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
