### PR TITLE
feat(CommandInteraction): make options a collection

### DIFF
--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -4,6 +4,7 @@ const APIMessage = require('./APIMessage');
 const Interaction = require('./Interaction');
 const WebhookClient = require('../client/WebhookClient');
 const { Error } = require('../errors');
+const Collection = require('../util/Collection');
 const { ApplicationCommandOptionTypes, InteractionResponseTypes } = require('../util/Constants');
 const MessageFlags = require('../util/MessageFlags');
 
@@ -35,9 +36,9 @@ class CommandInteraction extends Interaction {
 
     /**
      * The options passed to the command.
-     * @type {CommandInteractionOption[]}
+     * @type {Collection<string, CommandInteractionOption>}
      */
-    this.options = data.data.options?.map(o => this.transformOption(o, data.data.resolved)) ?? [];
+    this.options = this._createOptionsCollection(data.data.options, data.data.resolved);
 
     /**
      * Whether this interaction has already been replied to
@@ -226,7 +227,7 @@ class CommandInteraction extends Interaction {
     };
 
     if ('value' in option) result.value = option.value;
-    if ('options' in option) result.options = option.options.map(o => this.transformOption(o, resolved));
+    if ('options' in option) result.options = this._createOptionsCollection(option.options, resolved);
 
     const user = resolved?.users?.[option.value];
     if (user) result.user = this.client.users.add(user);
@@ -241,6 +242,20 @@ class CommandInteraction extends Interaction {
     if (role) result.role = this.guild?.roles.add(role) ?? role;
 
     return result;
+  }
+
+  /**
+   * Creates a collection of options from the received options array.
+   * @param {Object[]} options The received options
+   * @param {Object} resolved The resolved interaction data
+   * @returns {Collection<string, CommandInteractionOption>}
+   */
+  _createOptionsCollection(options, resolved) {
+    const optionsCollection = new Collection();
+    for (const option of options) {
+      optionsCollection.set(option.name, this.transformOption(option, resolved));
+    }
+    return optionsCollection;
   }
 }
 

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -188,7 +188,8 @@ class CommandInteraction extends Interaction {
    * @property {string} name The name of the option
    * @property {ApplicationCommandOptionType} type The type of the option
    * @property {string|number|boolean} [value] The value of the option
-   * @property {CommandInteractionOption[]} [options] Additional options if this option is a subcommand (group)
+   * @property {Collection<string, CommandInteractionOption>} [options] Additional options if this option is a
+   * subcommand (group)
    * @property {User} [user] The resolved user
    * @property {GuildMember|Object} [member] The resolved member
    * @property {GuildChannel|Object} [channel] The resolved channel

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -250,6 +250,7 @@ class CommandInteraction extends Interaction {
    * @param {Object[]} options The received options
    * @param {Object} resolved The resolved interaction data
    * @returns {Collection<string, CommandInteractionOption>}
+   * @private
    */
   _createOptionsCollection(options, resolved) {
     const optionsCollection = new Collection();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -440,7 +440,7 @@ declare module 'discord.js' {
     public commandID: string;
     public commandName: string;
     public deferred: boolean;
-    public options: CommandInteractionOption[];
+    public options: Collection<string, CommandInteractionOption>;
     public replied: boolean;
     public webhook: WebhookClient;
     public defer(options?: InteractionDeferOptions): Promise<void>;
@@ -457,6 +457,7 @@ declare module 'discord.js' {
     public reply(content: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
     public reply(content: string, options?: InteractionReplyOptions): Promise<void>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
+    private _createOptionsCollection(options: object[], resolved: object): Collection<string, CommandInteractionOption>;
   }
 
   type AllowedImageFormat = 'webp' | 'png' | 'jpg' | 'jpeg' | 'gif';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -457,7 +457,7 @@ declare module 'discord.js' {
     public reply(content: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
     public reply(content: string, options?: InteractionReplyOptions): Promise<void>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
-    private _createOptionsCollection(options: object[], resolved: object): Collection<string, CommandInteractionOption>;
+    private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
   }
 
   type AllowedImageFormat = 'webp' | 'png' | 'jpg' | 'jpeg' | 'gif';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently, `CommandInteraction#options` is an Array. This PR changes it to a Collection. As [discussed](https://discord.com/channels/222078108977594368/682166281826598932/848333889986101269) in the support server, `options` of a `CommandInteraction` have unique names. Thus, having a Collection with names as keys is much better than using an array in this case.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
