### PR TITLE
types(Snowflake): export the type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -78,6 +78,8 @@ declare module 'discord.js' {
 
   export const version: string;
 
+  export { Snowflake };
+
   //#region Classes
 
   export class Activity {


### PR DESCRIPTION
This re-exports discord-api-types Snowflake type so it can be imported from discord.js directly.
This will help improve the user experience for Typescript developers encountering the `${bigint}` type.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
