### PR TITLE
chore: allow three more types of commit msgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,10 @@
           "refactor",
           "revert",
           "style",
-          "test"
+          "test",
+          "types",
+          "workflow",
+          "wip"
         ]
       ]
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

According to the [contribution guide](https://github.com/discordjs/discord.js-next/blob/master/.github/COMMIT_CONVENTION.md) these three are valid commit message type but the rules still block them. 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
