### PR TITLE
fix: don't patch missing properties from partial payloads

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -35,37 +35,47 @@ class GuildChannel extends Channel {
      * @type {Guild}
      */
     this.guild = guild;
+
+    this.parentID = null;
   }
 
   _patch(data) {
     super._patch(data);
 
-    /**
-     * The name of the guild channel
-     * @type {string}
-     */
-    this.name = data.name;
+    if ('name' in data) {
+      /**
+       * The name of the guild channel
+       * @type {string}
+       */
+      this.name = data.name;
+    }
 
-    /**
-     * The raw position of the channel from discord
-     * @type {number}
-     */
-    this.rawPosition = data.position;
+    if ('position' in data) {
+      /**
+       * The raw position of the channel from discord
+       * @type {number}
+       */
+      this.rawPosition = data.position;
+    }
 
-    /**
-     * The ID of the category parent of this channel
-     * @type {?Snowflake}
-     */
-    this.parentID = data.parent_id || null;
+    if ('parent_id' in data) {
+      /**
+       * The ID of the category parent of this channel
+       * @type {?Snowflake}
+       */
+      this.parentID = data.parent_id;
+    }
 
-    /**
-     * A map of permission overwrites in this channel for roles and users
-     * @type {Collection<Snowflake, PermissionOverwrites>}
-     */
-    this.permissionOverwrites = new Collection();
-    if (data.permission_overwrites) {
-      for (const overwrite of data.permission_overwrites) {
-        this.permissionOverwrites.set(overwrite.id, new PermissionOverwrites(this, overwrite));
+    if ('permission_overwrites' in data) {
+      /**
+       * A map of permission overwrites in this channel for roles and users
+       * @type {Collection<Snowflake, PermissionOverwrites>}
+       */
+      this.permissionOverwrites = new Collection();
+      if (data.permission_overwrites) {
+        for (const overwrite of data.permission_overwrites) {
+          this.permissionOverwrites.set(overwrite.id, new PermissionOverwrites(this, overwrite));
+        }
       }
     }
   }

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -37,6 +37,7 @@ class GuildChannel extends Channel {
     this.guild = guild;
 
     this.parentID = null;
+    this.permissionOverwrites = new Collection();
   }
 
   _patch(data) {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -73,10 +73,8 @@ class GuildChannel extends Channel {
        * @type {Collection<Snowflake, PermissionOverwrites>}
        */
       this.permissionOverwrites = new Collection();
-      if (data.permission_overwrites) {
-        for (const overwrite of data.permission_overwrites) {
-          this.permissionOverwrites.set(overwrite.id, new PermissionOverwrites(this, overwrite));
-        }
+      for (const overwrite of data.permission_overwrites) {
+        this.permissionOverwrites.set(overwrite.id, new PermissionOverwrites(this, overwrite));
       }
     }
   }

--- a/src/structures/StageChannel.js
+++ b/src/structures/StageChannel.js
@@ -10,11 +10,13 @@ class StageChannel extends BaseGuildVoiceChannel {
   _patch(data) {
     super._patch(data);
 
-    /**
-     * The topic of the stage channel
-     * @type {?string}
-     */
-    this.topic = data.topic;
+    if ('topic' in data) {
+      /**
+       * The topic of the stage channel
+       * @type {?string}
+       */
+      this.topic = data.topic;
+    }
   }
 
   /**

--- a/src/structures/StoreChannel.js
+++ b/src/structures/StoreChannel.js
@@ -17,7 +17,6 @@ class StoreChannel extends GuildChannel {
     /**
      * If the guild considers this channel NSFW
      * @type {boolean}
-     * @readonly
      */
     this.nsfw = Boolean(data.nsfw);
   }
@@ -25,7 +24,9 @@ class StoreChannel extends GuildChannel {
   _patch(data) {
     super._patch(data);
 
-    if (typeof data.nsfw !== 'undefined') this.nsfw = Boolean(data.nsfw);
+    if ('nsfw' in data) {
+      this.nsfw = Boolean(data.nsfw);
+    }
   }
 }
 

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -28,7 +28,6 @@ class TextChannel extends GuildChannel {
     /**
      * If the guild considers this channel NSFW
      * @type {boolean}
-     * @readonly
      */
     this.nsfw = Boolean(data.nsfw);
     this._typing = new Map();
@@ -37,34 +36,46 @@ class TextChannel extends GuildChannel {
   _patch(data) {
     super._patch(data);
 
-    /**
-     * The topic of the text channel
-     * @type {?string}
-     */
-    this.topic = data.topic;
+    if ('topic' in data) {
+      /**
+       * The topic of the text channel
+       * @type {?string}
+       */
+      this.topic = data.topic;
+    }
 
-    if (typeof data.nsfw !== 'undefined') this.nsfw = Boolean(data.nsfw);
+    if ('nsfw' in data) {
+      this.nsfw = Boolean(data.nsfw);
+    }
 
-    /**
-     * The ID of the last message sent in this channel, if one was sent
-     * @type {?Snowflake}
-     */
-    this.lastMessageID = data.last_message_id;
+    if ('last_message_id' in data) {
+      /**
+       * The ID of the last message sent in this channel, if one was sent
+       * @type {?Snowflake}
+       */
+      this.lastMessageID = data.last_message_id;
+    }
 
-    /**
-     * The ratelimit per user for this channel in seconds
-     * <warn>It is not currently possible to set a rate limit per user on a `NewsChannel`.</warn>
-     * @type {number}
-     */
-    this.rateLimitPerUser = data.rate_limit_per_user || 0;
+    if ('rate_limit_per_user' in data) {
+      /**
+       * The ratelimit per user for this channel in seconds
+       * <warn>It is not currently possible to set a rate limit per user on a `NewsChannel`.</warn>
+       * @type {number}
+       */
+      this.rateLimitPerUser = data.rate_limit_per_user;
+    }
 
-    /**
-     * The timestamp when the last pinned message was pinned, if there was one
-     * @type {?number}
-     */
-    this.lastPinTimestamp = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
+    if ('last_pin_timestamp' in data) {
+      /**
+       * The timestamp when the last pinned message was pinned, if there was one
+       * @type {?number}
+       */
+      this.lastPinTimestamp = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
+    }
 
-    if (data.messages) for (const message of data.messages) this.messages.add(message);
+    if ('messages' in data) {
+      for (const message of data.messages) this.messages.add(message);
+    }
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -30,6 +30,18 @@ class User extends Base {
     this.system = null;
     this.flags = null;
 
+    /**
+     * The ID of the last message sent by the user, if one was sent
+     * @type {?Snowflake}
+     */
+    this.lastMessageID = null;
+
+    /**
+     * The ID of the channel for the last message sent by the user, if one was sent
+     * @type {?Snowflake}
+     */
+    this.lastMessageChannelID = null;
+
     this._patch(data);
   }
 
@@ -87,18 +99,6 @@ class User extends Base {
        */
       this.flags = new UserFlags(data.public_flags);
     }
-
-    /**
-     * The ID of the last message sent by the user, if one was sent
-     * @type {?Snowflake}
-     */
-    this.lastMessageID = null;
-
-    /**
-     * The ID of the channel for the last message sent by the user, if one was sent
-     * @type {?Snowflake}
-     */
-    this.lastMessageChannelID = null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR resolves #5605 by only updating properties of Channel and subclasses when they are in the payload.
In similar vein, if a user option was used, their last message properties would reset to null. Since this is something we provide on our own, there is no reason for those to be in `_patch`.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

