### PR TITLE
fix(WebSocketShard): don't catch errors thrown in event handlers

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -291,12 +291,12 @@ class WebSocketShard extends EventEmitter {
     let packet;
     try {
       packet = WebSocket.unpack(raw);
-      this.manager.client.emit(Events.RAW, packet, this.id);
-      if (packet.op === OPCodes.DISPATCH) this.manager.emit(packet.t, packet.d, this.id);
     } catch (err) {
       this.manager.client.emit(Events.SHARD_ERROR, err, this.id);
       return;
     }
+    this.manager.client.emit(Events.RAW, packet, this.id);
+    if (packet.op === OPCodes.DISPATCH) this.manager.emit(packet.t, packet.d, this.id);
     this.onPacket(packet);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a bug that causes errors thrown in `WebSocketManager`'s event handlers to be caught and emitted as shard error.
This PR does the same with some other unmentioned event which resolves #4987.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
