### PR TITLE
feat(CommandInteraction): ephemeral followup messages

### DIFF
--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -188,12 +188,12 @@ class CommandInteraction extends Interaction {
    */
 
   /**
-   * Send a followup message to this interaction.
+   * Send a follow-up message to this interaction.
    * @param {string|APIMessage|MessageAdditions} content The content for the reply
    * @param {InteractionReplyOptions} [options] Additional options for the reply
    * @returns {Promise<Message|Object>}
    */
-  async followup(content, options) {
+  async followUp(content, options) {
     const apiMessage = content instanceof APIMessage ? content : APIMessage.create(this, content, options);
     const { data, files } = await apiMessage.resolveData().resolveFiles();
 

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -191,16 +191,18 @@ class CommandInteraction extends Interaction {
    * Send a followup message to this interaction.
    * @param {string|APIMessage|MessageAdditions} content The content for the reply
    * @param {InteractionReplyOptions} [options] Additional options for the reply
-   * @returns {Promise<void>}
+   * @returns {Promise<Message|Object>}
    */
   async followup(content, options) {
     const apiMessage = content instanceof APIMessage ? content : APIMessage.create(this, content, options);
     const { data, files } = await apiMessage.resolveData().resolveFiles();
 
-    await this.client.api.webhooks(this.applicationID, this.token).post({
+    const raw = await this.client.api.webhooks(this.applicationID, this.token).post({
       data,
       files,
     });
+
+    return this.channel?.messages.add(raw) ?? raw;
   }
 
   /**

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -198,9 +198,7 @@ class CommandInteraction extends Interaction {
     const { data, files } = await apiMessage.resolveData().resolveFiles();
 
     await this.client.api.webhooks(this.applicationID, this.token).post({
-      data: {
-        data,
-      },
+      data,
       files,
     });
   }

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -188,6 +188,24 @@ class CommandInteraction extends Interaction {
    */
 
   /**
+   * Send a followup message to this interaction.
+   * @param {string|APIMessage|MessageAdditions} content The content for the reply
+   * @param {InteractionReplyOptions} [options] Additional options for the reply
+   * @returns {Promise<void>}
+   */
+  async followup(content, options) {
+    const apiMessage = content instanceof APIMessage ? content : APIMessage.create(this, content, options);
+    const { data, files } = await apiMessage.resolveData().resolveFiles();
+
+    await this.client.api.webhooks(this.applicationID, this.token).post({
+      data: {
+        data,
+      },
+      files,
+    });
+  }
+
+  /**
    * Transforms an option received from the API.
    * @param {Object} option The received option
    * @param {Object} resolved The resolved interaction data

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -425,10 +425,10 @@ declare module 'discord.js' {
     ): Promise<Message | RawMessage>;
     public editReply(content: string, options?: WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
-    public followup(
+    public followUp(
       content: string | APIMessage | InteractionReplyOptions | MessageAdditions,
     ): Promise<Message | RawMessage>;
-    public followup(content: string, options?: InteractionReplyOptions): Promise<Message | RawMessage>;
+    public followUp(content: string, options?: InteractionReplyOptions): Promise<Message | RawMessage>;
     public reply(content: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
     public reply(content: string, options?: InteractionReplyOptions): Promise<void>;
     private transformOption(option: object, resolved: object): CommandInteractionOption;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -425,6 +425,8 @@ declare module 'discord.js' {
     ): Promise<Message | RawMessage>;
     public editReply(content: string, options?: WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
+    public followup(content: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
+    public followup(content: string, options?: InteractionReplyOptions): Promise<void>;
     public reply(content: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
     public reply(content: string, options?: InteractionReplyOptions): Promise<void>;
     private transformOption(option: object, resolved: object): CommandInteractionOption;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -425,8 +425,10 @@ declare module 'discord.js' {
     ): Promise<Message | RawMessage>;
     public editReply(content: string, options?: WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
-    public followup(content: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
-    public followup(content: string, options?: InteractionReplyOptions): Promise<void>;
+    public followup(
+      content: string | APIMessage | InteractionReplyOptions | MessageAdditions,
+    ): Promise<Message | RawMessage>;
+    public followup(content: string, options?: InteractionReplyOptions): Promise<Message | RawMessage>;
     public reply(content: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
     public reply(content: string, options?: InteractionReplyOptions): Promise<void>;
     private transformOption(option: object, resolved: object): CommandInteractionOption;


### PR DESCRIPTION
This adds a new method `CommandInteraction#followUp` for sending ephemeral followup messages (if the option is provided).

This would not be possible via `CommandInteraction#webhook#send` as regular Webhook messages cannot be ephemeral. The methods should otherwise be equivalent for non-ephemeral messages.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
