### PR TITLE
fix(Resolvables): valid resolvables throw error when uncached

### DIFF
--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -51,7 +51,7 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
     if (roles) {
       data.roles = [];
       for (let role of roles instanceof Collection ? roles.values() : roles) {
-        let roleID = this.guild.roles.resolveID(role);
+        const roleID = this.guild.roles.resolveID(role);
         if (!roleID) {
           return Promise.reject(
             new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true),

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -51,13 +51,13 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
     if (roles) {
       data.roles = [];
       for (let role of roles instanceof Collection ? roles.values() : roles) {
-        role = this.guild.roles.resolve(role);
-        if (!role) {
+        let roleID = this.guild.roles.resolveID(role);
+        if (!roleID) {
           return Promise.reject(
             new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true),
           );
         }
-        data.roles.push(role.id);
+        data.roles.push(roleID);
       }
     }
 

--- a/src/managers/GuildEmojiRoleManager.js
+++ b/src/managers/GuildEmojiRoleManager.js
@@ -53,7 +53,7 @@ class GuildEmojiRoleManager {
   add(roleOrRoles) {
     if (roleOrRoles instanceof Collection) return this.add(roleOrRoles.keyArray());
     if (!Array.isArray(roleOrRoles)) return this.add([roleOrRoles]);
-    roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
+    roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
 
     if (roleOrRoles.includes(null)) {
       return Promise.reject(new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true));

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -100,7 +100,7 @@ class GuildMemberRoleManager {
    */
   async add(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
-      roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
+      roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
       if (roleOrRoles.includes(null)) {
         throw new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true);
       }
@@ -108,15 +108,15 @@ class GuildMemberRoleManager {
       const newRoles = [...new Set(roleOrRoles.concat(...this._roles.values()))];
       return this.set(newRoles, reason);
     } else {
-      roleOrRoles = this.guild.roles.resolve(roleOrRoles);
-      if (roleOrRoles === null) {
+      const roleID = this.guild.roles.resolveID(roleOrRoles);
+      if (roleID === null) {
         throw new TypeError('INVALID_TYPE', 'roles', 'Role, Snowflake or Array or Collection of Roles or Snowflakes');
       }
 
-      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].put({ reason });
+      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleID].put({ reason });
 
       const clone = this.member._clone();
-      clone._roles = [...this._roles.keys(), roleOrRoles.id];
+      clone._roles = [...this._roles.keys(), roleID];
       return clone;
     }
   }
@@ -129,7 +129,7 @@ class GuildMemberRoleManager {
    */
   async remove(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
-      roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolve(r));
+      roleOrRoles = roleOrRoles.map(r => this.guild.roles.resolveID(r));
       if (roleOrRoles.includes(null)) {
         throw new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true);
       }
@@ -137,15 +137,15 @@ class GuildMemberRoleManager {
       const newRoles = this._roles.filter(role => !roleOrRoles.includes(role));
       return this.set(newRoles, reason);
     } else {
-      roleOrRoles = this.guild.roles.resolve(roleOrRoles);
-      if (roleOrRoles === null) {
+      const roleID = this.guild.roles.resolveID(roleOrRoles);
+      if (roleID === null) {
         throw new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true);
       }
 
-      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleOrRoles.id].delete({ reason });
+      await this.client.api.guilds[this.guild.id].members[this.member.id].roles[roleID].delete({ reason });
 
       const clone = this.member._clone();
-      const newRoles = this._roles.filter(role => role.id !== roleOrRoles.id);
+      const newRoles = this._roles.filter(role => role.id !== roleID);
       clone._roles = [...newRoles.keys()];
       return clone;
     }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -911,11 +911,11 @@ class Guild extends Base {
     if (options.roles) {
       const roles = [];
       for (let role of options.roles instanceof Collection ? options.roles.values() : options.roles) {
-        role = this.roles.resolve(role);
-        if (!role) {
+        let roleID = this.roles.resolveID(role);
+        if (!roleID) {
           throw new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true);
         }
-        roles.push(role.id);
+        roles.push(roleID);
       }
       options.roles = roles;
     }

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -283,7 +283,7 @@ class GuildMember extends Base {
    */
   async edit(data, reason) {
     if (data.channel) {
-      let voiceChannelID = this.guild.channels.resolveID(data.channel);
+      const voiceChannelID = this.guild.channels.resolveID(data.channel);
       if (!voiceChannelID) {
         throw new Error('GUILD_VOICE_CHANNEL_RESOLVE');
       }

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -283,11 +283,11 @@ class GuildMember extends Base {
    */
   async edit(data, reason) {
     if (data.channel) {
-      data.channel = this.guild.channels.resolve(data.channel);
-      if (!data.channel || data.channel.type !== 'voice') {
+      let voiceChannelID = this.guild.channels.resolveID(data.channel);
+      if (!voiceChannelID) {
         throw new Error('GUILD_VOICE_CHANNEL_RESOLVE');
       }
-      data.channel_id = data.channel.id;
+      data.channel_id = voiceChannelID;
       data.channel = undefined;
     } else if (data.channel === null) {
       data.channel_id = null;

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -284,7 +284,8 @@ class GuildMember extends Base {
   async edit(data, reason) {
     if (data.channel) {
       const voiceChannelID = this.guild.channels.resolveID(data.channel);
-      if (!voiceChannelID) {
+      const voiceChannel = this.guild.channels.cache.get(voiceChannelID);
+      if (!voiceChannelID || (voiceChannel && voiceChannel?.type !== 'voice')) {
         throw new Error('GUILD_VOICE_CHANNEL_RESOLVE');
       }
       data.channel_id = voiceChannelID;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

answers/fixes: #5242

This PR is an extension of #5489 (unlike that PR. this one doesn't add any new parameter) and aims to fix errors that arise due IDs that belong to structures which aren't cached. This happens because the library tries to check for the validity of the resolvable by using `<Manager>#resolve`, this doesn't work in case of the resolvable being uncached. All of this can be fixed by using `<Manager>#resolveID` instead. This way we let the API do the validity test. I've tested **most** of the changes and the errors returned by API do a good job in letting the user know what's wrong.

⚠️ *The only change that I haven't tested belongs to `Guild#addMember` due to it being related to OAuth2. Even though it should work, It would be nice if someone can test it :)*


**Status and versioning classification:**
- Code changes **(except one)** have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
