### PR TITLE
docs: CommandInteraction#channelID is type of Snowflake

### DIFF
--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -23,6 +23,12 @@ class CommandInteraction extends Interaction {
      */
 
     /**
+     * The ID of the channel this interaction was sent in
+     * @type {Snowflake}
+     * @name CommandInteraction#channelID
+     */
+
+    /**
      * The ID of the invoked application command
      * @type {Snowflake}
      */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -462,6 +462,7 @@ declare module 'discord.js' {
   export class CommandInteraction extends Interaction {
     public readonly command: ApplicationCommand | null;
     public channel: TextChannel | DMChannel | NewsChannel;
+    public channelID: Snowflake;
     public commandID: Snowflake;
     public commandName: string;
     public deferred: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`CommandInteraction#channelID` is always type of `Snowflake` as Discord always sends this data.
Indirectly fixes inconsistency with `CommandInteraction#channel` always being type of `TextChannel | NewsChannel | DMChannel`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
