### PR TITLE
feat(Interactions): improve error handling for ephemeral responses

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -115,6 +115,7 @@ const Messages = {
     "or from a guild's application command manager.",
 
   INTERACTION_ALREADY_REPLIED: 'This interaction has already been deferred or replied to.',
+  INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be fetched or deleted.',
 };
 
 for (const [name, message] of Object.entries(Messages)) register(name, message);

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -115,6 +115,7 @@ const Messages = {
     "or from a guild's application command manager.",
 
   INTERACTION_ALREADY_REPLIED: 'This interaction has already been deferred or replied to.',
+  INTERACTION_NOT_REPLIED: 'This interaction has not been deferred or replied to.',
   INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be fetched or deleted.',
 };
 

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -59,6 +59,12 @@ class CommandInteraction extends Interaction {
     this.replied = false;
 
     /**
+     * Whether the reply to this interaction is ephemeral
+     * @type {?boolean}
+     */
+    this.ephemeral = null;
+
+    /**
      * An associated interaction webhook, can be used to further interact with this interaction
      * @type {InteractionWebhook}
      */

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -39,6 +39,12 @@ class MessageComponentInteraction extends Interaction {
     this.deferred = false;
 
     /**
+     * Whether the reply to this interaction is ephemeral
+     * @type {?boolean}
+     */
+    this.ephemeral = null;
+
+    /**
      * Whether this interaction has already been replied to
      * @type {boolean}
      */

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -116,7 +116,7 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   editReply(options) {
-    if (!this.deferred && !this.replied) throw new Error('INTERACTION_NO_RESPONSE');
+    if (!this.deferred && !this.replied) throw new Error('INTERACTION_NOT_REPLIED');
     return this.webhook.editMessage('@original', options);
   }
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -116,6 +116,7 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   editReply(options) {
+    if (!this.deferred && !this.replied) throw new Error('INTERACTION_NO_RESPONSE');
     return this.webhook.editMessage('@original', options);
   }
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -40,6 +40,7 @@ class InteractionResponses {
    */
   async defer({ ephemeral } = {}) {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
+    this.ephemeral = ephemeral ?? false;
     await this.client.api.interactions(this.id, this.token).callback.post({
       data: {
         type: InteractionResponseTypes.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
@@ -70,6 +71,7 @@ class InteractionResponses {
    */
   async reply(options) {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
+    this.ephemeral = options.ephemeral ?? false;
 
     let apiMessage;
     if (options instanceof APIMessage) apiMessage = options;
@@ -98,6 +100,7 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   fetchReply() {
+    if (this.ephemeral) throw new Error('INTERACTION_EPHEMERAL_REPLIED');
     return this.webhook.fetchMessage('@original');
   }
 
@@ -127,6 +130,7 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   async deleteReply() {
+    if (this.ephemeral) throw new Error('INTERACTION_EPHEMERAL_REPLIED');
     await this.webhook.deleteMessage('@original');
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -508,6 +508,7 @@ declare module 'discord.js' {
     public commandID: Snowflake;
     public commandName: string;
     public deferred: boolean;
+    public ephemeral: boolean | null;
     public options: Collection<string, CommandInteractionOption>;
     public replied: boolean;
     public webhook: InteractionWebhook;
@@ -1367,6 +1368,7 @@ declare module 'discord.js' {
     public componentType: MessageComponentType;
     public customID: string;
     public deferred: boolean;
+    public ephemeral: boolean | null;
     public message: Message | RawMessage;
     public replied: boolean;
     public webhook: InteractionWebhook;


### PR DESCRIPTION
Replaces and closes #5665 as that PR was abandoned. This applies the suggestions and also adds the error handling to the `deleteReply()` method.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)