### PR TITLE
fix(CommandInteraction): update typings and docs for #editReply

### DIFF
--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -146,7 +146,7 @@ class CommandInteraction extends Interaction {
   /**
    * Edits the initial reply to this interaction.
    * @see Webhook#editMessage
-   * @param {string|APIMessage|MessageEmbed|MessageEmbed[]} content The new content for the message
+   * @param {string|APIMessage|MessageAdditions} content The new content for the message
    * @param {WebhookEditMessageOptions} [options] The options to provide
    * @returns {Promise<Message|Object>}
    * @example

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -421,7 +421,7 @@ declare module 'discord.js' {
     public defer(ephemeral?: boolean): Promise<void>;
     public deleteReply(): Promise<void>;
     public editReply(
-      content: string | APIMessage | WebhookEditMessageOptions | MessageEmbed | MessageEmbed[],
+      content: string | APIMessage | WebhookEditMessageOptions | MessageAdditions,
     ): Promise<Message | RawMessage>;
     public editReply(content: string, options?: WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes: #5629
⚠️This PR is not a direct fix for that issue, see [this](https://github.com/discordjs/discord.js/issues/5629#issuecomment-841115233)

`CommandInteraction#editReply` can take `MessageAttachment` too. This PR updates the typings and docs for it.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
