### PR TITLE
refactor(MessageOptions): move replyTo to reply#messageReference and add failIfNotExists

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -2,7 +2,7 @@
 
 const MessageAttachment = require('./MessageAttachment');
 const MessageEmbed = require('./MessageEmbed');
-const { RangeError, TypeError } = require('../errors');
+const { RangeError } = require('../errors');
 const DataResolver = require('../util/DataResolver');
 const MessageFlags = require('../util/MessageFlags');
 const Util = require('../util/Util');
@@ -163,17 +163,14 @@ class APIMessage {
     }
 
     let message_reference;
-    if (typeof this.options.replyTo !== 'undefined') {
+    if (typeof this.options.reply === 'object') {
       const message_id = this.isMessage
-        ? this.target.channel.messages.resolveID(this.options.replyTo)
-        : this.target.messages.resolveID(this.options.replyTo);
-      if (this.options.errorOnInvalidReply && typeof this.options.errorOnInvalidReply !== 'boolean') {
-        throw new TypeError('INVALID_TYPE', 'options.errorOnInvalidReply', 'boolean');
-      }
+        ? this.target.channel.messages.resolveID(this.options.reply.messageReference)
+        : this.target.messages.resolveID(this.options.reply.messageReference);
       if (message_id) {
         message_reference = {
           message_id,
-          fail_if_not_exists: this.options.errorOnInvalidReply ?? true,
+          fail_if_not_exists: this.options.reply.failIfNotExists ?? true,
         };
       }
     }

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -2,7 +2,7 @@
 
 const MessageAttachment = require('./MessageAttachment');
 const MessageEmbed = require('./MessageEmbed');
-const { RangeError } = require('../errors');
+const { RangeError, TypeError } = require('../errors');
 const DataResolver = require('../util/DataResolver');
 const MessageFlags = require('../util/MessageFlags');
 const Util = require('../util/Util');
@@ -167,6 +167,9 @@ class APIMessage {
       const message_id = this.isMessage
         ? this.target.channel.messages.resolveID(this.options.replyTo)
         : this.target.messages.resolveID(this.options.replyTo);
+      if (this.options.errorOnInvalidReply && typeof this.options.errorOnInvalidReply !== 'boolean') {
+        throw new TypeError('INVALID_TYPE', 'options.errorOnInvalidReply', 'boolean');
+      }
       if (message_id) {
         message_reference = {
           message_id,

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -168,7 +168,10 @@ class APIMessage {
         ? this.target.channel.messages.resolveID(this.options.replyTo)
         : this.target.messages.resolveID(this.options.replyTo);
       if (message_id) {
-        message_reference = { message_id };
+        message_reference = {
+          message_id,
+          fail_if_not_exists: !this.options.replyIfDeleted,
+        };
       }
     }
 

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -170,7 +170,7 @@ class APIMessage {
       if (message_id) {
         message_reference = {
           message_id,
-          fail_if_not_exists: !this.options.replyIfDeleted,
+          fail_if_not_exists: this.options.errorOnInvalidReply ?? true,
         };
       }
     }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -572,7 +572,7 @@ class Message extends Base {
    * Send an inline reply to this message.
    * @param {StringResolvable|APIMessage} [content=''] The content for the message
    * @param {MessageOptions|MessageAdditions} [options] The additional options to provide
-   * @param {MessageResolvable} [options.replyTo=this] The message to reply to
+   * @param {MessageResolvable} [options.reply.messageReference=this] The message to reply to
    * @returns {Promise<Message|Message[]>}
    */
   reply(content, options) {
@@ -580,7 +580,7 @@ class Message extends Base {
       content instanceof APIMessage
         ? content
         : APIMessage.transformOptions(content, options, {
-            replyTo: this,
+            reply: { messageReference: this },
           }),
     );
   }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -576,11 +576,12 @@ class Message extends Base {
    * @returns {Promise<Message|Message[]>}
    */
   reply(content, options) {
+    const failIfNotExists = options?.reply?.failIfNotExists ?? content?.reply?.failIfNotExists ?? true;
     return this.channel.send(
       content instanceof APIMessage
         ? content
         : APIMessage.transformOptions(content, options, {
-            reply: { messageReference: this },
+            reply: { messageReference: this, failIfNotExists },
           }),
     );
   }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -576,12 +576,14 @@ class Message extends Base {
    * @returns {Promise<Message|Message[]>}
    */
   reply(content, options) {
-    const failIfNotExists = options?.reply?.failIfNotExists ?? content?.reply?.failIfNotExists ?? true;
     return this.channel.send(
       content instanceof APIMessage
         ? content
         : APIMessage.transformOptions(content, options, {
-            reply: { messageReference: this, failIfNotExists },
+            reply: {
+              messageReference: this,
+              failIfNotExists: options?.reply?.failIfNotExists ?? content?.reply?.failIfNotExists ?? true,
+            },
           }),
     );
   }

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -64,6 +64,8 @@ class TextBasedChannel {
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message
    * @property {MessageResolvable} [replyTo] The message to reply to (must be in the same channel and not system)
+   * @property {boolean} [replyIfDeleted=false] whether to create a standard message instead of erroring if
+   * the message referenced in replyTo is deleted (Ignored when replyTo is not set)
    */
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -102,7 +102,7 @@ class TextBasedChannel {
    * Options for sending a message with a reply.
    * @typedef {Object} ReplyOptions
    * @param {MessageResolvable} messageReference The message to reply to (must be in the same channel and not system)
-   * @param {boolean} [failIfNotExists=true] whether to error if the referenced message
+   * @param {boolean} [failIfNotExists=true] Whether to error if the referenced message
    * does not exist (creates a standard message in this case when false)
    */
 

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -102,8 +102,8 @@ class TextBasedChannel {
    * Options for sending a message with a reply.
    * @typedef {Object} ReplyOptions
    * @param {MessageResolvable} messageReference The message to reply to (must be in the same channel and not system)
-   * @param {boolean} [failIfNotExists=true] whether to error if the message reference
-   * creates an invalid reply (creates a standard message in this case when false)
+   * @param {boolean} [failIfNotExists=true] whether to error if the referenced message
+   * does not exist (creates a standard message in this case when false)
    */
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -64,8 +64,8 @@ class TextBasedChannel {
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message
    * @property {MessageResolvable} [replyTo] The message to reply to (must be in the same channel and not system)
-   * @property {boolean} [replyIfDeleted=false] whether to create a standard message instead of erroring if
-   * the message referenced in replyTo is deleted (Ignored when replyTo is not set)
+   * @property {boolean} [errorOnInvalidReply=true] whether to error when sending a reply if the message referenced in
+   * replyTo creates an invalid reply (creates a standard message in this case when false)
    */
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -63,9 +63,7 @@ class TextBasedChannel {
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message
-   * @property {MessageResolvable} [replyTo] The message to reply to (must be in the same channel and not system)
-   * @property {boolean} [errorOnInvalidReply=true] whether to error when sending a reply if the message referenced in
-   * replyTo creates an invalid reply (creates a standard message in this case when false)
+   * @property {ReplyOptions} [reply] The options for replying to a message
    */
 
   /**
@@ -98,6 +96,14 @@ class TextBasedChannel {
    * @property {string} [char='\n'] Character to split the message with
    * @property {string} [prepend=''] Text to prepend to every piece except the first
    * @property {string} [append=''] Text to append to every piece except the last
+   */
+
+  /**
+   * Options for sending a message with a reply.
+   * @typedef {Object} ReplyOptions
+   * @param {MessageResolvable} messageReference The message to reply to (must be in the same channel and not system)
+   * @param {boolean} [failIfNotExists=true] whether to error if the message reference
+   * creates an invalid reply (creates a standard message in this case when false)
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2941,6 +2941,7 @@ declare module 'discord.js' {
     code?: string | boolean;
     split?: boolean | SplitOptions;
     replyTo?: MessageResolvable;
+    replyIfDeleted?: boolean;
   }
 
   type MessageReactionResolvable = MessageReaction | Snowflake;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2941,7 +2941,7 @@ declare module 'discord.js' {
     code?: string | boolean;
     split?: boolean | SplitOptions;
     replyTo?: MessageResolvable;
-    replyIfDeleted?: boolean;
+    errorOnInvalidReply?: boolean;
   }
 
   type MessageReactionResolvable = MessageReaction | Snowflake;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3191,7 +3191,7 @@ declare module 'discord.js' {
 
   interface ReplyOptions {
     messageReference: MessageResolvable;
-    failIfNotExists: boolean;
+    failIfNotExists?: boolean;
   }
 
   interface ResolvedOverwriteOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2940,8 +2940,7 @@ declare module 'discord.js' {
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
     code?: string | boolean;
     split?: boolean | SplitOptions;
-    replyTo?: MessageResolvable;
-    errorOnInvalidReply?: boolean;
+    reply?: ReplyOptions;
   }
 
   type MessageReactionResolvable = MessageReaction | Snowflake;
@@ -3188,6 +3187,11 @@ declare module 'discord.js' {
     max?: number;
     maxEmojis?: number;
     maxUsers?: number;
+  }
+
+  interface ReplyOptions {
+    messageReference: MessageResolvable;
+    failIfNotExists: boolean;
   }
 
   interface ResolvedOverwriteOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Add support for new `fail_if_not_exists` parameter in `message_reference`
ref: https://github.com/discord/discord-api-docs/pull/2572

This also changes the replyTo parameter to be more in line with the API

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
