### PR TITLE
fix(GuildEmoji): check for changes to available in equals

### DIFF
--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -150,6 +150,7 @@ class GuildEmoji extends BaseGuildEmoji {
         other.id === this.id &&
         other.name === this.name &&
         other.managed === this.managed &&
+        other.available === this.available &&
         other.requiresColons === this.requiresColons &&
         other.roles.cache.size === this.roles.cache.size &&
         other.roles.cache.every(role => this.roles.cache.has(role.id))


### PR DESCRIPTION
The available property was unchecked in `GuildEmoji#equals` causing updates to available to go uncached.
closes: #5200

I do not have an available guild where the state of available can change to test this on, please do test this if you can.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
