### PR TITLE
feat(Client): make use of with_expiration in #fetchInvite

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -255,7 +255,7 @@ class Client extends BaseClient {
     const code = DataResolver.resolveInviteCode(invite);
     return this.api
       .invites(code)
-      .get({ query: { with_counts: true } })
+      .get({ query: { with_counts: true, with_expiration: true } })
       .then(data => new Invite(this, data));
   }
 

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -109,6 +109,8 @@ class Invite extends Base {
      * @type {?number}
      */
     this.createdTimestamp = 'created_at' in data ? new Date(data.created_at).getTime() : null;
+
+    this._expiresTimestamp = 'expires_at' in data ? new Date(data.expires_at).getTime() : null;
   }
 
   /**
@@ -141,7 +143,10 @@ class Invite extends Base {
    * @readonly
    */
   get expiresTimestamp() {
-    return this.createdTimestamp && this.maxAge ? this.createdTimestamp + this.maxAge * 1000 : null;
+    return (
+      this._expiresTimestamp ??
+      (this.createdTimestamp && this.maxAge ? this.createdTimestamp + this.maxAge * 1000 : null)
+    );
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Make use of the new `with_expiration` query option in Client#fetchInvite as per https://github.com/discord/discord-api-docs/pull/2858#event-4665641335

- leave fallback via age when not fetching via Client

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
