### PR TITLE
fix(GuildAuditLogsEntry): executor can be missing

### DIFF
--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -319,11 +319,13 @@ class GuildAuditLogsEntry {
 
     /**
      * The user that executed this entry
-     * @type {User}
+     * @type {?User}
      */
-    this.executor = guild.client.options.partials.includes(PartialTypes.USER)
-      ? guild.client.users.add({ id: data.user_id })
-      : guild.client.users.cache.get(data.user_id);
+    this.executor = data.user_id
+      ? guild.client.options.partials.includes(PartialTypes.USER)
+        ? guild.client.users.add({ id: data.user_id })
+        : guild.client.users.cache.get(data.user_id)
+      : null;
 
     /**
      * An entry in the audit log representing a specific change.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -727,7 +727,7 @@ declare module 'discord.js' {
     public changes: AuditLogChange[] | null;
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
-    public executor: User;
+    public executor: User | null;
     public extra: object | Role | GuildMember | null;
     public id: Snowflake;
     public reason: string | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

As per https://github.com/discord/discord-api-docs/pull/1659 `user_id` is nullable, which should accordingly be handled in `GuildAuditLogsEntry#executor`

ℹ️  Note: This is the case when a webhook is deleted using a webhook token rather than a user or bot through a guild.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
