### PR TITLE
feat: expose RESTManager & create rest typings

### DIFF
--- a/esm/discord.mjs
+++ b/esm/discord.mjs
@@ -9,6 +9,7 @@ export const {
   ShardClientUtil,
   ShardingManager,
   WebhookClient,
+  RESTManager,
   ActivityFlags,
   BitField,
   Collection,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1031,6 +1031,29 @@
       "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -4208,7 +4231,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "handlebars": {
       "version": "4.7.6",
@@ -4775,6 +4799,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -6197,6 +6222,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -6210,7 +6236,8 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7437,7 +7464,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-angular": "^11.0.0",
     "@types/node": "^12.12.6",
+    "@types/node-fetch": "^2.5.8",
     "@types/ws": "^7.2.7",
     "cross-env": "^7.0.2",
     "discord.js-docgen": "git+https://github.com/discordjs/docgen.git",

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,9 @@ module.exports = {
   ShardingManager: require('./sharding/ShardingManager'),
   WebhookClient: require('./client/WebhookClient'),
 
+  // Rest
+  RESTManager: require('./rest/RESTManager'),
+
   // Utilities
   ActivityFlags: require('./util/ActivityFlags'),
   BitField: require('./util/BitField'),

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,3 @@
-import { URLSearchParams } from 'url';
-
 declare enum ChannelType {
   text = 0,
   dm = 1,
@@ -18,6 +16,7 @@ declare module 'discord.js' {
   import { PathLike } from 'fs';
   import { Response } from 'node-fetch';
   import { Readable, Stream, Writable } from 'stream';
+  import { URLSearchParams } from 'url';
   import * as WebSocket from 'ws';
 
   export const version: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR creates typings for all REST-related classes and exposes RESTManager to the user.
Example:
```ts
import { Client, Intents, RESTManager } from 'discord.js';
// intents are redundant for this example but required per #4879
const client = new Client({ intents: Intents.FLAGS.GUILDS });
const manager = new RESTManager(client, 'Bearer', 'the bearer token');
manager.api.users('@me').get().then(console.dir)
```

The JSDoc I wrote is definitely lacking and likely riddled with mistakes. Your reviews are greatly appreciated 😜 

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
