### PR TITLE
docs(Constants): fix default options for ImageURLOptions

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -106,9 +106,9 @@ function makeImageUrl(root, { format = 'webp', size } = {}) {
 /**
  * Options for Image URLs.
  * @typedef {Object} ImageURLOptions
- * @property {string} [format] One of `webp`, `png`, `jpg`, `jpeg`, `gif`. If no format is provided,
+ * @property {string} [format='webp'] One of `webp`, `png`, `jpg`, `jpeg`, `gif`. If no format is provided,
  * defaults to `webp`.
- * @property {boolean} [dynamic] If true, the format will dynamically change to `gif` for
+ * @property {boolean} [dynamic=false] If true, the format will dynamically change to `gif` for
  * animated avatars; the default is false.
  * @property {number} [size] One of `16`, `32`, `64`, `128`, `256`, `512`, `1024`, `2048`, `4096`
  */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `format` and `dynamic` properties of `ImageURLOptions` have default values as stated in their respective jsdoc descriptions but, they are shown as `none` under the column for `Default` values. This PR fixes that by replacing `none` with appropriate default values for these two.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
