### PR TITLE
docs(ReplyMessageOptions,MessageEditOptions): replaced `embed` with `embeds`

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -646,6 +646,8 @@ class Message extends Base {
   /**
    * Options provided when sending a message as an inline reply.
    * @typedef {BaseMessageOptions} ReplyMessageOptions
+   * @property {MessageEmbed[]|Object[]} [embeds] The embeds for the message 
+   * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details) 
    * @property {boolean} [failIfNotExists=true] Whether to error if the referenced message
    * does not exist (creates a standard message in this case when false)
    */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -646,8 +646,6 @@ class Message extends Base {
   /**
    * Options provided when sending a message as an inline reply.
    * @typedef {BaseMessageOptions} ReplyMessageOptions
-   * @property {MessageEmbed|Object} [embed] An embed for the message
-   * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details)
    * @property {boolean} [failIfNotExists=true] Whether to error if the referenced message
    * does not exist (creates a standard message in this case when false)
    */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -537,7 +537,7 @@ class Message extends Base {
    * Options that can be passed into {@link Message#edit}.
    * @typedef {Object} MessageEditOptions
    * @property {?string} [content] Content to be edited
-   * @property {MessageEmbed|Object} [embed] An embed to be added/edited
+   * @property {MessageEmbed[]|Object[]} [embeds] Embeds to be added/edited
    * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * @property {MessageFlags} [flags] Which flags to set for the message. Only `SUPPRESS_EMBEDS` can be edited.

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -646,8 +646,8 @@ class Message extends Base {
   /**
    * Options provided when sending a message as an inline reply.
    * @typedef {BaseMessageOptions} ReplyMessageOptions
-   * @property {MessageEmbed[]|Object[]} [embeds] The embeds for the message 
-   * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details) 
+   * @property {MessageEmbed[]|Object[]} [embeds] The embeds for the message
+   * (see [here](https://discord.com/developers/docs/resources/channel#embed-object) for more details)
    * @property {boolean} [failIfNotExists=true] Whether to error if the referenced message
    * does not exist (creates a standard message in this case when false)
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Removed `ReplyMessageOptions#embed` to match typings

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.