### PR TITLE
feat(Rest): optional ratelimit errors

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -493,10 +493,10 @@ class Client extends BaseClient {
       throw new TypeError('CLIENT_INVALID_OPTION', 'retryLimit', 'a number');
     }
     if (
-      typeof options.disableRateLimitQueue !== 'undefined' &&
-      !(typeof options.disableRateLimitQueue === 'function' || Array.isArray(options.disableRateLimitQueue))
+      typeof options.rejectOnRateLimit !== 'undefined' &&
+      !(typeof options.rejectOnRateLimit === 'function' || Array.isArray(options.rejectOnRateLimit))
     ) {
-      throw new TypeError('CLIENT_INVALID_OPTION', 'disableRateLimitQueue', 'an array or a function');
+      throw new TypeError('CLIENT_INVALID_OPTION', 'rejectOnRateLimit', 'an array or a function');
     }
   }
 }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -492,6 +492,12 @@ class Client extends BaseClient {
     if (typeof options.retryLimit !== 'number' || isNaN(options.retryLimit)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'retryLimit', 'a number');
     }
+    if (
+      typeof options.disableRateLimitQueue !== 'undefined' &&
+      !(typeof options.disableRateLimitQueue === 'function' || Array.isArray(options.disableRateLimitQueue))
+    ) {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'disableRateLimitQueue', 'an array or a function');
+    }
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ module.exports = {
   BaseManager: require('./managers/BaseManager'),
   DiscordAPIError: require('./rest/DiscordAPIError'),
   HTTPError: require('./rest/HTTPError'),
+  RateLimitError: require('./rest/RateLimitError'),
   MessageFlags: require('./util/MessageFlags'),
   Intents: require('./util/Intents'),
   Permissions: require('./util/Permissions'),

--- a/src/rest/RateLimitError.js
+++ b/src/rest/RateLimitError.js
@@ -34,6 +34,7 @@ class RateLimitError extends Error {
 
     /**
      * The route of the request relative to the HTTP endpoint
+     * @type {string}
      */
     this.route = route;
 

--- a/src/rest/RateLimitError.js
+++ b/src/rest/RateLimitError.js
@@ -15,7 +15,7 @@ class RateLimitError extends Error {
     this.name = 'RateLimitError';
 
     /**
-     * HTTP error code returned from the request
+     * Time until this rate limit ends, in ms
      * @type {number}
      */
     this.timeout = timeout;
@@ -45,7 +45,7 @@ class RateLimitError extends Error {
     this.global = global;
 
     /**
-     * The rate limit of this endpoint
+     * The maximum amount of requests of this end point
      * @type {number}
      */
     this.limit = limit;

--- a/src/rest/RateLimitError.js
+++ b/src/rest/RateLimitError.js
@@ -1,0 +1,54 @@
+'use strict';
+
+/**
+ * Represents a RateLimit error from a request.
+ * @extends Error
+ */
+class RateLimitError extends Error {
+  constructor({ timeout, limit, method, path, route, global }) {
+    super(`A ${global ? 'global ' : ''}rate limit was hit on route ${route}`);
+
+    /**
+     * The name of the error
+     * @type {string}
+     */
+    this.name = 'RateLimitError';
+
+    /**
+     * HTTP error code returned from the request
+     * @type {number}
+     */
+    this.timeout = timeout;
+
+    /**
+     * The HTTP method used for the request
+     * @type {string}
+     */
+    this.method = method;
+
+    /**
+     * The path of the request relative to the HTTP endpoint
+     * @type {string}
+     */
+    this.path = path;
+
+    /**
+     * The route of the request relative to the HTTP endpoint
+     */
+    this.route = route;
+
+    /**
+     * Whether this rate limit is global
+     * @type {boolean}
+     */
+    this.global = global;
+
+    /**
+     * The rate limit of this endpoint
+     * @type {number}
+     */
+    this.limit = limit;
+  }
+}
+
+module.exports = RateLimitError;

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -83,22 +83,22 @@ class RequestHandler {
    */
   async onRateLimit(request, limit, timeout, isGlobal) {
     const { options } = this.manager.client;
-    if (options.disableRateLimitQueue) {
-      const rateLimitData = {
-        timeout,
-        limit,
-        method: request.method,
-        path: request.path,
-        route: request.route,
-        global: isGlobal,
-      };
-      const shouldThrow =
-        typeof options.disableRateLimitQueue === 'function'
-          ? await options.disableRateLimitQueue(rateLimitData)
-          : options.disableRateLimitQueue.some(route => rateLimitData.route.startsWith(route.toLowerCase()));
-      if (shouldThrow) {
-        throw new RateLimitError(rateLimitData);
-      }
+    if (!options.rejectOnRateLimit) return;
+
+    const rateLimitData = {
+      timeout,
+      limit,
+      method: request.method,
+      path: request.path,
+      route: request.route,
+      global: isGlobal,
+    };
+    const shouldThrow =
+      typeof options.rejectOnRateLimit === 'function'
+        ? await options.rejectOnRateLimit(rateLimitData)
+        : options.rejectOnRateLimit.some(route => rateLimitData.route.startsWith(route.toLowerCase()));
+    if (shouldThrow) {
+      throw new RateLimitError(rateLimitData);
     }
   }
 

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -143,7 +143,7 @@ class RequestHandler {
         });
       }
 
-      // Determine whether RateLimitError should be thrown
+      // Determine whether a RateLimitError should be thrown
       await this.onRateLimit(request, limit, timeout, isGlobal); // eslint-disable-line no-await-in-loop
 
       if (isGlobal) {

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -143,9 +143,6 @@ class RequestHandler {
         });
       }
 
-      // Determine whether a RateLimitError should be thrown
-      await this.onRateLimit(request, limit, timeout, isGlobal); // eslint-disable-line no-await-in-loop
-
       if (isGlobal) {
         // If this is the first task to reach the global timeout, set the global delay
         if (!this.manager.globalDelay) {
@@ -156,6 +153,9 @@ class RequestHandler {
       } else {
         delayPromise = Util.delayFor(timeout);
       }
+
+      // Determine whether a RateLimitError should be thrown
+      await this.onRateLimit(request, limit, timeout, isGlobal); // eslint-disable-line no-await-in-loop
 
       // Wait for the timeout to expire in order to avoid an actual 429
       await delayPromise; // eslint-disable-line no-await-in-loop

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -255,7 +255,7 @@ class RequestHandler {
     if (res.status >= 400 && res.status < 500) {
       // Handle ratelimited requests
       if (res.status === 429) {
-        // A ratelimit was hit - this should only happen if client is already rate limited when connecting
+        // A ratelimit was hit - this should never happen
         this.manager.client.emit('debug', `429 hit on route ${request.route}${sublimitTimeout ? ' for sublimit' : ''}`);
 
         const isGlobal = this.globalLimited;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -52,9 +52,10 @@ const { Error, RangeError } = require('../errors');
  * (or 0 for never)
  * @property {number} [restGlobalRateLimit=0] How many requests to allow sending per second (0 for unlimited, 50 for
  * the standard global limit used by Discord)
- * @property {string[]|RateLimitQueueFilter} [disableRateLimitQueue] Decides how rate limits (429) should be handled.
- * If this option is an array containing the route of the request or a function returning true, a {@link RateLimitError}
- *  will be thrown. Otherwise the request will be queued for later
+ * @property {string[]|RateLimitQueueFilter} [disableRateLimitQueue] Decides how rate limits and pre-emptive throttles
+ * should be handled. If this option is an array containing the prefix of the request route (e.g. /channels to match any
+ * route starting with /channels, such as /channels/222197033908436994/messages) or a function returning true, a
+ * {@link RateLimitError} will be thrown. Otherwise the request will be queued for later
  * @property {number} [retryLimit=1] How many times to retry on 5XX errors (Infinity for indefinite amount of retries)
  * @property {PresenceData} [presence={}] Presence data to use upon login
  * @property {IntentsResolvable} intents Intents to enable for this connection

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -4,6 +4,24 @@ const Package = (exports.Package = require('../../package.json'));
 const { Error, RangeError } = require('../errors');
 
 /**
+ * Rate limit data
+ * @typedef {Object} RateLimitData
+ * @property {number} timeout Time until this rate limit ends, in ms
+ * @property {number} limit The maximum amount of requests of this end point
+ * @property {string} method The http method of this request
+ * @property {string} path The path of the request relative to the HTTP endpoint
+ * @property {string} route The route of the request relative to the HTTP endpoint
+ * @property {boolean} global Whether this is a global rate limit
+ */
+
+/**
+ * Whether this rate limit should throw an Error
+ * @typedef {Function} RateLimitQueueFilter
+ * @param {RateLimitData} rateLimitData The data of this rate limit
+ * @returns {boolean|Promise<boolean>}
+ */
+
+/**
  * Options for a client.
  * @typedef {Object} ClientOptions
  * @property {number|number[]|string} [shards] ID of the shard to run, or an array of shard IDs. If not specified,
@@ -34,6 +52,9 @@ const { Error, RangeError } = require('../errors');
  * (or 0 for never)
  * @property {number} [restGlobalRateLimit=0] How many requests to allow sending per second (0 for unlimited, 50 for
  * the standard global limit used by Discord)
+ * @property {string[]|RateLimitQueueFilter} [disableRateLimitQueue] Decides how rate limits (429) should be handled.
+ * If this option is an array containing the route of the request or a function returning true, a {@link RateLimitError}
+ *  will be thrown. Otherwise the request will be queued for later
  * @property {number} [retryLimit=1] How many times to retry on 5XX errors (Infinity for indefinite amount of retries)
  * @property {PresenceData} [presence={}] Presence data to use upon login
  * @property {IntentsResolvable} intents Intents to enable for this connection

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -7,7 +7,7 @@ const { Error, RangeError } = require('../errors');
  * Rate limit data
  * @typedef {Object} RateLimitData
  * @property {number} timeout Time until this rate limit ends, in ms
- * @property {number} limit The maximum amount of requests of this end point
+ * @property {number} limit The maximum amount of requests of this endpoint
  * @property {string} method The http method of this request
  * @property {string} path The path of the request relative to the HTTP endpoint
  * @property {string} route The route of the request relative to the HTTP endpoint

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -52,7 +52,7 @@ const { Error, RangeError } = require('../errors');
  * (or 0 for never)
  * @property {number} [restGlobalRateLimit=0] How many requests to allow sending per second (0 for unlimited, 50 for
  * the standard global limit used by Discord)
- * @property {string[]|RateLimitQueueFilter} [disableRateLimitQueue] Decides how rate limits and pre-emptive throttles
+ * @property {string[]|RateLimitQueueFilter} [rejectOnRateLimit] Decides how rate limits and pre-emptive throttles
  * should be handled. If this option is an array containing the prefix of the request route (e.g. /channels to match any
  * route starting with /channels, such as /channels/222197033908436994/messages) or a function returning true, a
  * {@link RateLimitError} will be thrown. Otherwise the request will be queued for later

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2664,7 +2664,7 @@ declare module 'discord.js' {
     intents: BitFieldResolvable<IntentsString, number>;
     ws?: WebSocketOptions;
     http?: HTTPOptions;
-    disableRateLimitQueue?: string[] | ((data: RateLimitData) => boolean | Promise<boolean>);
+    rejectOnRateLimit?: string[] | ((data: RateLimitData) => boolean | Promise<boolean>);
   }
 
   type ClientPresenceStatus = 'online' | 'idle' | 'dnd';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1020,6 +1020,13 @@ declare module 'discord.js' {
     public path: string;
   }
 
+  // tslint:disable-next-line:no-empty-interface - Merge RateLimitData into RateLimitError to not have to type it again
+  interface RateLimitError extends RateLimitData {}
+  export class RateLimitError extends Error {
+    constructor(data: RateLimitData);
+    public name: 'RateLimitError';
+  }
+
   export class Integration extends Base {
     constructor(client: Client, data: object, guild: Guild);
     public account: IntegrationAccount;
@@ -2657,7 +2664,7 @@ declare module 'discord.js' {
     intents: BitFieldResolvable<IntentsString, number>;
     ws?: WebSocketOptions;
     http?: HTTPOptions;
-    disableRateLimitQueue?: string[] | ((data: RateLimitData) => boolean);
+    disableRateLimitQueue?: string[] | ((data: RateLimitData) => boolean | Promise<boolean>);
   }
 
   type ClientPresenceStatus = 'online' | 'idle' | 'dnd';
@@ -3486,13 +3493,6 @@ declare module 'discord.js' {
     path: string;
     route: string;
     global: boolean;
-  }
-
-  // tslint:disable-next-line:no-empty-interface - Merge RateLimitData interface to not have to type it again
-  interface RateLimitError extends RateLimitData {}
-  export class RateLimitError extends Error {
-    constructor(data: RateLimitData);
-    public name: 'RateLimitError';
   }
 
   interface InvalidRequestWarningData {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2657,7 +2657,7 @@ declare module 'discord.js' {
     intents: BitFieldResolvable<IntentsString, number>;
     ws?: WebSocketOptions;
     http?: HTTPOptions;
-    disableRateLimitQueue: string[] | ((data: RateLimitData) => boolean);
+    disableRateLimitQueue?: string[] | ((data: RateLimitData) => boolean);
   }
 
   type ClientPresenceStatus = 'online' | 'idle' | 'dnd';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3488,8 +3488,8 @@ declare module 'discord.js' {
     global: boolean;
   }
 
+  // tslint:disable-next-line:no-empty-interface - Merge RateLimitData interface to not have to type it again
   interface RateLimitError extends RateLimitData {}
-
   export class RateLimitError extends Error {
     constructor(data: RateLimitData);
     public name: 'RateLimitError';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -461,9 +461,7 @@ declare module 'discord.js' {
     Endpoints: {
       botGateway: string;
       invite: (root: string, code: string) => string;
-      CDN: (
-        root: string,
-      ) => {
+      CDN: (root: string) => {
         Asset: (name: string) => string;
         DefaultAvatar: (id: string | number) => string;
         Emoji: (emojiID: string, format: 'png' | 'gif') => string;
@@ -2659,6 +2657,7 @@ declare module 'discord.js' {
     intents: BitFieldResolvable<IntentsString, number>;
     ws?: WebSocketOptions;
     http?: HTTPOptions;
+    disableRateLimitQueue: string[] | ((data: RateLimitData) => boolean);
   }
 
   type ClientPresenceStatus = 'online' | 'idle' | 'dnd';
@@ -3487,6 +3486,13 @@ declare module 'discord.js' {
     path: string;
     route: string;
     global: boolean;
+  }
+
+  interface RateLimitError extends RateLimitData {}
+
+  export class RateLimitError extends Error {
+    constructor(data: RateLimitData);
+    public name: 'RateLimitError';
   }
 
   interface InvalidRequestWarningData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds new client option disableRateLimitQueue which takes either an array of routes or `(ratelimitData) => boolean`.
If a rate limit is hit, the RequestHandler first checks whether this rate limit should be thrown (route starts with one of the array values / function returns true) and if so throws an error instead of queueing the request

This closes https://github.com/discordjs/discord.js/issues/5449

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:



- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
