### PR TITLE
fix(GuildMemberManager): allow moving members to any non-text channel

### DIFF
--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -2,6 +2,7 @@
 
 const BaseManager = require('./BaseManager');
 const { Error, TypeError, RangeError } = require('../errors');
+const BaseGuildVoiceChannel = require('../structures/BaseGuildVoiceChannel');
 const GuildMember = require('../structures/GuildMember');
 const Role = require('../structures/Role');
 const Collection = require('../util/Collection');
@@ -166,7 +167,7 @@ class GuildMemberManager extends BaseManager {
     const _data = { ...data };
     if (_data.channel) {
       _data.channel = this.guild.channels.resolve(_data.channel);
-      if (!_data.channel || _data.channel.type !== 'voice') {
+      if (!(_data.channel instanceof BaseGuildVoiceChannel)) {
         throw new Error('GUILD_VOICE_CHANNEL_RESOLVE');
       }
       _data.channel_id = _data.channel.id;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This will allow moving members to channels with type `stage`. Closes #5673 🙂 


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
