### PR TITLE
fix(MessageMentions#channels): Fix type of channels of mentions

### DIFF
--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -147,7 +147,7 @@ class MessageMentions {
   /**
    * Any channels that were mentioned
    * <info>Order as they appear first in the message content</info>
-   * @type {Collection<Snowflake, GuildChannel>}
+   * @type {Collection<Snowflake, Channel>}
    * @readonly
    */
   get channels() {

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -87,7 +87,7 @@ class MessageMentions {
 
     /**
      * Cached channels for {@link MessageMentions#channels}
-     * @type {?Collection<Snowflake, GuildChannel>}
+     * @type {?Collection<Snowflake, Channel>}
      * @private
      */
     this._channels = null;
@@ -164,7 +164,7 @@ class MessageMentions {
   /**
    * Checks if a user, guild member, role, or channel is mentioned.
    * Takes into account user mentions, role mentions, and @everyone/@here mentions.
-   * @param {UserResolvable|RoleResolvable|GuildChannelResolvable} data User/Role/Channel to check
+   * @param {UserResolvable|RoleResolvable|ChannelResolvable} data User/Role/Channel to check
    * @param {Object} [options] Options
    * @param {boolean} [options.ignoreDirect=false] - Whether to ignore direct mentions to the item
    * @param {boolean} [options.ignoreRoles=false] - Whether to ignore role mentions to a guild member

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1112,7 +1112,7 @@ declare module 'discord.js' {
     private readonly _content: string;
     private _members: Collection<Snowflake, GuildMember> | null;
 
-    public readonly channels: Collection<Snowflake, TextChannel>;
+    public readonly channels: Collection<Snowflake, GuildChannel>;
     public readonly client: Client;
     public everyone: boolean;
     public readonly guild: Guild;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1108,7 +1108,7 @@ declare module 'discord.js' {
       roles: Snowflake[] | Collection<Snowflake, Role>,
       everyone: boolean,
     );
-    private _channels: Collection<Snowflake, GuildChannel> | null;
+    private _channels: Collection<Snowflake, Channel> | null;
     private readonly _content: string;
     private _members: Collection<Snowflake, GuildMember> | null;
 
@@ -1117,7 +1117,7 @@ declare module 'discord.js' {
     public everyone: boolean;
     public readonly guild: Guild;
     public has(
-      data: UserResolvable | RoleResolvable | GuildChannelResolvable,
+      data: UserResolvable | RoleResolvable | ChannelResolvable,
       options?: {
         ignoreDirect?: boolean;
         ignoreRoles?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1112,7 +1112,7 @@ declare module 'discord.js' {
     private readonly _content: string;
     private _members: Collection<Snowflake, GuildMember> | null;
 
-    public readonly channels: Collection<Snowflake, GuildChannel>;
+    public readonly channels: Collection<Snowflake, Channel>;
     public readonly client: Client;
     public everyone: boolean;
     public readonly guild: Guild;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Change type of channels mentions from TextChannel to GuildChannel.
`MessageMentions#channels` are defined as `Collection<Snowflake, TextChannels>` even though they return `Collection<Snowflake, GuildChannels>`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
