### PR TITLE
fix(Constants.Colors): change hex value of white to resolve on desktop

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -486,7 +486,7 @@ exports.ClientApplicationAssetTypes = {
 
 exports.Colors = {
   DEFAULT: 0x000000,
-  WHITE: 0xffffff,
+  WHITE: 0xfefefe,
   AQUA: 0x1abc9c,
   GREEN: 0x2ecc71,
   BLUE: 0x3498db,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -437,7 +437,7 @@ declare module 'discord.js' {
     };
     Colors: {
       DEFAULT: 0x000000;
-      WHITE: 0xffffff;
+      WHITE: 0xfefefe;
       AQUA: 0x1abc9c;
       GREEN: 0x2ecc71;
       BLUE: 0x3498db;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the value of `Colors.White` from `0xFFFFFF` to `0xFEFEFE` so it renders properly on desktop (mobile doesn't have this issue).

![Screen Shot 2021-02-28 at 4 01 24 PM](https://user-images.githubusercontent.com/60681223/109438418-ec1ae280-79f7-11eb-8201-ea85de6ff5b7.png)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
