### PR TITLE
fix: typings for 'WebhookMessageOptions'

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3381,7 +3381,11 @@ declare module 'discord.js' {
 
   type WebhookEditMessageOptions = Pick<WebhookMessageOptions, 'content' | 'embeds' | 'files' | 'allowedMentions'>;
 
-  type WebhookMessageOptions = Omit<MessageOptions, 'embed'> & { embeds?: (MessageEmbed | object)[] };
+  type WebhookMessageOptions = Omit<MessageOptions, 'embed' | 'replyTo'> & {
+    username?: string;
+    avatarURL?: string;
+    embeds?: (MessageEmbed | object)[];
+  };
 
   type WebhookRawMessageResponse = Omit<APIRawMessage, 'author'> & {
     author: {


### PR DESCRIPTION
Adds the missing `username` and `avatarURL` props and removes the `replyTo` prop from `WebhookMessageOptions` interface.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
