### PR TITLE
feat(Guild): allow description and features in edit

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -926,6 +926,7 @@ class Guild extends Base {
 
   /**
    * The data for editing a guild.
+   * <info>Only the `COMMUNITY` feature can be modified</info>
    * @typedef {Object} GuildEditData
    * @property {string} [name] The name of the guild
    * @property {string} [region] The region of the guild
@@ -944,6 +945,8 @@ class Guild extends Base {
    * @property {ChannelResolvable} [rulesChannel] The rules channel of the guild
    * @property {ChannelResolvable} [publicUpdatesChannel] The community updates channel of the guild
    * @property {string} [preferredLocale] The preferred locale of the guild
+   * @property {string} [description] The discovery description of the guild
+   * @property {Features[]} [features] The features of the guild
    */
 
   /**
@@ -1002,6 +1005,12 @@ class Guild extends Base {
     }
     if (typeof data.publicUpdatesChannel !== 'undefined') {
       _data.public_updates_channel_id = this.client.channels.resolveID(data.publicUpdatesChannel);
+    }
+    if (typeof data.features !== 'undefined') {
+      _data.features = data.features;
+    }
+    if (typeof data.description !== 'undefined') {
+      _data.description = data.description;
     }
     if (data.preferredLocale) _data.preferred_locale = data.preferredLocale;
     return this.client.api

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -926,7 +926,6 @@ class Guild extends Base {
 
   /**
    * The data for editing a guild.
-   * <info>Only the `COMMUNITY` feature can be modified</info>
    * @typedef {Object} GuildEditData
    * @property {string} [name] The name of the guild
    * @property {string} [region] The region of the guild

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2786,6 +2786,8 @@ declare module 'discord.js' {
     rulesChannel?: ChannelResolvable;
     publicUpdatesChannel?: ChannelResolvable;
     preferredLocale?: string;
+    description?: string;
+    features?: GuildFeatures[];
   }
 
   interface GuildEmojiCreateOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2786,7 +2786,7 @@ declare module 'discord.js' {
     rulesChannel?: ChannelResolvable;
     publicUpdatesChannel?: ChannelResolvable;
     preferredLocale?: string;
-    description?: string;
+    description?: string | null;
     features?: GuildFeatures[];
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- `Guild#edit` now allows modification of features (`COMMUNITY`, to enable community features)
- `Guild#edit` now allows the discovery description to be modified

as per https://github.com/discord/discord-api-docs/pull/1764

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
