### PR TITLE
fix(Guild/GuildChannel): methods reason arg usage

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1163,7 +1163,7 @@ class Guild extends Base {
    *  .catch(console.error);
    */
   async setIcon(icon, reason) {
-    return this.edit({ icon: await DataResolver.resolveImage(icon), reason });
+    return this.edit({ icon: await DataResolver.resolveImage(icon) }, reason);
   }
 
   /**
@@ -1193,7 +1193,7 @@ class Guild extends Base {
    *  .catch(console.error);
    */
   async setSplash(splash, reason) {
-    return this.edit({ splash: await DataResolver.resolveImage(splash), reason });
+    return this.edit({ splash: await DataResolver.resolveImage(splash) }, reason);
   }
 
   /**
@@ -1208,7 +1208,7 @@ class Guild extends Base {
    *   .catch(console.error);
    */
   async setDiscoverySplash(discoverySplash, reason) {
-    return this.edit({ discoverySplash: await DataResolver.resolveImage(discoverySplash), reason });
+    return this.edit({ discoverySplash: await DataResolver.resolveImage(discoverySplash) }, reason);
   }
 
   /**
@@ -1222,7 +1222,7 @@ class Guild extends Base {
    *  .catch(console.error);
    */
   async setBanner(banner, reason) {
-    return this.edit({ banner: await DataResolver.resolveImage(banner), reason });
+    return this.edit({ banner: await DataResolver.resolveImage(banner) }, reason);
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -209,7 +209,7 @@ class GuildChannel extends Channel {
     if (!Array.isArray(overwrites) && !(overwrites instanceof Collection)) {
       throw new TypeError('INVALID_TYPE', 'overwrites', 'Array or Collection of Permission Overwrites', true);
     }
-    await this.edit({ permissionOverwrites: overwrites, reason });
+    await this.edit({ permissionOverwrites: overwrites }, reason);
     return this;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I fixed an issue where the following methods were passing the reason argument as a property to the edit method instead of a parameter.
Most of these methods have had it that way for 3 years in which I don't know if y'all will want to fix it at this point. But I brought it up in case.

`Guild#setIcon` -> was introduced in #1975 (3 years ago)
`Guild#setSplash` -> was introduced in #1975 (3 years ago)
`Guild#setBanner` -> was introduced in #3364 (2 years ago)
`Guild#setDiscoverySplash` -> was introduced in #4619 (7 months ago)

`GuildChannel#overwritePermissions` -> was introduced in #3853 (1 year ago)


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

