### PR TITLE
Update APIRequest.js

### DIFF
--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -3,7 +3,7 @@
 const https = require('https');
 const FormData = require('@discordjs/form-data');
 const AbortController = require('abort-controller');
-const fetch = require('node-fetch');
+const fetch = require('node-fetch').default;
 const { UserAgent } = require('../util/Constants');
 
 if (https.Agent) var agent = new https.Agent({ keepAlive: true });


### PR DESCRIPTION
I am changing the require statement for node-fetch to include the default import. 
from:
```js
const fetch = require('node-fetch');
```

to:
```js
const fetch = require('node-fetch').default;
```

this will allow discord.js to be consumed by node.js apps with bundlers such as webpack.

**Please describe the changes this PR makes and why it should be merged:**



**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
-->
