### PR TITLE
docs(InteractionDeferOptions): correctly define the typedef

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -11,7 +11,7 @@ const APIMessage = require('../APIMessage');
 class InteractionResponses {
   /**
    * Options for deferring the reply to a {@link CommandInteraction}.
-   * @typedef {InteractionDeferOptions}
+   * @typedef {Object} InteractionDeferOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `InteractionDeferOptions` isn't showing up in the docs because it got a little wrong when it was moved in #5674. This PR fixes it by correctly defining this typedef.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
