### PR TITLE
feat(MessageAttachment): support for #contentType

### DIFF
--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -84,7 +84,7 @@ class MessageAttachment {
      * This media type of this attachment
      * @type {?string}
      */
-    this.contentType = typeof data.contentType !== 'undefined' ? data.contentType : null;
+    this.contentType = typeof data.content_type !== 'undefined' ? data.content_type : null;
   }
 
   /**

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -79,6 +79,12 @@ class MessageAttachment {
      * @type {?number}
      */
     this.width = typeof data.width !== 'undefined' ? data.width : null;
+
+    /**
+     * This media type of this attachment
+     * @type {?string}
+     */
+    this.contentType = typeof data.contentType !== 'undefined' ? data.contentType : null;
   }
 
   /**

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -84,7 +84,7 @@ class MessageAttachment {
      * This media type of this attachment
      * @type {?string}
      */
-    this.contentType = typeof data.content_type !== 'undefined' ? data.content_type : null;
+    this.contentType = data.content_type ?? null;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1037,6 +1037,7 @@ declare module 'discord.js' {
     public height: number | null;
     public id: Snowflake;
     public name: string | null;
+    public contentType: string | null;
     public proxyURL: string;
     public size: number;
     public readonly spoiler: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1034,10 +1034,10 @@ declare module 'discord.js' {
     constructor(attachment: BufferResolvable | Stream, name?: string, data?: object);
 
     public attachment: BufferResolvable | Stream;
+    public contentType: string | null;
     public height: number | null;
     public id: Snowflake;
     public name: string | null;
-    public contentType: string | null;
     public proxyURL: string;
     public size: number;
     public readonly spoiler: boolean;


### PR DESCRIPTION
As per https://github.com/discord/discord-api-docs/pull/2762

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)