### PR TITLE
fix(GuildEmojiRoleManager): bug in #remove

### DIFF
--- a/src/managers/GuildEmojiRoleManager.js
+++ b/src/managers/GuildEmojiRoleManager.js
@@ -74,16 +74,16 @@ class GuildEmojiRoleManager {
   remove(roleOrRoles) {
     if (!Array.isArray(roleOrRoles) && !(roleOrRoles instanceof Collection)) roleOrRoles = [roleOrRoles];
 
-    const resolvedRoles = [];
+    const resolvedRoleIDs = [];
     for (const role of roleOrRoles.values()) {
-      const resolvedRole = this.guild.roles.resolveID(role);
-      if (!resolvedRole) {
+      const roleID = this.guild.roles.resolveID(role);
+      if (!roleID) {
         return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
       }
-      resolvedRoles.push(resolvedRole);
+      resolvedRoleIDs.push(roleID);
     }
 
-    const newRoles = this._roles.keyArray().filter(role => !resolvedRoles.includes(role.id));
+    const newRoles = this._roles.keyArray().filter(id => !resolvedRoleIDs.includes(id));
     return this.set(newRoles);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a bug in `GuildEmojiRoleManager#remove`, where it wasn't removing role(s) from the emoji. This bug was a result of an [oversight](https://github.com/ckohen/discord.js/blob/217ea9d162762fa18f4d225c7e99131b0eeaef24/src/managers/GuildEmojiRoleManager.js#L86) in #5314. Since, `#keyArray` is being used there on `this._roles` collection, the `role` is already an ID, doing `role.id` returns `undefined` which results in `newRoles` containing IDs of the roles the emoji already has. This means no filtration happened and Discord got role IDs that were already on the emoji. Therefore, the role a user wants to remove from the emoji doesn't get removed.

ℹ️: Even tho the fix could be done by just changing `role.id` to `role`, I did some refactoring by renaming some identifiers in the `#remove` method so that oversight like this doesn't happen again. I noticed that some other methods also need this refactorization in `GuildEmojiRoleManager` file. I didn't do it in order to keep the initial review of the PR easy. Let me know If I should do it or not in this PR.

**Status and versioning classification:**
- Code changes have been tested against the Discord API
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
