### PR TITLE
fix(ApplicationCommand): remove undefined values from transformOption

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -204,7 +204,7 @@ class ApplicationCommand extends Base {
    * @private
    */
   static transformOption(option, received) {
-    return {
+    const transformOption = {
       type: typeof option.type === 'number' && !received ? option.type : ApplicationCommandOptionTypes[option.type],
       name: option.name,
       description: option.description,
@@ -212,6 +212,12 @@ class ApplicationCommand extends Base {
       choices: option.choices,
       options: option.options?.map(o => this.transformOption(o)),
     };
+
+    for (const prop in transformOption) {
+      if (transformOption[prop] === undefined) delete transformOption[prop];
+    }
+
+    return transformOption;
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes undefined keys returned by `<ApplicationCommand>.transformOption`

This allows for comparisons against what Discord returns and what you have on disk for a command for example using `require('util').isDeepStrictEqual` so you can determine if a command has changed on disk since the last check

I also believe this makes more sense than having some properties explicitly set as undefined and belive it follows suit with the rest of the library


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
