### PR TITLE
chore(*): streamline issue and PR templates and redirects

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,12 +6,6 @@ title: ''
 labels: 's: unverified, type: bug'
 assignees: ''
 ---
-<!--
-If you need help with discord.js installation or usage, please go to the discord.js Discord server instead:
-  https://discord.gg/bRCvFy9
-This issue tracker is only for bug reports and enhancement suggestions.
-You won't receive any basic help here.
--->
 
 **Please describe the problem you are having in as much detail as possible:**
 
@@ -35,11 +29,8 @@ You won't receive any basic help here.
 - other: none
 
 <!--
-If this applies to you, please check the respective checkbox: [ ] becomes [x].
-You don't have to modify the text to suit your particular situation – if you want to
-elaborate, please do so in the description.
-While it's not a requirement to test your issue on the master branch, it would make fixing
-the problem a lot easier for us, so please do so if possible.
--->
+Remove the comment and fill out the commit hash if this applies to you:
+(While it's not a requirement to test your issue on the master branch, it would make fixing the problem a lot easier for us, so please do so if possible.)
 
-- [ ] I have also tested the issue on latest master, commit hash:
+- I have also tested the issue on latest master, commit hash: `xxx`
+-->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 
 name: Bug report
-about: Report incorrect or unexpected behaviour of discord.js
+about: Report incorrect or unexpected behavior of discord.js
 title: ''
 labels: 's: unverified, type: bug'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,7 @@ title: ''
 labels: 's: unverified, type: bug'
 assignees: ''
 ---
+<!-- Use Discord for questions: https://discord.gg/bRCvFy9 -->
 
 **Please describe the problem you are having in as much detail as possible:**
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Discord server
     url: https://discord.gg/bRCvFy9
-    about: Have questions or need support? Please go to the Discord server, as issues that are just support-related will be closed and redirected there.
+    about: Please visit our Discord server for questions and support requests.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,12 +6,6 @@ title: ''
 labels: 'type: enhancement'
 assignees: ''
 ---
-<!--
-If you need help with discord.js installation or usage, please go to the discord.js Discord server instead:
-  https://discord.gg/bRCvFy9
-This issue tracker is only for bug reports and enhancement suggestions.
-You likely won't receive any basic help here.
--->
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Eg. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,7 @@ title: ''
 labels: 'type: enhancement'
 assignees: ''
 ---
+<!-- Use Discord for questions: https://discord.gg/bRCvFy9 -->
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Eg. I'm always frustrated when [...]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,14 @@
 **Please describe the changes this PR makes and why it should be merged:**
 
-**Status**
 
-- [ ] Code changes have been tested against the Discord API, or there are no code changes
-- [ ] I know how to update typings and have done so, or typings don't need updating
 
-**Semantic versioning classification:**
+**Status and versioning classification:**
 
-- [ ] This PR changes the library's interface (methods or parameters added)
-  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
+<!--
+Please move lines that apply to you out of the comment:
+- Code changes have been tested against the Discord API, or there are no code changes
+- I know how to update typings and have done so, or typings don't need updating
+- This PR changes the library's interface (methods or parameters added)
+- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
+- This PR **only** includes non-code changes, like changes to documentation, README, etc.
+-->

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,6 +1,6 @@
 # Seeking support?
 
-Sorry, we only use this issue tracker for bug reports and feature request. We are not able to provide general support or answer questions in the form of GitHub issues.
+We only use this issue tracker for bug reports and feature request. We are not able to provide general support or answer questions in the form of GitHub issues.
 
 For general questions about discord.js installation and use please use the dedicated support channels in our Discord server: https://discord.gg/bRCvFy9
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,7 +1,7 @@
 # Seeking support?
 
-We're sorry, we only use this issue tracker for bugs in the library itself and feature requests for it. We are not able to provide general support or answser questions on the issue tracker.
+Sorry, we only use this issue tracker for bug reports and feature request. We are not able to provide general support or answer questions in the form of GitHub issues.
 
-Should you want to ask such questions, please post in one of our support channels in our Discord server: https://discord.gg/bRCvFy9
+For general questions about discord.js installation and use please use the dedicated support channels in our Discord server: https://discord.gg/bRCvFy9
 
-Any issues that don't directly involve a bug in the library or a feature request will likely be closed and redirected to the Discord server.
+Any issues that don't directly involve a bug or a feature request will likely be closed and redirected.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- GitHub uses checkboxes as todo lists only. We currently use them as checkboxes for versioning classification, which intersects badly with GitHub native features (milestone progress, progress notifications, the progress bar in PR overview), to solve the issue this PR moves classification and optional lines into a comment at the bottom (see next point) to be moved out if applicable.
- Fix grammar and typo in various places, streamline wording to be more concise and compact
- Remove comments from the top. The "please ask questions on discord.js" is now covered with a button in the issue view. The comment is not stripped when posted to our webhook, blocking any and all useful information in favor of those lines.
