### PR TITLE
feat(GuildMemberManager): add kick method

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -105,6 +105,8 @@ const Messages = {
   FETCH_GROUP_DM_CHANNEL: "Bots don't have access to Group DM Channels and cannot fetch them",
 
   MEMBER_FETCH_NONCE_LENGTH: 'Nonce length must not exceed 32 characters.',
+
+  KICK_RESOLVE_ID: "Couldn't resolve the user ID to kick.",
 };
 
 for (const [name, message] of Object.entries(Messages)) register(name, message);

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -248,6 +248,37 @@ class GuildMemberManager extends BaseManager {
       .then(() => this.client.users.resolve(user));
   }
 
+  /**
+   * Kicks a user from the guild.
+   * @param {UserResolvable} user The user to kick
+   * @param {string} [reason] Reason for kicking
+   * @returns {Promise<GuildMember|User|Snowflake>} Result object will be resolved as specifically as possible.
+   * If the GuildMember cannot be resolved, the User will instead be attempted to be resolved. If that also cannot
+   * be resolved, the user ID will be the result.
+   * @example
+   * // Kicks a user by ID (or with a user/guild member object)
+   * guild.members.kick('620567262004248596')
+   *   .then(user => console.log(`Kicked ${user.username || user.id || user} from ${guild.name}`))
+   *   .catch(console.error);
+   */
+  kick(user, reason) {
+    const id = this.client.users.resolveID(user);
+    if (!id) return Promise.reject(new Error('KICK_RESOLVE_ID'));
+    return this.client.api
+      .guilds(this.guild.id)
+      .members(id)
+      .delete({ reason })
+      .then(() => {
+        if (user instanceof GuildMember) return user;
+        const _user = this.client.users.resolve(id);
+        if (_user) {
+          const member = this.resolve(_user);
+          return member || _user;
+        }
+        return id;
+      });
+  }
+
   _fetchSingle({ user, cache, force = false }) {
     if (!force) {
       const existing = this.cache.get(user);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1944,6 +1944,7 @@ declare module 'discord.js' {
       options: UserResolvable | FetchMemberOptions | (FetchMembersOptions & { user: UserResolvable }),
     ): Promise<GuildMember>;
     public fetch(options?: FetchMembersOptions): Promise<Collection<Snowflake, GuildMember>>;
+    public kick(user: UserResolvable, reason?: string): Promise<GuildMember | User | Snowflake>;
     public prune(options: GuildPruneMembersOptions & { dry?: false; count: false }): Promise<null>;
     public prune(options?: GuildPruneMembersOptions): Promise<number>;
     public unban(user: UserResolvable, reason?: string): Promise<User>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently, `GuildMember#kick` is the only way to kick a user from the guild. Although most of the times, the member we want to kick can be obtained either from mentions or cache but there can be some cases where we only have the id of an uncached member. To kick that uncached member we have to fetch the member first and then call `#kick` on it. This unnecessary API call can be avoided if we expose the `Remove Guild Member` endpoint via `GuildMemberManager#kick`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
