### PR TITLE
docs(AnonymousGuild): add missing extends tag

### DIFF
--- a/src/structures/AnonymousGuild.js
+++ b/src/structures/AnonymousGuild.js
@@ -5,6 +5,7 @@ const { VerificationLevels, NSFWLevels } = require('../util/Constants');
 
 /**
  * Bundles common attributes and methods between {@link Guild} and {@link InviteGuild}
+ * @extends {BaseGuild}
  * @abstract
  */
 class AnonymousGuild extends BaseGuild {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Master docs currently does not show properties Guild#name nor Guild#id (and possibly others). This should fix it :)


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
