### PR TITLE
fix: interfaces not importing due to re-export of Snowflake

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -69,7 +69,6 @@ declare module 'discord.js' {
     APIMessage as RawMessage,
     APIOverwrite as RawOverwrite,
     APIRole as RawRole,
-    Snowflake,
   } from 'discord-api-types/v8';
   import { EventEmitter } from 'events';
   import { PathLike } from 'fs';
@@ -77,8 +76,6 @@ declare module 'discord.js' {
   import * as WebSocket from 'ws';
 
   export const version: string;
-
-  export { Snowflake };
 
   //#region Classes
 
@@ -3614,6 +3611,8 @@ declare module 'discord.js' {
     token?: string;
     execArgv?: string[];
   }
+
+  type Snowflake = `${bigint}`;
 
   interface SplitOptions {
     maxLength?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -69,6 +69,7 @@ declare module 'discord.js' {
     APIMessage as RawMessage,
     APIOverwrite as RawOverwrite,
     APIRole as RawRole,
+    Snowflake as APISnowflake,
   } from 'discord-api-types/v8';
   import { EventEmitter } from 'events';
   import { PathLike } from 'fs';
@@ -3612,7 +3613,7 @@ declare module 'discord.js' {
     execArgv?: string[];
   }
 
-  type Snowflake = `${bigint}`;
+  type Snowflake = APISnowflake;
 
   interface SplitOptions {
     maxLength?: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR tries to fix the issue caused by re-export of `Snowflake` in #5722. The re-export of Snowflake made all the interfaces and types of discord.js non-importable. I tried to find a correct way of re-exporting types in a declaration file but couldn't find anything that helped. So, instead of importing the `Snowflake` type from `discord-api-types`, I defined the type in the lib itself just like other types. This kept the typings support that `Snowflake` introduced while also made it and other types importable again.

Thanks, @ToasterSticks for noticing a issue...again 😆

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
