### PR TITLE
fix(GuildChannel): spread clone options to avoid infinite recursion

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -573,7 +573,7 @@ class GuildChannel extends Channel {
    * @returns {Promise<GuildChannel>}
    */
   clone(options = {}) {
-    options = {
+    return this.guild.channels.create(options.name, {
       name: this.name,
       permissionOverwrites: this.permissionOverwrites,
       topic: this.topic,
@@ -586,8 +586,7 @@ class GuildChannel extends Channel {
       position: this.position,
       reason: null,
       ...options,
-    };
-    return this.guild.channels.create(options.name, options);
+    });
   }
   /* eslint-enable max-len */
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -573,22 +573,20 @@ class GuildChannel extends Channel {
    * @returns {Promise<GuildChannel>}
    */
   clone(options = {}) {
-    Util.mergeDefault(
-      {
-        name: this.name,
-        permissionOverwrites: this.permissionOverwrites,
-        topic: this.topic,
-        type: this.type,
-        nsfw: this.nsfw,
-        parent: this.parent,
-        bitrate: this.bitrate,
-        userLimit: this.userLimit,
-        rateLimitPerUser: this.rateLimitPerUser,
-        position: this.position,
-        reason: null,
-      },
-      options,
-    );
+    options = {
+      name: this.name,
+      permissionOverwrites: this.permissionOverwrites,
+      topic: this.topic,
+      type: this.type,
+      nsfw: this.nsfw,
+      parent: this.parent,
+      bitrate: this.bitrate,
+      userLimit: this.userLimit,
+      rateLimitPerUser: this.rateLimitPerUser,
+      position: this.position,
+      reason: null,
+      ...options,
+    };
     return this.guild.channels.create(options.name, options);
   }
   /* eslint-enable max-len */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR resolves #5553 by spreading the clone options instead of using `Util.mergeDefault`.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

