### PR TITLE
fix(UserFlags): correct early bot dev name, remove deprecated aliases

### DIFF
--- a/src/util/UserFlags.js
+++ b/src/util/UserFlags.js
@@ -18,7 +18,6 @@ class UserFlags extends BitField {}
  * Numeric user flags. All available properties:
  * * `DISCORD_EMPLOYEE`
  * * `PARTNERED_SERVER_OWNER`
- * * `DISCORD_PARTNER` **(deprecated)**
  * * `HYPESQUAD_EVENTS`
  * * `BUGHUNTER_LEVEL_1`
  * * `HOUSE_BRAVERY`
@@ -30,14 +29,12 @@ class UserFlags extends BitField {}
  * * `BUGHUNTER_LEVEL_2`
  * * `VERIFIED_BOT`
  * * `EARLY_VERIFIED_BOT_DEVELOPER`
- * * `VERIFIED_DEVELOPER` **(deprecated)**
  * @type {Object}
  * @see {@link https://discord.com/developers/docs/resources/user#user-object-user-flags}
  */
 UserFlags.FLAGS = {
   DISCORD_EMPLOYEE: 1 << 0,
   PARTNERED_SERVER_OWNER: 1 << 1,
-  DISCORD_PARTNER: 1 << 1,
   HYPESQUAD_EVENTS: 1 << 2,
   BUGHUNTER_LEVEL_1: 1 << 3,
   HOUSE_BRAVERY: 1 << 6,
@@ -48,8 +45,7 @@ UserFlags.FLAGS = {
   SYSTEM: 1 << 12,
   BUGHUNTER_LEVEL_2: 1 << 14,
   VERIFIED_BOT: 1 << 16,
-  EARLY_VERIFIED_DEVELOPER: 1 << 17,
-  VERIFIED_DEVELOPER: 1 << 17,
+  EARLY_VERIFIED_BOT_DEVELOPER: 1 << 17,
 };
 
 module.exports = UserFlags;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3161,7 +3161,6 @@ declare module 'discord.js' {
   type UserFlagsString =
     | 'DISCORD_EMPLOYEE'
     | 'PARTNERED_SERVER_OWNER'
-    | 'DISCORD_PARTNER'
     | 'HYPESQUAD_EVENTS'
     | 'BUGHUNTER_LEVEL_1'
     | 'HOUSE_BRAVERY'
@@ -3172,8 +3171,7 @@ declare module 'discord.js' {
     | 'SYSTEM'
     | 'BUGHUNTER_LEVEL_2'
     | 'VERIFIED_BOT'
-    | 'EARLY_VERIFIED_DEVELOPER'
-    | 'VERIFIED_DEVELOPER';
+    | 'EARLY_VERIFIED_BOT_DEVELOPER';
 
   type UserResolvable = User | Snowflake | Message | GuildMember;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR resolves #5102 by renaming the user flag `EARLY_VERIFIED_DEVELOPER` to `EARLY_VERIFIED_BOT_DEVELOPER`.
This is the name we [and Discord](https://discord.com/developers/docs/resources/user#user-object-user-flags) actually document.

This PR also removes the deprecated aliases.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
