### PR TITLE
refactor(*): return the invalid element when erroring from Array

### DIFF
--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -45,21 +45,17 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
    */
   async create(attachment, name, { roles, reason } = {}) {
     attachment = await DataResolver.resolveImage(attachment);
-    if (!attachment) return Promise.reject(new TypeError('REQ_RESOURCE_TYPE'));
+    if (!attachment) throw new TypeError('REQ_RESOURCE_TYPE');
 
     const data = { image: attachment, name };
     if (roles) {
       if (!Array.isArray(roles) && !(roles instanceof Collection)) {
-        return Promise.reject(
-          new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true),
-        );
+        throw new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true);
       }
       data.roles = [];
       for (const role of roles instanceof Collection ? roles.values() : roles) {
         const resolvedRole = this.guild.roles.resolve(role);
-        if (!resolvedRole) {
-          return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role));
-        }
+        if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role);
         data.roles.push(resolvedRole.id);
       }
     }

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -53,7 +53,7 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
         throw new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true);
       }
       data.roles = [];
-      for (const role of roles instanceof Collection ? roles.values() : roles) {
+      for (const role of roles.values()) {
         const resolvedRole = this.guild.roles.resolve(role);
         if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role);
         data.roles.push(resolvedRole.id);

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -54,9 +54,9 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
       }
       data.roles = [];
       for (const role of roles.values()) {
-        const resolvedRole = this.guild.roles.resolve(role);
+        const resolvedRole = this.guild.roles.resolveID(role);
         if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role);
-        data.roles.push(resolvedRole.id);
+        data.roles.push(resolvedRole);
       }
     }
 

--- a/src/managers/GuildEmojiRoleManager.js
+++ b/src/managers/GuildEmojiRoleManager.js
@@ -83,7 +83,7 @@ class GuildEmojiRoleManager {
       resolvedRoles.push(resolvedRole);
     }
 
-    const newRoles = this._roles.keyArray().filter(role => !resolvedRoles.includes(role));
+    const newRoles = this._roles.keyArray().filter(role => !resolvedRoles.includes(role.id));
     return this.set(newRoles);
   }
 

