### PR TITLE
docs: correct casing of `object` -> `Object` in AuditLogChange

### DIFF
--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -329,7 +329,7 @@ class GuildAuditLogsEntry {
 
     /**
      * An entry in the audit log representing a specific change.
-     * @typedef {object} AuditLogChange
+     * @typedef {Object} AuditLogChange
      * @property {string} key The property that was changed, e.g. `nick` for nickname changes
      * @property {*} [old] The old value of the change, e.g. for nicknames, the old nickname
      * @property {*} [new] The new value of the change, e.g. for nicknames, the new nickname


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Small bugfix for docs

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
