### PR TITLE
feat(Message): allow editing files into messages

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -124,8 +124,10 @@ class MessageManager extends BaseManager {
     message = this.resolveID(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
-    const { data } = (options instanceof APIMessage ? options : APIMessage.create(this, options)).resolveData();
-    const d = await this.client.api.channels[this.channel.id].messages[message].patch({ data });
+    const { data, files } = await (options instanceof APIMessage ? options : APIMessage.create(this, options))
+      .resolveData()
+      .resolveFiles();
+    const d = await this.client.api.channels[this.channel.id].messages[message].patch({ data, files });
 
     if (this.cache.has(message)) {
       const clone = this.cache.get(message)._clone();

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -479,7 +479,9 @@ class Message extends Base {
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * @property {MessageFlags} [flags] Which flags to set for the message. Only `SUPPRESS_EMBEDS` can be edited.
-   * @property {MessageAttachment[]} [attachments] The new attachments of the message (can only be removed, not added)
+   * @property {MessageAttachment[]} [attachments] An array of attachments to keep,
+   * all attachments will be kept if omitted
+   * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to add to the message
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3184,12 +3184,13 @@ declare module 'discord.js' {
   }
 
   interface MessageEditOptions {
+    attachments?: MessageAttachment[];
     content?: StringResolvable;
     embed?: MessageEmbed | MessageEmbedOptions | null;
     code?: string | boolean;
+    files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
     flags?: BitFieldResolvable<MessageFlagsString, number>;
     allowedMentions?: MessageMentionOptions;
-    attachments?: MessageAttachment[];
   }
 
   interface MessageEmbedAuthor {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds the ability to edit in new files to regular bot messages.

I changed the wording of the `attachments` option to remove the "can only remove" part to avoid confusion.

Relevant docs PR: https://github.com/discord/discord-api-docs/pull/2859

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
