### PR TITLE
refactor(MessageEmbed): remove files

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -223,26 +223,7 @@ class APIMessage {
   async resolveFiles() {
     if (this.files) return this;
 
-    const embedLikes = [];
-    if (this.isInteraction || this.isWebhook) {
-      if (this.options.embeds) {
-        embedLikes.push(...this.options.embeds);
-      }
-    } else if (this.options.embed) {
-      embedLikes.push(this.options.embed);
-    }
-
-    const fileLikes = [];
-    if (this.options.files) {
-      fileLikes.push(...this.options.files);
-    }
-    for (const embed of embedLikes) {
-      if (embed.files) {
-        fileLikes.push(...embed.files);
-      }
-    }
-
-    this.files = await Promise.all(fileLikes.map(f => this.constructor.resolveFile(f)));
+    this.files = await Promise.all(this.options.files?.map(file => this.constructor.resolveFile(file)) ?? []);
     return this;
   }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -23,7 +23,6 @@ class MessageEmbed {
    * @property {Date|number} [timestamp] The timestamp of this embed
    * @property {ColorResolvable} [color] The color of this embed
    * @property {EmbedFieldData[]} [fields] The fields of this embed
-   * @property {Array<FileOptions|string|MessageAttachment>} [files] The files of this embed
    * @property {Partial<MessageEmbedAuthor>} [author] The author of this embed
    * @property {Partial<MessageEmbedThumbnail>} [thumbnail] The thumbnail of this embed
    * @property {Partial<MessageEmbedImage>} [image] The image of this embed
@@ -222,12 +221,6 @@ class MessageEmbed {
           proxyIconURL: data.footer.proxyIconURL || data.footer.proxy_icon_url,
         }
       : null;
-
-    /**
-     * The files of this embed
-     * @type {Array<FileOptions|string|MessageAttachment>}
-     */
-    this.files = data.files || [];
   }
 
   /**
@@ -295,17 +288,6 @@ class MessageEmbed {
    */
   spliceFields(index, deleteCount, ...fields) {
     this.fields.splice(index, deleteCount, ...this.constructor.normalizeFields(...fields));
-    return this;
-  }
-
-  /**
-   * Sets the file to upload alongside the embed. This file can be accessed via `attachment://fileName.extension` when
-   * setting an embed image or author/footer icons. Multiple files can be attached.
-   * @param {Array<FileOptions|string|MessageAttachment>} files Files to attach
-   * @returns {MessageEmbed}
-   */
-  attachFiles(files) {
-    this.files = this.files.concat(files);
     return this;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1366,7 +1366,6 @@ declare module 'discord.js' {
     public readonly createdAt: Date | null;
     public description: string | null;
     public fields: EmbedField[];
-    public files: (MessageAttachment | string | FileOptions)[];
     public footer: MessageEmbedFooter | null;
     public readonly hexColor: string | null;
     public image: MessageEmbedImage | null;
@@ -1381,7 +1380,6 @@ declare module 'discord.js' {
     public readonly video: MessageEmbedVideo | null;
     public addField(name: string, value: string, inline?: boolean): this;
     public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
-    public attachFiles(file: (MessageAttachment | FileOptions | string)[]): this;
     public setAuthor(name: string, iconURL?: string, url?: string): this;
     public setColor(color: ColorResolvable): this;
     public setDescription(description: string): this;
@@ -3277,7 +3275,6 @@ declare module 'discord.js' {
     timestamp?: Date | number;
     color?: ColorResolvable;
     fields?: EmbedFieldData[];
-    files?: (MessageAttachment | string | FileOptions)[];
     author?: Partial<MessageEmbedAuthor> & { icon_url?: string; proxy_icon_url?: string };
     thumbnail?: Partial<MessageEmbedThumbnail> & { proxy_url?: string };
     image?: Partial<MessageEmbedImage> & { proxy_url?: string };

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -39,7 +39,7 @@ client.on('message', ({ channel }) => {
   const attachment = new MessageAttachment('file.png');
   const embed = new MessageEmbed();
   assertIsMessage(channel.send({ files: [attachment] }));
-  assertIsMessage(channel.send(embed));
+  assertIsMessage(channel.send({ embed }));
   assertIsMessage(channel.send({ embed, files: [attachment] }));
 
   assertIsMessageArray(channel.send({ split: true }));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Attaching files to MessageEmbeds doesn't do more than just adding them to the message options for the user. Especially with the changes in #5758, this has become less convenient than before, to the point where you could just pass the files directly with the message options.

It also fixes a "bug" where TypeScript lets you use `.send(<MessageEmbed>)` because MessageEmbed and InteractionReplyOptions both have a `files` property, however this is misleading because it doesn't actually send the full embed.

**Status and versioning classification:**

- I know how to update typings and have done so
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)