### PR TITLE
feat(MessageSelectMenu): droppybois

### DIFF
--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -21,6 +21,9 @@ class InteractionCreateAction extends Action {
           case MessageComponentTypes.BUTTON:
             InteractionType = Structures.get('ButtonInteraction');
             break;
+          case MessageComponentTypes.SELECT_MENU:
+            InteractionType = Structures.get('SelectMenuInteraction');
+            break;
           default:
             client.emit(
               Events.DEBUG,

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -50,6 +50,12 @@ const Messages = {
   BUTTON_URL: 'MessageButton url must be a string',
   BUTTON_CUSTOM_ID: 'MessageButton customID must be a string',
 
+  SELECT_MENU_CUSTOM_ID: 'MessageSelectMenu customID must be a string',
+  SELECT_MENU_PLACEHOLDER: 'MessageSelectMenu placeholder must be a string',
+  SELECT_OPTION_LABEL: 'MessageSelectOption label must be a string',
+  SELECT_OPTION_VALUE: 'MessageSelectOption value must be a string',
+  SELECT_OPTION_DESCRIPTION: 'MessageSelectOption description must be a string',
+
   INTERACTION_COLLECTOR_ERROR: reason => `Collector received no interactions before ending with reason: ${reason}`,
 
   FILE_NOT_FOUND: file => `File could not be found: ${file}`,

--- a/src/index.js
+++ b/src/index.js
@@ -97,6 +97,7 @@ module.exports = {
   MessageEmbed: require('./structures/MessageEmbed'),
   MessageMentions: require('./structures/MessageMentions'),
   MessageReaction: require('./structures/MessageReaction'),
+  MessageSelectMenu: require('./structures/MessageSelectMenu'),
   NewsChannel: require('./structures/NewsChannel'),
   OAuth2Guild: require('./structures/OAuth2Guild'),
   PermissionOverwrites: require('./structures/PermissionOverwrites'),

--- a/src/index.js
+++ b/src/index.js
@@ -107,6 +107,7 @@ module.exports = {
   ReactionEmoji: require('./structures/ReactionEmoji'),
   RichPresenceAssets: require('./structures/Presence').RichPresenceAssets,
   Role: require('./structures/Role'),
+  SelectMenuInteraction: require('./structures/SelectMenuInteraction'),
   Sticker: require('./structures/Sticker'),
   StoreChannel: require('./structures/StoreChannel'),
   StageChannel: require('./structures/StageChannel'),

--- a/src/structures/BaseMessageComponent.js
+++ b/src/structures/BaseMessageComponent.js
@@ -18,6 +18,7 @@ class BaseMessageComponent {
    * Data that can be resolved into options for a MessageComponent. This can be:
    * * MessageActionRowOptions
    * * MessageButtonOptions
+   * * MessageSelectMenuOptions
    * @typedef {MessageActionRowOptions|MessageButtonOptions|MessageSelectMenuOptions} MessageComponentOptions
    */
 
@@ -25,7 +26,8 @@ class BaseMessageComponent {
    * Components that can be sent in a message. This can be:
    * * MessageActionRow
    * * MessageButton
-   * @typedef {MessageActionRow|MessageButton} MessageComponent
+   * * MessageSelectMenu
+   * @typedef {MessageActionRow|MessageButton|MessageSelectMenu} MessageComponent
    */
 
   /**

--- a/src/structures/BaseMessageComponent.js
+++ b/src/structures/BaseMessageComponent.js
@@ -18,7 +18,7 @@ class BaseMessageComponent {
    * Data that can be resolved into options for a MessageComponent. This can be:
    * * MessageActionRowOptions
    * * MessageButtonOptions
-   * @typedef {MessageActionRowOptions|MessageButtonOptions} MessageComponentOptions
+   * @typedef {MessageActionRowOptions|MessageButtonOptions|MessageSelectMenuOptions} MessageComponentOptions
    */
 
   /**
@@ -70,6 +70,11 @@ class BaseMessageComponent {
       case MessageComponentTypes.BUTTON: {
         const MessageButton = require('./MessageButton');
         component = new MessageButton(data);
+        break;
+      }
+      case MessageComponentTypes.SELECT_MENU: {
+        const MessageSelectMenu = require('./MessageSelectMenu');
+        component = new MessageSelectMenu(data);
         break;
       }
       default:

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Base = require('./Base');
-const { InteractionTypes } = require('../util/Constants');
+const { InteractionTypes, MessageComponentTypes } = require('../util/Constants');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
 
 /**
@@ -126,7 +126,10 @@ class Interaction extends Base {
    * @returns {boolean}
    */
   isButton() {
-    return InteractionTypes[this.type] === InteractionTypes.MESSAGE_COMPONENT && this.componentType === 'BUTTON';
+    return (
+      InteractionTypes[this.type] === InteractionTypes.MESSAGE_COMPONENT &&
+      MessageComponentTypes[this.componentType] === MessageComponentTypes.BUTTON
+    );
   }
 
   /**
@@ -134,7 +137,10 @@ class Interaction extends Base {
    * @returns {boolean}
    */
   isSelectMenu() {
-    return InteractionTypes[this.type] === InteractionTypes.MESSAGE_COMPONENT && this.componentType === 'SELECT_MENU';
+    return (
+      InteractionTypes[this.type] === InteractionTypes.MESSAGE_COMPONENT &&
+      MessageComponentTypes[this.componentType] === MessageComponentTypes.SELECT_MENU
+    );
   }
 }
 

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -114,7 +114,7 @@ class Interaction extends Base {
   }
 
   /**
-   * Indicates whether this interaction is a component interaction.
+   * Indicates whether this interaction is a message component interaction.
    * @returns {boolean}
    */
   isMessageComponent() {
@@ -127,6 +127,14 @@ class Interaction extends Base {
    */
   isButton() {
     return InteractionTypes[this.type] === InteractionTypes.MESSAGE_COMPONENT && this.componentType === 'BUTTON';
+  }
+
+  /**
+   * Indicates whether this interaction is a select menu interaction.
+   * @returns {boolean}
+   */
+  isSelectMenu() {
+    return InteractionTypes[this.type] === InteractionTypes.MESSAGE_COMPONENT && this.componentType === 'SELECT_MENU';
   }
 }
 

--- a/src/structures/MessageActionRow.js
+++ b/src/structures/MessageActionRow.js
@@ -63,7 +63,7 @@ class MessageActionRow extends BaseMessageComponent {
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of components to remove
    * @param {...MessageActionRowComponentResolvable[]} [components] The replacing components
-   * @returns {MessageSelectMenu}
+   * @returns {MessageActionRow}
    */
   spliceComponents(index, deleteCount, ...components) {
     this.components.splice(

--- a/src/structures/MessageActionRow.js
+++ b/src/structures/MessageActionRow.js
@@ -23,7 +23,7 @@ class MessageActionRow extends BaseMessageComponent {
    */
 
   /**
-   * Data that can be resolved into a components that can be placed in an action row
+   * Data that can be resolved into components that can be placed in an action row
    * * MessageActionRowComponent
    * * MessageActionRowComponentOptions
    * @typedef {MessageActionRowComponent|MessageActionRowComponentOptions} MessageActionRowComponentResolvable

--- a/src/structures/MessageActionRow.js
+++ b/src/structures/MessageActionRow.js
@@ -11,13 +11,13 @@ class MessageActionRow extends BaseMessageComponent {
   /**
    * Components that can be placed in an action row
    * * MessageButton
-   * @typedef {MessageButton} MessageActionRowComponent
+   * @typedef {MessageButton|MessageSelectMenu} MessageActionRowComponent
    */
 
   /**
    * Options for components that can be placed in an action row
    * * MessageButtonOptions
-   * @typedef {MessageButtonOptions} MessageActionRowComponentOptions
+   * @typedef {MessageButtonOptions|MessageSelectMenuOptions} MessageActionRowComponentOptions
    */
 
   /**

--- a/src/structures/MessageActionRow.js
+++ b/src/structures/MessageActionRow.js
@@ -11,12 +11,14 @@ class MessageActionRow extends BaseMessageComponent {
   /**
    * Components that can be placed in an action row
    * * MessageButton
+   * * MessageSelectMenu
    * @typedef {MessageButton|MessageSelectMenu} MessageActionRowComponent
    */
 
   /**
    * Options for components that can be placed in an action row
    * * MessageButtonOptions
+   * * MessageSelectMenuOptions
    * @typedef {MessageButtonOptions|MessageSelectMenuOptions} MessageActionRowComponentOptions
    */
 

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -55,6 +55,12 @@ class MessageComponentInteraction extends Interaction {
      * @type {InteractionWebhook}
      */
     this.webhook = new InteractionWebhook(this.client, this.applicationID, this.token);
+
+    /**
+     * The values selected in a MessageSelectMenu interaction
+     * @type {string[]}
+     */
+    this.values = this.componentType === 'SELECT_MENU' ? data.data.values : null;
   }
 
   /**

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -57,7 +57,7 @@ class MessageComponentInteraction extends Interaction {
     this.webhook = new InteractionWebhook(this.client, this.applicationID, this.token);
 
     /**
-     * The values selected in a MessageSelectMenu interaction
+     * The values selected, if the component which was interacted with was a select menu
      * @type {string[]}
      */
     this.values = this.componentType === 'SELECT_MENU' ? data.data.values : null;

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -55,12 +55,6 @@ class MessageComponentInteraction extends Interaction {
      * @type {InteractionWebhook}
      */
     this.webhook = new InteractionWebhook(this.client, this.applicationID, this.token);
-
-    /**
-     * The values selected, if the component which was interacted with was a select menu
-     * @type {string[]}
-     */
-    this.values = this.componentType === 'SELECT_MENU' ? data.data.values : null;
   }
 
   /**

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseMessageComponent = require('./BaseMessageComponent');
+const { MessageComponentTypes } = require('../util/Constants');
 const Util = require('../util/Util');
 
 class MessageSelectMenu extends BaseMessageComponent {
@@ -31,7 +32,7 @@ class MessageSelectMenu extends BaseMessageComponent {
     this.setup(data);
   }
 
-  super(data) {
+  setup(data) {
     /**
      * A unique string to be sent in the interaction when clicked
      * @type {?string}
@@ -84,7 +85,8 @@ class MessageSelectMenu extends BaseMessageComponent {
   }
 
   /**
-   * Sets the minimum number of selection required for this select menu
+   * Sets the minimum number of selections required for this select menu
+   * <info>This will default the maxValues to the number of options, unless manually set</info>
    * @param {number} minValues Number of selections to be required
    * @returns {MessageSelectMenu}
    */
@@ -143,8 +145,9 @@ class MessageSelectMenu extends BaseMessageComponent {
       custom_id: this.customID,
       placeholder: this.placeholder,
       min_values: this.minValues,
-      max_values: this.maxValues,
+      max_values: this.maxValues ?? this.minValues ? this.options.length : undefined,
       options: this.options,
+      type: typeof this.type === 'string' ? MessageComponentTypes[this.type] : this.type,
     };
   }
 

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -135,6 +135,20 @@ class MessageSelectMenu extends BaseMessageComponent {
   }
 
   /**
+   * Transforms this select menu to a plain object
+   * @returns {Object} The raw data of this select menu
+   */
+  toJSON() {
+    return {
+      custom_id: this.customID,
+      placeholder: this.placeholder,
+      min_values: this.minValues,
+      max_values: this.maxValues,
+      options: this.options,
+    };
+  }
+
+  /**
    * Normalizes option input and resolves strings.
    * @param {MessageSelectOption} option The select menu option to normalize
    * @returns {MessageSelectOption}

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseMessageComponent = require('./BaseMessageComponent');
+const Util = require('../util/Util');
 
 class MessageSelectMenu extends BaseMessageComponent {
   /**
@@ -60,6 +61,101 @@ class MessageSelectMenu extends BaseMessageComponent {
      * @type {MessageSelectOption[]}
      */
     this.options = data.options ?? [];
+  }
+
+  /**
+   * Sets the custom ID of this select menu
+   * @param {string} customID A unique string to be sent in the interaction when clicked
+   * @returns {MessageSelectMenu}
+   */
+  setCustomID(customID) {
+    this.customID = Util.resolveString(customID);
+    return this;
+  }
+
+  /**
+   * Sets the maximum number of selection allowed for this select menu
+   * @param {number} maxValues Number of selections to be allowed
+   * @returns {MessageSelectMenu}
+   */
+  setMaxValues(maxValues) {
+    this.maxValues = maxValues;
+    return this;
+  }
+
+  /**
+   * Sets the minimum number of selection required for this select menu
+   * @param {number} minValues Number of selections to be required
+   * @returns {MessageSelectMenu}
+   */
+  setMinValues(minValues) {
+    this.minValues = minValues;
+    return this;
+  }
+
+  /**
+   * Sets the placeholder of this select menu
+   * @param {string} placeholder Custom placeholder text to display when nothing is selected
+   * @returns {MessageSelectMenu}
+   */
+  setPlaceholder(placeholder) {
+    this.placeholder = Util.resolveString(placeholder);
+    return this;
+  }
+
+  /**
+   * Adds an option to the select menu (max 25)
+   * @param {MessageSelectOption} option The option to add
+   * @returns {MessageSelectMenu}
+   */
+  addOption(option) {
+    return this.addOptions({ ...option });
+  }
+
+  /**
+   * Adds options to the select menu (max 5).
+   * @param {...(MessageSelectOption[]|MessageSelectOption[])} options The options to add
+   * @returns {MessageSelectMenu}
+   */
+  addOptions(...options) {
+    this.options.push(...this.constructor.normalizeOptions(options));
+    return this;
+  }
+
+  /**
+   * Removes, replaces, and inserts options in the select menu (max 25).
+   * @param {number} index The index to start at
+   * @param {number} deleteCount The number of options to remove
+   * @param {...MessageSelectOption|MessageSelectOption[]} [options] The replacing option objects
+   * @returns {MessageSelectMenu}
+   */
+  spliceFields(index, deleteCount, ...options) {
+    this.fields.splice(index, deleteCount, ...this.constructor.normalizeOptions(...options));
+    return this;
+  }
+
+  /**
+   * Normalizes option input and resolves strings.
+   * @param {MessageSelectOption} option The select menu option to normalize
+   * @returns {MessageSelectOption}
+   */
+  static normalizeOption(option) {
+    let { label, value, description, emoji } = option;
+
+    label = Util.resolveString(label);
+    value = Util.resolveString(value);
+    description = typeof description !== 'undefined' ? Util.resolveString(description) : undefined;
+
+    return { label, value, description, emoji, default: option.default };
+  }
+
+  /**
+   * Normalizes option input and resolves strings.
+   * @param {...MessageSelectOption|MessageSelectOption[]} options The select menu options to normalize
+   * @returns {MessageSelectOption[]}
+   */
+  static normalizeOptions(...options) {
+    return options.flat(2).map(option => this.normalizeOption(option));
   }
 }
 

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const BaseMessageComponent = require('./BaseMessageComponent');
+
+class MessageSelectMenu extends BaseMessageComponent {
+  /**
+   * @typedef {BaseMessageComponentOptions} MessageSelectMenuOptions
+   * @property {?string} [customID] A unique string to be sent in the interaction when clicked
+   * @property {?string} [placeholder] Custom placeholder text to display when nothing is selected
+   * @property {?number} [minValues] The minimum number of selections required
+   * @property {?number} [maxValues] The maximum number of selections allowed
+   * @property {?MessageSelectOption[]} [options] Options for the select menu
+   */
+
+  /**
+   * @typedef {Object} MessageSelectOption
+   * @property {string} label The text to be displayed on this option
+   * @property {string} value The value to be sent for this option
+   * @property {?string} [description] Optional description to show for this option
+   * @property {?Emoji} [emoji] Emoji to display for this option
+   * @property {boolean} [default] Render this option as the default selection
+   */
+
+  /**
+   * @param {MessageSelectMenu|MessageSelectMenuOptions} [data={}] MessageSelectMenu to clone or raw data
+   */
+  constructor(data = {}) {
+    super({ type: 'SELECT_MENU' });
+
+    this.setup(data);
+  }
+
+  super(data) {
+    /**
+     * A unique string to be sent in the interaction when clicked
+     * @type {?string}
+     */
+    this.customID = data.custom_id ?? data.customID ?? null;
+
+    /**
+     * Custom placeholder text to display when nothing is selected
+     * @type {?string}
+     */
+    this.placeholder = data.placeholder ?? null;
+
+    /**
+     * The minimum number of selections required
+     * @type {?number}
+     */
+    this.minValues = data.min_values ?? data.minValues ?? null;
+
+    /**
+     * The maximum number of selections allowed
+     * @type {?number}
+     */
+    this.maxValues = data.max_values ?? data.maxValues ?? null;
+
+    /**
+     * Options for the select menu
+     * @type {MessageSelectOption[]}
+     */
+    this.options = data.options ?? [];
+  }
+}
+
+module.exports = MessageSelectMenu;

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -149,7 +149,7 @@ class MessageSelectMenu extends BaseMessageComponent {
       custom_id: this.customID,
       placeholder: this.placeholder,
       min_values: this.minValues,
-      max_values: this.maxValues ?? this.minValues ? this.options.length : undefined,
+      max_values: this.maxValues ?? (this.minValues ? this.options.length : undefined),
       options: this.options,
       type: typeof this.type === 'string' ? MessageComponentTypes[this.type] : this.type,
     };

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -4,22 +4,26 @@ const BaseMessageComponent = require('./BaseMessageComponent');
 const { MessageComponentTypes } = require('../util/Constants');
 const Util = require('../util/Util');
 
+/**
+ * Represents a SelectMenu message components
+ * @extends {BaseMessageComponent}
+ */
 class MessageSelectMenu extends BaseMessageComponent {
   /**
    * @typedef {BaseMessageComponentOptions} MessageSelectMenuOptions
-   * @property {?string} [customID] A unique string to be sent in the interaction when clicked
-   * @property {?string} [placeholder] Custom placeholder text to display when nothing is selected
-   * @property {?number} [minValues] The minimum number of selections required
-   * @property {?number} [maxValues] The maximum number of selections allowed
-   * @property {?MessageSelectOption[]} [options] Options for the select menu
+   * @property {string} [customID] A unique string to be sent in the interaction when clicked
+   * @property {string} [placeholder] Custom placeholder text to display when nothing is selected
+   * @property {number} [minValues] The minimum number of selections required
+   * @property {number} [maxValues] The maximum number of selections allowed
+   * @property {MessageSelectOption[]} [options] Options for the select menu
    */
 
   /**
    * @typedef {Object} MessageSelectOption
    * @property {string} label The text to be displayed on this option
    * @property {string} value The value to be sent for this option
-   * @property {?string} [description] Optional description to show for this option
-   * @property {?Emoji} [emoji] Emoji to display for this option
+   * @property {string} [description] Optional description to show for this option
+   * @property {Emoji} [emoji] Emoji to display for this option
    * @property {boolean} [default] Render this option as the default selection
    */
 
@@ -106,16 +110,7 @@ class MessageSelectMenu extends BaseMessageComponent {
   }
 
   /**
-   * Adds an option to the select menu (max 25)
-   * @param {MessageSelectOption} option The option to add
-   * @returns {MessageSelectMenu}
-   */
-  addOption(option) {
-    return this.addOptions({ ...option });
-  }
-
-  /**
-   * Adds options to the select menu (max 5).
+   * Adds options to the select menu.
    * @param {...(MessageSelectOption[]|MessageSelectOption[])} options The options to add
    * @returns {MessageSelectMenu}
    */
@@ -125,7 +120,7 @@ class MessageSelectMenu extends BaseMessageComponent {
   }
 
   /**
-   * Removes, replaces, and inserts options in the select menu (max 25).
+   * Removes, replaces, and inserts options in the select menu.
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of options to remove
    * @param {...MessageSelectOption|MessageSelectOption[]} [options] The replacing option objects
@@ -161,14 +156,14 @@ class MessageSelectMenu extends BaseMessageComponent {
 
     label = Util.resolveString(label);
     value = Util.resolveString(value);
-    emoji = /^\d{17,19}$/.test(emoji) ? { id: value } : Util.parseEmoji(emoji);
+    emoji = /^\d{17,19}$/.test(emoji) ? { id: emoji } : Util.parseEmoji(emoji);
     description = typeof description !== 'undefined' ? Util.resolveString(description) : undefined;
 
     return { label, value, description, emoji, default: option.default };
   }
 
   /**
-   * Normalizes option input and resolves strings.
+   * Normalizes option input and resolves strings and emojis.
    * @param {...MessageSelectOption|MessageSelectOption[]} options The select menu options to normalize
    * @returns {MessageSelectOption[]}
    */

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -5,7 +5,7 @@ const { MessageComponentTypes } = require('../util/Constants');
 const Util = require('../util/Util');
 
 /**
- * Represents a SelectMenu message components
+ * Represents a select menu message component
  * @extends {BaseMessageComponent}
  */
 class MessageSelectMenu extends BaseMessageComponent {
@@ -79,7 +79,7 @@ class MessageSelectMenu extends BaseMessageComponent {
   }
 
   /**
-   * Sets the maximum number of selection allowed for this select menu
+   * Sets the maximum number of selections allowed for this select menu
    * @param {number} maxValues Number of selections to be allowed
    * @returns {MessageSelectMenu}
    */

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -16,6 +16,7 @@ class MessageSelectMenu extends BaseMessageComponent {
    * @property {number} [minValues] The minimum number of selections required
    * @property {number} [maxValues] The maximum number of selections allowed
    * @property {MessageSelectOption[]} [options] Options for the select menu
+   * @property {boolean} [disabled=false] Disables the select menu to prevent interactions
    */
 
   /**
@@ -75,6 +76,12 @@ class MessageSelectMenu extends BaseMessageComponent {
      * @type {MessageSelectOption[]}
      */
     this.options = this.constructor.normalizeOptions(data.options ?? []);
+
+    /**
+     * Whether this select menu is currently disabled
+     * @type {?boolean}
+     */
+    this.disabled = data.disabled ?? false;
   }
 
   /**
@@ -84,6 +91,16 @@ class MessageSelectMenu extends BaseMessageComponent {
    */
   setCustomID(customID) {
     this.customID = Util.verifyString(customID, RangeError, 'SELECT_MENU_CUSTOM_ID');
+    return this;
+  }
+
+  /**
+   * Sets the interactive status of the select menu
+   * @param {boolean} disabled Whether this select menu should be disabled
+   * @returns {MessageSelectMenu}
+   */
+  setDisabled(disabled) {
+    this.disabled = disabled;
     return this;
   }
 
@@ -147,6 +164,7 @@ class MessageSelectMenu extends BaseMessageComponent {
   toJSON() {
     return {
       custom_id: this.customID,
+      disabled: this.disabled,
       placeholder: this.placeholder,
       min_values: this.minValues,
       max_values: this.maxValues ?? (this.minValues ? this.options.length : undefined),

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -131,8 +131,8 @@ class MessageSelectMenu extends BaseMessageComponent {
    * @param {...MessageSelectOption|MessageSelectOption[]} [options] The replacing option objects
    * @returns {MessageSelectMenu}
    */
-  spliceFields(index, deleteCount, ...options) {
-    this.fields.splice(index, deleteCount, ...this.constructor.normalizeOptions(...options));
+  spliceOptions(index, deleteCount, ...options) {
+    this.options.splice(index, deleteCount, ...this.constructor.normalizeOptions(...options));
     return this;
   }
 
@@ -161,6 +161,7 @@ class MessageSelectMenu extends BaseMessageComponent {
 
     label = Util.resolveString(label);
     value = Util.resolveString(value);
+    emoji = /^\d{17,19}$/.test(emoji) ? { id: value } : Util.parseEmoji(emoji);
     description = typeof description !== 'undefined' ? Util.resolveString(description) : undefined;
 
     return { label, value, description, emoji, default: option.default };

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -74,7 +74,7 @@ class MessageSelectMenu extends BaseMessageComponent {
    * @returns {MessageSelectMenu}
    */
   setCustomID(customID) {
-    this.customID = Util.resolveString(customID);
+    this.customID = Util.verifyString(customID, RangeError, 'SELECT_MENU_CUSTOM_ID');
     return this;
   }
 
@@ -105,7 +105,7 @@ class MessageSelectMenu extends BaseMessageComponent {
    * @returns {MessageSelectMenu}
    */
   setPlaceholder(placeholder) {
-    this.placeholder = Util.resolveString(placeholder);
+    this.placeholder = Util.verifyString(placeholder, RangeError, 'SELECT_MENU_PLACEHOLDER');
     return this;
   }
 
@@ -154,10 +154,13 @@ class MessageSelectMenu extends BaseMessageComponent {
   static normalizeOption(option) {
     let { label, value, description, emoji } = option;
 
-    label = Util.resolveString(label);
-    value = Util.resolveString(value);
-    emoji = /^\d{17,19}$/.test(emoji) ? { id: emoji } : Util.parseEmoji(emoji);
-    description = typeof description !== 'undefined' ? Util.resolveString(description) : undefined;
+    label = Util.verifyString(label, RangeError, 'SELECT_OPTION_LABEL');
+    value = Util.verifyString(value, RangeError, 'SELECT_OPTION_VALUE');
+    emoji = /^\d{17,19}$/.test(emoji) ? { id: value } : Util.parseEmoji(emoji);
+    description =
+      typeof description !== 'undefined'
+        ? Util.verifyString(description, RangeError, 'SELECT_OPTION_DESCRIPTION', true)
+        : undefined;
 
     return { label, value, description, emoji, default: option.default };
   }

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -174,7 +174,7 @@ class MessageSelectMenu extends BaseMessageComponent {
   }
 
   /**
-   * Normalizes option input and resolves strings.
+   * Normalizes option input and resolves strings and emojis.
    * @param {MessageSelectOptionData} option The select menu option to normalize
    * @returns {MessageSelectOption}
    */

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -22,8 +22,17 @@ class MessageSelectMenu extends BaseMessageComponent {
    * @typedef {Object} MessageSelectOption
    * @property {string} label The text to be displayed on this option
    * @property {string} value The value to be sent for this option
+   * @property {?string} description Optional description to show for this option
+   * @property {?RawEmoji} emoji Emoji to display for this option
+   * @property {boolean} default Render this option as the default selection
+   */
+
+  /**
+   * @typedef {Object} MessageSelectOptionData
+   * @property {string} label The text to be displayed on this option
+   * @property {string} value The value to be sent for this option
    * @property {string} [description] Optional description to show for this option
-   * @property {Emoji} [emoji] Emoji to display for this option
+   * @property {EmojiIdentifierResolvable} [emoji] Emoji to display for this option
    * @property {boolean} [default] Render this option as the default selection
    */
 
@@ -65,7 +74,7 @@ class MessageSelectMenu extends BaseMessageComponent {
      * Options for the select menu
      * @type {MessageSelectOption[]}
      */
-    this.options = data.options ?? [];
+    this.options = this.constructor.normalizeOptions(data.options ?? []);
   }
 
   /**
@@ -148,7 +157,7 @@ class MessageSelectMenu extends BaseMessageComponent {
 
   /**
    * Normalizes option input and resolves strings.
-   * @param {MessageSelectOption} option The select menu option to normalize
+   * @param {MessageSelectOptionData} option The select menu option to normalize
    * @returns {MessageSelectOption}
    */
   static normalizeOption(option) {
@@ -156,18 +165,15 @@ class MessageSelectMenu extends BaseMessageComponent {
 
     label = Util.verifyString(label, RangeError, 'SELECT_OPTION_LABEL');
     value = Util.verifyString(value, RangeError, 'SELECT_OPTION_VALUE');
-    emoji = /^\d{17,19}$/.test(emoji) ? { id: value } : Util.parseEmoji(emoji);
-    description =
-      typeof description !== 'undefined'
-        ? Util.verifyString(description, RangeError, 'SELECT_OPTION_DESCRIPTION', true)
-        : undefined;
+    emoji = emoji ? Util.resolvePartialEmoji(emoji) : null;
+    description = description ? Util.verifyString(description, RangeError, 'SELECT_OPTION_DESCRIPTION', true) : null;
 
-    return { label, value, description, emoji, default: option.default };
+    return { label, value, description, emoji, default: option.default ?? false };
   }
 
   /**
    * Normalizes option input and resolves strings and emojis.
-   * @param {...MessageSelectOption|MessageSelectOption[]} options The select menu options to normalize
+   * @param {...MessageSelectOptionData|MessageSelectOption[]} options The select menu options to normalize
    * @returns {MessageSelectOption[]}
    */
   static normalizeOptions(...options) {

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -195,7 +195,7 @@ class MessageSelectMenu extends BaseMessageComponent {
    * @returns {MessageSelectOption[]}
    */
   static normalizeOptions(...options) {
-    return options.flat(2).map(option => this.normalizeOption(option));
+    return options.flat(Infinity).map(option => this.normalizeOption(option));
   }
 }
 

--- a/src/structures/SelectMenuInteraction.js
+++ b/src/structures/SelectMenuInteraction.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const MessageComponentInteraction = require('./MessageComponentInteraction');
+
+/**
+ * Represents a select menu interaction.
+ * @extends {MessageComponentInteraction}
+ */
+class SelectMenuInteraction extends MessageComponentInteraction {
+  constructor(client, data) {
+    super(client, data);
+
+    /**
+     * The values selected, if the component which was interacted with was a select menu
+     * @type {string[]}
+     */
+    this.values = this.componentType === 'SELECT_MENU' ? data.data.values : null;
+  }
+}
+
+module.exports = SelectMenuInteraction;

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -944,6 +944,7 @@ exports.InteractionResponseTypes = createEnum([
  * The type of a message component
  * * ACTION_ROW
  * * BUTTON
+ * * SELECT_MENU
  * @typedef {string} MessageComponentType
  */
 exports.MessageComponentTypes = createEnum([null, 'ACTION_ROW', 'BUTTON', 'SELECT_MENU']);

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -946,7 +946,7 @@ exports.InteractionResponseTypes = createEnum([
  * * BUTTON
  * @typedef {string} MessageComponentType
  */
-exports.MessageComponentTypes = createEnum([null, 'ACTION_ROW', 'BUTTON']);
+exports.MessageComponentTypes = createEnum([null, 'ACTION_ROW', 'BUTTON', 'SELECT_MENU']);
 
 /**
  * The style of a message button

--- a/src/util/Structures.js
+++ b/src/util/Structures.js
@@ -24,6 +24,7 @@
  * * **`CommandInteraction`**
  * * **`ButtonInteraction`**
  * * **`StageInstance`**
+ * * **`SelectMenuInteraction`**
  * @typedef {string} ExtendableStructure
  */
 
@@ -118,6 +119,7 @@ const structures = {
   User: require('../structures/User'),
   CommandInteraction: require('../structures/CommandInteraction'),
   ButtonInteraction: require('../structures/ButtonInteraction'),
+  SelectMenuInteraction: require('../structures/SelectMenuInteraction'),
   StageInstance: require('../structures/StageInstance'),
 };
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1541,7 +1541,6 @@ declare module 'discord.js' {
     public options: MessageSelectOption[];
     public placeholder: string | null;
     public type: 'SELECT_MENU';
-    public addOption(option: MessageSelectOption): this;
     public addOptions(options: MessageSelectOption[] | MessageSelectOption[][]): this;
     public setCustomID(customID: string): this;
     public setMaxValues(maxValues: number): this;
@@ -3794,7 +3793,7 @@ declare module 'discord.js' {
   interface MessageSelectOption {
     default?: boolean;
     description?: string;
-    emoji?: Emoji | RawEmoji;
+    emoji?: GuildEmoji | RawEmoji;
     label: string;
     value: string;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3602,9 +3602,6 @@ declare module 'discord.js' {
 
   type MembershipState = keyof typeof MembershipStates;
 
-  
-  type MessageActionRowComponent = MessageButton;
-
   type MessageActionRowComponent = MessageButton | MessageSelectMenu;
 
   type MessageActionRowComponentOptions = MessageButtonOptions | MessageSelectMenuOptions;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1547,6 +1547,11 @@ declare module 'discord.js' {
     public setMaxValues(maxValues: number): this;
     public setMinValues(minValues: number): this;
     public setPlaceholder(placeholder: string): this;
+    public spliceOptions(
+      index: number,
+      deleteCount: number,
+      ...options: MessageSelectOption[] | MessageSelectOption[][]
+    ): this;
     public toJSON(): object;
   }
 
@@ -3784,7 +3789,6 @@ declare module 'discord.js' {
     minValues?: number;
     options?: MessageSelectOption[];
     placeholder?: string;
-    type: 'SELECT_MENU' | MessageComponentTypes.SELECT_MENU;
   }
 
   interface MessageSelectOption {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1536,6 +1536,7 @@ declare module 'discord.js' {
   class MessageSelectMenu extends BaseMessageComponent {
     constructor(data?: MessageSelectMenu | MessageSelectMenuOptions);
     public customID: string | null;
+    public disabled: boolean;
     public maxValues: number | null;
     public minValues: number | null;
     public options: MessageSelectOption[];
@@ -1543,6 +1544,7 @@ declare module 'discord.js' {
     public type: 'SELECT_MENU';
     public addOptions(options: MessageSelectOptionData[] | MessageSelectOptionData[][]): this;
     public setCustomID(customID: string): this;
+    public setDisabled(disabled: boolean): this;
     public setMaxValues(maxValues: number): this;
     public setMinValues(minValues: number): this;
     public setPlaceholder(placeholder: string): this;
@@ -3784,6 +3786,7 @@ declare module 'discord.js' {
 
   interface MessageSelectMenuOptions extends BaseMessageComponentOptions {
     customID?: string;
+    disabled?: boolean;
     maxValues?: number;
     minValues?: number;
     options?: MessageSelectOptionData[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1393,6 +1393,7 @@ declare module 'discord.js' {
     public ephemeral: boolean | null;
     public message: Message | RawMessage;
     public replied: boolean;
+    public values: string[] | null;
     public webhook: InteractionWebhook;
     public defer(options?: InteractionDeferOptions): Promise<void>;
     public deferUpdate(): Promise<void>;
@@ -1540,6 +1541,13 @@ declare module 'discord.js' {
     public options: MessageSelectOption[];
     public placeholder: string | null;
     public type: 'SELECT_MENU';
+    public addOption(option: MessageSelectOption): this;
+    public addOptions(options: MessageSelectOption[] | MessageSelectOption[][]): this;
+    public setCustomID(customID: string): this;
+    public setMaxValues(maxValues: number): this;
+    public setMinValues(minValues: number): this;
+    public setPlaceholder(placeholder: string): this;
+    public toJSON(): object;
   }
 
   export class NewsChannel extends TextBasedChannel(GuildChannel) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1177,6 +1177,7 @@ declare module 'discord.js' {
     public isButton(): this is ButtonInteraction;
     public isCommand(): this is CommandInteraction;
     public isMessageComponent(): this is MessageComponentInteraction;
+    public isSelectMenu(): this is SelectMenuInteraction;
   }
 
   export class InteractionWebhook extends PartialWebhookMixin() {
@@ -1393,7 +1394,6 @@ declare module 'discord.js' {
     public ephemeral: boolean | null;
     public message: Message | RawMessage;
     public replied: boolean;
-    public values: string[] | null;
     public webhook: InteractionWebhook;
     public defer(options?: InteractionDeferOptions): Promise<void>;
     public deferUpdate(): Promise<void>;
@@ -1716,6 +1716,11 @@ declare module 'discord.js' {
     public toString(): string;
 
     public static comparePositions(role1: Role, role2: Role): number;
+  }
+
+  export class SelectMenuInteraction extends MessageComponentInteraction {
+    public componentType: 'SELECT_MENU';
+    public values: string[] | null;
   }
 
   export class Shard extends EventEmitter {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3212,6 +3212,7 @@ declare module 'discord.js' {
     User: typeof User;
     CommandInteraction: typeof CommandInteraction;
     ButtonInteraction: typeof ButtonInteraction;
+    SelectMenuInteraction: typeof SelectMenuInteraction;
   }
 
   interface FetchApplicationCommandOptions extends BaseFetchOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3591,9 +3591,12 @@ declare module 'discord.js' {
 
   type MembershipState = keyof typeof MembershipStates;
 
+  
   type MessageActionRowComponent = MessageButton;
 
-  type MessageActionRowComponentOptions = MessageButtonOptions;
+  type MessageActionRowComponent = MessageButton | MessageSelectMenu;
+
+  type MessageActionRowComponentOptions = MessageButtonOptions | MessageSelectMenuOptions;
 
   type MessageActionRowComponentResolvable = MessageActionRowComponent | MessageActionRowComponentOptions;
 
@@ -3605,6 +3608,8 @@ declare module 'discord.js' {
     partyID: string;
     type: number;
   }
+
+  type MessageAdditions = MessageEmbed | MessageAttachment | (MessageEmbed | MessageAttachment)[];
 
   interface MessageButtonOptions extends BaseMessageComponentOptions {
     customID?: string;
@@ -3625,6 +3630,7 @@ declare module 'discord.js' {
   }
 
   type MessageComponent = BaseMessageComponent | MessageActionRow | MessageButton | MessageSelectMenu;
+
   interface MessageComponentInteractionCollectorOptions extends CollectorOptions {
     max?: number;
     maxComponents?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1553,7 +1553,7 @@ declare module 'discord.js' {
       deleteCount: number,
       ...options: MessageSelectOptionData[] | MessageSelectOptionData[][]
     ): this;
-    public toJSON(): object;
+    public toJSON(): unknown;
   }
 
   export class NewsChannel extends TextBasedChannel(GuildChannel) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -82,6 +82,7 @@ declare enum MessageButtonStyles {
 declare enum MessageComponentTypes {
   ACTION_ROW = 1,
   BUTTON = 2,
+  SELECT_MENU = 3,
 }
 
 declare enum MFALevels {
@@ -1529,6 +1530,16 @@ declare module 'discord.js' {
     public remove(): Promise<MessageReaction>;
     public fetch(): Promise<MessageReaction>;
     public toJSON(): unknown;
+  }
+
+  class MessageSelectMenu extends BaseMessageComponent {
+    constructor(data?: MessageSelectMenu | MessageSelectMenuOptions);
+    public customID: string | null;
+    public maxValues: number | null;
+    public minValues: number | null;
+    public options: MessageSelectOption[];
+    public placeholder: string | null;
+    public type: 'SELECT_MENU';
   }
 
   export class NewsChannel extends TextBasedChannel(GuildChannel) {
@@ -3605,15 +3616,18 @@ declare module 'discord.js' {
     maxProcessed?: number;
   }
 
-  type MessageComponent = BaseMessageComponent | MessageActionRow | MessageButton;
-
+  type MessageComponent = BaseMessageComponent | MessageActionRow | MessageButton | MessageSelectMenu;
   interface MessageComponentInteractionCollectorOptions extends CollectorOptions {
     max?: number;
     maxComponents?: number;
     maxUsers?: number;
   }
 
-  type MessageComponentOptions = BaseMessageComponentOptions | MessageActionRowOptions | MessageButtonOptions;
+  type MessageComponentOptions =
+    | BaseMessageComponentOptions
+    | MessageActionRowOptions
+    | MessageButtonOptions
+    | MessageSelectMenuOptions;
 
   type MessageComponentType = keyof typeof MessageComponentTypes;
 
@@ -3749,6 +3763,23 @@ declare module 'discord.js' {
   }
 
   type MessageResolvable = Message | Snowflake;
+
+  interface MessageSelectMenuOptions extends BaseMessageComponentOptions {
+    customID?: string;
+    maxValues?: number;
+    minValues?: number;
+    options?: MessageSelectOption[];
+    placeholder?: string;
+    type: 'SELECT_MENU' | MessageComponentTypes.SELECT_MENU;
+  }
+
+  interface MessageSelectOption {
+    default?: boolean;
+    description?: string;
+    emoji?: RawEmoji;
+    label: string;
+    value: string;
+  }
 
   type MessageTarget =
     | Interaction

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3784,7 +3784,7 @@ declare module 'discord.js' {
   interface MessageSelectOption {
     default?: boolean;
     description?: string;
-    emoji?: RawEmoji;
+    emoji?: Emoji | RawEmoji;
     label: string;
     value: string;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1541,7 +1541,7 @@ declare module 'discord.js' {
     public options: MessageSelectOption[];
     public placeholder: string | null;
     public type: 'SELECT_MENU';
-    public addOptions(options: MessageSelectOption[] | MessageSelectOption[][]): this;
+    public addOptions(options: MessageSelectOptionData[] | MessageSelectOptionData[][]): this;
     public setCustomID(customID: string): this;
     public setMaxValues(maxValues: number): this;
     public setMinValues(minValues: number): this;
@@ -1549,7 +1549,7 @@ declare module 'discord.js' {
     public spliceOptions(
       index: number,
       deleteCount: number,
-      ...options: MessageSelectOption[] | MessageSelectOption[][]
+      ...options: MessageSelectOptionData[] | MessageSelectOptionData[][]
     ): this;
     public toJSON(): object;
   }
@@ -3786,14 +3786,22 @@ declare module 'discord.js' {
     customID?: string;
     maxValues?: number;
     minValues?: number;
-    options?: MessageSelectOption[];
+    options?: MessageSelectOptionData[];
     placeholder?: string;
   }
 
   interface MessageSelectOption {
+    default: boolean;
+    description: string | null;
+    emoji: RawEmoji | null;
+    label: string;
+    value: string;
+  }
+
+  interface MessageSelectOptionData {
     default?: boolean;
     description?: string;
-    emoji?: GuildEmoji | RawEmoji;
+    emoji?: EmojiIdentifierResolvable;
     label: string;
     value: string;
   }


### PR DESCRIPTION
### Select Menus are still in private beta. This PR will not function if you do not have access.

**Changelog**
 - New class `MessageSelectMenu`
 - New types `MessageSelectMenuOptions`, `MessageSelectOption`, `MessageSelectOptionData`
 - New utility method `resolvePartialEmoji` for resolving emoji without a Client
 - Improved emoji resolving in `MessageButton`, also applied to `MessageSelectOption` (fixes #5753)
 - Improved consistency of documentation across all component classes

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
