### PR TITLE
feat: remove permission getters attempt no.2, electric boogaloo

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -567,15 +567,6 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Whether the channel is deletable by the client user
-   * @type {boolean}
-   * @readonly
-   */
-  get deletable() {
-    return this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false);
-  }
-
-  /**
    * Whether the channel is manageable by the client user
    * @type {boolean}
    * @readonly

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -235,24 +235,6 @@ class GuildMember extends Base {
   }
 
   /**
-   * Whether this member is kickable by the client user
-   * @type {boolean}
-   * @readonly
-   */
-  get kickable() {
-    return this.manageable && this.guild.me.permissions.has(Permissions.FLAGS.KICK_MEMBERS);
-  }
-
-  /**
-   * Whether this member is bannable by the client user
-   * @type {boolean}
-   * @readonly
-   */
-  get bannable() {
-    return this.manageable && this.guild.me.permissions.has(Permissions.FLAGS.BAN_MEMBERS);
-  }
-
-  /**
    * Returns `channel.permissionsFor(guildMember)`. Returns permissions for a member in a guild channel,
    * taking into account roles and permission overwrites.
    * @param {ChannelResolvable} channel The guild channel to use as context

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -370,16 +370,7 @@ class Message extends Base {
       });
     });
   }
-
-  /**
-   * Whether the message is editable by the client user
-   * @type {boolean}
-   * @readonly
-   */
-  get editable() {
-    return this.author.id === this.client.user.id;
-  }
-
+  
   /**
    * Whether the message is deletable by the client user
    * @type {boolean}

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -370,7 +370,7 @@ class Message extends Base {
       });
     });
   }
-  
+
   /**
    * Whether the message is deletable by the client user
    * @type {boolean}
@@ -381,18 +381,6 @@ class Message extends Base {
       !this.deleted &&
         (this.author.id === this.client.user.id ||
           this.channel.permissionsFor?.(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES)),
-    );
-  }
-
-  /**
-   * Whether the message is pinnable by the client user
-   * @type {boolean}
-   * @readonly
-   */
-  get pinnable() {
-    return (
-      this.type === 'DEFAULT' &&
-      (!this.guild || this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false))
     );
   }
 

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -70,15 +70,6 @@ class VoiceChannel extends GuildChannel {
   }
 
   /**
-   * Checks if the client has permission to send audio to the voice channel
-   * @type {boolean}
-   * @readonly
-   */
-  get speakable() {
-    return this.permissionsFor(this.client.user).has(Permissions.FLAGS.SPEAK, false);
-  }
-
-  /**
    * Sets the bitrate of the channel.
    * @param {number} bitrate The new bitrate
    * @param {string} [reason] Reason for changing the channel's bitrate

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -49,15 +49,6 @@ class VoiceChannel extends GuildChannel {
   }
 
   /**
-   * Whether the channel is deletable by the client user
-   * @type {boolean}
-   * @readonly
-   */
-  get deletable() {
-    return super.deletable && this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false);
-  }
-
-  /**
    * Whether the channel is editable by the client user
    * @type {boolean}
    * @readonly

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -796,7 +796,6 @@ declare module 'discord.js' {
 
   export class GuildMember extends PartialTextBasedChannel(Base) {
     constructor(client: Client, data: object, guild: Guild);
-    public readonly bannable: boolean;
     public deleted: boolean;
     public readonly displayColor: number;
     public readonly displayHexColor: string;
@@ -806,7 +805,6 @@ declare module 'discord.js' {
     public pending: boolean;
     public readonly joinedAt: Date | null;
     public joinedTimestamp: number | null;
-    public readonly kickable: boolean;
     public lastMessageChannelID: Snowflake | null;
     public readonly manageable: boolean;
     public nickname: string | null;
@@ -3091,19 +3089,16 @@ declare module 'discord.js' {
   interface PartialGuildMember
     extends Partialize<
       GuildMember,
-      | 'bannable'
       | 'displayColor'
       | 'displayHexColor'
       | 'displayName'
       | 'guild'
-      | 'kickable'
       | 'permissions'
       | 'roles'
       | 'manageable'
       | 'presence'
       | 'voice'
     > {
-    readonly bannable: boolean;
     readonly displayColor: number;
     readonly displayHexColor: string;
     readonly displayName: string;
@@ -3111,7 +3106,6 @@ declare module 'discord.js' {
     readonly manageable: boolean;
     joinedAt: null;
     joinedTimestamp: null;
-    readonly kickable: boolean;
     readonly permissions: GuildMember['permissions'];
     readonly presence: GuildMember['presence'];
     readonly roles: GuildMember['roles'];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -962,7 +962,6 @@ declare module 'discord.js' {
     public createdTimestamp: number;
     public readonly deletable: boolean;
     public deleted: boolean;
-    public readonly editable: boolean;
     public readonly editedAt: Date | null;
     public editedTimestamp: number | null;
     public embeds: MessageEmbed[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3128,7 +3128,6 @@ declare module 'discord.js' {
       | 'channel'
       | 'deletable'
       | 'crosspostable'
-      | 'editable'
       | 'mentions'
       | 'url'
       | 'flags'
@@ -3138,7 +3137,6 @@ declare module 'discord.js' {
     channel: Message['channel'];
     readonly deletable: boolean;
     readonly crosspostable: boolean;
-    readonly editable: boolean;
     embeds: Message['embeds'];
     flags: Message['flags'];
     mentions: Message['mentions'];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -737,7 +737,6 @@ declare module 'discord.js' {
     private rolePermissions(role: Role): Readonly<Permissions>;
 
     public readonly calculatedPosition: number;
-    public readonly deletable: boolean;
     public guild: Guild;
     public readonly manageable: boolean;
     public readonly members: Collection<Snowflake, GuildMember>;
@@ -1608,7 +1607,6 @@ declare module 'discord.js' {
   export class VoiceChannel extends GuildChannel {
     constructor(guild: Guild, data?: object);
     public bitrate: number;
-    public readonly editable: boolean;
     public readonly full: boolean;
     public readonly joinable: boolean;
     public readonly speakable: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1609,7 +1609,6 @@ declare module 'discord.js' {
     public bitrate: number;
     public readonly full: boolean;
     public readonly joinable: boolean;
-    public readonly speakable: boolean;
     public type: 'voice';
     public userLimit: number;
     public join(): Promise<VoiceConnection>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -971,7 +971,6 @@ declare module 'discord.js' {
     public mentions: MessageMentions;
     public nonce: string | number | null;
     public readonly partial: false;
-    public readonly pinnable: boolean;
     public pinned: boolean;
     public reactions: ReactionManager;
     public system: boolean;
@@ -3131,7 +3130,6 @@ declare module 'discord.js' {
       | 'crosspostable'
       | 'editable'
       | 'mentions'
-      | 'pinnable'
       | 'url'
       | 'flags'
       | 'embeds'
@@ -3144,7 +3142,6 @@ declare module 'discord.js' {
     embeds: Message['embeds'];
     flags: Message['flags'];
     mentions: Message['mentions'];
-    readonly pinnable: boolean;
     reactions: Message['reactions'];
     readonly url: string;
   }


### PR DESCRIPTION
After further discussion in the Discord Server, I have decided to revive https://github.com/discordjs/discord.js/pull/5164 through this PR. I believe I prematurely closed that PR. This move is bound to be a controversial one, so more discussion is welcome on this topic. 

Before you go ahead and downvote the PR, be sure to understand that this PR only aims to cleanup useless getters that shouldn't be the responsibility of the lib to provide. 

## What will this PR remove?
- getters that are simple wrappers over easily doable permission checks/id checks

## What *won't* this PR remove?
- getters that are relied on heavily by other internal structures.
- getters that do a level of checking higher than simple user-doable checks

## Getters Removal List
- [X] Message#editable
- [x] Message#pinnable
- [ ] GuildChannel#viewable (by extension this will remove StoreChannel#viewable, TextChannel#viewable, VoiceChannel#viewable, NewsChannel#viewable)
- [x] GuildChannel#deletable (by extension this will remove StoreChannel#deletable, TextChannel#deletable, VoiceChannel#deletable, NewsChannel#deletable)
- [ ] VoiceChannel#editable
- [x] VoiceChannel#speakable
- [x] GuildMember#bannable
- [x] GuildMember#kickable

⚠️Before you suggest getters to add to the removal list, ensure that these getters **aren't** used heavily elsewhere. Don't want to break lib functionality do we now 👀 

-----
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
