### PR TITLE
fix(Message): editedTimestamp defaulting to 0

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -163,7 +163,7 @@ class Message extends Base {
      * The timestamp the message was last edited at (if applicable)
      * @type {?number}
      */
-    this.editedTimestamp = 'edited_timestamp' in data ? new Date(data.edited_timestamp).getTime() : null;
+    this.editedTimestamp = data.edited_timestamp ? new Date(data.edited_timestamp).getTime() : null;
 
     /**
      * A manager of the reactions belonging to this message
@@ -290,7 +290,7 @@ class Message extends Base {
   patch(data) {
     const clone = this._clone();
 
-    if ('edited_timestamp' in data) this.editedTimestamp = new Date(data.edited_timestamp).getTime();
+    if (data.edited_timestamp !== null) this.editedTimestamp = new Date(data.edited_timestamp).getTime();
     if ('content' in data) this.content = data.content;
     if ('pinned' in data) this.pinned = data.pinned;
     if ('tts' in data) this.tts = data.tts;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -290,7 +290,7 @@ class Message extends Base {
   patch(data) {
     const clone = this._clone();
 
-    if (data.edited_timestamp !== null) this.editedTimestamp = new Date(data.edited_timestamp).getTime();
+    if (data.edited_timestamp) this.editedTimestamp = new Date(data.edited_timestamp).getTime();
     if ('content' in data) this.content = data.content;
     if ('pinned' in data) this.pinned = data.pinned;
     if ('tts' in data) this.tts = data.tts;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since edited_timestamp is always present in the message data from Discord (see https://discord.com/developers/docs/resources/channel#message-object), the editedTimestamp property for messages that have never been edited would be 0. This fixes that so that it's null when it hasn't been edited, and the timestamp for edited messages, just like the data from Discord.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
