### PR TITLE
refactor(DJSError): remove redundant check for captureStackTrace

### DIFF
--- a/src/errors/DJSError.js
+++ b/src/errors/DJSError.js
@@ -15,7 +15,7 @@ function makeDiscordjsError(Base) {
     constructor(key, ...args) {
       super(message(key, args));
       this[kCode] = key;
-      if (Error.captureStackTrace) Error.captureStackTrace(this, DiscordjsError);
+      Error.captureStackTrace(this, DiscordjsError);
     }
 
     get name() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since, webpack isn't supported anymore, the check for `Error.captureStackTrace` is redundant. This PR removes it.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
