### PR TITLE
docs(GuildMember): document owner override in permissions getter

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -211,7 +211,7 @@ class GuildMember extends Base {
   }
 
   /**
-   * The overall set of permissions for this member, taking only roles into account
+   * The overall set of permissions for this member, taking only roles and owner status into account
    * @type {Readonly<Permissions>}
    * @readonly
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Document the implicit owner override in the GuildMember#permissions getter.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
