### PR TITLE
Added check for if guild is unavailable on guild object

### DIFF
--- a/src/client/actions/GuildDelete.js
+++ b/src/client/actions/GuildDelete.js
@@ -18,7 +18,7 @@ class GuildDeleteAction extends Action {
         if (channel.type === 'text') channel.stopTyping(true);
       }
 
-      if (data.unavailable) {
+      if (data.unavailable || !guild.available) {
         // Guild is unavailable
         guild.available = false;
 


### PR DESCRIPTION
**guildDelete event fires on startup due to an unavailable guild but not the guildUnavailable event**

There is a guild in my bot which is unavailable ( sitenote: I am pretty certain that this my bot user left this guild about a week or so ago ) and everytime the client starts up the `guildDelete` event fires and the `guildUnavailable` event does not fire.

I looked into it and it appears that the `GuildDeleteAction` event fires when this occurs but the data object that is sent to it just contains the guild id property: `{ id: '813428000925417513' }` with no `unavailable` property like [documented](https://discord.com/developers/docs/resources/guild#unavailable-guild-object)

However it appears that the guild does have the `available` property found on all guilds so I added an extra check for this property when deciding if to fire the `guildUnavailable` or `guildDelete` event.

I believe that this is an edge case on discords end as I mentioned earlier that I don't think that my bot is in this guild anymore. It has also been unavailable for about a week now.

Adding this change to my local library seemed to fix it. Let me know if I am missing anything here I hope my first PR has been useful!

edit: This will fix the behavior in #5350 which is a Discord bug 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes

