### PR TITLE
docs(VoiceState): `#setRequestToSpeak` and `#setSuppressed` returns a `Promise` instead of `void`

### DIFF
--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -218,6 +218,7 @@ class VoiceState extends Base {
    * @example
    * // Making the client cancel a request to speak
    * guild.me.voice.setRequestToSpeak(false);
+   * @returns {Promise<void>}
    */
   async setRequestToSpeak(request) {
     const channel = this.channel;
@@ -248,6 +249,7 @@ class VoiceState extends Base {
    * @example
    * // Moving another user to the audience, or cancelling their invite to speak
    * voiceState.setSuppressed(true);
+   * @returns {Promise<void>}
    */
   async setSuppressed(suppressed) {
     if (typeof suppressed !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'suppressed');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- In the documentation, `#setRequestToSpeak` and `#setSuppressed` returns `void`
- In the typings and source code, it returns `Promise<void>`

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.