### PR TITLE
feat(Message): replace referencedMessage with fetchReference

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -96,6 +96,7 @@ const Messages = {
   INVALID_ELEMENT: (type, name, elem) => `Supplied ${type} ${name} includes an invalid element: ${elem}`,
 
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
+  MESSAGE_REFERENCE_MISSING: 'The message does not reference another message',
 
   EMOJI_TYPE: 'Emoji must be a string or GuildEmoji/ReactionEmoji',
   EMOJI_MANAGED: 'Emoji is managed and has no Author.',

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -409,12 +409,13 @@ class Message extends Base {
    * Fetches the Message this crosspost/reply/pin-add references, if available to the client
    * @returns {Promise<Message>}
    */
-  fetchReference() {
+  async fetchReference() {
     if (!this.reference) throw new Error('MESSAGE_REFERENCE_MISSING');
     const { channelID, messageID } = this.reference;
     const channel = this.client.channels.resolve(channelID);
     if (!channel) throw new Error('GUILD_CHANNEL_RESOLVE');
-    return channel.messages.fetch(messageID);
+    const message = await channel.messages.fetch(messageID);
+    return message;
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -406,15 +406,15 @@ class Message extends Base {
   }
 
   /**
-   * The Message this crosspost/reply/pin-add references, if cached
-   * @type {?Message}
-   * @readonly
+   * Fetches the Message this crosspost/reply/pin-add references, if available to the client
+   * @returns {Promise<Message>}
    */
-  get referencedMessage() {
-    if (!this.reference) return null;
-    const referenceChannel = this.client.channels.resolve(this.reference.channelID);
-    if (!referenceChannel) return null;
-    return referenceChannel.messages.resolve(this.reference.messageID);
+  fetchReference() {
+    if (!this.reference) throw new Error('MESSAGE_REFERENCE_MISSING');
+    const { channelID, messageID } = this.reference;
+    const channel = this.client.channels.resolve(channelID);
+    if (!channel) throw new Error('GUILD_CHANNEL_RESOLVE');
+    return channel.messages.fetch(messageID);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1020,7 +1020,6 @@ declare module 'discord.js' {
     public webhookID: Snowflake | null;
     public flags: Readonly<MessageFlags>;
     public reference: MessageReference | null;
-    public readonly referencedMessage: Message | null;
     public awaitReactions(
       filter: CollectorFilter<[MessageReaction, User]>,
       options?: AwaitReactionsOptions,
@@ -1035,6 +1034,7 @@ declare module 'discord.js' {
     ): Promise<Message>;
     public edit(content: StringResolvable, options: MessageEditOptions | MessageEmbed): Promise<Message>;
     public equals(message: Message, rawData: object): boolean;
+    public fetchReference(): Promise<Message>;
     public fetchWebhook(): Promise<Webhook>;
     public crosspost(): Promise<Message>;
     public fetch(force?: boolean): Promise<Message>;


### PR DESCRIPTION
This replaces the cache-reliant `Message#referencedMessage` with a more reliable way to resolve the Message
This follows precedent set by #5480 

The method with throw an error if `Message#reference` is null, or if the channel to fetch the message from is not in the client's cache, as is likely to be the case when the message is a crosspost rather than a reply.

This seemed like the best way to handle it without getting into raw APIs calls and partial channels and all that mess.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- I know how to update typings and have done so, or typings don't need updating