### PR TITLE
fix(GuildMemberRoleManager): unable to remove roles when passed an array

### DIFF
--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -134,7 +134,7 @@ class GuildMemberRoleManager {
         throw new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true);
       }
 
-      const newRoles = this._roles.filter(role => !roleOrRoles.includes(role));
+      const newRoles = this._roles.filter(role => !roleOrRoles.includes(role.id));
       return this.set(newRoles, reason);
     } else {
       const roleID = this.guild.roles.resolveID(roleOrRoles);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fixes: #5555

Sorry for this oversight (see #5495) 🤦‍♂️
The `roleOrRoles` is an array of role IDs instead of roles now. This means the function passed to the `filter` method for creating `newRoles` array should be using `role.id` and not `role`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
