### PR TITLE
added send method to class Channel

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -195,6 +195,7 @@ declare module 'discord.js' {
     public fetch(force?: boolean): Promise<Channel>;
     public isText(): this is TextChannel | DMChannel | NewsChannel;
     public toString(): string;
+    public send(message: string): string
   }
 
   export class Client extends BaseClient {


### PR DESCRIPTION
**Added send method to the types**

without this typescript would give an error if we tried to write this code:
`const channel = await client.channels.fetch('<id>')`
`ch.send('<message>')`

even though the code works fine, yet typescript shows an error `Property 'send' does not exist on type 'Channel'.`

adding this line of code to the Channel class fixes this issue.