### PR TITLE
docs(ColorResolvable): Add Fuchsia to ColorResolvable typedef

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -379,11 +379,11 @@ class Util {
    * - `YELLOW`
    * - `PURPLE`
    * - `LUMINOUS_VIVID_PINK`
+   * - `FUCHSIA`
    * - `GOLD`
    * - `ORANGE`
    * - `RED`
    * - `GREY`
-   * - `DARKER_GREY`
    * - `NAVY`
    * - `DARK_AQUA`
    * - `DARK_GREEN`
@@ -394,6 +394,7 @@ class Util {
    * - `DARK_ORANGE`
    * - `DARK_RED`
    * - `DARK_GREY`
+   * - `DARKER_GREY`
    * - `LIGHT_GREY`
    * - `DARK_NAVY`
    * - `BLURPLE`


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the new Discord color FUCHSIA to the ColorResolvable typedef in the docs as this was missed in #5624. I also moved DARKER_GREY to its place in the Colors export on Constants.js.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
