### PR TITLE
fix(RoleManager): bug in #create

### DIFF
--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -115,7 +115,7 @@ class RoleManager extends BaseManager {
   create(options = {}) {
     let { name, color, hoist, permissions, position, mentionable, reason } = options;
     if (color) color = resolveColor(color);
-    permissions = new Permissions(permissions);
+    if (typeof permissions !== 'undefined') permissions = new Permissions(permissions);
 
     return this.client.api
       .guilds(this.guild.id)

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -115,7 +115,7 @@ class RoleManager extends BaseManager {
   create(options = {}) {
     let { name, color, hoist, permissions, position, mentionable, reason } = options;
     if (color) color = resolveColor(color);
-    permissions = Permissions.resolve(permissions).toString();
+    permissions = new Permissions(permissions);
 
     return this.client.api
       .guilds(this.guild.id)

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -115,7 +115,7 @@ class RoleManager extends BaseManager {
   create(options = {}) {
     let { name, color, hoist, permissions, position, mentionable, reason } = options;
     if (color) color = resolveColor(color);
-    if (typeof permissions !== 'undefined') permissions = Permissions.resolve(permissions).toString();
+    permissions = Permissions.resolve(permissions).toString();
 
     return this.client.api
       .guilds(this.guild.id)

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -115,7 +115,7 @@ class RoleManager extends BaseManager {
   create(options = {}) {
     let { name, color, hoist, permissions, position, mentionable, reason } = options;
     if (color) color = resolveColor(color);
-    if (permissions) permissions = Permissions.resolve(permissions).toString();
+    if (typeof permissions !== 'undefined') permissions = Permissions.resolve(permissions).toString();
 
     return this.client.api
       .guilds(this.guild.id)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`if (permissions)` is really bad idea, because somehow passing `0n` or **falsy value**. it will be directly passed to api
That resulting an error: `TypeError: Do not know how to serialize a BigInt`

```js
RoleManager#create({
   name: 'role-name',
   permissions: 0n
}) // -> TypeError: Do not know how to serialize a BigInt
```

**Status and versioning classification:**
* Typings don't need updating