### PR TITLE
fix(CommandInteraction): channel type should be text based channels

### DIFF
--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -16,6 +16,13 @@ class CommandInteraction extends Interaction {
     super(client, data);
 
     /**
+     * The channel this interaction was sent in
+     * @type {?TextChannel|NewsChannel|DMChannel}
+     * @name CommandInteraction#channel
+     * @readonly
+     */
+
+    /**
      * The ID of the invoked application command
      * @type {Snowflake}
      */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -419,6 +419,7 @@ declare module 'discord.js' {
 
   export class CommandInteraction extends Interaction {
     public readonly command: ApplicationCommand | null;
+    public channel: TextChannel;
     public commandID: string;
     public commandName: string;
     public deferred: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -419,7 +419,7 @@ declare module 'discord.js' {
 
   export class CommandInteraction extends Interaction {
     public readonly command: ApplicationCommand | null;
-    public channel: TextChannel;
+    public channel: TextChannel | DMChannel | NewsChannel;
     public commandID: string;
     public commandName: string;
     public deferred: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR change the Channel type from `CommandInteraction` to `TextChannel`, `DMChannel`, and `NewsChannel` because Slash Commands can't be used in another channel type than text

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

