### PR TITLE
fix(Voice): disconnect if voice channel not cached

### DIFF
--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -56,8 +56,14 @@ class ClientVoiceManager {
       this.connections.delete(guild_id);
       return;
     }
-    connection.channel = this.client.channels.cache.get(channel_id);
-    connection.setSessionID(session_id);
+    const channel = this.client.channels.cache.get(channel_id);
+    if (channel) {
+      connection.channel = channel;
+      connection.setSessionID(session_id);
+    } else {
+      this.client.emit('debug', `[VOICE] disconnecting from guild ${guild_id} as channel ${channel_id} is uncached`);
+      connection.disconnect();
+    }
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves an issue where bots will hard crash if they are moved from a voice channel into a stage channel. As stage channels are not currently cached by the library, the bot will unrecoverably crash when trying to access the channel.

This fix will cause a voice connection to be disconnected if it is updated with a channel that is not cached.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating