### PR TITLE
fix(MessageEmbed): import custom RangeError class

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { RangeError } = require('../errors');
 const Util = require('../util/Util');
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

#4880 introduced the `Util.verifyString()` method which takes an error constructor as a parameter, however the custom error class isn't imported in the MessageEmbed file.

**Status and versioning classification:**

- Typings don't need updating