### PR TITLE
fix(ApplicationCommandManager): fix typo in JSDoc

### DIFF
--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -214,7 +214,7 @@ class ApplicationCommandManager extends BaseManager {
    * @returns {Promise<ApplicationCommandPermissions[]|Collection<Snowflake, ApplicationCommandPermissions[]>>}
    * @example
    * // Set the permissions for one command
-   * client.commands.setPermissions('123456789012345678', [
+   * client.application.commands.setPermissions('123456789012345678', [
    *   {
    *     id: '876543210987654321',
    *     type: 'USER',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a typo in the JSDoc usage example of the `ApplicationCommandManager` where `client.commands` was used instead of `client.application.commands`.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
- This PR **only** includes non-code changes, like changes to documentation, README, etc.