### PR TITLE
types(MessageReactionResolvable): add string

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3488,7 +3488,8 @@ declare module 'discord.js' {
     | Snowflake
     | `${string}:${Snowflake}`
     | `<:${string}:${Snowflake}>`
-    | `<a:${string}:${Snowflake}>`;
+    | `<a:${string}:${Snowflake}>`
+    | string;
 
   interface MessageReference {
     channelID: Snowflake;


### PR DESCRIPTION
The change from string to Snowflake removed a valid case where string was a correct type (unicode emojis for `MessageReactionResolvable`). This adds the type back.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating