### PR TITLE
fix(Message): update typings and docs related to #edit

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -474,7 +474,7 @@ class Message extends Base {
   /**
    * Options that can be passed into {@link Message#edit}.
    * @typedef {Object} MessageEditOptions
-   * @property {string|null} [content] Content to be edited
+   * @property {?string} [content] Content to be edited
    * @property {MessageEmbed|Object} [embed] An embed to be added/edited
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -486,7 +486,7 @@ class Message extends Base {
 
   /**
    * Edits the content of the message.
-   * @param {string|APIMessage|null} [content] The new content for the message
+   * @param {?string|APIMessage} [content] The new content for the message
    * @param {MessageEditOptions|MessageEmbed|MessageAttachment|MessageAttachment[]} [options] The options to provide
    * @returns {Promise<Message>}
    * @example

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -474,7 +474,7 @@ class Message extends Base {
   /**
    * Options that can be passed into {@link Message#edit}.
    * @typedef {Object} MessageEditOptions
-   * @property {string} [content] Content to be edited
+   * @property {string|null} [content] Content to be edited
    * @property {MessageEmbed|Object} [embed] An embed to be added/edited
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -486,8 +486,8 @@ class Message extends Base {
 
   /**
    * Edits the content of the message.
-   * @param {string|APIMessage} [content] The new content for the message
-   * @param {MessageEditOptions|MessageEmbed} [options] The options to provide
+   * @param {string|APIMessage|null} [content] The new content for the message
+   * @param {MessageEditOptions|MessageEmbed|MessageAttachment|MessageAttachment[]} [options] The options to provide
    * @returns {Promise<Message>}
    * @example
    * // Update the content of a message

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1184,8 +1184,13 @@ declare module 'discord.js' {
       options?: ReactionCollectorOptions,
     ): ReactionCollector;
     public delete(): Promise<Message>;
-    public edit(content: string | null | MessageEditOptions | MessageEmbed | APIMessage): Promise<Message>;
-    public edit(content: string | null, options: MessageEditOptions | MessageEmbed): Promise<Message>;
+    public edit(
+      content: string | null | MessageEditOptions | MessageEmbed | APIMessage | MessageAttachment | MessageAttachment[],
+    ): Promise<Message>;
+    public edit(
+      content: string | null,
+      options: MessageEditOptions | MessageEmbed | MessageAttachment | MessageAttachment[],
+    ): Promise<Message>;
     public equals(message: Message, rawData: unknown): boolean;
     public fetchReference(): Promise<Message>;
     public fetchWebhook(): Promise<Webhook>;
@@ -3195,7 +3200,7 @@ declare module 'discord.js' {
 
   interface MessageEditOptions {
     attachments?: MessageAttachment[];
-    content?: string;
+    content?: string | null;
     embed?: MessageEmbed | MessageEmbedOptions | null;
     code?: string | boolean;
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the following:
1. The jsdoc of `Message#edit` doesn't show `content` can be null
2. `Message#edit` can take `MessageAttachment` or array of it in `options`
3. The `content` field in `MesssageEditOptions` can be null
4. The jsdoc of `MessageEditOptions` doesn't show `content` can be null

Thanks X 3, @ToasterSticks for noticing this issue too 👍 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
