### PR TITLE
docs(TextChannel): warning about setRateLimitPerUser NewsChannel

### DIFF
--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -1,131 +1,18 @@
 'use strict';
 
-const GuildChannel = require('./GuildChannel');
-const Webhook = require('./Webhook');
-const TextBasedChannel = require('./interfaces/TextBasedChannel');
+const TextChannel = require('./TextChannel');
 const { Error } = require('../errors');
-const MessageManager = require('../managers/MessageManager');
-const Collection = require('../util/Collection');
-const DataResolver = require('../util/DataResolver');
 
 /**
  * Represents a guild news channel on Discord.
- * @extends {GuildChannel}
+ * @extends {TextChannel}
  */
-class NewsChannel extends GuildChannel {
-  /**
-   * @param {Guild} guild The guild the news channel is part of
-   * @param {Object} data The data for the news channel
-   */
-  constructor(guild, data) {
-    super(guild, data);
-    /**
-     * A manager of the messages sent to this channel
-     * @type {MessageManager}
-     */
-    this.messages = new MessageManager(this);
-
-    /**
-     * If the guild considers this channel NSFW
-     * @type {boolean}
-     * @readonly
-     */
-    this.nsfw = Boolean(data.nsfw);
-    this._typing = new Map();
-  }
-
+class NewsChannel extends TextChannel {
   _patch(data) {
     super._patch(data);
 
-    /**
-     * The topic of the text channel
-     * @type {?string}
-     */
-    this.topic = data.topic;
-
-    if (typeof data.nsfw !== 'undefined') this.nsfw = Boolean(data.nsfw);
-
-    /**
-     * The ID of the last message sent in this channel, if one was sent
-     * @type {?Snowflake}
-     */
-    this.lastMessageID = data.last_message_id;
-
-    /**
-     * The timestamp when the last pinned message was pinned, if there was one
-     * @type {?number}
-     */
-    this.lastPinTimestamp = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
-
-    if (data.messages) for (const message of data.messages) this.messages.add(message);
-  }
-
-  /**
-   * Sets whether this channel is flagged as NSFW.
-   * @param {boolean} nsfw Whether the channel should be considered NSFW
-   * @param {string} [reason] Reason for changing the channel's NSFW flag
-   * @returns {Promise<TextChannel>}
-   */
-  setNSFW(nsfw, reason) {
-    return this.edit({ nsfw }, reason);
-  }
-
-  /**
-   * Sets the type of this channel (only conversion between text and news is supported)
-   * @param {string} type The new channel type
-   * @param {string} [reason] Reason for changing the channel's type
-   * @returns {Promise<GuildChannel>}
-   */
-  setType(type, reason) {
-    return this.edit({ type }, reason);
-  }
-
-  /**
-   * Fetches all webhooks for the channel.
-   * @returns {Promise<Collection<Snowflake, Webhook>>}
-   * @example
-   * // Fetch webhooks
-   * channel.fetchWebhooks()
-   *   .then(hooks => console.log(`This channel has ${hooks.size} hooks`))
-   *   .catch(console.error);
-   */
-  fetchWebhooks() {
-    return this.client.api.channels[this.id].webhooks.get().then(data => {
-      const hooks = new Collection();
-      for (const hook of data) hooks.set(hook.id, new Webhook(this.client, hook));
-      return hooks;
-    });
-  }
-
-  /**
-   * Creates a webhook for the channel.
-   * @param {string} name The name of the webhook
-   * @param {Object} [options] Options for creating the webhook
-   * @param {BufferResolvable|Base64Resolvable} [options.avatar] Avatar for the webhook
-   * @param {string} [options.reason] Reason for creating the webhook
-   * @returns {Promise<Webhook>} webhook The created webhook
-   * @example
-   * // Create a webhook for the current channel
-   * channel.createWebhook('Snek', {
-   *   avatar: 'https://i.imgur.com/mI8XcpG.jpg',
-   *   reason: 'Needed a cool new Webhook'
-   * })
-   *   .then(console.log)
-   *   .catch(console.error)
-   */
-  async createWebhook(name, { avatar, reason } = {}) {
-    if (typeof avatar === 'string' && !avatar.startsWith('data:')) {
-      avatar = await DataResolver.resolveImage(avatar);
-    }
-    return this.client.api.channels[this.id].webhooks
-      .post({
-        data: {
-          name,
-          avatar,
-        },
-        reason,
-      })
-      .then(data => new Webhook(this.client, data));
+    // News channels don't have a rate limit per user, remove it
+    this.rateLimitPerUser = undefined;
   }
 
   /**
@@ -146,21 +33,6 @@ class NewsChannel extends GuildChannel {
     await this.client.api.channels(this.id).followers.post({ data: { webhook_channel_id: channelID }, reason });
     return this;
   }
-
-  // These are here only for documentation purposes - they are implemented by TextBasedChannel
-  /* eslint-disable no-empty-function */
-  get lastMessage() {}
-  get lastPinAt() {}
-  send() {}
-  startTyping() {}
-  stopTyping() {}
-  get typing() {}
-  get typingCount() {}
-  createMessageCollector() {}
-  awaitMessages() {}
-  bulkDelete() {}
 }
-
-TextBasedChannel.applyToClass(NewsChannel, true);
 
 module.exports = NewsChannel;

--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -13,10 +13,10 @@ const DataResolver = require('../util/DataResolver');
  * @extends {GuildChannel}
  */
 class NewsChannel extends GuildChannel {
- /**
-  * @param {Guild} guild The guild the news channel is part of
-  * @param {Object} data The data for the news channel
-  */
+  /**
+   * @param {Guild} guild The guild the news channel is part of
+   * @param {Object} data The data for the news channel
+   */
   constructor(guild, data) {
     super(guild, data);
     /**

--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const GuildChannel = require('./GuildChannel');
+const Webhook = require('./Webhook');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
+const MessageManager = require('../managers/MessageManager');
+const Collection = require('../util/Collection');
+const DataResolver = require('../util/DataResolver');
 const { Error } = require('../errors');
 
 /**

--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -1,18 +1,127 @@
 'use strict';
 
-const TextChannel = require('./TextChannel');
+const GuildChannel = require('./GuildChannel');
+const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { Error } = require('../errors');
 
 /**
  * Represents a guild news channel on Discord.
- * @extends {TextChannel}
+ * @extends {GuildChannel}
  */
-class NewsChannel extends TextChannel {
+class NewsChannel extends GuildChannel {
+ /**
+  * @param {Guild} guild The guild the news channel is part of
+  * @param {Object} data The data for the news channel
+  */
+  constructor(guild, data) {
+    super(guild, data);
+    /**
+     * A manager of the messages sent to this channel
+     * @type {MessageManager}
+     */
+    this.messages = new MessageManager(this);
+
+    /**
+     * If the guild considers this channel NSFW
+     * @type {boolean}
+     * @readonly
+     */
+    this.nsfw = Boolean(data.nsfw);
+    this._typing = new Map();
+  }
+
   _patch(data) {
     super._patch(data);
 
-    // News channels don't have a rate limit per user, remove it
-    this.rateLimitPerUser = undefined;
+    /**
+     * The topic of the text channel
+     * @type {?string}
+     */
+    this.topic = data.topic;
+
+    if (typeof data.nsfw !== 'undefined') this.nsfw = Boolean(data.nsfw);
+
+    /**
+     * The ID of the last message sent in this channel, if one was sent
+     * @type {?Snowflake}
+     */
+    this.lastMessageID = data.last_message_id;
+
+    /**
+     * The timestamp when the last pinned message was pinned, if there was one
+     * @type {?number}
+     */
+    this.lastPinTimestamp = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
+
+    if (data.messages) for (const message of data.messages) this.messages.add(message);
+  }
+
+  /**
+   * Sets whether this channel is flagged as NSFW.
+   * @param {boolean} nsfw Whether the channel should be considered NSFW
+   * @param {string} [reason] Reason for changing the channel's NSFW flag
+   * @returns {Promise<TextChannel>}
+   */
+  setNSFW(nsfw, reason) {
+    return this.edit({ nsfw }, reason);
+  }
+
+  /**
+   * Sets the type of this channel (only conversion between text and news is supported)
+   * @param {string} type The new channel type
+   * @param {string} [reason] Reason for changing the channel's type
+   * @returns {Promise<GuildChannel>}
+   */
+  setType(type, reason) {
+    return this.edit({ type }, reason);
+  }
+
+  /**
+   * Fetches all webhooks for the channel.
+   * @returns {Promise<Collection<Snowflake, Webhook>>}
+   * @example
+   * // Fetch webhooks
+   * channel.fetchWebhooks()
+   *   .then(hooks => console.log(`This channel has ${hooks.size} hooks`))
+   *   .catch(console.error);
+   */
+  fetchWebhooks() {
+    return this.client.api.channels[this.id].webhooks.get().then(data => {
+      const hooks = new Collection();
+      for (const hook of data) hooks.set(hook.id, new Webhook(this.client, hook));
+      return hooks;
+    });
+  }
+
+  /**
+   * Creates a webhook for the channel.
+   * @param {string} name The name of the webhook
+   * @param {Object} [options] Options for creating the webhook
+   * @param {BufferResolvable|Base64Resolvable} [options.avatar] Avatar for the webhook
+   * @param {string} [options.reason] Reason for creating the webhook
+   * @returns {Promise<Webhook>} webhook The created webhook
+   * @example
+   * // Create a webhook for the current channel
+   * channel.createWebhook('Snek', {
+   *   avatar: 'https://i.imgur.com/mI8XcpG.jpg',
+   *   reason: 'Needed a cool new Webhook'
+   * })
+   *   .then(console.log)
+   *   .catch(console.error)
+   */
+  async createWebhook(name, { avatar, reason } = {}) {
+    if (typeof avatar === 'string' && !avatar.startsWith('data:')) {
+      avatar = await DataResolver.resolveImage(avatar);
+    }
+    return this.client.api.channels[this.id].webhooks
+      .post({
+        data: {
+          name,
+          avatar,
+        },
+        reason,
+      })
+      .then(data => new Webhook(this.client, data));
   }
 
   /**
@@ -33,6 +142,21 @@ class NewsChannel extends TextChannel {
     await this.client.api.channels(this.id).followers.post({ data: { webhook_channel_id: channelID }, reason });
     return this;
   }
+
+  // These are here only for documentation purposes - they are implemented by TextBasedChannel
+  /* eslint-disable no-empty-function */
+  get lastMessage() {}
+  get lastPinAt() {}
+  send() {}
+  startTyping() {}
+  stopTyping() {}
+  get typing() {}
+  get typingCount() {}
+  createMessageCollector() {}
+  awaitMessages() {}
+  bulkDelete() {}
 }
+
+TextBasedChannel.applyToClass(NewsChannel, true);
 
 module.exports = NewsChannel;

--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -3,10 +3,10 @@
 const GuildChannel = require('./GuildChannel');
 const Webhook = require('./Webhook');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
+const { Error } = require('../errors');
 const MessageManager = require('../managers/MessageManager');
 const Collection = require('../util/Collection');
 const DataResolver = require('../util/DataResolver');
-const { Error } = require('../errors');
 
 /**
  * Represents a guild news channel on Discord.

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -68,6 +68,7 @@ class TextChannel extends GuildChannel {
 
   /**
    * Sets the rate limit per user for this channel.
+   * <warn>It is not currently possible to set the rate limit per user on a `NewsChannel`.</warn>
    * @param {number} rateLimitPerUser The new ratelimit in seconds
    * @param {string} [reason] Reason for changing the channel's ratelimits
    * @returns {Promise<TextChannel>}

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -53,6 +53,7 @@ class TextChannel extends GuildChannel {
 
     /**
      * The ratelimit per user for this channel in seconds
+     * <warn>It is not currently possible to set a rate limit per user on a `NewsChannel`.</warn>
      * @type {number}
      */
     this.rateLimitPerUser = data.rate_limit_per_user || 0;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This adds a warning to the docs denoting that setRateLimitPerUser is not available on NewsChannels

**Status and versioning classification:**


- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
