### PR TITLE
Improve typesafety of Snowflake

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3128,7 +3128,7 @@ declare module 'discord.js' {
 
   type ShardingManagerMode = 'process' | 'worker';
 
-  type Snowflake = string;
+  type Snowflake = `${number}`;
 
   interface SplitOptions {
     maxLength?: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since `Snowflake`s are always ` number in string form, this updates the type to use a [template literal type](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-1.html#template-literal-types), which will grant TypeScript users safe usage of the type.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
