### PR TITLE
typings(PermissionOverwrites): use correct parameter type for resolveOverwriteOptions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1182,7 +1182,7 @@ declare module 'discord.js' {
     public delete(reason?: string): Promise<PermissionOverwrites>;
     public toJSON(): object;
     public static resolveOverwriteOptions(
-      options: ResolvedOverwriteOptions,
+      options: PermissionOverwriteOption,
       initialPermissions: { allow?: PermissionResolvable; deny?: PermissionResolvable },
     ): ResolvedOverwriteOptions;
     public static resolve(overwrite: OverwriteResolvable, guild: Guild): RawOverwriteData;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the typings for `PermissionOverwrites#resolveOverwriteOptions` to accept `PermissionOverwriteOption` instead of `ResolvedOverwriteOptions`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:


- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
