### PR TITLE
feat(MessageComponentInteraction): component getter

### DIFF
--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -59,7 +59,7 @@ class MessageComponentInteraction extends Interaction {
 
   /**
    * The component which was interacted with
-   * @type {?MessageActionRowComponent|Object}
+   * @type {?(MessageActionRowComponent|Object)}
    * @readonly
    */
   get component() {

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -66,7 +66,7 @@ class MessageComponentInteraction extends Interaction {
     return this.message.components
       .map(row => row.components)
       .flat()
-      .find(component => (component.customID ?? component.custom_id) === this.customID);
+      .find(component => (component.customID ?? component.custom_id) === this.customID) ?? null;
   }
 
   /**

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -59,14 +59,14 @@ class MessageComponentInteraction extends Interaction {
 
   /**
    * The component which was interacted with
-   * @type {?MessageActionRowComponent}
+   * @type {?MessageActionRowComponent|Object}
    * @readonly
    */
   get component() {
     return this.message.components
       .map(row => row.components)
       .flat()
-      .find(component => component.customID === this.customID);
+      .find(component => (component.customID ?? component.custom_id) === this.customID);
   }
 
   /**

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -58,6 +58,18 @@ class MessageComponentInteraction extends Interaction {
   }
 
   /**
+   * The component which was interacted with
+   * @type {?MessageActionRowComponent}
+   * @readonly
+   */
+  get component() {
+    return this.message.components
+      .map(row => row.components)
+      .flat()
+      .find(component => component.customID === this.customID);
+  }
+
+  /**
    * Resolves the type of a MessageComponent
    * @param {MessageComponentTypeResolvable} type The type to resolve
    * @returns {MessageComponentType}

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -64,8 +64,7 @@ class MessageComponentInteraction extends Interaction {
    */
   get component() {
     return this.message.components
-      .map(row => row.components)
-      .flat()
+      .flatMap(row => row.components)
       .find(component => (component.customID ?? component.custom_id) === this.customID) ?? null;
   }
 

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -63,9 +63,11 @@ class MessageComponentInteraction extends Interaction {
    * @readonly
    */
   get component() {
-    return this.message.components
-      .flatMap(row => row.components)
-      .find(component => (component.customID ?? component.custom_id) === this.customID) ?? null;
+    return (
+      this.message.components
+        .flatMap(row => row.components)
+        .find(component => (component.customID ?? component.custom_id) === this.customID) ?? null
+    );
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1388,7 +1388,7 @@ declare module 'discord.js' {
 
   export class MessageComponentInteraction extends Interaction {
     public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | null;
-    public readonly component: MessageActionRowComponent | null;
+    public readonly component: MessageActionRowComponent | unknown | null;
     public componentType: MessageComponentType;
     public customID: string;
     public deferred: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1388,6 +1388,7 @@ declare module 'discord.js' {
 
   export class MessageComponentInteraction extends Interaction {
     public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | null;
+    public readonly component: MessageActionRowComponent | null;
     public componentType: MessageComponentType;
     public customID: string;
     public deferred: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -139,10 +139,12 @@ declare module 'discord.js' {
   import BaseCollection from '@discordjs/collection';
   import { ChildProcess } from 'child_process';
   import {
+    APIActionRowComponent as RawActionRowComponent,
     APIInteractionDataResolvedChannel as RawInteractionDataResolvedChannel,
     APIInteractionDataResolvedGuildMember as RawInteractionDataResolvedGuildMember,
     APIInteractionGuildMember as RawInteractionGuildMember,
     APIMessage as RawMessage,
+    APIMessageComponent as RawMessageComponent,
     APIOverwrite as RawOverwrite,
     APIPartialEmoji as RawEmoji,
     APIRole as RawRole,
@@ -1388,7 +1390,7 @@ declare module 'discord.js' {
 
   export class MessageComponentInteraction extends Interaction {
     public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | null;
-    public readonly component: MessageActionRowComponent | unknown | null;
+    public readonly component: MessageActionRowComponent | Exclude<RawMessageComponent, RawActionRowComponent> | null;
     public componentType: MessageComponentType;
     public customID: string;
     public deferred: boolean;


### PR DESCRIPTION
Closes #5828

This currently uses generic Object/unknown typings for a raw message component, pending https://github.com/discordjs/discord-api-types/pull/132 being merged.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)