### PR TITLE
fix(Guild): don't patch before instance properties

### DIFF
--- a/src/structures/AnonymousGuild.js
+++ b/src/structures/AnonymousGuild.js
@@ -8,9 +8,9 @@ const { VerificationLevels, NSFWLevels } = require('../util/Constants');
  * @abstract
  */
 class AnonymousGuild extends BaseGuild {
-  constructor(client, data) {
+  constructor(client, data, immediatePatch = true) {
     super(client, data);
-    this._patch(data);
+    if (immediatePatch) this._patch(data);
   }
 
   _patch(data) {

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -41,7 +41,7 @@ const Util = require('../util/Util');
  */
 class Guild extends AnonymousGuild {
   constructor(client, data) {
-    super(client, data);
+    super(client, data, false);
 
     /**
      * A manager of the application commands belonging to this guild

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -188,6 +188,7 @@ declare module 'discord.js' {
   }
 
   export abstract class AnonymousGuild extends BaseGuild {
+    constructor(client: Client, data: unknown, immediatPatch?: boolean);
     public banner: string | null;
     public description: string | null;
     public nsfwLevel: NSFWLevel;
@@ -294,6 +295,7 @@ declare module 'discord.js' {
   }
 
   export abstract class BaseGuild extends Base {
+    constructor(client: Client, data: unknown);
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
     public features: GuildFeatures[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -188,7 +188,7 @@ declare module 'discord.js' {
   }
 
   export abstract class AnonymousGuild extends BaseGuild {
-    constructor(client: Client, data: unknown, immediatPatch?: boolean);
+    constructor(client: Client, data: unknown, immediatePatch?: boolean);
     public banner: string | null;
     public description: string | null;
     public nsfwLevel: NSFWLevel;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When `_patch` gets called by `super()` the instance properties created after the super call don't exist yet...causing hard crashes.

fixes #5884

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
