### PR TITLE
feat(Guild): add application_command_count property

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -128,6 +128,14 @@ class Guild extends BaseGuild {
     this.features = data.features;
     this.available = !data.unavailable;
 
+    if ('application_command_count' in data) {
+      /**
+       * The approximate number of slash commands in this guild
+       * @type {?number}
+       */
+      this.applicationCommandCount = data.application_command_count;
+    }
+
     /**
      * The hash of the guild invite splash image
      * @type {?string}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -744,7 +744,7 @@ declare module 'discord.js' {
     public readonly afkChannel: VoiceChannel | null;
     public afkChannelID: Snowflake | null;
     public afkTimeout: number;
-    public applicationCommandCount?: number;
+    public applicationCommandCount: number;
     public applicationID: Snowflake | null;
     public approximateMemberCount: number | null;
     public approximatePresenceCount: number | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -744,6 +744,7 @@ declare module 'discord.js' {
     public readonly afkChannel: VoiceChannel | null;
     public afkChannelID: Snowflake | null;
     public afkTimeout: number;
+    public applicationCommandCount?: number;
     public applicationID: Snowflake | null;
     public approximateMemberCount: number | null;
     public approximatePresenceCount: number | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds the new `application_command_count` property to the guild. The property does show up in the patch data for guild but [discord-api-docs](https://github.com/discord/discord-api-docs/pull/3063) has not merged it yet, so I'll keep this as a draft for now.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
