### PR TITLE
feat(Guild): add Guild#displayIcon() method

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -525,6 +525,16 @@ class Guild extends Base {
   }
 
   /**
+   * The URL to this guild's icon if it has one.
+   * Otherwise the guild's acronym will be returned.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string}
+   */
+  displayIcon(options) {
+    return this.iconURL(options) ?? this.nameAcronym;
+  }
+
+  /**
    * The URL to this guild's invite splash image.
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -638,7 +638,7 @@ declare module 'discord.js' {
     public createTemplate(name: string, description?: string): Promise<GuildTemplate>;
     public delete(): Promise<Guild>;
     public discoverySplashURL(options?: ImageURLOptions): string | null;
-	public displayIcon(options?: ImageURLOptions): string;
+    public displayIcon(options?: ImageURLOptions): string;
     public edit(data: GuildEditData, reason?: string): Promise<Guild>;
     public equals(guild: Guild): boolean;
     public fetch(): Promise<Guild>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -638,6 +638,7 @@ declare module 'discord.js' {
     public createTemplate(name: string, description?: string): Promise<GuildTemplate>;
     public delete(): Promise<Guild>;
     public discoverySplashURL(options?: ImageURLOptions): string | null;
+	public displayIcon(options?: ImageURLOptions): string;
     public edit(data: GuildEditData, reason?: string): Promise<Guild>;
     public equals(guild: Guild): boolean;
     public fetch(): Promise<Guild>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a `displayIcon()` method to the Guild object for convenience, similar to [`User#displayAvatarURL()`](https://discord.js.org/#/docs/main/stable/class/User?scrollTo=displayAvatarURL).

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
