### PR TITLE
fix(GuildChannel): channel type must be converted

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -357,7 +357,7 @@ class GuildChannel extends Channel {
     const newData = await this.client.api.channels(this.id).patch({
       data: {
         name: (data.name || this.name).trim(),
-        type: data.type ? ChannelTypes[data.type.toUpperCase()] : this.type,
+        type: ChannelTypes[(data.type || this.type).toUpperCase()],
         topic: data.topic,
         nsfw: data.nsfw,
         bitrate: data.bitrate || this.bitrate,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When editing a channel, if you send no type data the current type of the channel is not converted to the appropriate int.
This PR make that it is actually converting the edited channel type.


**Status and versioning classification:**
- Code changes have been tested against the Discord API
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
