### PR TITLE
Added asMention Getter

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -137,6 +137,14 @@ class User extends Base {
     const channel = this.client.channels.cache.get(this.lastMessageChannelID);
     return (channel && channel.messages.cache.get(this.lastMessageID)) || null;
   }
+  
+  /**
+   * This returns a mention string for the user
+   * @returns {string}
+   */
+  get asMention() {
+    return this.toString();
+  }
 
   /**
    * The presence of this user

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -137,10 +137,11 @@ class User extends Base {
     const channel = this.client.channels.cache.get(this.lastMessageChannelID);
     return (channel && channel.messages.cache.get(this.lastMessageID)) || null;
   }
-  
+
   /**
    * This returns a mention string for the user
    * @returns {string}
+   * @readonly
    */
   get asMention() {
     return this.toString();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When I was coding with discord.js, I was looking for a ``asMention`` getter or method for User objects.
The Getter I created is a simple alternative way for creating a mention of a user, which is also easier to find than the ``.toString()`` method.
In my opinion this should be used to make code when creating a mention for a user better readable, and understandable.
This also fits in any situation, and can be used instead of getting the ID and putting an @ and pointing brackets around it.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
