### PR TITLE
refactor(*): make typedefs for all options params

### DIFF
--- a/src/managers/GuildBanManager.js
+++ b/src/managers/GuildBanManager.js
@@ -121,8 +121,8 @@ class GuildBanManager extends BaseManager {
   /**
    * Options used to ban a user from a guild.
    * @typedef {Object} BanOptions
-   * @param {number} [days=0] Number of days of messages to delete, must be between 0 and 7, inclusive
-   * @param {string} [reason] The reason for the ban
+   * @property {number} [days=0] Number of days of messages to delete, must be between 0 and 7, inclusive
+   * @property {string} [reason] The reason for the ban
    */
 
   /**

--- a/src/managers/GuildBanManager.js
+++ b/src/managers/GuildBanManager.js
@@ -119,10 +119,10 @@ class GuildBanManager extends BaseManager {
   }
 
   /**
-   * Options for banning a user.
+   * Options used to ban a user from a guild.
    * @typedef {Object} BanOptions
-   * @property {number} [days] Number of days of messages to delete, must be between 0 and 7, inclusive
-   * @property {string} [reason] Reason for banning
+   * @param {number} [days=0] Number of days of messages to delete, must be between 0 and 7, inclusive
+   * @param {string} [reason] The reason for the ban
    */
 
   /**

--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -61,7 +61,7 @@ class GuildChannelManager extends BaseManager {
 
   /**
    * Options used to create a new channel in a guild.
-   * @typedef {Object} GuildCreateChannelOptions
+   * @typedef {Object} GuildChannelCreateOptions
    * @property {string} [type='text'] The type of the new channel, either `text`, `voice`, `category`, `news`,
    * `store`, or `stage`
    * @property {string} [topic] The topic for the new channel
@@ -79,7 +79,7 @@ class GuildChannelManager extends BaseManager {
   /**
    * Creates a new channel in the guild.
    * @param {string} name The name of the new channel
-   * @param {GuildCreateChannelOptions} [options={}] Options for creating the new channel
+   * @param {GuildChannelCreateOptions} [options={}] Options for creating the new channel
    * @returns {Promise<GuildChannel>}
    * @example
    * // Create a new text channel

--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -60,21 +60,26 @@ class GuildChannelManager extends BaseManager {
    */
 
   /**
+   * Options used to create a new channel in a guild.
+   * @typedef {Object} GuildCreateChannelOptions
+   * @property {string} [type='text'] The type of the new channel, either `text`, `voice`, `category`, `news`,
+   * `store`, or `stage`
+   * @property {string} [topic] The topic for the new channel
+   * @property {boolean} [nsfw] Whether the new channel is nsfw
+   * @property {number} [bitrate] Bitrate of the new channel in bits (only voice)
+   * @property {number} [userLimit] Maximum amount of users allowed in the new channel (only voice)
+   * @property {ChannelResolvable} [parent] Parent of the new channel
+   * @property {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [permissionOverwrites]
+   * Permission overwrites of the new channel
+   * @property {number} [position] Position of the new channel
+   * @property {number} [rateLimitPerUser] The ratelimit per user for the new channel
+   * @property {string} [reason] Reason for creating the new channel
+   */
+
+  /**
    * Creates a new channel in the guild.
    * @param {string} name The name of the new channel
-   * @param {Object} [options] Options
-   * @param {string} [options.type='text'] The type of the new channel, either `text`, `voice`, `category`, `news`,
-   * `store`, or `stage`
-   * @param {string} [options.topic] The topic for the new channel
-   * @param {boolean} [options.nsfw] Whether the new channel is nsfw
-   * @param {number} [options.bitrate] Bitrate of the new channel in bits (only voice)
-   * @param {number} [options.userLimit] Maximum amount of users allowed in the new channel (only voice)
-   * @param {ChannelResolvable} [options.parent] Parent of the new channel
-   * @param {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [options.permissionOverwrites]
-   * Permission overwrites of the new channel
-   * @param {number} [options.position] Position of the new channel
-   * @param {number} [options.rateLimitPerUser] The ratelimit per user for the channel
-   * @param {string} [options.reason] Reason for creating the channel
+   * @param {GuildCreateChannelOptions} [options={}] Options for creating the new channel
    * @returns {Promise<GuildChannel>}
    * @example
    * // Create a new text channel

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -25,12 +25,17 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
   }
 
   /**
+   * Options used for creating an emoji in a guild.
+   * @typedef {Object} GuildEmojiCreateOptions
+   * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles to limit the emoji to
+   * @property {string} [reason] The reason for creating the emoji
+   */
+
+  /**
    * Creates a new custom emoji in the guild.
    * @param {BufferResolvable|Base64Resolvable} attachment The image for the emoji
    * @param {string} name The name for the emoji
-   * @param {Object} [options] Options
-   * @param {Collection<Snowflake, Role>|RoleResolvable[]} [options.roles] Roles to limit the emoji to
-   * @param {string} [options.reason] Reason for creating the emoji
+   * @param {GuildEmojiCreateOptions} [options] Options for creating the emoji
    * @returns {Promise<Emoji>} The created emoji
    * @example
    * // Create a new emoji from a url

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -129,22 +129,28 @@ class GuildManager extends BaseManager {
   }
 
   /**
+   * Options used to create a guild.
+   * @typedef {Object} GuildCreateOptions
+   * @param {number} [afkChannelID] The ID of the AFK channel
+   * @param {number} [afkTimeout] The AFK timeout in seconds
+   * @param {PartialChannelData[]} [channels] The channels for this guild
+   * @param {DefaultMessageNotifications} [defaultMessageNotifications] The default message notifications
+   * for the guild
+   * @param {ExplicitContentFilterLevel} [explicitContentFilter] The explicit content filter level for the guild
+   * @param {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild
+   * @param {string} [region] The region for the server, defaults to the closest one available
+   * @param {PartialRoleData[]} [roles] The roles for this guild,
+   * the first element of this array is used to change properties of the guild's everyone role.
+   * @param {number} [systemChannelID] The ID of the system channel
+   * @param {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel
+   * @param {VerificationLevel} [verificationLevel] The verification level for the guild
+   */
+
+  /**
    * Creates a guild.
    * <warn>This is only available to bots in fewer than 10 guilds.</warn>
    * @param {string} name The name of the guild
-   * @param {Object} [options] Options for the creating
-   * @param {number} [options.afkChannelID] The ID of the AFK channel
-   * @param {number} [options.afkTimeout] The AFK timeout in seconds
-   * @param {PartialChannelData[]} [options.channels] The channels for this guild
-   * @param {DefaultMessageNotifications} [options.defaultMessageNotifications] The default message notifications
-   * for the guild
-   * @param {ExplicitContentFilterLevel} [options.explicitContentFilter] The explicit content filter level for the guild
-   * @param {BufferResolvable|Base64Resolvable} [options.icon=null] The icon for the guild
-   * @param {PartialRoleData[]} [options.roles] The roles for this guild,
-   * the first element of this array is used to change properties of the guild's everyone role.
-   * @param {number} [options.systemChannelID] The ID of the system channel
-   * @param {SystemChannelFlagsResolvable} [options.systemChannelFlags] The flags of the system channel
-   * @param {VerificationLevel} [options.verificationLevel] The verification level for the guild
+   * @param {GuildCreateOptions} [options] Options for creating the guild
    * @returns {Promise<Guild>} The guild that was created
    */
   async create(

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -50,7 +50,7 @@ class GuildManager extends BaseManager {
   /**
    * Partial data for a Role.
    * @typedef {Object} PartialRoleData
-   * @property {number} [id] The ID for this role, used to set channel overrides,
+   * @property {Snowflake} [id] The ID for this role, used to set channel overrides,
    * this is a placeholder and will be replaced by the API after consumption
    * @property {string} [name] The name of the role
    * @property {ColorResolvable} [color] The color of the role, either a hex string or a base 10 number
@@ -63,7 +63,7 @@ class GuildManager extends BaseManager {
   /**
    * Partial overwrite data.
    * @typedef {Object} PartialOverwriteData
-   * @property {number|Snowflake} id The Role or User ID for this overwrite
+   * @property {Snowflake} id The Role or User ID for this overwrite
    * @property {string} [type] The type of this overwrite
    * @property {PermissionResolvable} [allow] The permissions to allow
    * @property {PermissionResolvable} [deny] The permissions to deny
@@ -72,16 +72,16 @@ class GuildManager extends BaseManager {
   /**
    * Partial data for a Channel.
    * @typedef {Object} PartialChannelData
-   * @property {number} [id] The ID for this channel, used to set its parent,
+   * @property {Snowflake} [id] The ID for this channel, used to set its parent,
    * this is a placeholder and will be replaced by the API after consumption
-   * @property {number} [parentID] The parent ID for this channel
+   * @property {Snowflake} [parentID] The parent ID for this channel
    * @property {string} [type] The type of the channel
    * @property {string} name The name of the channel
    * @property {string} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel
-   * @property {PartialOverwriteData} [permissionOverwrites]
+   * @property {PartialOverwriteData[]} [permissionOverwrites]
    * Overwrites of the channel
    * @property {number} [rateLimitPerUser] The rate limit per user of the channel in seconds
    */
@@ -131,17 +131,16 @@ class GuildManager extends BaseManager {
   /**
    * Options used to create a guild.
    * @typedef {Object} GuildCreateOptions
-   * @property {number} [afkChannelID] The ID of the AFK channel
+   * @property {Snowflake} [afkChannelID] The ID of the AFK channel
    * @property {number} [afkTimeout] The AFK timeout in seconds
    * @property {PartialChannelData[]} [channels=[]] The channels for this guild
    * @property {DefaultMessageNotifications} [defaultMessageNotifications] The default message notifications
    * for the guild
    * @property {ExplicitContentFilterLevel} [explicitContentFilter] The explicit content filter level for the guild
    * @property {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild
-   * @property {string} [region] The region for the server, defaults to the closest one available
    * @property {PartialRoleData[]} [roles=[]] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.
-   * @property {number} [systemChannelID] The ID of the system channel
+   * @property {Snowflake} [systemChannelID] The ID of the system channel
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel
    * @property {VerificationLevel} [verificationLevel] The verification level for the guild
    */

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -50,7 +50,7 @@ class GuildManager extends BaseManager {
   /**
    * Partial data for a Role.
    * @typedef {Object} PartialRoleData
-   * @property {Snowflake} [id] The ID for this role, used to set channel overrides,
+   * @property {Snowflake|number} [id] The ID for this role, used to set channel overrides,
    * this is a placeholder and will be replaced by the API after consumption
    * @property {string} [name] The name of the role
    * @property {ColorResolvable} [color] The color of the role, either a hex string or a base 10 number
@@ -63,7 +63,7 @@ class GuildManager extends BaseManager {
   /**
    * Partial overwrite data.
    * @typedef {Object} PartialOverwriteData
-   * @property {Snowflake} id The Role or User ID for this overwrite
+   * @property {Snowflake|number} id The Role or User ID for this overwrite
    * @property {string} [type] The type of this overwrite
    * @property {PermissionResolvable} [allow] The permissions to allow
    * @property {PermissionResolvable} [deny] The permissions to deny
@@ -72,9 +72,9 @@ class GuildManager extends BaseManager {
   /**
    * Partial data for a Channel.
    * @typedef {Object} PartialChannelData
-   * @property {Snowflake} [id] The ID for this channel, used to set its parent,
+   * @property {Snowflake|number} [id] The ID for this channel, used to set its parent,
    * this is a placeholder and will be replaced by the API after consumption
-   * @property {Snowflake} [parentID] The parent ID for this channel
+   * @property {Snowflake|number} [parentID] The parent ID for this channel
    * @property {string} [type] The type of the channel
    * @property {string} name The name of the channel
    * @property {string} [topic] The topic of the text channel
@@ -131,7 +131,7 @@ class GuildManager extends BaseManager {
   /**
    * Options used to create a guild.
    * @typedef {Object} GuildCreateOptions
-   * @property {Snowflake} [afkChannelID] The ID of the AFK channel
+   * @property {Snowflake|number} [afkChannelID] The ID of the AFK channel
    * @property {number} [afkTimeout] The AFK timeout in seconds
    * @property {PartialChannelData[]} [channels=[]] The channels for this guild
    * @property {DefaultMessageNotifications} [defaultMessageNotifications] The default message notifications
@@ -140,7 +140,7 @@ class GuildManager extends BaseManager {
    * @property {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild
    * @property {PartialRoleData[]} [roles=[]] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.
-   * @property {Snowflake} [systemChannelID] The ID of the system channel
+   * @property {Snowflake|number} [systemChannelID] The ID of the system channel
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel
    * @property {VerificationLevel} [verificationLevel] The verification level for the guild
    */

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -133,13 +133,13 @@ class GuildManager extends BaseManager {
    * @typedef {Object} GuildCreateOptions
    * @property {number} [afkChannelID] The ID of the AFK channel
    * @property {number} [afkTimeout] The AFK timeout in seconds
-   * @property {PartialChannelData[]} [channels] The channels for this guild
+   * @property {PartialChannelData[]} [channels=[]] The channels for this guild
    * @property {DefaultMessageNotifications} [defaultMessageNotifications] The default message notifications
    * for the guild
    * @property {ExplicitContentFilterLevel} [explicitContentFilter] The explicit content filter level for the guild
    * @property {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild
    * @property {string} [region] The region for the server, defaults to the closest one available
-   * @property {PartialRoleData[]} [roles] The roles for this guild,
+   * @property {PartialRoleData[]} [roles=[]] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.
    * @property {number} [systemChannelID] The ID of the system channel
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -131,19 +131,19 @@ class GuildManager extends BaseManager {
   /**
    * Options used to create a guild.
    * @typedef {Object} GuildCreateOptions
-   * @param {number} [afkChannelID] The ID of the AFK channel
-   * @param {number} [afkTimeout] The AFK timeout in seconds
-   * @param {PartialChannelData[]} [channels] The channels for this guild
-   * @param {DefaultMessageNotifications} [defaultMessageNotifications] The default message notifications
+   * @property {number} [afkChannelID] The ID of the AFK channel
+   * @property {number} [afkTimeout] The AFK timeout in seconds
+   * @property {PartialChannelData[]} [channels] The channels for this guild
+   * @property {DefaultMessageNotifications} [defaultMessageNotifications] The default message notifications
    * for the guild
-   * @param {ExplicitContentFilterLevel} [explicitContentFilter] The explicit content filter level for the guild
-   * @param {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild
-   * @param {string} [region] The region for the server, defaults to the closest one available
-   * @param {PartialRoleData[]} [roles] The roles for this guild,
+   * @property {ExplicitContentFilterLevel} [explicitContentFilter] The explicit content filter level for the guild
+   * @property {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild
+   * @property {string} [region] The region for the server, defaults to the closest one available
+   * @property {PartialRoleData[]} [roles] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.
-   * @param {number} [systemChannelID] The ID of the system channel
-   * @param {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel
-   * @param {VerificationLevel} [verificationLevel] The verification level for the guild
+   * @property {number} [systemChannelID] The ID of the system channel
+   * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel
+   * @property {VerificationLevel} [verificationLevel] The verification level for the guild
    */
 
   /**

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -199,7 +199,7 @@ class GuildMemberManager extends BaseManager {
    * Options used for pruning guild members.
    * @typedef {Object} GuildPruneMembersOptions
    * @property {number} [days=7] Number of days of inactivity required to kick
-   * @property {boolean} [dry=false] Get number of users that will be kicked, without actually kicking them
+   * @property {boolean} [dry=false] Get the number of users that will be kicked, without actually kicking them
    * @property {boolean} [count=true] Whether or not to return the number of users that have been kicked.
    * @property {RoleResolvable[]} [roles] Array of roles to bypass the "...and no roles" constraint when pruning
    * @property {string} [reason] Reason for this prune

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -137,16 +137,16 @@ class GuildMemberManager extends BaseManager {
   }
 
   /**
-   * Options for searching for guild members.
+   * Options used for searching guild members.
    * @typedef {Object} GuildSearchMembersOptions
    * @property {string} query Filter members whose username or nickname start with this query
-   * @property {number} [limit] Maximum number of members to search
-   * @property {boolean} [cache] Whether or not to cache the fetched member(s)
+   * @property {number} [limit=1] Maximum number of members to search
+   * @property {boolean} [cache=true] Whether or not to cache the fetched member(s)
    */
 
   /**
-   * Search for members in the guild based on a query.
-   * @param {GuildSearchMembersOptions} options Search options
+   * Searches for members in the guild based on a query.
+   * @param {GuildSearchMembersOptions} options Options for searching members
    * @returns {Promise<Collection<Snowflake, GuildMember>>}
    */
   async search({ query, limit = 1, cache = true } = {}) {
@@ -196,19 +196,19 @@ class GuildMemberManager extends BaseManager {
   }
 
   /**
-   * Options for pruning guild members.
+   * Options used for pruning guild members.
    * @typedef {Object} GuildPruneMembersOptions
-   * @property {number} [days] Number of days of inactivity required to kick
-   * @property {boolean} [dry] Get number of users that will be kicked, without actually kicking them
-   * @property {boolean} [count] Whether or not to return the number of users that have been kicked.
+   * @property {number} [days=7] Number of days of inactivity required to kick
+   * @property {boolean} [dry=false] Get number of users that will be kicked, without actually kicking them
+   * @property {boolean} [count=true] Whether or not to return the number of users that have been kicked.
    * @property {RoleResolvable[]} [roles] Array of roles to bypass the "...and no roles" constraint when pruning
    * @property {string} [reason] Reason for this prune
    */
 
   /**
    * Prunes members from the guild based on how long they have been inactive.
-   * <info>It's recommended to set options.count to `false` for large guilds.</info>
-   * @param {GuildPruneMembersOptions} [options] Prune options
+   * <info>It's recommended to set `options.count` to `false` for large guilds.</info>
+   * @param {GuildPruneMembersOptions} [options] Options for pruning
    * @returns {Promise<number|null>} The number of members that were/will be kicked
    * @example
    * // See how many members will be pruned

--- a/src/managers/ReactionUserManager.js
+++ b/src/managers/ReactionUserManager.js
@@ -25,10 +25,15 @@ class ReactionUserManager extends BaseManager {
    */
 
   /**
+   * Options used to fetch users who gave a reaction.
+   * @typedef {Object} FetchReactionUsersOptions
+   * @property {number} [limit=100] The maximum amount of users to fetch, defaults to `100`
+   * @property {Snowflake} [after] Limit fetching users to those with an id greater than the supplied id
+   */
+
+  /**
    * Fetches all the users that gave this reaction. Resolves with a collection of users, mapped by their IDs.
-   * @param {Object} [options] Options for fetching the users
-   * @param {number} [options.limit=100] The maximum amount of users to fetch, defaults to 100
-   * @param {Snowflake} [options.after] Limit fetching users to those with an id greater than the supplied id
+   * @param {FetchReactionUsersOptions} [options] Options for fetching the users
    * @returns {Promise<Collection<Snowflake, User>>}
    */
   async fetch({ limit = 100, after } = {}) {

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -85,16 +85,21 @@ class RoleManager extends BaseManager {
    */
 
   /**
+   * Options used to create a new role.
+   * @typedef {Object} CreateRoleOptions
+   * @property {string} [name] The name of the new role
+   * @property {ColorResolvable} [color] The data to create the role with
+   * @property {boolean} [hoist] Whether or not the new role should be hoisted
+   * @property {PermissionResolvable} [permissions] The permissions for the new role
+   * @property {number} [position] The position of the new role
+   * @property {boolean} [mentionable] Whether or not the new role should be mentionable
+   * @property {string} [reason] The reason for creating this role
+   */
+
+  /**
    * Creates a new role in the guild with given information.
    * <warn>The position will silently reset to 1 if an invalid one is provided, or none.</warn>
-   * @param {Object} [options] Options
-   * @param {string} [options.name] The name of the new role
-   * @param {ColorResolvable} [options.color] The data to create the role with
-   * @param {boolean} [options.hoist] Whether or not the new role should be hoisted.
-   * @param {PermissionResolvable} [options.permissions] The permissions for the new role
-   * @param {number} [options.position] The position of the new role
-   * @param {boolean} [options.mentionable] Whether or not the new role should be mentionable.
-   * @param {string} [options.reason] Reason for creating this role
+   * @param {CreateRoleOptions} [options] Options for creating the new role
    * @returns {Promise<Role>}
    * @example
    * // Create a new role

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -232,7 +232,7 @@ class RequestHandler {
          */
 
         /**
-         * Emitted periodically when the process sends invalid messages to let users avoid the
+         * Emitted periodically when the process sends invalid requests to let users avoid the
          * 10k invalid requests in 10 minutes threshold that causes a ban
          * @event Client#invalidRequestWarning
          * @param {InvalidRequestWarningData} invalidRequestWarningData Object containing the invalid request info

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -125,13 +125,7 @@ class RequestHandler {
         /**
          * Emitted when the client hits a rate limit while making a request
          * @event Client#rateLimit
-         * @param {Object} rateLimitInfo Object containing the rate limit info
-         * @param {number} rateLimitInfo.timeout Timeout in ms
-         * @param {number} rateLimitInfo.limit Number of requests that can be made to this endpoint
-         * @param {string} rateLimitInfo.method HTTP method used for request that triggered this event
-         * @param {string} rateLimitInfo.path Path used for request that triggered this event
-         * @param {string} rateLimitInfo.route Route used for request that triggered this event
-         * @param {boolean} rateLimitInfo.global Whether the rate limit that was reached was the global limit
+         * @param {RateLimitData} rateLimitData Object containing the rate limit info
          */
         this.manager.client.emit(RATE_LIMIT, {
           timeout,
@@ -232,11 +226,16 @@ class RequestHandler {
         invalidCount % this.manager.client.options.invalidRequestWarningInterval === 0;
       if (emitInvalid) {
         /**
+         * @typedef {Object} InvalidRequestWarningData
+         * @property {number} count Number of invalid requests that have been made in the window
+         * @property {number} remainingTime Time in ms remaining before the count resets
+         */
+
+        /**
          * Emitted periodically when the process sends invalid messages to let users avoid the
          * 10k invalid requests in 10 minutes threshold that causes a ban
          * @event Client#invalidRequestWarning
-         * @param {number} invalidRequestWarningInfo.count Number of invalid requests that have been made in the window
-         * @param {number} invalidRequestWarningInfo.remainingTime Time in ms remaining before the count resets
+         * @param {InvalidRequestWarningData} invalidRequestWarningData Object containing the invalid request info
          */
         this.manager.client.emit(INVALID_REQUEST_WARNING, {
           count: invalidCount,

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -103,7 +103,7 @@ class Shard extends EventEmitter {
    * Forks a child process or creates a worker thread for the shard.
    * <warn>You should not need to call this manually.</warn>
    * @param {number} [timeout=30000] The amount in milliseconds to wait until the {@link Client} has become ready
-   * before resolving. (-1 or Infinity for no wait)
+   * before resolving (`-1` or `Infinity` for no wait)
    * @returns {Promise<ChildProcess>}
    */
   async spawn(timeout = 30000) {
@@ -187,13 +187,17 @@ class Shard extends EventEmitter {
   }
 
   /**
-   * Kills and restarts the shard's process/worker.
-   * @param {Object} [options] Respawn options for the shard
-   * @param {number} [options.delay=500] How long to wait between killing the process/worker and
+   * Options used to respawn a shard.
+   * @typedef {Object} ShardRespawnOptions
+   * @property {number} [delay=500] How long to wait between killing the process/worker and
    * restarting it (in milliseconds)
-   * @param {number} [options.timeout=30000] The amount in milliseconds to wait until the {@link Client}
-   * has become ready
-   * before resolving. (-1 or Infinity for no wait)
+   * @property {number} [timeout=30000] The amount in milliseconds to wait until the {@link Client}
+   * has become ready before resolving (`-1` or `Infinity` for no wait)
+   */
+
+  /**
+   * Kills and restarts the shard's process/worker.
+   * @param {ShardRespawnOptions} [options] Options for respawning the shard
    * @returns {Promise<ChildProcess>}
    */
   async respawn({ delay = 500, timeout = 30000 } = {}) {

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -163,12 +163,7 @@ class ShardClientUtil {
 
   /**
    * Requests a respawn of all shards.
-   * @param {Object} [options] Options for respawning shards
-   * @param {number} [options.shardDelay=5000] How long to wait between shards (in milliseconds)
-   * @param {number} [options.respawnDelay=500] How long to wait between killing a shard's process/worker and
-   * restarting it (in milliseconds)
-   * @param {number} [options.timeout=30000] The amount in milliseconds to wait for a shard to become ready before
-   * continuing to another. (-1 or Infinity for no wait)
+   * @param {MultipleShardRespawnOptions} [options] Options for respawning shards
    * @returns {Promise<void>} Resolves upon the message being sent
    * @see {@link ShardingManager#respawnAll}
    */

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -166,7 +166,7 @@ class ShardingManager extends EventEmitter {
 
   /**
    * Option used to spawn multiple shards.
-   * @typedef {Object} ShardSpawnOptions
+   * @typedef {Object} MultipleShardSpawnOptions
    * @property {number|string} [amount=this.totalShards] Number of shards to spawn
    * @property {number} [delay=5500] How long to wait in between spawning each shard (in milliseconds)
    * @property {number} [timeout=30000] The amount in milliseconds to wait until the {@link Client} has become ready
@@ -174,7 +174,7 @@ class ShardingManager extends EventEmitter {
 
   /**
    * Spawns multiple shards.
-   * @param {ShardSpawnOptions} [options] Options for spawning shards
+   * @param {MultipleShardSpawnOptions} [options] Options for spawning shards
    * @returns {Promise<Collection<number, Shard>>}
    */
   async spawn({ amount = this.totalShards, delay = 5500, timeout = 30000 } = {}) {
@@ -287,8 +287,8 @@ class ShardingManager extends EventEmitter {
   }
 
   /**
-   * Options used to respawn shards.
-   * @typedef {Object} ShardRespawnOptions
+   * Options used to respawn all shards.
+   * @typedef {Object} MultipleShardRespawnOptions
    * @property {number} [shardDelay=5000] How long to wait between shards (in milliseconds)
    * @property {number} [respawnDelay=500] How long to wait between killing a shard's process and restarting it
    * (in milliseconds)
@@ -298,7 +298,7 @@ class ShardingManager extends EventEmitter {
 
   /**
    * Kills all running shards and respawns them.
-   * @param {ShardRespawnOptions} [options] Options for respawning shards
+   * @param {MultipleShardRespawnOptions} [options] Options for respawning shards
    * @returns {Promise<Collection<string, Shard>>}
    */
   async respawnAll({ shardDelay = 5000, respawnDelay = 500, timeout = 30000 } = {}) {

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -25,7 +25,7 @@ class ShardingManager extends EventEmitter {
    */
 
   /**
-   * The options to spawn shards with for a {@link ShardingManager},
+   * The options to spawn shards with for a {@link ShardingManager}.
    * @typedef {Object} ShardingManagerOptions
    * @property {string|number} [totalShards='auto'] Number of total shards of all shard managers or "auto"
    * @property {string|number[]} [shardList='auto'] List of shards to spawn or "auto"
@@ -165,11 +165,16 @@ class ShardingManager extends EventEmitter {
   }
 
   /**
+   * Option used to spawn multiple shards.
+   * @typedef {Object} ShardSpawnOptions
+   * @property {number|string} [amount=this.totalShards] Number of shards to spawn
+   * @property {number} [delay=5500] How long to wait in between spawning each shard (in milliseconds)
+   * @property {number} [timeout=30000] The amount in milliseconds to wait until the {@link Client} has become ready
+   */
+
+  /**
    * Spawns multiple shards.
-   * @param {Object} [options] Options for spawning shards
-   * @param {number|string} [options.amount=this.totalShards] Number of shards to spawn
-   * @param {number} [options.delay=5500] How long to wait in between spawning each shard (in milliseconds)
-   * @param {number} [options.timeout=30000] The amount in milliseconds to wait until the {@link Client} has become
+   * @param {ShardSpawnOptions} [options] Options for spawning shards
    * @returns {Promise<Collection<number, Shard>>}
    */
   async spawn({ amount = this.totalShards, delay = 5500, timeout = 30000 } = {}) {
@@ -282,13 +287,18 @@ class ShardingManager extends EventEmitter {
   }
 
   /**
-   * Kills all running shards and respawns them.
-   * @param {Object} [options] Options for respawning shards
-   * @param {number} [options.shardDelay=5000] How long to wait between shards (in milliseconds)
-   * @param {number} [options.respawnDelay=500] How long to wait between killing a shard's process and restarting it
+   * Options used to respawn shards.
+   * @typedef {Object} ShardRespawnOptions
+   * @property {number} [shardDelay=5000] How long to wait between shards (in milliseconds)
+   * @property {number} [respawnDelay=500] How long to wait between killing a shard's process and restarting it
    * (in milliseconds)
-   * @param {number} [options.timeout=30000] The amount in milliseconds to wait for a shard to become ready before
-   * continuing to another. (-1 or Infinity for no wait)
+   * @property {number} [timeout=30000] The amount in milliseconds to wait for a shard to become ready before
+   * continuing to another (`-1` or `Infinity` for no wait)
+   */
+
+  /**
+   * Kills all running shards and respawns them.
+   * @param {ShardRespawnOptions} [options] Options for respawning shards
    * @returns {Promise<Collection<string, Shard>>}
    */
   async respawnAll({ shardDelay = 5000, respawnDelay = 500, timeout = 30000 } = {}) {

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -22,10 +22,8 @@ class CategoryChannel extends GuildChannel {
    * @method setParent
    * @memberof CategoryChannel
    * @instance
-   * @param {?GuildChannel|Snowflake} channel Parent channel
-   * @param {Object} [options={}] Options to pass
-   * @param {boolean} [options.lockPermissions=true] Lock the permissions to what the parent's permissions are
-   * @param {string} [options.reason] Reason for modifying the parent of this channel
+   * @param {?(GuildChannel|Snowflake)} channel The channel to set as parent
+   * @param {SetParentOptions} [options={}] The options for setting the parent
    * @returns {Promise<GuildChannel>}
    */
 }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -728,12 +728,17 @@ class Guild extends BaseGuild {
   }
 
   /**
+   * Options used to fetch audit logs.
+   * @typedef {Object} GuildAuditLogsFetchOptions
+   * @property {Snowflake|GuildAuditLogsEntry} [before] Only return entries before this entry
+   * @property {number} [limit] The number of entries to return
+   * @property {UserResolvable} [user] Only return entries for actions made by this user
+   * @property {AuditLogAction|number} [type] Only return entries for this action type
+   */
+
+  /**
    * Fetches audit logs for this guild.
-   * @param {Object} [options={}] Options for fetching audit logs
-   * @param {Snowflake|GuildAuditLogsEntry} [options.before] Limit to entries from before specified entry
-   * @param {number} [options.limit] Limit number of entries
-   * @param {UserResolvable} [options.user] Only show entries involving this user
-   * @param {AuditLogAction|number} [options.type] Only show entries involving this action type
+   * @param {GuildAuditLogsFetchOptions} [options={}] Options for fetching audit logs
    * @returns {Promise<GuildAuditLogs>}
    * @example
    * // Output audit log entries
@@ -759,16 +764,21 @@ class Guild extends BaseGuild {
   }
 
   /**
-   * Adds a user to the guild using OAuth2. Requires the `CREATE_INSTANT_INVITE` permission.
-   * @param {UserResolvable} user User to add to the guild
-   * @param {Object} options Options for the addition
-   * @param {string} options.accessToken An OAuth2 access token for the user with the `guilds.join` scope granted to the
+   * Options used to add a user to a guild using OAuth2.
+   * @typedef {Object} AddGuildMemberOptions
+   * @property {string} accessToken An OAuth2 access token for the user with the `guilds.join` scope granted to the
    * bot's application
-   * @param {string} [options.nick] Nickname to give the member (requires `MANAGE_NICKNAMES`)
-   * @param {Collection<Snowflake, Role>|RoleResolvable[]} [options.roles] Roles to add to the member
+   * @property {string} [nick] The nickname to give to the member (requires `MANAGE_NICKNAMES`)
+   * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles to add to the member
    * (requires `MANAGE_ROLES`)
-   * @param {boolean} [options.mute] Whether the member should be muted (requires `MUTE_MEMBERS`)
-   * @param {boolean} [options.deaf] Whether the member should be deafened (requires `DEAFEN_MEMBERS`)
+   * @property {boolean} [mute] Whether the member should be muted (requires `MUTE_MEMBERS`)
+   * @property {boolean} [deaf] Whether the member should be deafened (requires `DEAFEN_MEMBERS`)
+   */
+
+  /**
+   * Adds a user to the guild using OAuth2. Requires the `CREATE_INSTANT_INVITE` permission.
+   * @param {UserResolvable} user The user to add to the guild
+   * @param {AddGuildMemberOptions} options Options for adding the user to the guild
    * @returns {Promise<GuildMember>}
    */
   async addMember(user, options) {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -539,7 +539,7 @@ class GuildChannel extends Channel {
    */
 
   /**
-   * Options used to create an invite to a guild.
+   * Options used to create an invite to a guild channel.
    * @typedef {Object} InviteOptions
    * @property {boolean} [temporary=false] Whether members that joined via the invite should be automatically
    * kicked after 24 hours if they have not yet received a role

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -452,11 +452,16 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Sets the category parent of this channel.
-   * @param {?CategoryChannel|Snowflake} channel Parent channel
-   * @param {Object} [options={}] Options to pass
-   * @param {boolean} [options.lockPermissions=true] Lock the permissions to what the parent's permissions are
-   * @param {string} [options.reason] Reason for modifying the parent of this channel
+   * Options used to set parent of a channel.
+   * @typedef {Object} SetParentOptions
+   * @property {boolean} [lockPermissions=true] Whether to lock the permissions to what the parent's permissions are
+   * @property {string} [reason] The reason for modifying the parent of the channel
+   */
+
+  /**
+   * Sets the parent of this channel.
+   * @param {?(CategoryChannel|Snowflake)} channel The category channel to set as parent
+   * @param {SetParentOptions} [options={}] The options for setting the parent
    * @returns {Promise<GuildChannel>}
    * @example
    * // Add a parent to a channel
@@ -529,19 +534,24 @@ class GuildChannel extends Channel {
    */
 
   /**
-   * Creates an invite to this guild channel.
-   * @param {Object} [options={}] Options for the invite
-   * @param {boolean} [options.temporary=false] Whether members that joined via the invite should be automatically
+   * Options used to create an invite to a guild.
+   * @typedef {Object} InviteOptions
+   * @property {boolean} [temporary=false] Whether members that joined via the invite should be automatically
    * kicked after 24 hours if they have not yet received a role
-   * @param {number} [options.maxAge=86400] How long the invite should last (in seconds, 0 for forever)
-   * @param {number} [options.maxUses=0] Maximum number of uses
-   * @param {boolean} [options.unique=false] Create a unique invite, or use an existing one with similar settings
-   * @param {UserResolvable} [options.targetUser] The user whose stream to display for this invite,
+   * @property {number} [maxAge=86400] How long the invite should last (in seconds, 0 for forever)
+   * @property {number} [maxUses=0] Maximum number of uses
+   * @property {boolean} [unique=false] Create a unique invite, or use an existing one with similar settings
+   * @property {UserResolvable} [targetUser] The user whose stream to display for this invite,
    * required if `targetType` is 1, the user must be streaming in the channel
-   * @param {ApplicationResolvable} [options.targetApplication] The embedded application to open for this invite,
+   * @property {ApplicationResolvable} [targetApplication] The embedded application to open for this invite,
    * required if `targetType` is 2, the application must have the `EMBEDDED` flag
-   * @param {InviteTargetType} [options.targetType] The type of the target for this voice channel invite
-   * @param {string} [options.reason] Reason for creating this
+   * @property {InviteTargetType} [targetType] The type of the target for this voice channel invite
+   * @property {string} [reason] The reason for creating the invite
+   */
+
+  /**
+   * Creates an invite to this guild channel.
+   * @param {InviteOptions} [options={}] The options for creating the invite
    * @returns {Promise<Invite>}
    * @example
    * // Create an invite to a channel

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -540,7 +540,7 @@ class GuildChannel extends Channel {
 
   /**
    * Options used to create an invite to a guild channel.
-   * @typedef {Object} InviteOptions
+   * @typedef {Object} CreateInviteOptions
    * @property {boolean} [temporary=false] Whether members that joined via the invite should be automatically
    * kicked after 24 hours if they have not yet received a role
    * @property {number} [maxAge=86400] How long the invite should last (in seconds, 0 for forever)
@@ -556,7 +556,7 @@ class GuildChannel extends Channel {
 
   /**
    * Creates an invite to this guild channel.
-   * @param {InviteOptions} [options={}] The options for creating the invite
+   * @param {CreateInviteOptions} [options={}] The options for creating the invite
    * @returns {Promise<Invite>}
    * @example
    * // Create an invite to a channel
@@ -608,7 +608,7 @@ class GuildChannel extends Channel {
 
   /**
    * Options used to clone a guild channel.
-   * @typedef {GuildCreateChannelOptions} GuildChannelCloneOptions
+   * @typedef {GuildChannelCreateOptions} GuildChannelCloneOptions
    * @property {string} [name=this.name] Name of the new channel
    */
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -606,22 +606,15 @@ class GuildChannel extends Channel {
     return invites;
   }
 
-  /* eslint-disable max-len */
+  /**
+   * Options used to clone a guild channel.
+   * @typedef {GuildCreateChannelOptions} GuildChannelCloneOptions
+   * @property {string} [name=this.name] Name of the new channel
+   */
+
   /**
    * Clones this channel.
-   * @param {Object} [options] The options
-   * @param {string} [options.name=this.name] Name of the new channel
-   * @param {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [options.permissionOverwrites=this.permissionOverwrites]
-   * Permission overwrites of the new channel
-   * @param {string} [options.type=this.type] Type of the new channel
-   * @param {string} [options.topic=this.topic] Topic of the new channel (only text)
-   * @param {boolean} [options.nsfw=this.nsfw] Whether the new channel is nsfw (only text)
-   * @param {number} [options.bitrate=this.bitrate] Bitrate of the new channel in bits (only voice)
-   * @param {number} [options.userLimit=this.userLimit] Maximum amount of users allowed in the new channel (only voice)
-   * @param {number} [options.rateLimitPerUser=this.rateLimitPerUser] Ratelimit per user for the new channel (only text)
-   * @param {number} [options.position=this.position] Position of the new channel
-   * @param {ChannelResolvable} [options.parent=this.parent] Parent of the new channel
-   * @param {string} [options.reason] Reason for cloning this channel
+   * @param {GuildChannelCloneOptions} [options] The options for cloning this channel
    * @returns {Promise<GuildChannel>}
    */
   clone(options = {}) {
@@ -639,7 +632,6 @@ class GuildChannel extends Channel {
       ...options,
     });
   }
-  /* eslint-enable max-len */
 
   /**
    * Checks if this channel has the same type, topic, position, name, overwrites and ID as another channel.

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -496,11 +496,16 @@ class GuildChannel extends Channel {
   }
 
   /**
+   * Options used to set position of a channel.
+   * @typedef {Object} SetChannelPositionOptions
+   * @param {boolean} [relative=false] Whether or not to change the position relative to its current value
+   * @param {string} [reason] The reason for changing the position
+   */
+
+  /**
    * Sets a new position for the guild channel.
    * @param {number} position The new position for the guild channel
-   * @param {Object} [options] Options for setting position
-   * @param {boolean} [options.relative=false] Change the position relative to its current value
-   * @param {string} [options.reason] Reason for changing the position
+   * @param {SetChannelPositionOptions} [options] Options for setting position
    * @returns {Promise<GuildChannel>}
    * @example
    * // Set a new channel position

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -323,9 +323,7 @@ class GuildMember extends Base {
 
   /**
    * Bans this guild member.
-   * @param {Object} [options] Options for the ban
-   * @param {number} [options.days=0] Number of days of messages to delete, must be between 0 and 7, inclusive
-   * @param {string} [options.reason] Reason for banning
+   * @param {BanOptions} [options] Options for the ban
    * @returns {Promise<GuildMember>}
    * @example
    * // ban a guild member

--- a/src/structures/GuildTemplate.js
+++ b/src/structures/GuildTemplate.js
@@ -136,10 +136,15 @@ class GuildTemplate extends Base {
   }
 
   /**
-   * Updates the metadata on this template.
-   * @param {Object} options Options for the template
-   * @param {string} [options.name] The name of this template
-   * @param {string} [options.description] The description of this template
+   * Options used to edit a guild template.
+   * @typedef {Object} EditGuildTemplateOptions
+   * @property {string} [name] The name of this template
+   * @property {string} [description] The description of this template
+   */
+
+  /**
+   * Updates the metadata of this template.
+   * @param {EditGuildTemplateOptions} [options] Options for editing the template
    * @returns {Promise<GuildTemplate>}
    */
   edit({ name, description } = {}) {

--- a/src/structures/MessageComponentInteractionCollector.js
+++ b/src/structures/MessageComponentInteractionCollector.js
@@ -83,7 +83,7 @@ class MessageComponentInteractionCollector extends Collector {
   /**
    * Handles an incoming interaction for possible collection.
    * @param {Interaction} interaction The interaction to possibly collect
-   * @returns {?Snowflake|string}
+   * @returns {?(Snowflake|string)}
    * @private
    */
   collect(interaction) {

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -164,9 +164,9 @@ class MessageMentions {
   /**
    * Options used to check for a mention.
    * @typedef {Object} MessageMentionsHasOptions
-   * @property {boolean} [ignoreDirect=false] - Whether to ignore direct mentions to the item
-   * @property {boolean} [ignoreRoles=false] - Whether to ignore role mentions to a guild member
-   * @property {boolean} [ignoreEveryone=false] - Whether to ignore everyone/here mentions
+   * @property {boolean} [ignoreDirect=false] Whether to ignore direct mentions to the item
+   * @property {boolean} [ignoreRoles=false] Whether to ignore role mentions to a guild member
+   * @property {boolean} [ignoreEveryone=false] Whether to ignore everyone/here mentions
    */
 
   /**

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -162,13 +162,18 @@ class MessageMentions {
   }
 
   /**
+   * Options used to check a mention.
+   * @typedef {Object} MessageMentionsHasOptions
+   * @property {boolean} [ignoreDirect=false] - Whether to ignore direct mentions to the item
+   * @property {boolean} [ignoreRoles=false] - Whether to ignore role mentions to a guild member
+   * @property {boolean} [ignoreEveryone=false] - Whether to ignore everyone/here mentions
+   */
+
+  /**
    * Checks if a user, guild member, role, or channel is mentioned.
-   * Takes into account user mentions, role mentions, and @everyone/@here mentions.
-   * @param {UserResolvable|RoleResolvable|ChannelResolvable} data User/Role/Channel to check
-   * @param {Object} [options] Options
-   * @param {boolean} [options.ignoreDirect=false] - Whether to ignore direct mentions to the item
-   * @param {boolean} [options.ignoreRoles=false] - Whether to ignore role mentions to a guild member
-   * @param {boolean} [options.ignoreEveryone=false] - Whether to ignore everyone/here mentions
+   * Takes into account user mentions, role mentions, and `@everyone`/`@here` mentions.
+   * @param {UserResolvable|RoleResolvable|ChannelResolvable} data The User/Role/Channel to check for
+   * @param {MessageMentionsHasOptions} [options] The options for the check
    * @returns {boolean}
    */
   has(data, { ignoreDirect = false, ignoreRoles = false, ignoreEveryone = false } = {}) {

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -162,7 +162,7 @@ class MessageMentions {
   }
 
   /**
-   * Options used to check a mention.
+   * Options used to check for a mention.
    * @typedef {Object} MessageMentionsHasOptions
    * @property {boolean} [ignoreDirect=false] - Whether to ignore direct mentions to the item
    * @property {boolean} [ignoreRoles=false] - Whether to ignore role mentions to a guild member

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -82,7 +82,7 @@ class ReactionCollector extends Collector {
    * Handles an incoming reaction for possible collection.
    * @param {MessageReaction} reaction The reaction to possibly collect
    * @param {User} user The user that added the reaction
-   * @returns {?Snowflake|string}
+   * @returns {?(Snowflake|string)}
    * @private
    */
   collect(reaction, user) {
@@ -113,7 +113,7 @@ class ReactionCollector extends Collector {
    * Handles a reaction deletion for possible disposal.
    * @param {MessageReaction} reaction The reaction to possibly dispose of
    * @param {User} user The user that removed the reaction
-   * @returns {?Snowflake|string}
+   * @returns {?(Snowflake|string)}
    */
   dispose(reaction, user) {
     /**

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -323,11 +323,16 @@ class Role extends Base {
   }
 
   /**
-   * Sets the position of the role.
-   * @param {number} position The position of the role
-   * @param {Object} [options] Options for setting position
-   * @param {boolean} [options.relative=false] Change the position relative to its current value
-   * @param {string} [options.reason] Reason for changing the position
+   * Options used to set position of a role.
+   * @typedef {Object} SetRolePositionOptions
+   * @property {boolean} [relative=false] Whether to change the position relative to its current value or not
+   * @property {string} [reason] The reason for changing the position
+   */
+
+  /**
+   * Sets the new position of the role.
+   * @param {number} position The new position for the role
+   * @param {SetRolePositionOptions} [options] Options for setting the position
    * @returns {Promise<Role>}
    * @example
    * // Set the position of the role

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -194,10 +194,16 @@ class Collector extends EventEmitter {
   }
 
   /**
-   * Resets the collectors timeout and idle timer.
-   * @param {Object} [options] Options
-   * @param {number} [options.time] How long to run the collector for in milliseconds
-   * @param {number} [options.idle] How long to stop the collector after inactivity in milliseconds
+   * Options used to reset timeout and idle timer of a {@link Collector}.
+   * @typedef {Object} CollectorResetTimerOptions
+   * @property {number} [time] How long to run the collector for (in milliseconds)
+   * @property {number} [idle] How long to wait to stop the collector after inactivity (in milliseconds)
+   */
+
+  /**
+   * Resets the collector's timeout and idle timer.
+   * @param {CollectorResetTimerOptions} [options] Options for reseting
+
    */
   resetTimer({ time, idle } = {}) {
     if (this._timeout) {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -329,11 +329,16 @@ class Util {
   }
 
   /**
+   * Options used to make an error object.
+   * @typedef {Object} MakeErrorOptions
+   * @property {string} name Error type
+   * @property {string} message Message for the error
+   * @property {string} stack Stack for the error
+   */
+
+  /**
    * Makes an Error from a plain info object.
-   * @param {Object} obj Error info
-   * @param {string} obj.name Error type
-   * @param {string} obj.message Message for the error
-   * @param {string} obj.stack Stack for the error
+   * @param {MakeErrorOptions} obj Error info
    * @returns {Error}
    * @private
    */
@@ -347,7 +352,7 @@ class Util {
   /**
    * Makes a plain error info object from an Error.
    * @param {Error} err Error to get info from
-   * @returns {Object}
+   * @returns {MakeErrorOptions}
    * @private
    */
   static makePlainError(err) {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -91,18 +91,23 @@ class Util {
   }
 
   /**
+   * Options used to escape markdown.
+   * @typedef {Object} EscapeMarkdownOptions
+   * @property {boolean} [codeBlock=true] Whether to escape code blocks or not
+   * @property {boolean} [inlineCode=true] Whether to escape inline code or not
+   * @property {boolean} [bold=true] Whether to escape bolds or not
+   * @property {boolean} [italic=true] Whether to escape italics or not
+   * @property {boolean} [underline=true] Whether to escape underlines or not
+   * @property {boolean} [strikethrough=true] Whether to escape strikethroughs or not
+   * @property {boolean} [spoiler=true] Whether to escape spoilers or not
+   * @property {boolean} [codeBlockContent=true] Whether to escape text inside code blocks or not
+   * @property {boolean} [inlineCodeContent=true] Whether to escape text inside inline code or not
+   */
+
+  /**
    * Escapes any Discord-flavour markdown in a string.
    * @param {string} text Content to escape
-   * @param {Object} [options={}] What types of markdown to escape
-   * @param {boolean} [options.codeBlock=true] Whether to escape code blocks or not
-   * @param {boolean} [options.inlineCode=true] Whether to escape inline code or not
-   * @param {boolean} [options.bold=true] Whether to escape bolds or not
-   * @param {boolean} [options.italic=true] Whether to escape italics or not
-   * @param {boolean} [options.underline=true] Whether to escape underlines or not
-   * @param {boolean} [options.strikethrough=true] Whether to escape strikethroughs or not
-   * @param {boolean} [options.spoiler=true] Whether to escape spoilers or not
-   * @param {boolean} [options.codeBlockContent=true] Whether to escape text inside code blocks or not
-   * @param {boolean} [options.inlineCodeContent=true] Whether to escape text inside inline code or not
+   * @param {EscapeMarkdownOptions} [options={}] Options for escaping the markdown
    * @returns {string}
    */
   static escapeMarkdown(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1394,14 +1394,7 @@ declare module 'discord.js' {
     public readonly client: Client;
     public everyone: boolean;
     public readonly guild: Guild;
-    public has(
-      data: UserResolvable | RoleResolvable | ChannelResolvable,
-      options?: {
-        ignoreDirect?: boolean;
-        ignoreRoles?: boolean;
-        ignoreEveryone?: boolean;
-      },
-    ): boolean;
+    public has(data: UserResolvable | RoleResolvable | ChannelResolvable, options?: MessageMentionsHasOptions): boolean;
     public readonly members: Collection<Snowflake, GuildMember> | null;
     public roles: Collection<Snowflake, Role>;
     public users: Collection<Snowflake, User>;
@@ -3326,6 +3319,12 @@ declare module 'discord.js' {
     type: InteractionType;
     commandName: string;
     user: User;
+  }
+
+  interface MessageMentionsHasOptions {
+    ignoreDirect?: boolean;
+    ignoreRoles?: boolean;
+    ignoreEveryone?: boolean;
   }
 
   interface MessageMentionOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2990,7 +2990,7 @@ declare module 'discord.js' {
   }
 
   interface GuildCreateOptions {
-    afkChannelID?: number;
+    afkChannelID?: Snowflake;
     afkTimeout?: number;
     channels?: PartialChannelData[];
     defaultMessageNotifications?: DefaultMessageNotifications | number;
@@ -2998,7 +2998,7 @@ declare module 'discord.js' {
     icon?: BufferResolvable | Base64Resolvable | null;
     roles?: PartialRoleData[];
     systemChannelFlags?: SystemChannelFlagsResolvable;
-    systemChannelID?: number;
+    systemChannelID?: Snowflake;
     verificationLevel?: VerificationLevel | number;
   }
 
@@ -3527,17 +3527,12 @@ declare module 'discord.js' {
   }
 
   interface PartialChannelData {
-    id?: number;
+    id?: Snowflake;
     name: string;
     topic?: string;
     type?: ChannelType;
-    parentID?: number;
-    permissionOverwrites?: {
-      id: number | Snowflake;
-      type?: OverwriteType;
-      allow?: PermissionResolvable;
-      deny?: PermissionResolvable;
-    }[];
+    parentID?: Snowflake;
+    permissionOverwrites?: PartialOverwriteData[];
   }
 
   interface PartialGuildMember
@@ -3597,8 +3592,15 @@ declare module 'discord.js' {
     readonly url: string;
   }
 
+  interface PartialOverwriteData {
+    id: Snowflake;
+    type?: OverwriteType;
+    allow?: PermissionResolvable;
+    deny?: PermissionResolvable;
+  }
+
   interface PartialRoleData extends RoleData {
-    id?: number;
+    id?: Snowflake;
   }
 
   type PartialTypes = 'USER' | 'CHANNEL' | 'GUILD_MEMBER' | 'MESSAGE' | 'REACTION';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -909,10 +909,7 @@ declare module 'discord.js' {
     public permissionsFor(memberOrRole: GuildMember | Role): Readonly<Permissions>;
     public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
     public setName(name: string, reason?: string): Promise<this>;
-    public setParent(
-      channel: CategoryChannel | Snowflake | null,
-      options?: { lockPermissions?: boolean; reason?: string },
-    ): Promise<this>;
+    public setParent(channel: CategoryChannel | Snowflake | null, options?: SetParentOptions): Promise<this>;
     public setPosition(position: number, options?: { relative?: boolean; reason?: string }): Promise<this>;
     public setTopic(topic: string | null, reason?: string): Promise<this>;
     public updateOverwrite(
@@ -3644,6 +3641,11 @@ declare module 'discord.js' {
     botID?: Snowflake;
     integrationID?: Snowflake;
     premiumSubscriberRole?: true;
+  }
+
+  interface SetParentOptions {
+    lockPermissions?: boolean;
+    reason?: string;
   }
 
   type ShardingManagerMode = 'process' | 'worker';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1030,7 +1030,7 @@ declare module 'discord.js' {
   }
 
   // tslint:disable-next-line:no-empty-interface - Merge RateLimitData into RateLimitError to not have to type it again
-  interface RateLimitError extends RateLimitData {}
+  interface RateLimitError extends RateLimitData { }
   export class RateLimitError extends Error {
     constructor(data: RateLimitData);
     public name: 'RateLimitError';
@@ -1674,8 +1674,8 @@ declare module 'discord.js' {
     public createShard(id: number): Shard;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
-    public respawnAll(options?: ShardRespawnOptions): Promise<Collection<number, Shard>>;
-    public spawn(options?: ShardSpawnOptions): Promise<Collection<number, Shard>>;
+    public respawnAll(options?: MultipleShardRespawnOptions): Promise<Collection<number, Shard>>;
+    public spawn(options?: MultipleShardSpawnOptions): Promise<Collection<number, Shard>>;
 
     public on(event: 'shardCreate', listener: (shard: Shard) => Awaited<void>): this;
 
@@ -2268,9 +2268,9 @@ declare module 'discord.js' {
     public guild: Guild;
     public readonly premiumSubscriberRole: Role | null;
     public botRoleFor(user: UserResolvable): Role | null;
-    public create(options?: RoleData & { reason?: string }): Promise<Role>;
     public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<Role | null>;
     public fetch(id?: Snowflake, options?: BaseFetchOptions): Promise<Collection<Snowflake, Role>>;
+    public create(options?: CreateRoleOptions): Promise<Role>;
   }
 
   export class UserManager extends BaseManager<Snowflake, User, UserResolvable> {
@@ -2757,6 +2757,10 @@ declare module 'discord.js' {
     member?: GuildMember | RawInteractionDataResolvedGuildMember;
     channel?: GuildChannel | RawInteractionDataResolvedChannel;
     role?: Role | RawRole;
+  }
+
+  interface CreateRoleOptions extends RoleData {
+    reason?: string;
   }
 
   interface CrosspostedChannel {
@@ -3390,6 +3394,18 @@ declare module 'discord.js' {
 
   type MFALevel = keyof typeof MFALevels;
 
+  interface MultipleShardRespawnOptions {
+    shardDelay?: number;
+    respawnDelay?: number;
+    timeout?: number;
+  }
+
+  interface MultipleShardSpawnOptions {
+    amount?: number | 'auto';
+    delay?: number;
+    timeout?: number;
+  }
+
   type NSFWLevel = keyof typeof NSFWLevels;
 
   interface OverwriteData {
@@ -3403,11 +3419,11 @@ declare module 'discord.js' {
 
   type OverwriteType = 'member' | 'role';
 
-  interface PermissionFlags extends Record<PermissionString, bigint> {}
+  interface PermissionFlags extends Record<PermissionString, bigint> { }
 
-  interface PermissionObject extends Record<PermissionString, boolean> {}
+  interface PermissionObject extends Record<PermissionString, boolean> { }
 
-  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> {}
+  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> { }
 
   type PermissionResolvable = BitFieldResolvable<PermissionString, bigint>;
 
@@ -3446,7 +3462,7 @@ declare module 'discord.js' {
     | 'USE_APPLICATION_COMMANDS'
     | 'REQUEST_TO_SPEAK';
 
-  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> {}
+  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> { }
 
   type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray<T>>;
 
@@ -3470,16 +3486,16 @@ declare module 'discord.js' {
     partial: true;
     fetch(): Promise<T>;
   } & {
-    [K in keyof Omit<
-      T,
-      'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
-    >]: T[K] extends (...args: any) => void ? T[K] : T[K] | null;
-  };
+      [K in keyof Omit<
+        T,
+        'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
+      >]: T[K] extends (...args: any) => void ? T[K] : T[K] | null;
+    };
 
   interface PartialDMChannel
     extends Partialize<
-      DMChannel,
-      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+    DMChannel,
+    'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
     > {
     lastMessage: null;
     lastMessageID: undefined;
@@ -3506,18 +3522,18 @@ declare module 'discord.js' {
 
   interface PartialGuildMember
     extends Partialize<
-      GuildMember,
-      | 'bannable'
-      | 'displayColor'
-      | 'displayHexColor'
-      | 'displayName'
-      | 'guild'
-      | 'kickable'
-      | 'permissions'
-      | 'roles'
-      | 'manageable'
-      | 'presence'
-      | 'voice'
+    GuildMember,
+    | 'bannable'
+    | 'displayColor'
+    | 'displayHexColor'
+    | 'displayName'
+    | 'guild'
+    | 'kickable'
+    | 'permissions'
+    | 'roles'
+    | 'manageable'
+    | 'presence'
+    | 'voice'
     > {
     readonly bannable: boolean;
     readonly displayColor: number;
@@ -3536,17 +3552,17 @@ declare module 'discord.js' {
 
   interface PartialMessage
     extends Partialize<
-      Message,
-      | 'attachments'
-      | 'channel'
-      | 'deletable'
-      | 'crosspostable'
-      | 'editable'
-      | 'mentions'
-      | 'pinnable'
-      | 'url'
-      | 'flags'
-      | 'embeds'
+    Message,
+    | 'attachments'
+    | 'channel'
+    | 'deletable'
+    | 'crosspostable'
+    | 'editable'
+    | 'mentions'
+    | 'pinnable'
+    | 'url'
+    | 'flags'
+    | 'embeds'
     > {
     attachments: Message['attachments'];
     channel: Message['channel'];
@@ -3650,18 +3666,6 @@ declare module 'discord.js' {
     shardArgs?: string[];
     token?: string;
     execArgv?: string[];
-  }
-
-  interface ShardRespawnOptions {
-    shardDelay?: number;
-    respawnDelay?: number;
-    timeout?: number;
-  }
-
-  interface ShardSpawnOptions {
-    amount?: number | 'auto';
-    delay?: number;
-    timeout?: number;
   }
 
   type Snowflake = APISnowflake;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -892,7 +892,7 @@ declare module 'discord.js' {
     public type: Exclude<keyof typeof ChannelType, 'dm' | 'group' | 'unknown'>;
     public readonly viewable: boolean;
     public clone(options?: GuildChannelCloneOptions): Promise<this>;
-    public createInvite(options?: InviteOptions): Promise<Invite>;
+    public createInvite(options?: CreateInviteOptions): Promise<Invite>;
     public createOverwrite(
       userOrRole: RoleResolvable | UserResolvable,
       options: PermissionOverwriteOptions,
@@ -2115,15 +2115,15 @@ declare module 'discord.js' {
   export class GuildChannelManager extends BaseManager<Snowflake, GuildChannel, GuildChannelResolvable> {
     constructor(guild: Guild, iterable?: Iterable<any>);
     public guild: Guild;
-    public create(name: string, options: GuildCreateChannelOptions & { type: 'voice' }): Promise<VoiceChannel>;
-    public create(name: string, options: GuildCreateChannelOptions & { type: 'category' }): Promise<CategoryChannel>;
-    public create(name: string, options?: GuildCreateChannelOptions & { type?: 'text' }): Promise<TextChannel>;
-    public create(name: string, options: GuildCreateChannelOptions & { type: 'news' }): Promise<NewsChannel>;
-    public create(name: string, options: GuildCreateChannelOptions & { type: 'store' }): Promise<StoreChannel>;
-    public create(name: string, options: GuildCreateChannelOptions & { type: 'stage' }): Promise<StageChannel>;
+    public create(name: string, options: GuildChannelCreateOptions & { type: 'voice' }): Promise<VoiceChannel>;
+    public create(name: string, options: GuildChannelCreateOptions & { type: 'category' }): Promise<CategoryChannel>;
+    public create(name: string, options?: GuildChannelCreateOptions & { type?: 'text' }): Promise<TextChannel>;
+    public create(name: string, options: GuildChannelCreateOptions & { type: 'news' }): Promise<NewsChannel>;
+    public create(name: string, options: GuildChannelCreateOptions & { type: 'store' }): Promise<StoreChannel>;
+    public create(name: string, options: GuildChannelCreateOptions & { type: 'stage' }): Promise<StageChannel>;
     public create(
       name: string,
-      options: GuildCreateChannelOptions,
+      options: GuildChannelCreateOptions,
     ): Promise<TextChannel | VoiceChannel | CategoryChannel | NewsChannel | StoreChannel | StageChannel>;
     public fetch(
       id: Snowflake,
@@ -2969,7 +2969,7 @@ declare module 'discord.js' {
 
   type GuildChannelResolvable = Snowflake | GuildChannel;
 
-  interface GuildCreateChannelOptions {
+  interface GuildChannelCreateOptions {
     permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
     topic?: string;
     type?: Exclude<
@@ -2985,7 +2985,7 @@ declare module 'discord.js' {
     reason?: string;
   }
 
-  interface GuildChannelCloneOptions extends GuildCreateChannelOptions {
+  interface GuildChannelCloneOptions extends GuildChannelCreateOptions {
     name?: string;
   }
 
@@ -3170,7 +3170,7 @@ declare module 'discord.js' {
     additionalScopes?: InviteScope[];
   }
 
-  interface InviteOptions {
+  interface CreateInviteOptions {
     temporary?: boolean;
     maxAge?: number;
     maxUses?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1030,7 +1030,7 @@ declare module 'discord.js' {
   }
 
   // tslint:disable-next-line:no-empty-interface - Merge RateLimitData into RateLimitError to not have to type it again
-  interface RateLimitError extends RateLimitData { }
+  interface RateLimitError extends RateLimitData {}
   export class RateLimitError extends Error {
     constructor(data: RateLimitData);
     public name: 'RateLimitError';
@@ -1809,8 +1809,8 @@ declare module 'discord.js' {
     public static fetchRecommendedShards(token: string, guildsPerShard?: number): Promise<number>;
     public static flatten(obj: unknown, ...props: { [key: string]: boolean | string }[]): unknown;
     public static idToBinary(num: Snowflake): string;
-    public static makeError(obj: { name: string; message: string; stack: string }): Error;
-    public static makePlainError(err: Error): { name: string; message: string; stack: string };
+    public static makeError(obj: MakeErrorOptions): Error;
+    public static makePlainError(err: Error): MakeErrorOptions;
     public static mergeDefault(def: unknown, given: unknown): unknown;
     public static moveElementInArray(array: any[], element: any, newIndex: number, offset?: boolean): number;
     public static parseEmoji(text: string): { animated: boolean; name: string; id: Snowflake | null } | null;
@@ -3090,6 +3090,8 @@ declare module 'discord.js' {
     cache?: boolean;
   }
 
+  type GuildTemplateResolvable = string;
+
   interface HTTPAttachmentData {
     attachment: string | Buffer | Stream;
     name: string;
@@ -3194,7 +3196,11 @@ declare module 'discord.js' {
     | 'gdm.join'
     | 'webhook.incoming';
 
-  type GuildTemplateResolvable = string;
+  interface MakeErrorOptions {
+    name: string;
+    message: string;
+    stack: string;
+  }
 
   type MembershipStates = 'INVITED' | 'ACCEPTED';
 
@@ -3433,11 +3439,11 @@ declare module 'discord.js' {
 
   type OverwriteType = 'member' | 'role';
 
-  interface PermissionFlags extends Record<PermissionString, bigint> { }
+  interface PermissionFlags extends Record<PermissionString, bigint> {}
 
-  interface PermissionObject extends Record<PermissionString, boolean> { }
+  interface PermissionObject extends Record<PermissionString, boolean> {}
 
-  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> { }
+  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> {}
 
   type PermissionResolvable = BitFieldResolvable<PermissionString, bigint>;
 
@@ -3476,7 +3482,7 @@ declare module 'discord.js' {
     | 'USE_APPLICATION_COMMANDS'
     | 'REQUEST_TO_SPEAK';
 
-  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> { }
+  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> {}
 
   type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray<T>>;
 
@@ -3500,16 +3506,16 @@ declare module 'discord.js' {
     partial: true;
     fetch(): Promise<T>;
   } & {
-      [K in keyof Omit<
-        T,
-        'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
-      >]: T[K] extends (...args: any) => void ? T[K] : T[K] | null;
-    };
+    [K in keyof Omit<
+      T,
+      'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
+    >]: T[K] extends (...args: any) => void ? T[K] : T[K] | null;
+  };
 
   interface PartialDMChannel
     extends Partialize<
-    DMChannel,
-    'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+      DMChannel,
+      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
     > {
     lastMessage: null;
     lastMessageID: undefined;
@@ -3536,18 +3542,18 @@ declare module 'discord.js' {
 
   interface PartialGuildMember
     extends Partialize<
-    GuildMember,
-    | 'bannable'
-    | 'displayColor'
-    | 'displayHexColor'
-    | 'displayName'
-    | 'guild'
-    | 'kickable'
-    | 'permissions'
-    | 'roles'
-    | 'manageable'
-    | 'presence'
-    | 'voice'
+      GuildMember,
+      | 'bannable'
+      | 'displayColor'
+      | 'displayHexColor'
+      | 'displayName'
+      | 'guild'
+      | 'kickable'
+      | 'permissions'
+      | 'roles'
+      | 'manageable'
+      | 'presence'
+      | 'voice'
     > {
     readonly bannable: boolean;
     readonly displayColor: number;
@@ -3566,17 +3572,17 @@ declare module 'discord.js' {
 
   interface PartialMessage
     extends Partialize<
-    Message,
-    | 'attachments'
-    | 'channel'
-    | 'deletable'
-    | 'crosspostable'
-    | 'editable'
-    | 'mentions'
-    | 'pinnable'
-    | 'url'
-    | 'flags'
-    | 'embeds'
+      Message,
+      | 'attachments'
+      | 'channel'
+      | 'deletable'
+      | 'crosspostable'
+      | 'editable'
+      | 'mentions'
+      | 'pinnable'
+      | 'url'
+      | 'flags'
+      | 'embeds'
     > {
     attachments: Message['attachments'];
     channel: Message['channel'];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -910,7 +910,7 @@ declare module 'discord.js' {
     public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
     public setName(name: string, reason?: string): Promise<this>;
     public setParent(channel: CategoryChannel | Snowflake | null, options?: SetParentOptions): Promise<this>;
-    public setPosition(position: number, options?: { relative?: boolean; reason?: string }): Promise<this>;
+    public setPosition(position: number, options?: SetChannelPositionOptions): Promise<this>;
     public setTopic(topic: string | null, reason?: string): Promise<this>;
     public updateOverwrite(
       userOrRole: RoleResolvable | UserResolvable,
@@ -1643,7 +1643,7 @@ declare module 'discord.js' {
     ): Promise<T>;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
-    public respawnAll(options?: { shardDelay?: number; respawnDelay?: number; timeout?: number }): Promise<void>;
+    public respawnAll(options?: MultipleShardRespawnOptions): Promise<void>;
     public send(message: any): Promise<void>;
 
     public static singleton(client: Client, mode: ShardingManagerMode): ShardClientUtil;
@@ -2257,7 +2257,7 @@ declare module 'discord.js' {
   export class ReactionUserManager extends BaseManager<Snowflake, User, UserResolvable> {
     constructor(client: Client, iterable: Iterable<any> | undefined, reaction: MessageReaction);
     public reaction: MessageReaction;
-    public fetch(options?: { limit?: number; after?: Snowflake }): Promise<Collection<Snowflake, User>>;
+    public fetch(options?: FetchReactionUsersOptions): Promise<Collection<Snowflake, User>>;
     public remove(user?: UserResolvable): Promise<MessageReaction>;
   }
 
@@ -2875,6 +2875,11 @@ declare module 'discord.js' {
   }
 
   type FetchOwnerOptions = Omit<FetchMemberOptions, 'user'>;
+
+  interface FetchReactionUsersOptions {
+    limit?: number;
+    after?: Snowflake;
+  }
 
   interface FileOptions {
     attachment: BufferResolvable | Stream;
@@ -3649,6 +3654,11 @@ declare module 'discord.js' {
     botID?: Snowflake;
     integrationID?: Snowflake;
     premiumSubscriberRole?: true;
+  }
+
+  interface SetChannelPositionOptions {
+    relative?: boolean;
+    reason?: string;
   }
 
   interface SetParentOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2990,7 +2990,7 @@ declare module 'discord.js' {
   }
 
   interface GuildCreateOptions {
-    afkChannelID?: Snowflake;
+    afkChannelID?: Snowflake | number;
     afkTimeout?: number;
     channels?: PartialChannelData[];
     defaultMessageNotifications?: DefaultMessageNotifications | number;
@@ -2998,7 +2998,7 @@ declare module 'discord.js' {
     icon?: BufferResolvable | Base64Resolvable | null;
     roles?: PartialRoleData[];
     systemChannelFlags?: SystemChannelFlagsResolvable;
-    systemChannelID?: Snowflake;
+    systemChannelID?: Snowflake | number;
     verificationLevel?: VerificationLevel | number;
   }
 
@@ -3527,11 +3527,11 @@ declare module 'discord.js' {
   }
 
   interface PartialChannelData {
-    id?: Snowflake;
+    id?: Snowflake | number;
     name: string;
     topic?: string;
     type?: ChannelType;
-    parentID?: Snowflake;
+    parentID?: Snowflake | number;
     permissionOverwrites?: PartialOverwriteData[];
   }
 
@@ -3593,14 +3593,14 @@ declare module 'discord.js' {
   }
 
   interface PartialOverwriteData {
-    id: Snowflake;
+    id: Snowflake | number;
     type?: OverwriteType;
     allow?: PermissionResolvable;
     deny?: PermissionResolvable;
   }
 
   interface PartialRoleData extends RoleData {
-    id?: Snowflake;
+    id?: Snowflake | number;
   }
 
   type PartialTypes = 'USER' | 'CHANNEL' | 'GUILD_MEMBER' | 'MESSAGE' | 'REACTION';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1009,7 +1009,7 @@ declare module 'discord.js' {
     public unSynced: boolean | null;
     public createGuild(name: string, icon?: BufferResolvable | Base64Resolvable): Promise<Guild>;
     public delete(): Promise<GuildTemplate>;
-    public edit(options?: { name?: string; description?: string }): Promise<GuildTemplate>;
+    public edit(options?: EditGuildTemplateOptions): Promise<GuildTemplate>;
     public sync(): Promise<GuildTemplate>;
     public static GUILD_TEMPLATES_PATTERN: RegExp;
   }
@@ -2773,6 +2773,11 @@ declare module 'discord.js' {
   }
 
   type DefaultMessageNotifications = 'ALL' | 'MENTIONS';
+
+  interface EditGuildTemplateOptions {
+    name?: string;
+    description?: string;
+  }
 
   interface EmbedField {
     name: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -424,7 +424,7 @@ declare module 'discord.js' {
     public handleCollect(...args: any[]): void;
     public handleDispose(...args: any[]): void;
     public stop(reason?: string): void;
-    public resetTimer(options?: { time?: number; idle?: number }): void;
+    public resetTimer(options?: CollectorResetTimerOptions): void;
     public [Symbol.asyncIterator](): AsyncIterableIterator<V>;
     public toJSON(): unknown;
 
@@ -1572,7 +1572,7 @@ declare module 'discord.js' {
     public setMentionable(mentionable: boolean, reason?: string): Promise<Role>;
     public setName(name: string, reason?: string): Promise<Role>;
     public setPermissions(permissions: PermissionResolvable, reason?: string): Promise<Role>;
-    public setPosition(position: number, options?: { relative?: boolean; reason?: string }): Promise<Role>;
+    public setPosition(position: number, options?: SetRolePositionOptions): Promise<Role>;
     public toJSON(): unknown;
     public toString(): string;
 
@@ -2705,6 +2705,11 @@ declare module 'discord.js' {
     dispose?: boolean;
   }
 
+  interface CollectorResetTimerOptions {
+    time?: number;
+    idle?: number;
+  }
+
   type ColorResolvable =
     | 'DEFAULT'
     | 'WHITE'
@@ -3667,6 +3672,11 @@ declare module 'discord.js' {
 
   interface SetParentOptions {
     lockPermissions?: boolean;
+    reason?: string;
+  }
+
+  interface SetRolePositionOptions {
+    relative?: boolean;
     reason?: string;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1674,16 +1674,8 @@ declare module 'discord.js' {
     public createShard(id: number): Shard;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
-    public respawnAll(options?: {
-      shardDelay?: number;
-      respawnDelay?: number;
-      timeout?: number;
-    }): Promise<Collection<number, Shard>>;
-    public spawn(options?: {
-      amount?: number | 'auto';
-      delay?: number;
-      timeout?: number;
-    }): Promise<Collection<number, Shard>>;
+    public respawnAll(options?: ShardRespawnOptions): Promise<Collection<number, Shard>>;
+    public spawn(options?: ShardSpawnOptions): Promise<Collection<number, Shard>>;
 
     public on(event: 'shardCreate', listener: (shard: Shard) => Awaited<void>): this;
 
@@ -3658,6 +3650,18 @@ declare module 'discord.js' {
     shardArgs?: string[];
     token?: string;
     execArgv?: string[];
+  }
+
+  interface ShardRespawnOptions {
+    shardDelay?: number;
+    respawnDelay?: number;
+    timeout?: number;
+  }
+
+  interface ShardSpawnOptions {
+    amount?: number | 'auto';
+    delay?: number;
+    timeout?: number;
   }
 
   type Snowflake = APISnowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR starts the work of creating typedefs for `options` params of all the methods that don't have one. I've created a few so far but there are still few more to add. Since, #5784 added some new typedefs too, I'll rebase this PR once that one is merged to remove duplicate changes. This PR also tries to add more helpful description of a property in places where the old one is a little vague.

ℹ️ The names for the new typedefs are taken from their respective interfaces in the typings.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
