### PR TITLE
fix(ApplicationCommand): default option.required to false

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -210,11 +210,13 @@ class ApplicationCommand extends Base {
    * @private
    */
   static transformOption(option, received) {
+    const stringType = typeof option.type === 'string' ? option.type : ApplicationCommandOptionTypes[option.type];
     return {
       type: typeof option.type === 'number' && !received ? option.type : ApplicationCommandOptionTypes[option.type],
       name: option.name,
       description: option.description,
-      required: option.required ?? false,
+      required:
+        option.required ?? (stringType === 'SUB_COMMAND' || stringType === 'SUB_COMMAND_GROUP') ? undefined : false,
       choices: option.choices,
       options: option.options?.map(o => this.transformOption(o, received)),
     };

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -214,7 +214,7 @@ class ApplicationCommand extends Base {
       type: typeof option.type === 'number' && !received ? option.type : ApplicationCommandOptionTypes[option.type],
       name: option.name,
       description: option.description,
-      required: option.required,
+      required: option.required ?? false,
       choices: option.choices,
       options: option.options?.map(o => this.transformOption(o, received)),
     };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2485,13 +2485,14 @@ declare module 'discord.js' {
     type: ApplicationCommandOptionType | ApplicationCommandOptionTypes;
     name: string;
     description: string;
-    required: boolean;
+    required?: boolean;
     choices?: ApplicationCommandOptionChoice[];
     options?: this[];
   }
 
   interface ApplicationCommandOption extends ApplicationCommandOptionData {
     type: ApplicationCommandOptionType;
+    required: boolean;
   }
 
   interface ApplicationCommandOptionChoice {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2492,7 +2492,6 @@ declare module 'discord.js' {
 
   interface ApplicationCommandOption extends ApplicationCommandOptionData {
     type: ApplicationCommandOptionType;
-    required: boolean;
   }
 
   interface ApplicationCommandOptionChoice {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2485,7 +2485,7 @@ declare module 'discord.js' {
     type: ApplicationCommandOptionType | ApplicationCommandOptionTypes;
     name: string;
     description: string;
-    required?: boolean;
+    required: boolean;
     choices?: ApplicationCommandOptionChoice[];
     options?: this[];
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The data sent by Discord for the `required` field in ApplicationCommandOption is undefined if the option is not required. This PR fixes this so that it defaults to false instead to make it easier to compare with local commands for command updaters.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
