### PR TITLE
add optionalDependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,13 @@
     "tslint": "^6.1.3",
     "typescript": "^4.3.2"
   },
+  "optionalDependencies": {
+    "zlib-sync": "^0.1.7",
+    "discord/erlpack": "^0.1.3",
+    "bufferutil": "^4.0.3",
+    "utf-8-validate": "^5.0.5",
+    "@discordjs/voice": "^0.3.1"
+  },
   "engines": {
     "node": ">=14.0.0",
     "npm": ">=7.0.0"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This adds optionalDependencies to the package.json. This allows for easier addition of the optional packages listed in the readme file. 

To install without these optional packages you use: `npm install --no-optional discord.js` *or* `yarn add discord.js --ignore-optional`

To install with the optional packages you would run the command like usual.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
