### PR TITLE
feat(Client): add InviteGenerationOptions#additionalScopes

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -423,7 +423,7 @@ class Client extends BaseClient {
         }
       });
       scopes.unshift('bot');
-      query.set('scope', scopes.join('+'));
+      query.set('scope', scopes.join(' '));
     }
 
     return `${this.options.http.api}${this.api.oauth2.authorize}?${query}`;

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -417,11 +417,9 @@ class Client extends BaseClient {
 
     if (options.additionalScopes) {
       const scopes = options.additionalScopes;
-      scopes.forEach(scope => {
-        if (!InviteScopes.includes(scope)) {
-          throw new TypeError('INVALID_TYPE', 'additionalScopes', 'Array of Invite Scopes', true);
-        }
-      });
+      if (scopes.some(scope => !InviteScopes.includes(scope))) {
+        throw new TypeError('INVALID_TYPE', 'additionalScopes', 'Array of Invite Scopes', true);
+      }
       scopes.unshift('bot');
       query.set('scope', scopes.join(' '));
     }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -17,7 +17,7 @@ const Invite = require('../structures/Invite');
 const VoiceRegion = require('../structures/VoiceRegion');
 const Webhook = require('../structures/Webhook');
 const Collection = require('../util/Collection');
-const { Events, DefaultOptions } = require('../util/Constants');
+const { Events, DefaultOptions, InviteScopes } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const Intents = require('../util/Intents');
 const Permissions = require('../util/Permissions');
@@ -377,6 +377,7 @@ class Client extends BaseClient {
    * @property {PermissionResolvable} [permissions] Permissions to request
    * @property {GuildResolvable} [guild] Guild to preselect
    * @property {boolean} [disableGuildSelect] Whether to disable the guild selection
+   * @property {InviteScope[]} additionalScopes
    */
 
   /**
@@ -412,6 +413,17 @@ class Client extends BaseClient {
       const guildID = this.guilds.resolveID(options.guild);
       if (!guildID) throw new TypeError('INVALID_TYPE', 'options.guild', 'GuildResolvable');
       query.set('guild_id', guildID);
+    }
+
+    if (options.additionalScopes) {
+      const scopes = options.additionalScopes;
+      scopes.forEach(scope => {
+        if (!InviteScopes.includes(scope)) {
+          throw new TypeError('INVALID_TYPE', 'additionalScopes', 'Array of Invite Scopes', true);
+        }
+      });
+      scopes.unshift('bot');
+      query.set('scope', scopes.join('+'));
     }
 
     return `${this.options.http.api}${this.api.oauth2.authorize}?${query}`;

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -417,11 +417,10 @@ class Client extends BaseClient {
 
     if (options.additionalScopes) {
       const scopes = options.additionalScopes;
-      if (scopes.some(scope => !InviteScopes.includes(scope))) {
+      if (!Array.isArray(scopes) || scopes.some(scope => !InviteScopes.includes(scope))) {
         throw new TypeError('INVALID_TYPE', 'additionalScopes', 'Array of Invite Scopes', true);
       }
-      scopes.unshift('bot');
-      query.set('scope', scopes.join(' '));
+      query.set('scope', ['bot', ...scopes].join(' '));
     }
 
     return `${this.options.http.api}${this.api.oauth2.authorize}?${query}`;

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -419,8 +419,9 @@ class Client extends BaseClient {
       const scopes = options.additionalScopes;
       if (!Array.isArray(scopes)) {
         throw new TypeError('INVALID_TYPE', 'additionalScopes', 'Array of Invite Scopes', true);
-      } else if (scopes.some(scope => !InviteScopes.includes(scope))) {
-        const invalidScope = scopes.find(scope => !InviteScopes.includes(scope));
+      }
+      const invalidScope = scopes.find(scope => !InviteScopes.includes(scope));
+      if (invalidScope) {
         throw new TypeError('INVALID_ELEMENT', 'Array', 'additionalScopes', invalidScope);
       }
       query.set('scope', ['bot', ...scopes].join(' '));

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -377,7 +377,7 @@ class Client extends BaseClient {
    * @property {PermissionResolvable} [permissions] Permissions to request
    * @property {GuildResolvable} [guild] Guild to preselect
    * @property {boolean} [disableGuildSelect] Whether to disable the guild selection
-   * @property {InviteScope[]} additionalScopes
+   * @property {InviteScope[]} [additionalScopes] Whether any additional scopes should be requested
    */
 
   /**

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -417,8 +417,11 @@ class Client extends BaseClient {
 
     if (options.additionalScopes) {
       const scopes = options.additionalScopes;
-      if (!Array.isArray(scopes) || scopes.some(scope => !InviteScopes.includes(scope))) {
+      if (!Array.isArray(scopes)) {
         throw new TypeError('INVALID_TYPE', 'additionalScopes', 'Array of Invite Scopes', true);
+      } else if (scopes.some(scope => !InviteScopes.includes(scope))) {
+        const invalidScope = scopes.find(scope => !InviteScopes.includes(scope));
+        throw new TypeError('INVALID_ELEMENT', 'Array', 'additionalScopes', invalidScope);
       }
       query.set('scope', ['bot', ...scopes].join(' '));
     }

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -89,6 +89,7 @@ const Messages = {
   GUILD_UNCACHED_ME: 'The client user as a member of this guild is uncached.',
 
   INVALID_TYPE: (name, expected, an = false) => `Supplied ${name} is not a${an ? 'n' : ''} ${expected}.`,
+  INVALID_ELEMENT: (type, name, elem) => `Supplied ${type} ${name} includes an invalid element: ${elem}`,
 
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -383,6 +383,8 @@ exports.WSEvents = keyMirror([
  * <warn>Scopes that require whitelist are not considered valid for this generator</warn>
  * * `applications.builds.read`: allows reading build data for a users applications
  * * `applications.commands`: allows this bot to create commands in the server
+ * * `applications.entitlements`: allows reading entitlements for a users applications
+ * * `applications.store.update`: allows reading and updating of store data for a users applications
  * * `connections`: makes the endpoint for getting a users connections available
  * * `email`: allows the `/users/@me` endpoint return with an email
  * * `identify`: allows the `/users/@me` endpoint without an email

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -379,6 +379,34 @@ exports.WSEvents = keyMirror([
 ]);
 
 /**
+ * A valid scope to request when generating an invite link.
+ * <warn>Scopes that require whitelist are not considered valid for this generator</warn>
+ * * `applications.builds.read`: allows reading build data for a users applications
+ * * `applications.commands`: allows this bot to create commands in the server
+ * * `connections`: makes the endpoint for getting a users connections available
+ * * `email`: allows the `/users/@me` endpoint return with an email
+ * * `identify`: allows the `/users/@me` endpoint without an email
+ * * `guilds`: makes the `/users/@me/guilds` endpoint available for a user
+ * * `guilds.join`: allows the bot to join the user to any guild it is in using Guild#addMember
+ * * `gdm.join`: allows joining the user to a group dm
+ * * `webhook.incoming`: generates a webhook to a channel
+ * @typedef {string} InviteScope
+ */
+exports.InviteScopes = [
+  'applications.builds.read',
+  'applications.commands',
+  'applications.entitlements',
+  'applications.store.update',
+  'connections',
+  'email',
+  'identity',
+  'guilds',
+  'guilds.join',
+  'gdm.join',
+  'webhook.incoming',
+];
+
+/**
  * The type of a message, e.g. `DEFAULT`. Here are the available types:
  * * DEFAULT
  * * RECIPIENT_ADD

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -513,6 +513,7 @@ declare module 'discord.js' {
       SMALL: 1;
       BIG: 2;
     };
+    InviteScopes: InviteScope[];
     MessageTypes: MessageType[];
     SystemMessageTypes: SystemMessageType[];
     ActivityTypes: ActivityType[];
@@ -2729,6 +2730,7 @@ declare module 'discord.js' {
     permissions?: PermissionResolvable;
     guild?: GuildResolvable;
     disableGuildSelect?: boolean;
+    additionalScopes?: InviteScope[];
   }
 
   interface InviteOptions {
@@ -2740,6 +2742,19 @@ declare module 'discord.js' {
   }
 
   type InviteResolvable = string;
+
+  type InviteScope =
+    | 'applications.builds.read'
+    | 'applications.commands'
+    | 'applications.entitlements'
+    | 'applications.store.update'
+    | 'connections'
+    | 'email'
+    | 'identity'
+    | 'guilds'
+    | 'guilds.join'
+    | 'gdm.join'
+    | 'webhook.incoming';
 
   type GuildTemplateResolvable = string;
 


### PR DESCRIPTION
This PR adds the ability to generate an invite link with additional scopes. 
It does not accept all scopes as valid due to whitelist requirements and that combining those scopes with the bot scopes is highly unlikely

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
