### PR TITLE
docs: Consistent application name usage

### DIFF
--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -36,19 +36,19 @@ class ClientApplication extends Application {
     this.cover = data.cover_image ?? this.cover ?? null;
 
     /**
-     * The app's RPC origins, if enabled
+     * The application's RPC origins, if enabled
      * @type {string[]}
      */
     this.rpcOrigins = data.rpc_origins ?? this.rpcOrigins ?? [];
 
     /**
-     * If this app's bot requires a code grant when using the OAuth2 flow
+     * If this application's bot requires a code grant when using the OAuth2 flow
      * @type {?boolean}
      */
     this.botRequireCodeGrant = data.bot_require_code_grant ?? this.botRequireCodeGrant ?? null;
 
     /**
-     * If this app's bot is public
+     * If this application's bot is public
      * @type {?boolean}
      */
     this.botPublic = data.bot_public ?? this.botPublic ?? null;

--- a/src/structures/IntegrationApplication.js
+++ b/src/structures/IntegrationApplication.js
@@ -17,13 +17,13 @@ class IntegrationApplication extends Application {
     this.bot = data.bot ? this.client.users.add(data.bot) : this.bot ?? null;
 
     /**
-     * The url of the app's terms of service
+     * The url of the application's terms of service
      * @type {?string}
      */
     this.termsOfServiceURL = data.terms_of_service_url ?? this.termsOfServiceURL ?? null;
 
     /**
-     * The url of the app's privacy policy
+     * The url of the application's privacy policy
      * @type {?string}
      */
     this.privacyPolicyURL = data.privacy_policy_url ?? this.privacyPolicyURL ?? null;
@@ -35,7 +35,7 @@ class IntegrationApplication extends Application {
     this.rpcOrigins = data.rpc_origins ?? this.rpcOrigins ?? [];
 
     /**
-     * The application summary
+     * The application's summary
      * @type {?string}
      */
     this.summary = data.summary ?? this.summary ?? null;

--- a/src/structures/interfaces/Application.js
+++ b/src/structures/interfaces/Application.js
@@ -18,32 +18,32 @@ class Application extends Base {
 
   _patch(data) {
     /**
-     * The ID of the app
+     * The ID of the application
      * @type {Snowflake}
      */
     this.id = data.id;
 
     /**
-     * The name of the app
+     * The name of the application
      * @type {?string}
      */
     this.name = data.name ?? this.name ?? null;
 
     /**
-     * The app's description
+     * The application's description
      * @type {?string}
      */
     this.description = data.description ?? this.description ?? null;
 
     /**
-     * The app's icon hash
+     * The application's icon hash
      * @type {?string}
      */
     this.icon = data.icon ?? this.icon ?? null;
   }
 
   /**
-   * The timestamp the app was created at
+   * The timestamp the application was created at
    * @type {number}
    * @readonly
    */
@@ -52,7 +52,7 @@ class Application extends Base {
   }
 
   /**
-   * The time the app was created at
+   * The time the application was created at
    * @type {Date}
    * @readonly
    */
@@ -89,7 +89,7 @@ class Application extends Base {
    */
 
   /**
-   * Gets the clients rich presence assets.
+   * Gets the application's rich presence assets.
    * @returns {Promise<Array<ApplicationAsset>>}
    */
   fetchAssets() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Hi, small pull request!

I found a lil' typo in the `Application` interface ("Gets the clients rich presence assets.") so I decided to correct it by adding in the apostrophe. But then I noticed that the documentation doesn't use "client" anywhere else on the page, so I renamed it to "application's". Then I decided to change the inconsistent "app" vs. "application" in the `Application` files! Hope that's alright.


**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
