### PR TITLE
fix(CommandInteraction): cmds with no options throw error

### DIFF
--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -261,6 +261,7 @@ class CommandInteraction extends Interaction {
    */
   _createOptionsCollection(options, resolved) {
     const optionsCollection = new Collection();
+    if (typeof options === 'undefined') return optionsCollection;
     for (const option of options) {
       optionsCollection.set(option.name, this.transformOption(option, resolved));
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1184,9 +1184,7 @@ declare module 'discord.js' {
       options?: ReactionCollectorOptions,
     ): ReactionCollector;
     public delete(): Promise<Message>;
-    public edit(
-      content: string | null | MessageEditOptions | MessageEmbed | APIMessage,
-    ): Promise<Message>;
+    public edit(content: string | null | MessageEditOptions | MessageEmbed | APIMessage): Promise<Message>;
     public edit(content: string | null, options: MessageEditOptions | MessageEmbed): Promise<Message>;
     public equals(message: Message, rawData: unknown): boolean;
     public fetchReference(): Promise<Message>;
@@ -1971,9 +1969,7 @@ declare module 'discord.js' {
     ): Promise<RawMessage>;
     public editMessage(message: MessageResolvable, options: WebhookEditMessageOptions): Promise<RawMessage>;
     public fetchMessage(message: Snowflake, cache?: boolean): Promise<RawMessage>;
-    public send(
-      content: string | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<RawMessage>;
+    public send(content: string | (WebhookMessageOptions & { split?: false }) | MessageAdditions): Promise<RawMessage>;
     public send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<RawMessage[]>;
     public send(options: WebhookMessageOptions | APIMessage): Promise<RawMessage | RawMessage[]>;
     public send(
@@ -2761,7 +2757,7 @@ declare module 'discord.js' {
     name: string;
     type: ApplicationCommandOptionType;
     value?: string | number | boolean;
-    options?: CommandInteractionOption[];
+    options?: Collection<string, CommandInteractionOption>;
     user?: User;
     member?: GuildMember | RawInteractionDataResolvedGuildMember;
     channel?: GuildChannel | RawInteractionDataResolvedChannel;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

*cough* So, I totally forgot about slash cmds with no options in #5705. The `options` param in `CommandInteraction#_createOptionsCollection` would be `undefined` for such cmds and thus iterating over it will throw error. This PR fixes the issue by returning an empty collection when `options` is undefined. I did think of making `CommandInteraction#options` null at first:
```js
this.options = data.data?.options ? this._createOptionsCollection(data.data.options, data.data.resolved) : null;
```
but then I saw that before #5705, it was set to an empty array for cmds that have no options, so I went with the empty collection fix.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
