### PR TITLE
refactor(GuildPreviewEmoji): make roles an array

### DIFF
--- a/src/structures/BaseGuildEmoji.js
+++ b/src/structures/BaseGuildEmoji.js
@@ -21,14 +21,6 @@ class BaseGuildEmoji extends Emoji {
     this.managed = null;
     this.available = null;
 
-    /**
-     * Array of role ids this emoji is active for
-     * @name BaseGuildEmoji#_roles
-     * @type {Snowflake[]}
-     * @private
-     */
-    Object.defineProperty(this, '_roles', { value: [], writable: true });
-
     this._patch(data);
   }
 
@@ -58,8 +50,6 @@ class BaseGuildEmoji extends Emoji {
        */
       this.available = data.available;
     }
-
-    if (data.roles) this._roles = data.roles;
   }
 }
 

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -23,6 +23,14 @@ class GuildEmoji extends BaseGuildEmoji {
      * @type {?User}
      */
     this.author = null;
+
+    /**
+     * Array of role ids this emoji is active for
+     * @name GuildEmoji#_roles
+     * @type {Snowflake[]}
+     * @private
+     */
+    Object.defineProperty(this, '_roles', { value: [], writable: true });
   }
 
   /**
@@ -39,7 +47,9 @@ class GuildEmoji extends BaseGuildEmoji {
 
   _patch(data) {
     super._patch(data);
-    if (typeof data.user !== 'undefined') this.author = this.client.users.add(data.user);
+
+    if (data.user) this.author = this.client.users.add(data.user);
+    if (data.roles) this._roles = data.roles;
   }
 
   /**

--- a/src/structures/GuildPreviewEmoji.js
+++ b/src/structures/GuildPreviewEmoji.js
@@ -13,13 +13,14 @@ class GuildPreviewEmoji extends BaseGuildEmoji {
    * @name GuildPreviewEmoji#guild
    */
 
-  /**
-   * Set of roles this emoji is active for
-   * @type {Set<Snowflake>}
-   * @readonly
-   */
-  get roles() {
-    return new Set(this._roles);
+  constructor(client, data, guild) {
+    super(client, data, guild);
+
+    /**
+     * The roles this emoji is active for
+     * @type {Snowflake[]}
+     */
+    this.roles = data.roles;
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -248,7 +248,7 @@ declare module 'discord.js' {
   }
 
   export class BaseGuildEmoji extends Emoji {
-    constructor(client: Client, data: unknown, guild: Guild);
+    constructor(client: Client, data: unknown, guild: Guild | GuildPreview);
     public available: boolean | null;
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
@@ -922,6 +922,7 @@ declare module 'discord.js' {
   }
 
   export class GuildEmoji extends BaseGuildEmoji {
+    constructor(client: Client, data: unknown, guild: Guild);
     private _roles: Snowflake[];
 
     public readonly deletable: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -249,8 +249,6 @@ declare module 'discord.js' {
 
   export class BaseGuildEmoji extends Emoji {
     constructor(client: Client, data: unknown, guild: Guild);
-    private _roles: Snowflake[];
-
     public available: boolean | null;
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
@@ -924,6 +922,8 @@ declare module 'discord.js' {
   }
 
   export class GuildEmoji extends BaseGuildEmoji {
+    private _roles: Snowflake[];
+
     public readonly deletable: boolean;
     public guild: Guild;
     public author: User | null;
@@ -1020,7 +1020,7 @@ declare module 'discord.js' {
   export class GuildPreviewEmoji extends BaseGuildEmoji {
     constructor(client: Client, data: unknown, guild: GuildPreview);
     public guild: GuildPreview;
-    public readonly roles: Set<Snowflake>;
+    public roles: Snowflake[];
   }
 
   export class HTTPError extends Error {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes the type of `GuildPreviewEmoji#roles` from `Set<Snowflake>` to `Snowflake[]` because pretty much no other getter/method returns a set.

**Status and versioning classification:**

- I know how to update typings and have done so
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)