### PR TITLE
fix(Emoji): name can be null

### DIFF
--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -18,9 +18,9 @@ class Emoji extends Base {
 
     /**
      * The name of this emoji
-     * @type {string}
+     * @type {?string}
      */
-    this.name = emoji.name;
+    this.name = emoji.name ?? null;
 
     /**
      * The ID of this emoji

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -558,7 +558,7 @@ declare module 'discord.js' {
     public readonly createdTimestamp: number | null;
     public deleted: boolean;
     public id: Snowflake | null;
-    public name: string;
+    public name: string | null;
     public readonly identifier: string;
     public readonly url: string | null;
     public toJSON(): object;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Emoji#name can be null when received as reaction emojis, in case of:
1. unavailable custom emojis (based on guild boost level)
2. message history being queried

ℹ️  While technically breaking this should be considered a fix to handle existing API behavior properly.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
