### PR TITLE
feat(GuildManager): allow system channel flags in create

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -16,6 +16,7 @@ const {
 } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const Permissions = require('../util/Permissions');
+const SystemChannelFlags = require('../util/SystemChannelFlags');
 const { resolveColor } = require('../util/Util');
 
 /**
@@ -141,6 +142,7 @@ class GuildManager extends BaseManager {
    * @param {PartialRoleData[]} [options.roles] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.
    * @param {number} [options.systemChannelID] The ID of the system channel
+   * @param {SystemChannelFlagsResolvable} [options.systemChannelFlags] The flags of the system channel
    * @param {VerificationLevel} [options.verificationLevel] The verification level for the guild
    * @returns {Promise<Guild>} The guild that was created
    */
@@ -156,6 +158,7 @@ class GuildManager extends BaseManager {
       region,
       roles = [],
       systemChannelID,
+      systemChannelFlags,
       verificationLevel,
     } = {},
   ) {
@@ -200,6 +203,7 @@ class GuildManager extends BaseManager {
             afk_channel_id: afkChannelID,
             afk_timeout: afkTimeout,
             system_channel_id: systemChannelID,
+            system_channel_flags: SystemChannelFlags.resolve(systemChannelFlags),
           },
         })
         .then(data => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2761,6 +2761,7 @@ declare module 'discord.js' {
     roles?: PartialRoleData[];
     systemChannelID?: number;
     verificationLevel?: VerificationLevel | number;
+    systemChannelFlags?: SystemChannelFlagsResolvable;
   }
 
   interface GuildWidget {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Allow `systemChannelFlags` to be passed during guild creation as per https://github.com/discord/discord-api-docs/pull/1764

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
