### PR TITLE
feat(Sharding*): contexts for broadcastEval

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -23,6 +23,7 @@ const Messages = {
   DISALLOWED_INTENTS: 'Privileged intent provided is not enabled or whitelisted.',
   SHARDING_NO_SHARDS: 'No shards have been spawned.',
   SHARDING_IN_PROCESS: 'Shards are still being spawned.',
+  SHARDING_INVALID_EVAL_BROADCAST: 'Script to evaluate must be a function',
   SHARDING_SHARD_NOT_FOUND: id => `Shard ${id} could not be found.`,
   SHARDING_ALREADY_SPAWNED: count => `Already spawned ${count} shards.`,
   SHARDING_PROCESS_EXISTS: id => `Shard ${id} already has an active process.`,

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -348,7 +348,7 @@ class Shard extends EventEmitter {
       // Shard is requesting an eval broadcast
       if (message._sEval) {
         const resp = { _sEval: message._sEval, _sEvalShard: message._sEvalShard };
-        this.manager.broadcastEval(message._sEval, { shard: message._sEvalShard }).then(
+        this.manager.broadcastEvalRaw(message._sEval, { shard: message._sEvalShard }).then(
           results => this.send({ ...resp, _result: results }),
           err => this.send({ ...resp, _error: Util.makePlainError(err) }),
         );

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -348,7 +348,7 @@ class Shard extends EventEmitter {
       // Shard is requesting an eval broadcast
       if (message._sEval) {
         const resp = { _sEval: message._sEval, _sEvalShard: message._sEvalShard };
-        this.manager._broadcastEvalRaw(message._sEval, message._sEvalShard).then(
+        this.manager._performOnShards('eval', [message._sEval], message._sEvalShard).then(
           results => this.send({ ...resp, _result: results }),
           err => this.send({ ...resp, _error: Util.makePlainError(err) }),
         );

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -348,7 +348,7 @@ class Shard extends EventEmitter {
       // Shard is requesting an eval broadcast
       if (message._sEval) {
         const resp = { _sEval: message._sEval, _sEvalShard: message._sEvalShard };
-        this.manager.broadcastEval(message._sEval, message._sEvalShard).then(
+        this.manager.broadcastEval(message._sEval, { shard: message._sEvalShard }).then(
           results => this.send({ ...resp, _result: results }),
           err => this.send({ ...resp, _error: Util.makePlainError(err) }),
         );

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -348,7 +348,7 @@ class Shard extends EventEmitter {
       // Shard is requesting an eval broadcast
       if (message._sEval) {
         const resp = { _sEval: message._sEval, _sEvalShard: message._sEvalShard };
-        this.manager.broadcastEvalRaw(message._sEval, { shard: message._sEvalShard }).then(
+        this.manager._broadcastEvalRaw(message._sEval, message._sEvalShard).then(
           results => this.send({ ...resp, _result: results }),
           err => this.send({ ...resp, _error: Util.makePlainError(err) }),
         );

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -139,6 +139,10 @@ class ShardClientUtil {
   broadcastEval(script, options = {}) {
     return new Promise((resolve, reject) => {
       const parent = this.parentPort || process;
+      if (typeof script !== 'function') {
+        reject(new TypeError('SHARDING_INVALID_EVAL_BROADCAST'));
+        return;
+      }
       script = `(${script})(this, ${JSON.stringify(options.context)})`;
 
       const listener = message => {

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -129,6 +129,7 @@ class ShardClientUtil {
    * Evaluates a script or function on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {string|Function} script JavaScript to run on each shard
    * @param {number} [shard] Shard to run script on, all if undefined
+   * @param {Object} [parameterList={}] The JSON-stringifiable parameters to call the function with
    * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    * @example
    * client.shard.broadcastEval('this.guilds.cache.size')
@@ -136,10 +137,10 @@ class ShardClientUtil {
    *   .catch(console.error);
    * @see {@link ShardingManager#broadcastEval}
    */
-  broadcastEval(script, shard) {
+  broadcastEval(script, shard, parameterList = {}) {
     return new Promise((resolve, reject) => {
       const parent = this.parentPort || process;
-      script = typeof script === 'function' ? `(${script})(this)` : script;
+      script = typeof script === 'function' ? `(${script})(this, ${JSON.stringify(parameterList)})` : script;
 
       const listener = message => {
         if (!message || message._sEval !== script || message._sEvalShard !== shard) return;

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -127,11 +127,11 @@ class ShardClientUtil {
 
   /**
    * Evaluates a script or function on all shards, or a given shard, in the context of the {@link Client}s.
-   * @param {string|Function} script JavaScript to run on each shard
+   * @param {Function} script JavaScript to run on each shard
    * @param {BroadcastEvalOptions} [options={}] The options for the broadcast
    * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    * @example
-   * client.shard.broadcastEval('this.guilds.cache.size')
+   * client.shard.broadcastEval(client => client.guilds.cache.size)
    *   .then(results => console.log(`${results.reduce((prev, val) => prev + val, 0)} total guilds`))
    *   .catch(console.error);
    * @see {@link ShardingManager#broadcastEval}
@@ -139,7 +139,7 @@ class ShardClientUtil {
   broadcastEval(script, options = {}) {
     return new Promise((resolve, reject) => {
       const parent = this.parentPort || process;
-      script = typeof script === 'function' ? `(${script})(this, ${JSON.stringify(options.context)})` : script;
+      script = `(${script})(this, ${JSON.stringify(options.context)})`;
 
       const listener = message => {
         if (!message || message._sEval !== script || message._sEvalShard !== options.shard) return;

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -139,7 +139,7 @@ class ShardClientUtil {
   broadcastEval(script, options = {}) {
     return new Promise((resolve, reject) => {
       const parent = this.parentPort || process;
-      script = typeof script === 'function' ? `(${script})(this, ${JSON.stringify(options.context ?? {})})` : script;
+      script = typeof script === 'function' ? `(${script})(this, ${JSON.stringify(options.context)})` : script;
 
       const listener = message => {
         if (!message || message._sEval !== script || message._sEvalShard !== options.shard) return;

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -235,16 +235,22 @@ class ShardingManager extends EventEmitter {
 
   /**
    * Evaluates a script on all shards, or a given shard, in the context of the {@link Client}s.
-   * @param {string|Function} script JavaScript to run on each shard
+   * @param {Function} script JavaScript to run on each shard
    * @param {BroadcastEvalOptions} [options={}] The options for the broadcast
    * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    */
   broadcastEval(script, options = {}) {
-    return this._performOnShards(
-      'eval',
-      [typeof script === 'function' ? `(${script})(this, ${JSON.stringify(options.context)})` : script],
-      options.shard,
-    );
+    return this._broadcastEvalRaw(`(${script})(this, ${JSON.stringify(options.context)})`, options);
+  }
+  /**
+   * Evaluates a raw script on all shards, or a given shard, in the context of the {@link Client}s.
+   * @param {string} script JavaScript to run on each shard
+   * @param {BroadcastEvalOptions} [options={}] The options for the broadcast
+   * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
+   * @private
+   */
+  _broadcastEvalRaw(script, options = {}) {
+    return this._performOnShards('eval', [script], options.shard);
   }
 
   /**

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -227,17 +227,23 @@ class ShardingManager extends EventEmitter {
   }
 
   /**
+   * Options for {@link ShardingManager#broadcastEval} and {@link ShardClientUtil#broadcastEval}.
+   * @typedef {Object} BroadcastEvalOptions
+   * @property {number} [shard] Shard to run script on, all if undefined
+   * @property {*} [context={}] The JSON-stringifiable values to call the function with
+   */
+
+  /**
    * Evaluates a script on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {string|Function} script JavaScript to run on each shard
-   * @param {number} [shard] Shard to run script on, all if undefined
-   * @param {Object} [parameterList={}] The JSON-stringifiable parameters to call the function with
+   * @param {BroadcastEvalOptions} [options={}] The options for the broadcast
    * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    */
-  broadcastEval(script, shard, parameterList = {}) {
+  broadcastEval(script, options = {}) {
     return this._performOnShards(
       'eval',
-      [typeof script === 'function' ? `(${script})(this, ${JSON.stringify(parameterList)})` : script],
-      shard,
+      [typeof script === 'function' ? `(${script})(this, ${JSON.stringify(options.context ?? {})})` : script],
+      options.shard,
     );
   }
 

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -240,6 +240,7 @@ class ShardingManager extends EventEmitter {
    * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    */
   broadcastEval(script, options = {}) {
+    if (typeof script !== 'function') throw new TypeError('SHARDING_INVALID_EVAL_BROADCAST');
     return this._performOnShards('eval', [`(${script})(this, ${JSON.stringify(options.context)})`], options.shard);
   }
 

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -240,17 +240,17 @@ class ShardingManager extends EventEmitter {
    * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    */
   broadcastEval(script, options = {}) {
-    return this._broadcastEvalRaw(`(${script})(this, ${JSON.stringify(options.context)})`, options);
+    return this._broadcastEvalRaw(`(${script})(this, ${JSON.stringify(options.context)})`, options.shard);
   }
   /**
    * Evaluates a raw script on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {string} script JavaScript to run on each shard
-   * @param {BroadcastEvalOptions} [options={}] The options for the broadcast
+   * @param {number} [shard] Shard to run script on, all if undefined
    * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    * @private
    */
-  _broadcastEvalRaw(script, options = {}) {
-    return this._performOnShards('eval', [script], options.shard);
+  _broadcastEvalRaw(script, shard) {
+    return this._performOnShards('eval', [script], shard);
   }
 
   /**

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -228,12 +228,17 @@ class ShardingManager extends EventEmitter {
 
   /**
    * Evaluates a script on all shards, or a given shard, in the context of the {@link Client}s.
-   * @param {string} script JavaScript to run on each shard
-   * @param {number} [shard] Shard to run on, all if undefined
+   * @param {string|Function} script JavaScript to run on each shard
+   * @param {number} [shard] Shard to run script on, all if undefined
+   * @param {Object} [parameterList={}] The JSON-stringifiable parameters to call the function with
    * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    */
-  broadcastEval(script, shard) {
-    return this._performOnShards('eval', [script], shard);
+  broadcastEval(script, shard, parameterList = {}) {
+    return this._performOnShards(
+      'eval',
+      [typeof script === 'function' ? `(${script})(this, ${JSON.stringify(parameterList)})` : script],
+      shard,
+    );
   }
 
   /**

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -240,17 +240,7 @@ class ShardingManager extends EventEmitter {
    * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    */
   broadcastEval(script, options = {}) {
-    return this._broadcastEvalRaw(`(${script})(this, ${JSON.stringify(options.context)})`, options.shard);
-  }
-  /**
-   * Evaluates a raw script on all shards, or a given shard, in the context of the {@link Client}s.
-   * @param {string} script JavaScript to run on each shard
-   * @param {number} [shard] Shard to run script on, all if undefined
-   * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
-   * @private
-   */
-  _broadcastEvalRaw(script, shard) {
-    return this._performOnShards('eval', [script], shard);
+    return this._performOnShards('eval', [`(${script})(this, ${JSON.stringify(options.context)})`], options.shard);
   }
 
   /**

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -240,7 +240,7 @@ class ShardingManager extends EventEmitter {
    * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
    */
   broadcastEval(script, options = {}) {
-    if (typeof script !== 'function') throw new TypeError('SHARDING_INVALID_EVAL_BROADCAST');
+    if (typeof script !== 'function') return Promise.reject(new TypeError('SHARDING_INVALID_EVAL_BROADCAST'));
     return this._performOnShards('eval', [`(${script})(this, ${JSON.stringify(options.context)})`], options.shard);
   }
 

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -230,7 +230,7 @@ class ShardingManager extends EventEmitter {
    * Options for {@link ShardingManager#broadcastEval} and {@link ShardClientUtil#broadcastEval}.
    * @typedef {Object} BroadcastEvalOptions
    * @property {number} [shard] Shard to run script on, all if undefined
-   * @property {*} [context={}] The JSON-serializable values to call the script with
+   * @property {*} [context] The JSON-serializable values to call the script with
    */
 
   /**
@@ -242,7 +242,7 @@ class ShardingManager extends EventEmitter {
   broadcastEval(script, options = {}) {
     return this._performOnShards(
       'eval',
-      [typeof script === 'function' ? `(${script})(this, ${JSON.stringify(options.context ?? {})})` : script],
+      [typeof script === 'function' ? `(${script})(this, ${JSON.stringify(options.context)})` : script],
       options.shard,
     );
   }

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -230,7 +230,7 @@ class ShardingManager extends EventEmitter {
    * Options for {@link ShardingManager#broadcastEval} and {@link ShardClientUtil#broadcastEval}.
    * @typedef {Object} BroadcastEvalOptions
    * @property {number} [shard] Shard to run script on, all if undefined
-   * @property {*} [context={}] The JSON-stringifiable values to call the function with
+   * @property {*} [context={}] The JSON-serializable values to call the script with
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1697,8 +1697,8 @@ declare module 'discord.js' {
     public parentPort: any | null;
     public broadcastEval(script: string): Promise<any[]>;
     public broadcastEval(script: string, shard: number): Promise<any>;
-    public broadcastEval<T>(fn: (client: Client) => T): Promise<T[]>;
-    public broadcastEval<T>(fn: (client: Client) => T, shard: number): Promise<T>;
+    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, shard: undefined, parameterList: P): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, shard: number, parameterList: P): Promise<T>;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
     public respawnAll(options?: { shardDelay?: number; respawnDelay?: number; timeout?: number }): Promise<void>;
@@ -1723,6 +1723,8 @@ declare module 'discord.js' {
     public broadcast(message: any): Promise<Shard[]>;
     public broadcastEval(script: string): Promise<any[]>;
     public broadcastEval(script: string, shard: number): Promise<any>;
+    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, shard: undefined, parameterList: P): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, shard: number, parameterList: P): Promise<T>;
     public createShard(id: number): Shard;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1695,7 +1695,7 @@ declare module 'discord.js' {
     public readonly ids: number[];
     public mode: ShardingManagerMode;
     public parentPort: any | null;
-    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: undefined, context: P }?: BroadcastEvalOptions): Promise<T[]>;
     public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T>;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
@@ -1719,7 +1719,7 @@ declare module 'discord.js' {
     public totalShards: number | 'auto';
     public shardList: number[] | 'auto';
     public broadcast(message: any): Promise<Shard[]>;
-    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: undefined, context: P }?: BroadcastEvalOptions): Promise<T[]>;
     public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T>;
     public createShard(id: number): Shard;
     public fetchClientValues(prop: string): Promise<any[]>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1695,8 +1695,6 @@ declare module 'discord.js' {
     public readonly ids: number[];
     public mode: ShardingManagerMode;
     public parentPort: any | null;
-    public broadcastEval(script: string, { shard: undefined }: BroadcastEvalOptions): Promise<any[]>;
-    public broadcastEval(script: string, { shard: number }: BroadcastEvalOptions): Promise<any>;
     public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
     public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T>;
     public fetchClientValues(prop: string): Promise<any[]>;
@@ -1721,8 +1719,6 @@ declare module 'discord.js' {
     public totalShards: number | 'auto';
     public shardList: number[] | 'auto';
     public broadcast(message: any): Promise<Shard[]>;
-    public broadcastEval(script: string, { shard: undefined }: BroadcastEvalOptions): Promise<any[]>;
-    public broadcastEval(script: string, { shard: number }: BroadcastEvalOptions): Promise<any>;
     public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
     public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T>;
     public createShard(id: number): Shard;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1695,10 +1695,10 @@ declare module 'discord.js' {
     public readonly ids: number[];
     public mode: ShardingManagerMode;
     public parentPort: any | null;
-    public broadcastEval(script: string): Promise<any[]>;
-    public broadcastEval(script: string, shard: number): Promise<any>;
-    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, shard: undefined, parameterList: P): Promise<T[]>;
-    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, shard: number, parameterList: P): Promise<T>;
+    public broadcastEval(script: string, { shard: undefined }: BroadcastEvalOptions): Promise<any[]>;
+    public broadcastEval(script: string, { shard: number }: BroadcastEvalOptions): Promise<any>;
+    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T[]>;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
     public respawnAll(options?: { shardDelay?: number; respawnDelay?: number; timeout?: number }): Promise<void>;
@@ -1721,10 +1721,10 @@ declare module 'discord.js' {
     public totalShards: number | 'auto';
     public shardList: number[] | 'auto';
     public broadcast(message: any): Promise<Shard[]>;
-    public broadcastEval(script: string): Promise<any[]>;
-    public broadcastEval(script: string, shard: number): Promise<any>;
-    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, shard: undefined, parameterList: P): Promise<T[]>;
-    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, shard: number, parameterList: P): Promise<T>;
+    public broadcastEval(script: string, { shard: undefined }: BroadcastEvalOptions): Promise<any[]>;
+    public broadcastEval(script: string, { shard: number }: BroadcastEvalOptions): Promise<any>;
+    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T[]>;
     public createShard(id: number): Shard;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
@@ -2730,6 +2730,11 @@ declare module 'discord.js' {
     | T
     | N
     | Readonly<BitField<T, N>>;
+
+  interface BroadcastEvalOptions<T = unknown> {
+    shard?: number;
+    context?: T;
+  }
 
   type BufferResolvable = Buffer | string;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1697,8 +1697,8 @@ declare module 'discord.js' {
     public parentPort: any | null;
     public broadcastEval(script: string, { shard: undefined }: BroadcastEvalOptions): Promise<any[]>;
     public broadcastEval(script: string, { shard: number }: BroadcastEvalOptions): Promise<any>;
-    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
-    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T[]>;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
     public respawnAll(options?: { shardDelay?: number; respawnDelay?: number; timeout?: number }): Promise<void>;
@@ -1723,8 +1723,8 @@ declare module 'discord.js' {
     public broadcast(message: any): Promise<Shard[]>;
     public broadcastEval(script: string, { shard: undefined }: BroadcastEvalOptions): Promise<any[]>;
     public broadcastEval(script: string, { shard: number }: BroadcastEvalOptions): Promise<any>;
-    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
-    public broadcastEval<T, P>(fn: (client: Client, parameterList: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T[]>;
     public createShard(id: number): Shard;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1698,7 +1698,7 @@ declare module 'discord.js' {
     public broadcastEval(script: string, { shard: undefined }: BroadcastEvalOptions): Promise<any[]>;
     public broadcastEval(script: string, { shard: number }: BroadcastEvalOptions): Promise<any>;
     public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
-    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T>;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
     public respawnAll(options?: { shardDelay?: number; respawnDelay?: number; timeout?: number }): Promise<void>;
@@ -1724,7 +1724,7 @@ declare module 'discord.js' {
     public broadcastEval(script: string, { shard: undefined }: BroadcastEvalOptions): Promise<any[]>;
     public broadcastEval(script: string, { shard: number }: BroadcastEvalOptions): Promise<any>;
     public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: undefined, context: P }: BroadcastEvalOptions): Promise<T[]>;
-    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T[]>;
+    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, { shard: number, context: P }: BroadcastEvalOptions): Promise<T>;
     public createShard(id: number): Shard;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This allows developers to write safer eval code by allowing them to pass functions and contexts to `broadcastEval` in both `ShardClientUtil` and `ShardingManager`.

This avoids directly injecting malicious code into your eval scripts. Instead, you can treat your functions as templates (which you can make sure are safe) which are then injected with a context later on.

For example, the following code is vulnerable (taken and adapted from https://github.com/oadpoaw/discordjs-bot-rce). It's important to recognise that this isn't a security issue with discord.js -- using eval is inherently dangerous, and this is the clearest case of passing unsanitised input to eval.

```js
function findUser(userId) {
  return this.users.cache.get(userId);
}

const unsafe = `');process.exit();a=('`; // causes the shard to exit
const results = await client.shard.broadcastEval(`(${findUser}).call(this, '${unsafe}')`);
```

While this isn't a security issue with discord.js, we can definitely make it much easier to write safer code. The following code snippet is not vulnerable.

```js
function findUser(client, { userId }) {
  return this.users.cache.get(userId);
}

const unsafe = `');process.exit();a=('`;
const results = await client.shard.broadcastEval(findUser, { context: { userId: unsafe }});
```

It's important to note that the context you pass (e.g. in the above example, the context is `{ userId: unsafe }` must be JSON-serializable. This means you can't pass complex data types in the context directly.

This PR removes support for calling `broadcastEval` with strings to enforce better practice with security.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)