### PR TITLE
feat(SysChanFlags): new flag and rename in sync with client

### DIFF
--- a/src/util/SystemChannelFlags.js
+++ b/src/util/SystemChannelFlags.js
@@ -34,9 +34,9 @@ class SystemChannelFlags extends BitField {}
 
 /**
  * Numeric system channel flags. All available properties:
- * * `SUPPRESS_JOIN_NOTIFICATIONS`
- * * `SUPPRESS_PREMIUM_SUBSCRIPTIONS`
- * * `SUPPRESS_GUILD_REMINDER_NOTIFICATIONS`
+ * * `SUPPRESS_JOIN_NOTIFICATIONS` (Suppress member join notifications)
+ * * `SUPPRESS_PREMIUM_SUBSCRIPTIONS` (Suppress server boost notifications)
+ * * `SUPPRESS_GUILD_REMINDER_NOTIFICATIONS` (Suppress server setup tips)
  * @type {Object}
  */
 SystemChannelFlags.FLAGS = {

--- a/src/util/SystemChannelFlags.js
+++ b/src/util/SystemChannelFlags.js
@@ -39,8 +39,9 @@ class SystemChannelFlags extends BitField {}
  * @type {Object}
  */
 SystemChannelFlags.FLAGS = {
-  WELCOME_MESSAGE_DISABLED: 1 << 0,
-  BOOST_MESSAGE_DISABLED: 1 << 1,
+  SUPPRESS_JOIN_NOTIFICATIONS: 1 << 0,
+  SUPPRESS_PREMIUM_SUBSCRIPTIONS: 1 << 1,
+  SUPPRESS_GUILD_REMINDER_NOTIFICATIONS: 1 << 2,
 };
 
 module.exports = SystemChannelFlags;

--- a/src/util/SystemChannelFlags.js
+++ b/src/util/SystemChannelFlags.js
@@ -34,8 +34,9 @@ class SystemChannelFlags extends BitField {}
 
 /**
  * Numeric system channel flags. All available properties:
- * * `WELCOME_MESSAGE_DISABLED`
- * * `BOOST_MESSAGE_DISABLED`
+ * * `SUPPRESS_JOIN_NOTIFICATIONS`
+ * * `SUPPRESS_PREMIUM_SUBSCRIPTIONS`
+ * * `SUPPRESS_GUILD_REMINDER_NOTIFICATIONS`
  * @type {Object}
  */
 SystemChannelFlags.FLAGS = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3332,7 +3332,10 @@ declare module 'discord.js' {
 
   type StringResolvable = string | string[] | any;
 
-  type SystemChannelFlagsString = 'WELCOME_MESSAGE_DISABLED' | 'BOOST_MESSAGE_DISABLED';
+  type SystemChannelFlagsString =
+    | 'SUPPRESS_JOIN_NOTIFICATIONS'
+    | 'SUPPRESS_PREMIUM_SUBSCRIPTIONS'
+    | 'SUPPRESS_GUILD_REMINDER_NOTIFICATIONS';
 
   type SystemChannelFlagsResolvable = BitFieldResolvable<SystemChannelFlagsString, number>;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

As per https://github.com/discordjs/discord-api-types the flag names for system channel flags are inconsistent with the client, this PR aims to streamline this. Additionally, a new Flag for the new "Send helpful tips for server setup" guild setting has been introduced.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
