### PR TITLE
types: extend MessageComponentInteractionCollector correctly

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1374,17 +1374,23 @@ declare module 'discord.js' {
 
     public collect(interaction: Interaction): Snowflake;
     public dispose(interaction: Interaction): Snowflake;
-    public on(event: 'collect' | 'dispose', listener: (interaction: Interaction) => Awaited<void>): this;
+    public on(
+      event: 'collect' | 'dispose',
+      listener: (interaction: MessageComponentInteraction) => Awaited<void>,
+    ): this;
     public on(
       event: 'end',
-      listener: (collected: Collection<Snowflake, Interaction>, reason: string) => Awaited<void>,
+      listener: (collected: Collection<Snowflake, MessageComponentInteraction>, reason: string) => Awaited<void>,
     ): this;
     public on(event: string, listener: (...args: any[]) => Awaited<void>): this;
 
-    public once(event: 'collect' | 'dispose', listener: (interaction: Interaction) => Awaited<void>): this;
+    public once(
+      event: 'collect' | 'dispose',
+      listener: (interaction: MessageComponentInteraction) => Awaited<void>,
+    ): this;
     public once(
       event: 'end',
-      listener: (collected: Collection<Snowflake, Interaction>, reason: string) => Awaited<void>,
+      listener: (collected: Collection<Snowflake, MessageComponentInteraction>, reason: string) => Awaited<void>,
     ): this;
     public once(event: string, listener: (...args: any[]) => Awaited<void>): this;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1354,7 +1354,7 @@ declare module 'discord.js' {
     public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
   }
 
-  export class MessageComponentInteractionCollector extends Collector<Snowflake, Interaction> {
+  export class MessageComponentInteractionCollector extends Collector<Snowflake, MessageComponentInteraction> {
     constructor(
       source: Message | TextChannel | NewsChannel | DMChannel,
       filter: CollectorFilter<[MessageComponentInteraction]>,


### PR DESCRIPTION
Fixes a bug in the typings where MessageComponentInteractionCollector didn't pass type to the base Collector correctly.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating