### PR TITLE
fix(PermissionOverwrites): fix typo in typedef jsdoc

### DIFF
--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -110,7 +110,7 @@ class PermissionOverwrites {
    */
 
   /**
-   * @typedef {object} ResolvedOverwriteOptions
+   * @typedef {Object} ResolvedOverwriteOptions
    * @property {Permissions} allow The allowed permissions
    * @property {Permissions} deny The denied permissions
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a small typo in the typedef jsdoc for PermissionOverwrites


**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.