### PR TITLE
chore: set minimum npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "typescript": "^4.2.4"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.0.0",
+    "npm": ">=7.0.0"
   },
   "commitlint": {
     "extends": [


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The project is now using lockfile v2, which is designed for use with npm 7.x and above.

The project documentation currently points to Node 14 being the minimum version, and while this is true for use of the package, Node 14 ships with npm 6 which is not meant for lockfile v2 and so this may cause issues with folks developing on the library itself.

This PR sets the minimum npm version to 7.0.0 to ensure that lockfile v2 is supported.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.