### PR TITLE
fix(GuildChannel): clone errors when options.name isn't provided

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -582,8 +582,7 @@ class GuildChannel extends Channel {
    * @returns {Promise<GuildChannel>}
    */
   clone(options = {}) {
-    return this.guild.channels.create(options.name, {
-      name: this.name,
+    return this.guild.channels.create(options.name ?? this.name, {
       permissionOverwrites: this.permissionOverwrites,
       topic: this.topic,
       type: this.type,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes what appears to be a byproduct of #5800 where clone will return an API error as clone is expecting `options.name` to be provided. Noticed from the at-dev channel in the Discord server.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
