### PR TITLE
fix: add components to MessageOption typedefs

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -537,6 +537,7 @@ class Message extends Base {
    * @property {MessageAttachment[]} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to add to the message
+   * @property {MessageActionRow[]} [components] The components for the message
    */
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -537,7 +537,8 @@ class Message extends Base {
    * @property {MessageAttachment[]} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to add to the message
-   * @property {MessageActionRow[]} [components] The components for the message
+   * @property {MessageActionRow[]} [components] Action rows containing interactive components for the message
+   * (buttons, select menus)
    */
 
   /**

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -101,7 +101,8 @@ class Webhook {
    * @property {string} [content] See {@link BaseMessageOptions#content}
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
-   * @property {MessageActionRow[]} [components] The components for the message
+   * @property {MessageActionRow[]} [components] Action rows containing interactive components for the message
+   * (buttons, select menus)
    */
 
   /**

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -101,6 +101,7 @@ class Webhook {
    * @property {string} [content] See {@link BaseMessageOptions#content}
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
+   * @property {MessageActionRow[]} [components] The components for the message
    */
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -63,7 +63,8 @@ class TextBasedChannel {
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message
-   * @property {MessageActionRow[]} [components] The components for the message
+   * @property {MessageActionRow[]} [components] Action rows containing interactive components for the message
+   * (buttons, select menus)
    */
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -63,6 +63,7 @@ class TextBasedChannel {
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
    * it exceeds the character limit. If an object is provided, these are the options for splitting the message
+   * @property {MessageActionRow[]} [components] The components for the message
    */
 
   /**


### PR DESCRIPTION
Adds the docstring for the `components` prop to `BaseMessageOptions`, `MessageEditOptions` and `WebhookEditMessageOptions`

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.