### PR TITLE
docs(BaseManager): fix a typo in #resolveID description

### DIFF
--- a/src/managers/BaseManager.js
+++ b/src/managers/BaseManager.js
@@ -69,7 +69,7 @@ class BaseManager {
    */
   resolveID(idOrInstance) {
     if (idOrInstance instanceof this.holds) return idOrInstance.id;
-    if (typeof idOrInstance === 'string' && /^\d{17,19}$/.test(idOrInstance)) return idOrInstance;
+    if (typeof idOrInstance === 'string') return idOrInstance;
     return null;
   }
 

--- a/src/managers/BaseManager.js
+++ b/src/managers/BaseManager.js
@@ -63,13 +63,13 @@ class BaseManager {
   }
 
   /**
-   * Resolves a data entry to a instance ID.
+   * Resolves a data entry to an instance ID.
    * @param {string|Object} idOrInstance The id or instance of something in this Manager
    * @returns {?Snowflake}
    */
   resolveID(idOrInstance) {
     if (idOrInstance instanceof this.holds) return idOrInstance.id;
-    if (typeof idOrInstance === 'string') return idOrInstance;
+    if (typeof idOrInstance === 'string' && /^\d{17,19}$/.test(idOrInstance)) return idOrInstance;
     return null;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds an extra check in the `BaseManager#resolveID` method to make sure that it doesn't return the `idOrInstance` parameter back when it is a non-numeric string. I am aware of the fact that the method only expects a string in the case of a `Snowflake` and passing any other type of string is the fault of the user, but I think in case a user does pass a string, which is not a snowflake the method should return `null` instead of the string that was passed.

I had a chat about this in the discord server with @kyranet and that is from where I got the `regex` used in the PR. It was him who advised me to use regex instead of what I was doing in a somewhat related project. Using `{17, 19}` instead of `{17, 18}` in the regex was @almostSouji's idea for keeping the regex future proof.

While working on this method I noticed a typo in the description of the method, so I fixed that too :)

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [X] This PR **only** includes non-code changes, like changes to documentation, README, etc.
