### PR TITLE
fix(Guild): setChannelPositions null parenting

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1141,7 +1141,7 @@ class Guild extends BaseGuild {
       id: this.client.channels.resolveID(r.channel),
       position: r.position,
       lock_permissions: r.lockPermissions,
-      parent_id: this.channels.resolveID(r.parent),
+      parent_id: typeof r.parent !== 'undefined' ? this.channels.resolveID(r.parent) : undefined,
     }));
 
     return this.client.api

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2605,7 +2605,7 @@ declare module 'discord.js' {
   interface ChannelPosition {
     channel: ChannelResolvable;
     lockPermissions?: boolean;
-    parent?: CategoryChannelResolvable;
+    parent?: CategoryChannelResolvable | null;
     position?: number;
   }
 


### PR DESCRIPTION
This fixes a couple of issues introduced in #5507 where not providing a parent to `Guild#setChannelPositions` would resolve to `null`, clearing the parent instead of leaving it unchanged.

This also prevented the method from being used to set more than one channel position, due to `DiscordAPIError: Only one channel can have a parent_id modified at a time`.

Additionally, the typings are updated to accept `null` in order to move the channel out of the parent category.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)