### PR TITLE
refactor(Interactions): move Structures import out of switch block

### DIFF
--- a/src/client/websocket/handlers/INTERACTION_CREATE.js
+++ b/src/client/websocket/handlers/INTERACTION_CREATE.js
@@ -1,22 +1,18 @@
 'use strict';
 
 const { Events, InteractionTypes } = require('../../../util/Constants');
-let Structures;
+const Structures = require('../../../util/Structures');
 
 module.exports = (client, { d: data }) => {
   let interaction;
   switch (data.type) {
     case InteractionTypes.APPLICATION_COMMAND: {
-      if (!Structures) Structures = require('../../../util/Structures');
       const CommandInteraction = Structures.get('CommandInteraction');
-
       interaction = new CommandInteraction(client, data);
       break;
     }
     case InteractionTypes.MESSAGE_COMPONENT: {
-      if (!Structures) Structures = require('../../../util/Structures');
       const MessageComponentInteraction = Structures.get('MessageComponentInteraction');
-
       interaction = new MessageComponentInteraction(client, data);
       break;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR moves two instances of a `Structures` import out of the `switch (data.type)` block in `INTERACTION_CREATE`, where they are assigned via unnecessary conditionals.

**Status and versioning classification:**
- Typings don't need updating