### PR TITLE
fix(Message): #system non-zero message types are not guaranteed to be system

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -10,7 +10,7 @@ const ReactionCollector = require('./ReactionCollector');
 const { Error, TypeError } = require('../errors');
 const ReactionManager = require('../managers/ReactionManager');
 const Collection = require('../util/Collection');
-const { MessageTypes } = require('../util/Constants');
+const { MessageTypes, SystemMessageTypes } = require('../util/Constants');
 const MessageFlags = require('../util/MessageFlags');
 const Permissions = require('../util/Permissions');
 const SnowflakeUtil = require('../util/Snowflake');
@@ -62,7 +62,7 @@ class Message extends Base {
        * Whether or not this message was sent by Discord, not actually a user (e.g. pin notifications)
        * @type {?boolean}
        */
-      this.system = data.type !== 0;
+      this.system = SystemMessageTypes.includes(this.type);
     } else if (typeof this.type !== 'string') {
       this.system = null;
       this.type = null;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -435,8 +435,8 @@ exports.MessageTypes = [
  * * REPLY
  * @typedef {string} SystemMessageType
  */
-exports.SystemMessageTypes = module.exports.MessageTypes.filter(
-  type => type !== null && type !== 'DEFAULT' && type !== 'REPLY',
+exports.SystemMessageTypes = exports.MessageTypes.filter(
+  type => type && type !== 'DEFAULT' && type !== 'REPLY',
 );
 
 /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -435,9 +435,7 @@ exports.MessageTypes = [
  * * REPLY
  * @typedef {string} SystemMessageType
  */
-exports.SystemMessageTypes = exports.MessageTypes.filter(
-  type => type && type !== 'DEFAULT' && type !== 'REPLY',
-);
+exports.SystemMessageTypes = exports.MessageTypes.filter(type => type && type !== 'DEFAULT' && type !== 'REPLY');
 
 /**
  * <info>Bots cannot set a `CUSTOM_STATUS`, it is only for custom statuses received from users</info>

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -430,39 +430,14 @@ exports.MessageTypes = [
 ];
 
 /**
- * The types of messges that are considered `System`. Here are the available types:
- * * RECIPIENT_ADD
- * * RECIPIENT_REMOVE
- * * CALL
- * * CHANNEL_NAME_CHANGE
- * * CHANNEL_ICON_CHANGE
- * * PINS_ADD
- * * GUILD_MEMBER_JOIN
- * * USER_PREMIUM_GUILD_SUBSCRIPTION
- * * USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1
- * * USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_2
- * * USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_3
- * * CHANNEL_FOLLOW_ADD
- * * GUILD_DISCOVERY_DISQUALIFIED
- * * GUILD_DISCOVERY_REQUALIFIED
+ * The types of messages that are `System`. The available types are `MessageTypes` excluding:
+ * * DEFAULT
+ * * REPLY
  * @typedef {string} SystemMessageType
  */
-exports.SystemMessageTypes = [
-  'RECIPIENT_ADD',
-  'RECIPIENT_REMOVE',
-  'CALL',
-  'CHANNEL_NAME_CHANGE',
-  'CHANNEL_ICON_CHANGE',
-  'PINS_ADD',
-  'GUILD_MEMBER_JOIN',
-  'USER_PREMIUM_GUILD_SUBSCRIPTION',
-  'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1',
-  'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_2',
-  'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_3',
-  'CHANNEL_FOLLOW_ADD',
-  'GUILD_DISCOVERY_DISQUALIFIED',
-  'GUILD_DISCOVERY_REQUALIFIED',
-];
+exports.SystemMessageTypes = module.exports.MessageTypes.filter(
+  type => type !== null && type !== 'DEFAULT' && type !== 'REPLY',
+);
 
 /**
  * <info>Bots cannot set a `CUSTOM_STATUS`, it is only for custom statuses received from users</info>

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -430,6 +430,41 @@ exports.MessageTypes = [
 ];
 
 /**
+ * The types of messges that are considered `System`. Here are the available types:
+ * * RECIPIENT_ADD
+ * * RECIPIENT_REMOVE
+ * * CALL
+ * * CHANNEL_NAME_CHANGE
+ * * CHANNEL_ICON_CHANGE
+ * * PINS_ADD
+ * * GUILD_MEMBER_JOIN
+ * * USER_PREMIUM_GUILD_SUBSCRIPTION
+ * * USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1
+ * * USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_2
+ * * USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_3
+ * * CHANNEL_FOLLOW_ADD
+ * * GUILD_DISCOVERY_DISQUALIFIED
+ * * GUILD_DISCOVERY_REQUALIFIED
+ * @typedef {string} SystemMessageType
+ */
+exports.SystemMessageTypes = [
+  'RECIPIENT_ADD',
+  'RECIPIENT_REMOVE',
+  'CALL',
+  'CHANNEL_NAME_CHANGE',
+  'CHANNEL_ICON_CHANGE',
+  'PINS_ADD',
+  'GUILD_MEMBER_JOIN',
+  'USER_PREMIUM_GUILD_SUBSCRIPTION',
+  'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1',
+  'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_2',
+  'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_3',
+  'CHANNEL_FOLLOW_ADD',
+  'GUILD_DISCOVERY_DISQUALIFIED',
+  'GUILD_DISCOVERY_REQUALIFIED',
+];
+
+/**
  * <info>Bots cannot set a `CUSTOM_STATUS`, it is only for custom statuses received from users</info>
  * The type of an activity of a users presence, e.g. `PLAYING`. Here are the available types:
  * * PLAYING

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3148,21 +3148,7 @@ declare module 'discord.js' {
 
   type SystemChannelFlagsResolvable = BitFieldResolvable<SystemChannelFlagsString>;
 
-  type SystemMessageType =
-    | 'RECIPIENT_ADD'
-    | 'RECIPIENT_REMOVE'
-    | 'CALL'
-    | 'CHANNEL_NAME_CHANGE'
-    | 'CHANNEL_ICON_CHANGE'
-    | 'PINS_ADD'
-    | 'GUILD_MEMBER_JOIN'
-    | 'USER_PREMIUM_GUILD_SUBSCRIPTION'
-    | 'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1'
-    | 'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_2'
-    | 'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_3'
-    | 'CHANNEL_FOLLOW_ADD'
-    | 'GUILD_DISCOVERY_DISQUALIFIED'
-    | 'GUILD_DISCOVERY_REQUALIFIED';
+  type SystemMessageType = Exclude<MessageType, 'DEFAULT' | 'REPLY'>;
 
   type TargetUser = number;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -516,6 +516,7 @@ declare module 'discord.js' {
       BIG: 2;
     };
     MessageTypes: MessageType[];
+    SystemMessageTypes: SystemMessageType[];
     ActivityTypes: ActivityType[];
     ExplicitContentFilterLevels: ExplicitContentFilterLevel[];
     DefaultMessageNotifications: DefaultMessageNotifications[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3148,6 +3148,22 @@ declare module 'discord.js' {
 
   type SystemChannelFlagsResolvable = BitFieldResolvable<SystemChannelFlagsString>;
 
+  type SystemMessageType =
+    | 'RECIPIENT_ADD'
+    | 'RECIPIENT_REMOVE'
+    | 'CALL'
+    | 'CHANNEL_NAME_CHANGE'
+    | 'CHANNEL_ICON_CHANGE'
+    | 'PINS_ADD'
+    | 'GUILD_MEMBER_JOIN'
+    | 'USER_PREMIUM_GUILD_SUBSCRIPTION'
+    | 'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1'
+    | 'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_2'
+    | 'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_3'
+    | 'CHANNEL_FOLLOW_ADD'
+    | 'GUILD_DISCOVERY_DISQUALIFIED'
+    | 'GUILD_DISCOVERY_REQUALIFIED';
+
   type TargetUser = number;
 
   interface TypingData {


### PR DESCRIPTION
As of discord/discord-api-docs#2118 not all non-zero message types are system. 
Type 19 `Reply` is the only current type that benefits from this change.

Note: the reply type will only be recieved once #4879 is implemented.

This PR also introduces SystemMessageTypes so that future message types can be more easily sorted.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
