### PR TITLE
refactor: add discord-api-types as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8465,9 +8465,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-      "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "typical": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2383,9 +2383,9 @@
       "dev": true
     },
     "discord-api-types": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.17.0.tgz",
-      "integrity": "sha512-X60jqhr7Uj67DDDRwoGH3DQCb2Sz4nxU9VE14lcl5qpsHcJlilxflZb1kZ3vvfzfjBTCTYQFdH8mSN4QUZkFhg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.0.tgz",
+      "integrity": "sha512-KxS+opGqrNbzo+wb3SxOqfuv/xX2CyrwEjCQLTI68gzjbSMn55h6o7JtPkWAXItadkNrUWyDqMMsfOz8DnpiNA==",
       "dev": true
     },
     "discord.js-docgen": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2382,6 +2382,12 @@
       "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
       "dev": true
     },
+    "discord-api-types": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.17.0.tgz",
+      "integrity": "sha512-X60jqhr7Uj67DDDRwoGH3DQCb2Sz4nxU9VE14lcl5qpsHcJlilxflZb1kZ3vvfzfjBTCTYQFdH8mSN4QUZkFhg==",
+      "dev": true
+    },
     "discord.js-docgen": {
       "version": "git+https://github.com/discordjs/docgen.git#d40f54cfd2d0f03ff92d7ecfb29cd82694ee2c11",
       "from": "git+https://github.com/discordjs/docgen.git",
@@ -4208,7 +4214,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "handlebars": {
       "version": "4.7.6",
@@ -4775,6 +4782,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -6197,6 +6205,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -6210,7 +6219,8 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7437,7 +7447,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/node": "^12.12.6",
     "@types/ws": "^7.2.7",
     "cross-env": "^7.0.2",
+    "discord-api-types": "^0.17.0",
     "discord.js-docgen": "git+https://github.com/discordjs/docgen.git",
     "dtslint": "^4.0.4",
     "eslint": "^7.11.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@types/node": "^12.12.6",
     "@types/ws": "^7.2.7",
     "cross-env": "^7.0.2",
-    "discord-api-types": "^0.17.0",
+    "discord-api-types": "^0.18.0",
     "discord.js-docgen": "git+https://github.com/discordjs/docgen.git",
     "dtslint": "^4.0.4",
     "eslint": "^7.11.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lint-staged": "^10.4.2",
     "prettier": "^2.1.2",
     "tslint": "^6.1.3",
-    "typescript": "^4.0.3"
+    "typescript": "^4.2.4"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,6 +29,7 @@ declare enum OverwriteTypes {
 declare module 'discord.js' {
   import BaseCollection from '@discordjs/collection';
   import { ChildProcess } from 'child_process';
+  import { APIMessage as RawMessage, APIOverwrite as RawOverwrite } from 'discord-api-types';
   import { EventEmitter } from 'events';
   import { PathLike } from 'fs';
   import { Readable, Stream, Writable } from 'stream';
@@ -1228,7 +1229,7 @@ declare module 'discord.js' {
       options: PermissionOverwriteOption,
       initialPermissions: { allow?: PermissionResolvable; deny?: PermissionResolvable },
     ): ResolvedOverwriteOptions;
-    public static resolve(overwrite: OverwriteResolvable, guild: Guild): RawOverwriteData;
+    public static resolve(overwrite: OverwriteResolvable, guild: Guild): RawOverwrite;
   }
 
   export class Permissions extends BitField<PermissionString, bigint> {
@@ -1810,30 +1811,22 @@ declare module 'discord.js' {
       message: MessageResolvable,
       content: APIMessageContentResolvable | APIMessage | MessageEmbed | MessageEmbed[],
       options?: WebhookEditMessageOptions,
-    ): Promise<WebhookRawMessageResponse>;
-    public editMessage(
-      message: MessageResolvable,
-      options: WebhookEditMessageOptions,
-    ): Promise<WebhookRawMessageResponse>;
+    ): Promise<RawMessage>;
+    public editMessage(message: MessageResolvable, options: WebhookEditMessageOptions): Promise<RawMessage>;
     public send(
       content: APIMessageContentResolvable | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<WebhookRawMessageResponse>;
-    public send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<WebhookRawMessageResponse[]>;
-    public send(
-      options: WebhookMessageOptions | APIMessage,
-    ): Promise<WebhookRawMessageResponse | WebhookRawMessageResponse[]>;
+    ): Promise<RawMessage>;
+    public send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<RawMessage[]>;
+    public send(options: WebhookMessageOptions | APIMessage): Promise<RawMessage | RawMessage[]>;
     public send(
       content: StringResolvable,
       options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<WebhookRawMessageResponse>;
+    ): Promise<RawMessage>;
     public send(
       content: StringResolvable,
       options: WebhookMessageOptions & { split: true | SplitOptions },
-    ): Promise<WebhookRawMessageResponse[]>;
-    public send(
-      content: StringResolvable,
-      options: WebhookMessageOptions,
-    ): Promise<WebhookRawMessageResponse | WebhookRawMessageResponse[]>;
+    ): Promise<RawMessage[]>;
+    public send(content: StringResolvable, options: WebhookMessageOptions): Promise<RawMessage | RawMessage[]>;
   }
 
   export class WebSocketManager extends EventEmitter {
@@ -2165,32 +2158,25 @@ declare module 'discord.js' {
       message: MessageResolvable,
       content: APIMessageContentResolvable | APIMessage | MessageEmbed | MessageEmbed[],
       options?: WebhookEditMessageOptions,
-    ): Promise<Message | WebhookRawMessageResponse>;
-    editMessage(
-      message: MessageResolvable,
-      options: WebhookEditMessageOptions,
-    ): Promise<Message | WebhookRawMessageResponse>;
+    ): Promise<Message | RawMessage>;
+    editMessage(message: MessageResolvable, options: WebhookEditMessageOptions): Promise<Message | RawMessage>;
     send(
       content: APIMessageContentResolvable | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message | WebhookRawMessageResponse>;
-    send(
-      options: WebhookMessageOptions & { split: true | SplitOptions },
-    ): Promise<(Message | WebhookRawMessageResponse)[]>;
-    send(
-      options: WebhookMessageOptions | APIMessage,
-    ): Promise<Message | WebhookRawMessageResponse | (Message | WebhookRawMessageResponse)[]>;
+    ): Promise<Message | RawMessage>;
+    send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<(Message | RawMessage)[]>;
+    send(options: WebhookMessageOptions | APIMessage): Promise<Message | RawMessage | (Message | RawMessage)[]>;
     send(
       content: StringResolvable,
       options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message | WebhookRawMessageResponse>;
+    ): Promise<Message | RawMessage>;
     send(
       content: StringResolvable,
       options: WebhookMessageOptions & { split: true | SplitOptions },
-    ): Promise<(Message | WebhookRawMessageResponse)[]>;
+    ): Promise<(Message | RawMessage)[]>;
     send(
       content: StringResolvable,
       options: WebhookMessageOptions,
-    ): Promise<Message | WebhookRawMessageResponse | (Message | WebhookRawMessageResponse)[]>;
+    ): Promise<Message | RawMessage | (Message | RawMessage)[]>;
     sendSlackMessage(body: object): Promise<boolean>;
   }
 
