### PR TITLE
docs(README): re-add install command, remove voice remnants

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ discord.js is a powerful [Node.js](https://nodejs.org) module that allows you to
 ## Installation
 
 **Node.js 14.0.0 or newer is required.**  
-Ignore any warnings about unmet peer dependencies, as they're all optional.
+
+```sh-session
+npm install discord.js
+```
 
 ### Optional packages
 
 - [zlib-sync](https://www.npmjs.com/package/zlib-sync) for WebSocket data compression and inflation (`npm install zlib-sync`)
 - [erlpack](https://github.com/discord/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install discord/erlpack`)
-- One of the following packages can be installed for faster voice packet encryption and decryption:
-  - [sodium](https://www.npmjs.com/package/sodium) (`npm install sodium`)
-  - [libsodium.js](https://www.npmjs.com/package/libsodium-wrappers) (`npm install libsodium-wrappers`)
 - [bufferutil](https://www.npmjs.com/package/bufferutil) for a much faster WebSocket connection (`npm install bufferutil`)
 - [utf-8-validate](https://www.npmjs.com/package/utf-8-validate) in combination with `bufferutil` for much faster WebSocket processing (`npm install utf-8-validate`)
 - [@discordjs/voice](https://github.com/discordjs/voice) for interacting with the Discord Voice API


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Restores the installation command, previously removed in #5402.
- Removes the peer dependencies warning, as discord.js does not longer have them.
- Removes the voice-related libraries, as they moved to `discordjs/voice`.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
