### PR TITLE
docs(GuildChannelManager): add stage option

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -63,7 +63,7 @@ class GuildChannelManager extends BaseManager {
    * @param {string} name The name of the new channel
    * @param {Object} [options] Options
    * @param {string} [options.type='text'] The type of the new channel, either `text`, `voice`, `category`, `news`,
-   * or `store`
+   * `store`, or `stage`
    * @param {string} [options.topic] The topic for the new channel
    * @param {boolean} [options.nsfw] Whether the new channel is nsfw
    * @param {number} [options.bitrate] Bitrate of the new channel in bits (only voice)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2113,10 +2113,11 @@ declare module 'discord.js' {
     public create(name: string, options?: GuildCreateChannelOptions & { type?: 'text' }): Promise<TextChannel>;
     public create(name: string, options: GuildCreateChannelOptions & { type: 'news' }): Promise<NewsChannel>;
     public create(name: string, options: GuildCreateChannelOptions & { type: 'store' }): Promise<StoreChannel>;
+    public create(name: string, options: GuildCreateChannelOptions & { type: 'stage' }): Promise<StageChannel>;
     public create(
       name: string,
       options: GuildCreateChannelOptions,
-    ): Promise<TextChannel | VoiceChannel | CategoryChannel | NewsChannel | StoreChannel>;
+    ): Promise<TextChannel | VoiceChannel | CategoryChannel | NewsChannel | StoreChannel | StageChannel>;
   }
 
   export class GuildEmojiManager extends BaseGuildEmojiManager {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `stage` type was missing in the options of `GuildChannelManager.create`.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
