### PR TITLE
feat(Message): applicationID for interaction responses

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -192,7 +192,13 @@ class Message extends Base {
      * Supplemental application information for group activities
      * @type {?ClientApplication}
      */
-    this.application = data.application ? new ClientApplication(this.client, data.application) : null;
+    this.groupActivityApplication = data.application ? new ClientApplication(this.client, data.application) : null;
+
+    /**
+     * ID of the application of the interaction that sent this message, if any
+     * @type {?Snowflake}
+     */
+    this.applicationID = data.application_id ?? null;
 
     /**
      * Group activity
@@ -759,7 +765,7 @@ class Message extends Base {
     return super.toJSON({
       channel: 'channelID',
       author: 'authorID',
-      application: 'applicationID',
+      groupActivityApplication: 'groupActivityApplicationID',
       guild: 'guildID',
       cleanContent: true,
       member: false,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1195,7 +1195,7 @@ declare module 'discord.js' {
     private patch(data: unknown): Message;
 
     public activity: MessageActivity | null;
-    public application: ClientApplication | null;
+    public applicationID: Snowflake | null;
     public attachments: Collection<Snowflake, MessageAttachment>;
     public author: User;
     public channel: TextChannel | DMChannel | NewsChannel;
@@ -1211,6 +1211,7 @@ declare module 'discord.js' {
     public readonly editedAt: Date | null;
     public editedTimestamp: number | null;
     public embeds: MessageEmbed[];
+    public groupActivityApplication: ClientApplication | null;
     public readonly guild: Guild | null;
     public id: Snowflake;
     public interaction: MessageInteraction | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Provide application id for the application of the interaction that sent the response, if applicable - as per <https://github.com/discord/discord-api-docs/pull/2908>
-⚠ rename `application` to not conflict with the new `applicationID` parameter in `#toJSON` transformation

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
