### PR TITLE
docs: add new typedef to properly doc InteractionReplyOptions

### DIFF
--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -91,8 +91,9 @@ class CommandInteraction extends Interaction {
 
   /**
    * Options for a reply to an interaction.
-   * @typedef {WebhookMessageOptions} InteractionReplyOptions
+   * @typedef {BaseMessageOptions} InteractionReplyOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
+   * @property {MessageEmbed[]|Object[]} [embeds] An array of embeds for the message
    */
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -581,17 +581,9 @@ class Message extends Base {
 
   /**
    * Options provided when sending a message as an inline reply.
-   * @typedef {Object} ReplyMessageOptions
-   * @property {boolean} [tts=false] Whether or not the message should be spoken aloud
-   * @property {string} [nonce=''] The nonce for the message
-   * @property {string} [content=''] The content for the message
+   * @typedef {BaseMessageOptions} ReplyMessageOptions
    * @property {MessageEmbed|Object} [embed] An embed for the message
    * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
-   * @property {FileOptions[]|BufferResolvable[]} [files] Files to send with the message
-   * @property {string|boolean} [code] Language for optional codeblock formatting to apply
-   * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
-   * it exceeds the character limit. If an object is provided, these are the options for splitting the message
    * @property {boolean} [failIfNotExists=true] Whether to error if the referenced message
    * does not exist (creates a standard message in this case when false)
    */

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -88,19 +88,10 @@ class Webhook {
 
   /**
    * Options that can be passed into send.
-   * @typedef {Object} WebhookMessageOptions
+   * @typedef {BaseMessageOptions} WebhookMessageOptions
    * @property {string} [username=this.name] Username override for the message
    * @property {string} [avatarURL] Avatar URL override for the message
-   * @property {boolean} [tts=false] Whether or not the message should be spoken aloud
-   * @property {StringResolvable} [content] The content for the message
-   * @property {string} [nonce=''] The nonce for the message
    * @property {MessageEmbed[]|Object[]} [embeds] An array of embeds for the message
-   * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
-   * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details)
-   * @property {FileOptions[]|string[]} [files] Files to send with the message
-   * @property {string|boolean} [code] Language for optional codeblock formatting to apply
-   * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
-   * it exceeds the character limit. If an object is provided, these are the options for splitting the message.
    */
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -58,7 +58,7 @@ class TextBasedChannel {
    * @property {string} [content=''] The content for the message
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
-   * @property {FileOptions[]|BufferResolvable[]} [files] Files to send with the message
+   * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -51,18 +51,24 @@ class TextBasedChannel {
   }
 
   /**
-   * Options provided when sending or editing a message.
-   * @typedef {Object} MessageOptions
+   * Base options provided when sending.
+   * @typedef {Object} BaseMessageOptions
    * @property {boolean} [tts=false] Whether or not the message should be spoken aloud
    * @property {string} [nonce=''] The nonce for the message
    * @property {string} [content=''] The content for the message
-   * @property {MessageEmbed|Object} [embed] An embed for the message
-   * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details)
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
+   * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
    * @property {FileOptions[]|BufferResolvable[]} [files] Files to send with the message
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message
+   */
+
+  /**
+   * Options provided when sending or editing a message.
+   * @typedef {BaseMessageOptions} MessageOptions
+   * @property {MessageEmbed|Object} [embed] An embed for the message
+   * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details)
    * @property {ReplyOptions} [reply] The options for replying to a message
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

ℹ️ Preview: https://preview-5632.netlify.app

Currently, `InteractionReplyOptions` extends jsdoc of `WebhookMessageOptions` which results in a slightly wrong documentation as the latter one has some extra fields. The reason @vaporox gave for not making a new typedef from scratch for it was "code duplication". Which is correct because `MessageOptions`, `WebhookMessageOptions`, and `ReplyMessageOptions` all have a lot of common fields and these fields are documented for each of them.

This PR adds a new typedef `BaseMessageOptions` that contains fields that are common among the above typedefs. The above mentioned typedefs now extend this new typedef, making documention correct while keeping the code duplication at minimum.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
