### PR TITLE
fix(GuildMember): correctly check for premium_since

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -85,7 +85,7 @@ class GuildMember extends Base {
 
     if ('nick' in data) this.nickname = data.nick;
     if ('joined_at' in data) this.joinedTimestamp = new Date(data.joined_at).getTime();
-    if ('premium_since' in data) this.premiumSinceTimestamp = new Date(data.premium_since).getTime();
+    if (data.premium_since) this.premiumSinceTimestamp = new Date(data.premium_since).getTime();
     if ('roles' in data) this._roles = data.roles;
     this.pending = data.pending ?? false;
   }

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -85,7 +85,9 @@ class GuildMember extends Base {
 
     if ('nick' in data) this.nickname = data.nick;
     if ('joined_at' in data) this.joinedTimestamp = new Date(data.joined_at).getTime();
-    if (data.premium_since) this.premiumSinceTimestamp = new Date(data.premium_since).getTime();
+    if ('premium_since' in data) {
+      this.premiumSinceTimestamp = data.premium_since === null ? null : new Date(data.premium_since).getTime();
+    }
     if ('roles' in data) this._roles = data.roles;
     this.pending = data.pending ?? false;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a bug introduced by #4636, `GuildMember#premiumSinceTimestamp` was being set to 0 every time rather than null

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
