### PR TITLE
feat(*): remove ALL unnecessary getters

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -392,40 +392,6 @@ class Message extends Base {
   }
 
   /**
-   * Whether the message is editable by the client user
-   * @type {boolean}
-   * @readonly
-   */
-  get editable() {
-    return this.author.id === this.client.user.id;
-  }
-
-  /**
-   * Whether the message is deletable by the client user
-   * @type {boolean}
-   * @readonly
-   */
-  get deletable() {
-    return (
-      !this.deleted &&
-      (this.author.id === this.client.user.id ||
-        (this.guild && this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
-    );
-  }
-
-  /**
-   * Whether the message is pinnable by the client user
-   * @type {boolean}
-   * @readonly
-   */
-  get pinnable() {
-    return (
-      this.type === 'DEFAULT' &&
-      (!this.guild || this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false))
-    );
-  }
-
-  /**
    * Whether the message is crosspostable by the client user
    * @type {boolean}
    * @readonly

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -964,7 +964,6 @@ declare module 'discord.js' {
     public content: string;
     public readonly createdAt: Date;
     public createdTimestamp: number;
-    public readonly deletable: boolean;
     public deleted: boolean;
     public readonly editable: boolean;
     public readonly editedAt: Date | null;
@@ -977,7 +976,6 @@ declare module 'discord.js' {
     public mentions: MessageMentions;
     public nonce: string | number | null;
     public readonly partial: false;
-    public readonly pinnable: boolean;
     public pinned: boolean;
     public reactions: ReactionManager;
     public system: boolean;
@@ -3025,28 +3023,16 @@ declare module 'discord.js' {
   interface PartialMessage
     extends Partialize<
       Message,
-      | 'attachments'
-      | 'channel'
-      | 'deletable'
-      | 'crosspostable'
-      | 'editable'
-      | 'mentions'
-      | 'pinnable'
-      | 'url'
-      | 'flags'
-      | 'edits'
-      | 'embeds'
+      'attachments' | 'channel' | 'crosspostable' | 'editable' | 'mentions' | 'url' | 'flags' | 'edits' | 'embeds'
     > {
     attachments: Message['attachments'];
     channel: Message['channel'];
-    readonly deletable: boolean;
     readonly crosspostable: boolean;
     readonly editable: boolean;
     readonly edits: Message['edits'];
     embeds: Message['embeds'];
     flags: Message['flags'];
     mentions: Message['mentions'];
-    readonly pinnable: boolean;
     reactions: Message['reactions'];
     readonly url: string;
   }


### PR DESCRIPTION
This WIP pr is meant to remove ALL unnecessary getters like Message#editable or Message#deletable and etc. These getters do nothing but put more responsibility on the lib and pollute structures with getters that do things that can easily be done by the end user. This might take a bit 🤣.

All help is appreciated in this, if I miss some getters or if I mistakenly remove a necessary getter.

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
