### PR TITLE
[BREAKING] cleanup(Message): remove helper method #suppressEmbeds

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -480,6 +480,16 @@ class Message extends Base {
    * message.edit('This is my new content!')
    *   .then(msg => console.log(`Updated the content of a message to ${msg.content}`))
    *   .catch(console.error);
+   * @example
+   * // Suppress embeds on a message
+   * message.edit({ suppressEmbeds: true })
+   *   .then(msg => console.log(`Suppressed the embeds of a message`))
+   *   .catch(console.error);
+   * @example
+   * // Update a message and make sure it is unsuppressed
+   * message.edit({ embed: {MessageEmbed}, suppressEmbeds: false })
+   *   .then(msg => console.log(`Edited the content of a message, including an embed`))
+   *   .catch(console.error);
    */
   edit(content, options) {
     if (!options && typeof content === 'object' && !Array.isArray(content)) {

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -487,12 +487,12 @@ class Message extends Base {
       content = undefined;
     }
 
-    const editFlags = typeof this.options?.suppressEmbeds !== 'undefined';
+    const editFlags = typeof options?.suppressEmbeds !== 'undefined';
 
     if (editFlags) {
       const flags = new MessageFlags(this.flags.bitfield);
 
-      if (this.options.suppressEmbeds) {
+      if (options.suppressEmbeds) {
         flags.add(MessageFlags.FLAGS.SUPPRESS_EMBEDS);
       } else {
         flags.remove(MessageFlags.FLAGS.SUPPRESS_EMBEDS);

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -471,7 +471,7 @@ class Message extends Base {
   /* eslint-enable max-len */
 
   /**
-   * Edits the content of the message.
+   * Edits a message.
    * @param {StringResolvable|APIMessage} [content] The new content for the message
    * @param {MessageEditOptions|MessageEmbed} [options] The options to provide
    * @returns {Promise<Message>}
@@ -482,7 +482,12 @@ class Message extends Base {
    *   .catch(console.error);
    */
   edit(content, options) {
-    const editFlags = typeof this.options.suppressEmbeds !== 'undefined';
+    if (!options && typeof content === 'object' && !Array.isArray(content)) {
+      options = content;
+      content = undefined;
+    }
+
+    const editFlags = typeof this.options?.suppressEmbeds !== 'undefined';
 
     if (editFlags) {
       const flags = new MessageFlags(this.flags.bitfield);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2763,6 +2763,7 @@ declare module 'discord.js' {
     content?: StringResolvable;
     embed?: MessageEmbed | MessageEmbedOptions | null;
     code?: string | boolean;
+    suppressEmbeds?: boolean;
     flags?: BitFieldResolvable<MessageFlagsString>;
     allowedMentions?: MessageMentionOptions;
   }


### PR DESCRIPTION
Message#suppressEmbeds was a basic helper for Message#edit.
This is now handled inside Message#edit by adding a `suppressEmbeds` parameter to `MessageEditOptions`

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
