### PR TITLE
feat(GuildAuditLogs): make #target a channel for channel related logs

### DIFF
--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Channel = require('./Channel');
 const Integration = require('./Integration');
 const Webhook = require('./Webhook');
 const Collection = require('../util/Collection');
@@ -486,16 +485,12 @@ class GuildAuditLogsEntry {
     } else if (targetType === Targets.CHANNEL) {
       this.target =
         guild.channels.cache.get(data.target_id) ||
-        Channel.create(
-          guild.client,
-          this.changes.reduce(
-            (o, c) => {
-              o[c.key] = c.new || c.old;
-              return o;
-            },
-            { id: data.target_id },
-          ),
-          guild,
+        this.changes.reduce(
+          (o, c) => {
+            o[c.key] = c.new || c.old;
+            return o;
+          },
+          { id: data.target_id },
         );
     } else if (data.target_id) {
       this.target = guild[`${targetType.toLowerCase()}s`]?.cache.get(data.target_id) || { id: data.target_id };

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -351,7 +351,7 @@ class GuildAuditLogsEntry {
 
     /**
      * Any extra data from the entry
-     * @type {?(Object|Role|GuildMember|Channel)}
+     * @type {?(Object|Role|GuildMember)}
      */
     this.extra = null;
     switch (data.action_type) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently, for logs related to `CHANNEL_*` events, `GuildAuditLogsEntry#target` is an object containing only the id of the related channel. This PR turns this `target` prop into a channel using the data in the `changes` object. There are also some documentation related changes. 

**Status and versioning classification:**
- Code changes have been tested against the Discord API
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
