### PR TITLE
fix(GuildMemberRoleManager): fix remove method when passing collection/array

### DIFF
--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -134,7 +134,7 @@ class GuildMemberRoleManager {
         throw new TypeError('INVALID_TYPE', 'roles', 'Array or Collection of Roles or Snowflakes', true);
       }
 
-      const newRoles = this._roles.filter(role => !roleOrRoles.includes(role));
+      const newRoles = this._roles.filter(role => !roleOrRoles.includes(role.id));
       return this.set(newRoles, reason);
     } else {
       const roleID = this.guild.roles.resolveID(roleOrRoles);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When passing a collection of roles or an array of RoleResolvable, it gets mapped into an array of ids and then filtered but checking if the array contains the role and not the id.

This PR checks if the array contains the role id rather than role instance, allowing GuildMemberRoleManager#remove to work with a collection or array like it should.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

