### PR TITLE
fix(Client) added a forgotten keyword "this"

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -129,7 +129,7 @@ class Client extends BaseClient {
      * @private
      * @type {ClientPresence}
      */
-    this.presence = new ClientPresence(this, options.presence);
+    this.presence = new ClientPresence(this, this.options.presence);
 
     Object.defineProperty(this, 'token', { writable: true });
     if (!this.token && 'DISCORD_TOKEN' in process.env) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The keyword "this" was forgotten. Without it, the error occurred:
```
this.presence = new ClientPresence(this, options.presence || 'online');
                                                 ^
TypeError: Cannot read property 'presence' of undefined
```

**Status and versioning classification:**

- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)