### PR TITLE
docs(MessageEmbed): MessageEmbedOptions typedef

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -22,7 +22,7 @@ class MessageEmbed {
    * @property {string} [url] The URL of this embed
    * @property {Date|number} [timestamp] The timestamp of this embed
    * @property {ColorResolvable} [color] The color of this embed
-   * @property {EmbedFieldData} [fields] The fields of this embed
+   * @property {EmbedFieldData[]} [fields] The fields of this embed
    * @property {Array<FileOptions|string|MessageAttachment>} [files] The files of this embed
    * @property {Partial<MessageEmbedAuthor>} [author] The author of this embed
    * @property {Partial<MessageEmbedThumbnail>} [thumbnail] The thumbnail of this embed

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -11,7 +11,24 @@ class MessageEmbed {
    * @name MessageEmbed
    * @kind constructor
    * @memberof MessageEmbed
-   * @param {MessageEmbed|Object} [data={}] MessageEmbed to clone or raw embed data
+   * @param {MessageEmbed|MessageEmbedOptions} [data={}] MessageEmbed to clone or raw embed data
+   */
+
+  /**
+   * Represents the possible options for a MessageEmbed
+   * @typedef {Object} MessageEmbedOptions
+   * @property {string} [title] The title of this embed
+   * @property {string} [description] The description of this embed
+   * @property {string} [url] The URL of this embed
+   * @property {Date|number} [timestamp] The timestamp of this embed
+   * @property {ColorResolvable} [color] The color of this embed
+   * @property {EmbedFieldData} [fields] The fields of this embed
+   * @property {Array<FileOptions|string|MessageAttachment>} [files] The files of this embed
+   * @property {Partial<MessageEmbedAuthor>} [author] The author of this embed
+   * @property {Partial<MessageEmbedThumbnail>} [thumbnail] The thumbnail of this embed
+   * @property {Partial<MessageEmbedImage>} [image] The image of this embed
+   * @property {Partial<MessageEmbedVideo>} [video] The video of this embed
+   * @property {Partial<MessageEmbedFooter>} [footer] The footer of this embed
    */
 
   constructor(data = {}, skipValidation = false) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the MessageEmbedOptions typedef to the docs and updates the MessageEmbed data param to link to this typedef instead of a general object. This has no impact in the code and its purpose it to only improve the docs for MessageEmbed. I went off of the interface found in https://github.com/discordjs/discord.js/blob/master/typings/index.d.ts#L2922 but please let me know if there is anything that needs changing before this is merged.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
