### PR TITLE
Add GuildChannel.deleteOverwrite()

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -267,7 +267,7 @@ class GuildChannel extends Channel {
 
   /**
    * Deletes existing permission overwrites for a user or role in this channel.
-   * @param {RoleResolvable|UserResolvable} userOrRole The user or role to update
+   * @param {RoleResolvable|UserResolvable} userOrRole The user or role's permission overwrites to delete
    * @returns {Promise<GuildChannel>}
    * @example
    * // Delete permission overwrites for a message author

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -266,6 +266,26 @@ class GuildChannel extends Channel {
   }
 
   /**
+   * Deletes existing permission overwrites for a user or role in this channel.
+   * @param {RoleResolvable|UserResolvable} userOrRole The user or role to update
+   * @returns {Promise<GuildChannel>}
+   * @example
+   * // Delete permission overwrites for a message author
+   * message.channel.deleteOverwrite(message.author)
+   *   .then(() => console.log("Deleted permission overwrites for " + message.author.tag + " in " + message.channel))
+   *   .catch(console.error);
+   */
+  deleteOverwrite(userOrRole) {
+    userOrRole = this.guild.roles.resolve(userOrRole) || this.client.users.resolve(userOrRole);
+    if (!userOrRole) return Promise.reject(new TypeError('INVALID_TYPE', 'parameter', 'User nor a Role'));
+
+    return this.client.api
+      .channels(this.id)
+      .permissions[userOrRole.id].delete(userOrRole.id)
+      .then(() => this);
+  }
+
+  /**
    * Locks in the permission overwrites from the parent channel.
    * @returns {Promise<GuildChannel>}
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -757,6 +757,7 @@ declare module 'discord.js' {
       options: PermissionOverwriteOption,
       reason?: string,
     ): Promise<this>;
+    public deleteOverwrite(userOrRole: RoleResolvable | UserResolvable): Promise<this>;
     public edit(data: ChannelData, reason?: string): Promise<this>;
     public equals(channel: GuildChannel): boolean;
     public fetchInvites(): Promise<Collection<string, Invite>>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:** There were methods for creating and updating permission overwrites in a channel, but not for deleting them, so I added one. It doesn't support a reason due to apparent Discord API limitations so the only parameter it supports is the User or Role resolvable

**Status**

- [X] Code changes have been tested against the Discord API, or there are no code changes
- [X] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [X] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
