### PR TITLE
Type WebhookMessageOptions.avatarURL as string | null | undefined

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3971,7 +3971,7 @@ declare module 'discord.js' {
 
   interface WebhookMessageOptions extends Omit<MessageOptions, 'reply'> {
     username?: string;
-    avatarURL?: string;
+    avatarURL?: string | null;
   }
 
   type WebhookType = keyof typeof WebhookTypes;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Without this change you would not be able to directly pass `client.application?.iconURL()` into `WebhookMessageOptions.avatarURL`. Observe the following error:
```
Type 'string | null | undefined' is not assignable to type 'string | undefined'.
  Type 'null' is not assignable to type 'string | undefined'.
```

**Status and versioning classification:**
- This is only changes typings, it does not cause any breaking changes