@@ -2289,95 +2275,6 @@ declare module 'discord.js' {
   }
 
   type APIMessageContentResolvable = string | number | boolean | bigint | symbol | readonly StringResolvable[];
-
-  interface APIRawMessage {
-    id: Snowflake;
-    type: number;
-    content: string;
-    channel_id: Snowflake;
-    author: {
-      bot?: true;
-      id: Snowflake;
-      username: string;
-      avatar: string | null;
-      discriminator: string;
-    };
-    attachments: {
-      id: Snowflake;
-      filename: string;
-      size: number;
-      url: string;
-      proxy_url: string;
-      height: number | null;
-      width: number | null;
-    }[];
-    embeds: {
-      title?: string;
-      type?: 'rich' | 'image' | 'video' | 'gifv' | 'article' | 'link';
-      description?: string;
-      url?: string;
-      timestamp?: string;
-      color?: number;
-      footer?: {
-        text: string;
-        icon_url?: string;
-        proxy_icon_url?: string;
-      };
-      image?: {
-        url?: string;
-        proxy_url?: string;
-        height?: number;
-        width?: number;
-      };
-      thumbnail?: {
-        url?: string;
-        proxy_url?: string;
-        height?: number;
-        width?: number;
-      };
-      video?: {
-        url?: string;
-        height?: number;
-        width?: number;
-      };
-      provider?: { name?: string; url?: string };
-      author?: {
-        name?: string;
-        url?: string;
-        icon_url?: string;
-        proxy_icon_url?: string;
-      };
-      fields?: {
-        name: string;
-        value: string;
-        inline?: boolean;
-      }[];
-    }[];
-    mentions: {
-      id: Snowflake;
-      username: string;
-      discriminator: string;
-      avatar: string | null;
-      bot?: true;
-      public_flags?: number;
-      member?: {
-        nick: string | null;
-        roles: Snowflake[];
-        joined_at: string;
-        premium_since?: string | null;
-        deaf: boolean;
-        mute: boolean;
-      };
-    }[];
-    mention_roles: Snowflake[];
-    pinned: boolean;
-    mention_everyone: boolean;
-    tts: boolean;
-    timestamp: string;
-    edited_timestamp: string | null;
-    flags: number;
-    webhook_id: Snowflake;
-  }
 
   interface ApplicationAsset {
     name: string;
@@ -3307,13 +3204,6 @@ declare module 'discord.js' {
     remainingTime: number;
   }
 
-  interface RawOverwriteData {
-    id: Snowflake;
-    allow: string;
-    deny: string;
-    type: number;
-  }
-
   interface ReactionCollectorOptions extends CollectorOptions {
     max?: number;
     maxEmojis?: number;
@@ -3439,16 +3329,6 @@ declare module 'discord.js' {
     username?: string;
     avatarURL?: string;
     embeds?: (MessageEmbed | object)[];
-  };
-
-  type WebhookRawMessageResponse = Omit<APIRawMessage, 'author'> & {
-    author: {
-      bot: true;
-      id: Snowflake;
-      username: string;
-      avatar: string | null;
-      discriminator: '0000';
-    };
   };
 
   type WebhookTypes = 'Incoming' | 'Channel Follower';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,7 +29,7 @@ declare enum OverwriteTypes {
 declare module 'discord.js' {
   import BaseCollection from '@discordjs/collection';
   import { ChildProcess } from 'child_process';
-  import { APIMessage as RawMessage, APIOverwrite as RawOverwrite } from 'discord-api-types';
+  import { APIMessage as RawMessage, APIOverwrite as RawOverwrite } from 'discord-api-types/v8';
   import { EventEmitter } from 'events';
   import { PathLike } from 'fs';
   import { Readable, Stream, Writable } from 'stream';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This adds `discord-api-types` as a dev dependency. This way we don't need to keep interfaces of raw data in the declaration file and more imports can be added later if needed.

The imports were renamed from `API...` to `Raw...` to avoid conflicts with the local `APIMessage` class.

**Status and versioning classification:**

- There are no code changes
- I know how to update typings and have done so
- This PR **only** includes non-code changes, like changes to documentation, README, etc.