### PR TITLE
Added user.asMention() method

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -258,6 +258,14 @@ class User extends Base {
     const data = await this.client.api.channels(dmChannel.id).delete();
     return this.client.actions.ChannelDelete.handle(data).channel;
   }
+  
+  /**
+   * This creates a mention of an user, that no brackets need to be added in addition.
+   * @returns {string}
+   */
+  asMention() {
+    return `<@${this.id}>`;
+  }
 
   /**
    * Checks if the user is equal to another. It compares ID, username, discriminator, avatar, and bot flags.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When I used to code with discord.js I always looked for a simple way to create a user mention.
The toString method does not cover all usages, so I thought a user.asMention() method would be great to create a simple mention instead of manually adding pointing brackets for getting a mention string.
It should be added because it is simple to use and simple to find.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
