### PR TITLE
fix(Webhook): throw an error if no token is available when it's required

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -290,7 +290,7 @@ class Client extends BaseClient {
     return this.api
       .webhooks(id, token)
       .get()
-      .then(data => new Webhook(this, data));
+      .then(data => new Webhook(this, { token, ...data }));
   }
 
   /**

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -92,6 +92,7 @@ const Messages = {
   INVALID_ELEMENT: (type, name, elem) => `Supplied ${type} ${name} includes an invalid element: ${elem}`,
 
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
+  WEBHOOK_TOKEN_UNAVAILABLE: 'This action requires a webhook token, but none is available.',
   MESSAGE_REFERENCE_MISSING: 'The message does not reference another message',
 
   EMOJI_TYPE: 'Emoji must be a string or GuildEmoji/ReactionEmoji',

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -2,6 +2,7 @@
 
 const APIMessage = require('./APIMessage');
 const Channel = require('./Channel');
+const { Error } = require('../errors');
 const { WebhookTypes } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
@@ -29,7 +30,7 @@ class Webhook {
     this.name = data.name;
 
     /**
-     * The token for the webhook
+     * The token for the webhook, unavailable for follower webhooks and webhooks owned by another application.
      * @name Webhook#token
      * @type {?string}
      */
@@ -149,6 +150,8 @@ class Webhook {
    *   .catch(console.error);
    */
   async send(options) {
+    if (!this.token) throw new Error('WEBHOOK_TOKEN_UNAVAILABLE');
+
     let apiMessage;
 
     if (options instanceof APIMessage) {
@@ -194,6 +197,8 @@ class Webhook {
    * }).catch(console.error);
    */
   sendSlackMessage(body) {
+    if (!this.token) throw new Error('WEBHOOK_TOKEN_UNAVAILABLE');
+
     return this.client.api
       .webhooks(this.id, this.token)
       .slack.post({
@@ -237,6 +242,8 @@ class Webhook {
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */
   async fetchMessage(message, cache = true) {
+    if (!this.token) throw new Error('WEBHOOK_TOKEN_UNAVAILABLE');
+
     const data = await this.client.api.webhooks(this.id, this.token).messages(message).get();
     return this.client.channels?.cache.get(data.channel_id)?.messages.add(data, cache) ?? data;
   }
@@ -249,6 +256,8 @@ class Webhook {
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */
   async editMessage(message, options) {
+    if (!this.token) throw new Error('WEBHOOK_TOKEN_UNAVAILABLE');
+
     let apiMessage;
 
     if (options instanceof APIMessage) apiMessage = options;
@@ -287,6 +296,8 @@ class Webhook {
    * @returns {Promise<void>}
    */
   async deleteMessage(message) {
+    if (!this.token) throw new Error('WEBHOOK_TOKEN_UNAVAILABLE');
+
     await this.client.api
       .webhooks(this.id, this.token)
       .messages(typeof message === 'string' ? message : message.id)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Since Discord started sending application their own webhook's token again, #5731 is somewhat resolved.
This PR does the rest to resolve #5731.

- Use the optionally supplied token to `Client#fetchWebhook` if Discord did not include it in the payload. (i.e. fetching another application's webhook by id and token)
- Document when tokens are missing.
- Throw a more helpful error when trying to execute a message-related action on a webhook without a token.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

