### PR TITLE
Consider Cloudflare Ratelimits when hitting 429

### DIFF
--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -4,172 +4,170 @@ const AsyncQueue = require('./AsyncQueue');
 const DiscordAPIError = require('./DiscordAPIError');
 const HTTPError = require('./HTTPError');
 const {
-    Events: {
-        RATE_LIMIT
-    },
+  Events: { RATE_LIMIT },
 } = require('../util/Constants');
 const Util = require('../util/Util');
 
 function parseResponse(res) {
-    if (res.headers.get('content-type').startsWith('application/json')) return res.json();
-    return res.buffer();
+  if (res.headers.get('content-type').startsWith('application/json')) return res.json();
+  return res.buffer();
 }
 
 function getAPIOffset(serverDate) {
-    return new Date(serverDate).getTime() - Date.now();
+  return new Date(serverDate).getTime() - Date.now();
 }
 
 function calculateReset(reset, serverDate) {
-    return new Date(Number(reset) * 1000).getTime() - getAPIOffset(serverDate);
+  return new Date(Number(reset) * 1000).getTime() - getAPIOffset(serverDate);
 }
 
 class RequestHandler {
-    constructor(manager) {
-        this.manager = manager;
-        this.queue = new AsyncQueue();
-        this.reset = -1;
-        this.remaining = -1;
-        this.limit = -1;
-        this.retryAfter = -1;
+  constructor(manager) {
+    this.manager = manager;
+    this.queue = new AsyncQueue();
+    this.reset = -1;
+    this.remaining = -1;
+    this.limit = -1;
+    this.retryAfter = -1;
+  }
+
+  async push(request) {
+    await this.queue.wait();
+    try {
+      return await this.execute(request);
+    } finally {
+      this.queue.shift();
+    }
+  }
+
+  get limited() {
+    return Boolean(this.manager.globalTimeout) || (this.remaining <= 0 && Date.now() < this.reset);
+  }
+
+  get _inactive() {
+    return this.queue.remaining === 0 && !this.limited;
+  }
+
+  async execute(request) {
+    // After calculations and requests have been done, pre-emptively stop further requests
+    if (this.limited) {
+      const timeout = this.reset + this.manager.client.options.restTimeOffset - Date.now();
+
+      if (this.manager.client.listenerCount(RATE_LIMIT)) {
+        /**
+         * Emitted when the client hits a rate limit while making a request
+         * @event Client#rateLimit
+         * @param {Object} rateLimitInfo Object containing the rate limit info
+         * @param {number} rateLimitInfo.timeout Timeout in ms
+         * @param {number} rateLimitInfo.limit Number of requests that can be made to this endpoint
+         * @param {string} rateLimitInfo.method HTTP method used for request that triggered this event
+         * @param {string} rateLimitInfo.path Path used for request that triggered this event
+         * @param {string} rateLimitInfo.route Route used for request that triggered this event
+         */
+        this.manager.client.emit(RATE_LIMIT, {
+          timeout,
+          limit: this.limit,
+          method: request.method,
+          path: request.path,
+          route: request.route,
+        });
+      }
+
+      if (this.manager.globalTimeout) {
+        await this.manager.globalTimeout;
+      } else {
+        // Wait for the timeout to expire in order to avoid an actual 429
+        await Util.delayFor(timeout);
+      }
     }
 
-    async push(request) {
-        await this.queue.wait();
-        try {
-            return await this.execute(request);
-        } finally {
-            this.queue.shift();
-        }
+    // Perform the request
+    let res;
+    try {
+      res = await request.make();
+    } catch (error) {
+      // Retry the specified number of times for request abortions
+      if (request.retries === this.manager.client.options.retryLimit) {
+        throw new HTTPError(error.message, error.constructor.name, error.status, request.method, request.path);
+      }
+
+      request.retries++;
+      return this.execute(request);
     }
 
-    get limited() {
-        return Boolean(this.manager.globalTimeout) || (this.remaining <= 0 && Date.now() < this.reset);
+    if (res && res.headers) {
+      const serverDate = res.headers.get('date');
+      const limit = res.headers.get('x-ratelimit-limit');
+      const remaining = res.headers.get('x-ratelimit-remaining');
+      const reset = res.headers.get('x-ratelimit-reset');
+      const retryAfter = res.headers.get('retry-after');
+
+      this.limit = limit ? Number(limit) : Infinity;
+      this.remaining = remaining ? Number(remaining) : 1;
+      this.reset = reset ? calculateReset(reset, serverDate) : Date.now();
+      this.retryAfter = retryAfter ? Number(retryAfter) : -1;
+
+      // https://github.com/discordapp/discord-api-docs/issues/182
+      if (request.route.includes('reactions')) {
+        this.reset = new Date(serverDate).getTime() - getAPIOffset(serverDate) + 250;
+      }
+
+      // Handle global ratelimit
+      if (res.headers.get('x-ratelimit-global')) {
+        // Set the manager's global timeout as the promise for other requests to "wait"
+        this.manager.globalTimeout = Util.delayFor(this.retryAfter);
+
+        // Wait for the global timeout to resolve before continuing
+        await this.manager.globalTimeout;
+
+        // Clean up global timeout
+        this.manager.globalTimeout = null;
+      }
     }
 
-    get _inactive() {
-        return this.queue.remaining === 0 && !this.limited;
+    // Handle 2xx and 3xx responses
+    if (res.ok) {
+      // Nothing wrong with the request, proceed with the next one
+      return parseResponse(res);
     }
 
-    async execute(request) {
-        // After calculations and requests have been done, pre-emptively stop further requests
-        if (this.limited) {
-            const timeout = this.reset + this.manager.client.options.restTimeOffset - Date.now();
+    // Handle 4xx responses
+    if (res.status >= 400 && res.status < 500) {
+      // Handle ratelimited requests
+      if (res.status === 429) {
+        // A ratelimit was hit - this should never happen
+        const body = await res.json();
+        const CF_RM = (!res.headers.get('via')?.length || (body?.message?.startsWith("You are being blocked from accessing our API")));
+        this.manager.client.emit('debug', `429 hit${CF_RM ? ' [Cloudflare Ratelimit]' : ''} on route ${request.route}`);
+        await Util.delayFor(this.retryAfter * (CF_RM ? 1000 : 1)); // retryAfter is in seconds if we got ratelimited by Cloudflare
+        return this.execute(request);
+      }
 
-            if (this.manager.client.listenerCount(RATE_LIMIT)) {
-                /**
-                 * Emitted when the client hits a rate limit while making a request
-                 * @event Client#rateLimit
-                 * @param {Object} rateLimitInfo Object containing the rate limit info
-                 * @param {number} rateLimitInfo.timeout Timeout in ms
-                 * @param {number} rateLimitInfo.limit Number of requests that can be made to this endpoint
-                 * @param {string} rateLimitInfo.method HTTP method used for request that triggered this event
-                 * @param {string} rateLimitInfo.path Path used for request that triggered this event
-                 * @param {string} rateLimitInfo.route Route used for request that triggered this event
-                 */
-                this.manager.client.emit(RATE_LIMIT, {
-                    timeout,
-                    limit: this.limit,
-                    method: request.method,
-                    path: request.path,
-                    route: request.route,
-                });
-            }
+      // Handle possible malformed requests
+      let data;
+      try {
+        data = await parseResponse(res);
+      } catch (err) {
+        throw new HTTPError(err.message, err.constructor.name, err.status, request.method, request.path);
+      }
 
-            if (this.manager.globalTimeout) {
-                await this.manager.globalTimeout;
-            } else {
-                // Wait for the timeout to expire in order to avoid an actual 429
-                await Util.delayFor(timeout);
-            }
-        }
-
-        // Perform the request
-        let res;
-        try {
-            res = await request.make();
-        } catch (error) {
-            // Retry the specified number of times for request abortions
-            if (request.retries === this.manager.client.options.retryLimit) {
-                throw new HTTPError(error.message, error.constructor.name, error.status, request.method, request.path);
-            }
-
-            request.retries++;
-            return this.execute(request);
-        }
-
-        if (res && res.headers) {
-            const serverDate = res.headers.get('date');
-            const limit = res.headers.get('x-ratelimit-limit');
-            const remaining = res.headers.get('x-ratelimit-remaining');
-            const reset = res.headers.get('x-ratelimit-reset');
-            const retryAfter = res.headers.get('retry-after');
-
-            this.limit = limit ? Number(limit) : Infinity;
-            this.remaining = remaining ? Number(remaining) : 1;
-            this.reset = reset ? calculateReset(reset, serverDate) : Date.now();
-            this.retryAfter = retryAfter ? Number(retryAfter) : -1;
-
-            // https://github.com/discordapp/discord-api-docs/issues/182
-            if (request.route.includes('reactions')) {
-                this.reset = new Date(serverDate).getTime() - getAPIOffset(serverDate) + 250;
-            }
-
-            // Handle global ratelimit
-            if (res.headers.get('x-ratelimit-global')) {
-                // Set the manager's global timeout as the promise for other requests to "wait"
-                this.manager.globalTimeout = Util.delayFor(this.retryAfter);
-
-                // Wait for the global timeout to resolve before continuing
-                await this.manager.globalTimeout;
-
-                // Clean up global timeout
-                this.manager.globalTimeout = null;
-            }
-        }
-
-        // Handle 2xx and 3xx responses
-        if (res.ok) {
-            // Nothing wrong with the request, proceed with the next one
-            return parseResponse(res);
-        }
-
-        // Handle 4xx responses
-        if (res.status >= 400 && res.status < 500) {
-            // Handle ratelimited requests
-            if (res.status === 429) {
-                // A ratelimit was hit - this should never happen
-                const body = await res.json();
-                const CF_RM = (!res.headers.get('via')?.length || (body?.message?.startsWith("You are being blocked from accessing our API")));
-                this.manager.client.emit('debug', `429 hit${CF_RM ? ' [Cloudflare Ratelimit]' : ''} on route ${request.route}`);
-                await Util.delayFor(this.retryAfter * (CF_RM ? 1000 : 1)); // retryAfter is in seconds if we got ratelimited by Cloudflare
-                return this.execute(request);
-            }
-
-            // Handle possible malformed requests
-            let data;
-            try {
-                data = await parseResponse(res);
-            } catch (err) {
-                throw new HTTPError(err.message, err.constructor.name, err.status, request.method, request.path);
-            }
-
-            throw new DiscordAPIError(request.path, data, request.method, res.status);
-        }
-
-        // Handle 5xx responses
-        if (res.status >= 500 && res.status < 600) {
-            // Retry the specified number of times for possible serverside issues
-            if (request.retries === this.manager.client.options.retryLimit) {
-                throw new HTTPError(res.statusText, res.constructor.name, res.status, request.method, request.path);
-            }
-
-            request.retries++;
-            return this.execute(request);
-        }
-
-        // Fallback in the rare case a status code outside the range 200..=599 is returned
-        return null;
+      throw new DiscordAPIError(request.path, data, request.method, res.status);
     }
+
+    // Handle 5xx responses
+    if (res.status >= 500 && res.status < 600) {
+      // Retry the specified number of times for possible serverside issues
+      if (request.retries === this.manager.client.options.retryLimit) {
+        throw new HTTPError(res.statusText, res.constructor.name, res.status, request.method, request.path);
+      }
+
+      request.retries++;
+      return this.execute(request);
+    }
+
+    // Fallback in the rare case a status code outside the range 200..=599 is returned
+    return null;
+  }
 }
 
 module.exports = RequestHandler;

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -4,168 +4,172 @@ const AsyncQueue = require('./AsyncQueue');
 const DiscordAPIError = require('./DiscordAPIError');
 const HTTPError = require('./HTTPError');
 const {
-  Events: { RATE_LIMIT },
+    Events: {
+        RATE_LIMIT
+    },
 } = require('../util/Constants');
 const Util = require('../util/Util');
 
 function parseResponse(res) {
-  if (res.headers.get('content-type').startsWith('application/json')) return res.json();
-  return res.buffer();
+    if (res.headers.get('content-type').startsWith('application/json')) return res.json();
+    return res.buffer();
 }
 
 function getAPIOffset(serverDate) {
-  return new Date(serverDate).getTime() - Date.now();
+    return new Date(serverDate).getTime() - Date.now();
 }
 
 function calculateReset(reset, serverDate) {
-  return new Date(Number(reset) * 1000).getTime() - getAPIOffset(serverDate);
+    return new Date(Number(reset) * 1000).getTime() - getAPIOffset(serverDate);
 }
 
 class RequestHandler {
-  constructor(manager) {
-    this.manager = manager;
-    this.queue = new AsyncQueue();
-    this.reset = -1;
-    this.remaining = -1;
-    this.limit = -1;
-    this.retryAfter = -1;
-  }
-
-  async push(request) {
-    await this.queue.wait();
-    try {
-      return await this.execute(request);
-    } finally {
-      this.queue.shift();
-    }
-  }
-
-  get limited() {
-    return Boolean(this.manager.globalTimeout) || (this.remaining <= 0 && Date.now() < this.reset);
-  }
-
-  get _inactive() {
-    return this.queue.remaining === 0 && !this.limited;
-  }
-
-  async execute(request) {
-    // After calculations and requests have been done, pre-emptively stop further requests
-    if (this.limited) {
-      const timeout = this.reset + this.manager.client.options.restTimeOffset - Date.now();
-
-      if (this.manager.client.listenerCount(RATE_LIMIT)) {
-        /**
-         * Emitted when the client hits a rate limit while making a request
-         * @event Client#rateLimit
-         * @param {Object} rateLimitInfo Object containing the rate limit info
-         * @param {number} rateLimitInfo.timeout Timeout in ms
-         * @param {number} rateLimitInfo.limit Number of requests that can be made to this endpoint
-         * @param {string} rateLimitInfo.method HTTP method used for request that triggered this event
-         * @param {string} rateLimitInfo.path Path used for request that triggered this event
-         * @param {string} rateLimitInfo.route Route used for request that triggered this event
-         */
-        this.manager.client.emit(RATE_LIMIT, {
-          timeout,
-          limit: this.limit,
-          method: request.method,
-          path: request.path,
-          route: request.route,
-        });
-      }
-
-      if (this.manager.globalTimeout) {
-        await this.manager.globalTimeout;
-      } else {
-        // Wait for the timeout to expire in order to avoid an actual 429
-        await Util.delayFor(timeout);
-      }
+    constructor(manager) {
+        this.manager = manager;
+        this.queue = new AsyncQueue();
+        this.reset = -1;
+        this.remaining = -1;
+        this.limit = -1;
+        this.retryAfter = -1;
     }
 
-    // Perform the request
-    let res;
-    try {
-      res = await request.make();
-    } catch (error) {
-      // Retry the specified number of times for request abortions
-      if (request.retries === this.manager.client.options.retryLimit) {
-        throw new HTTPError(error.message, error.constructor.name, error.status, request.method, request.path);
-      }
-
-      request.retries++;
-      return this.execute(request);
+    async push(request) {
+        await this.queue.wait();
+        try {
+            return await this.execute(request);
+        } finally {
+            this.queue.shift();
+        }
     }
 
-    if (res && res.headers) {
-      const serverDate = res.headers.get('date');
-      const limit = res.headers.get('x-ratelimit-limit');
-      const remaining = res.headers.get('x-ratelimit-remaining');
-      const reset = res.headers.get('x-ratelimit-reset');
-      const retryAfter = res.headers.get('retry-after');
-
-      this.limit = limit ? Number(limit) : Infinity;
-      this.remaining = remaining ? Number(remaining) : 1;
-      this.reset = reset ? calculateReset(reset, serverDate) : Date.now();
-      this.retryAfter = retryAfter ? Number(retryAfter) : -1;
-
-      // https://github.com/discordapp/discord-api-docs/issues/182
-      if (request.route.includes('reactions')) {
-        this.reset = new Date(serverDate).getTime() - getAPIOffset(serverDate) + 250;
-      }
-
-      // Handle global ratelimit
-      if (res.headers.get('x-ratelimit-global')) {
-        // Set the manager's global timeout as the promise for other requests to "wait"
-        this.manager.globalTimeout = Util.delayFor(this.retryAfter);
-
-        // Wait for the global timeout to resolve before continuing
-        await this.manager.globalTimeout;
-
-        // Clean up global timeout
-        this.manager.globalTimeout = null;
-      }
+    get limited() {
+        return Boolean(this.manager.globalTimeout) || (this.remaining <= 0 && Date.now() < this.reset);
     }
 
-    // Handle 2xx and 3xx responses
-    if (res.ok) {
-      // Nothing wrong with the request, proceed with the next one
-      return parseResponse(res);
+    get _inactive() {
+        return this.queue.remaining === 0 && !this.limited;
     }
 
-    // Handle 4xx responses
-    if (res.status >= 400 && res.status < 500) {
-      // Handle ratelimited requests
-      if (res.status === 429) {
-        // A ratelimit was hit - this should never happen
-        this.manager.client.emit('debug', `429 hit on route ${request.route}`);
-        await Util.delayFor(this.retryAfter);
-        return this.execute(request);
-      }
+    async execute(request) {
+        // After calculations and requests have been done, pre-emptively stop further requests
+        if (this.limited) {
+            const timeout = this.reset + this.manager.client.options.restTimeOffset - Date.now();
 
-      // Handle possible malformed requests
-      let data;
-      try {
-        data = await parseResponse(res);
-      } catch (err) {
-        throw new HTTPError(err.message, err.constructor.name, err.status, request.method, request.path);
-      }
+            if (this.manager.client.listenerCount(RATE_LIMIT)) {
+                /**
+                 * Emitted when the client hits a rate limit while making a request
+                 * @event Client#rateLimit
+                 * @param {Object} rateLimitInfo Object containing the rate limit info
+                 * @param {number} rateLimitInfo.timeout Timeout in ms
+                 * @param {number} rateLimitInfo.limit Number of requests that can be made to this endpoint
+                 * @param {string} rateLimitInfo.method HTTP method used for request that triggered this event
+                 * @param {string} rateLimitInfo.path Path used for request that triggered this event
+                 * @param {string} rateLimitInfo.route Route used for request that triggered this event
+                 */
+                this.manager.client.emit(RATE_LIMIT, {
+                    timeout,
+                    limit: this.limit,
+                    method: request.method,
+                    path: request.path,
+                    route: request.route,
+                });
+            }
 
-      throw new DiscordAPIError(request.path, data, request.method, res.status);
+            if (this.manager.globalTimeout) {
+                await this.manager.globalTimeout;
+            } else {
+                // Wait for the timeout to expire in order to avoid an actual 429
+                await Util.delayFor(timeout);
+            }
+        }
+
+        // Perform the request
+        let res;
+        try {
+            res = await request.make();
+        } catch (error) {
+            // Retry the specified number of times for request abortions
+            if (request.retries === this.manager.client.options.retryLimit) {
+                throw new HTTPError(error.message, error.constructor.name, error.status, request.method, request.path);
+            }
+
+            request.retries++;
+            return this.execute(request);
+        }
+
+        if (res && res.headers) {
+            const serverDate = res.headers.get('date');
+            const limit = res.headers.get('x-ratelimit-limit');
+            const remaining = res.headers.get('x-ratelimit-remaining');
+            const reset = res.headers.get('x-ratelimit-reset');
+            const retryAfter = res.headers.get('retry-after');
+
+            this.limit = limit ? Number(limit) : Infinity;
+            this.remaining = remaining ? Number(remaining) : 1;
+            this.reset = reset ? calculateReset(reset, serverDate) : Date.now();
+            this.retryAfter = retryAfter ? Number(retryAfter) : -1;
+
+            // https://github.com/discordapp/discord-api-docs/issues/182
+            if (request.route.includes('reactions')) {
+                this.reset = new Date(serverDate).getTime() - getAPIOffset(serverDate) + 250;
+            }
+
+            // Handle global ratelimit
+            if (res.headers.get('x-ratelimit-global')) {
+                // Set the manager's global timeout as the promise for other requests to "wait"
+                this.manager.globalTimeout = Util.delayFor(this.retryAfter);
+
+                // Wait for the global timeout to resolve before continuing
+                await this.manager.globalTimeout;
+
+                // Clean up global timeout
+                this.manager.globalTimeout = null;
+            }
+        }
+
+        // Handle 2xx and 3xx responses
+        if (res.ok) {
+            // Nothing wrong with the request, proceed with the next one
+            return parseResponse(res);
+        }
+
+        // Handle 4xx responses
+        if (res.status >= 400 && res.status < 500) {
+            // Handle ratelimited requests
+            if (res.status === 429) {
+                // A ratelimit was hit - this should never happen
+                const body = await res.json();
+                const CF_RM = (!res.headers.get('via')?.length || (body?.message?.startsWith("You are being blocked from accessing our API")));
+                this.manager.client.emit('debug', `429 hit${CF_RM ? ' [Cloudflare Ratelimit]' : ''} on route ${request.route}`);
+                await Util.delayFor(this.retryAfter * (CF_RM ? 1000 : 1)); // retryAfter is in seconds if we got ratelimited by Cloudflare
+                return this.execute(request);
+            }
+
+            // Handle possible malformed requests
+            let data;
+            try {
+                data = await parseResponse(res);
+            } catch (err) {
+                throw new HTTPError(err.message, err.constructor.name, err.status, request.method, request.path);
+            }
+
+            throw new DiscordAPIError(request.path, data, request.method, res.status);
+        }
+
+        // Handle 5xx responses
+        if (res.status >= 500 && res.status < 600) {
+            // Retry the specified number of times for possible serverside issues
+            if (request.retries === this.manager.client.options.retryLimit) {
+                throw new HTTPError(res.statusText, res.constructor.name, res.status, request.method, request.path);
+            }
+
+            request.retries++;
+            return this.execute(request);
+        }
+
+        // Fallback in the rare case a status code outside the range 200..=599 is returned
+        return null;
     }
-
-    // Handle 5xx responses
-    if (res.status >= 500 && res.status < 600) {
-      // Retry the specified number of times for possible serverside issues
-      if (request.retries === this.manager.client.options.retryLimit) {
-        throw new HTTPError(res.statusText, res.constructor.name, res.status, request.method, request.path);
-      }
-
-      request.retries++;
-      return this.execute(request);
-    }
-
-    // Fallback in the rare case a status code outside the range 200..=599 is returned
-    return null;
-  }
 }
 
 module.exports = RequestHandler;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
We can get 429s from Cloudflare where the retryAfter is actually in seconds and not milliseconds which would result in an issue especially for large bots. I faced the issue myself and had to see how it can be identified.
When it's a cloudflare rate limit, the VIA header is missing and the body message has the "You are being blocked from accessing our API temporarily due to exceeding our rate limits frequently....". A safe solution would be awaiting in seconds and not milliseconds when this behavior is noticed. This fix did it for me.

**Status**

- [1] Code changes have been tested against the Discord API
- [1] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [0] This PR changes the library's interface (methods or parameters added)
- [0] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [0] This PR **only** includes non-code changes, like changes to documentation, README, etc.
