### PR TITLE
Add ! to all User/GuildMember mentions

### DIFF
--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -73,7 +73,7 @@ class DMChannel extends Channel {
    * DMChannel object.
    * @returns {string}
    * @example
-   * // Logs: Hello from <@123456789012345678>!
+   * // Logs: Hello from <@!123456789012345678>!
    * console.log(`Hello from ${channel}!`);
    */
   toString() {

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -378,11 +378,11 @@ class GuildMember extends Base {
    * When concatenated with a string, this automatically returns the user's mention instead of the GuildMember object.
    * @returns {string}
    * @example
-   * // Logs: Hello from <@123456789012345678>!
+   * // Logs: Hello from <@!123456789012345678>!
    * console.log(`Hello from ${member}!`);
    */
   toString() {
-    return `<@${this.nickname ? '!' : ''}${this.user.id}>`;
+    return `<@!${this.user.id}>`;
   }
 
   toJSON() {

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -205,7 +205,7 @@ class MessageMentions {
 MessageMentions.EVERYONE_PATTERN = /@(everyone|here)/g;
 
 /**
- * Regular expression that globally matches user mentions like `<@81440962496172032>`
+ * Regular expression that globally matches user mentions like `<@!81440962496172032>`
  * @type {RegExp}
  */
 MessageMentions.USERS_PATTERN = /<@!?(\d{17,19})>/g;

--- a/src/structures/TeamMember.js
+++ b/src/structures/TeamMember.js
@@ -54,7 +54,7 @@ class TeamMember extends Base {
    * TeamMember object.
    * @returns {string}
    * @example
-   * // Logs: Team Member's mention: <@123456789012345678>
+   * // Logs: Team Member's mention: <@!123456789012345678>
    * console.log(`Team Member's mention: ${teamMember}`);
    */
   toString() {

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -302,11 +302,11 @@ class User extends Base {
    * When concatenated with a string, this automatically returns the user's mention instead of the User object.
    * @returns {string}
    * @example
-   * // Logs: Hello from <@123456789012345678>!
+   * // Logs: Hello from <@!123456789012345678>!
    * console.log(`Hello from ${user}!`);
    */
   toString() {
-    return `<@${this.id}>`;
+    return `<@!${this.id}>`;
   }
 
   toJSON(...props) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Whenever mentioning a user in a message, the mention will always have the ! no matter if you write it or not (which you can observe through message.content), therefore this fixes that inconsistency with the toString method. The ! doesn't seem to have any practical use from what I was able to observe in my tests so adding this should not break anything

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
