### PR TITLE
fix(GuildChannel): overload permissionsFor and BaseManager#resolve[id]

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -765,6 +765,7 @@ declare module 'discord.js' {
       overwrites: readonly OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>,
       reason?: string,
     ): Promise<this>;
+    public permissionsFor(memberOrRole: Exclude<GuildMemberResolvable | RoleResolvable, string>): Readonly<Permissions>;
     public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
     public setName(name: string, reason?: string): Promise<this>;
     public setParent(
@@ -1873,7 +1874,9 @@ declare module 'discord.js' {
     public cacheType: Collection<K, Holds>;
     public readonly client: Client;
     public add(data: any, cache?: boolean, { id, extras }?: { id: K; extras: any[] }): Holds;
+    public resolve(resolvable: Holds): Holds;
     public resolve(resolvable: R): Holds | null;
+    public resolveID(resolvable: Holds): K;
     public resolveID(resolvable: R): K | null;
     public valueOf(): Collection<K, Holds>;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -765,7 +765,7 @@ declare module 'discord.js' {
       overwrites: readonly OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>,
       reason?: string,
     ): Promise<this>;
-    public permissionsFor(memberOrRole: Exclude<GuildMemberResolvable | RoleResolvable, string>): Readonly<Permissions>;
+    public permissionsFor(memberOrRole: GuildMember | Role): Readonly<Permissions>;
     public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
     public setName(name: string, reason?: string): Promise<this>;
     public setParent(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The behaviour of GuildChannel#permissionsFor, is that if it's able to resolve the data, it will always return permissions (since the private methods `memberPermissions` and `rolePermissions` never return `null`):

https://github.com/discordjs/discord.js/blob/9ffcd83027f0fc06d69df21475865ad55138de01/src/structures/GuildChannel.js#L113-L119

For data to be resolvable, it expects either an instance or a string:

https://github.com/discordjs/discord.js/blob/9ffcd83027f0fc06d69df21475865ad55138de01/src/managers/BaseManager.js#L59-L63

If an instance is provided, it will always return the instance itself, therefore, when passing a value that matches `Holds`, the type return should always be `Holds` as well.

When passing a string, the return can be nullable, so this is excluded from the non-nullable return.

Things change when `GuildMemberManager#resolve` is used, as it's overloaded to support more types (specifically `User` instances), which resolves an ID and then tries to get the `GuildMember` from it, that is why I am not using `Exclude<GuildMemberResolvable | RoleResolvable, string>`.

https://github.com/discordjs/discord.js/blob/9ffcd83027f0fc06d69df21475865ad55138de01/src/managers/GuildMemberManager.js#L46-L52

**Status**

- [x] Code changes have been tested against the Discord API, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.
