### PR TITLE
fix(ReactionUserManager): remove before query option

### DIFF
--- a/src/managers/ReactionUserManager.js
+++ b/src/managers/ReactionUserManager.js
@@ -28,15 +28,14 @@ class ReactionUserManager extends BaseManager {
    * Fetches all the users that gave this reaction. Resolves with a collection of users, mapped by their IDs.
    * @param {Object} [options] Options for fetching the users
    * @param {number} [options.limit=100] The maximum amount of users to fetch, defaults to 100
-   * @param {Snowflake} [options.before] Limit fetching users to those with an id lower than the supplied id
    * @param {Snowflake} [options.after] Limit fetching users to those with an id greater than the supplied id
    * @returns {Promise<Collection<Snowflake, User>>}
    */
-  async fetch({ limit = 100, after, before } = {}) {
+  async fetch({ limit = 100, after } = {}) {
     const message = this.reaction.message;
     const data = await this.client.api.channels[message.channel.id].messages[message.id].reactions[
       this.reaction.emoji.identifier
-    ].get({ query: { limit, before, after } });
+    ].get({ query: { limit, after } });
     const users = new Collection();
     for (const rawUser of data) {
       const user = this.client.users.add(rawUser);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2004,11 +2004,7 @@ declare module 'discord.js' {
   export class ReactionUserManager extends BaseManager<Snowflake, User, UserResolvable> {
     constructor(client: Client, iterable: Iterable<any> | undefined, reaction: MessageReaction);
     public reaction: MessageReaction;
-    public fetch(options?: {
-      limit?: number;
-      after?: Snowflake;
-      before?: Snowflake;
-    }): Promise<Collection<Snowflake, User>>;
+    public fetch(options?: { limit?: number; after?: Snowflake }): Promise<Collection<Snowflake, User>>;
     public remove(user?: UserResolvable): Promise<MessageReaction>;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `before` option is apparently not actually supported as per <https://github.com/discord/discord-api-docs/issues/1324#issuecomment-579019973> (despite documented)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)