### PR TITLE
chore(ClientOptions): reduce default edit history to 10

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -18,7 +18,7 @@ const { Error, RangeError } = require('../errors');
  * sweepable (in seconds, 0 for forever)
  * @property {number} [messageSweepInterval=0] How frequently to remove messages from the cache that are older than
  * the message cache lifetime (in seconds, 0 for never)
- * @property {number} [messageEditHistoryMaxSize=-1] Maximum number of previous versions to hold for an edited message
+ * @property {number} [messageEditHistoryMaxSize=10] Maximum number of previous versions to hold for an edited message
  * (-1 or Infinity for unlimited - don't do this without sweeping, otherwise memory usage may climb indefinitely.)
  * @property {boolean} [fetchAllMembers=false] Whether to cache all guild members and users upon startup, as well as
  * upon joining a guild (should be avoided whenever possible)
@@ -43,7 +43,7 @@ exports.DefaultOptions = {
   messageCacheMaxSize: 200,
   messageCacheLifetime: 0,
   messageSweepInterval: 0,
-  messageEditHistoryMaxSize: -1,
+  messageEditHistoryMaxSize: 10,
   fetchAllMembers: false,
   partials: [],
   restWsBridgeTimeout: 5000,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

As we're now in breaking/major change territory with v13, I'd like to propose we reduce the default limit to a message's edit history to 10 to avoid unexpected and potentially rather confusing memory usage for some users. When we added this feature originally, it was added as non-major so the default limit was set to be unlimited, a no-op for existing users, but now we can update it.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
