### PR TITLE
feat: promisified single interaction collection

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -48,6 +48,8 @@ const Messages = {
   BUTTON_URL: 'MessageButton url must be a string',
   BUTTON_CUSTOM_ID: 'MessageButton customID must be a string',
 
+  INTERACTION_COLLECTOR_TIMEOUT: 'Collector timed out without receiving any interactions',
+
   FILE_NOT_FOUND: file => `File could not be found: ${file}`,
 
   USER_NO_DMCHANNEL: 'No DM Channel exists!',

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1229,10 +1229,10 @@ declare module 'discord.js' {
     public webhookID: Snowflake | null;
     public flags: Readonly<MessageFlags>;
     public reference: MessageReference | null;
-    public awaitMessageComponentInteractions(
+    public awaitMessageComponentInteraction(
       filter: CollectorFilter<[MessageComponentInteraction]>,
-      options?: AwaitMessageComponentInteractionsOptions,
-    ): Promise<Collection<Snowflake, MessageComponentInteraction>>;
+      time?: number,
+    ): Promise<MessageComponentInteraction>;
     public awaitReactions(
       filter: CollectorFilter<[MessageReaction, User]>,
       options?: AwaitReactionsOptions,
@@ -1243,7 +1243,7 @@ declare module 'discord.js' {
     ): ReactionCollector;
     public createMessageComponentInteractionCollector(
       filter: CollectorFilter<[MessageComponentInteraction]>,
-      options?: AwaitMessageComponentInteractionsOptions,
+      options?: MessageComponentInteractionCollectorOptions,
     ): MessageComponentInteractionCollector;
     public delete(): Promise<Message>;
     public edit(
@@ -2501,10 +2501,10 @@ declare module 'discord.js' {
     readonly lastPinAt: Date | null;
     typing: boolean;
     typingCount: number;
-    awaitMessageComponentInteractions(
+    awaitMessageComponentInteraction(
       filter: CollectorFilter<[MessageComponentInteraction]>,
-      options?: AwaitMessageComponentInteractionsOptions,
-    ): Promise<Collection<Snowflake, MessageComponentInteraction>>;
+      time?: number,
+    ): Promise<MessageComponentInteraction>;
     awaitMessages(
       filter: CollectorFilter<[Message]>,
       options?: AwaitMessagesOptions,
@@ -2725,10 +2725,6 @@ declare module 'discord.js' {
     key: string;
     old?: any;
     new?: any;
-  }
-
-  interface AwaitMessageComponentInteractionsOptions extends MessageComponentInteractionCollectorOptions {
-    errors?: string[];
   }
 
   interface AwaitMessagesOptions extends MessageCollectorOptions {


### PR DESCRIPTION
Putting this one up here for discussion.

Conceptually, I don't think collecting multiple interactions with the promisified `Message#awaitMessageComponentInteractions` made any sense, since all interactions need to be responded to within 3 seconds.
Instead, I've modified the function to singular, taking only a `time` option (in addition to the filter).
The Promise resolves to a `MessageComponentInteraction` if one passes the filter, or rejects if the time runs out.

**Status and versioning classification:**
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- I know how to update typings and have done so, or typings don't need updating
