### PR TITLE
docs(Message): fix content param in #edit not showing as nullable

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -486,7 +486,7 @@ class Message extends Base {
 
   /**
    * Edits the content of the message.
-   * @param {?string|APIMessage} [content] The new content for the message
+   * @param {?(string|APIMessage)} [content] The new content for the message
    * @param {MessageEditOptions|MessageEmbed|MessageAttachment|MessageAttachment[]} [options] The options to provide
    * @returns {Promise<Message>}
    * @example


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

So, turns out `?` (nullable) does work for `@param` tag in jsdoc but if the param can be of more than one type (excluding null) we have to wrap them in parentheses. This time I made sure to test how it will look in docs. This is how it will render valid types for `content` now:

![example](https://i.imgur.com/97QwnHK.png)

also: *docs preview for PRs when :(*

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
