### PR TITLE
test(roles|channels): Added unit tests for roles and channels

### DIFF
--- a/test/channels.js
+++ b/test/channels.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const assert = require('assert');
+const { token, test_guild_id } = require('./auth');
+const { Client } = require('../src');
+
+// Create client
+const client = new Client({});
+
+// Test role create and deletion
+client.on('ready', async () => {
+
+  try {
+
+    // Fetch guild to use
+    const guild = await client.guilds.fetch(test_guild_id);
+
+    // Create a new text channel
+    let t_channel = await guild.channels.create('test-text-channel', {
+        type: 'text',
+        topic: 'A new super cool text channel'
+    });
+    // Check to make sure the channel was created successfully
+    assert.strictEqual(t_channel.name, 'test-text-channel')
+    assert.strictEqual(t_channel.type, 'text');
+    assert.strictEqual(t_channel.topic, 'A new super cool text channel');
+
+    // Create a new voice channel
+    let vc_channel = await guild.channels.create('test voice channel', {
+        type: 'voice'
+    });
+    // Check to make sure the channel was created successfully
+    assert.strictEqual(vc_channel.name, 'test voice channel')
+    assert.strictEqual(vc_channel.type, 'voice');
+
+    // Edit the text channel
+    await t_channel.edit({
+        name: 'new-test-text-channel',
+        topic: 'this is a new topic',
+        nsfw: true
+    });
+    // Check to make sure the channel was edited successfully
+    assert.strictEqual(t_channel.name, 'new-test-text-channel');
+    assert.strictEqual(t_channel.topic, 'this is a new topic');
+    assert.strictEqual(t_channel.nsfw, true);
+
+    // Edit the voice channel
+    await vc_channel.edit({
+        name: 'new test voice channel'
+    });
+    // Check to make sure the channel was edited successfully
+    assert.strictEqual(vc_channel.name, 'new test voice channel');
+
+    // Delete both channels
+    await t_channel.delete();
+    await vc_channel.delete();
+
+    // Check if both were deleted
+    assert.strictEqual(t_channel.deleted, true);
+    assert.strictEqual(vc_channel.deleted, true);
+
+  } catch (error) {
+    console.error(error);
+  }
+
+  // Destroy client and end test
+  client.destroy();
+
+});
+
+client.login(token).catch(console.error);

--- a/test/roles.js
+++ b/test/roles.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const assert = require('assert');
+const { token, test_guild_id, test_user_id } = require('./auth');
+const { Client } = require('../src');
+
+// Create client
+const client = new Client({});
+
+// Test role create and deletion
+client.on('ready', async () => {
+
+  try {
+
+    // Fetch guild to use
+    const guild = await client.guilds.fetch(test_guild_id);
+    
+    // Create the new role with specified details
+    let new_role = await guild.roles.create({
+      data: {
+        name: 'Super Cool People',
+        color: 'BLUE',
+        permissions: [
+          'ADMINISTRATOR'
+        ]
+      }
+    });
+
+    // Check to make sure role created successfully with specified details
+    assert.strictEqual(new_role.name, 'Super Cool People');
+    assert.strictEqual(new_role.color, 3447003);
+    assert.strictEqual(new_role.permissions.has('ADMINISTRATOR'), true);
+
+    // Edit role with new name and new permissions
+    await new_role.edit({
+      name: 'Super Duper Cool People',
+      permissions: [
+        'MANAGE_GUILD',
+        'KICK_MEMBERS'
+      ]
+    });
+
+    // Check to make sure role edited successfully with specified details
+    assert.strictEqual(new_role.name, 'Super Duper Cool People');
+    assert.strictEqual(new_role.color, 3447003);
+    assert.strictEqual(new_role.permissions.has('MANAGE_GUILD', 'KICK_MEMBERS'), true);
+
+    // Fetch member to use
+    let user = await guild.members.fetch(test_user_id);
+
+    // Try to assign role to the user
+    user = await user.roles.add(new_role);
+
+    // Check if role was added to the user
+    let role_added = false;
+    user._roles.forEach(element => {
+      if (element === new_role.id) {
+        role_added = true;
+      }
+    });
+    assert.strictEqual(role_added, true);
+
+    // Edit role with new name and permissions
+    await new_role.edit({
+      name: 'Administrator',
+      color: 'RED'
+    });
+
+    // Check to make sure role edited successfully with specified details
+    assert.strictEqual(new_role.name, 'Administrator');
+    assert.strictEqual(new_role.color, 15158332);
+    assert.strictEqual(new_role.permissions.has('MANAGE_GUILD', 'KICK_MEMBERS'), true);
+
+    // Remove role from user and delete role
+    user = await user.roles.remove(new_role);
+
+    // Check if role was added to the user
+    let role_removed = true;
+    user._roles.forEach(element => {
+      if (element === new_role.id) {
+        role_removed = false;
+      }
+    });
+    assert.strictEqual(role_removed, true);
+
+    // Delete the role from the server
+    await new_role.delete();
+    //assert.strictEqual(new_role.deleted, true);
+
+  } catch (error) {
+    console.error(error);
+  }
+
+  // Destroy client and end test
+  client.destroy();
+
+});
+
+client.login(token).catch(console.error);


### PR DESCRIPTION
Added tests for the creation, editing, assignment, and deletion of roles. Added tests for the creation, editing, and deletion of channels, both text and voice.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
