### PR TITLE
Add type definition for BaseClient#api

### DIFF
--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -51,7 +51,7 @@ class BaseClient extends EventEmitter {
 
   /**
    * API shortcut
-   * @type {Object}
+   * @type {RouteBuilder}
    * @readonly
    * @private
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -157,7 +157,7 @@ declare module 'discord.js' {
 
   type RouteBuilderReturn = RouteBuilder &
     RouteBuilderMethods & {
-      (...args: any[]): RouteBuilderReturn;
+      (...args: string[]): RouteBuilderReturn;
     };
 
   interface RouteBuilder {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -122,7 +122,7 @@ declare module 'discord.js' {
     private _timeouts: Set<NodeJS.Timeout>;
     private _intervals: Set<NodeJS.Timeout>;
     private _immediates: Set<NodeJS.Immediate>;
-    private readonly api: object;
+    private readonly api: RouteBuilder;
     private rest: object;
     private decrementMaxListeners(): void;
     private incrementMaxListeners(): void;
@@ -137,6 +137,34 @@ declare module 'discord.js' {
     public setImmediate(fn: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
     public toJSON(...props: { [key: string]: boolean | string }[]): object;
   }
+  
+	interface RouteBuilderMethodOptions {
+		query?: any;
+		versioned?: boolean;
+		auth?: boolean;
+		reason?: string;
+		headers?: {
+			[key: string]: string;
+		};
+		data: any;
+	}
+
+	interface RouteBuilderMethods {
+		get(opts?: RouteBuilderMethodOptions): Promise<any>;
+		post(opts?: RouteBuilderMethodOptions): Promise<any>;
+		delete(opts?: RouteBuilderMethodOptions): Promise<any>;
+		patch(opts?: RouteBuilderMethodOptions): Promise<any>;
+		put(opts?: RouteBuilderMethodOptions): Promise<any>;
+	}
+
+	type RouteBuilderReturn = RouteBuilder &
+		RouteBuilderMethods & {
+			(...args: any[]): RouteBuilderReturn;
+		};
+
+	interface RouteBuilder {
+		[key: string]: RouteBuilderReturn;
+	}
 
   export class BaseGuildEmoji extends Emoji {
     constructor(client: Client, data: object, guild: Guild);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -143,9 +143,7 @@ declare module 'discord.js' {
     versioned?: boolean;
     auth?: boolean;
     reason?: string;
-    headers?: {
-      [key: string]: string;
-    };
+    headers?: Record<string, string>;
     data: any;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -160,9 +160,7 @@ declare module 'discord.js' {
       (...args: string[]): RouteBuilderReturn;
     };
 
-  interface RouteBuilder {
-    [key: string]: RouteBuilderReturn;
-  }
+  type RouteBuilder = Record<string, RouteBuilderReturn>;
 
   export class BaseGuildEmoji extends Emoji {
     constructor(client: Client, data: object, guild: Guild);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -144,7 +144,7 @@ declare module 'discord.js' {
     auth?: boolean;
     reason?: string;
     headers?: Record<string, string>;
-    data: any;
+    data: Record<string, unknown>;
   }
 
   interface RouteBuilderMethods {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -137,34 +137,34 @@ declare module 'discord.js' {
     public setImmediate(fn: (...args: any[]) => void, ...args: any[]): NodeJS.Immediate;
     public toJSON(...props: { [key: string]: boolean | string }[]): object;
   }
-  
-	interface RouteBuilderMethodOptions {
-		query?: any;
-		versioned?: boolean;
-		auth?: boolean;
-		reason?: string;
-		headers?: {
-			[key: string]: string;
-		};
-		data: any;
-	}
 
-	interface RouteBuilderMethods {
-		get(opts?: RouteBuilderMethodOptions): Promise<any>;
-		post(opts?: RouteBuilderMethodOptions): Promise<any>;
-		delete(opts?: RouteBuilderMethodOptions): Promise<any>;
-		patch(opts?: RouteBuilderMethodOptions): Promise<any>;
-		put(opts?: RouteBuilderMethodOptions): Promise<any>;
-	}
+  interface RouteBuilderMethodOptions {
+    query?: any;
+    versioned?: boolean;
+    auth?: boolean;
+    reason?: string;
+    headers?: {
+      [key: string]: string;
+    };
+    data: any;
+  }
 
-	type RouteBuilderReturn = RouteBuilder &
-		RouteBuilderMethods & {
-			(...args: any[]): RouteBuilderReturn;
-		};
+  interface RouteBuilderMethods {
+    get(opts?: RouteBuilderMethodOptions): Promise<any>;
+    post(opts?: RouteBuilderMethodOptions): Promise<any>;
+    delete(opts?: RouteBuilderMethodOptions): Promise<any>;
+    patch(opts?: RouteBuilderMethodOptions): Promise<any>;
+    put(opts?: RouteBuilderMethodOptions): Promise<any>;
+  }
 
-	interface RouteBuilder {
-		[key: string]: RouteBuilderReturn;
-	}
+  type RouteBuilderReturn = RouteBuilder &
+    RouteBuilderMethods & {
+      (...args: any[]): RouteBuilderReturn;
+    };
+
+  interface RouteBuilder {
+    [key: string]: RouteBuilderReturn;
+  }
 
   export class BaseGuildEmoji extends Emoji {
     constructor(client: Client, data: object, guild: Guild);


### PR DESCRIPTION
Even if BaseClient#api is private, some libraries use it and it simplifies the use of the RouteBuilder proxy for the discord.js devs.
This PR adds type definition for BaseClient#api and has been tested.
Before that ``object`` was specified for BaseClient#api, which could lead to tsc errors. 

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
