### PR TITLE
fix(Role#edit): add missing toString() on permissions

### DIFF
--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -220,7 +220,7 @@ class Role extends Base {
           name: data.name || this.name,
           color: data.color !== null ? Util.resolveColor(data.color || this.color) : null,
           hoist: typeof data.hoist !== 'undefined' ? data.hoist : this.hoist,
-          permissions: data.permissions,
+          permissions: data.permissions.toString(),
           mentionable: typeof data.mentionable !== 'undefined' ? data.mentionable : this.mentionable,
         },
         reason,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a missing `toString` function on `permissions` in the `PATCH` request body.
This should be treated with high severity.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
