### PR TITLE
feat(Guild): replace `owner` with `fetchOwner`

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -526,17 +526,20 @@ class Guild extends Base {
   }
 
   /**
-   * The owner of the guild
-   * @type {?GuildMember}
-   * @readonly
+   * Options used to fetch the owner of guild.
+   * @typedef {Object} FetchOwnerOptions
+   * @property {boolean} [cache=true] Whether or not to cache the fetched member
+   * @property {boolean} [force=false] Whether to skip the cache check and request the API
    */
-  get owner() {
-    return (
-      this.members.cache.get(this.ownerID) ||
-      (this.client.options.partials.includes(PartialTypes.GUILD_MEMBER)
-        ? this.members.add({ user: { id: this.ownerID } }, true)
-        : null)
-    );
+
+  /**
+   * Fetches the owner of the guild
+   * If the member object isn't needed, use {@link Guild#ownerID} instead
+   * @param {FetchOwnerOptions} [options] The options for fetching the member
+   * @returns {Promise<GuildMember>}
+   */
+  fetchOwner(options) {
+    return this.members.fetch({ ...options, user: this.ownerID });
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -619,7 +619,6 @@ declare module 'discord.js' {
     public mfaLevel: number;
     public name: string;
     public readonly nameAcronym: string;
-    public readonly owner: GuildMember | null;
     public ownerID: Snowflake;
     public readonly partnered: boolean;
     public preferredLocale: string;
@@ -660,6 +659,7 @@ declare module 'discord.js' {
     public fetchBans(): Promise<Collection<Snowflake, { user: User; reason: string }>>;
     public fetchIntegrations(): Promise<Collection<string, Integration>>;
     public fetchInvites(): Promise<Collection<string, Invite>>;
+    public fetchOwner(): Promise<GuildMember>;
     public fetchPreview(): Promise<GuildPreview>;
     public fetchTemplates(): Promise<Collection<GuildTemplate['code'], GuildTemplate>>;
     public fetchVanityData(): Promise<Vanity>;
@@ -2654,6 +2654,8 @@ declare module 'discord.js' {
     attachment: BufferResolvable | Stream;
     name?: string;
   }
+
+  type FetchOwnerOptions = Omit<FetchMemberOptions, 'user'>;
 
   type GuildAuditLogsAction = keyof GuildAuditLogsActions;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -659,7 +659,7 @@ declare module 'discord.js' {
     public fetchBans(): Promise<Collection<Snowflake, { user: User; reason: string }>>;
     public fetchIntegrations(): Promise<Collection<string, Integration>>;
     public fetchInvites(): Promise<Collection<string, Invite>>;
-    public fetchOwner(): Promise<GuildMember>;
+    public fetchOwner(options?: FetchOwnerOptions): Promise<GuildMember>;
     public fetchPreview(): Promise<GuildPreview>;
     public fetchTemplates(): Promise<Collection<GuildTemplate['code'], GuildTemplate>>;
     public fetchVanityData(): Promise<Vanity>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes Guild#owner and adds Guild#fetchOwner

Guild#owner relies on cache, so it is unreliable and will not always work. This is more of an issue now due to intents, as much fewer members are usually cached.

Guild#fetchOwner is a reliable way to get the owner, while still being simple.

This change has been proposed in the d.js server a few times: [1](https://canary.discord.com/channels/222078108977594368/222197033908436994/771448280126586900), [2](https://canary.discord.com/channels/222078108977594368/222197033908436994/797968166588383262), [3](https://canary.discord.com/channels/222078108977594368/682166281826598932/806912661178023968) (paste the msg links into Quick Switcher)


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)