### PR TITLE
refactor(Collector): make endReason a getter

### DIFF
--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -90,12 +90,7 @@ class MessageCollector extends Collector {
     return message.channel.id === this.channel.id ? message.id : null;
   }
 
-  /**
-   * Checks after un/collection to see if the collector is done.
-   * @returns {?string}
-   * @private
-   */
-  endReason() {
+  get endReason() {
     if (this.options.max && this.collected.size >= this.options.max) return 'limit';
     if (this.options.maxProcessed && this.received === this.options.maxProcessed) return 'processedLimit';
     return null;

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -146,7 +146,7 @@ class ReactionCollector extends Collector {
     this.checkEnd();
   }
 
-  endReason() {
+  get endReason() {
     if (this.options.max && this.total >= this.options.max) return 'limit';
     if (this.options.maxEmojis && this.collected.size >= this.options.maxEmojis) return 'emojiLimit';
     if (this.options.maxUsers && this.users.size >= this.options.maxUsers) return 'userLimit';

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -214,7 +214,7 @@ class Collector extends EventEmitter {
    * Checks whether the collector should end, and if so, ends it.
    */
   checkEnd() {
-    const reason = this.endReason();
+    const reason = this.endReason;
     if (reason) this.stop(reason);
   }
 
@@ -253,7 +253,7 @@ class Collector extends EventEmitter {
     return Util.flatten(this);
   }
 
-  /* eslint-disable no-empty-function, valid-jsdoc */
+  /* eslint-disable no-empty-function */
   /**
    * Handles incoming events from the `handleCollect` function. Returns null if the event should not
    * be collected, or returns an object describing the data that should be stored.
@@ -273,14 +273,14 @@ class Collector extends EventEmitter {
    * @abstract
    */
   dispose() {}
+  /* eslint-enable no-empty-function */
 
   /**
-   * The reason this collector has ended or will end with.
-   * @returns {?string} Reason to end the collector, if any
+   * The reason this collector has ended with, or null if it hasn't ended yet
+   * @name Collector#endReason
+   * @type {?string}
    * @abstract
    */
-  endReason() {}
-  /* eslint-enable no-empty-function, valid-jsdoc */
 }
 
 module.exports = Collector;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -286,6 +286,7 @@ declare module 'discord.js' {
     public readonly client: Client;
     public collected: Collection<K, V>;
     public ended: boolean;
+    public abstract endReason: string | null;
     public filter: CollectorFilter;
     public readonly next: Promise<V>;
     public options: CollectorOptions;
@@ -300,7 +301,6 @@ declare module 'discord.js' {
     protected listener: (...args: any[]) => void;
     public abstract collect(...args: any[]): K;
     public abstract dispose(...args: any[]): K;
-    public abstract endReason(): void;
 
     public on(event: 'collect' | 'dispose', listener: (...args: any[]) => void): this;
     public on(event: 'end', listener: (collected: Collection<K, V>, reason: string) => void): this;
@@ -1042,12 +1042,12 @@ declare module 'discord.js' {
     private _handleGuildDeletion(guild: Guild): void;
 
     public channel: Channel;
+    public readonly endReason: string | null;
     public options: MessageCollectorOptions;
     public received: number;
 
     public collect(message: Message): Snowflake;
     public dispose(message: Message): Snowflake;
-    public endReason(): string;
   }
 
   export class MessageEmbed {
@@ -1219,6 +1219,7 @@ declare module 'discord.js' {
     private _handleGuildDeletion(guild: Guild): void;
     private _handleMessageDeletion(message: Message): void;
 
+    public readonly endReason: string | null;
     public message: Message;
     public options: ReactionCollectorOptions;
     public total: number;
@@ -1229,7 +1230,6 @@ declare module 'discord.js' {
     public collect(reaction: MessageReaction): Snowflake | string;
     public dispose(reaction: MessageReaction, user: User): Snowflake | string;
     public empty(): void;
-    public endReason(): string | null;
 
     public on(event: 'collect' | 'dispose' | 'remove', listener: (reaction: MessageReaction, user: User) => void): this;
     public on(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`endReason` only returns a value, so there's no reason why it should be a method.

**Status and versioning classification:**

- I know how to update typings and have done so
- This PR includes breaking changes