### PR TITLE
fix(ApiMessage): only pass objects as options directly

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -320,7 +320,7 @@ class APIMessage {
    * @returns {MessageOptions|WebhookMessageOptions}
    */
   static create(target, options, extra = {}) {
-    if (typeof options === 'string') return new this(target, { content: options, ...extra });
+    if (typeof options !== 'object' || options === null) return new this(target, { content: options, ...extra });
     else return new this(target, { ...options, ...extra });
   }
 }

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -320,8 +320,10 @@ class APIMessage {
    * @returns {MessageOptions|WebhookMessageOptions}
    */
   static create(target, options, extra = {}) {
-    if (typeof options !== 'object' || options === null) return new this(target, { content: options, ...extra });
-    else return new this(target, { ...options, ...extra });
+    return new this(
+      target,
+      typeof options !== 'object' || options === null ? { content: options, ...extra } : { ...options, ...extra },
+    );
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

#5758 Introduced a small bug with throwing on invalid content, this fixes that.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
