### PR TITLE
Add ShardingManager.shardList to type definitions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1386,6 +1386,7 @@ declare module 'discord.js' {
     public shards: Collection<number, Shard>;
     public token: string | null;
     public totalShards: number | 'auto';
+    public shardList: number[] | 'auto';
     public broadcast(message: any): Promise<Shard[]>;
     public broadcastEval(script: string): Promise<any[]>;
     public broadcastEval(script: string, shard: number): Promise<any>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This change adds the "ShardingManager.shardList" property that was previously missing from the typescript definitions file.


**Status and versioning classification:**
Patch (only index.d.ts affected)