### PR TITLE
docs(MessageOptions): indicate that replyTo cannot be system

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -65,7 +65,7 @@ class TextBasedChannel {
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message
-   * @property {MessageResolvable} [replyTo] The message to reply to (must be in the same channel)
+   * @property {MessageResolvable} [replyTo] The message to reply to (must be in the same channel and not system)
    */
 
   /**


### PR DESCRIPTION
Documents that system messages cannot be replied to. 
There is no built in check for this as it is unlikely to attempt a reply to a system message, but it should be documented.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
