### PR TITLE
feat(BitField): move problematic bit into the error message

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -13,7 +13,7 @@ const Messages = {
   WS_CONNECTION_EXISTS: 'There is already an existing WebSocket connection.',
   WS_NOT_OPEN: (data = 'data') => `Websocket not open to send ${data}`,
 
-  BITFIELD_INVALID: 'Invalid bitfield flag or number.',
+  BITFIELD_INVALID: bit => `Invalid bitfield flag or number: ${bit}.`,
 
   SHARDING_INVALID: 'Invalid shard settings were provided.',
   SHARDING_REQUIRED: 'This session would have handled too many guilds - Sharding is required.',

--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -147,8 +147,7 @@ class BitField {
     if (bit instanceof BitField) return bit.bitfield;
     if (Array.isArray(bit)) return bit.map(p => this.resolve(p)).reduce((prev, p) => prev | p, 0);
     if (typeof bit === 'string' && typeof this.FLAGS[bit] !== 'undefined') return this.FLAGS[bit];
-    const error = new RangeError('BITFIELD_INVALID', bit);
-    throw error;
+    throw new RangeError('BITFIELD_INVALID', bit);
   }
 }
 

--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -147,8 +147,7 @@ class BitField {
     if (bit instanceof BitField) return bit.bitfield;
     if (Array.isArray(bit)) return bit.map(p => this.resolve(p)).reduce((prev, p) => prev | p, 0);
     if (typeof bit === 'string' && typeof this.FLAGS[bit] !== 'undefined') return this.FLAGS[bit];
-    const error = new RangeError('BITFIELD_INVALID');
-    error.bit = bit;
+    const error = new RangeError('BITFIELD_INVALID', bit);
     throw error;
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR moves the invalid bit for BITFIELD_INVALID errors into the error message. This was previously the preferred approach, reverted due to forcing semver major by changing a public-facing message (#4617).

This should greatly increase the visibility of invalid bits being passed in various places, reducing the number of requests regarding typos and outright wrong flags being used in support.

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
