### PR TITLE
feat(Webhook): add 'fetchMessage' method

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -227,6 +227,18 @@ class Webhook {
   }
 
   /**
+   * Gets a message that was sent by this webhook.
+   * @param {Snowflake} message The ID of the message to fetch
+   * @param {boolean} [cache=true] Whether to cache the message
+   * @returns {Promise<Message|Object>} Returns the raw message data if the webhook was instantiated as a
+   * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
+   */
+  async fetchMessage(message, cache = true) {
+    const data = await this.client.api.webhooks(this.id, this.token).messages(message).get();
+    return this.client.channels?.cache.get(data.channel_id)?.messages.add(data, cache) ?? data;
+  }
+
+  /**
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable} message The message to edit
    * @param {StringResolvable|APIMessage} [content] The new content for the message
@@ -316,6 +328,7 @@ class Webhook {
     for (const prop of [
       'send',
       'sendSlackMessage',
+      'fetchMessage',
       'edit',
       'editMessage',
       'delete',

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1815,6 +1815,7 @@ declare module 'discord.js' {
       options?: WebhookEditMessageOptions,
     ): Promise<RawMessage>;
     public editMessage(message: MessageResolvable, options: WebhookEditMessageOptions): Promise<RawMessage>;
+    public fetchMessage(message: Snowflake, cache?: boolean): Promise<RawMessage>;
     public send(
       content: APIMessageContentResolvable | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<RawMessage>;
@@ -2162,6 +2163,7 @@ declare module 'discord.js' {
       options?: WebhookEditMessageOptions,
     ): Promise<Message | RawMessage>;
     editMessage(message: MessageResolvable, options: WebhookEditMessageOptions): Promise<Message | RawMessage>;
+    fetchMessage(message: Snowflake, cache?: boolean): Promise<Message | RawMessage>;
     send(
       content: APIMessageContentResolvable | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message | RawMessage>;


### PR DESCRIPTION
Ref: https://github.com/discord/discord-api-docs/pull/2812
~~This PR will be marked as draft until the referenced PR above has been merged.~~

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
