### PR TITLE
docs(VoiceState): channel can be null

### DIFF
--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -93,7 +93,7 @@ class VoiceState extends Base {
 
   /**
    * The channel that the member is connected to
-   * @type {?VoiceChannel|StageChannel}
+   * @type {?(VoiceChannel|StageChannel)}
    * @readonly
    */
   get channel() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The docs does not show that VoiceState#channel can be null
![Docs Image](https://i.imgur.com/fLqRBqm.png)
This should fix the issue


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
