### PR TITLE
docs: update invite link, change version in the intro

### DIFF
--- a/docs/general/welcome.md
+++ b/docs/general/welcome.md
@@ -19,7 +19,7 @@
 
 # Welcome!
 
-Welcome to the discord.js v12 documentation.
+Welcome to the discord.js v13 documentation.
 
 ## About
 
@@ -81,7 +81,7 @@ client.login('token');
 - [Documentation](https://discord.js.org/#/docs/main/master/general/welcome)
 - [Guide](https://discordjs.guide/) ([source](https://github.com/discordjs/guide)) - this is still for stable  
   See also the WIP [Update Guide](https://discordjs.guide/additional-info/changes-in-v12.html) also including updated and removed items in the library.
-- [Discord.js Discord server](https://discord.gg/bRCvFy9)
+- [Discord.js Discord server](https://discord.gg/djs)
 - [Discord API Discord server](https://discord.gg/discord-api)
 - [GitHub](https://github.com/discordjs/discord.js)
 - [NPM](https://www.npmjs.com/package/discord.js)
@@ -100,4 +100,4 @@ See [the contribution guide](https://github.com/discordjs/discord.js/blob/master
 ## Help
 
 If you don't understand something in the documentation, you are experiencing problems, or you just need a gentle
-nudge in the right direction, please don't hesitate to join our official [Discord.js Server](https://discord.gg/bRCvFy9).
+nudge in the right direction, please don't hesitate to join our official [Discord.js Server](https://discord.gg/djs).


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR updates the Discord.js version in the intro of the docs' welcome page, changing it to v13, instead of v12. It should be merged since users might be confused on why it says version 12, when they're looking at the master branch's docs. 

Lastly, this changes the invite link of the Discord.js server to the vanity url, since it recently got verified. This would help people (who are new, mostly) memorize/recognize the link, in case they accidentally left it or something. It's also more shorter.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.