### PR TITLE
fix(GuildChannel): don't force parentID/permissionOverwrites to empty on create

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -36,8 +36,8 @@ class GuildChannel extends Channel {
      */
     this.guild = guild;
 
-    this.parentID = this.parentID || null;
-    this.permissionOverwrites = this.permissionOverwrites || new Collection();
+    this.parentID = this.parentID ?? null;
+    this.permissionOverwrites = this.permissionOverwrites ?? new Collection();
   }
 
   _patch(data) {

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -36,8 +36,8 @@ class GuildChannel extends Channel {
      */
     this.guild = guild;
 
-    this.parentID = null;
-    this.permissionOverwrites = new Collection();
+    this.parentID = this.parentID || null;
+    this.permissionOverwrites = this.permissionOverwrites || new Collection();
   }
 
   _patch(data) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

In #5796 a change was made that forced `parentID` to be null and `permissionOverwrites` to be an empty collection on all GuildChannels when they are created. This PR changes that logic to only apply those defaults if they're not set by the initial patch during the super call.

This should resolve the issue of channels firing an update event with parentID changing when they're patched by an event for the first time since the client starts.

Kudos to [muchnameless](https://discord.com/channels/222078108977594368/682166281826598932/853036819264569364) for spotting this before I could.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating