### PR TITLE
add default case for new channel type: text

### DIFF
--- a/src/client/ClientDataManager.js
+++ b/src/client/ClientDataManager.js
@@ -76,6 +76,9 @@ class ClientDataManager {
           case Constants.ChannelTypes.STORE:
             channel = new StoreChannel(guild, data);
             break;
+          default:
+            // console.warn('Unexpected data type:', data.type); // could be 13 for example
+            channel = new TextChannel(guild, data);
         }
 
         guild.channels.set(channel.id, channel);


### PR DESCRIPTION
data.type may get a new value of 13. Set default new channel type to: text (it was blocking the connection of my bot)

**Please describe the changes this PR makes and why it should be merged:**

I think the new channel type value (13) comes from the server side.

**Status and versioning classification:**

- Code changes have been tested against the Discord API
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->