### PR TITLE
typings(WebhookMessageOptions): omit reply instead of replyTo

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3609,7 +3609,7 @@ declare module 'discord.js' {
 
   type WebhookEditMessageOptions = Pick<WebhookMessageOptions, 'content' | 'embeds' | 'files' | 'allowedMentions'>;
 
-  interface WebhookMessageOptions extends Omit<MessageOptions, 'embed' | 'replyTo'> {
+  interface WebhookMessageOptions extends Omit<MessageOptions, 'embed' | 'reply'> {
     username?: string;
     avatarURL?: string;
     embeds?: (MessageEmbed | object)[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

#5298 replaced `replyTo` with `reply` in `MessageOptions`. This PR updates typings for `WebhookMessageOptions` to reflect this change.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
