### PR TITLE
docs(Webhook): update typings and docs for #editMessage

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -98,9 +98,9 @@ class Webhook {
    * Options that can be passed into editMessage.
    * @typedef {Object} WebhookEditMessageOptions
    * @property {MessageEmbed[]|Object[]} [embeds] See {@link WebhookMessageOptions#embeds}
-   * @property {StringResolvable} [content] See {@link WebhookMessageOptions#content}
-   * @property {FileOptions[]|string[]} [files] See {@link WebhookMessageOptions#files}
-   * @property {MessageMentionOptions} [allowedMentions] See {@link WebhookMessageOptions#allowedMentions}
+   * @property {StringResolvable} [content] See {@link BaseMessageOptions#content}
+   * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
+   * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
    */
 
   /**
@@ -243,7 +243,7 @@ class Webhook {
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable|'@original'} message The message to edit
    * @param {StringResolvable|APIMessage} [content] The new content for the message
-   * @param {WebhookEditMessageOptions|MessageEmbed|MessageEmbed[]} [options] The options to provide
+   * @param {WebhookEditMessageOptions|MessageAdditions} [options] The options to provide
    * @returns {Promise<Message|Object>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2346,7 +2346,7 @@ declare module 'discord.js' {
     edit(options: WebhookEditData): Promise<Webhook>;
     editMessage(
       message: MessageResolvable | '@original',
-      content: APIMessageContentResolvable | APIMessage | MessageEmbed | MessageEmbed[],
+      content: APIMessageContentResolvable | APIMessage | MessageAdditions,
       options?: WebhookEditMessageOptions,
     ): Promise<Message | RawMessage>;
     editMessage(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Discord.js supports editing attachments for Webhooks but it isn't properly documented. As discussed in #5630, this PR adds documentation for this and also updates some jsdoc links to keep up with the changes made in #5632

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
