### PR TITLE
fix(ApplicationCommandManager): limit permission methods to guilds

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -112,7 +112,8 @@ const Messages = {
 
   MEMBER_FETCH_NONCE_LENGTH: 'Nonce length must not exceed 32 characters.',
 
-  GLOBAL_COMMAND: "Permissions for global commands may only be fetched or modified from a guild's application command manager.",
+  GLOBAL_COMMAND:
+    "Permissions for global commands may only be fetched or modified from a guild's application command manager.",
 
   INTERACTION_ALREADY_REPLIED: 'This interaction has already been deferred or replied to.',
 };

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -112,7 +112,7 @@ const Messages = {
 
   MEMBER_FETCH_NONCE_LENGTH: 'Nonce length must not exceed 32 characters.',
 
-  GLOBAL_COMMAND: 'This method cannot be used on global application commands.',
+  GLOBAL_COMMAND: "Permissions for global commands may only be fetched or modified from a guild's application command manager.",
 
   INTERACTION_ALREADY_REPLIED: 'This interaction has already been deferred or replied to.',
 };

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -112,6 +112,8 @@ const Messages = {
 
   MEMBER_FETCH_NONCE_LENGTH: 'Nonce length must not exceed 32 characters.',
 
+  GLOBAL_COMMAND: 'This method cannot be used on global application commands.',
+
   INTERACTION_ALREADY_REPLIED: 'This interaction has already been deferred or replied to.',
 };
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -112,7 +112,7 @@ const Messages = {
 
   MEMBER_FETCH_NONCE_LENGTH: 'Nonce length must not exceed 32 characters.',
 
-  GLOBAL_COMMAND:
+  GLOBAL_COMMAND_PERMISSIONS:
     "Permissions for global commands may only be fetched or modified from a guild's application command manager.",
 
   INTERACTION_ALREADY_REPLIED: 'This interaction has already been deferred or replied to.',

--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -4,7 +4,6 @@ const BaseManager = require('./BaseManager');
 const { TypeError } = require('../errors');
 const ApplicationCommand = require('../structures/ApplicationCommand');
 const Collection = require('../util/Collection');
-const { ApplicationCommandPermissionTypes } = require('../util/Constants');
 
 /**
  * Manages API methods for application commands and stores their cache.
@@ -165,106 +164,6 @@ class ApplicationCommandManager extends BaseManager {
   }
 
   /**
-   * Fetches the permissions for one or multiple commands.
-   * @param {ApplicationCommandResolvable} [command] The command to get the permissions from
-   * @returns {Promise<ApplicationCommandPermissions[]|Collection<Snowflake, ApplicationCommandPermissions[]>>}
-   * @example
-   * // Fetch permissions for one command
-   * guild.commands.fetchPermissions('123456789012345678')
-   *   .then(perms => console.log(`Fetched permissions for ${perms.length} users`))
-   *   .catch(console.error);
-   * @example
-   * // Fetch permissions for all commands
-   * client.application.commands.fetchPermissions()
-   *   .then(perms => console.log(`Fetched permissions for ${perms.size} commands`))
-   *   .catch(console.error);
-   */
-  async fetchPermissions(command) {
-    if (command) {
-      const id = this.resolveID(command);
-      if (!id) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
-
-      const data = await this.commandPath(id).permissions.get();
-      return data.permissions.map(perm => this.constructor.transformPermissions(perm, true));
-    }
-
-    const data = await this.commandPath.permissions.get();
-    return data.reduce(
-      (coll, perm) =>
-        coll.set(
-          perm.id,
-          perm.permissions.map(p => this.constructor.transformPermissions(p, true)),
-        ),
-      new Collection(),
-    );
-  }
-
-  /**
-   * Data used for overwriting the permissions for all application commands in a guild.
-   * @typedef {object} GuildApplicationCommandPermissionData
-   * @prop {Snowflake} command The ID of the command
-   * @prop {ApplicationCommandPermissionData[]} permissions The permissions for this command
-   */
-
-  /**
-   * Sets the permissions for a command.
-   * @param {ApplicationCommandResolvable|GuildApplicationCommandPermissionData[]} command The command to edit the
-   * permissions for, or an array of guild application command permissions to set the permissions of all commands
-   * @param {ApplicationCommandPermissionData[]} permissions The new permissions for the command
-   * @returns {Promise<ApplicationCommandPermissions[]|Collection<Snowflake, ApplicationCommandPermissions[]>>}
-   * @example
-   * // Set the permissions for one command
-   * client.application.commands.setPermissions('123456789012345678', [
-   *   {
-   *     id: '876543210987654321',
-   *     type: 'USER',
-   *     permission: false,
-   *   },
-   * ])
-   *   .then(console.log)
-   *   .catch(console.error);
-   * @example
-   * // Set the permissions for all commands
-   * guild.commands.setPermissions([
-   *   {
-   *     id: '123456789012345678',
-   *     permissions: [{
-   *       id: '876543210987654321',
-   *       type: 'USER',
-   *       permission: false,
-   *     }],
-   *   },
-   * ])
-   *   .then(console.log)
-   *   .catch(console.error);
-   */
-  async setPermissions(command, permissions) {
-    const id = this.resolveID(command);
-
-    if (id) {
-      const data = await this.commandPath(id).permissions.put({
-        data: { permissions: permissions.map(perm => this.constructor.transformPermissions(perm)) },
-      });
-      return data.permissions.map(perm => this.constructor.transformPermissions(perm, true));
-    }
-
-    const data = await this.commandPath.permissions.put({
-      data: command.map(perm => ({
-        id: perm.id,
-        permissions: perm.permissions.map(p => this.constructor.transformPermissions(p)),
-      })),
-    });
-    return data.reduce(
-      (coll, perm) =>
-        coll.set(
-          perm.id,
-          perm.permissions.map(p => this.constructor.transformPermissions(p, true)),
-        ),
-      new Collection(),
-    );
-  }
-
-  /**
    * Transforms an {@link ApplicationCommandData} object into something that can be used with the API.
    * @param {ApplicationCommandData} command The command to transform
    * @returns {Object}
@@ -276,24 +175,6 @@ class ApplicationCommandManager extends BaseManager {
       description: command.description,
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
       default_permission: command.defaultPermission,
-    };
-  }
-
-  /**
-   * Transforms an {@link ApplicationCommandPermissionData} object into something that can be used with the API.
-   * @param {ApplicationCommandPermissionData} permissions The permissions to transform
-   * @param {boolean} [received] Whether these permissions have been received from Discord
-   * @returns {Object}
-   * @private
-   */
-  static transformPermissions(permissions, received) {
-    return {
-      id: permissions.id,
-      permission: permissions.permission,
-      type:
-        typeof permissions.type === 'number' && !received
-          ? permissions.type
-          : ApplicationCommandPermissionTypes[permissions.type],
     };
   }
 }

