### PR TITLE
fix: typings for 'Message'

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -976,6 +976,7 @@ declare module 'discord.js' {
     public content: string;
     public readonly createdAt: Date;
     public createdTimestamp: number;
+    public readonly crosspostable: boolean;
     public readonly deletable: boolean;
     public deleted: boolean;
     public readonly editable: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Typings are missing the `crosspostable` property on the `Message` class.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
