### PR TITLE
fix(GuildManager): #create throws when systemChannelFlags is undefined

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -188,7 +188,7 @@ class GuildManager extends BaseManager {
       if (role.color) role.color = resolveColor(role.color);
       if (role.permissions) role.permissions = Permissions.resolve(role.permissions).toString();
     }
-    if (systemChannelFlags) SystemChannelFlags.resolve(systemChannelFlags);
+    if (systemChannelFlags) systemChannelFlags = SystemChannelFlags.resolve(systemChannelFlags);
 
     return new Promise((resolve, reject) =>
       this.client.api.guilds

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -188,6 +188,8 @@ class GuildManager extends BaseManager {
       if (role.color) role.color = resolveColor(role.color);
       if (role.permissions) role.permissions = Permissions.resolve(role.permissions).toString();
     }
+    if (systemChannelFlags) SystemChannelFlags.resolve(systemChannelFlags);
+
     return new Promise((resolve, reject) =>
       this.client.api.guilds
         .post({
@@ -202,7 +204,7 @@ class GuildManager extends BaseManager {
             afk_channel_id: afkChannelID,
             afk_timeout: afkTimeout,
             system_channel_id: systemChannelID,
-            system_channel_flags: SystemChannelFlags.resolve(systemChannelFlags),
+            system_channel_flags: systemChannelFlags,
           },
         })
         .then(data => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a bug in `GuildManager#create` where it throws error if the optional `systemChannelFlags` param isn't provided. This happens because the method calls `SystemChannelFlags#resolve` without checking whether `systemChannelFlags` is defined or not. Since, it's an optional param, it can be undefined sometimes and passing undefined param to `SystemChannelFlags#resolve` always throws error.

**Status and versioning classification:**
- Code changes have been tested against the Discord API
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