--- a/src/managers/GuildApplicationCommandManager.js
+++ b/src/managers/GuildApplicationCommandManager.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const ApplicationCommandManager = require('./ApplicationCommandManager');
+const Collection = require('../util/Collection');
+const { ApplicationCommandPermissionTypes } = require('../util/Constants');
 
 /**
  * An extension for guild-specific application commands.
@@ -15,6 +17,124 @@ class GuildApplicationCommandManager extends ApplicationCommandManager {
      * @type {Guild}
      */
     this.guild = guild;
+  }
+
+  /**
+   * Fetches the permissions for one or multiple commands.
+   * @param {ApplicationCommandResolvable} [command] The command to get the permissions from
+   * @returns {Promise<ApplicationCommandPermissions[]|Collection<Snowflake, ApplicationCommandPermissions[]>>}
+   * @example
+   * // Fetch permissions for one command
+   * guild.commands.fetchPermissions('123456789012345678')
+   *   .then(perms => console.log(`Fetched permissions for ${perms.length} users`))
+   *   .catch(console.error);
+   * @example
+   * // Fetch permissions for all commands
+   * client.application.commands.fetchPermissions()
+   *   .then(perms => console.log(`Fetched permissions for ${perms.size} commands`))
+   *   .catch(console.error);
+   */
+  async fetchPermissions(command) {
+    if (command) {
+      const id = this.resolveID(command);
+      if (!id) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
+
+      const data = await this.commandPath(id).permissions.get();
+      return data.permissions.map(perm => this.constructor.transformPermissions(perm, true));
+    }
+
+    const data = await this.commandPath.permissions.get();
+    return data.reduce(
+      (coll, perm) =>
+        coll.set(
+          perm.id,
+          perm.permissions.map(p => this.constructor.transformPermissions(p, true)),
+        ),
+      new Collection(),
+    );
+  }
+
+  /**
+   * Data used for overwriting the permissions for all application commands in a guild.
+   * @typedef {object} GuildApplicationCommandPermissionData
+   * @prop {Snowflake} command The ID of the command
+   * @prop {ApplicationCommandPermissionData[]} permissions The permissions for this command
+   */
+
+  /**
+   * Sets the permissions for a command.
+   * @param {ApplicationCommandResolvable|GuildApplicationCommandPermissionData[]} command The command to edit the
+   * permissions for, or an array of guild application command permissions to set the permissions of all commands
+   * @param {ApplicationCommandPermissionData[]} permissions The new permissions for the command
+   * @returns {Promise<ApplicationCommandPermissions[]|Collection<Snowflake, ApplicationCommandPermissions[]>>}
+   * @example
+   * // Set the permissions for one command
+   * client.application.commands.setPermissions('123456789012345678', [
+   *   {
+   *     id: '876543210987654321',
+   *     type: 'USER',
+   *     permission: false,
+   *   },
+   * ])
+   *   .then(console.log)
+   *   .catch(console.error);
+   * @example
+   * // Set the permissions for all commands
+   * guild.commands.setPermissions([
+   *   {
+   *     id: '123456789012345678',
+   *     permissions: [{
+   *       id: '876543210987654321',
+   *       type: 'USER',
+   *       permission: false,
+   *     }],
+   *   },
+   * ])
+   *   .then(console.log)
+   *   .catch(console.error);
+   */
+  async setPermissions(command, permissions) {
+    const id = this.resolveID(command);
+
+    if (id) {
+      const data = await this.commandPath(id).permissions.put({
+        data: { permissions: permissions.map(perm => this.constructor.transformPermissions(perm)) },
+      });
+      return data.permissions.map(perm => this.constructor.transformPermissions(perm, true));
+    }
+
+    const data = await this.commandPath.permissions.put({
+      data: command.map(perm => ({
+        id: perm.id,
+        permissions: perm.permissions.map(p => this.constructor.transformPermissions(p)),
+      })),
+    });
+    return data.reduce(
+      (coll, perm) =>
+        coll.set(
+          perm.id,
+          perm.permissions.map(p => this.constructor.transformPermissions(p, true)),
+        ),
+      new Collection(),
+    );
+  }
+
+  /**
+   * Transforms an {@link ApplicationCommandPermissionData} object into something that can be used with the API.
+   * @param {ApplicationCommandPermissionData} permissions The permissions to transform
+   * @param {boolean} [received] Whether these permissions have been received from Discord
+   * @returns {Object}
+   * @private
+   */
+  static transformPermissions(permissions, received) {
+    return {
+      id: permissions.id,
+      permission: permissions.permission,
+      type:
+        typeof permissions.type === 'number' && !received
+          ? permissions.type
+          : ApplicationCommandPermissionTypes[permissions.type],
+    };
   }
 }
 

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -148,6 +148,7 @@ class ApplicationCommand extends Base {
 
   /**
    * Fetches the permissions for this command.
+   * <warn>This is only available for guild application commands.</warn>
    * @returns {Promise<ApplicationCommandPermissions[]>}
    * @example
    * // Fetch permissions for this command
@@ -162,6 +163,7 @@ class ApplicationCommand extends Base {
 
   /**
    * Sets the permissions for this command.
+   * <warn>This is only available for guild application commands.</warn>
    * @param {ApplicationCommandPermissionData[]} permissions The new permissions for the command
    * @returns {Promise<ApplicationCommandPermissions[]>}
    * @example

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -157,7 +157,7 @@ class ApplicationCommand extends Base {
    *   .catch(console.error);
    */
   fetchPermissions() {
-    if (!this.guild) throw new Error('GLOBAL_COMMAND');
+    if (!this.guild) throw new Error('GLOBAL_COMMAND_PERMISSIONS');
     return this.manager.fetchPermissions(this);
   }
 
@@ -179,7 +179,7 @@ class ApplicationCommand extends Base {
    *   .catch(console.error);
    */
   setPermissions(permissions) {
-    if (!this.guild) throw new Error('GLOBAL_COMMAND');
+    if (!this.guild) throw new Error('GLOBAL_COMMAND_PERMISSIONS');
     return this.manager.setPermissions(this, permissions);
   }
 

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Base = require('./Base');
+const { Error } = require('../errors');
 const { ApplicationCommandOptionTypes } = require('../util/Constants');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
 
@@ -130,7 +131,7 @@ class ApplicationCommand extends Base {
   }
 
   /**
-   * The object returned when fetching permissions for an application command.
+   * Data for setting the permissions of an application command.
    * @typedef {object} ApplicationCommandPermissionData
    * @property {Snowflake} id The ID of the role or user
    * @property {ApplicationCommandPermissionType|number} type Whether this permission if for a role or a user
@@ -155,6 +156,7 @@ class ApplicationCommand extends Base {
    *   .catch(console.error);
    */
   fetchPermissions() {
+    if (!this.guild) throw new Error('GLOBAL_COMMAND');
     return this.manager.fetchPermissions(this);
   }
 
@@ -175,6 +177,7 @@ class ApplicationCommand extends Base {
    *   .catch(console.error);
    */
   setPermissions(permissions) {
+    if (!this.guild) throw new Error('GLOBAL_COMMAND');
     return this.manager.setPermissions(this, permissions);
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2065,18 +2065,8 @@ declare module 'discord.js' {
     public edit(command: ApplicationCommandResolvable, data: ApplicationCommandData): Promise<ApplicationCommand>;
     public fetch(id: Snowflake, cache?: boolean, force?: boolean): Promise<ApplicationCommand>;
     public fetch(id?: Snowflake, cache?: boolean, force?: boolean): Promise<Collection<Snowflake, ApplicationCommand>>;
-    public fetchPermissions(): Promise<Collection<Snowflake, ApplicationCommandPermissions[]>>;
-    public fetchPermissions(command: ApplicationCommandResolvable): Promise<ApplicationCommandPermissions[]>;
     public set(commands: ApplicationCommandData[]): Promise<Collection<Snowflake, ApplicationCommand>>;
-    public setPermissions(
-      command: ApplicationCommandResolvable,
-      permissions: ApplicationCommandPermissionData[],
-    ): Promise<ApplicationCommandPermissions[]>;
-    public setPermissions(
-      permissions: GuildApplicationCommandPermissionData[],
-    ): Promise<Collection<Snowflake, ApplicationCommandPermissions[]>>;
     private static transformCommand(command: ApplicationCommandData): object;
-    private static transformPermissions(permissions: ApplicationCommandPermissionData, received?: boolean): object;
   }
 
   export class BaseGuildEmojiManager extends BaseManager<Snowflake, GuildEmoji, EmojiResolvable> {
@@ -2092,6 +2082,16 @@ declare module 'discord.js' {
   export class GuildApplicationCommandManager extends ApplicationCommandManager {
     constructor(guild: Guild, iterable?: Iterable<any>);
     public guild: Guild;
+    public fetchPermissions(): Promise<Collection<Snowflake, ApplicationCommandPermissions[]>>;
+    public fetchPermissions(command: ApplicationCommandResolvable): Promise<ApplicationCommandPermissions[]>;
+    public setPermissions(
+      command: ApplicationCommandResolvable,
+      permissions: ApplicationCommandPermissionData[],
+    ): Promise<ApplicationCommandPermissions[]>;
+    public setPermissions(
+      permissions: GuildApplicationCommandPermissionData[],
+    ): Promise<Collection<Snowflake, ApplicationCommandPermissions[]>>;
+    private static transformPermissions(permissions: ApplicationCommandPermissionData, received?: boolean): object;
   }
 
   export class GuildChannelManager extends BaseManager<Snowflake, GuildChannel, GuildChannelResolvable> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

These endpoints are not available for global commands.

**Status and versioning classification:**

- I know how to update typings and have done so
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)