### PR TITLE
debug(WebSocketShard): emit intents used in identify

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -600,7 +600,7 @@ class WebSocketShard extends EventEmitter {
       shard: [this.id, Number(client.options.shardCount)],
     };
 
-    this.debug(`[IDENTIFY] Shard ${this.id}/${client.options.shardCount}`);
+    this.debug(`[IDENTIFY] Shard ${this.id}/${client.options.shardCount} with intents: ${d.intents}`);
     this.send({ op: OPCodes.IDENTIFY, d }, true);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds the used intents to the debug output emitted whenever a shard sends an identify.
This will help debugging (or ruling out) issues caused by missing intents.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
