### PR TITLE
fix(VoiceConnection): make #dispatcher nullable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1648,7 +1648,7 @@ declare module 'discord.js' {
 
     public channel: VoiceChannel;
     public readonly client: Client;
-    public readonly dispatcher: StreamDispatcher;
+    public readonly dispatcher: StreamDispatcher | null;
     public player: object;
     public receiver: VoiceReceiver;
     public speaking: Readonly<Speaking>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

fixes: #5205
The `dispatcher` property of `VoiceConnection` is marked as nullable in docs but only got `StreamDispatcher` as its type in typings. This PR fixes it.

**Status**

- [ ] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [X] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
