### PR TITLE
fix(ApplicationCommand): default option.required fix

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -216,7 +216,7 @@ class ApplicationCommand extends Base {
       name: option.name,
       description: option.description,
       required:
-        option.required ?? (stringType === 'SUB_COMMAND' || stringType === 'SUB_COMMAND_GROUP') ? undefined : false,
+        option.required ?? ((stringType === 'SUB_COMMAND' || stringType === 'SUB_COMMAND_GROUP') ? undefined : false),
       choices: option.choices,
       options: option.options?.map(o => this.transformOption(o, received)),
     };

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -216,7 +216,7 @@ class ApplicationCommand extends Base {
       name: option.name,
       description: option.description,
       required:
-        option.required ?? ((stringType === 'SUB_COMMAND' || stringType === 'SUB_COMMAND_GROUP') ? undefined : false),
+        option.required ?? (stringType === 'SUB_COMMAND' || stringType === 'SUB_COMMAND_GROUP' ? undefined : false),
       choices: option.choices,
       options: option.options?.map(o => this.transformOption(o, received)),
     };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#5838 introduced a bug that made it impossible to set the required option to `true` due to operator precedence, this PR fixes that


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
