### PR TITLE
types(RateLimitData): remove timeDifference property

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3076,7 +3076,6 @@ declare module 'discord.js' {
   interface RateLimitData {
     timeout: number;
     limit: number;
-    timeDifference: number;
     method: string;
     path: string;
     route: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR removes the "timeDifference " property from the RateLimitData type, since this property no longer exists in the implementation:
```javascript
this.manager.client.emit(RATE_LIMIT, {
  timeout,
  limit: this.limit,
  method: request.method,
  path: request.path,
  route: request.route,
});
```

**Status**

- [ x] Code changes have been tested against the Discord API, or there are no code changes
- [ x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ x] This PR **only** includes non-code changes, like changes to documentation, README, etc.