### PR TITLE
refactor(APIRouter): require square brackets for endpoint paths

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -265,10 +265,7 @@ class Client extends BaseClient {
    */
   fetchGuildTemplate(template) {
     const code = DataResolver.resolveGuildTemplateCode(template);
-    return this.api.guilds
-      .templates(code)
-      .get()
-      .then(data => new GuildTemplate(this, data));
+    return this.api.guilds.templates[code].get().then(data => new GuildTemplate(this, data));
   }
 
   /**
@@ -351,10 +348,7 @@ class Client extends BaseClient {
    * @returns {Promise<ClientApplication>}
    */
   fetchApplication() {
-    return this.api.oauth2
-      .applications('@me')
-      .get()
-      .then(app => new ClientApplication(this, app));
+    return this.api.oauth2.applications['@me'].get().then(app => new ClientApplication(this, app));
   }
 
   /**

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -248,10 +248,7 @@ class Client extends BaseClient {
    */
   fetchInvite(invite) {
     const code = DataResolver.resolveInviteCode(invite);
-    return this.api
-      .invites(code)
-      .get({ query: { with_counts: true } })
-      .then(data => new Invite(this, data));
+    return this.api.invites[code].get({ query: { with_counts: true } }).then(data => new Invite(this, data));
   }
 
   /**
@@ -279,10 +276,7 @@ class Client extends BaseClient {
    *   .catch(console.error);
    */
   fetchWebhook(id, token) {
-    return this.api
-      .webhooks(id, token)
-      .get()
-      .then(data => new Webhook(this, data));
+    return this.api.webhooks[id][token].get().then(data => new Webhook(this, data));
   }
 
   /**
@@ -359,10 +353,7 @@ class Client extends BaseClient {
   fetchGuildPreview(guild) {
     const id = this.guilds.resolveID(guild);
     if (!id) throw new TypeError('INVALID_TYPE', 'guild', 'GuildResolvable');
-    return this.api
-      .guilds(id)
-      .preview.get()
-      .then(data => new GuildPreview(this, data));
+    return this.api.guilds[id].preview.get().then(data => new GuildPreview(this, data));
   }
 
   /**

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -105,6 +105,8 @@ const Messages = {
   FETCH_GROUP_DM_CHANNEL: "Bots don't have access to Group DM Channels and cannot fetch them",
 
   MEMBER_FETCH_NONCE_LENGTH: 'Nonce length must not exceed 32 characters.',
+
+  API_ROUTER_INVALID_CALL: 'API router function calls must use HTTP verbs.',
 };
 
 for (const [name, message] of Object.entries(Messages)) register(name, message);

--- a/src/managers/ChannelManager.js
+++ b/src/managers/ChannelManager.js
@@ -88,7 +88,7 @@ class ChannelManager extends BaseManager {
       if (existing && !existing.partial) return existing;
     }
 
-    const data = await this.client.api.channels(id).get();
+    const data = await this.client.api.channels[id].get();
     return this.add(data, null, cache);
   }
 }

--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -109,7 +109,7 @@ class GuildChannelManager extends BaseManager {
       permissionOverwrites = permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
     }
 
-    const data = await this.client.api.guilds(this.guild.id).channels.post({
+    const data = await this.client.api.guilds[this.guild.id].channels.post({
       data: {
         name,
         topic,

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -61,9 +61,8 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
       }
     }
 
-    return this.client.api
-      .guilds(this.guild.id)
-      .emojis.post({ data, reason })
+    return this.client.api.guilds[this.guild.id].emojis
+      .post({ data, reason })
       .then(emoji => this.client.actions.GuildEmojiCreate.handle(this.guild, emoji).emoji);
   }
 

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -90,11 +90,11 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
         const existing = this.cache.get(id);
         if (existing) return existing;
       }
-      const emoji = await this.client.api.guilds(this.guild.id).emojis(id).get();
+      const emoji = await this.client.api.guilds[this.guild.id].emojis[id].get();
       return this.add(emoji, cache);
     }
 
-    const data = await this.client.api.guilds(this.guild.id).emojis.get();
+    const data = await this.client.api.guilds[this.guild.id].emojis.get();
     const emojis = new Collection();
     for (const emoji of data) emojis.set(emoji.id, this.add(emoji, cache));
     return emojis;

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -244,7 +244,7 @@ class GuildManager extends BaseManager {
       if (existing) return existing;
     }
 
-    const data = await this.client.api.guilds(id).get({ query: { with_counts: true } });
+    const data = await this.client.api.guilds[id].get({ query: { with_counts: true } });
     return this.add(data, cache);
   }
 }

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -180,7 +180,7 @@ class GuildMemberManager extends BaseManager {
       query.include_roles = dry ? resolvedRoles.join(',') : resolvedRoles;
     }
 
-    const endpoint = this.client.api.guilds(this.guild.id).prune;
+    const endpoint = this.client.api.guilds[this.guild.id].prune;
 
     if (dry) {
       return endpoint.get({ query, reason }).then(data => data.pruned);

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -214,18 +214,15 @@ class GuildMemberManager extends BaseManager {
     if (options.days) options.delete_message_days = options.days;
     const id = this.client.users.resolveID(user);
     if (!id) return Promise.reject(new Error('BAN_RESOLVE_ID', true));
-    return this.client.api
-      .guilds(this.guild.id)
-      .bans[id].put({ data: options })
-      .then(() => {
-        if (user instanceof GuildMember) return user;
-        const _user = this.client.users.resolve(id);
-        if (_user) {
-          const member = this.resolve(_user);
-          return member || _user;
-        }
-        return id;
-      });
+    return this.client.api.guilds[this.guild.id].bans[id].put({ data: options }).then(() => {
+      if (user instanceof GuildMember) return user;
+      const _user = this.client.users.resolve(id);
+      if (_user) {
+        const member = this.resolve(_user);
+        return member || _user;
+      }
+      return id;
+    });
   }
 
   /**
@@ -242,9 +239,8 @@ class GuildMemberManager extends BaseManager {
   unban(user, reason) {
     const id = this.client.users.resolveID(user);
     if (!id) return Promise.reject(new Error('BAN_RESOLVE_ID'));
-    return this.client.api
-      .guilds(this.guild.id)
-      .bans[id].delete({ reason })
+    return this.client.api.guilds[this.guild.id].bans[id]
+      .delete({ reason })
       .then(() => this.client.users.resolve(user));
   }
 
@@ -254,11 +250,7 @@ class GuildMemberManager extends BaseManager {
       if (existing && !existing.partial) return Promise.resolve(existing);
     }
 
-    return this.client.api
-      .guilds(this.guild.id)
-      .members(user)
-      .get()
-      .then(data => this.add(data, cache));
+    return this.client.api.guilds[this.guild.id].members[user].get().then(data => this.add(data, cache));
   }
 
   _fetchMany({

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -122,7 +122,7 @@ class MessageManager extends BaseManager {
     message = this.resolveID(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
-    await this.client.api.channels(this.channel.id).messages(message).delete();
+    await this.client.api.channels[this.channel.id].messages[message].delete();
   }
 
   async _fetchId(messageID, cache, force) {

--- a/src/managers/ReactionManager.js
+++ b/src/managers/ReactionManager.js
@@ -58,10 +58,8 @@ class ReactionManager extends BaseManager {
    * @returns {Promise<Message>}
    */
   removeAll() {
-    return this.client.api
-      .channels(this.message.channel.id)
-      .messages(this.message.id)
-      .reactions.delete()
+    return this.client.api.channels[this.message.channel.id].messages[this.message.id].reactions
+      .delete()
       .then(() => this.message);
   }
 }

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -54,7 +54,7 @@ class RoleManager extends BaseManager {
     }
 
     // We cannot fetch a single role, as of this commit's date, Discord API throws with 405
