### PR TITLE
Session restoring during boot/login

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -201,7 +201,7 @@ class Client extends BaseClient {
    * @param {string|string[]} [sessionID] ID(s) of previous session(s) to restory
    * @returns {Promise<string>} Token of the account used
    * @example
-   * client.login('my token');
+   * client.login('my token', 'aaaaaaaaaa');
    */
   async login(token = this.token, sessionID) {
     if (!token || typeof token !== 'string') throw new Error('TOKEN_INVALID');

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -201,7 +201,7 @@ class Client extends BaseClient {
    * @param {string|string[]} [sessionID] ID(s) of previous session(s) to restory
    * @returns {Promise<string>} Token of the account used
    * @example
-   * client.login('my token', 'aaaaaaaaaa');
+   * client.login('my token');
    */
   async login(token = this.token, sessionID) {
     if (!token || typeof token !== 'string') throw new Error('TOKEN_INVALID');

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -198,11 +198,12 @@ class Client extends BaseClient {
   /**
    * Logs the client in, establishing a websocket connection to Discord.
    * @param {string} [token=this.token] Token of the account to log in with
+   * @param {string|string[]} [sessionID] ID(s) of previous session(s) to restory
    * @returns {Promise<string>} Token of the account used
    * @example
    * client.login('my token');
    */
-  async login(token = this.token) {
+  async login(token = this.token, sessionID) {
     if (!token || typeof token !== 'string') throw new Error('TOKEN_INVALID');
     this.token = token = token.replace(/^(Bot|Bearer)\s*/i, '');
     this.emit(
@@ -220,7 +221,7 @@ class Client extends BaseClient {
     this.emit(Events.DEBUG, 'Preparing to connect to the gateway...');
 
     try {
-      await this.ws.connect();
+      await this.ws.connect(sessionID);
       return this.token;
     } catch (error) {
       this.destroy();

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -198,7 +198,7 @@ class Client extends BaseClient {
   /**
    * Logs the client in, establishing a websocket connection to Discord.
    * @param {string} [token=this.token] Token of the account to log in with
-   * @param {string|string[]} [sessionID] ID(s) of previous session(s) to restory
+   * @param {string|string[]} [sessionID] ID(s) of previous session(s) to restore
    * @returns {Promise<string>} Token of the account used
    * @example
    * client.login('my token');

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -127,9 +127,10 @@ class WebSocketManager extends EventEmitter {
 
   /**
    * Connects this manager to the gateway.
+   * @param {string|string[]} sessionID IDs of previous session(s) to restore
    * @private
    */
-  async connect() {
+  async connect(sessionID) {
     const invalidToken = new DJSError(WSCodes[4004]);
     const {
       url: gatewayURL,
@@ -161,9 +162,11 @@ class WebSocketManager extends EventEmitter {
       shards = this.client.options.shards = Array.from({ length: recommendedShards }, (_, i) => i);
     }
 
+    const sessionIDs = !sessionID ? [] : Array.isArray(sessionID) ? sessionID : [sessionID];
+
     this.totalShards = shards.length;
     this.debug(`Spawning shards: ${shards.join(', ')}`);
-    this.shardQueue = new Set(shards.map(id => new WebSocketShard(this, id)));
+    this.shardQueue = new Set(shards.map(id => new WebSocketShard(this, id, sessionIDs[id])));
 
     await this._handleSessionLimit(remaining, reset_after);
 

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -59,7 +59,7 @@ class WebSocketShard extends EventEmitter {
      * @type {?string}
      * @private
      */
-    this.sessionID = sessionIDs;
+    this.sessionID = sessionID ?? null;
 
     /**
      * The previous heartbeat ping of the shard

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -19,7 +19,7 @@ if (!browser) {
  * Represents a Shard's WebSocket connection
  */
 class WebSocketShard extends EventEmitter {
-  constructor(manager, id, sessionIDs) {
+  constructor(manager, id, sessionID) {
     super();
 
     /**

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -19,7 +19,7 @@ if (!browser) {
  * Represents a Shard's WebSocket connection
  */
 class WebSocketShard extends EventEmitter {
-  constructor(manager, id) {
+  constructor(manager, id, sessionIDs) {
     super();
 
     /**
@@ -59,7 +59,7 @@ class WebSocketShard extends EventEmitter {
      * @type {?string}
      * @private
      */
-    this.sessionID = null;
+    this.sessionID = sessionIDs;
 
     /**
      * The previous heartbeat ping of the shard

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -218,7 +218,7 @@ declare module 'discord.js' {
     public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
     public fetchWebhook(id: Snowflake, token?: string): Promise<Webhook>;
     public generateInvite(options?: InviteGenerationOptions | PermissionResolvable): Promise<string>;
-    public login(token?: string): Promise<string>;
+    public login(token?: string, sessionID?: string|string[]): Promise<string>;
     public sweepMessages(lifetime?: number): number;
     public toJSON(): object;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds parameter `sessionID` to `Client.login` allowing Discord.js to restore previous session(s).

Snippets showing my use of this feature (supports one shard, but the PR itself should be able to handle multiple):
```typescript
client.once("ready", () => {
  fs.writeFileSync("cache/sessionID", client.ws.shards.get(0)["sessionID"]);
});

let sessionID: string;
if (fs.existsSync("cache/sessionID",)) {
  sessionID = fs.readFileSync("cache/sessionID").toString();
}
client.login(process.env.DISCORD_TOKEN, sessionID);
```
This feature is really useful mainly during development, when you're restarting the bot often, or most probably if you have for example nodemon restart the bot for you, you might eventually hit the IDENTIFY rate limit, this doesn't happen with session restoring.
Passing invalid/expired sessionID(s) slows down the boot, partially because d.js waits for 5 seconds before creating new session, but passing `null` or not passing `sessionID` parameter at all has no impact on logging-in.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
