### PR TITLE
fix(ShardingManager): client error event cannot be emitted

### DIFF
--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -199,8 +199,7 @@ class ShardClientUtil {
    */
   _respond(type, message) {
     this.send(message).catch(err => {
-      let error = {err}
-      error.message = `Error when sending ${type} response to master process: ${err.message}`;
+      let error = new Error(`Error when sending ${type} response to master process: ${err.message}`);
       /**
        * Emitted when the client encounters an error.
        * @event Client#error

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -199,7 +199,7 @@ class ShardClientUtil {
    */
   _respond(type, message) {
     this.send(message).catch(err => {
-      let error = new Error(`Error when sending ${type} response to master process: ${err.message}`);
+      const error = new Error(`Error when sending ${type} response to master process: ${err.message}`);
       /**
        * Emitted when the client encounters an error.
        * @event Client#error

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -200,6 +200,7 @@ class ShardClientUtil {
   _respond(type, message) {
     this.send(message).catch(err => {
       const error = new Error(`Error when sending ${type} response to master process: ${err.message}`);
+      error.stack = err.stack;
       /**
        * Emitted when the client encounters an error.
        * @event Client#error

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -199,13 +199,14 @@ class ShardClientUtil {
    */
   _respond(type, message) {
     this.send(message).catch(err => {
-      err.message = `Error when sending ${type} response to master process: ${err.message}`;
+      let error = {err}
+      error.message = `Error when sending ${type} response to master process: ${err.message}`;
       /**
        * Emitted when the client encounters an error.
        * @event Client#error
        * @param {Error} error The error encountered
        */
-      this.client.emit(Events.ERROR, err);
+      this.client.emit(Events.ERROR, error);
     });
   }
 


### PR DESCRIPTION
When a Error happens during sending, it can not overwrite err.message. So that a error happens: "TypeError: Cannot set property message of  which has only a getter"

**Please describe the changes this PR makes and why it should be merged:**
The Error can be reproduced with having the Sharding Manager on Worker Mode and than broadcastEvaling `this.guilds.cache`,
the upper scenario works fine for child processes, bc they support many types, but worker threads does not support functions and some other types. So a error comes:  `DOMException [DataCloneError]: #<Object> could not be cloned.`
This Error can just be logged out when you merge the commit, bc there is a error itself on the _respond function, which should be fixed with the commit. I checked it, multiply times...


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

