### PR TITLE
fix(Message): editing with MessageEmbed or APIMessage

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -117,14 +117,14 @@ class MessageManager extends BaseManager {
   /**
    * Edits a message, even if it's not cached.
    * @param {MessageResolvable} message The message to edit
-   * @param {MessageEditOptions} [options] The options to provide
+   * @param {MessageEditOptions|APIMessage} [options] The options to provide
    * @returns {Promise<Message>}
    */
   async edit(message, options) {
     message = this.resolveID(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
-    const { data } = APIMessage.create(this, options).resolveData();
+    const { data } = (options instanceof APIMessage ? options : APIMessage.create(this, options)).resolveData();
     const d = await this.client.api.channels[this.channel.id].messages[message].patch({ data });
 
     if (this.cache.has(message)) {

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -494,11 +494,8 @@ class Message extends Base {
    *   .catch(console.error);
    */
   edit(content, options) {
-    if (!options && typeof content === 'object' && !Array.isArray(content)) {
-      options = content;
-      content = undefined;
-    }
-    return this.channel.messages.edit(this.id, { content, ...options });
+    options = content instanceof APIMessage ? content : APIMessage.create(this.channel, content, options);
+    return this.channel.messages.edit(this.id, options);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a bug in `Message#edit` causing operations that tried to edit a message either using an `APIMessage` or a `MessageEmbed` to fail (treated as omitted).

This PR resolves that issue by creating an `APIMessage` from the provided options or pass along the provided `APIMessage` to `MessageManager#edit`, which now also accepts an `APIMessage`.


**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)
