### PR TITLE
fix: emit non-cached MessageDelete events

### DIFF
--- a/src/client/actions/MessageDelete.js
+++ b/src/client/actions/MessageDelete.js
@@ -13,13 +13,13 @@ class MessageDeleteAction extends Action {
       if (message) {
         channel.messages.cache.delete(message.id);
         message.deleted = true;
-        /**
-         * Emitted whenever a message is deleted.
-         * @event Client#messageDelete
-         * @param {Message} message The deleted message
-         */
-        client.emit(Events.MESSAGE_DELETE, message);
       }
+      /**
+       * Emitted whenever a message is deleted.
+       * @event Client#messageDelete
+       * @param {?Message} message The deleted message
+       */
+      client.emit(Events.MESSAGE_DELETE, message);
     }
 
     return { message };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This change will ensure the `MessageDelete` event will fire in the event a message has not been cached.
This effectively makes `message` nullable in the `MessageDelete` context.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
