### PR TITLE
fix: remove remnants of awaitMessageComponentInteractions

### DIFF
--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -92,7 +92,7 @@ class DMChannel extends Channel {
   createMessageCollector() {}
   awaitMessages() {}
   createMessageComponentInteractionCollector() {}
-  awaitMessageComponentInteractions() {}
+  awaitMessageComponentInteraction() {}
   // Doesn't work on DM channels; bulkDelete() {}
 }
 

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -158,7 +158,7 @@ class TextChannel extends GuildChannel {
   createMessageCollector() {}
   awaitMessages() {}
   createMessageComponentInteractionCollector() {}
-  awaitMessageComponentInteractions() {}
+  awaitMessageComponentInteraction() {}
   bulkDelete() {}
 }
 

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -423,7 +423,7 @@ class TextBasedChannel {
         'createMessageCollector',
         'awaitMessages',
         'createMessageComponentInteractionCollector',
-        'awaitMessageComponentInteractions',
+        'awaitMessageComponentInteraction',
       );
     }
     for (const prop of props) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This changes `Message#awaitMessageComponentInteraction` to only collect one interaction, similar to how it was changed for TextBasedChannel in #5770. It also fixes a bug where `TextBasedChannel#applyToClass` would throw with `TypeError: Property description must be an object: undefined` because the method name wasn't updated there.

**Status and versioning classification:**

- Typings don't need updating