### PR TITLE
feat(ShardingManager): Allow b-Eval/fetchClientValues on a specific shard when not all are ready

### DIFF
--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -255,12 +255,13 @@ class ShardingManager extends EventEmitter {
    */
   _performOnShards(method, args, shard) {
     if (this.shards.size === 0) return Promise.reject(new Error('SHARDING_NO_SHARDS'));
-    if (this.shards.size !== this.shardList.length) return Promise.reject(new Error('SHARDING_IN_PROCESS'));
 
     if (typeof shard === 'number') {
       if (this.shards.has(shard)) return this.shards.get(shard)[method](...args);
       return Promise.reject(new Error('SHARDING_SHARD_NOT_FOUND', shard));
     }
+
+    if (this.shards.size !== this.shardList.length) return Promise.reject(new Error('SHARDING_IN_PROCESS'));
 
     const promises = [];
     for (const sh of this.shards.values()) promises.push(sh[method](...args));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
