### PR TITLE
cleanup(Client): guard emitting GMU and PU on user updates

### DIFF
--- a/src/client/actions/GuildMemberUpdate.js
+++ b/src/client/actions/GuildMemberUpdate.js
@@ -27,7 +27,7 @@ class GuildMemberUpdateAction extends Action {
          * @param {GuildMember} oldMember The member before the update
          * @param {GuildMember} newMember The member after the update
          */
-        if (shard.status === Status.READY) client.emit(Events.GUILD_MEMBER_UPDATE, old, member);
+        if (shard.status === Status.READY && !member.equals(old)) client.emit(Events.GUILD_MEMBER_UPDATE, old, member);
       } else {
         const newMember = guild.members.add(data);
         /**

--- a/src/client/actions/PresenceUpdate.js
+++ b/src/client/actions/PresenceUpdate.js
@@ -28,7 +28,7 @@ class PresenceUpdateAction extends Action {
       this.client.emit(Events.GUILD_MEMBER_AVAILABLE, member);
     }
     guild.presences.add(Object.assign(data, { guild }));
-    if (member && this.client.listenerCount(Events.PRESENCE_UPDATE)) {
+    if (member && this.client.listenerCount(Events.PRESENCE_UPDATE) && !member.presence.equals(oldPresence)) {
       /**
        * Emitted whenever a guild member's presence (e.g. status, activity) is changed.
        * @event Client#presenceUpdate

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -347,6 +347,29 @@ class GuildMember extends Base {
   }
 
   /**
+   * Whether this guild member equals another guild member. It compares all properties, so for most
+   * comparison it is advisable to just compare `member.id === member2.id` as it is significantly faster
+   * and is often what most users need.
+   * @param {GuildMember} member The member to compare with
+   * @returns {boolean}
+   */
+  equals(member) {
+    return (
+      member instanceof this.constructor &&
+      this.id === member.id &&
+      this.partial === member.partial &&
+      this.guild.id === member.guild.id &&
+      this.joinedTimestamp === member.joinedTimestamp &&
+      this.lastMessageID === member.lastMessageID &&
+      this.lastMessageChannelID === member.lastMessageChannelID &&
+      this.nickname === member.nickname &&
+      this.pending === member.pending &&
+      (this._roles === member._roles ||
+        (this._roles.length === member._roles.length && this._roles.every((role, i) => role === member._roles[i])))
+    );
+  }
+
+  /**
    * When concatenated with a string, this automatically returns the user's mention instead of the GuildMember object.
    * @returns {string}
    * @example


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Attempt 2!

This is the continuation of #5161 in hopefully a much more accepted fashion.

GMU and PU are currently emitted regardless of the content of the update. Discord also send these events when the underlying user is updated. Since the library abstracts this away into `userUpdate` many PU and GMU events would contain the same exact data in both the old and new objects of their respective events. This simply guards against emitting the event when the objects are identical.

To note: GMU and PU are emitted by discord once for **every** guild the bot shares with a user normally, with this change, you will only get **1** `userUpdate` event, not 1 per guild.

I have not made any docs changes other than documenting `GuildMember#equals()` because the current docs still feel accurate. Feel free to suggest changes if you disagree!

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
