### PR TITLE
docs(GuildMemberManager): fix docs for #search()

### DIFF
--- a/src/managers/GuildBanManager.js
+++ b/src/managers/GuildBanManager.js
@@ -121,11 +121,16 @@ class GuildBanManager extends BaseManager {
   }
 
   /**
+   * Options for banning a user.
+   * @typedef {Object} BanOptions
+   * @property {number} [days] Number of days of messages to delete, must be between 0 and 7, inclusive
+   * @property {string} [reason] Reason for banning
+   */
+
+  /**
    * Bans a user from the guild.
    * @param {UserResolvable} user The user to ban
-   * @param {Object} [options] Options for the ban
-   * @param {number} [options.days=0] Number of days of messages to delete, must be between 0 and 7, inclusive
-   * @param {string} [options.reason] Reason for banning
+   * @param {BanOptions} [options] Options for the ban
    * @returns {Promise<GuildMember|User|Snowflake>} Result object will be resolved as specifically as possible.
    * If the GuildMember cannot be resolved, the User will instead be attempted to be resolved. If that also cannot
    * be resolved, the user ID will be the result.

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -139,11 +139,16 @@ class GuildMemberManager extends BaseManager {
   }
 
   /**
+   * Options for searching for guild members.
+   * @typedef {Object} GuildSearchMembersOptions
+   * @property {string} query Filter members whose username or nickname start with this query
+   * @property {number} [limit] Maximum number of members to search
+   * @property {boolean} [cache] Whether or not to cache the fetched member(s)
+   */
+
+  /**
    * Search for members in the guild based on a query.
-   * @param {Object} options Search options
-   * @property {string} options.query Filter members whose username or nickname start with this query
-   * @property {number} [options.limit=1] Maximum number of members to search
-   * @property {boolean} [options.cache=true] Whether or not to cache the fetched member(s)
+   * @param {GuildSearchMembersOptions} options Search options
    * @returns {Promise<Collection<Snowflake, GuildMember>>}
    */
   async search({ query, limit = 1, cache = true } = {}) {
@@ -193,14 +198,19 @@ class GuildMemberManager extends BaseManager {
   }
 
   /**
+   * Options for pruning guild members.
+   * @typedef {Object} GuildPruneMembersOptions
+   * @property {number} [days] Number of days of inactivity required to kick
+   * @property {boolean} [dry] Get number of users that will be kicked, without actually kicking them
+   * @property {boolean} [count] Whether or not to return the number of users that have been kicked.
+   * @property {RoleResolvable[]} [roles] Array of roles to bypass the "...and no roles" constraint when pruning
+   * @property {string} [reason] Reason for this prune
+   */
+
+  /**
    * Prunes members from the guild based on how long they have been inactive.
    * <info>It's recommended to set options.count to `false` for large guilds.</info>
-   * @param {Object} [options] Prune options
-   * @param {number} [options.days=7] Number of days of inactivity required to kick
-   * @param {boolean} [options.dry=false] Get number of users that will be kicked, without actually kicking them
-   * @param {boolean} [options.count=true] Whether or not to return the number of users that have been kicked.
-   * @param {RoleResolvable[]} [options.roles=[]] Array of roles to bypass the "...and no roles" constraint when pruning
-   * @param {string} [options.reason] Reason for this prune
+   * @param {GuildPruneMembersOptions} [options] Prune options
    * @returns {Promise<number|null>} The number of members that were/will be kicked
    * @example
    * // See how many members will be pruned
@@ -276,9 +286,7 @@ class GuildMemberManager extends BaseManager {
   /**
    * Bans a user from the guild.
    * @param {UserResolvable} user The user to ban
-   * @param {Object} [options] Options for the ban
-   * @param {number} [options.days=0] Number of days of messages to delete, must be between 0 and 7, inclusive
-   * @param {string} [options.reason] Reason for banning
+   * @param {BanOptions} [options] Options for the ban
    * @returns {Promise<GuildMember|User|Snowflake>} Result object will be resolved as specifically as possible.
    * If the GuildMember cannot be resolved, the User will instead be attempted to be resolved. If that also cannot
    * be resolved, the user ID will be the result.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The docs for `GuildMemberManager#search()` are using `@property` instead of `@param`, causing it to not show up on the docs site. To fix this, new typedefs have been added to be more consistent with the typings.

**Status and versioning classification:**

- There are no code changes
- Typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.