### PR TITLE
feat(Message): message reaction listener

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -407,6 +407,36 @@ class Message extends Base {
     });
   }
 
+  /** Listens to individual user reactions. In contrast to one-time callback by awaitReactions,
+   *  this provides a callback fired every time a new reaction is added to a message.
+   * 
+   *  @param {Function} callback
+   *  @example
+   *  // Attaches a reaction listener to a message
+   *  message.catchReactions((reaction, user)=>{
+   *    console.log(`${user.tag} reacted ${reaction.emoji.name}`);
+   *  });
+   */
+  catchReactions(callback) {
+
+    /** Since the filter is called twice for every reaction,
+    * a counter will be used to disregard odd indexes
+    * which represent a duplicate from the preceding even index
+    */
+    let index = 0;
+
+    // This utilizes awaitReactions and simplifies it into a single callback
+    this.awaitReactions(
+      // awaitReaction's filter function is called every time a reaction
+      // is checked for collection. This will be attached to the callback.
+      (reaction, user)=>{
+        if(index%2==0) callback(reaction, user);
+        index++;
+
+        return true;
+    }, {max: Infinity});
+  }
+
   /**
    * Whether the message is editable by the client user
    * @type {boolean}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1149,6 +1149,9 @@ declare module 'discord.js' {
       filter: CollectorFilter<[MessageReaction, User]>,
       options?: AwaitReactionsOptions,
     ): Promise<Collection<Snowflake, MessageReaction>>;
+    public catchReactions(
+      filter: MessageReactionsCallback<[MessageReaction, User]>
+    ): void;
     public createReactionCollector(
       filter: CollectorFilter<[MessageReaction, User]>,
       options?: ReactionCollectorOptions,
@@ -2682,6 +2685,7 @@ declare module 'discord.js' {
   }
 
   type CollectorFilter<T extends any[]> = (...args: T) => boolean | Promise<boolean>;
+  type MessageReactionsCallback<T extends any[]> = (...args: T) => any | Promise<any>;
 
   interface CollectorOptions {
     time?: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This adds `Message#catchReactions` method to listen to individual message reactions. Compared to `Message#awaitReactions`, this only needs one callback function (with similar parameters as the `filter` param) as argument, which is fired *every time* a reaction is added to the message.


**Status and versioning classification:**
* Code changes have been tested against the Discord API, or there are no code changes
* I know how to update typings and have done so
* This PR changes the library's interface (methods or parameters added)
