### PR TITLE
fix(GuildChannel): improve empty overwrite handling for permissionsLocked

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -95,13 +95,27 @@ class GuildChannel extends Channel {
    */
   get permissionsLocked() {
     if (!this.parent) return null;
-    if (this.permissionOverwrites.size !== this.parent.permissionOverwrites.size) return false;
-    return this.permissionOverwrites.every((value, key) => {
-      const testVal = this.parent.permissionOverwrites.get(key);
+
+    // Get all overwrites
+    const overwriteIds = new Set([...this.permissionOverwrites.keys(), ...this.parent.permissionOverwrites.keys()]);
+
+    // Compare all overwrites
+    return [...overwriteIds].every(key => {
+      const channelVal = this.permissionOverwrites.get(key);
+      const parentVal = this.parent.permissionOverwrites.get(key);
+
+      // Handle empty overwrite
+      // eslint-disable-next-line eqeqeq
+      if (channelVal === undefined && parentVal.deny.bitfield == 0 && parentVal.allow.bitfield == 0) return true;
+      // eslint-disable-next-line eqeqeq
+      if (parentVal === undefined && channelVal.deny.bitfield == 0 && channelVal.allow.bitfield == 0) return true;
+
+      // Compare overwrites
       return (
-        testVal !== undefined &&
-        testVal.deny.bitfield === value.deny.bitfield &&
-        testVal.allow.bitfield === value.allow.bitfield
+        channelVal !== undefined &&
+        parentVal !== undefined &&
+        channelVal.deny.bitfield === parentVal.deny.bitfield &&
+        channelVal.allow.bitfield === parentVal.allow.bitfield
       );
     });
   }

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -5,6 +5,7 @@ const Invite = require('./Invite');
 const PermissionOverwrites = require('./PermissionOverwrites');
 const Role = require('./Role');
 const { Error, TypeError } = require('../errors');
+const BitField = require('../util/BitField');
 const Collection = require('../util/Collection');
 const { ChannelTypes } = require('../util/Constants');
 const { OverwriteTypes } = require('../util/Constants');
@@ -105,10 +106,16 @@ class GuildChannel extends Channel {
       const parentVal = this.parent.permissionOverwrites.get(key);
 
       // Handle empty overwrite
-      // eslint-disable-next-line eqeqeq
-      if (channelVal === undefined && parentVal.deny.bitfield == 0 && parentVal.allow.bitfield == 0) return true;
-      // eslint-disable-next-line eqeqeq
-      if (parentVal === undefined && channelVal.deny.bitfield == 0 && channelVal.allow.bitfield == 0) return true;
+      if (
+        (channelVal === undefined &&
+          parentVal.deny.bitfield === BitField.defaultBit &&
+          parentVal.allow.bitfield === BitField.defaultBit) ||
+        (parentVal === undefined &&
+          channelVal.deny.bitfield === BitField.defaultBit &&
+          channelVal.allow.bitfield === BitField.defaultBit)
+      ) {
+        return true;
+      }
 
       // Compare overwrites
       return (

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -5,7 +5,6 @@ const Invite = require('./Invite');
 const PermissionOverwrites = require('./PermissionOverwrites');
 const Role = require('./Role');
 const { Error, TypeError } = require('../errors');
-const BitField = require('../util/BitField');
 const Collection = require('../util/Collection');
 const { ChannelTypes } = require('../util/Constants');
 const { OverwriteTypes } = require('../util/Constants');
@@ -108,11 +107,11 @@ class GuildChannel extends Channel {
       // Handle empty overwrite
       if (
         (channelVal === undefined &&
-          parentVal.deny.bitfield === BitField.defaultBit &&
-          parentVal.allow.bitfield === BitField.defaultBit) ||
+          parentVal.deny.bitfield === Permissions.defaultBit &&
+          parentVal.allow.bitfield === Permissions.defaultBit) ||
         (parentVal === undefined &&
-          channelVal.deny.bitfield === BitField.defaultBit &&
-          channelVal.allow.bitfield === BitField.defaultBit)
+          channelVal.deny.bitfield === Permissions.defaultBit &&
+          channelVal.allow.bitfield === Permissions.defaultBit)
       ) {
         return true;
       }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #5819 by handling the edge case where there is an empty overwrite present on a channel and simply not present on the parent, or vice-versa.

(I should note that this fix only worked when I was actively fetching channel parents on each channel update from the API, but I think that's just a side-effect/requirement of the channels partial now)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating