### PR TITLE
fix(GuildChannel): regression on default channel type

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -357,7 +357,7 @@ class GuildChannel extends Channel {
     const newData = await this.client.api.channels(this.id).patch({
       data: {
         name: (data.name || this.name).trim(),
-        type: data.type ? ChannelTypes[data.type.toUpperCase()] : this.type,
+        type: data.type ? ChannelTypes[data.type.toUpperCase()] : ChannelTypes[this.type.toUpperCase()],
         topic: data.topic,
         nsfw: data.nsfw,
         bitrate: data.bitrate || this.bitrate,

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -357,7 +357,7 @@ class GuildChannel extends Channel {
     const newData = await this.client.api.channels(this.id).patch({
       data: {
         name: (data.name || this.name).trim(),
-        type: data.type ? ChannelTypes[data.type.toUpperCase()] : ChannelTypes[this.type.toUpperCase()],
+        type: ChannelTypes[data.type?.toUpperCase()],
         topic: data.topic,
         nsfw: data.nsfw,
         bitrate: data.bitrate || this.bitrate,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

⚠️ closes #5273

The merge of #5022 has caused a regression, which this PR aims to fix.

When no channel is provided in data the PR defaults to `this.type`. This is however not the required numerical for the channel type the API expects resulting in

```
DiscordAPIError: Invalid Form Body
type: Value "text" is not int.
```

~~The other case (type is present in data) chooses to do the defaulting through the ChannelTypes enum and uppercasing the expected text value, which I have accordingly replicated in the defaulting case.~~

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
