### PR TITLE
fix(WebSocketShard): key name in WebSocketShard#_send.

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -648,7 +648,7 @@ class WebSocketShard extends EventEmitter {
   _send(data) {
     if (!this.connection || this.connection.readyState !== WebSocket.OPEN) {
       this.debug(`Tried to send packet '${JSON.stringify(data)}' but no WebSocket is available!`);
-      this.destroy({ close: 4000 });
+      this.destroy({ closeCode: 4000 });
       return;
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I just changed an incorrect key name that was introduced in Pull Request #3722. When destroying the websocket from the WebSocketShard#_send method it's using `close` as the key name instead of `closeCode`. This was just a small thing that I noticed while going through the files and I did a little bit of testing before I made this pr and it didn't break or solve anything that I know of.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes