### PR TITLE
chore: remove webpack from .*ignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,3 @@ deploy/deploy_key.pub
 .idea/
 docs/docs.json
 typings/index.js
-webpack/

--- a/.npmignore
+++ b/.npmignore
@@ -19,7 +19,6 @@ docs/
 .gitattributes
 .gitignore
 .travis.yml
-webpack.config.js
 .github/
 test/
 tsconfig.json


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR removes the webpack files from `.npmignore` and `.gitignore` as they no longer need to be ignored

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
