### PR TITLE
fix(ApplicationCommand): return string equivalent of ApplicationCommandOptionType

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -210,7 +210,7 @@ class ApplicationCommand extends Base {
       description: option.description,
       required: option.required,
       choices: option.choices,
-      options: option.options?.map(o => this.transformOption(o)),
+      options: option.options?.map(o => this.transformOption(o, received)),
     };
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the returned `ApplicationCommandOption.type` of child-options.

The current output of `options`:
```js
ApplicationCommand.options = [
  {
    name: 'parent',
    description: 'parent description',
    type: 'SUB_COMMAND', // <-- Returns the string equivalent of the ApplicationCommandOptionType ✅
    options: [
      {
        name: 'child',
        description: 'child description',
        type: 6, // <-- Returns the raw API value of the ApplicationCommandOptionType ❌
      }
    ]
  }
]
```

The proposed output of `options`:
```js
ApplicationCommand.options = [
  {
    name: 'parent',
    description: 'parent description',
    type: 'SUB_COMMAND',
    options: [
      {
        name: 'child',
        description: 'child description',
        type: 'USER',
      }
    ]
  }
]
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

Note: This is my first time in contributing to the library so please go easy on me :)