### PR TITLE
chore(Deps): remove setimmediate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7418,11 +7418,6 @@
         }
       }
     },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "abort-controller": "^3.0.0",
     "node-fetch": "^2.6.1",
     "prism-media": "^1.2.2",
-    "setimmediate": "^1.0.5",
     "tweetnacl": "^1.0.3",
     "ws": "^7.3.1"
   },

--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -1,6 +1,5 @@
 'use strict';
 
-require('setimmediate');
 const EventEmitter = require('events');
 const RESTManager = require('../rest/RESTManager');
 const { DefaultOptions } = require('../util/Constants');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

[`setimmediate`](https://github.com/yuzujs/setImmediate) is a browser polyfill that is executed when `global.setTimeout` does not exist, and since we do not support webpack anymore, there is no reason to keep it here.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
