### PR TITLE
refactor(Sharding): use options objects

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -102,11 +102,11 @@ class Shard extends EventEmitter {
   /**
    * Forks a child process or creates a worker thread for the shard.
    * <warn>You should not need to call this manually.</warn>
-   * @param {number} [spawnTimeout=30000] The amount in milliseconds to wait until the {@link Client} has become ready
+   * @param {number} [timeout=30000] The amount in milliseconds to wait until the {@link Client} has become ready
    * before resolving. (-1 or Infinity for no wait)
    * @returns {Promise<ChildProcess>}
    */
-  async spawn(spawnTimeout = 30000) {
+  async spawn(timeout = 30000) {
     if (this.process) throw new Error('SHARDING_PROCESS_EXISTS', this.id);
     if (this.worker) throw new Error('SHARDING_WORKER_EXISTS', this.id);
 
@@ -134,7 +134,7 @@ class Shard extends EventEmitter {
      */
     this.emit('spawn', this.process || this.worker);
 
-    if (spawnTimeout === -1 || spawnTimeout === Infinity) return this.process || this.worker;
+    if (timeout === -1 || timeout === Infinity) return this.process || this.worker;
     await new Promise((resolve, reject) => {
       const cleanup = () => {
         clearTimeout(spawnTimeoutTimer);
@@ -163,7 +163,7 @@ class Shard extends EventEmitter {
         reject(new Error('SHARDING_READY_TIMEOUT', this.id));
       };
 
-      const spawnTimeoutTimer = setTimeout(onTimeout, spawnTimeout);
+      const spawnTimeoutTimer = setTimeout(onTimeout, timeout);
       this.once('ready', onReady);
       this.once('disconnect', onDisconnect);
       this.once('death', onDeath);
@@ -188,15 +188,16 @@ class Shard extends EventEmitter {
 
   /**
    * Kills and restarts the shard's process/worker.
-   * @param {number} [delay=500] How long to wait between killing the process/worker and restarting it (in milliseconds)
-   * @param {number} [spawnTimeout=30000] The amount in milliseconds to wait until the {@link Client} has become ready
+   * @param {Object} [options] Respawn options for the shard
+   * @param {number} [options.delay=500] How long to wait between killing the process/worker and restarting it (in milliseconds)
+   * @param {number} [options.timeout=30000] The amount in milliseconds to wait until the {@link Client} has become ready
    * before resolving. (-1 or Infinity for no wait)
    * @returns {Promise<ChildProcess>}
    */
-  async respawn(delay = 500, spawnTimeout) {
+  async respawn({ delay = 500, timeout } = {}) {
     this.kill();
     if (delay > 0) await Util.delayFor(delay);
-    return this.spawn(spawnTimeout);
+    return this.spawn(timeout);
   }
 
   /**
@@ -354,8 +355,8 @@ class Shard extends EventEmitter {
 
       // Shard is requesting a respawn of all shards
       if (message._sRespawnAll) {
-        const { shardDelay, respawnDelay, spawnTimeout } = message._sRespawnAll;
-        this.manager.respawnAll(shardDelay, respawnDelay, spawnTimeout).catch(() => {
+        const { shardDelay, respawnDelay, timeout } = message._sRespawnAll;
+        this.manager.respawnAll({ shardDelay, respawnDelay, timeout }).catch(() => {
           // Do nothing
         });
         return;

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -196,7 +196,7 @@ class Shard extends EventEmitter {
    * before resolving. (-1 or Infinity for no wait)
    * @returns {Promise<ChildProcess>}
    */
-  async respawn({ delay = 500, timeout } = {}) {
+  async respawn({ delay = 500, timeout = 30000 } = {}) {
     this.kill();
     if (delay > 0) await Util.delayFor(delay);
     return this.spawn(timeout);

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -189,8 +189,10 @@ class Shard extends EventEmitter {
   /**
    * Kills and restarts the shard's process/worker.
    * @param {Object} [options] Respawn options for the shard
-   * @param {number} [options.delay=500] How long to wait between killing the process/worker and restarting it (in milliseconds)
-   * @param {number} [options.timeout=30000] The amount in milliseconds to wait until the {@link Client} has become ready
+   * @param {number} [options.delay=500] How long to wait between killing the process/worker and
+   * restarting it (in milliseconds)
+   * @param {number} [options.timeout=30000] The amount in milliseconds to wait until the {@link Client}
+   * has become ready
    * before resolving. (-1 or Infinity for no wait)
    * @returns {Promise<ChildProcess>}
    */

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -158,16 +158,17 @@ class ShardClientUtil {
 
   /**
    * Requests a respawn of all shards.
-   * @param {number} [shardDelay=5000] How long to wait between shards (in milliseconds)
-   * @param {number} [respawnDelay=500] How long to wait between killing a shard's process/worker and restarting it
+   * @param {Object} [options] Options for respawning shards
+   * @param {number} [options.shardDelay=5000] How long to wait between shards (in milliseconds)
+   * @param {number} [options.respawnDelay=500] How long to wait between killing a shard's process/worker and restarting it
    * (in milliseconds)
-   * @param {number} [spawnTimeout=30000] The amount in milliseconds to wait for a shard to become ready before
+   * @param {number} [options.timeout=30000] The amount in milliseconds to wait for a shard to become ready before
    * continuing to another. (-1 or Infinity for no wait)
    * @returns {Promise<void>} Resolves upon the message being sent
    * @see {@link ShardingManager#respawnAll}
    */
-  respawnAll(shardDelay = 5000, respawnDelay = 500, spawnTimeout = 30000) {
-    return this.send({ _sRespawnAll: { shardDelay, respawnDelay, spawnTimeout } });
+  respawnAll({ shardDelay = 5000, respawnDelay = 500, timeout = 30000 } = {}) {
+    return this.send({ _sRespawnAll: { shardDelay, respawnDelay, timeout } });
   }
 
   /**

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -160,8 +160,8 @@ class ShardClientUtil {
    * Requests a respawn of all shards.
    * @param {Object} [options] Options for respawning shards
    * @param {number} [options.shardDelay=5000] How long to wait between shards (in milliseconds)
-   * @param {number} [options.respawnDelay=500] How long to wait between killing a shard's process/worker and restarting it
-   * (in milliseconds)
+   * @param {number} [options.respawnDelay=500] How long to wait between killing a shard's process/worker and
+   * restarting it (in milliseconds)
    * @param {number} [options.timeout=30000] The amount in milliseconds to wait for a shard to become ready before
    * continuing to another. (-1 or Infinity for no wait)
    * @returns {Promise<void>} Resolves upon the message being sent

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -161,13 +161,13 @@ class ShardingManager extends EventEmitter {
 
   /**
    * Spawns multiple shards.
-   * @param {number|string} [amount=this.totalShards] Number of shards to spawn
-   * @param {number} [delay=5500] How long to wait in between spawning each shard (in milliseconds)
-   * @param {number} [spawnTimeout=30000] The amount in milliseconds to wait until the {@link Client} has become ready
-   * before resolving. (-1 or Infinity for no wait)
+   * @param {Object} [options] Options for spawning shards
+   * @param {number|string} [options.amount=this.totalShards] Number of shards to spawn
+   * @param {number} [options.delay=5500] How long to wait in between spawning each shard (in milliseconds)
+   * @param {number} [options.timeout=30000] The amount in milliseconds to wait until the {@link Client} has become
    * @returns {Promise<Collection<number, Shard>>}
    */
-  async spawn(amount = this.totalShards, delay = 5500, spawnTimeout) {
+  async spawn({ amount = this.totalShards, delay = 5500, timeout } = {}) {
     // Obtain/verify the number of shards to spawn
     if (amount === 'auto') {
       amount = await Util.fetchRecommendedShards(this.token);
@@ -202,7 +202,7 @@ class ShardingManager extends EventEmitter {
     for (const shardID of this.shardList) {
       const promises = [];
       const shard = this.createShard(shardID);
-      promises.push(shard.spawn(spawnTimeout));
+      promises.push(shard.spawn(timeout));
       if (delay > 0 && this.shards.size !== this.shardList.length) promises.push(Util.delayFor(delay));
       await Promise.all(promises); // eslint-disable-line no-await-in-loop
     }
@@ -270,17 +270,18 @@ class ShardingManager extends EventEmitter {
 
   /**
    * Kills all running shards and respawns them.
-   * @param {number} [shardDelay=5000] How long to wait between shards (in milliseconds)
-   * @param {number} [respawnDelay=500] How long to wait between killing a shard's process and restarting it
+   * @param {Object} [options] Options for respawning shards
+   * @param {number} [options.shardDelay=5000] How long to wait between shards (in milliseconds)
+   * @param {number} [options.respawnDelay=500] How long to wait between killing a shard's process and restarting it
    * (in milliseconds)
-   * @param {number} [spawnTimeout=30000] The amount in milliseconds to wait for a shard to become ready before
+   * @param {number} [options.timeout=30000] The amount in milliseconds to wait for a shard to become ready before
    * continuing to another. (-1 or Infinity for no wait)
    * @returns {Promise<Collection<string, Shard>>}
    */
-  async respawnAll(shardDelay = 5000, respawnDelay = 500, spawnTimeout) {
+  async respawnAll({ shardDelay = 5000, respawnDelay = 500, timeout } = {}) {
     let s = 0;
     for (const shard of this.shards.values()) {
-      const promises = [shard.respawn(respawnDelay, spawnTimeout)];
+      const promises = [shard.respawn({respawnDelay, timeout})];
       if (++s < this.shards.size && shardDelay > 0) promises.push(Util.delayFor(shardDelay));
       await Promise.all(promises); // eslint-disable-line no-await-in-loop
     }

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -167,7 +167,7 @@ class ShardingManager extends EventEmitter {
    * @param {number} [options.timeout=30000] The amount in milliseconds to wait until the {@link Client} has become
    * @returns {Promise<Collection<number, Shard>>}
    */
-  async spawn({ amount = this.totalShards, delay = 5500, timeout } = {}) {
+  async spawn({ amount = this.totalShards, delay = 5500, timeout = 30000 } = {}) {
     // Obtain/verify the number of shards to spawn
     if (amount === 'auto') {
       amount = await Util.fetchRecommendedShards(this.token);
@@ -278,7 +278,7 @@ class ShardingManager extends EventEmitter {
    * continuing to another. (-1 or Infinity for no wait)
    * @returns {Promise<Collection<string, Shard>>}
    */
-  async respawnAll({ shardDelay = 5000, respawnDelay = 500, timeout } = {}) {
+  async respawnAll({ shardDelay = 5000, respawnDelay = 500, timeout = 30000 } = {}) {
     let s = 0;
     for (const shard of this.shards.values()) {
       const promises = [shard.respawn({ respawnDelay, timeout })];

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -281,7 +281,7 @@ class ShardingManager extends EventEmitter {
   async respawnAll({ shardDelay = 5000, respawnDelay = 500, timeout } = {}) {
     let s = 0;
     for (const shard of this.shards.values()) {
-      const promises = [shard.respawn({respawnDelay, timeout})];
+      const promises = [shard.respawn({ respawnDelay, timeout })];
       if (++s < this.shards.size && shardDelay > 0) promises.push(Util.delayFor(shardDelay));
       await Promise.all(promises); // eslint-disable-line no-await-in-loop
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1337,9 +1337,9 @@ declare module 'discord.js' {
     public eval<T>(fn: (client: Client) => T): Promise<T[]>;
     public fetchClientValue(prop: string): Promise<any>;
     public kill(): void;
-    public respawn(delay?: number, spawnTimeout?: number): Promise<ChildProcess>;
+    public respawn(options?: { delay?: number, timeout?: number }): Promise<ChildProcess>;
     public send(message: any): Promise<Shard>;
-    public spawn(spawnTimeout?: number): Promise<ChildProcess>;
+    public spawn(timeout?: number): Promise<ChildProcess>;
 
     public on(event: 'spawn' | 'death', listener: (child: ChildProcess) => void): this;
     public on(event: 'disconnect' | 'ready' | 'reconnecting', listener: () => void): this;
@@ -1370,7 +1370,7 @@ declare module 'discord.js' {
     public broadcastEval<T>(fn: (client: Client) => T, shard: number): Promise<T>;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
-    public respawnAll(shardDelay?: number, respawnDelay?: number, spawnTimeout?: number): Promise<void>;
+    public respawnAll(options?: { shardDelay?: number, respawnDelay?: number, timeout?: number }): Promise<void>;
     public send(message: any): Promise<void>;
 
     public static singleton(client: Client, mode: ShardingManagerMode): ShardClientUtil;
@@ -1405,12 +1405,12 @@ declare module 'discord.js' {
     public createShard(id: number): Shard;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
-    public respawnAll(
+    public respawnAll(options?: {
       shardDelay?: number,
       respawnDelay?: number,
-      spawnTimeout?: number,
-    ): Promise<Collection<number, Shard>>;
-    public spawn(amount?: number | 'auto', delay?: number, spawnTimeout?: number): Promise<Collection<number, Shard>>;
+      timeout?: number,
+    }): Promise<Collection<number, Shard>>;
+    public spawn(options?: { amount?: number | 'auto', delay?: number, timeout?: number }): Promise<Collection<number, Shard>>;
 
     public on(event: 'shardCreate', listener: (shard: Shard) => void): this;
 


### PR DESCRIPTION
This refactors the spawn/respawn methods on Sharding classes to use a single, optional object parameter with optional properties, rather than up to three separate optional parameters.

This should make it easier for developers to address the `SHARD_READY_TIMEOUT` issue by providing the `spawnTimeout` without needing to fill the other two optional params. It also renames the `spawnTimeout` parameter to `timeout` for simplicity and ease of use.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
