### PR TITLE
feat(Util): make `cleanContent` take a channel instead of a message

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -323,7 +323,7 @@ class Message extends Base {
    */
   get cleanContent() {
     // eslint-disable-next-line eqeqeq
-    return this.content != null ? Util.cleanContent(this.content, this) : null;
+    return this.content != null ? Util.cleanContent(this.content, this.channel) : null;
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -531,33 +531,33 @@ class Util {
   /**
    * The content to have all mentions replaced by the equivalent text.
    * @param {string} str The string to be converted
-   * @param {Message} message The message object to reference
+   * @param {Channel} channel The channel the string was sent in
    * @returns {string}
    */
-  static cleanContent(str, message) {
+  static cleanContent(str, channel) {
     str = str
       .replace(/<@!?[0-9]+>/g, input => {
         const id = input.replace(/<|!|>|@/g, '');
-        if (message.channel.type === 'dm') {
-          const user = message.client.users.cache.get(id);
+        if (channel.type === 'dm') {
+          const user = channel.client.users.cache.get(id);
           return user ? Util.removeMentions(`@${user.username}`) : input;
         }
 
-        const member = message.channel.guild.members.cache.get(id);
+        const member = channel.guild.members.cache.get(id);
         if (member) {
           return Util.removeMentions(`@${member.displayName}`);
         } else {
-          const user = message.client.users.cache.get(id);
+          const user = channel.client.users.cache.get(id);
           return user ? Util.removeMentions(`@${user.username}`) : input;
         }
       })
       .replace(/<#[0-9]+>/g, input => {
-        const channel = message.client.channels.cache.get(input.replace(/<|#|>/g, ''));
-        return channel ? `#${channel.name}` : input;
+        const mentionedChannel = channel.client.channels.cache.get(input.replace(/<|#|>/g, ''));
+        return mentionedChannel ? `#${mentionedChannel.name}` : input;
       })
       .replace(/<@&[0-9]+>/g, input => {
-        if (message.channel.type === 'dm') return input;
-        const role = message.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
+        if (channel.type === 'dm') return input;
+        const role = channel.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
         return role ? `@${role.name}` : input;
       });
     return str;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1569,7 +1569,7 @@ declare module 'discord.js' {
   export class Util {
     public static basename(path: string, ext?: string): string;
     public static binaryToID(num: string): Snowflake;
-    public static cleanContent(str: string, message: Message): string;
+    public static cleanContent(str: string, channel: Channel): string;
     public static removeMentions(str: string): string;
     public static cloneObject(obj: object): object;
     public static delayFor(ms: number): Promise<void>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently `Util#cleanContent` takes a Message object in addition to the string. All the info accessed from the Message object can also be accessed from the message's channel. This PR makes it take a channel instead.

This is beneficial because now `Util#cleanContent` can be used in other contexts, such as interactions.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
