### PR TITLE
fix: resolve emoji in Message#react

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -555,6 +555,7 @@ class Message extends Base {
    *   .catch(console.error);
    */
   async react(emoji) {
+    emoji = this.client.emojis.resolveIdentifier(emoji);
     await this.channel.messages.react(this.id, emoji);
     return this.client.actions.MessageReactionAdd.handle({
       user: this.client.user,


### PR DESCRIPTION
This fixes a bug I caused in `Message#react` when I moved the functionality to the manager.

Because emoji resolution was moved, this meant a GuildEmoji object could be passed directly to `Util#parseEmoji`, which would throw as it expected a string.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
