### PR TITLE
fix(ClientPresence): produce valid activities for set presences

### DIFF
--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -35,11 +35,7 @@ class ClientPresence extends Presence {
       since: typeof since === 'number' && !Number.isNaN(since) ? since : null,
       status: status || this.status,
     };
-    if (activities === null) {
-      data.activities = null;
-      return data;
-    }
-    if (activities && activities.length) {
+    if (activities?.length) {
       for (const [i, activity] of activities.entries()) {
         if (typeof activity.name !== 'string') throw new TypeError('INVALID_TYPE', `activities[${i}].name`, 'string');
         if (!activity.type) activity.type = 0;
@@ -50,8 +46,14 @@ class ClientPresence extends Presence {
           url: activity.url,
         });
       }
-    } else if ((status || afk || since) && this.activities.length) {
-      data.activities.push(...this.activities);
+    } else if (!activities && (status || afk || since) && this.activities.length) {
+      data.activities.push(
+        ...this.activities.map(a => ({
+          name: a.name,
+          type: ActivityTypes.indexOf(a.type),
+          url: a.url ?? undefined,
+        })),
+      );
     }
 
     return data;

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -161,7 +161,7 @@ class ClientUser extends Structures.get('User') {
    * client.user.setActivity('discord.js', { type: 'WATCHING' });
    */
   setActivity(name, options = {}) {
-    if (!name) return this.setPresence({ activities: null, shardID: options.shardID });
+    if (!name) return this.setPresence({ activities: [], shardID: options.shardID });
 
     const activity = Object.assign({}, options, typeof name === 'object' ? name : { name });
     return this.setPresence({ activities: [activity], shardID: activity.shardID });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR resolves #5706 and resolves #5584.

The [Gateway Presence Update Structure](https://discord.com/developers/docs/topics/gateway#update-presence-gateway-presence-update-structure)'s activities array is documented to not be nullable.
So this PR defaults it to an empty array then.

Also as noted for the [Activity Structure](https://discord.com/developers/docs/topics/gateway#activity-object-activity-structure), bots may only send `name`, `type` and optionally `url`.
So this PR maps previously set activities to only have those properties left (defaulting url to undefined since sending `null` invalidates your session too, albeit being documented as nullable).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating