### PR TITLE
fix(*): add missing imports for custom errors

### DIFF
--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events');
 const WebSocketShard = require('./WebSocketShard');
 const PacketHandlers = require('./handlers');
-const { Error: DJSError } = require('../../errors');
+const { Error } = require('../../errors');
 const Collection = require('../../util/Collection');
 const { Events, ShardEvents, Status, WSCodes, WSEvents } = require('../../util/Constants');
 const Util = require('../../util/Util');
@@ -120,7 +120,7 @@ class WebSocketManager extends EventEmitter {
    * @private
    */
   async connect() {
-    const invalidToken = new DJSError(WSCodes[4004]);
+    const invalidToken = new Error(WSCodes[4004]);
     const {
       url: gatewayURL,
       shards: recommendedShards,
@@ -241,7 +241,7 @@ class WebSocketManager extends EventEmitter {
       await shard.connect();
     } catch (error) {
       if (error && error.code && UNRECOVERABLE_CLOSE_CODES.includes(error.code)) {
-        throw new DJSError(WSCodes[error.code]);
+        throw new Error(WSCodes[error.code]);
         // Undefined if session is invalid, error event for regular closes
       } else if (!error || error.code) {
         this.debug('Failed to connect to the gateway, requeueing...', shard);

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -14,6 +14,7 @@ const Messages = {
   WS_CLOSE_REQUESTED: 'WebSocket closed due to user request.',
   WS_CONNECTION_EXISTS: 'There is already an existing WebSocket connection.',
   WS_NOT_OPEN: (data = 'data') => `Websocket not open to send ${data}`,
+  MANAGER_DESTROYED: 'Manager was destroyed.',
 
   BITFIELD_INVALID: bit => `Invalid bitfield flag or number: ${bit}.`,
 

--- a/src/managers/GuildApplicationCommandManager.js
+++ b/src/managers/GuildApplicationCommandManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ApplicationCommandManager = require('./ApplicationCommandManager');
+const { TypeError } = require('../errors');
 const Collection = require('../util/Collection');
 const { ApplicationCommandPermissionTypes } = require('../util/Constants');
 

--- a/src/managers/GuildBanManager.js
+++ b/src/managers/GuildBanManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseManager = require('./BaseManager');
+const { TypeError, Error } = require('../errors');
 const GuildBan = require('../structures/GuildBan');
 const GuildMember = require('../structures/GuildMember');
 const Collection = require('../util/Collection');

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Error } = require('../errors');
 const { Events } = require('../util/Constants');
 const Util = require('../util/Util');
 

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -2,6 +2,7 @@
 
 const Base = require('./Base');
 const IntegrationApplication = require('./IntegrationApplication');
+const { Error } = require('../errors');
 const { Endpoints } = require('../util/Constants');
 const Permissions = require('../util/Permissions');
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Error } = require('../../errors');
 const { InteractionResponseTypes } = require('../../util/Constants');
 const MessageFlags = require('../../util/MessageFlags');
 const APIMessage = require('../APIMessage');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since, custom errors have same names as native errors, they get left un-imported sometimes. Which results in errors that don't have any message in it. This PR fixes it by importing these errors in places where they are being used but were not imported.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
