### PR TITLE
feat(Guild): setChannelPositions parent, lockPermissions keys

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1255,11 +1255,14 @@ class Guild extends Base {
    * The data needed for updating a channel's position.
    * @typedef {Object} ChannelPosition
    * @property {ChannelResolvable} channel Channel to update
-   * @property {number} position New position for the channel
+   * @property {number} [position] New position for the channel
+   * @property {ChannelResolvable} [parent] Parent channel for this channel
+   * @property {boolean} [lockPermissions] If the overwrites should be locked to the parents overwrites
    */
 
   /**
    * Batch-updates the guild's channels' positions.
+   * <info>Only one channel's parent can be changed at a time</info>
    * @param {ChannelPosition[]} channelPositions Channel positions to update
    * @returns {Promise<Guild>}
    * @example
@@ -1271,6 +1274,8 @@ class Guild extends Base {
     const updatedChannels = channelPositions.map(r => ({
       id: this.client.channels.resolveID(r.channel),
       position: r.position,
+      lock_permissions: r.lockPermissions,
+      parent_id: this.channels.resolveID(r.parent),
     }));
 
     return this.client.api

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1252,11 +1252,18 @@ class Guild extends Base {
   }
 
   /**
+   * Data that can be resolved to give a Category Channel object. This can be:
+   * * A CategoryChannel object
+   * * A Snowflake
+   * @typedef {CategoryChannel|Snowflake} CategoryChannelResolvable
+   */
+
+  /**
    * The data needed for updating a channel's position.
    * @typedef {Object} ChannelPosition
    * @property {ChannelResolvable} channel Channel to update
    * @property {number} [position] New position for the channel
-   * @property {ChannelResolvable} [parent] Parent channel for this channel
+   * @property {CategoryChannelResolvable} [parent] Parent channel for this channel
    * @property {boolean} [lockPermissions] If the overwrites should be locked to the parents overwrites
    */
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2425,7 +2425,7 @@ declare module 'discord.js' {
   interface ChannelPosition {
     channel: ChannelResolvable;
     lockPermissions?: boolean;
-    parent?: ChannelResolvable;
+    parent?: CategoryChannelResolvable;
     position?: number;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2424,9 +2424,9 @@ declare module 'discord.js' {
 
   interface ChannelPosition {
     channel: ChannelResolvable;
-    position?: number;
-    parent?: ChannelResolvable;
     lockPermissions?: boolean;
+    parent?: ChannelResolvable;
+    position?: number;
   }
 
   type ChannelResolvable = Channel | Snowflake;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -194,6 +194,8 @@ declare module 'discord.js' {
     public type: 'category';
   }
 
+  type CategoryChannelResolvable = Snowflake | CategoryChannel;
+
   export class Channel extends Base {
     constructor(client: Client, data?: object);
     public readonly createdAt: Date;
@@ -2422,7 +2424,9 @@ declare module 'discord.js' {
 
   interface ChannelPosition {
     channel: ChannelResolvable;
-    position: number;
+    position?: number;
+    parent?: ChannelResolvable;
+    lockPermissions?: boolean;
   }
 
   type ChannelResolvable = Channel | Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- `Guild#setChannelPositions` takes the options `parent` and `lockPermissions` as per https://github.com/discord/discord-api-docs/pull/1776
- This makes the `position` key optional, however is still only a patch level PR, since the old approach (position being mandatory) can still be used, making this non-breaking.
- c732669d49713efa707fe5df9731028f40ffbc2e adds CategoryChannelResolvable for this PR only, #5521 to keep track of and apply the type to the rest of the library


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)