### PR TITLE
fix(Message): flags not being parsed on some edits

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -131,8 +131,9 @@ class MessageManager extends BaseManager {
       .resolveFiles();
     const d = await this.client.api.channels[this.channel.id].messages[messageID].patch({ data, files });
 
-    if (this.cache.has(messageID)) {
-      const clone = this.cache.get(messageID)._clone();
+    const existing = this.cache.get(messageID);
+    if (existing) {
+      const clone = existing._clone();
       clone._patch(d);
       return clone;
     }

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -120,16 +120,19 @@ class MessageManager extends BaseManager {
    * @returns {Promise<Message>}
    */
   async edit(message, options) {
-    message = this.resolveID(message);
-    if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
+    const messageID = this.resolveID(message);
+    if (!messageID) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
-    const { data, files } = await (options instanceof APIMessage ? options : APIMessage.create(this, options))
+    const { data, files } = await (options instanceof APIMessage
+      ? options
+      : APIMessage.create(message instanceof Message ? message : this, options)
+    )
       .resolveData()
       .resolveFiles();
-    const d = await this.client.api.channels[this.channel.id].messages[message].patch({ data, files });
+    const d = await this.client.api.channels[this.channel.id].messages[messageID].patch({ data, files });
 
-    if (this.cache.has(message)) {
-      const clone = this.cache.get(message)._clone();
+    if (this.cache.has(messageID)) {
+      const clone = this.cache.get(messageID)._clone();
       clone._patch(d);
       return clone;
     }

--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -75,6 +75,16 @@ class APIMessage {
   }
 
   /**
+   * Wether or not the target is a message manager
+   * @type {boolean}
+   * @readonly
+   */
+  get isMessageManager() {
+    const MessageManager = require('../managers/MessageManager');
+    return this.target instanceof MessageManager;
+  }
+
+  /**
    * Whether or not the target is an interaction
    * @type {boolean}
    * @readonly
@@ -156,9 +166,9 @@ class APIMessage {
     }
 
     let flags;
-    if (this.isMessage) {
+    if (this.isMessage || this.isMessageManager) {
       // eslint-disable-next-line eqeqeq
-      flags = this.options.flags != null ? new MessageFlags(this.options.flags).bitfield : this.target.flags.bitfield;
+      flags = this.options.flags != null ? new MessageFlags(this.options.flags).bitfield : this.target.flags?.bitfield;
     } else if (isInteraction && this.options.ephemeral) {
       flags = MessageFlags.FLAGS.EPHEMERAL;
     }
@@ -300,5 +310,6 @@ module.exports = APIMessage;
 
 /**
  * A target for a message.
- * @typedef {TextChannel|DMChannel|User|GuildMember|Webhook|WebhookClient|Interaction|InteractionWebhook} MessageTarget
+ * @typedef {TextChannel|DMChannel|User|GuildMember|Webhook|WebhookClient|Interaction|InteractionWebhook|
+ * Message|MessageManager} MessageTarget
  */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -559,7 +559,7 @@ class Message extends Base {
    *   .catch(console.error);
    */
   edit(options) {
-    return this.channel.messages.edit(this.id, options);
+    return this.channel.messages.edit(this, options);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -204,6 +204,7 @@ declare module 'discord.js' {
     public readonly isUser: boolean;
     public readonly isWebhook: boolean;
     public readonly isMessage: boolean;
+    public readonly isMessageManager: boolean;
     public readonly isInteraction: boolean;
     public files: unknown[] | null;
     public options: MessageOptions | WebhookMessageOptions;
@@ -3556,7 +3557,9 @@ declare module 'discord.js' {
     | User
     | GuildMember
     | Webhook
-    | WebhookClient;
+    | WebhookClient
+    | Message
+    | MessageManager;
 
   type MessageType =
     | 'DEFAULT'


### PR DESCRIPTION
One of those rabbit hole bugs that made me change a few things.

To start with, `Message#suppressEmbeds` was broken. This is because:

1. Internally that method calls `Message#edit({ flags: 4 })`.
2. That method then calls `MessageManager#edit(this.id, options)`
3. `MessageManager#edit` constructs an `APIMessage` with `this` as the target.
4. `APIMessage#resolveData` only resolves `flags` if the `APIMessage#target` is a `Message` or `Interaction`.
https://github.com/discordjs/discord.js/blob/master/src/structures/APIMessage.js#L159-L164

So, I decided that:

1. `Message#edit` should pass `this` rather than `this.id`.
2. `MessageManager#edit` should pass the whole message to `APIMessage#target` if provided with one.
3. `APIMessage` should support `MessageManager` as a target also, for when making cacheless edits by ID.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
