### PR TITLE
fix(HTTPOptions): change default value in jsdoc to 8

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -75,7 +75,7 @@ exports.DefaultOptions = {
   /**
    * HTTP options
    * @typedef {Object} HTTPOptions
-   * @property {number} [version=7] API version to use
+   * @property {number} [version=8] API version to use
    * @property {string} [api='https://discord.com/api'] Base url of the API
    * @property {string} [cdn='https://cdn.discordapp.com'] Base url of the CDN
    * @property {string} [invite='https://discord.gg'] Base url of invites


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Change the default value in the HTTPOptions typedef from `7` to `8`.


**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
