### PR TITLE
feat(WelcomeScreen): welcome screens

### DIFF
--- a/src/managers/BaseGuildEmojiManager.js
+++ b/src/managers/BaseGuildEmojiManager.js
@@ -37,7 +37,7 @@ class BaseGuildEmojiManager extends BaseManager {
     if (emoji instanceof ReactionEmoji) return super.resolve(emoji.id);
     if (typeof emoji === 'string') {
       const res = parseEmoji(emoji);
-      if (res && res.name.length) {
+      if (res?.name.length) {
         return super.resolve(res.id);
       }
     }
@@ -53,7 +53,7 @@ class BaseGuildEmojiManager extends BaseManager {
     if (emoji instanceof ReactionEmoji) return emoji.id;
     if (typeof emoji === 'string') {
       const res = parseEmoji(emoji);
-      if (res && res.name.length) {
+      if (res?.name.length) {
         return super.resolveID(res.id);
       }
     }

--- a/src/managers/BaseGuildEmojiManager.js
+++ b/src/managers/BaseGuildEmojiManager.js
@@ -30,35 +30,21 @@ class BaseGuildEmojiManager extends BaseManager {
 
   /**
    * Resolves an EmojiResolvable to an Emoji object.
-   * @param {EmojiIdentifierResolvable} emoji The Emoji resolvable to identify
+   * @param {EmojiResolvable} emoji The Emoji resolvable to identify
    * @returns {?GuildEmoji}
    */
   resolve(emoji) {
     if (emoji instanceof ReactionEmoji) return super.resolve(emoji.id);
-    if (typeof emoji === 'string') {
-      const res = parseEmoji(emoji);
-      // Check for custom emojis with both name and id (filtering out global ones with just id)
-      if (res?.name.length) {
-        return super.resolve(res.id);
-      }
-    }
     return super.resolve(emoji);
   }
 
   /**
    * Resolves an EmojiResolvable to an Emoji ID string.
-   * @param {EmojiIdentifierResolvable} emoji The Emoji resolvable to identify
+   * @param {EmojiResolvable} emoji The Emoji resolvable to identify
    * @returns {?Snowflake}
    */
   resolveID(emoji) {
     if (emoji instanceof ReactionEmoji) return emoji.id;
-    if (typeof emoji === 'string') {
-      const res = parseEmoji(emoji);
-      // Check for custom emojis with both name and id (filtering out global ones with just id)
-      if (res?.name.length) {
-        return super.resolveID(res.id);
-      }
-    }
     return super.resolveID(emoji);
   }
 

--- a/src/managers/BaseGuildEmojiManager.js
+++ b/src/managers/BaseGuildEmojiManager.js
@@ -37,6 +37,7 @@ class BaseGuildEmojiManager extends BaseManager {
     if (emoji instanceof ReactionEmoji) return super.resolve(emoji.id);
     if (typeof emoji === 'string') {
       const res = parseEmoji(emoji);
+      // Check for custom emojis with both name and id (filtering out global ones with just id)
       if (res?.name.length) {
         return super.resolve(res.id);
       }
@@ -53,6 +54,7 @@ class BaseGuildEmojiManager extends BaseManager {
     if (emoji instanceof ReactionEmoji) return emoji.id;
     if (typeof emoji === 'string') {
       const res = parseEmoji(emoji);
+      // Check for custom emojis with both name and id (filtering out global ones with just id)
       if (res?.name.length) {
         return super.resolveID(res.id);
       }

--- a/src/managers/BaseGuildEmojiManager.js
+++ b/src/managers/BaseGuildEmojiManager.js
@@ -30,21 +30,33 @@ class BaseGuildEmojiManager extends BaseManager {
 
   /**
    * Resolves an EmojiResolvable to an Emoji object.
-   * @param {EmojiResolvable} emoji The Emoji resolvable to identify
+   * @param {EmojiIdentifierResolvable} emoji The Emoji resolvable to identify
    * @returns {?GuildEmoji}
    */
   resolve(emoji) {
     if (emoji instanceof ReactionEmoji) return super.resolve(emoji.id);
+    if (typeof emoji === 'string') {
+      const res = parseEmoji(emoji);
+      if (res && res.name.length) {
+        return super.resolve(res.id);
+      }
+    }
     return super.resolve(emoji);
   }
 
   /**
    * Resolves an EmojiResolvable to an Emoji ID string.
-   * @param {EmojiResolvable} emoji The Emoji resolvable to identify
+   * @param {EmojiIdentifierResolvable} emoji The Emoji resolvable to identify
    * @returns {?Snowflake}
    */
   resolveID(emoji) {
     if (emoji instanceof ReactionEmoji) return emoji.id;
+    if (typeof emoji === 'string') {
+      const res = parseEmoji(emoji);
+      if (res && res.name.length) {
+        return super.resolveID(res.id);
+      }
+    }
     return super.resolveID(emoji);
   }
 

--- a/src/managers/ChannelManager.js
+++ b/src/managers/ChannelManager.js
@@ -23,7 +23,7 @@ class ChannelManager extends BaseManager {
     const existing = this.cache.get(data.id);
     if (existing) {
       if (existing._patch && cache) existing._patch(data);
-      if (guild) guild.channels.add(existing);
+      if (guild) guild.channels?.add(existing);
       return existing;
     }
 

--- a/src/structures/AnonymousGuild.js
+++ b/src/structures/AnonymousGuild.js
@@ -4,7 +4,7 @@ const BaseGuild = require('./BaseGuild');
 const { VerificationLevels, NSFWLevels } = require('../util/Constants');
 
 /**
- * Bundles common attributes between guild classes
+ * Bundles common attributes and methods between {@link Guild} and {@link InviteGuild}
  * @abstract
  */
 class AnonymousGuild extends BaseGuild {

--- a/src/structures/AnonymousGuild.js
+++ b/src/structures/AnonymousGuild.js
@@ -4,7 +4,7 @@ const BaseGuild = require('./BaseGuild');
 const { VerificationLevels, NSFWLevels } = require('../util/Constants');
 
 /**
- * Bundles common attributes between
+ * Bundles common attributes between guild classes
  * @abstract
  */
 class AnonymousGuild extends BaseGuild {

--- a/src/structures/AnonymousGuild.js
+++ b/src/structures/AnonymousGuild.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const BaseGuild = require('./BaseGuild');
+const { VerificationLevels, NSFWLevels } = require('../util/Constants');
+
+/**
+ * Bundles common attributes between
+ * @abstract
+ */
+class AnonymousGuild extends BaseGuild {
+  constructor(client, data) {
+    super(client, data);
+    this._patch(data);
+  }
+
+  _patch(data) {
+    this.features = data.features;
+    /**
+     * The hash of the guild invite splash image
+     * @type {?string}
+     */
+    this.splash = data.splash;
+
+    /**
+     * The hash of the guild banner
+     * @type {?string}
+     */
+    this.banner = data.banner;
+
+    /**
+     * The description of the guild, if any
+     * @type {?string}
+     */
+    this.description = data.description;
+
+    /**
+     * The verification level of the guild
+     * @type {VerificationLevel}
+     */
+    this.verificationLevel = VerificationLevels[data.verification_level];
+
+    /**
+     * The vanity invite code of the guild, if any
+     * @type {?string}
+     */
+    this.vanityURLCode = data.vanity_url_code;
+
+    if ('nsfw_level' in data) {
+      /**
+       * The NSFW level of this guild
+       * @type {NSFWLevel}
+       */
+      this.nsfwLevel = NSFWLevels[data.nsfw_level];
+    }
+  }
+
+  /**
+   * The URL to this guild's banner.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string}
+   */
+  bannerURL({ format, size } = {}) {
+    if (!this.banner) return null;
+    return this.client.rest.cdn.Banner(this.id, this.banner, format, size);
+  }
+
+  /**
+   * The URL to this guild's invite splash image.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string}
+   */
+  splashURL({ format, size } = {}) {
+    if (!this.splash) return null;
+    return this.client.rest.cdn.Splash(this.id, this.splash, format, size);
+  }
+}
+
+module.exports = AnonymousGuild;

--- a/src/structures/BaseGuild.js
+++ b/src/structures/BaseGuild.js
@@ -6,6 +6,7 @@ const SnowflakeUtil = require('../util/SnowflakeUtil');
 /**
  * The base class for {@link Guild} and {@link OAuth2Guild}.
  * @extends {Base}
+ * @abstract
  */
 class BaseGuild extends Base {
   constructor(client, data) {

--- a/src/structures/BaseGuild.js
+++ b/src/structures/BaseGuild.js
@@ -4,7 +4,7 @@ const Base = require('./Base');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
 
 /**
- * The base class for {@link Guild} and {@link OAuth2Guild}.
+ * The base class for {@link Guild}, {@link OAuth2Guild} and {@link InviteGuild}.
  * @extends {Base}
  * @abstract
  */

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -153,7 +153,7 @@ class Channel extends Base {
             break;
           }
         }
-        if (channel) guild.channels.cache.set(channel.id, channel);
+        if (channel) guild.channels?.cache.set(channel.id, channel);
       }
     }
     return channel;

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -20,9 +20,9 @@ class Emoji extends Base {
     super(client);
     /**
      * Whether this emoji is animated
-     * @type {boolean}
+     * @type {?boolean}
      */
-    this.animated = emoji.animated;
+    this.animated = emoji.animated ?? null;
 
     /**
      * The name of this emoji

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -97,6 +97,10 @@ class Guild extends BaseGuild {
      */
     this.deleted = false;
 
+    /**
+     * The welcome screen for this guild
+     * @type {?WelcomeScreen}
+     */
     this.welcomeScreen = null;
 
     if (!data) return;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -7,6 +7,7 @@ const GuildTemplate = require('./GuildTemplate');
 const Integration = require('./Integration');
 const Invite = require('./Invite');
 const Webhook = require('./Webhook');
+const WelcomeScreen = require('./WelcomeScreen');
 const { Error, TypeError } = require('../errors');
 const GuildApplicationCommandManager = require('../managers/GuildApplicationCommandManager');
 const GuildBanManager = require('../managers/GuildBanManager');
@@ -582,6 +583,13 @@ class Guild extends BaseGuild {
       .then(templates =>
         templates.reduce((col, data) => col.set(data.code, new GuildTemplate(this.client, data)), new Collection()),
       );
+  }
+
+  fetchWelcomeScreen() {
+    return this.client.api
+      .guilds(this.id)
+      ['welcome-screen'].get()
+      .then(data => new WelcomeScreen(this.client, this, data));
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const BaseGuild = require('./BaseGuild');
+const AnonymousGuild = require('./AnonymousGuild');
 const GuildAuditLogs = require('./GuildAuditLogs');
 const GuildPreview = require('./GuildPreview');
 const GuildTemplate = require('./GuildTemplate');
@@ -25,7 +25,6 @@ const {
   PartialTypes,
   VerificationLevels,
   ExplicitContentFilterLevels,
-  NSFWLevels,
   Status,
   MFALevels,
 } = require('../util/Constants');
@@ -37,9 +36,9 @@ const Util = require('../util/Util');
  * Represents a guild (or a server) on Discord.
  * <info>It's recommended to see if a guild is available before performing operations or reading data from it. You can
  * check this with `guild.available`.</info>
- * @extends {BaseGuild}
+ * @extends {AnonymousGuild}
  */
-class Guild extends BaseGuild {
+class Guild extends AnonymousGuild {
   constructor(client, data) {
     super(client, data);
 
@@ -134,14 +133,7 @@ class Guild extends BaseGuild {
     this.id = data.id;
     this.name = data.name;
     this.icon = data.icon;
-    this.features = data.features;
     this.available = !data.unavailable;
-
-    /**
-     * The hash of the guild invite splash image
-     * @type {?string}
-     */
-    this.splash = data.splash;
 
     /**
      * The hash of the guild discovery splash image
@@ -154,14 +146,6 @@ class Guild extends BaseGuild {
      * @type {number}
      */
     this.memberCount = data.member_count || this.memberCount;
-
-    if ('nsfw_level' in data) {
-      /**
-       * The NSFW level of this guild
-       * @type {NSFWLevel}
-       */
-      this.nsfwLevel = NSFWLevels[data.nsfw_level];
-    }
 
     /**
      * Whether the guild is "large" (has more than large_threshold members, 50 by default)
@@ -257,12 +241,6 @@ class Guild extends BaseGuild {
     }
 
     /**
-     * The verification level of the guild
-     * @type {VerificationLevel}
-     */
-    this.verificationLevel = VerificationLevels[data.verification_level];
-
-    /**
      * The explicit content filter level of the guild
      * @type {ExplicitContentFilterLevel}
      */
@@ -336,29 +314,11 @@ class Guild extends BaseGuild {
     }
 
     /**
-     * The vanity invite code of the guild, if any
-     * @type {?string}
-     */
-    this.vanityURLCode = data.vanity_url_code;
-
-    /**
      * The use count of the vanity URL code of the guild, if any
      * <info>You will need to fetch this parameter using {@link Guild#fetchVanityData} if you want to receive it</info>
      * @type {?number}
      */
     this.vanityURLUses = null;
-
-    /**
-     * The description of the guild, if any
-     * @type {?string}
-     */
-    this.description = data.description;
-
-    /**
-     * The hash of the guild banner
-     * @type {?string}
-     */
-    this.banner = data.banner;
 
     /**
      * The ID of the rules channel for the guild
@@ -436,6 +396,7 @@ class Guild extends BaseGuild {
         emojis: data.emojis,
       });
     }
+    super._patch(data);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -962,7 +962,7 @@ class Guild extends BaseGuild {
     });
 
     const patchData = await this.client.api.guilds(this.id, 'welcome-screen').patch({
-      patchData: {
+      data: {
         welcome_channels,
         description,
         enabled,

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -932,7 +932,7 @@ class Guild extends BaseGuild {
    * Welcome channel data
    * @typedef {Object} WelcomeChannelData
    * @property {string} description The description to show for this welcome channel
-   * @property {GuildChannelResolvable} channel The channel to link for this welcome channel
+   * @property {GuildTextChannelResolvable} channel The channel to link for this welcome channel
    * @property {EmojiIdentifierResolvable} [emoji] The emoji to display for this welcome channel
    */
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -97,6 +97,8 @@ class Guild extends BaseGuild {
      */
     this.deleted = false;
 
+    this.welcomeScreen = null;
+
     if (!data) return;
     if (data.unavailable) {
       /**
@@ -333,6 +335,10 @@ class Guild extends BaseGuild {
       this.approximatePresenceCount = data.approximate_presence_count;
     } else if (typeof this.approximatePresenceCount === 'undefined') {
       this.approximatePresenceCount = null;
+    }
+
+    if (typeof data.welcome_screen !== 'undefined') {
+      this.welcomeScreen = new WelcomeScreen(guild, data.welcome_screen)
     }
 
     /**
@@ -589,7 +595,7 @@ class Guild extends BaseGuild {
     return this.client.api
       .guilds(this.id)
       ['welcome-screen'].get()
-      .then(data => new WelcomeScreen(this.client, this, data));
+      .then(data => new WelcomeScreen(this, data));
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -936,7 +936,7 @@ class Guild extends BaseGuild {
 
   /**
    * Updates the guild's welcome screen
-   * @param {WelcomeScreenEditData} [data] Data to edit the welcome screen with
+   * @param {WelcomeScreenEditData} data Data to edit the welcome screen with
    * @returns {Promise<WelcomeScreen>}
    * @example
    * guild.editWelcomeScreen({
@@ -950,24 +950,25 @@ class Guild extends BaseGuild {
    *   ],
    * })
    */
-  async editWelcomeScreen({ enabled, description, welcomeChannels } = {}) {
-    const welcome_channels = welcomeChannels?.map(data => {
-      const emoji = this.emojis.resolve(data.emoji);
+  async editWelcomeScreen(data) {
+    const { enabled, description, welcomeChannels } = data;
+    const welcome_channels = welcomeChannels?.map(welcomeChannelData => {
+      const emoji = this.emojis.resolve(welcomeChannelData.emoji);
       return {
         emoji_id: emoji?.id ?? null,
         emoji_name: emoji?.name ?? emoji,
-        channel_id: this.channels.resolveID(data.channel),
+        channel_id: this.channels.resolveID(welcomeChannelData.channel),
       };
     });
 
-    const data = await this.client.api.guilds(this.id, 'welcome-screen').patch({
-      data: {
+    const patchData = await this.client.api.guilds(this.id, 'welcome-screen').patch({
+      patchData: {
         welcome_channels,
         description,
         enabled,
       },
     });
-    return new WelcomeScreen(this, data);
+    return new WelcomeScreen(this, patchData);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -338,7 +338,7 @@ class Guild extends BaseGuild {
     }
 
     if (typeof data.welcome_screen !== 'undefined') {
-      this.welcomeScreen = new WelcomeScreen(guild, data.welcome_screen)
+      this.welcomeScreen = new WelcomeScreen(this, data.welcome_screen);
     }
 
     /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -956,7 +956,7 @@ class Guild extends BaseGuild {
       const emoji = this.emojis.resolve(welcomeChannelData.emoji);
       return {
         emoji_id: emoji?.id ?? null,
-        emoji_name: emoji?.name ?? emoji,
+        emoji_name: emoji?.name ?? welcomeChannelData.emoji,
         channel_id: this.channels.resolveID(welcomeChannelData.channel),
         description: welcomeChannelData.description,
       };

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -958,6 +958,7 @@ class Guild extends BaseGuild {
         emoji_id: emoji?.id ?? null,
         emoji_name: emoji?.name ?? emoji,
         channel_id: this.channels.resolveID(welcomeChannelData.channel),
+        description: welcomeChannelData.description,
       };
     });
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -97,12 +97,6 @@ class Guild extends BaseGuild {
      */
     this.deleted = false;
 
-    /**
-     * The welcome screen for this guild
-     * @type {?WelcomeScreen}
-     */
-    this.welcomeScreen = null;
-
     if (!data) return;
     if (data.unavailable) {
       /**
@@ -339,10 +333,6 @@ class Guild extends BaseGuild {
       this.approximatePresenceCount = data.approximate_presence_count;
     } else if (typeof this.approximatePresenceCount === 'undefined') {
       this.approximatePresenceCount = null;
-    }
-
-    if (typeof data.welcome_screen !== 'undefined') {
-      this.welcomeScreen = new WelcomeScreen(this, data.welcome_screen);
     }
 
     /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -961,20 +961,18 @@ class Guild extends BaseGuild {
    * })
    */
   editWelcomeScreen({ enabled, description, welcomeChannels } = {}) {
-    const welcome_channels =
-      welcomeChannels?.map(data => {
-        const channel_id = this.channels.resolveID(data.channel);
-        const emoji = this.emojis.resolve(data.emoji);
-        return {
-          emoji_id: emoji?.id ?? null,
-          emoji_name: emoji?.name ?? emoji,
-          channel_id,
-        };
-      }) ?? undefined;
+    const welcome_channels = welcomeChannels?.map(data => {
+      const emoji = this.emojis.resolve(data.emoji);
+      return {
+        emoji_id: emoji?.id ?? null,
+        emoji_name: emoji?.name ?? emoji,
+        channel_id: this.channels.resolveID(data.channel),
+      };
+    });
 
     return this.client.api
-      .guilds(this.id)
-      ['welcome-screen'].patch({
+      .guilds(this.id, 'welcome-screen')
+      .patch({
         data: {
           welcome_channels,
           description,

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -595,11 +595,13 @@ class Guild extends BaseGuild {
       );
   }
 
-  fetchWelcomeScreen() {
-    return this.client.api
-      .guilds(this.id)
-      ['welcome-screen'].get()
-      .then(data => new WelcomeScreen(this, data));
+  /**
+   * Fetches the welcome screen for this guild.
+   * @returns {Promise<WelcomeScreen>}
+   */
+  async fetchWelcomeScreen() {
+    const data = await this.client.api.guilds(this.id, 'welcome-screen').get();
+    return new WelcomeScreen(this, data);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -929,6 +929,62 @@ class Guild extends BaseGuild {
   }
 
   /**
+   * Welcome channel data
+   * @typedef {Object} WelcomeChannelData
+   * @property {string} description The description to show for this welcome channel
+   * @property {GuildChannelResolvable} channel The channel to link for this welcome channel
+   * @property {EmojiIdentifierResolvable} [emoji] The emoji to display for this welcome channel
+   */
+
+  /**
+   * Welcome screen edit data
+   * @typedef {Object} WelcomeScreenEditData
+   * @property {boolean} [enabled] Whether the welcome screen is enabled
+   * @property {string} [description] The description for the welcome screen
+   * @property {WelcomeChannelData[]} [welcomeChannels] The welcome channel data for the welcome screen
+   */
+
+  /**
+   * Updates the guild's welcome screen
+   * @param {WelcomeScreenEditData} [data] Data to edit the welcome screen with
+   * @returns {Promise<WelcomeScreen>}
+   * @example
+   * guild.editWelcomeScreen({
+   *   description: 'Hello World',
+   *   enabled: true,
+   *   welcomeChannels: [
+   *     {
+   *       description: 'foobar',
+   *       channel: '222197033908436994',
+   *     }
+   *   ],
+   * })
+   */
+  editWelcomeScreen({ enabled, description, welcomeChannels } = {}) {
+    const welcome_channels =
+      welcomeChannels?.map(data => {
+        const channel_id = this.channels.resolveID(data.channel);
+        const emoji = this.emojis.resolve(data.emoji);
+        return {
+          emoji_id: emoji?.id ?? null,
+          emoji_name: emoji?.name ?? emoji,
+          channel_id,
+        };
+      }) ?? undefined;
+
+    return this.client.api
+      .guilds(this.id)
+      ['welcome-screen'].patch({
+        data: {
+          welcome_channels,
+          description,
+          enabled,
+        },
+      })
+      .then(data => new WelcomeScreen(this, data));
+  }
+
+  /**
    * Edits the level of the explicit content filter.
    * @param {ExplicitContentFilterLevel|number} explicitContentFilter The new level of the explicit content filter
    * @param {string} [reason] Reason for changing the level of the guild's explicit content filter

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -130,6 +130,7 @@ class Guild extends AnonymousGuild {
    * @private
    */
   _patch(data) {
+    super._patch(data);
     this.id = data.id;
     this.name = data.name;
     this.icon = data.icon;
@@ -396,7 +397,6 @@ class Guild extends AnonymousGuild {
         emojis: data.emojis,
       });
     }
-    super._patch(data);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -950,7 +950,7 @@ class Guild extends BaseGuild {
    *   ],
    * })
    */
-  editWelcomeScreen({ enabled, description, welcomeChannels } = {}) {
+  async editWelcomeScreen({ enabled, description, welcomeChannels } = {}) {
     const welcome_channels = welcomeChannels?.map(data => {
       const emoji = this.emojis.resolve(data.emoji);
       return {
@@ -960,16 +960,14 @@ class Guild extends BaseGuild {
       };
     });
 
-    return this.client.api
-      .guilds(this.id, 'welcome-screen')
-      .patch({
-        data: {
-          welcome_channels,
-          description,
-          enabled,
-        },
-      })
-      .then(data => new WelcomeScreen(this, data));
+    const data = await this.client.api.guilds(this.id, 'welcome-screen').patch({
+      data: {
+        welcome_channels,
+        description,
+        enabled,
+      },
+    });
+    return new WelcomeScreen(this, data);
   }
 
   /**

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -22,7 +22,7 @@ class Invite extends Base {
     const Guild = require('./Guild');
     /**
      * The guild the invite is for including welcome screen data if present
-     * @type {?Guild|InviteGuild}
+     * @type {?(Guild|InviteGuild)}
      */
     this.guild = null;
     if (data.guild) {

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -18,11 +18,16 @@ class Invite extends Base {
   }
 
   _patch(data) {
+    const InviteGuild = require('./InviteGuild');
     /**
-     * The guild the invite is for
-     * @type {?Guild}
+     * The guild the invite is for including welcome screen data if present
+     * @type {?Guild|InviteGuild}
      */
-    this.guild = data.guild ? this.client.guilds.add(data.guild, false) : null;
+    this.guild = null;
+    if (data.guild) {
+      const guild = this.client.guilds.resolve(data.guild.id);
+      this.guild = guild ?? new InviteGuild(this.client, data.guild);
+    }
 
     /**
      * The code for this invite

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -19,14 +19,14 @@ class Invite extends Base {
 
   _patch(data) {
     const InviteGuild = require('./InviteGuild');
+    const Guild = require('./Guild');
     /**
      * The guild the invite is for including welcome screen data if present
      * @type {?Guild|InviteGuild}
      */
     this.guild = null;
     if (data.guild) {
-      const guild = this.client.guilds.resolve(data.guild.id);
-      this.guild = guild ?? new InviteGuild(this.client, data.guild);
+      this.guild = data.guild instanceof Guild ? data.guild : new InviteGuild(this.client, data.guild);
     }
 
     /**

--- a/src/structures/InviteGuild.js
+++ b/src/structures/InviteGuild.js
@@ -4,7 +4,7 @@ const AnonymousGuild = require('./AnonymousGuild');
 const WelcomeScreen = require('./WelcomeScreen');
 
 /**
- * Represents a guild received from an invite, including welcome screen data if available.
+ * Represents a guild received from an invite, includes welcome screen data if available.
  * @extends {AnonymousGuild}
  */
 class InviteGuild extends AnonymousGuild {

--- a/src/structures/InviteGuild.js
+++ b/src/structures/InviteGuild.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const BaseGuild = require('./BaseGuild');
+const AnonymousGuild = require('./AnonymousGuild');
 const WelcomeScreen = require('./WelcomeScreen');
 
 /**
  * Represents a guild received from an invite, including welcome screen data if available.
- * @extends {BaseGuild}
+ * @extends {AnonymousGuild}
  */
-class InviteGuild extends BaseGuild {
+class InviteGuild extends AnonymousGuild {
   constructor(client, data) {
     super(client, data);
     this.welcomeScreen =

--- a/src/structures/InviteGuild.js
+++ b/src/structures/InviteGuild.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const Guild = require('./Guild');
+const WelcomeScreen = require('./WelcomeScreen');
+
+/**
+ * Represents a guild received from an invite, including welcome screen data if available.
+ * @extends {Guild}
+ */
+class InviteGuild extends Guild {
+  constructor(client, data) {
+    super(client, data);
+    this.welcomeScreen =
+      typeof data.welcome_screen !== 'undefined' ? new WelcomeScreen(this, data.welcome_screen) : null;
+  }
+}
+
+module.exports = InviteGuild;

--- a/src/structures/InviteGuild.js
+++ b/src/structures/InviteGuild.js
@@ -10,6 +10,11 @@ const WelcomeScreen = require('./WelcomeScreen');
 class InviteGuild extends AnonymousGuild {
   constructor(client, data) {
     super(client, data);
+
+    /**
+     * The welcome screen for this invite guild
+     * @type {?WelcomeScreen}
+     */
     this.welcomeScreen =
       typeof data.welcome_screen !== 'undefined' ? new WelcomeScreen(this, data.welcome_screen) : null;
   }

--- a/src/structures/InviteGuild.js
+++ b/src/structures/InviteGuild.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const Guild = require('./Guild');
+const BaseGuild = require('./BaseGuild');
 const WelcomeScreen = require('./WelcomeScreen');
 
 /**
  * Represents a guild received from an invite, including welcome screen data if available.
- * @extends {Guild}
+ * @extends {BaseGuild}
  */
-class InviteGuild extends Guild {
+class InviteGuild extends BaseGuild {
   constructor(client, data) {
     super(client, data);
     this.welcomeScreen =

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -3,29 +3,57 @@
 const Base = require('./Base');
 const Emoji = require('./Emoji');
 
+/**
+ * Represents a channel link in a guild's welcome screen.
+ */
 class WelcomeChannel extends Base {
   constructor(guild, data) {
     super(guild.client);
+    /**
+     * The guild for this welcome channel
+     * @type {Guild}
+     */
     this.guild = guild;
 
     this._patch(data);
   }
 
+  /**
+   * Builds the welcome channel with the provided data.
+   * @param {*} data The raw data of this welcome channel
+   * @private
+   */
   _patch(data) {
     if (!data) return;
+    /**
+     * The description of this welcome channel
+     * @type {string}
+     */
     this.description = data.description;
     this._emoji = {
       name: data.emoji_name,
       id: data.emoji_id,
     };
 
+    /**
+     * The id of this welcome channel
+     * @type {Snowflake}
+     */
     this.channelID = data.channel_id;
   }
 
+  /**
+   * The channel of this welcome channel
+   * @type {?(TextChannel|NewsChannel)}
+   */
   get channel() {
     return this.client.channels.resolve(this.channelID);
   }
 
+  /**
+   * The emoji of this welcome channel
+   * @type {GuildEmoji|Emoji}
+   */
   get emoji() {
     return this.client.emojis.resolve(this._emoji.id) ?? new Emoji(this.client, this._emoji);
   }

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -17,16 +17,6 @@ class WelcomeChannel extends Base {
      */
     this.guild = guild;
 
-    this._patch(data);
-  }
-
-  /**
-   * Builds the welcome channel with the provided data.
-   * @param {*} data The raw data of this welcome channel
-   * @private
-   */
-  _patch(data) {
-    if (!data) return;
     /**
      * The description of this welcome channel
      * @type {string}

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -20,7 +20,7 @@ class WelcomeChannel extends Base {
   }
 
   get channel() {
-    return this.client.guilds.add({ id: this.channelID }, null, false);
+    return this.client.channels.add({ id: this.channelID }, null, false);
   }
 
   get emoji() {

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const Base = require('./Base');
+const Emoji = require('./Emoji');
+
+class WelcomeChannel extends Base {
+  constructor(client, guild, data) {
+    super(client);
+    this.guild = guild;
+
+    this._patch(data);
+  }
+
+  _patch(data) {
+    if (!data) return;
+    this.description = data.description;
+    this._data = data;
+
+    this.channelID = data.channel_id;
+  }
+
+  get channel() {
+    return this.client.guilds.add({ id: this.channelID }, null, false);
+  }
+
+  get emoji() {
+    const { emoji_id, emoji_name } = this._data;
+    return (
+      this.client.emojis.resolve(emoji_id) ??
+      new Emoji(this.client, {
+        name: emoji_name,
+        id: emoji_id,
+      })
+    );
+  }
+}
+
+module.exports = WelcomeChannel;

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -52,7 +52,7 @@ class WelcomeChannel extends Base {
 
   /**
    * The channel of this welcome channel
-   * @type {?(TextChannel|NewsChannel)}
+   * @type {?TextChannel|NewsChannel}
    */
   get channel() {
     return this.client.channels.resolve(this.channelID);

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -14,24 +14,20 @@ class WelcomeChannel extends Base {
   _patch(data) {
     if (!data) return;
     this.description = data.description;
-    this._data = data;
+    this._emoji = {
+      name: data.emoji_name,
+      id: data.emoji_id,
+    };
 
     this.channelID = data.channel_id;
   }
 
   get channel() {
-    return this.client.channels.add({ id: this.channelID }, null, false);
+    return this.client.channels.resolve(this.channelID);
   }
 
   get emoji() {
-    const { emoji_id, emoji_name } = this._data;
-    return (
-      this.client.emojis.resolve(emoji_id) ??
-      new Emoji(this.client, {
-        name: emoji_name,
-        id: emoji_id,
-      })
-    );
+    return this.client.emojis.resolve(this._emoji.id) ?? new Emoji(this.client, this._emoji);
   }
 }
 

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -5,10 +5,12 @@ const Emoji = require('./Emoji');
 
 /**
  * Represents a channel link in a guild's welcome screen.
+ * @extends {Base}
  */
 class WelcomeChannel extends Base {
   constructor(guild, data) {
     super(guild.client);
+
     /**
      * The guild for this welcome channel
      * @type {Guild}
@@ -30,6 +32,12 @@ class WelcomeChannel extends Base {
      * @type {string}
      */
     this.description = data.description;
+
+    /**
+     * The raw emoji data
+     * @type {Object}
+     * @private
+     */
     this._emoji = {
       name: data.emoji_name,
       id: data.emoji_id,

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -13,7 +13,7 @@ class WelcomeChannel extends Base {
 
     /**
      * The guild for this welcome channel
-     * @type {Guild}
+     * @type {Guild|WelcomeGuild}
      */
     this.guild = guild;
 

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -4,8 +4,8 @@ const Base = require('./Base');
 const Emoji = require('./Emoji');
 
 class WelcomeChannel extends Base {
-  constructor(client, guild, data) {
-    super(client);
+  constructor(guild, data) {
+    super(guild.client);
     this.guild = guild;
 
     this._patch(data);

--- a/src/structures/WelcomeScreen.js
+++ b/src/structures/WelcomeScreen.js
@@ -18,30 +18,17 @@ class WelcomeScreen extends Base {
      */
     this.guild = guild;
 
-    this._patch(data);
-  }
-
-  /**
-   * Builds the welcome screen with the provided data.
-   * @param {*} data The raw data of the welcome screen
-   * @private
-   */
-  _patch(data) {
-    if (!data) return;
-
     /**
      * The description of this welcome screen
      * @type {?string}
      */
     this.description = data.description ?? null;
 
-    if (!this.welcomeChannels) {
-      /**
-       * Collection of welcome channels belonging to this welcome screen
-       * @type {Collection<Snowflake, WelcomeChannel>}
-       */
-      this.welcomeChannels = new Collection();
-    }
+    /**
+     * Collection of welcome channels belonging to this welcome screen
+     * @type {Collection<Snowflake, WelcomeChannel>}
+     */
+    this.welcomeChannels = new Collection();
 
     for (const channel of data.welcome_channels) {
       const welcomeChannel = new WelcomeChannel(this.guild, channel);

--- a/src/structures/WelcomeScreen.js
+++ b/src/structures/WelcomeScreen.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Collection = require('../util/Collection');
 const Base = require('./Base');
 const WelcomeChannel = require('./WelcomeChannel');
+const Collection = require('../util/Collection');
 
 /**
  * Represents a welcome screen.

--- a/src/structures/WelcomeScreen.js
+++ b/src/structures/WelcomeScreen.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { default: Collection } = require('@discordjs/collection');
+const Base = require('./Base');
+const WelcomeChannel = require('./WelcomeChannel');
+
+class WelcomeScreen extends Base {
+  constructor(client, guild, data) {
+    super(client);
+    this.guild = guild;
+
+    this._patch(data);
+  }
+
+  /**
+   * Builds the welcome screen with the provided data.
+   * @param {*} data The raw data of the welcome screen
+   * @private
+   */
+  _patch(data) {
+    if (!data) return;
+    this.description = data.description;
+
+    if (!this.welcomeChannels) {
+      /**
+       * Collection of welcome channels belonging to this welcome screen
+       * @type {Collection<Snowflake, NewsChannel|TextChannel>}
+       */
+      this.welcomeChannels = new Collection();
+    }
+
+    for (const channel of data.welcome_channels) {
+      const welcomeChannel = new WelcomeChannel(this.client, this.guild, channel);
+      this.welcomeChannels.set(welcomeChannel.channelID, welcomeChannel);
+    }
+  }
+}
+
+module.exports = WelcomeScreen;

--- a/src/structures/WelcomeScreen.js
+++ b/src/structures/WelcomeScreen.js
@@ -5,8 +5,8 @@ const Base = require('./Base');
 const WelcomeChannel = require('./WelcomeChannel');
 
 class WelcomeScreen extends Base {
-  constructor(client, guild, data) {
-    super(client);
+  constructor(guild, data) {
+    super(guild.client);
     this.guild = guild;
 
     this._patch(data);
@@ -30,7 +30,7 @@ class WelcomeScreen extends Base {
     }
 
     for (const channel of data.welcome_channels) {
-      const welcomeChannel = new WelcomeChannel(this.client, this.guild, channel);
+      const welcomeChannel = new WelcomeChannel(this.guild, channel);
       this.welcomeChannels.set(welcomeChannel.channelID, welcomeChannel);
     }
   }

--- a/src/structures/WelcomeScreen.js
+++ b/src/structures/WelcomeScreen.js
@@ -1,15 +1,17 @@
 'use strict';
 
-const { default: Collection } = require('@discordjs/collection');
+const Collection = require('../util/Collection');
 const Base = require('./Base');
 const WelcomeChannel = require('./WelcomeChannel');
 
 /**
  * Represents a welcome screen.
+ * @extends {Base}
  */
 class WelcomeScreen extends Base {
   constructor(guild, data) {
     super(guild.client);
+
     /**
      * The guild for this welcome screen
      * @type {Guild}

--- a/src/structures/WelcomeScreen.js
+++ b/src/structures/WelcomeScreen.js
@@ -4,9 +4,16 @@ const { default: Collection } = require('@discordjs/collection');
 const Base = require('./Base');
 const WelcomeChannel = require('./WelcomeChannel');
 
+/**
+ * Represents a welcome screen.
+ */
 class WelcomeScreen extends Base {
   constructor(guild, data) {
     super(guild.client);
+    /**
+     * The guild for this welcome screen
+     * @type {Guild}
+     */
     this.guild = guild;
 
     this._patch(data);
@@ -19,12 +26,17 @@ class WelcomeScreen extends Base {
    */
   _patch(data) {
     if (!data) return;
-    this.description = data.description;
+
+    /**
+     * The description of this welcome screen
+     * @type {?string}
+     */
+    this.description = data.description ?? null;
 
     if (!this.welcomeChannels) {
       /**
        * Collection of welcome channels belonging to this welcome screen
-       * @type {Collection<Snowflake, NewsChannel|TextChannel>}
+       * @type {Collection<Snowflake, WelcomeChannel>}
        */
       this.welcomeChannels = new Collection();
     }

--- a/src/structures/WelcomeScreen.js
+++ b/src/structures/WelcomeScreen.js
@@ -35,6 +35,14 @@ class WelcomeScreen extends Base {
       this.welcomeChannels.set(welcomeChannel.channelID, welcomeChannel);
     }
   }
+
+  /**
+   * Whether the welcome screen is enabled on the guild or not
+   * @type {boolean}
+   */
+  get enabled() {
+    return this.guild.features.includes('WELCOME_SCREEN_ENABLED');
+  }
 }
 
 module.exports = WelcomeScreen;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2711,6 +2711,7 @@ declare module 'discord.js' {
     position?: number;
   }
 
+  type GuildTextChannelResolvable = TextChannel | NewsChannel | Snowflake;
   type ChannelResolvable = Channel | Snowflake;
 
   interface ChannelWebhookCreateOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -286,7 +286,7 @@ declare module 'discord.js' {
     public toJSON(...props: { [key: string]: boolean | string }[]): unknown;
   }
 
-  export class BaseGuild extends Base {
+  export abstract class BaseGuild extends Base {
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
     public features: GuildFeatures[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -750,7 +750,7 @@ declare module 'discord.js' {
   }
 
   export class Emoji extends Base {
-    constructor(client: Client, emoji: object);
+    constructor(client: Client, emoji: unknown);
     public animated: boolean | null;
     public readonly createdAt: Date | null;
     public readonly createdTimestamp: number | null;
@@ -3581,11 +3581,11 @@ declare module 'discord.js' {
 
   type OverwriteType = 'member' | 'role';
 
-  interface PermissionFlags extends Record<PermissionString, bigint> { }
+  interface PermissionFlags extends Record<PermissionString, bigint> {}
 
-  interface PermissionObject extends Record<PermissionString, boolean> { }
+  interface PermissionObject extends Record<PermissionString, boolean> {}
 
-  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> { }
+  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> {}
 
   type PermissionResolvable = BitFieldResolvable<PermissionString, bigint>;
 
@@ -3624,7 +3624,7 @@ declare module 'discord.js' {
     | 'USE_APPLICATION_COMMANDS'
     | 'REQUEST_TO_SPEAK';
 
-  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> { }
+  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> {}
 
   type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray<T>>;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1191,7 +1191,7 @@ declare module 'discord.js' {
     public static INVITES_PATTERN: RegExp;
   }
 
-  export class InviteGuild extends BaseGuild {
+  export class InviteGuild extends AnonymousGuild {
     constructor(client: Client, data: unknown);
     public welcomeScreen: WelcomeScreen | null;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1188,7 +1188,7 @@ declare module 'discord.js' {
     public static INVITES_PATTERN: RegExp;
   }
 
-  export class InviteGuild extends Guild {
+  export class InviteGuild extends BaseGuild {
     constructor(client: Client, data: unknown);
     public welcomeScreen: WelcomeScreen | null;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -817,6 +817,7 @@ declare module 'discord.js' {
     public verificationLevel: VerificationLevel;
     public readonly voiceAdapterCreator: DiscordGatewayAdapterCreator;
     public readonly voiceStates: VoiceStateManager;
+    public welcomeScreen: WelcomeScreen | null;
     public readonly widgetChannel: TextChannel | null;
     public widgetChannelID: Snowflake | null;
     public widgetEnabled: boolean | null;
@@ -837,6 +838,7 @@ declare module 'discord.js' {
     public fetchVanityData(): Promise<Vanity>;
     public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
+    public fetchWelcomeScreen(): Promise<WelcomeScreen>;
     public fetchWidget(): Promise<GuildWidget>;
     public leave(): Promise<Guild>;
     public setAFKChannel(afkChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
@@ -2094,6 +2096,20 @@ declare module 'discord.js' {
     public channelID?: Snowflake;
     public avatarURL: string;
     public activity?: WidgetActivity;
+  }
+
+  export class WelcomeChannel extends Base {
+    public channelID: Snowflake;
+    public guild: Guild;
+    public description: string;
+    public readonly channel: TextChannel | NewsChannel | null;
+    public readonly emoji: GuildEmoji | Emoji;
+  }
+
+  export class WelcomeScreen extends Base {
+    public guild: Guild;
+    public description: string | null;
+    public welcomeChannels: Collection<Snowflake, WelcomeChannel>;
   }
 
   //#endregion

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -750,8 +750,8 @@ declare module 'discord.js' {
   }
 
   export class Emoji extends Base {
-    constructor(client: Client, emoji: unknown);
-    public animated: boolean;
+    constructor(client: Client, emoji: object);
+    public animated: boolean | null;
     public readonly createdAt: Date | null;
     public readonly createdTimestamp: number | null;
     public deleted: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1189,7 +1189,7 @@ declare module 'discord.js' {
   }
 
   export class InviteGuild extends Guild {
-    constructor(client: Client, data: object);
+    constructor(client: Client, data: unknown);
     public welcomeScreen: WelcomeScreen | null;
   }
 
@@ -2104,7 +2104,7 @@ declare module 'discord.js' {
   }
 
   export class WelcomeChannel extends Base {
-    private _emoji: object;
+    private _emoji: unknown;
     public channelID: Snowflake;
     public guild: Guild | InviteGuild;
     public description: string;
@@ -3651,7 +3651,7 @@ declare module 'discord.js' {
     [K in keyof Omit<
       T,
       'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
-    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-line:ban-types
+    >]: T[K] extends (...args: any) => void ? T[K] : T[K] | null;
   };
 
   interface PartialDMChannel

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2100,7 +2100,7 @@ declare module 'discord.js' {
   }
 
   export class WelcomeChannel extends Base {
-    private _emojis: object;
+    private _emoji: object;
     public channelID: Snowflake;
     public guild: Guild;
     public description: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -180,6 +180,17 @@ declare module 'discord.js' {
     public static resolve(bit?: BitFieldResolvable<ActivityFlagsString, number>): number;
   }
 
+  export abstract class AnonymousGuild extends BaseGuild {
+    public banner: string | null;
+    public description: string | null;
+    public nsfwLevel: NSFWLevel;
+    public splash: string | null;
+    public vanityURLCode: string | null;
+    public verificationLevel: VerificationLevel;
+    public bannerURL(options?: StaticImageURLOptions): string | null;
+    public splashURL(options?: StaticImageURLOptions): string | null;
+  }
+
   export class APIMessage {
     constructor(target: MessageTarget, options: MessageOptions | WebhookMessageOptions);
     public data: unknown | null;
@@ -763,7 +774,7 @@ declare module 'discord.js' {
     public toString(): string;
   }
 
-  export class Guild extends BaseGuild {
+  export class Guild extends AnonymousGuild {
     constructor(client: Client, data: unknown);
     private _sortedRoles(): Collection<Snowflake, Role>;
     private _sortedChannels(channel: Channel): Collection<Snowflake, GuildChannel>;
@@ -775,13 +786,11 @@ declare module 'discord.js' {
     public approximateMemberCount: number | null;
     public approximatePresenceCount: number | null;
     public available: boolean;
-    public banner: string | null;
     public bans: GuildBanManager;
     public channels: GuildChannelManager;
     public commands: GuildApplicationCommandManager;
     public defaultMessageNotifications: DefaultMessageNotificationLevel | number;
     public deleted: boolean;
-    public description: string | null;
     public discoverySplash: string | null;
     public emojis: GuildEmojiManager;
     public explicitContentFilter: ExplicitContentFilterLevel;
@@ -794,7 +803,6 @@ declare module 'discord.js' {
     public memberCount: number;
     public members: GuildMemberManager;
     public mfaLevel: MFALevel;
-    public nsfwLevel: NSFWLevel;
     public ownerID: Snowflake;
     public preferredLocale: string;
     public premiumSubscriptionCount: number | null;
@@ -807,21 +815,17 @@ declare module 'discord.js' {
     public rulesChannelID: Snowflake | null;
     public readonly shard: WebSocketShard;
     public shardID: number;
-    public splash: string | null;
     public stageInstances: StageInstanceManager;
     public readonly systemChannel: TextChannel | null;
     public systemChannelFlags: Readonly<SystemChannelFlags>;
     public systemChannelID: Snowflake | null;
-    public vanityURLCode: string | null;
     public vanityURLUses: number | null;
-    public verificationLevel: VerificationLevel;
     public readonly voiceAdapterCreator: DiscordGatewayAdapterCreator;
     public readonly voiceStates: VoiceStateManager;
     public readonly widgetChannel: TextChannel | null;
     public widgetChannelID: Snowflake | null;
     public widgetEnabled: boolean | null;
     public addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
-    public bannerURL(options?: StaticImageURLOptions): string | null;
     public createIntegration(data: IntegrationData, reason?: string): Promise<Guild>;
     public createTemplate(name: string, description?: string): Promise<GuildTemplate>;
     public delete(): Promise<Guild>;
@@ -866,7 +870,6 @@ declare module 'discord.js' {
     public setSystemChannelFlags(systemChannelFlags: SystemChannelFlagsResolvable, reason?: string): Promise<Guild>;
     public setVerificationLevel(verificationLevel: VerificationLevel | number, reason?: string): Promise<Guild>;
     public setWidget(widget: GuildWidgetData, reason?: string): Promise<Guild>;
-    public splashURL(options?: StaticImageURLOptions): string | null;
     public toJSON(): unknown;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2109,6 +2109,7 @@ declare module 'discord.js' {
   }
 
   export class WelcomeScreen extends Base {
+    public enabled: boolean;
     public guild: Guild;
     public description: string | null;
     public welcomeChannels: Collection<Snowflake, WelcomeChannel>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2196,7 +2196,7 @@ declare module 'discord.js' {
     private static transformPermissions(permissions: ApplicationCommandPermissionData, received?: boolean): unknown;
   }
 
-  export class BaseGuildEmojiManager extends BaseManager<Snowflake, GuildEmoji, EmojiResolvable> {
+  export class BaseGuildEmojiManager extends BaseManager<Snowflake, GuildEmoji, EmojiIdentifierResolvable> {
     constructor(client: Client, iterable?: Iterable<any>);
     public resolveIdentifier(emoji: EmojiIdentifierResolvable): string | null;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2099,6 +2099,7 @@ declare module 'discord.js' {
   }
 
   export class WelcomeChannel extends Base {
+    private _emojis: object;
     public channelID: Snowflake;
     public guild: Guild;
     public description: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -817,7 +817,6 @@ declare module 'discord.js' {
     public verificationLevel: VerificationLevel;
     public readonly voiceAdapterCreator: DiscordGatewayAdapterCreator;
     public readonly voiceStates: VoiceStateManager;
-    public welcomeScreen: WelcomeScreen | null;
     public readonly widgetChannel: TextChannel | null;
     public widgetChannelID: Snowflake | null;
     public widgetEnabled: boolean | null;
@@ -1171,7 +1170,7 @@ declare module 'discord.js' {
     public createdTimestamp: number | null;
     public readonly expiresAt: Date | null;
     public readonly expiresTimestamp: number | null;
-    public guild: Guild | null;
+    public guild: InviteGuild | Guild | null;
     public inviter: User | null;
     public maxAge: number | null;
     public maxUses: number | null;
@@ -1187,6 +1186,11 @@ declare module 'discord.js' {
     public toJSON(): unknown;
     public toString(): string;
     public static INVITES_PATTERN: RegExp;
+  }
+
+  export class InviteGuild extends Guild {
+    constructor(client: Client, data: object);
+    public welcomeScreen: WelcomeScreen | null;
   }
 
   export class Message extends Base {
@@ -2102,7 +2106,7 @@ declare module 'discord.js' {
   export class WelcomeChannel extends Base {
     private _emoji: object;
     public channelID: Snowflake;
-    public guild: Guild;
+    public guild: Guild | InviteGuild;
     public description: string;
     public readonly channel: TextChannel | NewsChannel | null;
     public readonly emoji: GuildEmoji | Emoji;
@@ -2110,7 +2114,7 @@ declare module 'discord.js' {
 
   export class WelcomeScreen extends Base {
     public enabled: boolean;
-    public guild: Guild;
+    public guild: Guild | InviteGuild;
     public description: string | null;
     public welcomeChannels: Collection<Snowflake, WelcomeChannel>;
   }
@@ -3577,11 +3581,11 @@ declare module 'discord.js' {
 
   type OverwriteType = 'member' | 'role';
 
-  interface PermissionFlags extends Record<PermissionString, bigint> {}
+  interface PermissionFlags extends Record<PermissionString, bigint> { }
 
-  interface PermissionObject extends Record<PermissionString, boolean> {}
+  interface PermissionObject extends Record<PermissionString, boolean> { }
 
-  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> {}
+  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> { }
 
   type PermissionResolvable = BitFieldResolvable<PermissionString, bigint>;
 
@@ -3620,7 +3624,7 @@ declare module 'discord.js' {
     | 'USE_APPLICATION_COMMANDS'
     | 'REQUEST_TO_SPEAK';
 
-  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> {}
+  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> { }
 
   type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray<T>>;
 
@@ -3644,16 +3648,16 @@ declare module 'discord.js' {
     partial: true;
     fetch(): Promise<T>;
   } & {
-    [K in keyof Omit<
-      T,
-      'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
-    >]: T[K] extends (...args: any) => void ? T[K] : T[K] | null;
-  };
+      [K in keyof Omit<
+        T,
+        'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
+      >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-line:ban-types
+    };
 
   interface PartialDMChannel
     extends Partialize<
-      DMChannel,
-      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+    DMChannel,
+    'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
     > {
     lastMessage: null;
     lastMessageID: undefined;
@@ -3675,18 +3679,18 @@ declare module 'discord.js' {
 
   interface PartialGuildMember
     extends Partialize<
-      GuildMember,
-      | 'bannable'
-      | 'displayColor'
-      | 'displayHexColor'
-      | 'displayName'
-      | 'guild'
-      | 'kickable'
-      | 'permissions'
-      | 'roles'
-      | 'manageable'
-      | 'presence'
-      | 'voice'
+    GuildMember,
+    | 'bannable'
+    | 'displayColor'
+    | 'displayHexColor'
+    | 'displayName'
+    | 'guild'
+    | 'kickable'
+    | 'permissions'
+    | 'roles'
+    | 'manageable'
+    | 'presence'
+    | 'voice'
     > {
     readonly bannable: boolean;
     readonly displayColor: number;
@@ -3705,17 +3709,17 @@ declare module 'discord.js' {
 
   interface PartialMessage
     extends Partialize<
-      Message,
-      | 'attachments'
-      | 'channel'
-      | 'deletable'
-      | 'crosspostable'
-      | 'editable'
-      | 'mentions'
-      | 'pinnable'
-      | 'url'
-      | 'flags'
-      | 'embeds'
+    Message,
+    | 'attachments'
+    | 'channel'
+    | 'deletable'
+    | 'crosspostable'
+    | 'editable'
+    | 'mentions'
+    | 'pinnable'
+    | 'url'
+    | 'flags'
+    | 'embeds'
     > {
     attachments: Message['attachments'];
     channel: Message['channel'];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -828,6 +828,7 @@ declare module 'discord.js' {
     public delete(): Promise<Guild>;
     public discoverySplashURL(options?: StaticImageURLOptions): string | null;
     public edit(data: GuildEditData, reason?: string): Promise<Guild>;
+    public editWelcomeScreen(data?: WelcomeChannelData): Promise<WelcomeScreen>;
     public equals(guild: Guild): boolean;
     public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
     public fetchIntegrations(): Promise<Collection<string, Integration>>;
@@ -3960,6 +3961,18 @@ declare module 'discord.js' {
     id: Snowflake;
     name: string;
     position: number;
+  }
+
+  interface WelcomeChannelData {
+    description: string;
+    channel: GuildChannelResolvable;
+    emoji?: EmojiIdentifierResolvable;
+  }
+
+  interface WelcomeScreenEditData {
+    enabled?: boolean;
+    description?: string;
+    welcomeChannels?: WelcomeChannelData[];
   }
 
   type WSEventType =

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2205,7 +2205,7 @@ declare module 'discord.js' {
     private static transformPermissions(permissions: ApplicationCommandPermissionData, received?: boolean): unknown;
   }
 
-  export class BaseGuildEmojiManager extends BaseManager<Snowflake, GuildEmoji, EmojiIdentifierResolvable> {
+  export class BaseGuildEmojiManager extends BaseManager<Snowflake, GuildEmoji, EmojiResolvable> {
     constructor(client: Client, iterable?: Iterable<any>);
     public resolveIdentifier(emoji: EmojiIdentifierResolvable): string | null;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -827,7 +827,7 @@ declare module 'discord.js' {
     public delete(): Promise<Guild>;
     public discoverySplashURL(options?: StaticImageURLOptions): string | null;
     public edit(data: GuildEditData, reason?: string): Promise<Guild>;
-    public editWelcomeScreen(data?: WelcomeChannelData): Promise<WelcomeScreen>;
+    public editWelcomeScreen(data: WelcomeScreenEditData): Promise<WelcomeScreen>;
     public equals(guild: Guild): boolean;
     public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
     public fetchIntegrations(): Promise<Collection<string, Integration>>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3648,16 +3648,16 @@ declare module 'discord.js' {
     partial: true;
     fetch(): Promise<T>;
   } & {
-      [K in keyof Omit<
-        T,
-        'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
-      >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-line:ban-types
-    };
+    [K in keyof Omit<
+      T,
+      'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
+    >]: T[K] extends Function ? T[K] : T[K] | null; // tslint:disable-line:ban-types
+  };
 
   interface PartialDMChannel
     extends Partialize<
-    DMChannel,
-    'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+      DMChannel,
+      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
     > {
     lastMessage: null;
     lastMessageID: undefined;
@@ -3679,18 +3679,18 @@ declare module 'discord.js' {
 
   interface PartialGuildMember
     extends Partialize<
-    GuildMember,
-    | 'bannable'
-    | 'displayColor'
-    | 'displayHexColor'
-    | 'displayName'
-    | 'guild'
-    | 'kickable'
-    | 'permissions'
-    | 'roles'
-    | 'manageable'
-    | 'presence'
-    | 'voice'
+      GuildMember,
+      | 'bannable'
+      | 'displayColor'
+      | 'displayHexColor'
+      | 'displayName'
+      | 'guild'
+      | 'kickable'
+      | 'permissions'
+      | 'roles'
+      | 'manageable'
+      | 'presence'
+      | 'voice'
     > {
     readonly bannable: boolean;
     readonly displayColor: number;
@@ -3709,17 +3709,17 @@ declare module 'discord.js' {
 
   interface PartialMessage
     extends Partialize<
-    Message,
-    | 'attachments'
-    | 'channel'
-    | 'deletable'
-    | 'crosspostable'
-    | 'editable'
-    | 'mentions'
-    | 'pinnable'
-    | 'url'
-    | 'flags'
-    | 'embeds'
+      Message,
+      | 'attachments'
+      | 'channel'
+      | 'deletable'
+      | 'crosspostable'
+      | 'editable'
+      | 'mentions'
+      | 'pinnable'
+      | 'url'
+      | 'flags'
+      | 'embeds'
     > {
     attachments: Message['attachments'];
     channel: Message['channel'];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2113,7 +2113,7 @@ declare module 'discord.js' {
   }
 
   export class WelcomeScreen extends Base {
-    public enabled: boolean;
+    public readonly enabled: boolean;
     public guild: Guild | InviteGuild;
     public description: string | null;
     public welcomeChannels: Collection<Snowflake, WelcomeChannel>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Implement `Guild#fetchWelcomeScreen`, `Guild#editWelcomeScreen`, add welcome screen data to invites retrieved via invite fetching (`Client#fetchInvite`) as per:

- https://github.com/discord/discord-api-docs/pull/1636
- https://github.com/discord/discord-api-docs/pull/2398

**Notes:**
- *(reverted)* ~~QoL change for `BaseGuildEmojiManager` to accept the `<:name:id>` and `name:id` syntax in resolve* methods~~ 
- ⚠️  Due to the nature of the emoji data we receive, this requires for Emoji#animated to potentially return null, making this a semver major PR. (upstream issue see below, not too much hope on that happening, though)
- ⚠  Changing the return value of Invite#guild (major)
- implement "enabled" via getter from guild features to not rely on upstream
- in-function reply is a hacky workaround for circular dependencies
- introduce intermediary, abstract guild to not dupe code for Guild and InviteGuild

**Upstream:**

- https://github.com/discord/discord-api-docs/issues/2795 can be handled via guild feature
- https://github.com/discord/discord-api-docs/issues/2796

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
