### PR TITLE
feat(RequestHandler): emit more info when a rate limit was hit

### DIFF
--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -5,7 +5,7 @@ const DiscordAPIError = require('./DiscordAPIError');
 const HTTPError = require('./HTTPError');
 const RateLimitError = require('./RateLimitError');
 const {
-  Events: { RATE_LIMIT, INVALID_REQUEST_WARNING },
+  Events: { DEBUG, RATE_LIMIT, INVALID_REQUEST_WARNING },
 } = require('../util/Constants');
 const Util = require('../util/Util');
 
@@ -255,9 +255,6 @@ class RequestHandler {
     if (res.status >= 400 && res.status < 500) {
       // Handle ratelimited requests
       if (res.status === 429) {
-        // A ratelimit was hit - this should never happen
-        this.manager.client.emit('debug', `429 hit on route ${request.route}${sublimitTimeout ? ' for sublimit' : ''}`);
-
         const isGlobal = this.globalLimited;
         let limit, timeout;
         if (isGlobal) {
@@ -269,6 +266,19 @@ class RequestHandler {
           limit = this.limit;
           timeout = this.reset + this.manager.client.options.restTimeOffset - Date.now();
         }
+
+        this.manager.client.emit(
+          DEBUG,
+          `Hit a 429 while executing a request.
+    Global  : ${isGlobal}
+    Method  : ${request.method}
+    Path    : ${request.path}
+    Route   : ${request.route}
+    Limit   : ${limit}
+    Timeout : ${timeout}ms
+    Sublimit: ${sublimitTimeout ? `${sublimitTimeout}ms` : false}`,
+        );
+
         await this.onRateLimit(request, limit, timeout, isGlobal);
 
         // If caused by a sublimit, wait it out here so other requests on the route can be handled

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -276,7 +276,7 @@ class RequestHandler {
     Route   : ${request.route}
     Limit   : ${limit}
     Timeout : ${timeout}ms
-    Sublimit: ${sublimitTimeout ? `${sublimitTimeout}ms` : false}`,
+    Sublimit: ${sublimitTimeout ? `${sublimitTimeout}ms` : 'None'}`,
         );
 
         await this.onRateLimit(request, limit, timeout, isGlobal);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds more info into the string that gets emitted when a request gets a 429 response.
Being added is:
- Whether the rate limit is global
- The HTTP method / verb
- The path of the request
- The limit the rate limit bucket has
- The timeout to wait for
- Whether this is a sublimit (and if so, how long to wait)

I kept it similar to how the WebSocket emits debug events, since putting all of that into one line wasn't feasible:
https://github.com/discordjs/discord.js/blob/a1f763ee75a7d906bbe727f616e33206dcc6792c/src/client/websocket/WebSocketShard.js#L243-L247


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

