### PR TITLE
Change messageReactionAdd and messageReactionRemove to return member instead of user

### DIFF
--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -20,8 +20,13 @@ class MessageReactionAdd extends Action {
 
     const client = this.client;
     const guild = client.guilds.cache.get(data.guild_id);
-    const member = this.getMember({ user: data.member.user }, guild);
+    let member = null
+    if (guild) member = this.getMember({ user: data.member.user }, guild);
+    else member = this.getUserFromMember(data)
     if (!member) return false;
+    let me = false
+    if (member.user) me = member.user.id === this.client.user.id
+    else me = member.id === this.client.user.id
 
     // Verify channel
     const channel = this.getChannel(data);
@@ -38,7 +43,7 @@ class MessageReactionAdd extends Action {
     const reaction = message.reactions.add({
       emoji: data.emoji,
       count: message.partial ? null : 0,
-      me: member.user.id === this.client.user.id,
+      me: me,
     });
     if (!reaction) return false;
     reaction._add(member);
@@ -46,7 +51,7 @@ class MessageReactionAdd extends Action {
      * Emitted whenever a reaction is added to a cached message.
      * @event Client#messageReactionAdd
      * @param {MessageReaction} messageReaction The reaction object
-     * @param {Member} member The guild member that applied the guild or reaction emoji
+     * @param {GuildMember} member The guild member that applied the guild or reaction emoji
      */
     this.client.emit(Events.MESSAGE_REACTION_ADD, reaction, member);
 

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -20,13 +20,13 @@ class MessageReactionAdd extends Action {
 
     const client = this.client;
     const guild = client.guilds.cache.get(data.guild_id);
-    let member = null
+    let member = null;
     if (guild) member = this.getMember({ user: data.member.user }, guild);
-    else member = this.getUserFromMember(data)
+    else member = this.getUserFromMember(data);
     if (!member) return false;
-    let me = false
-    if (member.user) me = member.user.id === this.client.user.id
-    else me = member.id === this.client.user.id
+    let me = false;
+    if (member.user) me = member.user.id === this.client.user.id;
+    else me = member.id === this.client.user.id;
 
     // Verify channel
     const channel = this.getChannel(data);

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -18,8 +18,7 @@ class MessageReactionAdd extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const client = this.client;
-    const guild = client.guilds.cache.get(data.guild_id);
+    const guild = this.client.guilds.cache.get(data.guild_id);
     let member = null;
     if (guild) member = this.getMember({ user: data.member.user }, guild);
     else member = this.getUserFromMember(data);
@@ -51,7 +50,7 @@ class MessageReactionAdd extends Action {
      * Emitted whenever a reaction is added to a cached message.
      * @event Client#messageReactionAdd
      * @param {MessageReaction} messageReaction The reaction object
-     * @param {GuildMember} member The guild member that applied the guild or reaction emoji
+     * @param {Member} member The member that applied the guild or reaction emoji
      */
     this.client.emit(Events.MESSAGE_REACTION_ADD, reaction, member);
 

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -50,7 +50,7 @@ class MessageReactionAdd extends Action {
      * Emitted whenever a reaction is added to a cached message.
      * @event Client#messageReactionAdd
      * @param {MessageReaction} messageReaction The reaction object
-     * @param {Member} member The member that applied the guild or reaction emoji
+     * @param {GuildMember} member The member that applied the guild or reaction emoji
      */
     this.client.emit(Events.MESSAGE_REACTION_ADD, reaction, member);
 

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -18,7 +18,9 @@ class MessageReactionAdd extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const member = this.getMember(data);
+    const client = this.client;
+    const guild = client.guilds.cache.get(data.guild_id);
+    const member = this.getMember({ user: data.member.user }, guild);
     if (!member) return false;
 
     // Verify channel

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -18,8 +18,8 @@ class MessageReactionAdd extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const user = this.getUserFromMember(data);
-    if (!user) return false;
+    const member = this.getMember(data);
+    if (!member) return false;
 
     // Verify channel
     const channel = this.getChannel(data);
@@ -32,23 +32,23 @@ class MessageReactionAdd extends Action {
     // Verify reaction
     if (message.partial && !this.client.options.partials.includes(PartialTypes.REACTION)) return false;
     const existing = message.reactions.cache.get(data.emoji.id || data.emoji.name);
-    if (existing && existing.users.cache.has(user.id)) return { message, reaction: existing, user };
+    if (existing && existing.users.cache.has(member.user.id)) return { message, reaction: existing, member };
     const reaction = message.reactions.add({
       emoji: data.emoji,
       count: message.partial ? null : 0,
-      me: user.id === this.client.user.id,
+      me: member.user.id === this.client.user.id,
     });
     if (!reaction) return false;
-    reaction._add(user);
+    reaction._add(member);
     /**
      * Emitted whenever a reaction is added to a cached message.
      * @event Client#messageReactionAdd
      * @param {MessageReaction} messageReaction The reaction object
-     * @param {User} user The user that applied the guild or reaction emoji
+     * @param {Member} member The guild member that applied the guild or reaction emoji
      */
-    this.client.emit(Events.MESSAGE_REACTION_ADD, reaction, user);
+    this.client.emit(Events.MESSAGE_REACTION_ADD, reaction, member);
 
-    return { message, reaction, user };
+    return { message, reaction, member };
   }
 }
 

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -15,8 +15,8 @@ class MessageReactionRemove extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const user = this.getUser(data);
-    if (!user) return false;
+    const member = this.getUser(data);
+    if (!member) return false;
 
     // Verify channel
     const channel = this.getChannel(data);
@@ -27,18 +27,18 @@ class MessageReactionRemove extends Action {
     if (!message) return false;
 
     // Verify reaction
-    const reaction = this.getReaction(data, message, user);
+    const reaction = this.getReaction(data, message, member);
     if (!reaction) return false;
-    reaction._remove(user);
+    reaction._remove(member);
     /**
      * Emitted whenever a reaction is removed from a cached message.
      * @event Client#messageReactionRemove
      * @param {MessageReaction} messageReaction The reaction object
-     * @param {User} user The user whose emoji or reaction emoji was removed
+     * @param {Member} member The guild member whose emoji or reaction emoji was removed
      */
-    this.client.emit(Events.MESSAGE_REACTION_REMOVE, reaction, user);
+    this.client.emit(Events.MESSAGE_REACTION_REMOVE, reaction, member);
 
-    return { message, reaction, user };
+    return { message, reaction, member };
   }
 }
 

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -17,9 +17,9 @@ class MessageReactionRemove extends Action {
 
     const client = this.client;
     const guild = client.guilds.cache.get(data.guild_id);
-    let member = null
+    let member = null;
     if (guild) member = this.getMember({ user: { id: data.user_id } }, guild);
-    else member = this.getUserFromMember(data)
+    else member = this.getUserFromMember(data);
     if (!member) return false;
 
     // Verify channel

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -17,7 +17,9 @@ class MessageReactionRemove extends Action {
 
     const client = this.client;
     const guild = client.guilds.cache.get(data.guild_id);
-    const member = this.getMember({ user: { id: data.user_id } }, guild);
+    let member = null
+    if (guild) member = this.getMember({ user: { id: data.user_id } }, guild);
+    else member = this.getUserFromMember(data)
     if (!member) return false;
 
     // Verify channel
@@ -36,7 +38,7 @@ class MessageReactionRemove extends Action {
      * Emitted whenever a reaction is removed from a cached message.
      * @event Client#messageReactionRemove
      * @param {MessageReaction} messageReaction The reaction object
-     * @param {Member} member The guild member whose emoji or reaction emoji was removed
+     * @param {GuildMember} member The guild member whose emoji or reaction emoji was removed
      */
     this.client.emit(Events.MESSAGE_REACTION_REMOVE, reaction, member);
 

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -15,7 +15,9 @@ class MessageReactionRemove extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const member = this.getUser(data);
+    const client = this.client;
+    const guild = client.guilds.cache.get(data.guild_id);
+    const member = this.getMember({ user: { id: data.user_id } }, guild);
     if (!member) return false;
 
     // Verify channel

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -15,8 +15,7 @@ class MessageReactionRemove extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const client = this.client;
-    const guild = client.guilds.cache.get(data.guild_id);
+    const guild = this.client.guilds.cache.get(data.guild_id);
     let member = null;
     if (guild) member = this.getMember({ user: { id: data.user_id } }, guild);
     else member = this.getUserFromMember(data);
@@ -38,7 +37,7 @@ class MessageReactionRemove extends Action {
      * Emitted whenever a reaction is removed from a cached message.
      * @event Client#messageReactionRemove
      * @param {MessageReaction} messageReaction The reaction object
-     * @param {GuildMember} member The guild member whose emoji or reaction emoji was removed
+     * @param {Member} member The member whose emoji or reaction emoji was removed
      */
     this.client.emit(Events.MESSAGE_REACTION_REMOVE, reaction, member);
 

--- a/test/random.js
+++ b/test/random.js
@@ -217,14 +217,14 @@ client.on('message', msg => {
   }
 });
 
-client.on('messageReactionAdd', (reaction, user) => {
+client.on('messageReactionAdd', (reaction, member) => {
   if (reaction.message.channel.id !== '222086648706498562') return;
-  reaction.message.channel.send(`${user.username} added reaction ${reaction.emoji}, count is now ${reaction.count}`);
+  reaction.message.channel.send(`${member.user.username} added reaction ${reaction.emoji}, count is now ${reaction.count}`);
 });
 
-client.on('messageReactionRemove', (reaction, user) => {
+client.on('messageReactionRemove', (reaction, member) => {
   if (reaction.message.channel.id !== '222086648706498562') return;
-  reaction.message.channel.send(`${user.username} removed reaction ${reaction.emoji}, count is now ${reaction.count}`);
+  reaction.message.channel.send(`${member.user.username} removed reaction ${reaction.emoji}, count is now ${reaction.count}`);
 });
 
 client.on('message', m => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2303,8 +2303,8 @@ declare module 'discord.js' {
     messageReactionRemoveAll: [Message | PartialMessage];
     messageReactionRemoveEmoji: [MessageReaction];
     messageDeleteBulk: [Collection<Snowflake, Message | PartialMessage>];
-    messageReactionAdd: [MessageReaction, User | PartialUser];
-    messageReactionRemove: [MessageReaction, User | PartialUser];
+    messageReactionAdd: [MessageReaction, GuildMember | PartialGuildMember];
+    messageReactionRemove: [MessageReaction, GuildMember | PartialGuildMember];
     messageUpdate: [Message | PartialMessage, Message | PartialMessage];
     presenceUpdate: [Presence | undefined, Presence];
     rateLimit: [RateLimitData];
@@ -2888,11 +2888,11 @@ declare module 'discord.js' {
 
   type OverwriteType = 'member' | 'role';
 
-  interface PermissionFlags extends Record<PermissionString, number> {}
+  interface PermissionFlags extends Record<PermissionString, number> { }
 
-  interface PermissionObject extends Record<PermissionString, boolean> {}
+  interface PermissionObject extends Record<PermissionString, boolean> { }
 
-  interface PermissionOverwriteOption extends Partial<Record<PermissionString, boolean | null>> {}
+  interface PermissionOverwriteOption extends Partial<Record<PermissionString, boolean | null>> { }
 
   type PermissionResolvable = BitFieldResolvable<PermissionString>;
 
@@ -2929,7 +2929,7 @@ declare module 'discord.js' {
     | 'MANAGE_WEBHOOKS'
     | 'MANAGE_EMOJIS';
 
-  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> {}
+  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> { }
 
   type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray<T>>;
 
@@ -2963,16 +2963,16 @@ declare module 'discord.js' {
     partial: true;
     fetch(): Promise<T>;
   } & {
-    [K in keyof Omit<
-      T,
-      'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
-    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-line:ban-types
-  };
+      [K in keyof Omit<
+        T,
+        'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
+      >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-line:ban-types
+    };
 
   interface PartialDMChannel
     extends Partialize<
-      DMChannel,
-      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+    DMChannel,
+    'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
     > {
     lastMessage: null;
     lastMessageID: undefined;
@@ -2999,18 +2999,18 @@ declare module 'discord.js' {
 
   interface PartialGuildMember
     extends Partialize<
-      GuildMember,
-      | 'bannable'
-      | 'displayColor'
-      | 'displayHexColor'
-      | 'displayName'
-      | 'guild'
-      | 'kickable'
-      | 'permissions'
-      | 'roles'
-      | 'manageable'
-      | 'presence'
-      | 'voice'
+    GuildMember,
+    | 'bannable'
+    | 'displayColor'
+    | 'displayHexColor'
+    | 'displayName'
+    | 'guild'
+    | 'kickable'
+    | 'permissions'
+    | 'roles'
+    | 'manageable'
+    | 'presence'
+    | 'voice'
     > {
     readonly bannable: boolean;
     readonly displayColor: number;
@@ -3029,17 +3029,17 @@ declare module 'discord.js' {
 
   interface PartialMessage
     extends Partialize<
-      Message,
-      | 'attachments'
-      | 'channel'
-      | 'deletable'
-      | 'crosspostable'
-      | 'editable'
-      | 'mentions'
-      | 'pinnable'
-      | 'url'
-      | 'flags'
-      | 'embeds'
+    Message,
+    | 'attachments'
+    | 'channel'
+    | 'deletable'
+    | 'crosspostable'
+    | 'editable'
+    | 'mentions'
+    | 'pinnable'
+    | 'url'
+    | 'flags'
+    | 'embeds'
     > {
     attachments: Message['attachments'];
     channel: Message['channel'];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2888,11 +2888,11 @@ declare module 'discord.js' {
 
   type OverwriteType = 'member' | 'role';
 
-  interface PermissionFlags extends Record<PermissionString, number> { }
+  interface PermissionFlags extends Record<PermissionString, number> {}
 
-  interface PermissionObject extends Record<PermissionString, boolean> { }
+  interface PermissionObject extends Record<PermissionString, boolean> {}
 
-  interface PermissionOverwriteOption extends Partial<Record<PermissionString, boolean | null>> { }
+  interface PermissionOverwriteOption extends Partial<Record<PermissionString, boolean | null>> {}
 
   type PermissionResolvable = BitFieldResolvable<PermissionString>;
 
@@ -2929,7 +2929,7 @@ declare module 'discord.js' {
     | 'MANAGE_WEBHOOKS'
     | 'MANAGE_EMOJIS';
 
-  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> { }
+  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> {}
 
   type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray<T>>;
 
@@ -2963,16 +2963,16 @@ declare module 'discord.js' {
     partial: true;
     fetch(): Promise<T>;
   } & {
-      [K in keyof Omit<
-        T,
-        'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
-      >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-line:ban-types
-    };
+    [K in keyof Omit<
+      T,
+      'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
+    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-line:ban-types
+  };
 
   interface PartialDMChannel
     extends Partialize<
-    DMChannel,
-    'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+      DMChannel,
+      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
     > {
     lastMessage: null;
     lastMessageID: undefined;
@@ -2999,18 +2999,18 @@ declare module 'discord.js' {
 
   interface PartialGuildMember
     extends Partialize<
-    GuildMember,
-    | 'bannable'
-    | 'displayColor'
-    | 'displayHexColor'
-    | 'displayName'
-    | 'guild'
-    | 'kickable'
-    | 'permissions'
-    | 'roles'
-    | 'manageable'
-    | 'presence'
-    | 'voice'
+      GuildMember,
+      | 'bannable'
+      | 'displayColor'
+      | 'displayHexColor'
+      | 'displayName'
+      | 'guild'
+      | 'kickable'
+      | 'permissions'
+      | 'roles'
+      | 'manageable'
+      | 'presence'
+      | 'voice'
     > {
     readonly bannable: boolean;
     readonly displayColor: number;
@@ -3029,17 +3029,17 @@ declare module 'discord.js' {
 
   interface PartialMessage
     extends Partialize<
-    Message,
-    | 'attachments'
-    | 'channel'
-    | 'deletable'
-    | 'crosspostable'
-    | 'editable'
-    | 'mentions'
-    | 'pinnable'
-    | 'url'
-    | 'flags'
-    | 'embeds'
+      Message,
+      | 'attachments'
+      | 'channel'
+      | 'deletable'
+      | 'crosspostable'
+      | 'editable'
+      | 'mentions'
+      | 'pinnable'
+      | 'url'
+      | 'flags'
+      | 'embeds'
     > {
     attachments: Message['attachments'];
     channel: Message['channel'];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:** I changed the "user" variable in both of these events to "member" so that people can easily check for the member's roles/other data inside that same guild

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
