### PR TITLE
fix(Webhook): #editMessage throws error when content is null

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -98,7 +98,7 @@ class Webhook {
    * Options that can be passed into editMessage.
    * @typedef {Object} WebhookEditMessageOptions
    * @property {MessageEmbed[]|Object[]} [embeds] See {@link WebhookMessageOptions#embeds}
-   * @property {string} [content] See {@link BaseMessageOptions#content}
+   * @property {?string} [content] See {@link BaseMessageOptions#content}
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
    */
@@ -242,14 +242,14 @@ class Webhook {
   /**
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable|'@original'} message The message to edit
-   * @param {string|APIMessage} [content] The new content for the message
+   * @param {?(string|APIMessage)} [content] The new content for the message
    * @param {WebhookEditMessageOptions|MessageAdditions} [options] The options to provide
    * @returns {Promise<Message|Object>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */
   async editMessage(message, content, options) {
     const { data, files } = await (
-      content.resolveData?.() ?? APIMessage.create(this, content, options).resolveData()
+      content?.resolveData?.() ?? APIMessage.create(this, content, options).resolveData()
     ).resolveFiles();
     const d = await this.client.api
       .webhooks(this.id, this.token)

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -98,7 +98,7 @@ class Webhook {
    * Options that can be passed into editMessage.
    * @typedef {Object} WebhookEditMessageOptions
    * @property {MessageEmbed[]|Object[]} [embeds] See {@link WebhookMessageOptions#embeds}
-   * @property {?string} [content] See {@link BaseMessageOptions#content}
+   * @property {string} [content] See {@link BaseMessageOptions#content}
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a bug in `Webhook#editMessage` where it throws an error when the `content` param is `null`, even tho discord.js supports it as a way to remove content on edits. It also documents that `content` can be `null` in `Webhook#editMessage`. The typings already support `null` as a valid type for `content` so it doesn't need any change.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