--- a/src/managers/GuildEmojiRoleManager.js
+++ b/src/managers/GuildEmojiRoleManager.js
@@ -53,13 +53,17 @@ class GuildEmojiRoleManager {
   add(roleOrRoles) {
     if (roleOrRoles instanceof Collection) return this.add(roleOrRoles.keyArray());
     if (!Array.isArray(roleOrRoles)) return this.add([roleOrRoles]);
-    roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
 
-    if (roleOrRoles.includes(null)) {
-      return Promise.reject(new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true));
+    const resolvedRoles = [];
+    for (const role of roleOrRoles) {
+      const resolvedRole = this.guild.roles.resolveID(role);
+      if (!resolvedRole) {
+        return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
+      }
+      resolvedRoles.push(resolvedRole);
     }
 
-    const newRoles = [...new Set(roleOrRoles.concat(...this._roles.values()))];
+    const newRoles = [...new Set(resolvedRoles.concat(...this._roles.values()))];
     return this.set(newRoles);
   }
 
@@ -71,13 +75,17 @@ class GuildEmojiRoleManager {
   remove(roleOrRoles) {
     if (roleOrRoles instanceof Collection) return this.remove(roleOrRoles.keyArray());
     if (!Array.isArray(roleOrRoles)) return this.remove([roleOrRoles]);
-    roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
 
-    if (roleOrRoles.includes(null)) {
-      return Promise.reject(new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true));
+    const resolvedIDs = [];
+    for (const role of roleOrRoles) {
+      const resolvedID = this.guild.roles.resolveID(role);
+      if (!resolvedID) {
+        return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
+      }
+      resolvedIDs.push(resolvedID);
     }
 
-    const newRoles = this._roles.keyArray().filter(role => !roleOrRoles.includes(role));
+    const newRoles = this._roles.keyArray().filter(role => !resolvedIDs.includes(role));
     return this.set(newRoles);
   }
 

--- a/src/managers/GuildEmojiRoleManager.js
+++ b/src/managers/GuildEmojiRoleManager.js
@@ -51,11 +51,10 @@ class GuildEmojiRoleManager {
    * @returns {Promise<GuildEmoji>}
    */
   add(roleOrRoles) {
-    if (roleOrRoles instanceof Collection) return this.add(roleOrRoles.keyArray());
-    if (!Array.isArray(roleOrRoles)) return this.add([roleOrRoles]);
+    if (!Array.isArray(roleOrRoles) && !(roleOrRoles instanceof Collection)) roleOrRoles = [roleOrRoles];
 
     const resolvedRoles = [];
-    for (const role of roleOrRoles) {
+    for (const role of roleOrRoles.values()) {
       const resolvedRole = this.guild.roles.resolveID(role);
       if (!resolvedRole) {
         return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
@@ -73,19 +72,18 @@ class GuildEmojiRoleManager {
    * @returns {Promise<GuildEmoji>}
    */
   remove(roleOrRoles) {
-    if (roleOrRoles instanceof Collection) return this.remove(roleOrRoles.keyArray());
-    if (!Array.isArray(roleOrRoles)) return this.remove([roleOrRoles]);
+    if (!Array.isArray(roleOrRoles) && !(roleOrRoles instanceof Collection)) roleOrRoles = [roleOrRoles];
 
-    const resolvedIDs = [];
-    for (const role of roleOrRoles) {
-      const resolvedID = this.guild.roles.resolveID(role);
-      if (!resolvedID) {
+    const resolvedRoles = [];
+    for (const role of roleOrRoles.values()) {
+      const resolvedRole = this.guild.roles.resolveID(role);
+      if (!resolvedRole) {
         return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
       }
-      resolvedIDs.push(resolvedID);
+      resolvedRoles.push(resolvedRole);
     }
 
-    const newRoles = this._roles.keyArray().filter(role => !resolvedIDs.includes(role));
+    const newRoles = this._roles.keyArray().filter(role => !resolvedRoles.includes(role));
     return this.set(newRoles);
   }
 

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -176,7 +176,7 @@ class GuildMemberManager extends BaseManager {
    *    .catch(console.error);
    */
   prune({ days = 7, dry = false, count: compute_prune_count = true, roles = [], reason } = {}) {
-    if (typeof days !== 'number') throw new TypeError('PRUNE_DAYS_TYPE');
+    if (typeof days !== 'number') return Promise.reject(new TypeError('PRUNE_DAYS_TYPE'));
 
     const query = { days };
     const resolvedRoles = [];
@@ -184,7 +184,7 @@ class GuildMemberManager extends BaseManager {
     for (const role of roles) {
       const resolvedRole = this.guild.roles.resolveID(role);
       if (!resolvedRole) {
-        return Promise.reject(new TypeError('INVALID_TYPE', 'roles', 'Array of Roles or Snowflakes', true));
+        return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array', 'roles', role));
       }
       resolvedRoles.push(resolvedRole);
     }

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -184,7 +184,7 @@ class GuildMemberManager extends BaseManager {
     for (const role of roles) {
       const resolvedRole = this.guild.roles.resolveID(role);
       if (!resolvedRole) {
-        return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array', 'roles', role));
+        return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array', 'options.roles', role));
       }
       resolvedRoles.push(resolvedRole);
     }

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -101,7 +101,7 @@ class GuildMemberRoleManager {
   async add(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
       const resolvedRoles = [];
-      for (const role of roleOrRoles instanceof Collection ? roleOrRoles.values() : roleOrRoles) {
+      for (const role of roleOrRoles.values()) {
         const resolvedRole = this.guild.roles.resolve(role);
         if (!resolvedRole) {
           return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
@@ -136,7 +136,7 @@ class GuildMemberRoleManager {
   async remove(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
       const resolvedRoles = [];
-      for (const role of roleOrRoles instanceof Collection ? roleOrRoles.values() : roleOrRoles) {
+      for (const role of roleOrRoles.values()) {
         const resolvedRole = this.guild.roles.resolve(role);
         if (!resolvedRole) {
           return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -102,7 +102,7 @@ class GuildMemberRoleManager {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
       const resolvedRoles = [];
       for (const role of roleOrRoles.values()) {
-        const resolvedRole = this.guild.roles.resolve(role);
+        const resolvedRole = this.guild.roles.resolveID(role);
         if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role);
         resolvedRoles.push(resolvedRole);
       }
@@ -110,15 +110,15 @@ class GuildMemberRoleManager {
       const newRoles = [...new Set(resolvedRoles.concat(...this._roles.values()))];
       return this.set(newRoles, reason);
     } else {
-      roleOrRoles = this.guild.roles.resolve(roleOrRoles);
+      roleOrRoles = this.guild.roles.resolveID(roleOrRoles);
       if (roleOrRoles === null) {
         throw new TypeError('INVALID_TYPE', 'roles', 'Role, Snowflake or Array or Collection of Roles or Snowflakes');
       }
 
-      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleID].put({ reason });
+      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles].put({ reason });
 
       const clone = this.member._clone();
-      clone._roles = [...this._roles.keys(), roleID];
+      clone._roles = [...this._roles.keys(), roleOrRoles];
       return clone;
     }
   }
@@ -133,23 +133,23 @@ class GuildMemberRoleManager {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
       const resolvedRoles = [];
       for (const role of roleOrRoles.values()) {
-        const resolvedRole = this.guild.roles.resolve(role);
+        const resolvedRole = this.guild.roles.resolveID(role);
         if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role);
         resolvedRoles.push(resolvedRole);
       }
 
-      const newRoles = this._roles.filter(role => !resolvedRoles.includes(role));
+      const newRoles = this._roles.filter(role => !resolvedRoles.includes(role.id));
       return this.set(newRoles, reason);
     } else {
-      roleOrRoles = this.guild.roles.resolve(roleOrRoles);
+      roleOrRoles = this.guild.roles.resolveID(roleOrRoles);
       if (roleOrRoles === null) {
         throw new TypeError('INVALID_TYPE', 'roles', 'Role, Snwoflake or Array or Collection of Roles or Snowflakes');
       }
 
-      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleID].delete({ reason });
+      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles].delete({ reason });
 
       const clone = this.member._clone();
-      const newRoles = this._roles.filter(role => role.id !== roleID);
+      const newRoles = this._roles.filter(role => role.id !== roleOrRoles);
       clone._roles = [...newRoles.keys()];
       return clone;
     }

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -100,17 +100,23 @@ class GuildMemberRoleManager {
    */
   async add(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
-      roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
-      if (roleOrRoles.includes(null)) {
-        throw new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true);
+      const resolvedRoles = [];
+      for (const role of roleOrRoles instanceof Collection ? roleOrRoles.values() : roleOrRoles) {
+        const resolvedRole = this.guild.roles.resolve(role);
+        if (!resolvedRole) {
+          return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
+        }
+        resolvedRoles.push(resolvedRole);
       }
 
-      const newRoles = [...new Set(roleOrRoles.concat(...this._roles.values()))];
+      const newRoles = [...new Set(resolvedRoles.concat(...this._roles.values()))];
       return this.set(newRoles, reason);
     } else {
-      const roleID = this.guild.roles.resolveID(roleOrRoles);
-      if (roleID === null) {
-        throw new TypeError('INVALID_TYPE', 'roles', 'Role, Snowflake or Array or Collection of Roles or Snowflakes');
+      roleOrRoles = this.guild.roles.resolve(roleOrRoles);
+      if (roleOrRoles === null) {
+        return Promise.reject(
+          new TypeError('INVALID_TYPE', 'roles', 'Role, Snowflake or Array or Collection of Roles or Snowflakes'),
+        );
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleID].put({ reason });
@@ -129,17 +135,23 @@ class GuildMemberRoleManager {
    */
   async remove(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
-      roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
-      if (roleOrRoles.includes(null)) {
-        throw new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true);
+      const resolvedRoles = [];
+      for (const role of roleOrRoles instanceof Collection ? roleOrRoles.values() : roleOrRoles) {
+        const resolvedRole = this.guild.roles.resolve(role);
+        if (!resolvedRole) {
+          return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
+        }
+        resolvedRoles.push(resolvedRole);
       }
 
-      const newRoles = this._roles.filter(role => !roleOrRoles.includes(role.id));
+      const newRoles = this._roles.filter(role => !resolvedRoles.includes(role));
       return this.set(newRoles, reason);
     } else {
-      const roleID = this.guild.roles.resolveID(roleOrRoles);
-      if (roleID === null) {
-        throw new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true);
+      roleOrRoles = this.guild.roles.resolve(roleOrRoles);
+      if (roleOrRoles === null) {
+        return Promise.reject(
+          new TypeError('INVALID_TYPE', 'roles', 'Role, Snwoflake or Array or Collection of Roles or Snowflakes'),
+        );
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleID].delete({ reason });

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -103,9 +103,7 @@ class GuildMemberRoleManager {
       const resolvedRoles = [];
       for (const role of roleOrRoles.values()) {
         const resolvedRole = this.guild.roles.resolve(role);
-        if (!resolvedRole) {
-          return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
-        }
+        if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role);
         resolvedRoles.push(resolvedRole);
       }
 
@@ -114,9 +112,7 @@ class GuildMemberRoleManager {
     } else {
       roleOrRoles = this.guild.roles.resolve(roleOrRoles);
       if (roleOrRoles === null) {
-        return Promise.reject(
-          new TypeError('INVALID_TYPE', 'roles', 'Role, Snowflake or Array or Collection of Roles or Snowflakes'),
-        );
+        throw new TypeError('INVALID_TYPE', 'roles', 'Role, Snowflake or Array or Collection of Roles or Snowflakes');
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleID].put({ reason });
@@ -138,9 +134,7 @@ class GuildMemberRoleManager {
       const resolvedRoles = [];
       for (const role of roleOrRoles.values()) {
         const resolvedRole = this.guild.roles.resolve(role);
-        if (!resolvedRole) {
-          return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
-        }
+        if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role);
         resolvedRoles.push(resolvedRole);
       }
 
@@ -149,9 +143,7 @@ class GuildMemberRoleManager {
     } else {
       roleOrRoles = this.guild.roles.resolve(roleOrRoles);
       if (roleOrRoles === null) {
-        return Promise.reject(
-          new TypeError('INVALID_TYPE', 'roles', 'Role, Snwoflake or Array or Collection of Roles or Snowflakes'),
-        );
+        throw new TypeError('INVALID_TYPE', 'roles', 'Role, Snwoflake or Array or Collection of Roles or Snowflakes');
       }
 
       await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleID].delete({ reason });

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -918,21 +918,17 @@ class Guild extends Base {
    */
   async addMember(user, options) {
     user = this.client.users.resolveID(user);
-    if (!user) return Promise.reject(new TypeError('INVALID_TYPE', 'user', 'UserResolvable'));
+    if (!user) throw new TypeError('INVALID_TYPE', 'user', 'UserResolvable');
     if (this.members.cache.has(user)) return this.members.cache.get(user);
     options.access_token = options.accessToken;
     if (options.roles) {
       if (!Array.isArray(options.roles) && !(options.roles instanceof Collection)) {
-        return Promise.reject(
-          new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true),
-        );
+        throw new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true);
       }
       const resolvedRoles = [];
       for (const role of options.roles.values()) {
         const resolvedRole = this.roles.resolve(role);
-        if (!role) {
-          return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role));
-        }
+        if (!role) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role);
         resolvedRoles.push(resolvedRole.id);
       }
       options.roles = resolvedRoles;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -918,19 +918,24 @@ class Guild extends Base {
    */
   async addMember(user, options) {
     user = this.client.users.resolveID(user);
-    if (!user) throw new TypeError('INVALID_TYPE', 'user', 'UserResolvable');
+    if (!user) return Promise.reject(new TypeError('INVALID_TYPE', 'user', 'UserResolvable'));
     if (this.members.cache.has(user)) return this.members.cache.get(user);
     options.access_token = options.accessToken;
     if (options.roles) {
-      const roles = [];
-      for (let role of options.roles instanceof Collection ? options.roles.values() : options.roles) {
-        let roleID = this.roles.resolveID(role);
-        if (!roleID) {
-          throw new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true);
-        }
-        roles.push(roleID);
+      if (!Array.isArray(options.roles) && !(options.roles instanceof Collection)) {
+        return Promise.reject(
+          new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true),
+        );
       }
-      options.roles = roles;
+      const resolvedRoles = [];
+      for (const role of options.roles instanceof Collection ? options.roles.values() : options.roles) {
+        const resolvedRole = this.roles.resolve(role);
+        if (!role) {
+          return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role));
+        }
+        resolvedRoles.push(resolvedRole.id);
+      }
+      options.roles = resolvedRoles;
     }
     const data = await this.client.api.guilds(this.id).members(user).put({ data: options });
     // Data is an empty buffer if the member is already part of the guild.

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -928,7 +928,7 @@ class Guild extends Base {
         );
       }
       const resolvedRoles = [];
-      for (const role of options.roles instanceof Collection ? options.roles.values() : options.roles) {
+      for (const role of options.roles.values()) {
         const resolvedRole = this.roles.resolve(role);
         if (!role) {
           return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role));

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -927,9 +927,9 @@ class Guild extends Base {
       }
       const resolvedRoles = [];
       for (const role of options.roles.values()) {
-        const resolvedRole = this.roles.resolve(role);
+        const resolvedRole = this.roles.resolveID(role);
         if (!role) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role);
-        resolvedRoles.push(resolvedRole.id);
+        resolvedRoles.push(resolvedRole);
       }
       options.roles = resolvedRoles;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR uses the new error from #5215 to provide more detailed errors when erroring from an Array or Collection.

⚠️ This has not been fully tested
⚠️ This changes some methods to use Promise.reject instead of throw or vice-versa

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
