### PR TITLE
fix(Voice): only skip undocumented voice packet byte if present

### DIFF
--- a/src/client/voice/receiver/PacketHandler.js
+++ b/src/client/voice/receiver/PacketHandler.js
@@ -72,8 +72,10 @@ class PacketHandler extends EventEmitter {
         if (byte === 0) continue;
         offset += 1 + (0b1111 & (byte >> 4));
       }
-      // Skip over undocumented Discord byte
-      offset++;
+      // Skip over undocumented Discord byte (if present)
+      const byte = packet.readUInt8(offset);
+      if (byte == 0x00 || byte == 0x02)
+        offset++;
 
       packet = packet.slice(offset);
     }

--- a/src/client/voice/receiver/PacketHandler.js
+++ b/src/client/voice/receiver/PacketHandler.js
@@ -74,8 +74,7 @@ class PacketHandler extends EventEmitter {
       }
       // Skip over undocumented Discord byte (if present)
       const byte = packet.readUInt8(offset);
-      if (byte == 0x00 || byte == 0x02)
-        offset++;
+      if (byte === 0x00 || byte === 0x02) offset++;
 
       packet = packet.slice(offset);
     }


### PR DESCRIPTION
Discord's Chrome client doesn't add a certain undocumented byte to voice packets, this implements a workaround for it that prevents a crash. Fixes #5105.

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
