### PR TITLE
feat(MessageEmbed): remove normalizeField validation

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -37,9 +37,6 @@ const Messages = {
   COLOR_RANGE: 'Color must be within the range 0 - 16777215 (0xFFFFFF).',
   COLOR_CONVERT: 'Unable to convert color to a number.',
 
-  EMBED_FIELD_NAME: 'MessageEmbed field names may not be empty.',
-  EMBED_FIELD_VALUE: 'MessageEmbed field values may not be empty.',
-
   FILE_NOT_FOUND: file => `File could not be found: ${file}`,
 
   USER_NO_DMCHANNEL: 'No DM Channel exists!',

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -428,9 +428,7 @@ class MessageEmbed {
    */
   static normalizeField(name, value, inline = false) {
     name = Util.resolveString(name);
-    if (!name) throw new RangeError('EMBED_FIELD_NAME');
     value = Util.resolveString(value);
-    if (!value) throw new RangeError('EMBED_FIELD_VALUE');
     return { name, value, inline };
   }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { RangeError } = require('../errors');
 const Util = require('../util/Util');
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`normalizeField` was made with a custom error to throw, this PR removes that so that a proper API error with path will be thrown instead.  This makes the error message more informative.

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
