### PR TITLE
feat(Message): allow removing attachments

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -184,6 +184,7 @@ class APIMessage {
         typeof content === 'undefined' && typeof message_reference === 'undefined' ? undefined : allowedMentions,
       flags,
       message_reference,
+      attachments: this.options.removeAttachments ? [] : undefined,
     };
     return this;
   }

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -184,7 +184,7 @@ class APIMessage {
         typeof content === 'undefined' && typeof message_reference === 'undefined' ? undefined : allowedMentions,
       flags,
       message_reference,
-      attachments: this.options.removeAttachments ? [] : undefined,
+      attachments: this.options.attachments,
     };
     return this;
   }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -442,6 +442,7 @@ class Message extends Base {
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * @property {MessageFlags} [flags] Which flags to set for the message. Only `SUPPRESS_EMBEDS` can be edited.
+   * @property {boolean} [removeAttachments] Whether the attachments of the message should be removed
    */
 
   /**
@@ -618,6 +619,14 @@ class Message extends Base {
     }
 
     return this.edit({ flags });
+  }
+
+  /**
+   * Removes the attachments from this message.
+   * @returns {Promise<Message>}
+   */
+  removeAttachments() {
+    return this.edit({ removeAttachments: true });
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -442,7 +442,7 @@ class Message extends Base {
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * @property {MessageFlags} [flags] Which flags to set for the message. Only `SUPPRESS_EMBEDS` can be edited.
-   * @property {boolean} [removeAttachments] Whether the attachments of the message should be removed
+   * @property {MessageAttachment[]} [attachments] The new attachments of the message (can only be removed, not added)
    */
 
   /**
@@ -626,7 +626,7 @@ class Message extends Base {
    * @returns {Promise<Message>}
    */
   removeAttachments() {
-    return this.edit({ removeAttachments: true });
+    return this.edit({ attachments: [] });
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1039,6 +1039,7 @@ declare module 'discord.js' {
     public fetch(force?: boolean): Promise<Message>;
     public pin(options?: { reason?: string }): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
+    public removeAttachments(): Promise<Message>;
     public reply(
       content: APIMessageContentResolvable | (MessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message>;
@@ -2986,6 +2987,7 @@ declare module 'discord.js' {
     code?: string | boolean;
     flags?: BitFieldResolvable<MessageFlagsString, number>;
     allowedMentions?: MessageMentionOptions;
+    removeAttachments?: boolean;
   }
 
   interface MessageEmbedAuthor {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2987,7 +2987,7 @@ declare module 'discord.js' {
     code?: string | boolean;
     flags?: BitFieldResolvable<MessageFlagsString, number>;
     allowedMentions?: MessageMentionOptions;
-    removeAttachments?: boolean;
+    attachments?: MessageAttachment[];
   }
 
   interface MessageEmbedAuthor {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This adds support for removing attachments from a message.

**Status and versioning classification:**

- Code changes have been tested against the Discord API
- I know how to update typings and have done so
- This PR changes the library's interface (methods or parameters added)