### PR TITLE
fix(MessageComponentInteraction): correctly type defer method

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1333,7 +1333,7 @@ declare module 'discord.js' {
     public message: Message | RawMessage;
     public replied: boolean;
     public webhook: WebhookClient;
-    public defer(ephemeral?: boolean): Promise<void>;
+    public defer(options?: InteractionDeferOptions): Promise<void>;
     public deferUpdate(): Promise<void>;
     public deleteReply(): Promise<void>;
     public editReply(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #5759 by specifying that `MessageComponentInteraction#defer` optionally accepts a `InteractionDeferOptions`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
