### PR TITLE
fix(InteractionResponses): set replied status on editReply

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -113,6 +113,8 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   editReply(options) {
+    this.replied = true;
+    
     return this.webhook.editMessage('@original', options);
   }
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -112,13 +112,12 @@ class InteractionResponses {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  editReply(options) {
-    return this.webhook.editMessage('@original', options)
-      .then((message) => {
-        this.replied = true;
-        
-        return message;
-      });
+  async editReply(options) {
+    const message = await this.webhook.editMessage('@original', options);
+    
+    this.replied = true;
+      
+    return message;
   }
 
   /**

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -114,9 +114,7 @@ class InteractionResponses {
    */
   async editReply(options) {
     const message = await this.webhook.editMessage('@original', options);
-    
     this.replied = true;
-      
     return message;
   }
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -114,7 +114,7 @@ class InteractionResponses {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  editReply(options) {
+  async editReply(options) {
     if (!this.deferred && !this.replied) throw new Error('INTERACTION_NOT_REPLIED');
     const message = await this.webhook.editMessage('@original', options);
     this.replied = true;

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -113,9 +113,12 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   editReply(options) {
-    this.replied = true;
-    
-    return this.webhook.editMessage('@original', options);
+    return this.webhook.editMessage('@original', options)
+      .then((message) => {
+        this.replied = true;
+        
+        return message;
+      });
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When editing a deferred response (editReply), we are not able to check whether we have replied to this interaction.

**Status and versioning classification:**

- Code changes have been tested against the Discord API
- I know how to update typings and have done so, or **typings don't need updating**
