### PR TITLE
feat(*): document and support embeds field in message create endpoint

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -198,7 +198,7 @@ class APIMessage {
       content,
       tts,
       nonce,
-      embeds,
+      embeds: this.options.embeds ? embeds : undefined,
       components,
       username,
       avatar_url: avatarURL,

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -147,9 +147,7 @@ class APIMessage {
     if (this.options.embeds) {
       embedLikes.push(...this.options.embeds);
     }
-    else if (this.options.embed) {
-      embedLikes.push(this.options.embed);
-    }
+
     const embeds = embedLikes.map(e => new MessageEmbed(e).toJSON());
 
     const components = this.options.components?.map(c =>
@@ -221,6 +219,22 @@ class APIMessage {
    */
   async resolveFiles() {
     if (this.files) return this;
+    
+    const embedLikes = [];
+
+    if (this.options.embeds) {
+      embedLikes.push(...this.options.embeds);
+    }
+
+    const fileLikes = [];
+    if (this.options.files) {
+      fileLikes.push(...this.options.files);
+    }
+    for (const embed of embedLikes) {
+      if (embed.files) {
+        fileLikes.push(...embed.files);
+      }
+    }
 
     this.files = await Promise.all(this.options.files?.map(file => this.constructor.resolveFile(file)) ?? []);
     return this;
@@ -300,10 +314,9 @@ class APIMessage {
    * @returns {MessageOptions|WebhookMessageOptions}
    */
   static create(target, options, extra = {}) {
-    return new this(
-      target,
-      typeof options !== 'object' || options === null ? { content: options, ...extra } : { ...options, ...extra },
-    );
+    if (typeof options !== 'object' || options === null) return new this(target, { content: options, ...extra });
+    if (options.embed) options.embeds = [options.embed];
+    return new this(target, { ...options, ...extra });
   }
 }
 

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -312,9 +312,10 @@ class APIMessage {
    * @returns {MessageOptions|WebhookMessageOptions}
    */
   static create(target, options, extra = {}) {
-    if (typeof options !== 'object' || options === null) return new this(target, { content: options, ...extra });
-    if (options.embed) options.embeds = [options.embed];
-    return new this(target, { ...options, ...extra });
+    return new this(
+      target,
+      typeof options !== 'object' || options === null ? { content: options, ...extra } : { ...options, ...extra },
+    );
   }
 }
 

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -129,7 +129,6 @@ class APIMessage {
     if (this.data) return this;
     const isInteraction = this.isInteraction;
     const isWebhook = this.isWebhook;
-    const isWebhookLike = isInteraction || isWebhook;
 
     const content = this.makeContent();
     const tts = Boolean(this.options.tts);
@@ -199,8 +198,7 @@ class APIMessage {
       content,
       tts,
       nonce,
-      embed: !isWebhookLike ? (this.options.embed === null ? null : embeds[0]) : undefined,
-      embeds: isWebhookLike ? embeds : undefined,
+      embeds,
       components,
       username,
       avatar_url: avatarURL,

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -147,8 +147,6 @@ class APIMessage {
       embedLikes.push(...this.options.embeds);
     }
 
-    const embeds = embedLikes.map(e => new MessageEmbed(e).toJSON());
-
     const components = this.options.components?.map(c =>
       BaseMessageComponent.create(
         Array.isArray(c) ? { type: MessageComponentTypes.ACTION_ROW, components: c } : c,
@@ -217,7 +215,7 @@ class APIMessage {
    */
   async resolveFiles() {
     if (this.files) return this;
-    
+
     const embedLikes = [];
 
     if (this.options.embeds) {

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -144,11 +144,10 @@ class APIMessage {
     }
 
     const embedLikes = [];
-    if (isWebhookLike) {
-      if (this.options.embeds) {
-        embedLikes.push(...this.options.embeds);
-      }
-    } else if (this.options.embed) {
+    if (this.options.embeds) {
+      embedLikes.push(...this.options.embeds);
+    }
+    else if (this.options.embed) {
       embedLikes.push(this.options.embed);
     }
     const embeds = embedLikes.map(e => new MessageEmbed(e).toJSON());

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -198,7 +198,7 @@ class APIMessage {
       content,
       tts,
       nonce,
-      embeds: this.options.embeds ? embeds : undefined,
+      embeds: this.options.embeds?.map(embed => new MessageEmbed(embed).toJSON()),
       components,
       username,
       avatar_url: avatarURL,

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -70,7 +70,7 @@ class TextBasedChannel {
   /**
    * Options provided when sending or editing a message.
    * @typedef {BaseMessageOptions} MessageOptions
-   * @property {MessageEmbed|Object} [embed] An embed for the message
+   * @property {MessageEmbed[]|Object[]} [embeds] The embeds for the message
    * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details)
    * @property {ReplyOptions} [reply] The options for replying to a message
    */

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -70,7 +70,7 @@ class TextBasedChannel {
   /**
    * Options provided when sending or editing a message.
    * @typedef {BaseMessageOptions} MessageOptions
-   * @property {MessageEmbed[]|Object[]} [embeds] The embeds for the message
+   * @property {(MessageEmbed|Object)[]} [embeds] The embeds for the message
    * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details)
    * @property {ReplyOptions} [reply] The options for replying to a message
    */

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -70,7 +70,7 @@ class TextBasedChannel {
   /**
    * Options provided when sending or editing a message.
    * @typedef {BaseMessageOptions} MessageOptions
-   * @property {(MessageEmbed|Object)[]} [embeds] The embeds for the message
+   * @property {MessageEmbed[]|Object[]} [embeds] The embeds for the message
    * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details)
    * @property {ReplyOptions} [reply] The options for replying to a message
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3240,7 +3240,6 @@ declare module 'discord.js' {
   interface MessageEditOptions {
     attachments?: MessageAttachment[];
     content?: string | null;
-    embed?: MessageEmbed | MessageEmbedOptions | null;
     embeds?: (MessageEmbed | MessageEmbedOptions)[] | null;
     code?: string | boolean;
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
@@ -3337,7 +3336,6 @@ declare module 'discord.js' {
     tts?: boolean;
     nonce?: string | number;
     content?: string;
-    embed?: MessageEmbed | MessageEmbedOptions;
     embeds?: (MessageEmbed | MessageEmbedOptions)[];
     components?: MessageActionRow[] | MessageActionRowOptions[] | MessageActionRowComponentResolvable[][];
     allowedMentions?: MessageMentionOptions;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3337,6 +3337,7 @@ declare module 'discord.js' {
     nonce?: string | number;
     content?: string;
     embed?: MessageEmbed | MessageEmbedOptions;
+    embeds?: (MessageEmbed | MessageEmbedOptions)[];
     components?: MessageActionRow[] | MessageActionRowOptions[] | MessageActionRowComponentResolvable[][];
     allowedMentions?: MessageMentionOptions;
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3241,6 +3241,7 @@ declare module 'discord.js' {
     attachments?: MessageAttachment[];
     content?: string | null;
     embed?: MessageEmbed | MessageEmbedOptions | null;
+    embeds?: (MessageEmbed | MessageEmbedOptions)[] | null;
     code?: string | boolean;
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
     flags?: BitFieldResolvable<MessageFlagsString, number>;
@@ -3754,7 +3755,6 @@ declare module 'discord.js' {
   interface WebhookMessageOptions extends Omit<MessageOptions, 'embed' | 'reply'> {
     username?: string;
     avatarURL?: string;
-    embeds?: (MessageEmbed | unknown)[];
   }
 
   type WebhookTypes = 'Incoming' | 'Channel Follower';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3750,7 +3750,7 @@ declare module 'discord.js' {
     'content' | 'embeds' | 'files' | 'allowedMentions' | 'components'
   >;
 
-  interface WebhookMessageOptions extends Omit<MessageOptions, 'embed' | 'reply'> {
+  interface WebhookMessageOptions extends Omit<MessageOptions, 'reply'> {
     username?: string;
     avatarURL?: string;
   }

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -34,13 +34,13 @@ declare const assertIsMessageArray: (m: Promise<Message[]>) => void;
 client.on('message', ({ channel }) => {
   assertIsMessage(channel.send('string'));
   assertIsMessage(channel.send({}));
-  assertIsMessage(channel.send({ embed: {} }));
+  assertIsMessage(channel.send({ embeds: [] }));
 
   const attachment = new MessageAttachment('file.png');
   const embed = new MessageEmbed();
   assertIsMessage(channel.send({ files: [attachment] }));
-  assertIsMessage(channel.send({ embed }));
-  assertIsMessage(channel.send({ embed, files: [attachment] }));
+  assertIsMessage(channel.send({ embeds: [embed] }));
+  assertIsMessage(channel.send({ embeds: [embed], files: [attachment] }));
 
   assertIsMessageArray(channel.send({ split: true }));
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The message create endpoint now supports up to 10 embeds just like the webhook endpoint, these changes reflect that addition within the typings and APIMessage#create function.


**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:


-->
