### PR TITLE
fix(Typings): Fix BitField toJSON/valueOf return types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -287,7 +287,7 @@ declare module 'discord.js' {
     public remove(...bits: BitFieldResolvable<S, N>[]): BitField<S, N>;
     public serialize(...hasParam: readonly unknown[]): Record<S, boolean>;
     public toArray(...hasParam: readonly unknown[]): S[];
-    public toJSON(): N extends number ? number : string; // TODO https://github.com/discordjs/discord.js/pull/4879
+    public toJSON(): N extends number ? number : string;
     public valueOf(): N;
     public [Symbol.iterator](): IterableIterator<S>;
     public static FLAGS: unknown;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -287,8 +287,8 @@ declare module 'discord.js' {
     public remove(...bits: BitFieldResolvable<S, N>[]): BitField<S, N>;
     public serialize(...hasParam: readonly unknown[]): Record<S, boolean>;
     public toArray(...hasParam: readonly unknown[]): S[];
-    public toJSON(): number;
-    public valueOf(): number;
+    public toJSON(): N extends number ? number : string; // TODO https://github.com/discordjs/discord.js/pull/4879
+    public valueOf(): N;
     public [Symbol.iterator](): IterableIterator<S>;
     public static FLAGS: unknown;
     public static resolve(bit?: BitFieldResolvable<any, number | bigint>): number | bigint;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

In #4879 BitFields were updated to support other value types such as BigInts, however some of the typings weren't updated accordingly.
Reference: https://github.com/discordjs/discord.js/blob/f5f3f772865ee98bbb44df938e0e71f9f8865c10/src/util/BitField.js#L117-L123

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
