### PR TITLE
fix(*): typedefs and typings for image & webhook options

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -426,7 +426,7 @@ class Guild extends BaseGuild {
 
   /**
    * The URL to this guild's banner.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   bannerURL({ format, size } = {}) {
@@ -445,7 +445,7 @@ class Guild extends BaseGuild {
 
   /**
    * The URL to this guild's invite splash image.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   splashURL({ format, size } = {}) {
@@ -455,7 +455,7 @@ class Guild extends BaseGuild {
 
   /**
    * The URL to this guild's discovery splash image.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   discoverySplashURL({ format, size } = {}) {

--- a/src/structures/GuildPreview.js
+++ b/src/structures/GuildPreview.js
@@ -93,7 +93,7 @@ class GuildPreview extends Base {
 
   /**
    * The URL to this guild's splash.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   splashURL({ format, size } = {}) {
@@ -103,7 +103,7 @@ class GuildPreview extends Base {
 
   /**
    * The URL to this guild's discovery splash.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   discoverySplashURL({ format, size } = {}) {

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -26,7 +26,7 @@ class PartialGroupDMChannel extends Channel {
 
   /**
    * The URL to this channel's icon.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   iconURL({ format, size } = {}) {

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -335,9 +335,7 @@ class RichPresenceAssets {
 
   /**
    * Gets the URL of the small image asset
-   * @param {Object} [options] Options for the image url
-   * @param {string} [options.format] Format of the image
-   * @param {number} [options.size] Size of the image
+   * @param {StaticImageURLOptions} [options] Options for the image url
    * @returns {?string} The small image URL
    */
   smallImageURL({ format, size } = {}) {
@@ -350,9 +348,7 @@ class RichPresenceAssets {
 
   /**
    * Gets the URL of the large image asset
-   * @param {Object} [options] Options for the image url
-   * @param {string} [options.format] Format of the image
-   * @param {number} [options.size] Size of the image
+   * @param {StaticImageURLOptions} [options] Options for the image url
    * @returns {?string} The large image URL
    */
   largeImageURL({ format, size } = {}) {

--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -81,7 +81,7 @@ class Team extends Base {
 
   /**
    * A link to the teams's icon.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string} URL to the icon
    */
   iconURL({ format, size } = {}) {

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -127,11 +127,16 @@ class TextChannel extends GuildChannel {
   }
 
   /**
+   * Options used to create a {@link Webhook} for {@link TextChannel} and {@link NewsChannel}.
+   * @typedef {Object} ChannelWebhookCreateOptions
+   * @property {BufferResolvable|Base64Resolvable} [avatar] Avatar for the webhook
+   * @property {string} [reason] Reason for creating the webhook
+   */
+
+  /**
    * Creates a webhook for the channel.
    * @param {string} name The name of the webhook
-   * @param {Object} [options] Options for creating the webhook
-   * @param {BufferResolvable|Base64Resolvable} [options.avatar] Avatar for the webhook
-   * @param {string} [options.reason] Reason for creating the webhook
+   * @param {ChannelWebhookCreateOptions} [options] Options for creating the webhook
    * @returns {Promise<Webhook>} webhook The created webhook
    * @example
    * // Create a webhook for the current channel

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -210,12 +210,17 @@ class Webhook {
   }
 
   /**
-   * Edits the webhook.
-   * @param {Object} options Options
-   * @param {string} [options.name=this.name] New name for this webhook
-   * @param {BufferResolvable} [options.avatar] New avatar for this webhook
-   * @param {ChannelResolvable} [options.channel] New channel for this webhook
-   * @param {string} [reason] Reason for editing this webhook
+   * Options used to edit a {@link Webhook}.
+   * @typedef {Object} WebhookEditData
+   * @property {string} [name=this.name] The new name for the webhook
+   * @property {BufferResolvable} [avatar] The new avatar for the webhook
+   * @property {ChannelResolvable} [channel] The new channel for the webhook
+   */
+
+  /**
+   * Edits this webhook.
+   * @param {WebhookEditData} options Options for editing the webhook
+   * @param {string} [reason] Reason for editing the webhook
    * @returns {Promise<Webhook>}
    */
   async edit({ name = this.name, avatar, channel }, reason) {
@@ -333,7 +338,7 @@ class Webhook {
 
   /**
    * A link to the webhook's avatar.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   avatarURL({ format, size } = {}) {

--- a/src/structures/interfaces/Application.js
+++ b/src/structures/interfaces/Application.js
@@ -62,7 +62,7 @@ class Application extends Base {
 
   /**
    * A link to the application's icon.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string} URL to the icon
    */
   iconURL({ format, size } = {}) {
@@ -72,7 +72,7 @@ class Application extends Base {
 
   /**
    * A link to this application's cover image.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string} URL to the cover image
    */
   coverURL({ format, size } = {}) {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -136,11 +136,16 @@ function makeImageUrl(root, { format = 'webp', size } = {}) {
 
 /**
  * Options for Image URLs.
- * @typedef {Object} ImageURLOptions
- * @property {string} [format] One of `webp`, `png`, `jpg`, `jpeg`, `gif`. If no format is provided,
- * defaults to `webp`.
+ * @typedef {StaticImageURLOptions} ImageURLOptions
  * @property {boolean} [dynamic] If true, the format will dynamically change to `gif` for
- * animated avatars; the default is false.
+ * animated avatars; the default is false
+ */
+
+/**
+ * Options for static Image URLs.
+ * @typedef {Object} StaticImageURLOptions
+ * @property {string} [format] One of `webp`, `png`, `jpg`, `jpeg`, `gif`. If no format is provided,
+ * defaults to `webp`
  * @property {number} [size] One of `16`, `32`, `64`, `128`, `256`, `512`, `1024`, `2048`, `4096`
  */
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -169,9 +169,9 @@ declare module 'discord.js' {
     public icon: string | null;
     public id: Snowflake;
     public name: string | null;
-    public coverURL(options?: ImageURLOptions): string | null;
+    public coverURL(options?: StaticImageURLOptions): string | null;
     public fetchAssets(): Promise<ApplicationAsset[]>;
-    public iconURL(options?: ImageURLOptions): string | null;
+    public iconURL(options?: StaticImageURLOptions): string | null;
     public toJSON(): unknown;
     public toString(): string | null;
   }
@@ -240,7 +240,7 @@ declare module 'discord.js' {
     public readonly partnered: boolean;
     public readonly verified: boolean;
     public fetch(): Promise<Guild>;
-    public iconURL(options?: ImageURLOptions & { dynamic?: boolean }): string | null;
+    public iconURL(options?: ImageURLOptions): string | null;
     public toString(): string;
   }
 
@@ -792,11 +792,11 @@ declare module 'discord.js' {
     public widgetChannelID: Snowflake | null;
     public widgetEnabled: boolean | null;
     public addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
-    public bannerURL(options?: ImageURLOptions): string | null;
+    public bannerURL(options?: StaticImageURLOptions): string | null;
     public createIntegration(data: IntegrationData, reason?: string): Promise<Guild>;
     public createTemplate(name: string, description?: string): Promise<GuildTemplate>;
     public delete(): Promise<Guild>;
-    public discoverySplashURL(options?: ImageURLOptions): string | null;
+    public discoverySplashURL(options?: StaticImageURLOptions): string | null;
     public edit(data: GuildEditData, reason?: string): Promise<Guild>;
     public equals(guild: Guild): boolean;
     public fetchAuditLogs(options?: GuildAuditLogsFetchOptions): Promise<GuildAuditLogs>;
@@ -835,7 +835,7 @@ declare module 'discord.js' {
     public setSystemChannelFlags(systemChannelFlags: SystemChannelFlagsResolvable, reason?: string): Promise<Guild>;
     public setVerificationLevel(verificationLevel: VerificationLevel | number, reason?: string): Promise<Guild>;
     public setWidget(widget: GuildWidgetData, reason?: string): Promise<Guild>;
-    public splashURL(options?: ImageURLOptions): string | null;
+    public splashURL(options?: StaticImageURLOptions): string | null;
     public toJSON(): unknown;
   }
 
@@ -1004,9 +1004,9 @@ declare module 'discord.js' {
     public id: Snowflake;
     public name: string;
     public splash: string | null;
-    public discoverySplashURL(options?: ImageURLOptions): string | null;
-    public iconURL(options?: ImageURLOptions & { dynamic?: boolean }): string | null;
-    public splashURL(options?: ImageURLOptions): string | null;
+    public discoverySplashURL(options?: StaticImageURLOptions): string | null;
+    public iconURL(options?: ImageURLOptions): string | null;
+    public splashURL(options?: StaticImageURLOptions): string | null;
     public fetch(): Promise<GuildPreview>;
     public toJSON(): unknown;
     public toString(): string;
@@ -1460,10 +1460,7 @@ declare module 'discord.js' {
     public nsfw: boolean;
     public topic: string | null;
     public type: 'news';
-    public createWebhook(
-      name: string,
-      options?: { avatar?: BufferResolvable | Base64Resolvable; reason?: string },
-    ): Promise<Webhook>;
+    public createWebhook(name: string, options?: ChannelWebhookCreateOptions): Promise<Webhook>;
     public setNSFW(nsfw: boolean, reason?: string): Promise<NewsChannel>;
     public setType(type: Pick<typeof ChannelType, 'text' | 'news'>, reason?: string): Promise<GuildChannel>;
     public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
@@ -1479,7 +1476,7 @@ declare module 'discord.js' {
     constructor(client: Client, data: unknown);
     public name: string;
     public icon: string | null;
-    public iconURL(options?: ImageURLOptions): string | null;
+    public iconURL(options?: StaticImageURLOptions): string | null;
   }
 
   export class PermissionOverwrites {
@@ -1573,8 +1570,8 @@ declare module 'discord.js' {
     public largeText: string | null;
     public smallImage: Snowflake | null;
     public smallText: string | null;
-    public largeImageURL(options?: ImageURLOptions): string | null;
-    public smallImageURL(options?: ImageURLOptions): string | null;
+    public largeImageURL(options?: StaticImageURLOptions): string | null;
+    public smallImageURL(options?: StaticImageURLOptions): string | null;
   }
 
   export class Role extends Base {
@@ -1769,7 +1766,7 @@ declare module 'discord.js' {
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
 
-    public iconURL(options?: ImageURLOptions): string;
+    public iconURL(options?: StaticImageURLOptions): string;
     public toJSON(): unknown;
     public toString(): string;
   }
@@ -1792,10 +1789,7 @@ declare module 'discord.js' {
     public type: 'text';
     public rateLimitPerUser: number;
     public topic: string | null;
-    public createWebhook(
-      name: string,
-      options?: { avatar?: BufferResolvable | Base64Resolvable; reason?: string },
-    ): Promise<Webhook>;
+    public createWebhook(name: string, options?: ChannelWebhookCreateOptions): Promise<Webhook>;
     public setNSFW(nsfw: boolean, reason?: string): Promise<TextChannel>;
     public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
     public setType(type: Pick<typeof ChannelType, 'text' | 'news'>, reason?: string): Promise<GuildChannel>;
@@ -1819,10 +1813,10 @@ declare module 'discord.js' {
     public system: boolean | null;
     public readonly tag: string;
     public username: string;
-    public avatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string | null;
+    public avatarURL(options?: ImageURLOptions): string | null;
     public createDM(): Promise<DMChannel>;
     public deleteDM(): Promise<DMChannel>;
-    public displayAvatarURL(options?: ImageURLOptions & { dynamic?: boolean }): string;
+    public displayAvatarURL(options?: ImageURLOptions): string;
     public equals(user: User): boolean;
     public fetch(force?: boolean): Promise<User>;
     public fetchFlags(force?: boolean): Promise<UserFlags>;
@@ -1942,7 +1936,7 @@ declare module 'discord.js' {
   export class Webhook extends WebhookMixin() {
     constructor(client: Client, data?: unknown);
     public avatar: string;
-    public avatarURL(options?: ImageURLOptions): string | null;
+    public avatarURL(options?: StaticImageURLOptions): string | null;
     public channelID: Snowflake;
     public client: Client;
     public guildID: Snowflake;
@@ -2369,7 +2363,7 @@ declare module 'discord.js' {
     readonly createdAt: Date;
     readonly createdTimestamp: number;
     delete(reason?: string): Promise<void>;
-    edit(options: WebhookEditData): Promise<Webhook>;
+    edit(options: WebhookEditData, reason?: string): Promise<Webhook>;
     sendSlackMessage(body: object): Promise<boolean>;
   }
 
@@ -2604,6 +2598,11 @@ declare module 'discord.js' {
   }
 
   type ChannelResolvable = Channel | Snowflake;
+
+  interface ChannelWebhookCreateOptions {
+    avatar?: BufferResolvable | Base64Resolvable;
+    reason?: string;
+  }
 
   interface ClientEvents {
     applicationCommandCreate: [command: ApplicationCommand];
@@ -3106,9 +3105,8 @@ declare module 'discord.js' {
 
   type ImageSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096;
 
-  interface ImageURLOptions {
-    format?: AllowedImageFormat;
-    size?: ImageSize;
+  interface ImageURLOptions extends StaticImageURLOptions {
+    dynamic?: boolean;
   }
 
   interface IntegrationData {
@@ -3663,6 +3661,11 @@ declare module 'discord.js' {
     append?: string;
   }
 
+  interface StaticImageURLOptions {
+    format?: AllowedImageFormat;
+    size?: ImageSize;
+  }
+
   type Status = number;
 
   export class Sticker extends Base {
@@ -3745,7 +3748,6 @@ declare module 'discord.js' {
     name?: string;
     avatar?: BufferResolvable;
     channel?: ChannelResolvable;
-    reason?: string;
   }
 
   type WebhookEditMessageOptions = Pick<


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

While working on #5785, I found some inconsistencies between typedefs and typings of options for editing/creating webhook and fetching image. For eg, the typings for `Webhook#edit` show that it takes only a single param, whereas in code it takes an object as first param and `reason` as second. Similarly, the `ImageURLOptions` typedef is used for even those methods that don't support/use `dynamic` param at all. This PR fixes all these inconsistencies by adding new typedefs and interfaces for these options.  

**Status and versioning classification:**
- I know how to update typings and have done so
- This PR includes breaking changes ( just one 😺)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
