### PR TITLE
feat(BaseManager): remove stale data in cache

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -569,7 +569,7 @@ class Client extends BaseClient {
     if (typeof options.retryLimit !== 'number' || isNaN(options.retryLimit)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'retryLimit', 'a number');
     }
-    if (typeof x !== 'undefined') {
+    if (typeof options.cacheData !== 'undefined') {
       if (typeof options.cacheData !== 'object') {
         throw new TypeError('CLIENT_INVALID_OPTION', 'cacheData', 'an object or undefined');
       }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -167,7 +167,7 @@ class Client extends BaseClient {
       this.setInterval(this.sweepMessages.bind(this), this.options.messageSweepInterval * 1000);
     }
 
-    if (this.options.cacheData !== undefined) {
+    if (typeof this.options.cacheData !== 'undefined') {
       let lifetimes = this.options.cacheData.dataLifetime;
       if (typeof lifetimes === 'number') {
         lifetimes = {
@@ -368,7 +368,6 @@ class Client extends BaseClient {
    * Removes all the stale data in the caches older than the provided lifetimes.
    * @param {Lifetimes} lifetime Data that has been stale for longer than
    * this will be removed.
-   * @returns {number} -1 if the lifetime is invalid and 1 on success
    * @example
    * // Remove all the stale cached user data older than 1800 seconds
    * client.sweepCaches({ user: 1800 * 1000 }); // x 1000 to convert to seconds
@@ -379,22 +378,22 @@ class Client extends BaseClient {
     }
 
     const { user, channel, guild, emoji } = lifetime;
-    if (user !== undefined && (typeof user !== 'number' || isNaN(user))) {
+    if (typeof user !== 'undefined' && (typeof user !== 'number' || isNaN(user))) {
       throw new TypeError('INVALID_TYPE', 'lifetime.user', 'number or undefined');
     }
-    if (channel !== undefined && (typeof channel !== 'number' || isNaN(channel))) {
+    if (typeof channel !== 'undefined' && (typeof channel !== 'number' || isNaN(channel))) {
       throw new TypeError('INVALID_TYPE', 'lifetime.channel', 'number or undefined');
     }
-    if (guild !== undefined && (typeof guild !== 'number' || isNaN(guild))) {
+    if (typeof guild !== 'undefined' && (typeof guild !== 'number' || isNaN(guild))) {
       throw new TypeError('INVALID_TYPE', 'lifetime.guild', 'number or undefined');
     }
-    if (emoji !== undefined && (typeof emoji !== 'number' || isNaN(emoji))) {
+    if (typeof emoji !== 'undefined' && (typeof emoji !== 'number' || isNaN(emoji))) {
       throw new TypeError('INVALID_TYPE', 'lifetime.emoji', 'number or undefined');
     }
 
     this.emit(Events.DEBUG, 'Cache sweep initiated, polling all the caches');
 
-    if (user !== undefined) {
+    if (typeof user !== 'undefined') {
       if (user <= 0) {
         this.emit(Events.DEBUG, "Didn't sweep user cache - lifetime is unlimited");
       } else {
@@ -402,7 +401,7 @@ class Client extends BaseClient {
       }
     }
 
-    if (channel !== undefined) {
+    if (typeof channel !== 'undefined') {
       if (channel <= 0) {
         this.emit(Events.DEBUG, "Didn't sweep channel cache - lifetime is unlimited");
       } else {
@@ -410,7 +409,7 @@ class Client extends BaseClient {
       }
     }
 
-    if (guild !== undefined) {
+    if (typeof guild !== 'undefined') {
       if (guild <= 0) {
         this.emit(Events.DEBUG, "Didn't sweep guild cache - lifetime is unlimited");
       } else {
@@ -418,7 +417,7 @@ class Client extends BaseClient {
       }
     }
 
-    if (emoji !== undefined) {
+    if (typeof emoji !== 'undefined') {
       if (emoji <= 0) {
         this.emit(Events.DEBUG, "Didn't sweep emoji cache - lifetime is unlimited");
       } else {
@@ -427,7 +426,6 @@ class Client extends BaseClient {
     }
 
     this.emit(Events.DEBUG, `Swept all the stale data older than ${lifetime / 1000} seconds`);
-    return 1;
   }
 
   /**
@@ -571,44 +569,32 @@ class Client extends BaseClient {
     if (typeof options.retryLimit !== 'number' || isNaN(options.retryLimit)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'retryLimit', 'a number');
     }
-    if (options.cacheData !== undefined) {
+    if (typeof x !== 'undefined') {
       if (typeof options.cacheData !== 'object') {
-        throw new TypeError('CLIENT_INVALID_OPTION', 'The cacheData', 'an object or undefined');
+        throw new TypeError('CLIENT_INVALID_OPTION', 'cacheData', 'an object or undefined');
       }
       if (typeof options.cacheData.pollInterval !== 'number' || isNaN(options.cacheData.pollInterval)) {
-        throw new TypeError('CLIENT_INVALID_OPTION', 'The cacheData.pollInterval', 'a number');
+        throw new TypeError('CLIENT_INVALID_OPTION', 'cacheData.pollInterval', 'a number');
       }
       if (typeof options.cacheData.dataLifetime === 'number') {
         if (isNaN(options.cacheData.dataLifetime)) {
-          throw new TypeError('CLIENT_INVALID_OPTION', 'The cacheData.dataLifetime', 'a number or Lifetimes object');
+          throw new TypeError('CLIENT_INVALID_OPTION', 'cacheData.dataLifetime', 'a number or Lifetimes object');
         }
       } else if (typeof options.cacheData.dataLifetime === 'object') {
-        if (
-          options.cacheData.dataLifetime.user !== undefined &&
-          typeof options.cacheData.dataLifetime.user !== 'number'
-        ) {
-          throw new TypeError('CLIENT_INVALID_OPTION', 'The cacheData.dataLifetime.user', 'a number or undefined');
+        if (!['number', 'undefined'].includes(typeof options.cacheData.dataLifetime.user)) {
+          throw new TypeError('CLIENT_INVALID_OPTION', 'cacheData.dataLifetime.user', 'a number or undefined');
         }
-        if (
-          options.cacheData.dataLifetime.channel !== undefined &&
-          typeof options.cacheData.dataLifetime.channel !== 'number'
-        ) {
-          throw new TypeError('CLIENT_INVALID_OPTION', 'The cacheData.dataLifetime.channel', 'a number or undefined');
+        if (!['number', 'undefined'].includes(typeof options.cacheData.dataLifetime.channel)) {
+          throw new TypeError('CLIENT_INVALID_OPTION', 'cacheData.dataLifetime.channel', 'a number or undefined');
         }
-        if (
-          options.cacheData.dataLifetime.guild !== undefined &&
-          typeof options.cacheData.dataLifetime.guild !== 'number'
-        ) {
-          throw new TypeError('CLIENT_INVALID_OPTION', 'The cacheData.dataLifetime.guild', 'a number or undefined');
+        if (!['number', 'undefined'].includes(typeof options.cacheData.dataLifetime.guild)) {
+          throw new TypeError('CLIENT_INVALID_OPTION', 'cacheData.dataLifetime.guild', 'a number or undefined');
         }
-        if (
-          options.cacheData.dataLifetime.emoji !== undefined &&
-          typeof options.cacheData.dataLifetime.emoji !== 'number'
-        ) {
-          throw new TypeError('CLIENT_INVALID_OPTION', 'The cacheData.dataLifetime.emoji', 'a number or undefined');
+        if (!['number', 'undefined'].includes(typeof options.cacheData.dataLifetime.emoji)) {
+          throw new TypeError('CLIENT_INVALID_OPTION', 'cacheData.dataLifetime.emoji', 'a number or undefined');
         }
       } else {
-        throw new TypeError('CLIENT_INVALID_OPTION', 'The cacheData.dataLifetime', 'a number or Lifetimes object');
+        throw new TypeError('CLIENT_INVALID_OPTION', 'cacheData.dataLifetime', 'a number or Lifetimes object');
       }
     }
   }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -425,7 +425,7 @@ class Client extends BaseClient {
       }
     }
 
-    this.emit(Events.DEBUG, `Swept all the stale data older than ${lifetime / 1000} seconds`);
+    this.emit(Events.DEBUG, `Swept all the stale data from the caches`);
   }
 
   /**

--- a/src/managers/BaseManager.js
+++ b/src/managers/BaseManager.js
@@ -43,14 +43,14 @@ class BaseManager {
 
   add(data, cache = true, { id, extras = [] } = {}) {
     const existing = this.cache.get(id || data.id);
-    if (existing && existing.entry._patch && cache) existing.entry._patch(data);
+    if (existing?.entry._patch && cache) existing.entry._patch(data);
     if (existing) {
-      existing.lastHit = new Date();
+      existing.lastHit = Date.now();
       return existing.entry;
     }
 
     const entry = this.holds ? new this.holds(this.client, data, ...extras) : data;
-    if (cache) this.cache.set(id || entry.id, { entry, lastHit: new Date() });
+    if (cache) this.cache.set(id || entry.id, { entry, lastHit: Date.now() });
     return entry;
   }
 
@@ -81,8 +81,8 @@ class BaseManager {
    * @param {number} lifetime The maximum duration (in milliseconds) stale data should live.
    */
   poll(lifetime) {
-    const now = new Date();
-    this.cache.sweep(data => now - data.lastHit.getTime() > lifetime);
+    const now = Date.now();
+    this.cache.sweep(data => now - data.lastHit > lifetime);
   }
 
   valueOf() {

--- a/src/util/Cache.js
+++ b/src/util/Cache.js
@@ -1,0 +1,141 @@
+'use strict';
+
+const Collection = require('./Collection');
+
+/**
+ * Keeps track of all the lifetimes of all the entries present in the collection.
+ * When polled, the entries who have outlived their lifetime will be removed from the collection.
+ * When the cache has reached its max capacity new entries will not be added to the collection.
+ * @extends {Collection}
+ * @param {number} [maxSize] The maximum size of the Collection
+ * @private
+ */
+class Cache extends Collection {
+  constructor(maxSize) {
+    super();
+    /**
+     * The max size of the Collection.
+     * @type {number | undefined}
+     */
+    this.maxSize = maxSize;
+    /**
+     * Contains the date of the last hit of all the entries.
+     * @type {Collection}
+     */
+    this.lastHit = new Collection();
+  }
+
+  get(key) {
+    const data = super.get(key);
+    if (data === undefined) return undefined;
+    this.lastHit.set(key, Date.now());
+    return data;
+  }
+
+  set(key, value) {
+    if (this.maxSize !== undefined && super.size() >= this.maxSize) {
+      return this;
+    }
+    this.lastHit.set(key, Date.now());
+    return super.set(key, value);
+  }
+
+  delete(key) {
+    this.lastHit.delete(key);
+    return super.delete(key);
+  }
+
+  clear() {
+    this.lastHit.clear();
+    return super.clear();
+  }
+
+  first(amount) {
+    if (amount === undefined) {
+      const data = super.first();
+      if (data === undefined) return undefined;
+      this.lastHit.set(super.firstKey(), Date.now());
+      return data;
+    }
+    const data = super.first(amount);
+    if (data.length === 0) return [];
+    const keys = super.firstKey(amount);
+    const now = Date.now();
+    keys.forEach(key => this.lastHit.set(key, now));
+    return data;
+  }
+
+  last(amount) {
+    if (amount === undefined) {
+      const data = super.last();
+      if (data === undefined) return undefined;
+      this.lastHit.set(super.lastKey(), Date.now());
+      return data;
+    }
+    const data = super.last(amount);
+    if (data.length === 0) return [];
+    const keys = super.lastKey(amount);
+    const now = Date.now();
+    keys.forEach(key => this.lastHit.set(key, now));
+    return data;
+  }
+
+  random(amount) {
+    if (amount === undefined) {
+      const key = super.randomKey();
+      if (key === undefined) return undefined;
+      this.lastHit.set(key, Date.now());
+      return super.get(key);
+    }
+    const keys = super.randomKey(amount);
+    if (keys.length === 0) return [];
+    const now = Date.now();
+    keys.forEach(key => this.lastHit.set(key, now));
+    return keys.map(key => super.get(key));
+  }
+
+  find(fn) {
+    const key = super.findKey(fn);
+    if (key === undefined) return undefined;
+    this.lastHit.set(key, Date.now());
+    return super.get(key);
+  }
+
+  sweep(fn) {
+    return super.sweep((value, key, collection) => {
+      const val = fn(value, key, collection);
+      if (val === true) this.lastHit.delete(key);
+      return val;
+    });
+  }
+
+  filter(fn) {
+    const now = Date.now();
+    return super.filter((value, key, collection) => {
+      const val = fn(value, key, collection);
+      if (val === true) this.lastHit.set(key, now);
+      return val;
+    });
+  }
+
+  partition(fn) {
+    const now = Date.now();
+    return super.partition((value, key, collection) => {
+      const val = fn(value, key, collection);
+      if (val === true) this.lastHit.set(key, now);
+      return val;
+    });
+  }
+
+  /**
+   * Removes all entries which have outlived their lifetimes.
+   * @param {number} lifetime The maximum duration (in milliseconds) stale entries should live.
+   */
+  poll(lifetime) {
+    const now = Date.now();
+    const keysToRemove = this.lastHit.filter(hit => now - hit >= lifetime);
+    keysToRemove.each((_val, key) => this.delete(key));
+  }
+}
+
+module.exports = Cache;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -4,6 +4,24 @@ const Package = (exports.Package = require('../../package.json'));
 const { Error, RangeError } = require('../errors');
 
 /**
+ * Lifetimes for the cached data. When some data goes stale (unused) for longer than the lifetime provided,
+ * the data will be removed from the cache.
+ * @typedef {Object} Lifetimes
+ * @property {number} [user] The lifetime, in milliseconds, of the cached user data.
+ * @property {number} [channel] The lifetime, in milliseconds, of the cached channel data.
+ * @property {number} [guild] The lifetime, in milliseconds, of the cached guild data.
+ * @property {number} [emoji] The lifetime, in milliseconds, of the cached emoji data.
+ */
+
+/**
+ * Options for cache polling and cache data lifetimes.
+ * @typedef {Object} CacheDataOptions
+ * @property {number} pollInterval The amount of time between each poll to the cache. When the caches get
+ * polled it will remove all the expired data from its caches.
+ * @property {number|Lifetimes} dataLifetime The lifetime/s, in milliseconds, of the cached data.
+ */
+
+/**
  * Options for a client.
  * @typedef {Object} ClientOptions
  * @property {number|number[]|string} [shards] ID of the shard to run, or an array of shard IDs. If not specified,
@@ -18,6 +36,7 @@ const { Error, RangeError } = require('../errors');
  * sweepable (in seconds, 0 for forever)
  * @property {number} [messageSweepInterval=0] How frequently to remove messages from the cache that are older than
  * the message cache lifetime (in seconds, 0 for never)
+ * @property {CacheDataOptions} [cacheData] Control the cache poll rates and cached data lifetimes
  * @property {MessageMentionOptions} [allowedMentions] Default value for {@link MessageOptions#allowedMentions}
  * @property {number} [invalidRequestWarningInterval=0] The number of invalid REST requests (those that return
  * 401, 403, or 429) in a 10 minute window between emitted warnings (0 for no warnings). That is, if set to 500,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2491,16 +2491,18 @@ declare module 'discord.js' {
     emoji?: number;
   }
 
+  interface CacheDataOptions {
+    pollInterval: number;
+    dataLifetime: number | Lifetimes;
+  }
+
   interface ClientOptions {
     shards?: number | number[] | 'auto';
     shardCount?: number;
     messageCacheMaxSize?: number;
     messageCacheLifetime?: number;
     messageSweepInterval?: number;
-    cacheData?: {
-      pollInterval: number;
-      dataLifetime: number | Lifetimes;
-    };
+    cacheData?: CacheDataOptions;
     allowedMentions?: MessageMentionOptions;
     invalidRequestWarningInterval?: number;
     partials?: PartialTypes[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2484,12 +2484,23 @@ declare module 'discord.js' {
     shardResume: [shardID: number, replayedEvents: number];
   }
 
+  interface Lifetimes {
+    user?: number;
+    channel?: number;
+    guild?: number;
+    emoji?: number;
+  }
+
   interface ClientOptions {
     shards?: number | number[] | 'auto';
     shardCount?: number;
     messageCacheMaxSize?: number;
     messageCacheLifetime?: number;
     messageSweepInterval?: number;
+    cacheData?: {
+      pollInterval: number;
+      dataLifetime: number | Lifetimes;
+    };
     allowedMentions?: MessageMentionOptions;
     invalidRequestWarningInterval?: number;
     partials?: PartialTypes[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Caches are most effective when the data being stored in them are data which are being required quite often by the client, otherwise, the data stored in the cache will just be hogging up memory without any good justification.

I've implemented a new method for the `BaseManager` class, `poll(lifetime: number): void`, which will remove data in that manager's cache which has been stale for longer than the lifetime provided. The staleness is kept track of by a new property introduced to all the data being stored in the cache, `lastHit: Date`, every time some data gets accessed and the cache gets hit this value will be updated to the current time. When being polled the manager compares the current time to the time stored in the `lastHit` property to determine whether or not the data has outlived it's lifetime. The polling of the managers is managed by the `Client` which owns the manager. A new property has been introduced to the `ClientOptions` object which allows you to set the lifetimes for the data. Just like the implementation for message sweeping, the polling also uses an interval to call the poll method on all the managers.

My implementation has room for optimization, such as not keeping track of the `lastHit` property when the polling has been disabled (which is the case by default)

The idea for this is to keep only the most relevant data in the cache to maximize the cache effectiveness and the relevancy can be controlled by the end-user as they wish.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)