### PR TITLE
feat: move internal regular expressions to static properties

### DIFF
--- a/src/structures/GuildTemplate.js
+++ b/src/structures/GuildTemplate.js
@@ -222,4 +222,10 @@ class GuildTemplate extends Base {
   }
 }
 
+/**
+ * Regular expression that globally matches guild template links
+ * @type {RegExp}
+ */
+GuildTemplate.GUILD_TEMPLATES_PATTERN = /discord(?:app)?\.(?:com\/template|new)\/([\w-]{2,255})/gi;
+
 module.exports = GuildTemplate;

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -191,4 +191,10 @@ class Invite extends Base {
   }
 }
 
+/**
+ * Regular expression that globally matches Discord invite links
+ * @type {RegExp}
+ */
+Invite.INVITES_PATTERN = /discord(?:(?:app)?\.com\/invite|\.gg(?:\/invite)?)\/([\w-]{2,255})/gi;
+
 module.exports = Invite;

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -5,6 +5,8 @@ const path = require('path');
 const stream = require('stream');
 const fetch = require('node-fetch');
 const { Error: DiscordError, TypeError } = require('../errors');
+const GuildTemplate = require('../structures/GuildTemplate');
+const Invite = require('../structures/Invite');
 
 /**
  * The DataResolver identifies different objects and tries to resolve a specific piece of information from them.
@@ -46,7 +48,7 @@ class DataResolver {
    * @returns {string}
    */
   static resolveInviteCode(data) {
-    return this.resolveCode(data, /discord(?:(?:app)?\.com\/invite|\.gg(?:\/invite)?)\/([\w-]{2,255})/i);
+    return this.resolveCode(data, Invite.INVITES_PATTERN);
   }
 
   /**
@@ -55,7 +57,7 @@ class DataResolver {
    * @returns {string}
    */
   static resolveGuildTemplateCode(data) {
-    return this.resolveCode(data, /discord(?:app)?\.(?:com\/template|new)\/([\w-]{2,255})/i);
+    return this.resolveCode(data, GuildTemplate.GUILD_TEMPLATES_PATTERN);
   }
 
   /**

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -38,8 +38,7 @@ class DataResolver {
    * @returns {string}
    */
   static resolveCode(data, regex) {
-    const match = regex.exec(data);
-    return match ? match[1] || data : data;
+    return data.matchAll(regex).next().value?.[1] ?? data;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -877,6 +877,7 @@ declare module 'discord.js' {
     public delete(): Promise<GuildTemplate>;
     public edit(options?: { name?: string; description?: string }): Promise<GuildTemplate>;
     public sync(): Promise<GuildTemplate>;
+    public static GUILD_TEMPLATES_PATTERN: RegExp;
   }
 
   export class GuildPreviewEmoji extends BaseGuildEmoji {
@@ -949,6 +950,7 @@ declare module 'discord.js' {
     public delete(reason?: string): Promise<Invite>;
     public toJSON(): object;
     public toString(): string;
+    public static INVITES_PATTERN: RegExp;
   }
 
   export class Message extends Base {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This moves the regular expressions used in the `DataResolver` class to static properties for external use.

**Status and versioning classification:**

- I know how to update typings and have done so
- This PR changes the library's interface (methods or parameters added)