### PR TITLE
feat(*): use enums for consistency and speed

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -171,17 +171,11 @@ class GuildManager extends BaseManager {
     if (typeof verificationLevel === 'string') {
       verificationLevel = VerificationLevels[verificationLevel];
     }
-    if (defaultMessageNotifications) {
-      defaultMessageNotifications =
-        typeof defaultMessageNotifications === 'number'
-          ? defaultMessageNotifications
-          : DefaultMessageNotificationLevels[defaultMessageNotifications];
+    if (typeof defaultMessageNotifications === 'string') {
+      defaultMessageNotifications = DefaultMessageNotificationLevels[defaultMessageNotifications];
     }
-    if (explicitContentFilter) {
-      explicitContentFilter =
-        typeof explicitContentFilter === 'number'
-          ? explicitContentFilter
-          : ExplicitContentFilterLevels[explicitContentFilter];
+    if (typeof explicitContentFilter === 'string') {
+      explicitContentFilter = ExplicitContentFilterLevels[explicitContentFilter];
     }
     for (const channel of channels) {
       if (channel.type) channel.type = ChannelTypes[channel.type.toUpperCase()];

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -13,7 +13,7 @@ const {
   ChannelTypes,
   Events,
   VerificationLevels,
-  DefaultMessageNotifications,
+  DefaultMessageNotificationLevels,
   ExplicitContentFilterLevels,
 } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
@@ -168,14 +168,21 @@ class GuildManager extends BaseManager {
     } = {},
   ) {
     icon = await DataResolver.resolveImage(icon);
-    if (typeof verificationLevel !== 'undefined' && typeof verificationLevel !== 'number') {
-      verificationLevel = VerificationLevels.indexOf(verificationLevel);
+    if (verificationLevel) {
+      verificationLevel =
+        typeof verificationLevel === 'number' ? verificationLevel : VerificationLevels[verificationLevel];
     }
-    if (typeof defaultMessageNotifications !== 'undefined' && typeof defaultMessageNotifications !== 'number') {
-      defaultMessageNotifications = DefaultMessageNotifications.indexOf(defaultMessageNotifications);
+    if (defaultMessageNotifications) {
+      defaultMessageNotifications =
+        typeof defaultMessageNotifications === 'number'
+          ? defaultMessageNotifications
+          : DefaultMessageNotificationLevels[defaultMessageNotifications];
     }
-    if (typeof explicitContentFilter !== 'undefined' && typeof explicitContentFilter !== 'number') {
-      explicitContentFilter = ExplicitContentFilterLevels.indexOf(explicitContentFilter);
+    if (explicitContentFilter) {
+      explicitContentFilter =
+        typeof explicitContentFilter === 'number'
+          ? explicitContentFilter
+          : ExplicitContentFilterLevels[explicitContentFilter];
     }
     for (const channel of channels) {
       if (channel.type) channel.type = ChannelTypes[channel.type.toUpperCase()];

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -168,9 +168,8 @@ class GuildManager extends BaseManager {
     } = {},
   ) {
     icon = await DataResolver.resolveImage(icon);
-    if (verificationLevel) {
-      verificationLevel =
-        typeof verificationLevel === 'number' ? verificationLevel : VerificationLevels[verificationLevel];
+    if (typeof verificationLevel === 'string') {
+      verificationLevel = VerificationLevels[verificationLevel];
     }
     if (defaultMessageNotifications) {
       defaultMessageNotifications =

--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -41,7 +41,7 @@ class ClientPresence extends Presence {
         if (!activity.type) activity.type = 0;
 
         data.activities.push({
-          type: typeof activity.type === 'number' ? activity.type : ActivityTypes.indexOf(activity.type),
+          type: typeof activity.type === 'number' ? activity.type : ActivityTypes[activity.type],
           name: activity.name,
           url: activity.url,
         });
@@ -50,7 +50,7 @@ class ClientPresence extends Presence {
       data.activities.push(
         ...this.activities.map(a => ({
           name: a.name,
-          type: ActivityTypes.indexOf(a.type),
+          type: ActivityTypes[a.type],
           url: a.url ?? undefined,
         })),
       );

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -20,7 +20,7 @@ const VoiceStateManager = require('../managers/VoiceStateManager');
 const Collection = require('../util/Collection');
 const {
   ChannelTypes,
-  DefaultMessageNotifications,
+  DefaultMessageNotificationLevels,
   PartialTypes,
   VerificationLevels,
   ExplicitContentFilterLevels,
@@ -280,11 +280,10 @@ class Guild extends BaseGuild {
     this.joinedTimestamp = data.joined_at ? new Date(data.joined_at).getTime() : this.joinedTimestamp;
 
     /**
-     * The value set for the guild's default message notifications
-     * @type {DefaultMessageNotifications|number}
+     * The default message notification level of the guild
+     * @type {DefaultMessageNotificationLevel}
      */
-    this.defaultMessageNotifications =
-      DefaultMessageNotifications[data.default_message_notifications] || data.default_message_notifications;
+    this.defaultMessageNotifications = DefaultMessageNotificationLevels[data.default_message_notifications];
 
     /**
      * The value set for the guild's system channel flags
@@ -831,7 +830,8 @@ class Guild extends BaseGuild {
    * @property {Base64Resolvable} [splash] The invite splash image of the guild
    * @property {Base64Resolvable} [discoverySplash] The discovery splash image of the guild
    * @property {Base64Resolvable} [banner] The banner of the guild
-   * @property {DefaultMessageNotifications|number} [defaultMessageNotifications] The default message notifications
+   * @property {DefaultMessageNotificationLevel|number} [defaultMessageNotifications] The default message notification
+   * level of the guild
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The system channel flags of the guild
    * @property {ChannelResolvable} [rulesChannel] The rules channel of the guild
    * @property {ChannelResolvable} [publicUpdatesChannel] The community updates channel of the guild
@@ -856,11 +856,11 @@ class Guild extends BaseGuild {
   edit(data, reason) {
     const _data = {};
     if (data.name) _data.name = data.name;
-    if (typeof data.verificationLevel !== 'undefined') {
+    if (data.verificationLevel) {
       _data.verification_level =
         typeof data.verificationLevel === 'number'
-          ? Number(data.verificationLevel)
-          : VerificationLevels.indexOf(data.verificationLevel);
+          ? data.verificationLevel
+          : VerificationLevels[data.verificationLevel];
     }
     if (typeof data.afkChannel !== 'undefined') {
       _data.afk_channel_id = this.client.channels.resolveID(data.afkChannel);
@@ -874,17 +874,17 @@ class Guild extends BaseGuild {
     if (data.splash) _data.splash = data.splash;
     if (data.discoverySplash) _data.discovery_splash = data.discoverySplash;
     if (data.banner) _data.banner = data.banner;
-    if (typeof data.explicitContentFilter !== 'undefined') {
+    if (data.explicitContentFilter) {
       _data.explicit_content_filter =
         typeof data.explicitContentFilter === 'number'
           ? data.explicitContentFilter
-          : ExplicitContentFilterLevels.indexOf(data.explicitContentFilter);
+          : ExplicitContentFilterLevels[data.explicitContentFilter];
     }
-    if (typeof data.defaultMessageNotifications !== 'undefined') {
+    if (data.defaultMessageNotifications) {
       _data.default_message_notifications =
-        typeof data.defaultMessageNotifications === 'string'
-          ? DefaultMessageNotifications.indexOf(data.defaultMessageNotifications)
-          : data.defaultMessageNotifications;
+        typeof data.defaultMessageNotifications === 'number'
+          ? data.defaultMessageNotifications
+          : DefaultMessageNotificationLevels[data.defaultMessageNotifications];
     }
     if (typeof data.systemChannelFlags !== 'undefined') {
       _data.system_channel_flags = SystemChannelFlags.resolve(data.systemChannelFlags);
@@ -921,7 +921,7 @@ class Guild extends BaseGuild {
   /* eslint-disable max-len */
   /**
    * Edits the setting of the default message notifications of the guild.
-   * @param {DefaultMessageNotifications|number} defaultMessageNotifications The new setting for the default message notifications
+   * @param {DefaultMessageNotificationLevel|number} defaultMessageNotifications The new default message notification level of the guild
    * @param {string} [reason] Reason for changing the setting of the default message notifications
    * @returns {Promise<Guild>}
    */

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -856,7 +856,7 @@ class Guild extends BaseGuild {
   edit(data, reason) {
     const _data = {};
     if (data.name) _data.name = data.name;
-    if (data.verificationLevel) {
+    if (typeof data.verificationLevel !== 'undefined') {
       _data.verification_level =
         typeof data.verificationLevel === 'number'
           ? data.verificationLevel
@@ -874,13 +874,13 @@ class Guild extends BaseGuild {
     if (data.splash) _data.splash = data.splash;
     if (data.discoverySplash) _data.discovery_splash = data.discoverySplash;
     if (data.banner) _data.banner = data.banner;
-    if (data.explicitContentFilter) {
+    if (typeof data.explicitContentFilter !== 'undefined') {
       _data.explicit_content_filter =
         typeof data.explicitContentFilter === 'number'
           ? data.explicitContentFilter
           : ExplicitContentFilterLevels[data.explicitContentFilter];
     }
-    if (data.defaultMessageNotifications) {
+    if (typeof data.defaultMessageNotifications !== 'undefined') {
       _data.default_message_notifications =
         typeof data.defaultMessageNotifications === 'number'
           ? data.defaultMessageNotifications

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -169,7 +169,7 @@ class Activity {
      * The type of the activity status
      * @type {ActivityType}
      */
-    this.type = ActivityTypes[data.type] || ActivityTypes[ActivityTypes.indexOf(data.type)];
+    this.type = typeof data.type === 'number' ? ActivityTypes[data.type] : data.type;
 
     /**
      * If the activity is being streamed, a link to the stream

--- a/src/structures/Sticker.js
+++ b/src/structures/Sticker.js
@@ -31,7 +31,7 @@ class Sticker extends Base {
 
     /**
      * The format of the sticker
-     * @type {StickerFormatTypes}
+     * @type {StickerFormatType}
      */
     this.format = StickerFormatTypes[sticker.format_type];
 

--- a/src/structures/TeamMember.js
+++ b/src/structures/TeamMember.js
@@ -29,7 +29,7 @@ class TeamMember extends Base {
 
     /**
      * The permissions this Team Member has with regard to the team
-     * @type {MembershipStates}
+     * @type {MembershipState}
      */
     this.membershipState = MembershipStates[data.membership_state];
 

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -50,7 +50,7 @@ class Webhook {
 
     /**
      * The type of the webhook
-     * @type {WebhookTypes}
+     * @type {WebhookType}
      */
     this.type = WebhookTypes[data.type];
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -488,17 +488,17 @@ exports.SystemMessageTypes = exports.MessageTypes.filter(
 );
 
 /**
- * <info>Bots cannot set a `CUSTOM_STATUS`, it is only for custom statuses received from users</info>
+ * <info>Bots cannot set a `CUSTOM` activity type, it is only for custom statuses received from users</info>
  * The type of an activity of a users presence, e.g. `PLAYING`. Here are the available types:
  * * PLAYING
  * * STREAMING
  * * LISTENING
  * * WATCHING
- * * CUSTOM_STATUS
+ * * CUSTOM
  * * COMPETING
  * @typedef {string} ActivityType
  */
-exports.ActivityTypes = ['PLAYING', 'STREAMING', 'LISTENING', 'WATCHING', 'CUSTOM_STATUS', 'COMPETING'];
+exports.ActivityTypes = createEnum(['PLAYING', 'STREAMING', 'LISTENING', 'WATCHING', 'CUSTOM', 'COMPETING']);
 
 exports.ChannelTypes = createEnum([
   'TEXT',
@@ -559,7 +559,7 @@ exports.Colors = {
  * * ALL_MEMBERS
  * @typedef {string} ExplicitContentFilterLevel
  */
-exports.ExplicitContentFilterLevels = ['DISABLED', 'MEMBERS_WITHOUT_ROLES', 'ALL_MEMBERS'];
+exports.ExplicitContentFilterLevels = createEnum(['DISABLED', 'MEMBERS_WITHOUT_ROLES', 'ALL_MEMBERS']);
 
 /**
  * The value set for the verification levels for a guild:
@@ -570,7 +570,7 @@ exports.ExplicitContentFilterLevels = ['DISABLED', 'MEMBERS_WITHOUT_ROLES', 'ALL
  * * VERY_HIGH
  * @typedef {string} VerificationLevel
  */
-exports.VerificationLevels = ['NONE', 'LOW', 'MEDIUM', 'HIGH', 'VERY_HIGH'];
+exports.VerificationLevels = createEnum(['NONE', 'LOW', 'MEDIUM', 'HIGH', 'VERY_HIGH']);
 
 /**
  * An error encountered while performing an API request. Here are the potential errors:
@@ -720,35 +720,25 @@ exports.APIErrors = {
  * The value set for a guild's default message notifications, e.g. `ALL`. Here are the available types:
  * * ALL
  * * MENTIONS
- * @typedef {string} DefaultMessageNotifications
+ * @typedef {string} DefaultMessageNotificationLevel
  */
-exports.DefaultMessageNotifications = ['ALL', 'MENTIONS'];
+exports.DefaultMessageNotificationLevels = createEnum(['ALL', 'MENTIONS']);
 
 /**
  * The value set for a team members's membership state:
  * * INVITED
  * * ACCEPTED
- * @typedef {string} MembershipStates
+ * @typedef {string} MembershipState
  */
-exports.MembershipStates = [
-  // They start at 1
-  null,
-  'INVITED',
-  'ACCEPTED',
-];
+exports.MembershipStates = createEnum([null, 'INVITED', 'ACCEPTED']);
 
 /**
  * The value set for a webhook's type:
  * * Incoming
  * * Channel Follower
- * @typedef {string} WebhookTypes
+ * @typedef {string} WebhookType
  */
-exports.WebhookTypes = [
-  // They start at 1
-  null,
-  'Incoming',
-  'Channel Follower',
-];
+exports.WebhookTypes = createEnum([null, 'Incoming', 'Channel Follower']);
 
 /**
  * The value set for a sticker's type:

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -717,12 +717,12 @@ exports.APIErrors = {
 };
 
 /**
- * The value set for a guild's default message notifications, e.g. `ALL`. Here are the available types:
- * * ALL
- * * MENTIONS
+ * The value set for a guild's default message notifications, e.g. `ALL_MESSAGES`. Here are the available types:
+ * * ALL_MESSAGES
+ * * ONLY_MENTIONS
  * @typedef {string} DefaultMessageNotificationLevel
  */
-exports.DefaultMessageNotificationLevels = createEnum(['ALL', 'MENTIONS']);
+exports.DefaultMessageNotificationLevels = createEnum(['ALL_MESSAGES', 'ONLY_MENTIONS']);
 
 /**
  * The value set for a team members's membership state:

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -745,7 +745,7 @@ exports.WebhookTypes = createEnum([null, 'Incoming', 'Channel Follower']);
  * * PNG
  * * APNG
  * * LOTTIE
- * @typedef {string} StickerFormatTypes
+ * @typedef {string} StickerFormatType
  */
 exports.StickerFormatTypes = createEnum([null, 'PNG', 'APNG', 'LOTTIE']);
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1082,7 +1082,7 @@ declare module 'discord.js' {
   }
 
   // tslint:disable-next-line:no-empty-interface - Merge RateLimitData into RateLimitError to not have to type it again
-  interface RateLimitError extends RateLimitData { }
+  interface RateLimitError extends RateLimitData {}
   export class RateLimitError extends Error {
     constructor(data: RateLimitData);
     public name: 'RateLimitError';
@@ -3557,11 +3557,11 @@ declare module 'discord.js' {
 
   type OverwriteType = 'member' | 'role';
 
-  interface PermissionFlags extends Record<PermissionString, bigint> { }
+  interface PermissionFlags extends Record<PermissionString, bigint> {}
 
-  interface PermissionObject extends Record<PermissionString, boolean> { }
+  interface PermissionObject extends Record<PermissionString, boolean> {}
 
-  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> { }
+  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> {}
 
   type PermissionResolvable = BitFieldResolvable<PermissionString, bigint>;
 
@@ -3600,7 +3600,7 @@ declare module 'discord.js' {
     | 'USE_APPLICATION_COMMANDS'
     | 'REQUEST_TO_SPEAK';
 
-  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> { }
+  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> {}
 
   type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray<T>>;
 
@@ -3624,16 +3624,16 @@ declare module 'discord.js' {
     partial: true;
     fetch(): Promise<T>;
   } & {
-      [K in keyof Omit<
-        T,
-        'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
-      >]: T[K] extends (...args: any) => void ? T[K] : T[K] | null;
-    };
+    [K in keyof Omit<
+      T,
+      'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
+    >]: T[K] extends (...args: any) => void ? T[K] : T[K] | null;
+  };
 
   interface PartialDMChannel
     extends Partialize<
-    DMChannel,
-    'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+      DMChannel,
+      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
     > {
     lastMessage: null;
     lastMessageID: undefined;
@@ -3655,18 +3655,18 @@ declare module 'discord.js' {
 
   interface PartialGuildMember
     extends Partialize<
-    GuildMember,
-    | 'bannable'
-    | 'displayColor'
-    | 'displayHexColor'
-    | 'displayName'
-    | 'guild'
-    | 'kickable'
-    | 'permissions'
-    | 'roles'
-    | 'manageable'
-    | 'presence'
-    | 'voice'
+      GuildMember,
+      | 'bannable'
+      | 'displayColor'
+      | 'displayHexColor'
+      | 'displayName'
+      | 'guild'
+      | 'kickable'
+      | 'permissions'
+      | 'roles'
+      | 'manageable'
+      | 'presence'
+      | 'voice'
     > {
     readonly bannable: boolean;
     readonly displayColor: number;
@@ -3685,17 +3685,17 @@ declare module 'discord.js' {
 
   interface PartialMessage
     extends Partialize<
-    Message,
-    | 'attachments'
-    | 'channel'
-    | 'deletable'
-    | 'crosspostable'
-    | 'editable'
-    | 'mentions'
-    | 'pinnable'
-    | 'url'
-    | 'flags'
-    | 'embeds'
+      Message,
+      | 'attachments'
+      | 'channel'
+      | 'deletable'
+      | 'crosspostable'
+      | 'editable'
+      | 'mentions'
+      | 'pinnable'
+      | 'url'
+      | 'flags'
+      | 'embeds'
     > {
     attachments: Message['attachments'];
     channel: Message['channel'];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3844,13 +3844,15 @@ declare module 'discord.js' {
     public readonly createdTimestamp: number;
     public readonly createdAt: Date;
     public description: string;
-    public format: StickerFormatTypes;
+    public format: StickerFormatType;
     public id: Snowflake;
     public name: string;
     public packID: Snowflake;
     public tags: string[];
     public readonly url: string;
   }
+
+  type StickerFormatType = keyof typeof StickerFormatTypes;
 
   type SystemChannelFlagsString =
     | 'SUPPRESS_JOIN_NOTIFICATIONS'

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,3 +1,12 @@
+declare enum ActivityTypes {
+  PLAYING = 0,
+  STREAMING = 1,
+  LISTENING = 2,
+  WATCHING = 3,
+  CUSTOM = 4,
+  COMPETING = 5,
+}
+
 declare enum ChannelType {
   text = 0,
   dm = 1,
@@ -21,6 +30,17 @@ declare enum ChannelTypes {
   STAGE = 13,
 }
 
+declare enum DefaultMessageNotificationLevels {
+  ALL_MESSAGES = 0,
+  ONLY_MENTIONS = 1,
+}
+
+declare enum ExplicitContentFilterLevels {
+  DISABLED = 0,
+  MEMBERS_WITHOUT_ROLES = 1,
+  ALL_MEMBERS = 2,
+}
+
 declare enum InteractionResponseTypes {
   PONG = 1,
   CHANNEL_MESSAGE_WITH_SOURCE = 4,
@@ -38,6 +58,11 @@ declare enum InteractionTypes {
 declare enum InviteTargetType {
   STREAM = 1,
   EMBEDDED_APPLICATION = 2,
+}
+
+declare enum MembershipStates {
+  INVITED = 1,
+  ACCEPTED = 2,
 }
 
 declare enum MessageButtonStyles {
@@ -79,6 +104,19 @@ declare enum StickerFormatTypes {
   PNG = 1,
   APNG = 2,
   LOTTIE = 3,
+}
+
+declare enum VerificationLevels {
+  NONE = 0,
+  LOW = 1,
+  MEDIUM = 2,
+  HIGH = 3,
+  VERY_HIGH = 4,
+}
+
+declare enum WebhookTypes {
+  Incoming = 1,
+  'Channel Follower' = 2,
 }
 
 type Awaited<T> = T | Promise<T>;
@@ -662,13 +700,13 @@ declare module 'discord.js' {
     InviteScopes: InviteScope[];
     MessageTypes: MessageType[];
     SystemMessageTypes: SystemMessageType[];
-    ActivityTypes: ActivityType[];
+    ActivityTypes: typeof ActivityTypes;
     StickerFormatTypes: typeof StickerFormatTypes;
     OverwriteTypes: typeof OverwriteTypes;
-    ExplicitContentFilterLevels: ExplicitContentFilterLevel[];
-    DefaultMessageNotifications: DefaultMessageNotifications[];
-    VerificationLevels: VerificationLevel[];
-    MembershipStates: 'INVITED' | 'ACCEPTED';
+    ExplicitContentFilterLevels: typeof ExplicitContentFilterLevels;
+    DefaultMessageNotificationLevels: typeof DefaultMessageNotificationLevels;
+    VerificationLevels: typeof VerificationLevels;
+    MembershipStates: typeof MembershipStates;
     ApplicationCommandOptionTypes: typeof ApplicationCommandOptionTypes;
     ApplicationCommandPermissionTypes: typeof ApplicationCommandPermissionTypes;
     InteractionTypes: typeof InteractionTypes;
@@ -678,6 +716,7 @@ declare module 'discord.js' {
     MFALevels: typeof MFALevels;
     NSFWLevels: typeof NSFWLevels;
     PrivacyLevels: typeof PrivacyLevels;
+    WebhookTypes: typeof WebhookTypes;
   };
 
   export class DataResolver {
@@ -740,7 +779,7 @@ declare module 'discord.js' {
     public bans: GuildBanManager;
     public channels: GuildChannelManager;
     public commands: GuildApplicationCommandManager;
-    public defaultMessageNotifications: DefaultMessageNotifications | number;
+    public defaultMessageNotifications: DefaultMessageNotificationLevel | number;
     public deleted: boolean;
     public description: string | null;
     public discoverySplash: string | null;
@@ -805,7 +844,7 @@ declare module 'discord.js' {
     public setBanner(banner: Base64Resolvable | null, reason?: string): Promise<Guild>;
     public setChannelPositions(channelPositions: readonly ChannelPosition[]): Promise<Guild>;
     public setDefaultMessageNotifications(
-      defaultMessageNotifications: DefaultMessageNotifications | number,
+      defaultMessageNotifications: DefaultMessageNotificationLevel | number,
       reason?: string,
     ): Promise<Guild>;
     public setDiscoverySplash(discoverySplash: Base64Resolvable | null, reason?: string): Promise<Guild>;
@@ -1043,7 +1082,7 @@ declare module 'discord.js' {
   }
 
   // tslint:disable-next-line:no-empty-interface - Merge RateLimitData into RateLimitError to not have to type it again
-  interface RateLimitError extends RateLimitData {}
+  interface RateLimitError extends RateLimitData { }
   export class RateLimitError extends Error {
     constructor(data: RateLimitData);
     public name: 'RateLimitError';
@@ -1762,7 +1801,7 @@ declare module 'discord.js' {
     public team: Team;
     public readonly id: Snowflake;
     public permissions: string[];
-    public membershipState: MembershipStates;
+    public membershipState: MembershipState;
     public user: User;
 
     public toString(): string;
@@ -1931,7 +1970,7 @@ declare module 'discord.js' {
     public sourceGuild: Guild | unknown | null;
     public sourceChannel: Channel | unknown | null;
     public token: string | null;
-    public type: WebhookTypes;
+    public type: WebhookType;
   }
 
   export class WebhookClient extends WebhookMixin(BaseClient) {
@@ -2437,7 +2476,7 @@ declare module 'discord.js' {
 
   type ActivityPlatform = 'desktop' | 'samsung' | 'xbox';
 
-  type ActivityType = 'PLAYING' | 'STREAMING' | 'LISTENING' | 'WATCHING' | 'CUSTOM_STATUS' | 'COMPETING';
+  type ActivityType = keyof typeof ActivityTypes;
 
   interface AddGuildMemberOptions {
     accessToken: string;
@@ -2852,7 +2891,7 @@ declare module 'discord.js' {
     binary: string;
   }
 
-  type DefaultMessageNotifications = 'ALL' | 'MENTIONS';
+  type DefaultMessageNotificationLevel = keyof typeof DefaultMessageNotificationLevels;
 
   interface EditGuildTemplateOptions {
     name?: string;
@@ -2894,7 +2933,7 @@ declare module 'discord.js' {
     codeBlockContent?: boolean;
   }
 
-  type ExplicitContentFilterLevel = 'DISABLED' | 'MEMBERS_WITHOUT_ROLES' | 'ALL_MEMBERS';
+  type ExplicitContentFilterLevel = keyof typeof ExplicitContentFilterLevels;
 
   interface Extendable {
     GuildEmoji: typeof GuildEmoji;
@@ -3072,7 +3111,7 @@ declare module 'discord.js' {
     afkChannelID?: Snowflake | number;
     afkTimeout?: number;
     channels?: PartialChannelData[];
-    defaultMessageNotifications?: DefaultMessageNotifications | number;
+    defaultMessageNotifications?: DefaultMessageNotificationLevel | number;
     explicitContentFilter?: ExplicitContentFilterLevel | number;
     icon?: BufferResolvable | Base64Resolvable | null;
     roles?: PartialRoleData[];
@@ -3090,7 +3129,7 @@ declare module 'discord.js' {
     name?: string;
     verificationLevel?: VerificationLevel | number;
     explicitContentFilter?: ExplicitContentFilterLevel | number;
-    defaultMessageNotifications?: DefaultMessageNotifications | number;
+    defaultMessageNotifications?: DefaultMessageNotificationLevel | number;
     afkChannel?: ChannelResolvable;
     systemChannel?: ChannelResolvable;
     systemChannelFlags?: SystemChannelFlagsResolvable;
@@ -3281,7 +3320,7 @@ declare module 'discord.js' {
     stack: string;
   }
 
-  type MembershipStates = 'INVITED' | 'ACCEPTED';
+  type MembershipState = keyof typeof MembershipStates;
 
   type MessageActionRowComponent = MessageButton;
 
@@ -3518,11 +3557,11 @@ declare module 'discord.js' {
 
   type OverwriteType = 'member' | 'role';
 
-  interface PermissionFlags extends Record<PermissionString, bigint> {}
+  interface PermissionFlags extends Record<PermissionString, bigint> { }
 
-  interface PermissionObject extends Record<PermissionString, boolean> {}
+  interface PermissionObject extends Record<PermissionString, boolean> { }
 
-  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> {}
+  interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> { }
 
   type PermissionResolvable = BitFieldResolvable<PermissionString, bigint>;
 
@@ -3561,7 +3600,7 @@ declare module 'discord.js' {
     | 'USE_APPLICATION_COMMANDS'
     | 'REQUEST_TO_SPEAK';
 
-  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> {}
+  interface RecursiveArray<T> extends ReadonlyArray<T | RecursiveArray<T>> { }
 
   type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray<T>>;
 
@@ -3585,16 +3624,16 @@ declare module 'discord.js' {
     partial: true;
     fetch(): Promise<T>;
   } & {
-    [K in keyof Omit<
-      T,
-      'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
-    >]: T[K] extends (...args: any) => void ? T[K] : T[K] | null;
-  };
+      [K in keyof Omit<
+        T,
+        'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
+      >]: T[K] extends (...args: any) => void ? T[K] : T[K] | null;
+    };
 
   interface PartialDMChannel
     extends Partialize<
-      DMChannel,
-      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+    DMChannel,
+    'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
     > {
     lastMessage: null;
     lastMessageID: undefined;
@@ -3616,18 +3655,18 @@ declare module 'discord.js' {
 
   interface PartialGuildMember
     extends Partialize<
-      GuildMember,
-      | 'bannable'
-      | 'displayColor'
-      | 'displayHexColor'
-      | 'displayName'
-      | 'guild'
-      | 'kickable'
-      | 'permissions'
-      | 'roles'
-      | 'manageable'
-      | 'presence'
-      | 'voice'
+    GuildMember,
+    | 'bannable'
+    | 'displayColor'
+    | 'displayHexColor'
+    | 'displayName'
+    | 'guild'
+    | 'kickable'
+    | 'permissions'
+    | 'roles'
+    | 'manageable'
+    | 'presence'
+    | 'voice'
     > {
     readonly bannable: boolean;
     readonly displayColor: number;
@@ -3646,17 +3685,17 @@ declare module 'discord.js' {
 
   interface PartialMessage
     extends Partialize<
-      Message,
-      | 'attachments'
-      | 'channel'
-      | 'deletable'
-      | 'crosspostable'
-      | 'editable'
-      | 'mentions'
-      | 'pinnable'
-      | 'url'
-      | 'flags'
-      | 'embeds'
+    Message,
+    | 'attachments'
+    | 'channel'
+    | 'deletable'
+    | 'crosspostable'
+    | 'editable'
+    | 'mentions'
+    | 'pinnable'
+    | 'url'
+    | 'flags'
+    | 'embeds'
     > {
     attachments: Message['attachments'];
     channel: Message['channel'];
@@ -3857,7 +3896,7 @@ declare module 'discord.js' {
     uses: number | null;
   }
 
-  type VerificationLevel = 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH' | 'VERY_HIGH';
+  type VerificationLevel = keyof typeof VerificationLevels;
 
   type WebhookClientOptions = Pick<
     ClientOptions,
@@ -3880,7 +3919,7 @@ declare module 'discord.js' {
     avatarURL?: string;
   }
 
-  type WebhookTypes = 'Incoming' | 'Channel Follower';
+  type WebhookType = keyof typeof WebhookTypes;
 
   interface WebSocketOptions {
     large_threshold?: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Okay, there are a lot of related changes here:

1) Use enums instead of arrays. This brings consistency and speed (`indexOf` is slow).
2) Some enums (that were arrays earlier) had same name for the enums themselves and the type of elements they hold.
3) `WebhookTypes` enum (ex-array) was missing from typings for `Constants`
4) Some methods that used arrays as enums earlier wouldn't let user to pass `number` type.
5) `DefaultMessageNotifcations` is now `DefaultMessageNotificationLevels` to keep the naming consistent with other enums in djs (discord uses 'level' in the name for enums in documentaion).
6) `DefaultMessageNotifcations` types were not same as what the api has documented ( eg. `ALL` instead of `ALL_MESSAGES`)
6) Although, the raw activity data's `name` property's value is `Custom_Status`, the `type` for it is documented as `Custom`. So, the activity type `CUSTOM_STATUS` is now `CUSTOM`.  

**Status and versioning classification:**
- Code changes have been tested against the Discord API
- I know how to update typings and have done so
- This PR includes breaking changes