### PR TITLE
fix(MessageEmbed): null = field: undefined;

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -255,6 +255,10 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   addField(name, value, inline) {
+    if(value == null) {
+       return this.addFields({ name, 'undefined', inline });
+    }
+    
     return this.addFields({ name, value, inline });
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

if the messageembed, field is null/undefined then:

set text: undefined -> before: not always working/error in console.


**Status and versioning classification:**

- This PR changes the library's interface (methods or parameters added)

