### PR TITLE
fix(ApplicationCommandOptionData): options property should be itself

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2471,7 +2471,7 @@ declare module 'discord.js' {
     description: string;
     required?: boolean;
     choices?: ApplicationCommandOptionChoice[];
-    options?: ApplicationCommandOption[];
+    options?: ApplicationCommandOptionData[];
   }
 
   interface ApplicationCommandOption extends ApplicationCommandOptionData {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2471,7 +2471,7 @@ declare module 'discord.js' {
     description: string;
     required?: boolean;
     choices?: ApplicationCommandOptionChoice[];
-    options?: ApplicationCommandOptionData[];
+    options?: this[];
   }
 
   interface ApplicationCommandOption extends ApplicationCommandOptionData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`ApplicationCommandOptionData`'s `options` property should be `ApplicationCommandOptionData` itself to allow the usage of the `ApplicationCommandOptionTypes` enum.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
