### PR TITLE
refactor: remove error-silencing try/catch on event handler imports

### DIFF
--- a/src/client/websocket/handlers/index.js
+++ b/src/client/websocket/handlers/index.js
@@ -5,9 +5,7 @@ const { WSEvents } = require('../../../util/Constants');
 const handlers = {};
 
 for (const name of Object.keys(WSEvents)) {
-  try {
-    handlers[name] = require(`./${name}.js`);
-  } catch {} // eslint-disable-line no-empty
+  handlers[name] = require(`./${name}.js`);
 }
 
 module.exports = handlers;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes the try/catch block around requiring event handlers. Before, errors would be silently swallowed, resulting in impacted events unexpectedly not firing. This should only happen due to a bad change or incompatible toolchain (e.g., a bundler that doesn't support dynamic require statements).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

Previous change statement:

~**Please describe the changes this PR makes and why it should be merged:**~

~This PR changes how action handlers are loaded. Previously, file paths would be resolved via dynamic interpolation with event names (`./${name}.js`). Some static bundlers, such as esbuild, are unable to resolve these and leave them as-is, which does not work since the bundled file location is going to be different than the source code. Since the require statements were surrounding by try/catch blocks, esbuild would not raise a warning.`~