### PR TITLE
docs(ChannelManager): `fetch` can return Promise<null>

### DIFF
--- a/src/managers/ChannelManager.js
+++ b/src/managers/ChannelManager.js
@@ -75,7 +75,7 @@ class ChannelManager extends BaseManager {
    * @param {Snowflake} id ID of the channel
    * @param {boolean} [cache=true] Whether to cache the new channel object if it isn't already
    * @param {boolean} [force=false] Whether to skip the cache check and request the API
-   * @returns {Promise<Channel>}
+   * @returns {Promise<?Channel>}
    * @example
    * // Fetch a channel by its id
    * client.channels.fetch('222109930545610754')

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1893,7 +1893,7 @@ declare module 'discord.js' {
 
   export class ChannelManager extends BaseManager<Snowflake, Channel, ChannelResolvable> {
     constructor(client: Client, iterable: Iterable<any>);
-    public fetch(id: Snowflake, cache?: boolean, force?: boolean): Promise<Channel>;
+    public fetch(id: Snowflake, cache?: boolean, force?: boolean): Promise<Channel | null>;
   }
 
   export class GuildChannelManager extends BaseManager<Snowflake, GuildChannel, GuildChannelResolvable> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
ChannelManager#fetch can return Promise\<null> but is only documented to return Promise\<Channel>, this PR fixes the docs and typings.

fetch:
https://github.com/discordjs/discord.js/blob/d744e51c1bdb4c7a26c0faeea1f2f45baaf5fd3c/src/managers/ChannelManager.js#L92

add:
https://github.com/discordjs/discord.js/blob/d744e51c1bdb4c7a26c0faeea1f2f45baaf5fd3c/src/managers/ChannelManager.js#L32-L35

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

