### PR TITLE
feat(Interactions): auto-fetch replies where possible

### DIFF
--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -16,9 +16,9 @@ class MessageComponentInteraction extends Interaction {
 
     /**
      * The message to which the component was attached
-     * @type {?Message|Object}
+     * @type {Message|Object}
      */
-    this.message = data.message ? this.channel?.messages.add(data.message) ?? data.message : null;
+    this.message = this.channel?.messages.add(data.message) ?? data.message;
 
     /**
      * The custom ID of the component which was interacted with

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -24,9 +24,9 @@ class InteractionResponses {
    */
 
   /**
-   * Defers the reply to this interaction.
+   * Defers the reply to this interaction. Resolves to the sent Message if not ephemeral.
    * @param {InteractionDeferOptions} [options] Options for deferring the reply to this interaction
-   * @returns {Promise<void>}
+   * @returns {Promise<Message|void>}
    * @example
    * // Defer the reply to this interaction
    * interaction.defer()
@@ -49,12 +49,14 @@ class InteractionResponses {
       },
     });
     this.deferred = true;
+
+    return ephemeral ? undefined : this.fetchReply();
   }
 
   /**
-   * Creates a reply to this interaction.
+   * Creates a reply to this interaction. Resolves to the sent Message if not ephemeral.
    * @param {string|APIMessage|InteractionReplyOptions} options The options for the reply
-   * @returns {Promise<void>}
+   * @returns {Promise<Message|void>}
    * @example
    * // Reply to the interaction with an embed
    * const embed = new MessageEmbed().setDescription('Pong!');
@@ -85,6 +87,8 @@ class InteractionResponses {
       files,
     });
     this.replied = true;
+
+    return options.ephemeral ? undefined : this.fetchReply();
   }
 
   /**
@@ -140,8 +144,9 @@ class InteractionResponses {
   }
 
   /**
-   * Defers an update to the message to which the component was attached
-   * @returns {Promise<void>}
+   * Defers an update to the message to which the component was attached.
+   * Resolves to that message, if it was not ephemeral.
+   * @returns {Promise<Message|void>}
    * @example
    * // Defer updating and reset the component's loading state
    * interaction.deferUpdate()
@@ -156,12 +161,17 @@ class InteractionResponses {
       },
     });
     this.deferred = true;
+
+    return (this.message.flags & MessageFlags.FLAGS.EPHEMERAL) === MessageFlags.FLAGS.EPHEMERAL
+      ? undefined
+      : this.fetchReply();
   }
 
   /**
-   * Updates the original message whose button was pressed
+   * Updates the original message whose button was pressed.
+   * Resolves to that message, if it was not ephemeral.
    * @param {string|APIMessage|WebhookEditMessageOptions} options The options for the reply
-   * @returns {Promise<void>}
+   * @returns {Promise<Message|void>}
    * @example
    * // Remove the components from the message
    * interaction.update({
@@ -188,6 +198,10 @@ class InteractionResponses {
       files,
     });
     this.replied = true;
+
+    return (this.message.flags & MessageFlags.FLAGS.EPHEMERAL) === MessageFlags.FLAGS.EPHEMERAL
+      ? undefined
+      : this.fetchReply();
   }
 
   static applyToClass(structure, ignore = []) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -491,12 +491,16 @@ declare module 'discord.js' {
     public options: Collection<string, CommandInteractionOption>;
     public replied: boolean;
     public webhook: InteractionWebhook;
-    public defer(options?: InteractionDeferOptions): Promise<void>;
+    public defer(options?: InteractionDeferOptions & { ephemeral: true }): Promise<void>;
+    public defer(options?: InteractionDeferOptions & { ephemeral?: false }): Promise<Message | RawMessage>;
     public deleteReply(): Promise<void>;
     public editReply(options: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
     public followUp(options: string | APIMessage | InteractionReplyOptions): Promise<Message | RawMessage>;
-    public reply(options: string | APIMessage | InteractionReplyOptions): Promise<void>;
+    public reply(options: string | APIMessage | (InteractionReplyOptions & { ephemeral: true })): Promise<void>;
+    public reply(
+      options: string | APIMessage | (InteractionReplyOptions & { ephemeral?: false }),
+    ): Promise<Message | RawMessage>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
     private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
   }
@@ -1337,14 +1341,18 @@ declare module 'discord.js' {
     public message: Message | RawMessage;
     public replied: boolean;
     public webhook: InteractionWebhook;
-    public defer(options?: InteractionDeferOptions): Promise<void>;
-    public deferUpdate(): Promise<void>;
+    public defer(options?: InteractionDeferOptions & { ephemeral: true }): Promise<void>;
+    public defer(options?: InteractionDeferOptions & { ephemeral?: false }): Promise<Message | RawMessage>;
+    public deferUpdate(): Promise<Message | RawMessage | void>;
     public deleteReply(): Promise<void>;
     public editReply(options: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
     public followUp(options: string | APIMessage | InteractionReplyOptions): Promise<Message | RawMessage>;
-    public reply(options: string | APIMessage | InteractionReplyOptions): Promise<void>;
-    public update(content: string | APIMessage | WebhookEditMessageOptions): Promise<void>;
+    public reply(options: string | APIMessage | (InteractionReplyOptions & { ephemeral: true })): Promise<void>;
+    public reply(
+      options: string | APIMessage | (InteractionReplyOptions & { ephemeral?: false }),
+    ): Promise<Message | RawMessage>;
+    public update(content: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage | void>;
     public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1343,7 +1343,7 @@ declare module 'discord.js' {
     public webhook: InteractionWebhook;
     public defer(options?: InteractionDeferOptions & { ephemeral: true }): Promise<void>;
     public defer(options?: InteractionDeferOptions & { ephemeral?: false }): Promise<Message | RawMessage>;
-    public deferUpdate(): Promise<Message | RawMessage | void>;
+    public deferUpdate(): Promise<Message | RawMessage | undefined>;
     public deleteReply(): Promise<void>;
     public editReply(options: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
@@ -1352,7 +1352,7 @@ declare module 'discord.js' {
     public reply(
       options: string | APIMessage | (InteractionReplyOptions & { ephemeral?: false }),
     ): Promise<Message | RawMessage>;
-    public update(content: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage | void>;
+    public update(content: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage | undefined>;
     public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
   }
 


### PR DESCRIPTION
Stemming from internal discussion, this is one of two opposing PRs which provide a way to automatically fetch the reply/deferral/update to an interaction, assuming it's not ephemeral.

This PR does the fetching automatically no matter what, returning a `Promise<Message>` where possible.

Note: I had to return `undefined` manually here instead of the blank `return` due to linting, unsure if this matters or if this still counts as `void`.

(Testing cross-PR closing) - Closes #5831 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)