### PR TITLE
fix(GuildChannel): check for community required channels in GuildChannel#deletable

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -572,8 +572,8 @@ class GuildChannel extends Channel {
    */
   get deletable() {
     return (
-        this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false) && 
-        (this.guild.rulesChannelID !== this.id || this.guild.systemChannelID !== this.id)
+      this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false) && 
+      (this.guild.rulesChannelID !== this.id || this.guild.publicUpdatesChannelID !== this.id)
     );
   }
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -572,7 +572,7 @@ class GuildChannel extends Channel {
    */
   get deletable() {
     return (
-      this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false) && 
+      this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false) &&
       (this.guild.rulesChannelID !== this.id || this.guild.publicUpdatesChannelID !== this.id)
     );
   }

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -573,7 +573,8 @@ class GuildChannel extends Channel {
   get deletable() {
     return (
       this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false) &&
-      (this.guild.rulesChannelID !== this.id || this.guild.publicUpdatesChannelID !== this.id)
+      this.guild.rulesChannelID !== this.id &&
+      this.guild.publicUpdatesChannelID !== this.id
     );
   }
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -571,7 +571,10 @@ class GuildChannel extends Channel {
    * @readonly
    */
   get deletable() {
-    return this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false);
+    return (
+        this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false) && 
+        (this.guild.rulesChannelID !== this.id || this.guild.systemChannelID !== this.id)
+    );
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently, `GuildChannel#deletable` will return true regardless if the channel is required for a community (rules, public updates) and will throw a `50074: Cannot delete a channel required for Community guilds`. This PR adds an inequality check between the `GuildChannel#id` and the `Guild#rulesChannelID` or `Guild#publicUpdatesChannelID`

--

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
