### PR TITLE
Added an option to provide custom FFMPEG arguments.

### DIFF
--- a/src/client/voice/player/BasePlayer.js
+++ b/src/client/voice/player/BasePlayer.js
@@ -41,7 +41,8 @@ class BasePlayer extends EventEmitter {
 
     const isStream = input instanceof ReadableStream;
 
-    const args = isStream ? FFMPEG_ARGUMENTS.slice() : ['-i', input, ...FFMPEG_ARGUMENTS];
+    const ARGS = options.replaceArgs ? options.customFFMPEGArgs : [...FFMPEG_ARGUMENTS, ...options.customFFMPEGArgs];
+    const args = isStream ? ARGS.slice() : ['-i', input, ...ARGS];
     if (options.seek) args.unshift('-ss', String(options.seek));
 
     const ffmpeg = new prism.FFmpeg({ args });

--- a/src/client/voice/util/PlayInterface.js
+++ b/src/client/voice/util/PlayInterface.js
@@ -59,7 +59,7 @@ class PlayInterface {
    * connection.play('http://www.sample-videos.com/audio/mp3/wave.mp3');
    * @returns {StreamDispatcher}
    */
-  play(resource, options = {}) {
+  play(resource, options = { replaceArgs: false, customFFMPEGArgs: [] }) {
     const VoiceBroadcast = require('../VoiceBroadcast');
     if (resource instanceof VoiceBroadcast) {
       if (!this.player.playBroadcast) throw new Error('VOICE_PLAY_INTERFACE_NO_BROADCAST');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3133,6 +3133,8 @@ declare module 'discord.js' {
     fec?: boolean;
     bitrate?: number | 'auto';
     highWaterMark?: number;
+    replaceArgs?: boolean;
+    customFFMPEGArgs?: string[];
   }
 
   type SpeakingString = 'SPEAKING' | 'SOUNDSHARE' | 'PRIORITY_SPEAKING';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Added a new property to the `StreamOptions` object which gives users the ability to provide custom FFMPEG arguments or entirely replace the already existing FFMPEG arguments with their own. This gives more control over to users who are using FFMPEG for streaming.

**Status**

- [ * ] Code changes have been tested against the Discord API, or there are no code changes
- [ * ] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ * ] This PR changes the library's interface (methods or parameters added)
- [   ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [   ] This PR **only** includes non-code changes, like changes to documentation, README, etc.