### PR TITLE
fix(IntegrationApplication): add missing export to index.js

### DIFF
--- a/esm/discord.mjs
+++ b/esm/discord.mjs
@@ -69,6 +69,7 @@ export const {
   GuildPreview,
   GuildTemplate,
   Integration,
+  IntegrationApplication,
   Invite,
   Message,
   MessageAttachment,

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,7 @@ module.exports = {
   GuildPreview: require('./structures/GuildPreview'),
   GuildTemplate: require('./structures/GuildTemplate'),
   Integration: require('./structures/Integration'),
+  IntegrationApplication: require('./structures/IntegrationApplication'),
   Invite: require('./structures/Invite'),
   Message: require('./structures/Message'),
   MessageAttachment: require('./structures/MessageAttachment'),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Add the missing IntegrationApplication structure export to `index.js` (introduced in #4762)
- Add the missing IntegrationApplication structure export to `esm/index.js` (introduced in #4762)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
