### PR TITLE
feat(Permissions): new bits USE_SLASH_COMMANDS, REQUEST_TO_SPEAK

### DIFF
--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -78,6 +78,8 @@ class Permissions extends BitField {
  * * `MANAGE_ROLES`
  * * `MANAGE_WEBHOOKS`
  * * `MANAGE_EMOJIS`
+ * * `USE_SLASH_COMMANDS`
+ * * `REQUEST_TO_SPEAK`
  * @type {Object<string, bigint>}
  * @see {@link https://discord.com/developers/docs/topics/permissions}
  */
@@ -113,6 +115,8 @@ Permissions.FLAGS = {
   MANAGE_ROLES: 1n << 28n,
   MANAGE_WEBHOOKS: 1n << 29n,
   MANAGE_EMOJIS: 1n << 30n,
+  USE_SLASH_COMMANDS: 1n << 31n,
+  REQUEST_TO_SPEAK: 1n << 32n,
 };
 
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3104,7 +3104,9 @@ declare module 'discord.js' {
     | 'MANAGE_NICKNAMES'
     | 'MANAGE_ROLES'
     | 'MANAGE_WEBHOOKS'
-    | 'MANAGE_EMOJIS';
+    | 'MANAGE_EMOJIS'
+    | 'USE_SLASH_COMMANDS'
+    | 'REQUEST_TO_SPEAK';
 
   interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> {}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Introduces the two new permission bits (as per Discord API Docs (linked PRs are merged)):

- `USE_SLASH_COMMANDS` https://github.com/discord/discord-api-docs/pull/2632
- `REQUEST_TO_SPEAK` https://github.com/discord/discord-api-docs/pull/2751

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
