### PR TITLE
types(MessageComponentInteraction): update should return Promise<void>

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1295,7 +1295,7 @@ declare module 'discord.js' {
     public fetchReply(): Promise<Message | RawMessage>;
     public followUp(options: string | APIMessage | InteractionReplyOptions): Promise<Message | RawMessage>;
     public reply(options: string | APIMessage | InteractionReplyOptions): Promise<void>;
-    public update(content: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage>;
+    public update(content: string | APIMessage | WebhookEditMessageOptions): Promise<void>;
     public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
   }
 


### PR DESCRIPTION
`MessageComponentInteraction#update()` was incorrectly typed as returning `Promise<Message | RawMessage>`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
