### PR TITLE
docs: remove traces of StringResolvable

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -592,7 +592,7 @@ class Message extends Base {
 
   /**
    * Send an inline reply to this message.
-   * @param {StringResolvable|APIMessage} [content=''] The content for the message
+   * @param {string|APIMessage} [content=''] The content for the message
    * @param {ReplyMessageOptions|MessageAdditions} [options] The additional options to provide
    * @returns {Promise<Message|Message[]>}
    * @example

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -98,7 +98,7 @@ class Webhook {
    * Options that can be passed into editMessage.
    * @typedef {Object} WebhookEditMessageOptions
    * @property {MessageEmbed[]|Object[]} [embeds] See {@link WebhookMessageOptions#embeds}
-   * @property {StringResolvable} [content] See {@link BaseMessageOptions#content}
+   * @property {string} [content] See {@link BaseMessageOptions#content}
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
    */
@@ -242,7 +242,7 @@ class Webhook {
   /**
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable|'@original'} message The message to edit
-   * @param {StringResolvable|APIMessage} [content] The new content for the message
+   * @param {string|APIMessage} [content] The new content for the message
    * @param {WebhookEditMessageOptions|MessageAdditions} [options] The options to provide
    * @returns {Promise<Message|Object>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`StringResolvable` was removed in #4880. This PR removes it from places that still has it.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
