### PR TITLE
chore(UserFlags): remove system flag

### DIFF
--- a/src/util/UserFlags.js
+++ b/src/util/UserFlags.js
@@ -31,7 +31,6 @@ class UserFlags extends BitField {}
  * * `HOUSE_BALANCE`
  * * `EARLY_SUPPORTER`
  * * `TEAM_USER`
- * * `SYSTEM`
  * * `BUGHUNTER_LEVEL_2`
  * * `VERIFIED_BOT`
  * * `EARLY_VERIFIED_BOT_DEVELOPER`
@@ -48,7 +47,6 @@ UserFlags.FLAGS = {
   HOUSE_BALANCE: 1 << 8,
   EARLY_SUPPORTER: 1 << 9,
   TEAM_USER: 1 << 10,
-  SYSTEM: 1 << 12,
   BUGHUNTER_LEVEL_2: 1 << 14,
   VERIFIED_BOT: 1 << 16,
   EARLY_VERIFIED_BOT_DEVELOPER: 1 << 17,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3358,7 +3358,6 @@ declare module 'discord.js' {
     | 'HOUSE_BALANCE'
     | 'EARLY_SUPPORTER'
     | 'TEAM_USER'
-    | 'SYSTEM'
     | 'BUGHUNTER_LEVEL_2'
     | 'VERIFIED_BOT'
     | 'EARLY_VERIFIED_BOT_DEVELOPER';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

> In the next API deploy the system user flag will disappear. None of our clients use it, and it looks to be a mistakenly exposed internal flag value.
<https://github.com/discord/discord-api-docs/issues/2494#issuecomment-816970401>

The `SYSTEM` flag was removed from API docs as of https://github.com/discord/discord-api-docs/commit/9293f0d490ac6acf9d627e429e5a8131b303b528

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
