### PR TITLE
ci(publish-dev): improve resolving of next version

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Publish
         run: |
-          npm version --git-tag-version=false $(cat package.json | grep -oP '"version": "\K[^"]+(?=")').$(git rev-parse --verify HEAD)
+          npm version --git-tag-version=false $(cat package.json | grep -oP '"version": "\K[^"]+(?=")')-dev.$(git rev-parse --verify --short=7 HEAD)
           npm publish --tag dev || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Publish
         run: |
-          npm version --git-tag-version=false $(jq --raw-output '.version' package.json)-dev.$(git rev-parse --verify --short=7 HEAD)
+          npm version --git-tag-version=false $(jq --raw-output '.version' package.json).$(git rev-parse --verify HEAD)
           npm publish --tag dev || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Publish
         run: |
-          npm version --git-tag-version=false $(cat package.json | grep -oP '"version": "\K[^"]+(?=")')-dev.$(git rev-parse --verify --short=7 HEAD)
+          npm version --git-tag-version=false $(jq --raw-output '.version' package.json)-dev.$(git rev-parse --verify --short=7 HEAD)
           npm publish --tag dev || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This removes the somewhat-hacky-looking regex and uses `jq` instead to parse the `package.json` file.

Tested the output with WSL:

![image](https://user-images.githubusercontent.com/4019718/120120217-284b1400-c19c-11eb-8230-675366a25326.png)

Also tested in a private repo to validate the command in GitHub actions:

![image](https://user-images.githubusercontent.com/4019718/120120240-46b10f80-c19c-11eb-86f1-f3dbc73eb7f3.png)

---

Original description:

~~While not strictly required in [Semantic Versioning rule 9](semver.org/#spec-item-9), based on their examples it seems strongly recommended to first add a hyphenated specification for pre-releases, ergo I added `-dev` before the Git SHA.~~

~~The addition of `--short=7` strips the Git SHA to the first 7 characters, which are the same as you would see when browsing commits on GitHub, making it a bit easier to match versions to their respective Git commit. AFAIK the first 7 characters are still pretty much always unique.~~

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

