### PR TITLE
docs(ReactionUserManager): fetch description

### DIFF
--- a/src/managers/ReactionUserManager.js
+++ b/src/managers/ReactionUserManager.js
@@ -25,7 +25,7 @@ class ReactionUserManager extends BaseManager {
    */
 
   /**
-   * Fetches all the users that gave this reaction. Resolves with a collection of users, mapped by their IDs.
+   * Fetches the users that gave this reaction. Resolves with a collection of users, mapped by their IDs.
    * @param {Object} [options] Options for fetching the users
    * @param {number} [options.limit=100] The maximum amount of users to fetch, defaults to 100
    * @param {Snowflake} [options.before] Limit fetching users to those with an id lower than the supplied id


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The description currently says that fetching returns all users on the reaction.  This is incorrect, as there is an API limit of 100 users per fetch.  This PR changes the description to better match the actual behavior.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
