### PR TITLE
refactor: remove exported shortcuts to util methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const Util = require('./util/Util');
-
 module.exports = {
   // "Root" classes (starting points)
   BaseClient: require('./client/BaseClient'),
@@ -29,7 +27,7 @@ module.exports = {
   Structures: require('./util/Structures'),
   SystemChannelFlags: require('./util/SystemChannelFlags'),
   UserFlags: require('./util/UserFlags'),
-  Util: Util,
+  Util: require('./util/Util'),
   version: require('../package.json').version,
 
   // Managers
@@ -50,14 +48,6 @@ module.exports = {
   PresenceManager: require('./managers/PresenceManager'),
   RoleManager: require('./managers/RoleManager'),
   UserManager: require('./managers/UserManager'),
-
-  // Shortcuts to Util methods
-  discordSort: Util.discordSort,
-  escapeMarkdown: Util.escapeMarkdown,
-  fetchRecommendedShards: Util.fetchRecommendedShards,
-  resolveColor: Util.resolveColor,
-  verifyString: Util.verifyString,
-  splitMessage: Util.splitMessage,
 
   // Structures
   Application: require('./structures/interfaces/Application'),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This removes the additional exports for some of the util methods because the methods that get exported there seem rather arbitrary and you can access them from the Util class anyway. They were also not added to the typings, meaning that TypeScript users were never able to import them to begin with.

**Status and versioning classification:**

- Typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)