### PR TITLE
fix(presenceUpdate): fire when only state/details change on an activity

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -275,11 +275,12 @@ class Activity {
   equals(activity) {
     return (
       this === activity ||
-      (activity && this.name === activity.name &&
-       this.type === activity.type &&
-       this.url === activity.url &&
-       this.state === activity.state &&
-       this.details === activity.details)
+      (activity && 
+        this.name === activity.name &&
+        this.type === activity.type &&
+        this.url === activity.url &&
+        this.state === activity.state &&
+        this.details === activity.details)
     );
   }
 

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -275,7 +275,7 @@ class Activity {
   equals(activity) {
     return (
       this === activity ||
-      (activity && this.name === activity.name && this.type === activity.type && this.url === activity.url)
+      (activity && this.name === activity.name && this.type === activity.type && this.url === activity.url && this.state === activity.state && this.details === activity.details)
     );
   }
 

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -275,7 +275,7 @@ class Activity {
   equals(activity) {
     return (
       this === activity ||
-      (activity && 
+      (activity &&
         this.name === activity.name &&
         this.type === activity.type &&
         this.url === activity.url &&

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -275,7 +275,11 @@ class Activity {
   equals(activity) {
     return (
       this === activity ||
-      (activity && this.name === activity.name && this.type === activity.type && this.url === activity.url && this.state === activity.state && this.details === activity.details)
+      (activity && this.name === activity.name &&
+       this.type === activity.type &&
+       this.url === activity.url &&
+       this.state === activity.state &&
+       this.details === activity.details)
     );
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add support for firing presence update events when the only thing that changes is an activity's state or details.

Fixes https://github.com/discordjs/discord.js/issues/5845

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
