### PR TITLE
feat(Webhook): sourceGuild, sourceChannel, improve owner

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -67,9 +67,9 @@ class Webhook {
 
     /**
      * The owner of the webhook
-     * @type {?User}
+     * @type {?User|Object}
      */
-    this.owner = data.user ? this.client.users?.add(data.user, true) : null;
+    this.owner = data.user ? this.client.users?.add(data.user) ?? data.user : null;
 
     /**
      * The source guild of the webhook

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -73,9 +73,11 @@ class Webhook {
 
     /**
      * The source guild of the webhook
-     * @type {?Guild}
+     * @type {?Guild|Object}
      */
-    this.sourceGuild = data.source_guild ? this.client.guilds?.add(data.source_guild, false) : null;
+    this.sourceGuild = data.source_guild
+      ? this.client.guilds?.add(data.source_guild, false) ?? data.source_guild
+      : null;
 
     /**
      * The source channel of the webhook

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -65,15 +65,23 @@ class Webhook {
      */
     this.channelID = data.channel_id;
 
-    if (data.user) {
-      /**
-       * The owner of the webhook
-       * @type {?User|Object}
-       */
-      this.owner = this.client.users ? this.client.users.cache.get(data.user.id) : data.user;
-    } else {
-      this.owner = null;
-    }
+    /**
+     * The owner of the webhook
+     * @type {?User|Object}
+     */
+    this.owner = data.user ? this.client.users?.add(data.user, false) ?? data.user ?? null : null;
+
+    /**
+     * The source guild of the webhook
+     * @type {?Guild}
+     */
+    this.sourceGuild = data.source_guild ? this.client.guilds?.add(data.source_guild, false) ?? null : null;
+
+    /**
+     * The source channel of the webhook
+     * @type {?Channel|Object}
+     */
+    this.sourceChannel = this.client.channels?.resolve(data.source_channel?.id) ?? data.source_channel ?? null;
   }
 
   /**

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -67,15 +67,15 @@ class Webhook {
 
     /**
      * The owner of the webhook
-     * @type {?User|Object}
+     * @type {?User}
      */
-    this.owner = data.user ? this.client.users?.add(data.user, false) ?? data.user ?? null : null;
+    this.owner = data.user ? this.client.users?.add(data.user, true) : null;
 
     /**
      * The source guild of the webhook
      * @type {?Guild}
      */
-    this.sourceGuild = data.source_guild ? this.client.guilds?.add(data.source_guild, false) ?? null : null;
+    this.sourceGuild = data.source_guild ? this.client.guilds?.add(data.source_guild, false) : null;
 
     /**
      * The source channel of the webhook

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1765,7 +1765,7 @@ declare module 'discord.js' {
     public client: Client;
     public guildID: Snowflake;
     public name: string;
-    public owner: User | null;
+    public owner: User | object | null;
     public sourceGuild: Guild | null;
     public sourceChannel: Channel | object | null;
     public token: string | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1766,6 +1766,8 @@ declare module 'discord.js' {
     public guildID: Snowflake;
     public name: string;
     public owner: User | object | null;
+    public sourceGuild: Guild | null;
+    public sourceChannel: Channel | object | null;
     public token: string | null;
     public type: WebhookTypes;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1765,7 +1765,7 @@ declare module 'discord.js' {
     public client: Client;
     public guildID: Snowflake;
     public name: string;
-    public owner: User | object | null;
+    public owner: User | null;
     public sourceGuild: Guild | null;
     public sourceChannel: Channel | object | null;
     public token: string | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1766,7 +1766,7 @@ declare module 'discord.js' {
     public guildID: Snowflake;
     public name: string;
     public owner: User | object | null;
-    public sourceGuild: Guild | null;
+    public sourceGuild: Guild | object | null;
     public sourceChannel: Channel | object | null;
     public token: string | null;
     public type: WebhookTypes;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Webhooks can have a `source_guild` and a `source_channel` as per https://github.com/discord/discord-api-docs/pull/1837

- `owner `user data is fully available, meaning we can always construct a user here, and even cache it
- `source_guild` data is not fully available, by not caching but constructing a Guild instance we can leverage some guild methods (invites use the same approach to construct "partial" guilds - very empty guilds)
- `source_channel` for guilds the bot is not on, only consists of name and id, not enough to construct a channel from, meaning the data object default is required here

**Edit: Object fallbacks are needed for WebhookClient**

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
