### PR TITLE
fix(Message): reply method; 

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -580,7 +580,7 @@ class Message extends Base {
       content instanceof APIMessage
         ? content
         : APIMessage.transformOptions(content, options, {
-            replyTo: this,
+            replyTo: options && options.replyTo || this,
           }),
     );
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
this PR will check if there is a replyTo option exist in reply method; if there is, it would reply to message according to replyTo property pass into the reply method by end user if not it would default to current message (this). 


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
