### PR TITLE
fix(typings): update GuildMemberRoleManager typings to match implementation

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1992,8 +1992,9 @@ declare module 'discord.js' {
     public unban(user: UserResolvable, reason?: string): Promise<User>;
   }
 
-  export class GuildMemberRoleManager extends OverridableManager<Snowflake, Role, RoleResolvable> {
+  export class GuildMemberRoleManager {
     constructor(member: GuildMember);
+    public readonly cache: Collection<Snowflake, Role>;
     public readonly hoist: Role | null;
     public readonly color: Role | null;
     public readonly highest: Role;
@@ -2026,12 +2027,6 @@ declare module 'discord.js' {
     ): Promise<Collection<Snowflake, Message>>;
     public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;
     public delete(message: MessageResolvable): Promise<void>;
-  }
-
-  // Hacky workaround because changing the signature of an overridden method errors
-  class OverridableManager<V, K, R = any> extends BaseManager<V, K, R> {
-    public add(data: any, cache: any): any;
-    public set(key: any): any;
   }
 
   export class PresenceManager extends BaseManager<Snowflake, Presence, PresenceResolvable> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the typings for `GuildMemberRoleManager` to match the [documentation](https://discord.js.org/#/docs/main/stable/class/GuildMemberRoleManager) and js implementation.

Also removed `OverridableManager` as it is unecessary, it was only used by `GuildMemberRoleManager`.

Ran into this bug myself when trying to call `member.roles.resolve()`, which doesn't exist but existed in the typings because `GuildMemberRoleManager` (indirectly) inherits from `BaseManager`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
