### PR TITLE
refactor: enforce single param on sending/editing methods

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const BaseMessageComponent = require('./BaseMessageComponent');
-const MessageAttachment = require('./MessageAttachment');
 const MessageEmbed = require('./MessageEmbed');
 const { RangeError } = require('../errors');
 const DataResolver = require('../util/DataResolver');
@@ -309,81 +308,15 @@ class APIMessage {
   }
 
   /**
-   * Partitions embeds and attachments.
-   * @param {Array<MessageEmbed|MessageAttachment>} items Items to partition
-   * @returns {Array<MessageEmbed[], MessageAttachment[]>}
-   */
-  static partitionMessageAdditions(items) {
-    const embeds = [];
-    const files = [];
-    for (const item of items) {
-      if (item instanceof MessageEmbed) {
-        embeds.push(item);
-      } else if (item instanceof MessageAttachment) {
-        files.push(item);
-      }
-    }
-
-    return [embeds, files];
-  }
-
-  /**
-   * Transforms the user-level arguments into a final options object. Passing a transformed options object alone into
-   * this method will keep it the same, allowing for the reuse of the final options object.
-   * @param {string} [content] Content to send
-   * @param {MessageOptions|WebhookMessageOptions|MessageAdditions} [options={}] Options to use
-   * @param {MessageOptions|WebhookMessageOptions} [extra={}] Extra options to add onto transformed options
-   * @param {boolean} [isWebhook=false] Whether or not to use WebhookMessageOptions as the result
-   * @returns {MessageOptions|WebhookMessageOptions}
-   */
-  static transformOptions(content, options, extra = {}, isWebhook = false) {
-    if (!options && typeof content === 'object' && !Array.isArray(content)) {
-      options = content;
-      content = undefined;
-    }
-
-    if (!options) {
-      options = {};
-    } else if (options instanceof MessageEmbed) {
-      return isWebhook ? { content, embeds: [options], ...extra } : { content, embed: options, ...extra };
-    } else if (options instanceof MessageAttachment) {
-      return { content, files: [options], ...extra };
-    }
-
-    if (Array.isArray(options)) {
-      const [embeds, files] = this.partitionMessageAdditions(options);
-      return isWebhook ? { content, embeds, files, ...extra } : { content, embed: embeds[0], files, ...extra };
-    } else if (Array.isArray(content)) {
-      const [embeds, files] = this.partitionMessageAdditions(content);
-      if (embeds.length || files.length) {
-        return isWebhook ? { embeds, files, ...extra } : { embed: embeds[0], files, ...extra };
-      }
-    }
-
-    return { content, ...options, ...extra };
-  }
-
-  /**
    * Creates an `APIMessage` from user-level arguments.
    * @param {MessageTarget} target Target to send to
-   * @param {string} [content] Content to send
-   * @param {MessageOptions|WebhookMessageOptions|MessageAdditions} [options={}] Options to use
-   * @param {MessageOptions|WebhookMessageOptions} [extra={}] - Extra options to add onto transformed options
+   * @param {MessageOptions|WebhookMessageOptions} options Options to use
+   * @param {MessageOptions|WebhookMessageOptions} [extra={}] - Extra options to add onto specified options
    * @returns {MessageOptions|WebhookMessageOptions}
    */
-  static create(target, content, options, extra = {}) {
-    const Interaction = require('./Interaction');
-    const InteractionWebhook = require('./InteractionWebhook');
-    const Webhook = require('./Webhook');
-    const WebhookClient = require('../client/WebhookClient');
-
-    const isWebhook =
-      target instanceof Interaction ||
-      target instanceof InteractionWebhook ||
-      target instanceof Webhook ||
-      target instanceof WebhookClient;
-    const transformed = this.transformOptions(content, options, extra, isWebhook);
-    return new this(target, transformed);
+  static create(target, options, extra = {}) {
+    if (typeof options === 'string') return new this(target, { content: options, ...extra });
+    else return new this(target, { ...options, ...extra });
   }
 }
 
