### PR TITLE
docs(GuildChannel): #members add cached spec, include voice

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -287,7 +287,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * A collection of members of this channel, mapped by their ID.
+   * A collection of cached members of this channel, mapped by their ID.
    * Members that can view this channel, if the channel is text based.
    * Members in the channel, if a voice channel.
    * @type {Collection<Snowflake, GuildMember>}

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -289,7 +289,7 @@ class GuildChannel extends Channel {
   /**
    * A collection of cached members of this channel, mapped by their ID.
    * Members that can view this channel, if the channel is text based.
-   * Members in the channel, if a voice channel.
+   * Members in the channel, if the channel is voice based.
    * @type {Collection<Snowflake, GuildMember>}
    * @readonly
    */

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -287,7 +287,9 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * A collection of members that can see this channel, mapped by their ID
+   * A collection of members of this channel, mapped by their ID.
+   * Members that can view this channel, if the channel is text based.
+   * Members in the channel, if a voice channel.
    * @type {Collection<Snowflake, GuildMember>}
    * @readonly
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`GuildChannel#members` currently reads

> A collection of members that can see this channel, mapped by their ID.

- This is not true for `voice` type channels, where it instead reflects the members in the channel (which can differ from members being able to view the channel)
- This does not specify that only cached members are considered (due to it being a convenience wrapper around a `Guild#members` cache filter)



**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
