### PR TITLE
Fixed jsdoc for Role#tags docs showing "optional" field.

### DIFF
--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -86,9 +86,9 @@ class Role extends Base {
     /**
      * The tags this role has
      * @type {?Object}
-     * @property {Snowflake} [botID] The id of the bot this role belongs to
-     * @property {Snowflake} [integrationID] The id of the integration this role belongs to
-     * @property {true} [premiumSubscriberRole] Whether this is the guild's premium subscription role
+     * @property {?Snowflake} botID The id of the bot this role belongs to
+     * @property {?Snowflake} integrationID The id of the integration this role belongs to
+     * @property {?true} premiumSubscriberRole Whether this is the guild's premium subscription role
      */
     this.tags = data.tags ? {} : null;
     if (data.tags) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In the documentation [Role#tags](https://discord.js.org/#/docs/main/master/class/Role?scrollTo=tags) is documented as a method where the "optional" field is displayed while all other object-based properties in the documentations do not. For example [Presence#clientStatus](https://discord.js.org/#/docs/main/master/class/Presence?scrollTo=clientStatus) which is how Role#tags should look.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.