-    const data = await this.client.api.guilds(this.guild.id).roles.get();
+    const data = await this.client.api.guilds[this.guild.id].roles.get();
     const roles = new Collection();
     for (const role of data) roles.set(role.id, this.add(role, cache));
     return id ? roles.get(id) ?? null : roles;
@@ -117,9 +117,8 @@ class RoleManager extends BaseManager {
     if (color) color = resolveColor(color);
     if (permissions) permissions = Permissions.resolve(permissions);
 
-    return this.client.api
-      .guilds(this.guild.id)
-      .roles.post({
+    return this.client.api.guilds[this.guild.id].roles
+      .post({
         data: {
           name,
           color,

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -64,7 +64,7 @@ class UserManager extends BaseManager {
       if (existing && !existing.partial) return existing;
     }
 
-    const data = await this.client.api.users(id).get();
+    const data = await this.client.api.users[id].get();
     return this.add(data, cache);
   }
 }

--- a/src/rest/APIRouter.js
+++ b/src/rest/APIRouter.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { Error } = require('../errors');
+
 const noop = () => {}; // eslint-disable-line no-empty-function
 const methods = ['get', 'post', 'delete', 'patch', 'put'];
 const reflectors = [
@@ -22,8 +24,7 @@ function buildRoute(manager) {
     apply(target, _, args) {
       const method = route[route.length - 1];
       if (!methods.includes(method)) {
-        route.push(...args.filter(x => x != null)); // eslint-disable-line eqeqeq
-        return new Proxy(noop, handler);
+        return Promise.reject(new Error('API_ROUTER_INVALID_CALL'));
       }
 
       route.pop();

--- a/src/rest/APIRouter.js
+++ b/src/rest/APIRouter.js
@@ -16,35 +16,37 @@ function buildRoute(manager) {
   const handler = {
     get(target, name) {
       if (reflectors.includes(name)) return () => route.join('/');
-      if (methods.includes(name)) {
-        const routeBucket = [];
-        for (let i = 0; i < route.length; i++) {
-          // Reactions routes and sub-routes all share the same bucket
-          if (route[i - 1] === 'reactions') break;
-          // Literal IDs should only be taken account if they are the Major ID (the Channel/Guild ID)
-          if (/\d{16,19}/g.test(route[i]) && !/channels|guilds/.test(route[i - 1])) routeBucket.push(':id');
-          // All other parts of the route should be considered as part of the bucket identifier
-          else routeBucket.push(route[i]);
-        }
-        return options =>
-          manager.request(
-            name,
-            route.join('/'),
-            Object.assign(
-              {
-                versioned: manager.versioned,
-                route: routeBucket.join('/'),
-              },
-              options,
-            ),
-          );
-      }
       route.push(name);
       return new Proxy(noop, handler);
     },
     apply(target, _, args) {
-      route.push(...args.filter(x => x != null)); // eslint-disable-line eqeqeq
-      return new Proxy(noop, handler);
+      const method = route[route.length - 1];
+      if (!methods.includes(method)) {
+        route.push(...args.filter(x => x != null)); // eslint-disable-line eqeqeq
+        return new Proxy(noop, handler);
+      }
+
+      route.pop();
+      const routeBucket = [];
+      for (let i = 0; i < route.length; i++) {
+        // Reactions routes and sub-routes all share the same bucket
+        if (route[i - 1] === 'reactions') break;
+        // Literal IDs should only be taken account if they are the Major ID (the Channel/Guild ID)
+        if (/\d{16,19}/g.test(route[i]) && !/channels|guilds/.test(route[i - 1])) routeBucket.push(':id');
+        // All other parts of the route should be considered as part of the bucket identifier
+        else routeBucket.push(route[i]);
+      }
+      return manager.request(
+        method,
+        route.join('/'),
+        Object.assign(
+          {
+            versioned: manager.versioned,
+            route: routeBucket.join('/'),
+          },
+          args[0],
+        ),
+      );
     },
   };
   return new Proxy(noop, handler);

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -83,10 +83,7 @@ class Channel extends Base {
    *   .catch(console.error);
    */
   delete() {
-    return this.client.api
-      .channels(this.id)
-      .delete()
-      .then(() => this);
+    return this.client.api.channels[this.id].delete().then(() => this);
   }
 
   /**

--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -37,7 +37,7 @@ class ClientPresence extends Presence {
       if (!activity.type) activity.type = 0;
       if (activity.assets && applicationID) {
         try {
-          const a = await this.client.api.oauth2.applications(applicationID).assets.get();
+          const a = await this.client.api.oauth2.applications[applicationID].assets.get();
           for (const asset of a) assets.set(asset.name, asset.id);
         } catch {} // eslint-disable-line no-empty
       }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -47,15 +47,12 @@ class ClientUser extends Structures.get('User') {
   }
 
   edit(data) {
-    return this.client.api
-      .users('@me')
-      .patch({ data })
-      .then(newData => {
-        this.client.token = newData.token;
-        const { updated } = this.client.actions.UserUpdate.handle(newData);
-        if (updated) return updated;
-        return this;
-      });
+    return this.client.api.users['@me'].patch({ data }).then(newData => {
+      this.client.token = newData.token;
+      const { updated } = this.client.actions.UserUpdate.handle(newData);
+      if (updated) return updated;
+      return this;
+    });
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -632,13 +632,10 @@ class Guild extends Base {
    * @returns {Promise<Guild>}
    */
   fetch() {
-    return this.client.api
-      .guilds(this.id)
-      .get({ query: { with_counts: true } })
-      .then(data => {
-        this._patch(data);
-        return this;
-      });
+    return this.client.api.guilds[this.id].get({ query: { with_counts: true } }).then(data => {
+      this._patch(data);
+      return this;
+    });
   }
 
   /**
@@ -656,14 +653,10 @@ class Guild extends Base {
   fetchBan(user) {
     const id = this.client.users.resolveID(user);
     if (!id) throw new Error('FETCH_BAN_RESOLVE_ID');
-    return this.client.api
-      .guilds(this.id)
-      .bans(id)
-      .get()
-      .then(ban => ({
-        reason: ban.reason,
-        user: this.client.users.add(ban.user),
-      }));
+    return this.client.api.guilds[this.id].bans[id].get().then(ban => ({
+      reason: ban.reason,
+      user: this.client.users.add(ban.user),
+    }));
   }
 
   /**
@@ -671,18 +664,15 @@ class Guild extends Base {
    * @returns {Promise<Collection<Snowflake, BanInfo>>}
    */
   fetchBans() {
-    return this.client.api
-      .guilds(this.id)
-      .bans.get()
-      .then(bans =>
-        bans.reduce((collection, ban) => {
-          collection.set(ban.user.id, {
-            reason: ban.reason,
-            user: this.client.users.add(ban.user),
-          });
-          return collection;
-        }, new Collection()),
-      );
+    return this.client.api.guilds[this.id].bans.get().then(bans =>
+      bans.reduce((collection, ban) => {
+        collection.set(ban.user.id, {
+          reason: ban.reason,
+          user: this.client.users.add(ban.user),
+        });
+        return collection;
+      }, new Collection()),
+    );
   }
 
   /**
@@ -698,9 +688,8 @@ class Guild extends Base {
    *   .catch(console.error);
    */
   fetchIntegrations({ includeApplications = false } = {}) {
-    return this.client.api
-      .guilds(this.id)
-      .integrations.get({
+    return this.client.api.guilds[this.id].integrations
+      .get({
         query: {
           include_applications: includeApplications,
         },
@@ -719,9 +708,8 @@ class Guild extends Base {
    * @returns {Promise<Collection<string, GuildTemplate>>}
    */
   fetchTemplates() {
-    return this.client.api
-      .guilds(this.id)
-      .templates.get()
+    return this.client.api.guilds[this.id].templates
+      .get()
       .then(templates =>
         templates.reduce((col, data) => col.set(data.code, new GuildTemplate(this.client, data)), new Collection()),
       );
@@ -741,10 +729,7 @@ class Guild extends Base {
    * @returns {Promise<Guild>}
    */
   createIntegration(data, reason) {
-    return this.client.api
-      .guilds(this.id)
-      .integrations.post({ data, reason })
-      .then(() => this);
+    return this.client.api.guilds[this.id].integrations.post({ data, reason }).then(() => this);
   }
 
   /**
@@ -754,9 +739,8 @@ class Guild extends Base {
    * @returns {Promise<GuildTemplate>}
    */
   createTemplate(name, description) {
-    return this.client.api
-      .guilds(this.id)
-      .templates.post({ data: { name, description } })
+    return this.client.api.guilds[this.id].templates
+      .post({ data: { name, description } })
       .then(data => new GuildTemplate(this.client, data));
   }
 
@@ -776,17 +760,14 @@ class Guild extends Base {
    *  .catch(console.error);
    */
   fetchInvites() {
-    return this.client.api
-      .guilds(this.id)
-      .invites.get()
-      .then(inviteItems => {
-        const invites = new Collection();
-        for (const inviteItem of inviteItems) {
-          const invite = new Invite(this.client, inviteItem);
-          invites.set(invite.code, invite);
-        }
-        return invites;
-      });
+    return this.client.api.guilds[this.id].invites.get().then(inviteItems => {
+      const invites = new Collection();
+      for (const inviteItem of inviteItems) {
+        const invite = new Invite(this.client, inviteItem);
+        invites.set(invite.code, invite);
+      }
+      return invites;
+    });
   }
 
   /**
@@ -794,10 +775,7 @@ class Guild extends Base {
    * @returns {Promise<GuildPreview>}
    */
   fetchPreview() {
-    return this.client.api
-      .guilds(this.id)
-      .preview.get()
-      .then(data => new GuildPreview(this.client, data));
+    return this.client.api.guilds[this.id].preview.get().then(data => new GuildPreview(this.client, data));
   }
 
   /**
@@ -856,14 +834,11 @@ class Guild extends Base {
    *   .catch(console.error);
    */
   fetchWebhooks() {
-    return this.client.api
-      .guilds(this.id)
-      .webhooks.get()
-      .then(data => {
-        const hooks = new Collection();
-        for (const hook of data) hooks.set(hook.id, new Webhook(this.client, hook));
-        return hooks;
-      });
+    return this.client.api.guilds[this.id].webhooks.get().then(data => {
+      const hooks = new Collection();
+      for (const hook of data) hooks.set(hook.id, new Webhook(this.client, hook));
+      return hooks;
+    });
   }
 
   /**
@@ -871,14 +846,11 @@ class Guild extends Base {
    * @returns {Promise<Collection<string, VoiceRegion>>}
    */
   fetchVoiceRegions() {
-    return this.client.api
-      .guilds(this.id)
-      .regions.get()
-      .then(res => {
-        const regions = new Collection();
-        for (const region of res) regions.set(region.id, new VoiceRegion(region));
-        return regions;
-      });
+    return this.client.api.guilds[this.id].regions.get().then(res => {
+      const regions = new Collection();
+      for (const region of res) regions.set(region.id, new VoiceRegion(region));
+      return regions;
+    });
   }
 
   /**
@@ -946,9 +918,8 @@ class Guild extends Base {
     if (options.before && options.before instanceof GuildAuditLogs.Entry) options.before = options.before.id;
     if (typeof options.type === 'string') options.type = GuildAuditLogs.Actions[options.type];
 
-    return this.client.api
-      .guilds(this.id)
-      ['audit-logs'].get({
+    return this.client.api.guilds[this.id]['audit-logs']
+      .get({
         query: {
           before: options.before,
           limit: options.limit,
@@ -1073,8 +1044,7 @@ class Guild extends Base {
       _data.public_updates_channel_id = this.client.channels.resolveID(data.publicUpdatesChannel);
     }
     if (data.preferredLocale) _data.preferred_locale = data.preferredLocale;
-    return this.client.api
-      .guilds(this.id)
+    return this.client.api.guilds[this.id]
       .patch({ data: _data, reason })
       .then(newData => this.client.actions.GuildUpdate.handle(newData).updated);
   }
@@ -1342,16 +1312,13 @@ class Guild extends Base {
       position: r.position,
     }));
 
-    return this.client.api
-      .guilds(this.id)
-      .channels.patch({ data: updatedChannels })
-      .then(
-        () =>
-          this.client.actions.GuildChannelsPositionUpdate.handle({
-            guild_id: this.id,
-            channels: updatedChannels,
-          }).guild,
-      );
+    return this.client.api.guilds[this.id].channels.patch({ data: updatedChannels }).then(
+      () =>
+        this.client.actions.GuildChannelsPositionUpdate.handle({
+          guild_id: this.id,
+          channels: updatedChannels,
+        }).guild,
+    );
   }
 
   /**
@@ -1378,9 +1345,8 @@ class Guild extends Base {
     }));
 
     // Call the API to update role positions
-    return this.client.api
-      .guilds(this.id)
-      .roles.patch({
+    return this.client.api.guilds[this.id].roles
+      .patch({
         data: rolePositions,
       })
       .then(
@@ -1410,9 +1376,8 @@ class Guild extends Base {
    * @returns {Promise<Guild>}
    */
   setWidget(widget, reason) {
-    return this.client.api
-      .guilds(this.id)
-      .widget.patch({
+    return this.client.api.guilds[this.id].widget
+      .patch({
         data: {
           enabled: widget.enabled,
           channel_id: this.channels.resolveID(widget.channel),
@@ -1433,9 +1398,7 @@ class Guild extends Base {
    */
   leave() {
     if (this.ownerID === this.client.user.id) return Promise.reject(new Error('GUILD_OWNED'));
-    return this.client.api
-      .users('@me')
-      .guilds(this.id)
+    return this.client.api.users['@me'].guilds[this.id]
       .delete()
       .then(() => this.client.actions.GuildDelete.handle({ id: this.id }).guild);
   }
@@ -1450,8 +1413,7 @@ class Guild extends Base {
    *   .catch(console.error);
    */
   delete() {
-    return this.client.api
-      .guilds(this.id)
+    return this.client.api.guilds[this.id]
       .delete()
       .then(() => this.client.actions.GuildDelete.handle({ id: this.id }).guild);
   }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -840,7 +840,7 @@ class Guild extends Base {
     if (!this.features.includes('VANITY_URL')) {
       throw new Error('VANITY_URL');
     }
-    const data = await this.client.api.guilds(this.id, 'vanity-url').get();
+    const data = await this.client.api.guilds[this.id]['vanity-url'].get();
     this.vanityURLUses = data.uses;
 
     return data;
@@ -919,7 +919,7 @@ class Guild extends Base {
    *   .catch(console.error);
    */
   async fetchWidget() {
-    const data = await this.client.api.guilds(this.id).widget.get();
+    const data = await this.client.api.guilds[this.id].widget.get();
     this.widgetEnabled = this.embedEnabled = data.enabled;
     this.widgetChannelID = this.embedChannelID = data.channel_id;
     return {
@@ -988,7 +988,7 @@ class Guild extends Base {
       }
       options.roles = roles;
     }
-    const data = await this.client.api.guilds(this.id).members(user).put({ data: options });
+    const data = await this.client.api.guilds[this.id].members[user].put({ data: options });
     // Data is an empty buffer if the member is already part of the guild.
     return data instanceof Buffer ? this.members.fetch(user) : this.members.add(data);
   }

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -257,9 +257,8 @@ class GuildChannel extends Channel {
     const type = userOrRole instanceof Role ? 'role' : 'member';
     const { allow, deny } = PermissionOverwrites.resolveOverwriteOptions(options);
 
-    return this.client.api
-      .channels(this.id)
-      .permissions[userOrRole.id].put({
+    return this.client.api.channels[this.id].permissions[userOrRole.id]
+      .put({
         data: { id: userOrRole.id, type, allow: allow.bitfield, deny: deny.bitfield },
         reason,
       })
@@ -474,9 +473,8 @@ class GuildChannel extends Channel {
    *   .catch(console.error);
    */
   createInvite({ temporary = false, maxAge = 86400, maxUses = 0, unique, reason } = {}) {
-    return this.client.api
-      .channels(this.id)
-      .invites.post({
+    return this.client.api.channels[this.id].invites
+      .post({
         data: {
           temporary,
           max_age: maxAge,
@@ -615,10 +613,7 @@ class GuildChannel extends Channel {
    *   .catch(console.error);
    */
   delete(reason) {
-    return this.client.api
-      .channels(this.id)
-      .delete({ reason })
-      .then(() => this);
+    return this.client.api.channels[this.id].delete({ reason }).then(() => this);
   }
 }
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -327,7 +327,7 @@ class GuildChannel extends Channel {
         data.position,
         false,
         this.guild._sortedChannels(this),
-        this.client.api.guilds(this.guild.id).channels,
+        this.client.api.guilds[this.guild.id].channels,
         reason,
       ).then(updatedChannels => {
         this.client.actions.GuildChannelsPositionUpdate.handle({
@@ -354,7 +354,7 @@ class GuildChannel extends Channel {
       }
     }
 
-    const newData = await this.client.api.channels(this.id).patch({
+    const newData = await this.client.api.channels[this.id].patch({
       data: {
         name: (data.name || this.name).trim(),
         type: data.type ? ChannelTypes[data.type.toUpperCase()] : this.type,
@@ -446,7 +446,7 @@ class GuildChannel extends Channel {
       position,
       relative,
       this.guild._sortedChannels(this),
-      this.client.api.guilds(this.guild.id).channels,
+      this.client.api.guilds[this.guild.id].channels,
       reason,
     ).then(updatedChannels => {
       this.client.actions.GuildChannelsPositionUpdate.handle({
@@ -494,7 +494,7 @@ class GuildChannel extends Channel {
    * @returns {Promise<Collection<string, Invite>>}
    */
   async fetchInvites() {
-    const inviteItems = await this.client.api.channels(this.id).invites.get();
+    const inviteItems = await this.client.api.channels[this.id].invites.get();
     const invites = new Collection();
     for (const inviteItem of inviteItems) {
       const invite = new Invite(this.client, inviteItem);

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -74,7 +74,7 @@ class GuildEmoji extends BaseGuildEmoji {
         throw new Error('MISSING_MANAGE_EMOJIS_PERMISSION', this.guild);
       }
     }
-    const data = await this.client.api.guilds(this.guild.id).emojis(this.id).get();
+    const data = await this.client.api.guilds[this.guild.id].emojis[this.id].get();
     this._patch(data);
     return this.author;
   }

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -99,9 +99,7 @@ class GuildEmoji extends BaseGuildEmoji {
    */
   edit(data, reason) {
     const roles = data.roles ? data.roles.map(r => r.id || r) : undefined;
-    return this.client.api
-      .guilds(this.guild.id)
-      .emojis(this.id)
+    return this.client.api.guilds[this.guild.id].emojis[this.id]
       .patch({
         data: {
           name: data.name,
@@ -132,11 +130,7 @@ class GuildEmoji extends BaseGuildEmoji {
    * @returns {Promise<GuildEmoji>}
    */
   delete(reason) {
-    return this.client.api
-      .guilds(this.guild.id)
-      .emojis(this.id)
-      .delete({ reason })
-      .then(() => this);
+    return this.client.api.guilds[this.guild.id].emojis[this.id].delete({ reason }).then(() => this);
   }
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -311,10 +311,10 @@ class GuildMember extends Base {
     let endpoint = this.client.api.guilds[this.guild.id];
     if (this.user.id === this.client.user.id) {
       const keys = Object.keys(data);
-      if (keys.length === 1 && keys[0] === 'nick') endpoint = endpoint.members('@me').nick;
-      else endpoint = endpoint.members(this.id);
+      if (keys.length === 1 && keys[0] === 'nick') endpoint = endpoint.members['@me'].nick;
+      else endpoint = endpoint.members[this.id];
     } else {
-      endpoint = endpoint.members(this.id);
+      endpoint = endpoint.members[this.id];
     }
     await endpoint.patch({ data, reason });
 

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -308,7 +308,7 @@ class GuildMember extends Base {
       data.channel = undefined;
     }
     if (data.roles) data.roles = data.roles.map(role => (role instanceof Role ? role.id : role));
-    let endpoint = this.client.api.guilds(this.guild.id);
+    let endpoint = this.client.api.guilds[this.guild.id];
     if (this.user.id === this.client.user.id) {
       const keys = Object.keys(data);
       if (keys.length === 1 && keys[0] === 'nick') endpoint = endpoint.members('@me').nick;

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -356,11 +356,7 @@ class GuildMember extends Base {
    * @returns {Promise<GuildMember>}
    */
   kick(reason) {
-    return this.client.api
-      .guilds(this.guild.id)
-      .members(this.user.id)
-      .delete({ reason })
-      .then(() => this);
+    return this.client.api.guilds[this.guild.id].members[this.user.id].delete({ reason }).then(() => this);
   }
 
   /**

--- a/src/structures/GuildPreview.js
+++ b/src/structures/GuildPreview.js
@@ -126,13 +126,10 @@ class GuildPreview extends Base {
    * @returns {Promise<GuildPreview>}
    */
   fetch() {
-    return this.client.api
-      .guilds(this.id)
-      .preview.get()
-      .then(data => {
-        this._patch(data);
-        return this;
-      });
+    return this.client.api.guilds[this.id].preview.get().then(data => {
+      this._patch(data);
+      return this;
+    });
   }
 
   /**

--- a/src/structures/GuildTemplate.js
+++ b/src/structures/GuildTemplate.js
@@ -104,7 +104,7 @@ class GuildTemplate extends Base {
    */
   async createGuild(name, icon) {
     const { client } = this;
-    const data = await client.api.guilds.templates(this.code).post({
+    const data = await client.api.guilds.templates[this.code].post({
       data: {
         name,
         icon: await DataResolver.resolveImage(icon),

--- a/src/structures/GuildTemplate.js
+++ b/src/structures/GuildTemplate.js
@@ -143,9 +143,7 @@ class GuildTemplate extends Base {
    * @returns {Promise<GuildTemplate>}
    */
   edit({ name, description } = {}) {
-    return this.client.api
-      .guilds(this.guildID)
-      .templates(this.code)
+    return this.client.api.guilds[this.guildID].templates[this.code]
       .patch({ data: { name, description } })
       .then(data => this._patch(data));
   }
@@ -155,11 +153,7 @@ class GuildTemplate extends Base {
    * @returns {Promise<GuildTemplate>}
    */
   delete() {
-    return this.client.api
-      .guilds(this.guildID)
-      .templates(this.code)
-      .delete()
-      .then(() => this);
+    return this.client.api.guilds[this.guildID].templates[this.code].delete().then(() => this);
   }
 
   /**
@@ -167,11 +161,7 @@ class GuildTemplate extends Base {
    * @returns {Promise<GuildTemplate>}
    */
   sync() {
-    return this.client.api
-      .guilds(this.guildID)
-      .templates(this.code)
-      .put()
-      .then(data => this._patch(data));
+    return this.client.api.guilds[this.guildID].templates[this.code].put().then(data => this._patch(data));
   }
 
   /**

--- a/src/structures/Integration.js
+++ b/src/structures/Integration.js
@@ -127,15 +127,11 @@ class Integration extends Base {
    */
   sync() {
     this.syncing = true;
-    return this.client.api
-      .guilds(this.guild.id)
-      .integrations(this.id)
-      .post()
-      .then(() => {
-        this.syncing = false;
-        this.syncedAt = Date.now();
-        return this;
-      });
+    return this.client.api.guilds[this.guild.id].integrations[this.ids].post().then(() => {
+      this.syncing = false;
+      this.syncedAt = Date.now();
+      return this;
+    });
   }
 
   /**
@@ -161,14 +157,10 @@ class Integration extends Base {
       data.expireGracePeriod = null;
     }
     // The option enable_emoticons is only available for Twitch at this moment
-    return this.client.api
-      .guilds(this.guild.id)
-      .integrations(this.id)
-      .patch({ data, reason })
-      .then(() => {
-        this._patch(data);
-        return this;
-      });
+    return this.client.api.guilds[this.guild.id].integrations[this.id].patch({ data, reason }).then(() => {
+      this._patch(data);
+      return this;
+    });
   }
 
   /**
@@ -177,11 +169,7 @@ class Integration extends Base {
    * @param {string} [reason] Reason for deleting this integration
    */
   delete(reason) {
-    return this.client.api
-      .guilds(this.guild.id)
-      .integrations(this.id)
-      .delete({ reason })
-      .then(() => this);
+    return this.client.api.guilds[this.guild.id].integrations[this.id].delete({ reason }).then(() => this);
   }
 
   toJSON() {

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -493,11 +493,7 @@ class Message extends Base {
    *   .catch(console.error)
    */
   pin(options) {
-    return this.client.api
-      .channels(this.channel.id)
-      .pins(this.id)
-      .put(options)
-      .then(() => this);
+    return this.client.api.channels[this.channel.id].pins[this.id].put(options).then(() => this);
   }
 
   /**
@@ -512,11 +508,7 @@ class Message extends Base {
    *   .catch(console.error)
    */
   unpin(options) {
-    return this.client.api
-      .channels(this.channel.id)
-      .pins(this.id)
-      .delete(options)
-      .then(() => this);
+    return this.client.api.channels[this.channel.id].pins[this.id].delete(options).then(() => this);
   }
 
   /**
@@ -538,20 +530,15 @@ class Message extends Base {
     emoji = this.client.emojis.resolveIdentifier(emoji);
     if (!emoji) throw new TypeError('EMOJI_TYPE');
 
-    return this.client.api
-      .channels(this.channel.id)
-      .messages(this.id)
-      .reactions(emoji, '@me')
-      .put()
-      .then(
-        () =>
-          this.client.actions.MessageReactionAdd.handle({
-            user: this.client.user,
-            channel: this.channel,
-            message: this,
-            emoji: Util.parseEmoji(emoji),
-          }).reaction,
-      );
+    return this.client.api.channels[this.channel.id].messages[this.id].reactions[emoji]['@me'].put().then(
+      () =>
+        this.client.actions.MessageReactionAdd.handle({
+          user: this.client.user,
+          channel: this.channel,
+          message: this,
+          emoji: Util.parseEmoji(emoji),
+        }).reaction,
+    );
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -477,7 +477,7 @@ class Message extends Base {
    * }
    */
   async crosspost() {
-    await this.client.api.channels(this.channel.id).messages(this.id).crosspost.post();
+    await this.client.api.channels[this.channel.id].messages[this.id].crosspost.post();
     return this;
   }
 

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -61,11 +61,9 @@ class MessageReaction {
    * @returns {Promise<MessageReaction>}
    */
   async remove() {
-    await this.client.api
-      .channels(this.message.channel.id)
-      .messages(this.message.id)
-      .reactions(this._emoji.identifier)
-      .delete();
+    await this.client.api.channels[this.message.channel.id].messages[this.message.id].reactions[
+      this._emoji.identifier
+    ].delete();
     return this;
   }
 

--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -30,7 +30,7 @@ class NewsChannel extends TextChannel {
   async addFollower(channel, reason) {
     const channelID = this.guild.channels.resolveID(channel);
     if (!channelID) throw new Error('GUILD_CHANNEL_RESOLVE');
-    await this.client.api.channels(this.id).followers.post({ data: { webhook_channel_id: channelID }, reason });
+    await this.client.api.channels[this.id].followers.post({ data: { webhook_channel_id: channelID }, reason });
     return this;
   }
 }

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -70,9 +70,8 @@ class PermissionOverwrites {
   update(options, reason) {
     const { allow, deny } = this.constructor.resolveOverwriteOptions(options, this);
 
-    return this.channel.client.api
-      .channels(this.channel.id)
-      .permissions[this.id].put({
+    return this.channel.client.api.channels[this.channel.id].permissions[this.id]
+      .put({
         data: { id: this.id, type: this.type, allow: allow.bitfield, deny: deny.bitfield },
         reason,
       })

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -205,7 +205,7 @@ class Role extends Base {
         data.position,
         false,
         this.guild._sortedRoles(),
-        this.client.api.guilds(this.guild.id).roles,
+        this.client.api.guilds[this.guild.id].roles,
         reason,
       ).then(updatedRoles => {
         this.client.actions.GuildRolesPositionUpdate.handle({
@@ -343,7 +343,7 @@ class Role extends Base {
       position,
       relative,
       this.guild._sortedRoles(),
-      this.client.api.guilds(this.guild.id).roles,
+      this.client.api.guilds[this.guild.id].roles,
       reason,
     ).then(updatedRoles => {
       this.client.actions.GuildRolesPositionUpdate.handle({

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -240,7 +240,7 @@ class User extends Base {
       if (dmChannel && !dmChannel.partial) return dmChannel;
     }
 
-    const data = await this.client.api.users(this.client.user.id).channels.post({
+    const data = await this.client.api.users[this.client.user.id].channels.post({
       data: {
         recipient_id: this.id,
       },
@@ -255,7 +255,7 @@ class User extends Base {
   async deleteDM() {
     const { dmChannel } = this;
     if (!dmChannel) throw new Error('USER_NO_DMCHANNEL');
-    const data = await this.client.api.channels(dmChannel.id).delete();
+    const data = await this.client.api.channels[dmChannel.id].delete();
     return this.client.actions.ChannelDelete.handle(data).channel;
   }
 
@@ -283,7 +283,7 @@ class User extends Base {
    */
   async fetchFlags(force = false) {
     if (this.flags && !force) return this.flags;
-    const data = await this.client.api.users(this.id).get();
+    const data = await this.client.api.users[this.id].get();
     this._patch(data);
     return this.flags;
   }

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -205,7 +205,9 @@ class Webhook {
       avatar = await DataResolver.resolveImage(avatar);
     }
     if (channel) channel = channel instanceof Channel ? channel.id : channel;
-    const data = await this.client.api.webhooks(this.id, channel ? undefined : this.token).patch({
+    let endpoint = this.client.api.webhooks[this.id];
+    if (!channel) endpoint = endpoint[this.token];
+    const data = await endpoint.patch({
       data: { name, avatar, channel_id: channel },
       reason,
     });
@@ -222,7 +224,7 @@ class Webhook {
    * @returns {Promise}
    */
   delete(reason) {
-    return this.client.api.webhooks(this.id, this.token).delete({ reason });
+    return this.client.api.webhooks[this.id][this.token].delete({ reason });
   }
   /**
    * The timestamp the webhook was created at
@@ -248,7 +250,7 @@ class Webhook {
    * @readonly
    */
   get url() {
-    return this.client.options.http.api + this.client.api.webhooks(this.id, this.token);
+    return this.client.options.http.api + this.client.api.webhooks[this.id][this.token];
   }
 
   /**

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -148,8 +148,7 @@ class Webhook {
     }
 
     const { data, files } = await apiMessage.resolveFiles();
-    return this.client.api
-      .webhooks(this.id, this.token)
+    return this.client.api.webhooks[this.id][this.token]
       .post({
         data,
         files,
@@ -181,9 +180,8 @@ class Webhook {
    * }).catch(console.error);
    */
   sendSlackMessage(body) {
-    return this.client.api
-      .webhooks(this.id, this.token)
-      .slack.post({
+    return this.client.api.webhooks[this.id][this.token].slack
+      .post({
         query: { wait: true },
         auth: false,
         data: body,

--- a/src/structures/interfaces/Application.js
+++ b/src/structures/interfaces/Application.js
@@ -93,16 +93,13 @@ class Application extends Base {
    * @returns {Promise<Array<ApplicationAsset>>}
    */
   fetchAssets() {
-    return this.client.api.oauth2
-      .applications(this.id)
-      .assets.get()
-      .then(assets =>
-        assets.map(a => ({
-          id: a.id,
-          name: a.name,
-          type: AssetTypes[a.type - 1],
-        })),
-      );
+    return this.client.api.oauth2.applications[this.id].assets.get().then(assets =>
+      assets.map(a => ({
+        id: a.id,
+        name: a.name,
+        type: AssetTypes[a.type - 1],
+      })),
+    );
   }
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -321,7 +321,7 @@ class TextBasedChannel {
       }
       if (messageIDs.length === 0) return new Collection();
       if (messageIDs.length === 1) {
-        await this.client.api.channels(this.id).messages(messageIDs[0]).delete();
+        await this.client.api.channels[this.id].messages(messageIDs[0]).delete();
         const message = this.client.actions.MessageDelete.getMessage(
           {
             message_id: messageIDs[0],

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -321,7 +321,7 @@ class TextBasedChannel {
       }
       if (messageIDs.length === 0) return new Collection();
       if (messageIDs.length === 1) {
-        await this.client.api.channels[this.id].messages(messageIDs[0]).delete();
+        await this.client.api.channels[this.id].messages[messageIDs[0]].delete();
         const message = this.client.actions.MessageDelete.getMessage(
           {
             message_id: messageIDs[0],


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Requires consistent use of `[]` for paths when using the route builder.
```diff
- api.users('@me').get()
+ api.users['@me'].get()

- api.guilds(guild.id).emojis(emoji).get()
+ api.guilds[guild.id].emojis[emoji].get()
```
This also protects the option that in the future routes will have `get`, `post`, or any other HTTP method in them:
```js
// old
api.a.b.c.get.toString() // options => manager.request(...
api.a.b.c.get() // GET /a/b/c
// new
api.a.b.c.get.toString() // '/a/b/c/get'
api.a.b.c.get() // GET /a/b/c
```
#### Notes
- **The goal of this PR is to enforce one style over the other - literally throw when not used "incorrectly". This goes farther than simply changing all occurrences to one style. We could stick to the other style (`()`) and manually make sure new PRs don't add `[]` by mistake, but that's not really enforcing it.**
 
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating