### PR TITLE
Update button style constants to match the official names

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -837,11 +837,11 @@ exports.MessageComponentTypes = createEnum([null, 'ACTION_ROW', 'BUTTON']);
  * PRIMARY
  * SECONDARY
  * SUCCESS
- * DANGER
+ * DESTRUCTIVE
  * LINK
  * @typedef {string} MessageButtonStyle
  */
-exports.MessageButtonStyles = createEnum([null, 'PRIMARY', 'SECONDARY', 'SUCCESS', 'DANGER', 'LINK']);
+exports.MessageButtonStyles = createEnum([null, 'PRIMARY', 'SECONDARY', 'SUCCESS', 'DESTRUCTIVE', 'LINK']);
 
 /**
  * NSFW level of a Guild

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -44,7 +44,7 @@ declare enum MessageButtonStyles {
   PRIMARY = 1,
   SECONDARY = 2,
   SUCCESS = 3,
-  DANGER = 4,
+  DESTRUCTIVE = 4,
   LINK = 5,
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

From the Discord client:
```js
e[e.PRIMARY = 1] = "PRIMARY", e[e.SECONDARY = 2] = "SECONDARY", e[e.SUCCESS = 3] = "SUCCESS", e[e.DESTRUCTIVE = 4] = "DESTRUCTIVE", e[e.LINK = 5] = "LINK"
```