### PR TITLE
feat(Interactions): option to auto-fetch replies

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -125,6 +125,7 @@ const Messages = {
   INTERACTION_ALREADY_REPLIED: 'This interaction has already been deferred or replied to.',
   INTERACTION_NOT_REPLIED: 'This interaction has not been deferred or replied to.',
   INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be fetched or deleted.',
+  INTERACTION_FETCH_EPHEMERAL: 'Ephemeral responses cannot be fetched.',
 };
 
 for (const [name, message] of Object.entries(Messages)) register(name, message);

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -16,7 +16,7 @@ class MessageComponentInteraction extends Interaction {
 
     /**
      * The message to which the component was attached
-     * @type {?(Message|APIMessage)}
+     * @type {Message|APIMessage}
      */
     this.message = this.channel?.messages.add(data.message) ?? data.message;
 

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -18,7 +18,7 @@ class MessageComponentInteraction extends Interaction {
      * The message to which the component was attached
      * @type {?(Message|APIMessage)}
      */
-    this.message = data.message ? this.channel?.messages.add(data.message) ?? data.message : null;
+    this.message = this.channel?.messages.add(data.message) ?? data.message;
 
     /**
      * The custom ID of the component which was interacted with

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -163,7 +163,7 @@ class InteractionResponses {
    */
   async deferUpdate(options = {}) {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
-    if (options.fetchReply && (this.message.flags & MessageFlags.FLAGS.EPHEMERAL) === MessageFlags.FLAGS.EPHEMERAL) {
+    if (options.fetchReply && new MessageFlags(this.message.flags).has(MessageFlags.FLAGS.EPHEMERAL)) {
       throw new Error('INTERACTION_FETCH_EPHEMERAL');
     }
     await this.client.api.interactions(this.id, this.token).callback.post({
@@ -191,7 +191,7 @@ class InteractionResponses {
    */
   async update(options) {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
-    if (options.fetchReply && (this.message.flags & MessageFlags.FLAGS.EPHEMERAL) === MessageFlags.FLAGS.EPHEMERAL) {
+    if (options.fetchReply && new MessageFlags(this.message.flags).has(MessageFlags.FLAGS.EPHEMERAL)) {
       throw new Error('INTERACTION_FETCH_EPHEMERAL');
     }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -537,15 +537,15 @@ declare module 'discord.js' {
     public options: Collection<string, CommandInteractionOption>;
     public replied: boolean;
     public webhook: InteractionWebhook;
-    public defer(options?: InteractionDeferOptions & { fetchReply?: false }): Promise<void>;
     public defer(options?: InteractionDeferOptions & { fetchReply: true }): Promise<Message | RawMessage>;
+    public defer(options?: InteractionDeferOptions): Promise<void>;
     public deleteReply(): Promise<void>;
     public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;
     public fetchReply(): Promise<Message | APIMessage>;
-    public reply(options: string | MessagePayload | (InteractionReplyOptions & { fetchReply?: false })): Promise<void>;
     public reply(
       options: string | MessagePayload | (InteractionReplyOptions & { fetchReply: true }),
     ): Promise<Message | APIMessage>;
+    public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
     private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
   }
@@ -1398,22 +1398,23 @@ declare module 'discord.js' {
     public message: Message | APIMessage;
     public replied: boolean;
     public webhook: InteractionWebhook;
-    public defer(options?: InteractionDeferOptions & { fetchReply?: false }): Promise<void>;
     public defer(options?: InteractionDeferOptions & { fetchReply: true }): Promise<Message | RawMessage>;
-    public deferUpdate(options?: InteractionDeferUpdateOptions & { fetchReply?: false }): Promise<void>;
+    public defer(options?: InteractionDeferOptions): Promise<void>;
     public deferUpdate(options?: InteractionDeferUpdateOptions & { fetchReply: true }): Promise<Message | RawMessage>;
+    public deferUpdate(options?: InteractionDeferUpdateOptions): Promise<void>;
     public deleteReply(): Promise<void>;
     public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;
     public fetchReply(): Promise<Message | APIMessage>;
     public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
-    public reply(options: string | MessagePayload | (InteractionReplyOptions & { fetchReply?: false })): Promise<void>;
     public reply(
       options: string | MessagePayload | (InteractionReplyOptions & { fetchReply: true }),
     ): Promise<Message | APIMessage>;
-    public update(content: string | MessagePayload | (InteractionUpdateOptions & { fetchReply?: false })): Promise<void>;
+    public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
     public update(
       content: string | MessagePayload | (InteractionUpdateOptions & { fetchReply: true }),
     ): Promise<Message | APIMessage>;
+    public update(content: string | MessagePayload | InteractionUpdateOptions): Promise<void>;
+
     public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -537,12 +537,15 @@ declare module 'discord.js' {
     public options: Collection<string, CommandInteractionOption>;
     public replied: boolean;
     public webhook: InteractionWebhook;
-    public defer(options?: InteractionDeferOptions): Promise<void>;
+    public defer(options?: InteractionDeferOptions & { fetchReply?: false }): Promise<void>;
+    public defer(options?: InteractionDeferOptions & { fetchReply: true }): Promise<Message | RawMessage>;
     public deleteReply(): Promise<void>;
     public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;
     public fetchReply(): Promise<Message | APIMessage>;
-    public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
-    public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
+    public reply(options: string | MessagePayload | (InteractionReplyOptions & { fetchReply?: false })): Promise<void>;
+    public reply(
+      options: string | MessagePayload | (InteractionReplyOptions & { fetchReply: true }),
+    ): Promise<Message | APIMessage>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
     private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
   }
@@ -1395,14 +1398,22 @@ declare module 'discord.js' {
     public message: Message | APIMessage;
     public replied: boolean;
     public webhook: InteractionWebhook;
-    public defer(options?: InteractionDeferOptions): Promise<void>;
-    public deferUpdate(): Promise<void>;
+    public defer(options?: InteractionDeferOptions & { fetchReply?: false }): Promise<void>;
+    public defer(options?: InteractionDeferOptions & { fetchReply: true }): Promise<Message | RawMessage>;
+    public deferUpdate(options?: InteractionDeferUpdateOptions & { fetchReply?: false }): Promise<void>;
+    public deferUpdate(options?: InteractionDeferUpdateOptions & { fetchReply: true }): Promise<Message | RawMessage>;
     public deleteReply(): Promise<void>;
     public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;
     public fetchReply(): Promise<Message | APIMessage>;
     public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
-    public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
-    public update(content: string | MessagePayload | WebhookEditMessageOptions): Promise<void>;
+    public reply(options: string | MessagePayload | (InteractionReplyOptions & { fetchReply?: false })): Promise<void>;
+    public reply(
+      options: string | MessagePayload | (InteractionReplyOptions & { fetchReply: true }),
+    ): Promise<Message | APIMessage>;
+    public update(content: string | MessagePayload | (InteractionUpdateOptions & { fetchReply?: false })): Promise<void>;
+    public update(
+      content: string | MessagePayload | (InteractionUpdateOptions & { fetchReply: true }),
+    ): Promise<Message | APIMessage>;
     public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
   }
 
@@ -3531,15 +3542,21 @@ declare module 'discord.js' {
 
   interface InteractionDeferOptions {
     ephemeral?: boolean;
+    fetchReply?: boolean;
   }
+
+  interface InteractionDeferUpdateOptions extends Omit<InteractionDeferOptions, 'ephemeral'> {}
 
   interface InteractionReplyOptions extends Omit<WebhookMessageOptions, 'username' | 'avatarURL'> {
     ephemeral?: boolean;
+    fetchReply?: boolean;
   }
 
   type InteractionResponseType = keyof typeof InteractionResponseTypes;
 
   type InteractionType = keyof typeof InteractionTypes;
+
+  interface InteractionUpdateOptions extends Omit<InteractionReplyOptions, 'ephemeral'> {}
 
   type IntentsString =
     | 'GUILDS'


### PR DESCRIPTION
Stemming from internal discussion, this is one of two opposing PRs which provide a way to automatically fetch the reply/deferral/update to an interaction, assuming it's not ephemeral.

This PR adds an option to the methods, allowing the user to enable auto-fetching. The default maintains the existing behaviour. I've written it such that attempting to auto-fetch an ephemeral reply, or auto-fetch an update to an ephemeral message throws an error - this can be changed of course.

(Testing cross-PR closing) - Closes #5830

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)