### PR TITLE
fix(VoiceReceiver): fix memory leak

### DIFF
--- a/src/client/voice/receiver/Receiver.js
+++ b/src/client/voice/receiver/Receiver.js
@@ -48,6 +48,7 @@ class VoiceReceiver extends EventEmitter {
     const stream = this.packets.makeStream(user.id, end);
     if (mode === 'pcm') {
       const decoder = new prism.opus.Decoder({ channels: 2, rate: 48000, frameSize: 960 });
+      decoder.on('close', () => stream.destroy());
       stream.pipe(decoder);
       return decoder;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When you destroy the opus decoder stream that ``createStream`` returns when you set ``mode: 'pcm'``, the internal stream doesn't get closed and keeps building up data. This is most apparent when setting ``end: 'manual'``. This PR makes sure to close ``stream`` when ``decoder`` is destroyed.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
