### PR TITLE
docs(Messages): fix examples in messages after changes in #5758

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -164,7 +164,10 @@ class InteractionResponses {
    * @returns {Promise<void>}
    * @example
    * // Remove the components from the message
-   * interaction.update("A button was clicked", { components: [] })
+   * interaction.update({
+   *   content: "A button was clicked",
+   *   components: []
+   * })
    *   .then(console.log)
    *   .catch(console.error);
    */

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -143,7 +143,8 @@ class TextBasedChannel {
    *   .catch(console.error);
    * @example
    * // Send an embed with a local image inside
-   * channel.send('This is an embed', {
+   * channel.send({
+   *   content: 'This is an embed',
    *   embed: {
    *     thumbnail: {
    *          url: 'attachment://file.jpg'


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes some docs examples due to changes of #5758 (refactor messages options when sending/editing them)

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.