### PR TITLE
fix(TextBasedChannel): allow passing an APIMessage with split

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -158,9 +158,10 @@ class Webhook {
       apiMessage = options.resolveData();
     } else {
       apiMessage = APIMessage.create(this, options).resolveData();
-      if (Array.isArray(apiMessage.data.content)) {
-        return Promise.all(apiMessage.split().map(this.send.bind(this)));
-      }
+    }
+
+    if (Array.isArray(apiMessage.data.content)) {
+      return Promise.all(apiMessage.split().map(this.send.bind(this)));
     }
 
     const { data, files } = await apiMessage.resolveFiles();

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -173,9 +173,10 @@ class TextBasedChannel {
       apiMessage = options.resolveData();
     } else {
       apiMessage = APIMessage.create(this, options).resolveData();
-      if (Array.isArray(apiMessage.data.content)) {
-        return Promise.all(apiMessage.split().map(this.send.bind(this)));
-      }
+    }
+
+    if (Array.isArray(apiMessage.data.content)) {
+      return Promise.all(apiMessage.split().map(this.send.bind(this)));
     }
 
     const { data, files } = await apiMessage.resolveFiles();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Previously, replying to a message (or passing an APIMessage to a `TextBasedChannel#send`) with `split` enabled threw a `DiscordAPIError: Invalid Form Body`.

Example: 

```js
message.reply({ content: '<message content>', split: true });
```

Error:
```
DiscordAPIError: Invalid Form Body
content: Could not interpret "['```\n<message content>\n```']" as string.
```

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
