### PR TITLE
Update WebSocketShard.js

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -265,7 +265,7 @@ class WebSocketShard extends EventEmitter {
    * @private
    */
   onOpen() {
-    this.debug(`[CONNECTED] ${(this.connection? this.connection.url : "CONNECTION URL NOT FOUND")} in ${Date.now() - this.connectedAt}ms`);
+    this.debug(`[CONNECTED] ${(this.connection ? this.connection.url : "CONNECTION URL NOT FOUND")} in ${Date.now() - this.connectedAt}ms`);
     this.status = Status.NEARLY;
   }
 

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -265,7 +265,7 @@ class WebSocketShard extends EventEmitter {
    * @private
    */
   onOpen() {
-    this.debug(`[CONNECTED] ${this.connection.url} in ${Date.now() - this.connectedAt}ms`);
+    this.debug(`[CONNECTED] ${(this.connection? this.connection.url : "CONNECTION URL NOT FOUND")} in ${Date.now() - this.connectedAt}ms`);
     this.status = Status.NEARLY;
   }
 

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -265,7 +265,8 @@ class WebSocketShard extends EventEmitter {
    * @private
    */
   onOpen() {
-    this.debug(`[CONNECTED] ${(this.connection ? this.connection.url : "CONNECTION URL NOT FOUND")} in ${Date.now() - this.connectedAt}ms`);
+    const connectionurl = this.connection ? this.connection.url : 'CONNECTION URL NOT FOUND';
+    this.debug(`[CONNECTED] ${connectionurl} in ${Date.now() - this.connectedAt}ms`);
     this.status = Status.NEARLY;
   }
 


### PR DESCRIPTION
Causing a Error and a bot crash, because this.connection is null, which causes a Type Error on accessing this.connection.url
This should be a small fix, moreover, we have to find , why this.connection is null

**Please describe the changes this PR makes and why it should be merged:**
Its just a small typerror, when this.connection is null. Its a mid term solution, so bots does not crashes.

replaced:
```diff
 - this.connection.url
 +  this.connection ? this.connection.url : "NO CONNECTION URL DEFINED";
```


**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- Code changes have been tested against the Discord API, or there are no code changes




