### PR TITLE
fix(Interaction): add missing types and fix docs lists

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -826,19 +826,19 @@ exports.InteractionResponseTypes = createEnum([
 
 /**
  * The type of a message component
- * ACTION_ROW
- * BUTTON
+ * * ACTION_ROW
+ * * BUTTON
  * @typedef {string} MessageComponentType
  */
 exports.MessageComponentTypes = createEnum([null, 'ACTION_ROW', 'BUTTON']);
 
 /**
  * The style of a message button
- * PRIMARY
- * SECONDARY
- * SUCCESS
- * DANGER
- * LINK
+ * * PRIMARY
+ * * SECONDARY
+ * * SUCCESS
+ * * DANGER
+ * * LINK
  * @typedef {string} MessageButtonStyle
  */
 exports.MessageButtonStyles = createEnum([null, 'PRIMARY', 'SECONDARY', 'SUCCESS', 'DANGER', 'LINK']);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1328,6 +1328,7 @@ declare module 'discord.js' {
   }
 
   export class MessageComponentInteraction extends Interaction {
+    public componentType: MessageComponentType | MessageComponentTypes;
     public customID: string;
     public deferred: boolean;
     public message: Message | RawMessage;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1328,7 +1328,7 @@ declare module 'discord.js' {
   }
 
   export class MessageComponentInteraction extends Interaction {
-    public componentType: MessageComponentType | MessageComponentTypes;
+    public componentType: MessageComponentType;
     public customID: string;
     public deferred: boolean;
     public message: Message | RawMessage;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes #5751 as well as a bug in two typedefs that had their possible types listed incorrectly.
Decided to make this smaller PR to fix that issue as it can be quite annoying for users that are just now starting to try MessageComponents to have to wait for #5692 to be merged, as this will clearly take a while

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
