### PR TITLE
refactor(Guild): remove fetchVanityCode()

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { deprecate } = require('util');
 const Base = require('./Base');
 const GuildAuditLogs = require('./GuildAuditLogs');
 const GuildPreview = require('./GuildPreview');
@@ -335,14 +334,12 @@ class Guild extends Base {
      */
     this.vanityURLCode = data.vanity_url_code;
 
-    /* eslint-disable max-len */
     /**
      * The use count of the vanity URL code of the guild, if any
      * <info>You will need to fetch this parameter using {@link Guild#fetchVanityData} if you want to receive it</info>
      * @type {?number}
      */
     this.vanityURLUses = null;
-    /* eslint-enable max-len */
 
     /**
      * The description of the guild, if any
@@ -765,23 +762,6 @@ class Guild extends Base {
   }
 
   /**
-   * Fetches the vanity url invite code to this guild.
-   * Resolves with a string matching the vanity url invite code, not the full url.
-   * @returns {Promise<string>}
-   * @deprecated
-   * @example
-   * // Fetch invites
-   * guild.fetchVanityCode()
-   *   .then(code => {
-   *     console.log(`Vanity URL: https://discord.gg/${code}`);
-   *   })
-   *   .catch(console.error);
-   */
-  fetchVanityCode() {
-    return this.fetchVanityData().then(vanity => vanity.code);
-  }
-
-  /**
    * An object containing information about a guild's vanity invite.
    * @typedef {Object} Vanity
    * @property {?string} code Vanity invite code
@@ -805,6 +785,7 @@ class Guild extends Base {
       throw new Error('VANITY_URL');
     }
     const data = await this.client.api.guilds(this.id, 'vanity-url').get();
+    this.vanityURLCode = data.code;
     this.vanityURLUses = data.uses;
 
     return data;
@@ -1477,10 +1458,5 @@ class Guild extends Base {
     );
   }
 }
-
-Guild.prototype.fetchVanityCode = deprecate(
-  Guild.prototype.fetchVanityCode,
-  'Guild#fetchVanityCode: Use fetchVanityData() instead',
-);
 
 module.exports = Guild;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -662,8 +662,7 @@ declare module 'discord.js' {
     public fetchInvites(): Promise<Collection<string, Invite>>;
     public fetchPreview(): Promise<GuildPreview>;
     public fetchTemplates(): Promise<Collection<GuildTemplate['code'], GuildTemplate>>;
-    public fetchVanityCode(): Promise<string>;
-    public fetchVanityData(): Promise<{ code: string; uses: number }>;
+    public fetchVanityData(): Promise<Vanity>;
     public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
     public fetchWidget(): Promise<GuildWidget>;
@@ -3358,6 +3357,11 @@ declare module 'discord.js' {
     | 'EARLY_VERIFIED_BOT_DEVELOPER';
 
   type UserResolvable = User | Snowflake | Message | GuildMember;
+
+  interface Vanity {
+    code: string | null;
+    uses: number | null;
+  }
 
   type VerificationLevel = 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH' | 'VERY_HIGH';
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This method has been deprecated in #4103. Also adds a `Vanity` interface.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)