### PR TITLE
feat: easier guards for channelUpdate

### DIFF
--- a/src/client/actions/TypingStart.js
+++ b/src/client/actions/TypingStart.js
@@ -40,7 +40,7 @@ class TypingStart extends Action {
         /**
          * Emitted whenever a user starts typing in a channel.
          * @event Client#typingStart
-         * @param {Channel} channel The channel the user started typing in
+         * @param {DMChannel|TextChannel|NewsChannel} channel The channel the user started typing in
          * @param {User} user The user that started typing
          */
         this.client.emit(Events.TYPING_START, channel, user);

--- a/src/client/websocket/handlers/CHANNEL_PINS_UPDATE.js
+++ b/src/client/websocket/handlers/CHANNEL_PINS_UPDATE.js
@@ -14,7 +14,7 @@ module.exports = (client, { d: data }) => {
      * Emitted whenever the pins of a channel are updated. Due to the nature of the WebSocket event,
      * not much information can be provided easily here - you need to manually check the pins yourself.
      * @event Client#channelPinsUpdate
-     * @param {DMChannel|TextChannel} channel The channel that the pins update occurred in
+     * @param {DMChannel|TextChannel|NewsChannel} channel The channel that the pins update occurred in
      * @param {Date} time The time of the pins update
      */
     client.emit(Events.CHANNEL_PINS_UPDATE, channel, time);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2603,7 +2603,7 @@ declare module 'discord.js' {
     applicationCommandUpdate: [oldCommand: ApplicationCommand | null, newCommand: ApplicationCommand];
     channelCreate: [channel: GuildChannel];
     channelDelete: [channel: DMChannel | GuildChannel];
-    channelPinsUpdate: [channel: Channel | PartialDMChannel, date: Date];
+    channelPinsUpdate: [channel: TextChannel | NewsChannel | DMChannel | PartialDMChannel, date: Date];
     channelUpdate: [oldChannel: DMChannel | GuildChannel, newChannel: DMChannel | GuildChannel];
     debug: [message: string];
     warn: [message: string];
@@ -2646,7 +2646,7 @@ declare module 'discord.js' {
     roleCreate: [role: Role];
     roleDelete: [role: Role];
     roleUpdate: [oldRole: Role, newRole: Role];
-    typingStart: [channel: Channel | PartialDMChannel, user: User | PartialUser];
+    typingStart: [channel: TextChannel | NewsChannel | DMChannel | PartialDMChannel, user: User | PartialUser];
     userUpdate: [oldUser: User | PartialUser, newUser: User];
     voiceStateUpdate: [oldState: VoiceState, newState: VoiceState];
     webhookUpdate: [channel: TextChannel];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2604,7 +2604,7 @@ declare module 'discord.js' {
     channelCreate: [channel: GuildChannel];
     channelDelete: [channel: DMChannel | GuildChannel];
     channelPinsUpdate: [channel: Channel | PartialDMChannel, date: Date];
-    channelUpdate: [oldChannel: Channel, newChannel: Channel];
+    channelUpdate: [oldChannel: DMChannel | GuildChannel, newChannel: DMChannel | GuildChannel];
     debug: [message: string];
     warn: [message: string];
     emojiCreate: [emoji: GuildEmoji];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Below guard fails on `channelUpdate` client events, however works flawlessly on `channelDelete`. By adapting the typings to `DMChannel | GuildChannel` the types are much easier guardable but still encompass all channel types.

```ts
if (channel instanceof DMChannel || !channel.isText()) return;
```

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