@@ -392,9 +325,4 @@ module.exports = APIMessage;
 /**
  * A target for a message.
  * @typedef {TextChannel|DMChannel|User|GuildMember|Webhook|WebhookClient|Interaction|InteractionWebhook} MessageTarget
- */
-
-/**
- * Additional items that can be sent with a message.
- * @typedef {MessageEmbed|MessageAttachment|Array<MessageEmbed|MessageAttachment>} MessageAdditions
  */

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -310,7 +310,7 @@ class APIMessage {
   /**
    * Creates an `APIMessage` from user-level arguments.
    * @param {MessageTarget} target Target to send to
-   * @param {MessageOptions|WebhookMessageOptions} options Options to use
+   * @param {string|MessageOptions|WebhookMessageOptions} options Options or content to use
    * @param {MessageOptions|WebhookMessageOptions} [extra={}] - Extra options to add onto specified options
    * @returns {MessageOptions|WebhookMessageOptions}
    */

--- a/src/structures/InteractionWebhook.js
+++ b/src/structures/InteractionWebhook.js
@@ -28,8 +28,7 @@ class InteractionWebhook {
   /* eslint-disable no-empty-function, valid-jsdoc */
   /**
    * Sends a message with this webhook.
-   * @param {string|APIMessage|MessageAdditions} content The content for the reply
-   * @param {InteractionReplyOptions} [options] Additional options for the reply
+   * @param {string|APIMessage|InteractionReplyOptions} options The content for the reply
    * @returns {Promise<Message|Object>}
    */
   send() {}

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -651,7 +651,7 @@ class Message extends Base {
 
   /**
    * Send an inline reply to this message.
-   * @param {string|APIMessage|ReplyMessageOptions|MessageAdditions} options The options to provide
+   * @param {string|APIMessage|ReplyMessageOptions} options The options to provide
    * @returns {Promise<Message|Message[]>}
    * @example
    * // Reply to a message

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -551,12 +551,7 @@ class Message extends Base {
    *   .catch(console.error);
    */
   edit(options) {
-    let apiMessage;
-
-    if (options instanceof APIMessage) apiMessage = options.resolveData();
-    else apiMessage = APIMessage.create(this, options).resolveData();
-
-    return this.channel.messages.edit(this.id, apiMessage);
+    return this.channel.messages.edit(this.id, options);
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -665,7 +665,7 @@ class Message extends Base {
     if (options instanceof APIMessage) {
       data = options;
     } else {
-      data = APIMessage.transformOptions(options, {
+      data = APIMessage.create(this, options, {
         reply: {
           messageReference: this,
           failIfNotExists: options?.failIfNotExists ?? true,

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -541,8 +541,7 @@ class Message extends Base {
 
   /**
    * Edits the content of the message.
-   * @param {string|APIMessage|MessageEditOptions|MessageEmbed
-   * |MessageAttachment|MessageAttachment[]} options The options to provide
+   * @param {string|APIMessage|MessageEditOptions} options The options to provide
    * @returns {Promise<Message>}
    * @example
    * // Update the content of a message

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -551,17 +551,12 @@ class Message extends Base {
    *   .catch(console.error);
    */
   edit(options) {
-    let data;
+    let apiMessage;
 
-    if (options instanceof APIMessage) {
-      data = options.resolveData();
-    } else if (typeof options === 'string') {
-      data = APIMessage.create(this, options);
-    } else {
-      data = APIMessage.create(this, null, options).resolveData();
-    }
+    if (options instanceof APIMessage) apiMessage = options.resolveData();
+    else apiMessage = APIMessage.create(this, options).resolveData();
 
-    return this.channel.messages.edit(this.id, data);
+    return this.channel.messages.edit(this.id, apiMessage);
   }
 
   /**
@@ -669,22 +664,14 @@ class Message extends Base {
 
     if (options instanceof APIMessage) {
       data = options;
-    } else if (typeof options === 'string') {
-      data = APIMessage.transformOptions(options, null, {
-        reply: {
-          messageReference: this,
-          failIfNotExists: options?.failIfNotExists ?? true,
-        },
-      });
     } else {
-      data = APIMessage.transformOptions(null, options, {
+      data = APIMessage.transformOptions(options, {
         reply: {
           messageReference: this,
           failIfNotExists: options?.failIfNotExists ?? true,
         },
       });
     }
-
     return this.channel.send(data);
   }
 

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -105,7 +105,7 @@ class Webhook {
 
   /**
    * Sends a message with this webhook.
-   * @param {string|APIMessage|WebhookMessageOptions|MessageAdditions} options The options to provide
+   * @param {string|APIMessage|WebhookMessageOptions} options The options to provide
    * @returns {Promise<Message|Object>}
    * @example
    * // Send a basic message
@@ -242,7 +242,7 @@ class Webhook {
   /**
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable|'@original'} message The message to edit
-   * @param {string|APIMessage|WebhookEditMessageOptions|MessageAdditions} options The options to provide
+   * @param {string|APIMessage|WebhookEditMessageOptions} options The options to provide
    * @returns {Promise<Message|Object>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -249,10 +249,10 @@ class Webhook {
   async editMessage(message, options) {
     let apiMessage;
 
-    if (options instanceof APIMessage) apiMessage = options.resolveData();
-    else apiMessage = APIMessage.create(this, options).resolveData();
+    if (options instanceof APIMessage) apiMessage = options;
+    else apiMessage = APIMessage.create(this, options);
 
-    const { data, files } = await apiMessage.resolveFiles();
+    const { data, files } = await apiMessage.resolveData().resolveFiles();
 
     const d = await this.client.api
       .webhooks(this.id, this.token)

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -105,8 +105,7 @@ class Webhook {
 
   /**
    * Sends a message with this webhook.
-   * @param {string|APIMessage} [content=''] The content to send
-   * @param {WebhookMessageOptions|MessageAdditions} [options={}] The options to provide
+   * @param {string|APIMessage|WebhookMessageOptions|MessageAdditions} options The options to provide
    * @returns {Promise<Message|Object>}
    * @example
    * // Send a basic message
@@ -132,7 +131,8 @@ class Webhook {
    *   .catch(console.error);
    * @example
    * // Send an embed with a local image inside
-   * webhook.send('This is an embed', {
+   * webhook.send({
+   * content: 'This is an embed',
    *   embeds: [{
    *     thumbnail: {
    *          url: 'attachment://file.jpg'
@@ -146,13 +146,15 @@ class Webhook {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async send(content, options) {
+  async send(options) {
     let apiMessage;
 
-    if (content instanceof APIMessage) {
-      apiMessage = content.resolveData();
+    if (options instanceof APIMessage) {
+      apiMessage = options.resolveData();
+    } else if (typeof options === 'string') {
+      apiMessage = APIMessage.create(this, options);
     } else {
-      apiMessage = APIMessage.create(this, content, options).resolveData();
+      apiMessage = APIMessage.create(this, null, options).resolveData();
       if (Array.isArray(apiMessage.data.content)) {
         return Promise.all(apiMessage.split().map(this.send.bind(this)));
       }
@@ -242,15 +244,19 @@ class Webhook {
   /**
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable|'@original'} message The message to edit
-   * @param {?(string|APIMessage)} [content] The new content for the message
-   * @param {WebhookEditMessageOptions|MessageAdditions} [options] The options to provide
+   * @param {string|APIMessage|WebhookEditMessageOptions|MessageAdditions} options The options to provide
    * @returns {Promise<Message|Object>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */
-  async editMessage(message, content, options) {
-    const { data, files } = await (
-      content?.resolveData?.() ?? APIMessage.create(this, content, options).resolveData()
-    ).resolveFiles();
+  async editMessage(message, options) {
+    let apiMessage;
+
+    if (options instanceof APIMessage) apiMessage = options.resolveData();
+    else if (typeof options === 'string') apiMessage = APIMessage.create(this, options).resolveData();
+    else apiMessage = APIMessage.create(this, null, options).resolveData();
+
+    const { data, files } = await apiMessage.resolveFiles();
+
     const d = await this.client.api
       .webhooks(this.id, this.token)
       .messages(typeof message === 'string' ? message : message.id)

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -151,10 +151,8 @@ class Webhook {
 
     if (options instanceof APIMessage) {
       apiMessage = options.resolveData();
-    } else if (typeof options === 'string') {
-      apiMessage = APIMessage.create(this, options);
     } else {
-      apiMessage = APIMessage.create(this, null, options).resolveData();
+      apiMessage = APIMessage.create(this, options).resolveData();
       if (Array.isArray(apiMessage.data.content)) {
         return Promise.all(apiMessage.split().map(this.send.bind(this)));
       }
@@ -252,8 +250,7 @@ class Webhook {
     let apiMessage;
 
     if (options instanceof APIMessage) apiMessage = options.resolveData();
-    else if (typeof options === 'string') apiMessage = APIMessage.create(this, options).resolveData();
-    else apiMessage = APIMessage.create(this, null, options).resolveData();
+    else apiMessage = APIMessage.create(this, options).resolveData();
 
     const { data, files } = await apiMessage.resolveFiles();
 

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -132,7 +132,7 @@ class Webhook {
    * @example
    * // Send an embed with a local image inside
    * webhook.send({
-   * content: 'This is an embed',
+   *   content: 'This is an embed',
    *   embeds: [{
    *     thumbnail: {
    *          url: 'attachment://file.jpg'

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -140,8 +140,7 @@ class InteractionResponses {
    * @returns {Promise<Message|Object>}
    */
   followUp(options) {
-    if (typeof options === 'string' || options instanceof APIMessage) return this.webhook.send(options);
-    else return this.webhook.send(null, options);
+    return this.webhook.send(options);
   }
 
   /**

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -73,7 +73,7 @@ class InteractionResponses {
     let apiMessage;
     if (options instanceof APIMessage) apiMessage = options;
     else if (typeof options === 'string') apiMessage = APIMessage.create(this, options);
-    else apiMessage = APIMessage.create(this, null, options);
+    else apiMessage = APIMessage.create(this, options);
 
     const { data, files } = await apiMessage.resolveData().resolveFiles();
 
@@ -116,7 +116,7 @@ class InteractionResponses {
     if (typeof options === 'string' || options instanceof APIMessage) {
       return this.webhook.editMessage('@original', options);
     } else {
-      return this.webhook.editMessage('@original', null, options);
+      return this.webhook.editMessage('@original', options);
     }
   }
 
@@ -178,7 +178,7 @@ class InteractionResponses {
     let apiMessage;
     if (options instanceof APIMessage) apiMessage = options;
     else if (typeof options === 'string') apiMessage = APIMessage.create(this, options);
-    else apiMessage = APIMessage.create(this, null, options);
+    else apiMessage = APIMessage.create(this, options);
 
     const { data, files } = await apiMessage.resolveData().resolveFiles();
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -73,7 +73,7 @@ class InteractionResponses {
     let apiMessage;
     if (options instanceof APIMessage) apiMessage = options;
     else if (typeof options === 'string') apiMessage = APIMessage.create(this, options);
-    else apiMessage = APIMessage.create(this, options.content, options);
+    else apiMessage = APIMessage.create(this, null, options);
 
     const { data, files } = await apiMessage.resolveData().resolveFiles();
 
@@ -116,7 +116,7 @@ class InteractionResponses {
     if (typeof options === 'string' || options instanceof APIMessage) {
       return this.webhook.editMessage('@original', options);
     } else {
-      return this.webhook.editMessage('@original', options.content, options);
+      return this.webhook.editMessage('@original', null, options);
     }
   }
 
@@ -141,7 +141,7 @@ class InteractionResponses {
    */
   followUp(options) {
     if (typeof options === 'string' || options instanceof APIMessage) return this.webhook.send(options);
-    else return this.webhook.send(options.content, options);
+    else return this.webhook.send(null, options);
   }
 
   /**
@@ -179,7 +179,7 @@ class InteractionResponses {
     let apiMessage;
     if (options instanceof APIMessage) apiMessage = options;
     else if (typeof options === 'string') apiMessage = APIMessage.create(this, options);
-    else apiMessage = APIMessage.create(this, options.content, options);
+    else apiMessage = APIMessage.create(this, null, options);
 
     const { data, files } = await apiMessage.resolveData().resolveFiles();
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -72,7 +72,6 @@ class InteractionResponses {
 
     let apiMessage;
     if (options instanceof APIMessage) apiMessage = options;
-    else if (typeof options === 'string') apiMessage = APIMessage.create(this, options);
     else apiMessage = APIMessage.create(this, options);
 
     const { data, files } = await apiMessage.resolveData().resolveFiles();

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -112,11 +112,7 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   editReply(options) {
-    if (typeof options === 'string' || options instanceof APIMessage) {
-      return this.webhook.editMessage('@original', options);
-    } else {
-      return this.webhook.editMessage('@original', options);
-    }
+    return this.webhook.editMessage('@original', options);
   }
 
   /**

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -52,7 +52,7 @@ class InteractionResponses {
 
   /**
    * Creates a reply to this interaction.
-   * @param {string|APIMessage|MessageAdditions|InteractionReplyOptions} options The options for the reply
+   * @param {string|APIMessage|InteractionReplyOptions} options The options for the reply
    * @returns {Promise<void>}
    * @example
    * // Reply to the interaction with an embed
@@ -104,7 +104,7 @@ class InteractionResponses {
   /**
    * Edits the initial reply to this interaction.
    * @see Webhook#editMessage
-   * @param {string|APIMessage|MessageAdditions|WebhookEditMessageOptions} options The new options for the message
+   * @param {string|APIMessage|WebhookEditMessageOptions} options The new options for the message
    * @returns {Promise<Message|Object>}
    * @example
    * // Edit the reply to this interaction
@@ -136,7 +136,7 @@ class InteractionResponses {
 
   /**
    * Send a follow-up message to this interaction.
-   * @param {string|APIMessage|MessageAdditions|InteractionReplyOptions} options The options for the reply
+   * @param {string|APIMessage|InteractionReplyOptions} options The options for the reply
    * @returns {Promise<Message|Object>}
    */
   followUp(options) {
@@ -164,7 +164,7 @@ class InteractionResponses {
 
   /**
    * Updates the original message whose button was pressed
-   * @param {string|APIMessage|MessageAdditions|WebhookEditMessageOptions} options The options for the reply
+   * @param {string|APIMessage|WebhookEditMessageOptions} options The options for the reply
    * @returns {Promise<void>}
    * @example
    * // Remove the buttons from the message

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -172,7 +172,6 @@ class InteractionResponses {
 
     let apiMessage;
     if (options instanceof APIMessage) apiMessage = options;
-    else if (typeof options === 'string') apiMessage = APIMessage.create(this, options);
     else apiMessage = APIMessage.create(this, options);
 
     const { data, files } = await apiMessage.resolveData().resolveFiles();

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -167,10 +167,8 @@ class TextBasedChannel {
 
     if (options instanceof APIMessage) {
       apiMessage = options.resolveData();
-    } else if (typeof options === 'string') {
-      apiMessage = APIMessage.create(this, options);
     } else {
-      apiMessage = APIMessage.create(this, null, options).resolveData();
+      apiMessage = APIMessage.create(this, options).resolveData();
       if (Array.isArray(apiMessage.data.content)) {
         return Promise.all(apiMessage.split().map(this.send.bind(this)));
       }

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -160,7 +160,7 @@ class TextBasedChannel {
     const GuildMember = require('../GuildMember');
 
     if (this instanceof User || this instanceof GuildMember) {
-      return this.createDM().then(dm => dm.send(null, options));
+      return this.createDM().then(dm => dm.send(options));
     }
 
     let apiMessage;

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -115,8 +115,7 @@ class TextBasedChannel {
 
   /**
    * Sends a message to this channel.
-   * @param {string|APIMessage} [content=''] The content to send
-   * @param {MessageOptions|MessageAdditions} [options={}] The options to provide
+   * @param {string|APIMessage|MessageOptions|MessageAdditions} options The options to provide
    * @returns {Promise<Message|Message[]>}
    * @example
    * // Send a basic message
@@ -156,20 +155,22 @@ class TextBasedChannel {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async send(content, options) {
+  async send(options) {
     const User = require('../User');
     const GuildMember = require('../GuildMember');
 
     if (this instanceof User || this instanceof GuildMember) {
-      return this.createDM().then(dm => dm.send(content, options));
+      return this.createDM().then(dm => dm.send(options.content, options));
     }
 
     let apiMessage;
 
-    if (content instanceof APIMessage) {
-      apiMessage = content.resolveData();
+    if (options instanceof APIMessage) {
+      apiMessage = options.resolveData();
+    } else if (typeof options === 'string') {
+      apiMessage = APIMessage.create(this, options);
     } else {
-      apiMessage = APIMessage.create(this, content, options).resolveData();
+      apiMessage = APIMessage.create(this, options.content, options).resolveData();
       if (Array.isArray(apiMessage.data.content)) {
         return Promise.all(apiMessage.split().map(this.send.bind(this)));
       }

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -115,7 +115,7 @@ class TextBasedChannel {
 
   /**
    * Sends a message to this channel.
-   * @param {string|APIMessage|MessageOptions|MessageAdditions} options The options to provide
+   * @param {string|APIMessage|MessageOptions} options The options to provide
    * @returns {Promise<Message|Message[]>}
    * @example
    * // Send a basic message

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -160,7 +160,7 @@ class TextBasedChannel {
     const GuildMember = require('../GuildMember');
 
     if (this instanceof User || this instanceof GuildMember) {
-      return this.createDM().then(dm => dm.send(options.content, options));
+      return this.createDM().then(dm => dm.send(null, options));
     }
 
     let apiMessage;
@@ -170,7 +170,7 @@ class TextBasedChannel {
     } else if (typeof options === 'string') {
       apiMessage = APIMessage.create(this, options);
     } else {
-      apiMessage = APIMessage.create(this, options.content, options).resolveData();
+      apiMessage = APIMessage.create(this, null, options).resolveData();
       if (Array.isArray(apiMessage.data.content)) {
         return Promise.all(apiMessage.split().map(this.send.bind(this)));
       }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1220,7 +1220,7 @@ declare module 'discord.js' {
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public removeAttachments(): Promise<Message>;
     public reply(options: string | (ReplyMessageOptions & { split?: false })): Promise<Message>;
-    public reply(options: string | (ReplyMessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
+    public reply(options: APIMessage | (ReplyMessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): unknown;
     public toString(): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2480,12 +2480,8 @@ declare module 'discord.js' {
   interface PartialTextBasedChannelFields {
     lastMessageID: Snowflake | null;
     readonly lastMessage: Message | null;
-    send(content: string | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-    send(options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    send(options: MessageOptions | APIMessage): Promise<Message | Message[]>;
-    send(content: string | null, options: (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
-    send(content: string | null, options: MessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    send(content: string | null, options: MessageOptions): Promise<Message | Message[]>;
+    send(options: string | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+    send(options: string | (MessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
   }
 
   interface TextBasedChannelFields extends PartialTextBasedChannelFields {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1244,11 +1244,7 @@ declare module 'discord.js' {
     ): MessageComponentInteractionCollector;
     public delete(): Promise<Message>;
     public edit(
-      content: string | null | MessageEditOptions | MessageEmbed | APIMessage | MessageAttachment | MessageAttachment[],
-    ): Promise<Message>;
-    public edit(
-      content: string | null,
-      options: MessageEditOptions | MessageEmbed | MessageAttachment | MessageAttachment[],
+      content: string | MessageEditOptions | MessageEmbed | APIMessage | MessageAttachment | MessageAttachment[],
     ): Promise<Message>;
     public equals(message: Message, rawData: unknown): boolean;
     public fetchReference(): Promise<Message>;
@@ -1258,20 +1254,8 @@ declare module 'discord.js' {
     public pin(): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public removeAttachments(): Promise<Message>;
-    public reply(
-      content: string | null | (ReplyMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message>;
-    public reply(options: ReplyMessageOptions & { split: true | SplitOptions }): Promise<Message[]>;
-    public reply(options: ReplyMessageOptions | APIMessage): Promise<Message | Message[]>;
-    public reply(
-      content: string | null,
-      options: (ReplyMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message>;
-    public reply(
-      content: string | null,
-      options: ReplyMessageOptions & { split: true | SplitOptions },
-    ): Promise<Message[]>;
-    public reply(content: string | null, options: ReplyMessageOptions): Promise<Message | Message[]>;
+    public reply(options: string | (ReplyMessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+    public reply(options: string | (ReplyMessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): unknown;
     public toString(): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2413,7 +2413,7 @@ declare module 'discord.js' {
   interface PartialTextBasedChannelFields {
     lastMessageID: Snowflake | null;
     readonly lastMessage: Message | null;
-    send(options: string | (MessageOptions & { split?: false })): Promise<Message>;
+    send(options: string | APIMessage | (MessageOptions & { split?: false })): Promise<Message>;
     send(options: APIMessage (MessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1117,7 +1117,7 @@ declare module 'discord.js' {
       options: string | APIMessage | (InteractionReplyOptions & { split?: false }),
     ): Promise<Message | RawMessage>;
     public send(
-      options: string | APIMessage | (InteractionReplyOptions & { split: true | SplitOptions }),
+      options: APIMessage | (InteractionReplyOptions & { split: true | SplitOptions }),
     ): Promise<(Message | RawMessage)[]>;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -471,13 +471,13 @@ declare module 'discord.js' {
     public defer(options?: InteractionDeferOptions): Promise<void>;
     public deleteReply(): Promise<void>;
     public editReply(
-      options: string | null | APIMessage | WebhookEditMessageOptions | MessageAdditions,
+      options: string | APIMessage | WebhookEditMessageOptions | MessageAdditions,
     ): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
     public followUp(
       options: string | APIMessage | InteractionReplyOptions | MessageAdditions,
     ): Promise<Message | RawMessage>;
-    public reply(options: string | null | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
+    public reply(options: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
     private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -144,12 +144,6 @@ declare module 'discord.js' {
 
     public static create(
       target: MessageTarget,
-      content: string | null,
-      options?: undefined,
-      extra?: MessageOptions | WebhookMessageOptions,
-    ): APIMessage;
-    public static create(
-      target: MessageTarget,
       options: string | MessageOptions | WebhookMessageOptions,
       extra?: MessageOptions | WebhookMessageOptions,
     ): APIMessage;
@@ -2414,7 +2408,7 @@ declare module 'discord.js' {
     lastMessageID: Snowflake | null;
     readonly lastMessage: Message | null;
     send(options: string | APIMessage | (MessageOptions & { split?: false })): Promise<Message>;
-    send(options: APIMessage (MessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
+    send(options: APIMessage | (MessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
   }
 
   interface TextBasedChannelFields extends PartialTextBasedChannelFields {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1219,7 +1219,7 @@ declare module 'discord.js' {
     public pin(): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public removeAttachments(): Promise<Message>;
-    public reply(options: string | (ReplyMessageOptions & { split?: false })): Promise<Message>;
+    public reply(options: string | APIMessage | (ReplyMessageOptions & { split?: false })): Promise<Message>;
     public reply(options: APIMessage | (ReplyMessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): unknown;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -471,16 +471,13 @@ declare module 'discord.js' {
     public defer(options?: InteractionDeferOptions): Promise<void>;
     public deleteReply(): Promise<void>;
     public editReply(
-      content: string | null | APIMessage | WebhookEditMessageOptions | MessageAdditions,
+      options: string | null | APIMessage | WebhookEditMessageOptions | MessageAdditions,
     ): Promise<Message | RawMessage>;
-    public editReply(content: string | null, options?: WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
     public followUp(
-      content: string | APIMessage | InteractionReplyOptions | MessageAdditions,
+      options: string | APIMessage | InteractionReplyOptions | MessageAdditions,
     ): Promise<Message | RawMessage>;
-    public followUp(content: string | null, options?: InteractionReplyOptions): Promise<Message | RawMessage>;
-    public reply(content: string | null | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
-    public reply(content: string | null, options?: InteractionReplyOptions): Promise<void>;
+    public reply(options: string | null | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
     private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
   }
@@ -1362,20 +1359,16 @@ declare module 'discord.js' {
     public deferUpdate(): Promise<void>;
     public deleteReply(): Promise<void>;
     public editReply(
-      content: string | APIMessage | WebhookEditMessageOptions | MessageEmbed | MessageEmbed[],
+      options: string | APIMessage | WebhookEditMessageOptions | MessageEmbed,
     ): Promise<Message | RawMessage>;
-    public editReply(content: string, options?: WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
     public followUp(
-      content: string | APIMessage | InteractionReplyOptions | MessageAdditions,
+      options: string | APIMessage | InteractionReplyOptions | MessageAdditions,
     ): Promise<Message | RawMessage>;
-    public followUp(content: string, options?: InteractionReplyOptions): Promise<Message | RawMessage>;
-    public reply(content: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
-    public reply(content: string, options?: InteractionReplyOptions): Promise<void>;
+    public reply(options: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
     public update(
-      content: string | APIMessage | WebhookEditMessageOptions | MessageEmbed | MessageEmbed[],
+      content: string | APIMessage | WebhookEditMessageOptions | MessageEmbed,
     ): Promise<Message | RawMessage>;
-    public update(content: string, options?: WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -150,7 +150,6 @@ declare module 'discord.js' {
     ): APIMessage;
     public static create(
       target: MessageTarget,
-      content: string | null,
       options: MessageOptions | WebhookMessageOptions,
       extra?: MessageOptions | WebhookMessageOptions,
     ): APIMessage;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2502,9 +2502,6 @@ declare module 'discord.js' {
     ): Promise<Message | RawMessage>;
     fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | RawMessage>;
     send(
-      content: string | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message | RawMessage>;
-    send(
       options: string | APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
     ): Promise<(Message | RawMessage)[]>;
     send(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -150,7 +150,7 @@ declare module 'discord.js' {
     ): APIMessage;
     public static create(
       target: MessageTarget,
-      options: MessageOptions | WebhookMessageOptions,
+      options: string | MessageOptions | WebhookMessageOptions,
       extra?: MessageOptions | WebhookMessageOptions,
     ): APIMessage;
     public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | MessageAttachment): Promise<unknown>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2459,7 +2459,7 @@ declare module 'discord.js' {
     ): Promise<Message | RawMessage>;
     fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | RawMessage>;
     send(
-      options: string | APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
+      options: APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
     ): Promise<(Message | RawMessage)[]>;
     send(options: string | APIMessage | (WebhookMessageOptions & { split?: false })): Promise<Message | RawMessage>;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2414,7 +2414,7 @@ declare module 'discord.js' {
     lastMessageID: Snowflake | null;
     readonly lastMessage: Message | null;
     send(options: string | (MessageOptions & { split?: false })): Promise<Message>;
-    send(options: string | (MessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
+    send(options: APIMessage (MessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
   }
 
   interface TextBasedChannelFields extends PartialTextBasedChannelFields {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2069,7 +2069,7 @@ declare module 'discord.js' {
     public fetchMessage(message: Snowflake, cache?: boolean): Promise<RawMessage>;
     public send(options: string | APIMessage | (WebhookMessageOptions & { split?: false })): Promise<RawMessage>;
     public send(
-      options: string | APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
+      options: APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
     ): Promise<RawMessage[]>;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2111,23 +2111,15 @@ declare module 'discord.js' {
     public token: string;
     public editMessage(
       message: MessageResolvable,
-      content: string | null | APIMessage | MessageEmbed | MessageEmbed[],
-      options?: WebhookEditMessageOptions,
+      options: string | APIMessage | WebhookEditMessageOptions | MessageEmbed | MessageEmbed[],
     ): Promise<RawMessage>;
-    public editMessage(message: MessageResolvable, options: WebhookEditMessageOptions): Promise<RawMessage>;
     public fetchMessage(message: Snowflake, cache?: boolean): Promise<RawMessage>;
-    public send(content: string | (WebhookMessageOptions & { split?: false }) | MessageAdditions): Promise<RawMessage>;
-    public send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<RawMessage[]>;
-    public send(options: WebhookMessageOptions | APIMessage): Promise<RawMessage | RawMessage[]>;
     public send(
-      content: string | null,
-      options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
+      content: string | APIMessage | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<RawMessage>;
     public send(
-      content: string | null,
-      options: WebhookMessageOptions & { split: true | SplitOptions },
+      options: string | APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
     ): Promise<RawMessage[]>;
-    public send(content: string | null, options: WebhookMessageOptions): Promise<RawMessage | RawMessage[]>;
   }
 
   export class WebSocketManager extends EventEmitter {
@@ -2506,31 +2498,18 @@ declare module 'discord.js' {
     deleteMessage(message: MessageResolvable | '@original'): Promise<void>;
     editMessage(
       message: MessageResolvable | '@original',
-      content: string | null | APIMessage | MessageAdditions,
-      options?: WebhookEditMessageOptions,
-    ): Promise<Message | RawMessage>;
-    editMessage(
-      message: MessageResolvable | '@original',
-      options: WebhookEditMessageOptions,
+      options: string | APIMessage | WebhookEditMessageOptions | MessageAdditions,
     ): Promise<Message | RawMessage>;
     fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | RawMessage>;
     send(
       content: string | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
     ): Promise<Message | RawMessage>;
-    send(options: WebhookMessageOptions & { split: true | SplitOptions }): Promise<(Message | RawMessage)[]>;
-    send(options: WebhookMessageOptions | APIMessage): Promise<Message | RawMessage | (Message | RawMessage)[]>;
     send(
-      content: string | null,
-      options: (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message | RawMessage>;
-    send(
-      content: string | null,
-      options: WebhookMessageOptions & { split: true | SplitOptions },
+      options: string | APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
     ): Promise<(Message | RawMessage)[]>;
     send(
-      content: string | null,
-      options: WebhookMessageOptions,
-    ): Promise<Message | RawMessage | (Message | RawMessage)[]>;
+      options: string | APIMessage | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
+    ): Promise<Message | RawMessage>;
   }
 
   interface WebhookFields extends PartialWebhookFields {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1120,23 +1120,12 @@ declare module 'discord.js' {
   export class InteractionWebhook extends PartialWebhookMixin() {
     constructor(client: Client, id: Snowflake, token: string);
     public token: string;
-    public send(content: string | (InteractionReplyOptions & { split?: false })): Promise<Message | RawMessage>;
-    public send(options: InteractionReplyOptions & { split: true | SplitOptions }): Promise<(Message | RawMessage)[]>;
     public send(
-      options: InteractionReplyOptions | APIMessage,
-    ): Promise<Message | RawMessage | (Message | RawMessage)[]>;
-    public send(
-      content: string | null,
-      options: InteractionReplyOptions & { split?: false },
+      options: string | APIMessage | (InteractionReplyOptions & { split?: false }),
     ): Promise<Message | RawMessage>;
     public send(
-      content: string | null,
-      options: InteractionReplyOptions & { split: true | SplitOptions },
+      options: string | APIMessage | (InteractionReplyOptions & { split: true | SplitOptions }),
     ): Promise<(Message | RawMessage)[]>;
-    public send(
-      content: string | null,
-      options: InteractionReplyOptions,
-    ): Promise<Message | RawMessage | (Message | RawMessage)[]>;
   }
 
   export class Invite extends Base {
@@ -2085,7 +2074,7 @@ declare module 'discord.js' {
       options: string | APIMessage | WebhookEditMessageOptions,
     ): Promise<RawMessage>;
     public fetchMessage(message: Snowflake, cache?: boolean): Promise<RawMessage>;
-    public send(content: string | APIMessage | (WebhookMessageOptions & { split?: false })): Promise<RawMessage>;
+    public send(options: string | APIMessage | (WebhookMessageOptions & { split?: false })): Promise<RawMessage>;
     public send(
       options: string | APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
     ): Promise<RawMessage[]>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -151,25 +151,10 @@ declare module 'discord.js' {
     public static create(
       target: MessageTarget,
       content: string | null,
-      options: MessageOptions | WebhookMessageOptions | MessageAdditions,
+      options: MessageOptions | WebhookMessageOptions,
       extra?: MessageOptions | WebhookMessageOptions,
     ): APIMessage;
-    public static partitionMessageAdditions(
-      items: readonly (MessageEmbed | MessageAttachment)[],
-    ): [MessageEmbed[], MessageAttachment[]];
     public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | MessageAttachment): Promise<unknown>;
-    public static transformOptions(
-      content: string | null,
-      options?: undefined,
-      extra?: MessageOptions | WebhookMessageOptions,
-      isWebhook?: boolean,
-    ): MessageOptions | WebhookMessageOptions;
-    public static transformOptions(
-      content: string | null,
-      options: MessageOptions | WebhookMessageOptions | MessageAdditions,
-      extra?: MessageOptions | WebhookMessageOptions,
-      isWebhook?: boolean,
-    ): MessageOptions | WebhookMessageOptions;
 
     public makeContent(): string | string[] | undefined;
     public resolveData(): this;
@@ -470,14 +455,10 @@ declare module 'discord.js' {
     public webhook: InteractionWebhook;
     public defer(options?: InteractionDeferOptions): Promise<void>;
     public deleteReply(): Promise<void>;
-    public editReply(
-      options: string | APIMessage | WebhookEditMessageOptions | MessageAdditions,
-    ): Promise<Message | RawMessage>;
+    public editReply(options: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
-    public followUp(
-      options: string | APIMessage | InteractionReplyOptions | MessageAdditions,
-    ): Promise<Message | RawMessage>;
-    public reply(options: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
+    public followUp(options: string | APIMessage | InteractionReplyOptions): Promise<Message | RawMessage>;
+    public reply(options: string | APIMessage | InteractionReplyOptions): Promise<void>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
     private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
   }
@@ -1139,16 +1120,14 @@ declare module 'discord.js' {
   export class InteractionWebhook extends PartialWebhookMixin() {
     constructor(client: Client, id: Snowflake, token: string);
     public token: string;
-    public send(
-      content: string | (InteractionReplyOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message | RawMessage>;
+    public send(content: string | (InteractionReplyOptions & { split?: false })): Promise<Message | RawMessage>;
     public send(options: InteractionReplyOptions & { split: true | SplitOptions }): Promise<(Message | RawMessage)[]>;
     public send(
       options: InteractionReplyOptions | APIMessage,
     ): Promise<Message | RawMessage | (Message | RawMessage)[]>;
     public send(
       content: string | null,
-      options: (InteractionReplyOptions & { split?: false }) | MessageAdditions,
+      options: InteractionReplyOptions & { split?: false },
     ): Promise<Message | RawMessage>;
     public send(
       content: string | null,
@@ -1243,9 +1222,7 @@ declare module 'discord.js' {
       options?: AwaitMessageComponentInteractionsOptions,
     ): MessageComponentInteractionCollector;
     public delete(): Promise<Message>;
-    public edit(
-      content: string | MessageEditOptions | MessageEmbed | APIMessage | MessageAttachment | MessageAttachment[],
-    ): Promise<Message>;
+    public edit(content: string | MessageEditOptions | APIMessage): Promise<Message>;
     public equals(message: Message, rawData: unknown): boolean;
     public fetchReference(): Promise<Message>;
     public fetchWebhook(): Promise<Webhook>;
@@ -1254,7 +1231,7 @@ declare module 'discord.js' {
     public pin(): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public removeAttachments(): Promise<Message>;
-    public reply(options: string | (ReplyMessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+    public reply(options: string | (ReplyMessageOptions & { split?: false })): Promise<Message>;
     public reply(options: string | (ReplyMessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): unknown;
@@ -1342,17 +1319,11 @@ declare module 'discord.js' {
     public defer(options?: InteractionDeferOptions): Promise<void>;
     public deferUpdate(): Promise<void>;
     public deleteReply(): Promise<void>;
-    public editReply(
-      options: string | APIMessage | WebhookEditMessageOptions | MessageEmbed,
-    ): Promise<Message | RawMessage>;
+    public editReply(options: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
-    public followUp(
-      options: string | APIMessage | InteractionReplyOptions | MessageAdditions,
-    ): Promise<Message | RawMessage>;
-    public reply(options: string | APIMessage | InteractionReplyOptions | MessageAdditions): Promise<void>;
-    public update(
-      content: string | APIMessage | WebhookEditMessageOptions | MessageEmbed,
-    ): Promise<Message | RawMessage>;
+    public followUp(options: string | APIMessage | InteractionReplyOptions): Promise<Message | RawMessage>;
+    public reply(options: string | APIMessage | InteractionReplyOptions): Promise<void>;
+    public update(content: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
   }
 
@@ -2111,12 +2082,10 @@ declare module 'discord.js' {
     public token: string;
     public editMessage(
       message: MessageResolvable,
-      options: string | APIMessage | WebhookEditMessageOptions | MessageEmbed | MessageEmbed[],
+      options: string | APIMessage | WebhookEditMessageOptions,
     ): Promise<RawMessage>;
     public fetchMessage(message: Snowflake, cache?: boolean): Promise<RawMessage>;
-    public send(
-      content: string | APIMessage | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<RawMessage>;
+    public send(content: string | APIMessage | (WebhookMessageOptions & { split?: false })): Promise<RawMessage>;
     public send(
       options: string | APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
     ): Promise<RawMessage[]>;
@@ -2456,7 +2425,7 @@ declare module 'discord.js' {
   interface PartialTextBasedChannelFields {
     lastMessageID: Snowflake | null;
     readonly lastMessage: Message | null;
-    send(options: string | (MessageOptions & { split?: false }) | MessageAdditions): Promise<Message>;
+    send(options: string | (MessageOptions & { split?: false })): Promise<Message>;
     send(options: string | (MessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
   }
 
@@ -2498,15 +2467,13 @@ declare module 'discord.js' {
     deleteMessage(message: MessageResolvable | '@original'): Promise<void>;
     editMessage(
       message: MessageResolvable | '@original',
-      options: string | APIMessage | WebhookEditMessageOptions | MessageAdditions,
+      options: string | APIMessage | WebhookEditMessageOptions,
     ): Promise<Message | RawMessage>;
     fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | RawMessage>;
     send(
       options: string | APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
     ): Promise<(Message | RawMessage)[]>;
-    send(
-      options: string | APIMessage | (WebhookMessageOptions & { split?: false }) | MessageAdditions,
-    ): Promise<Message | RawMessage>;
+    send(options: string | APIMessage | (WebhookMessageOptions & { split?: false })): Promise<Message | RawMessage>;
   }
 
   interface WebhookFields extends PartialWebhookFields {
@@ -3333,8 +3300,6 @@ declare module 'discord.js' {
   type GuildTemplateResolvable = string;
 
   type MembershipStates = 'INVITED' | 'ACCEPTED';
-
-  type MessageAdditions = MessageEmbed | MessageAttachment | (MessageEmbed | MessageAttachment)[];
 
   type MessageActionRowComponent = MessageButton;
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -40,7 +40,7 @@ client.on('message', ({ channel }) => {
   const embed = new MessageEmbed();
   assertIsMessage(channel.send({ files: [attachment] }));
   assertIsMessage(channel.send(embed));
-  assertIsMessage(channel.send({ embed: embed, files: [attachment] }));
+  assertIsMessage(channel.send({ embed, files: [attachment] }));
 
   assertIsMessageArray(channel.send({ split: true }));
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -38,9 +38,9 @@ client.on('message', ({ channel }) => {
 
   const attachment = new MessageAttachment('file.png');
   const embed = new MessageEmbed();
-  assertIsMessage(channel.send(attachment));
+  assertIsMessage(channel.send({ files: [attachment] }));
   assertIsMessage(channel.send(embed));
-  assertIsMessage(channel.send([attachment, embed]));
+  assertIsMessage(channel.send({ embed: embed, files: [attachment] }));
 
   assertIsMessageArray(channel.send({ split: true }));
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR refactors the methods across the the lib's sending/editing methods to avoid inconsistent overloads by removing multiple param options and enforcing single param usage as laid out in #5771.

(and let's pretend that there isn't a typo in the branch name)
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I pretend to know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
