### PR TITLE
Added deprecation advisory for MessageEmbed.type

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -44,7 +44,9 @@ class MessageEmbed {
      * * `gifv` - a gifv embed
      * * `article` - an article embed
      * * `link` - a link embed
+     * <warn>Discord advises that "Embed types should be considered deprecated and might be removed in a future API version."</warn>
      * @type {string}
+     * @deprecated
      */
     this.type = data.type || 'rich';
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- After reading [Discord's Documentation for Embeds](https://discord.com/developers/docs/resources/channel#embed-object-embed-types), I noticed that they recommend for developers to treat `Embed.type` as deprecated. I have updated the documentation to reflect that.
- Added `<warn>Discord advises that "Embed types should be considered deprecated and might be removed in a future API version."</warn>` for `MessageEmbed.type`
- Added `@deprecated` for `MessageEmbed.type`


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.