### PR TITLE
refactor(Package): remove `runkitExampleFilename`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "url": "https://github.com/discordjs/discord.js/issues"
   },
   "homepage": "https://github.com/discordjs/discord.js#readme",
-  "runkitExampleFilename": "./docs/examples/ping.js",
   "dependencies": {
     "@discordjs/collection": "^0.1.6",
     "@discordjs/form-data": "^3.0.1",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes the last mention of the `/docs/examples` folder, as it not longer exists.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
