### PR TITLE
feat(MessageMentions): add repliedUser

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -180,7 +180,14 @@ class Message extends Base {
      * All valid mentions that the message contains
      * @type {MessageMentions}
      */
-    this.mentions = new Mentions(this, data.mentions, data.mention_roles, data.mention_everyone, data.mention_channels);
+    this.mentions = new Mentions(
+      this,
+      data.mentions,
+      data.mention_roles,
+      data.mention_everyone,
+      data.mention_channels,
+      data.referenced_message?.author,
+    );
 
     /**
      * ID of the webhook that sent the message, if applicable
@@ -314,6 +321,7 @@ class Message extends Base {
       'mention_roles' in data ? data.mention_roles : this.mentions.roles,
       'mention_everyone' in data ? data.mention_everyone : this.mentions.everyone,
       'mention_channels' in data ? data.mention_channels : this.mentions.crosspostedChannels,
+      data.referenced_message?.author,
     );
 
     this.flags = new MessageFlags('flags' in data ? data.flags : 0).freeze();

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -321,7 +321,7 @@ class Message extends Base {
       'mention_roles' in data ? data.mention_roles : this.mentions.roles,
       'mention_everyone' in data ? data.mention_everyone : this.mentions.everyone,
       'mention_channels' in data ? data.mention_channels : this.mentions.crosspostedChannels,
-      data.referenced_message?.author,
+      'referenced_message' in data ? data.referenced_message.author : this.mentions.repliedUser,
     );
 
     this.flags = new MessageFlags('flags' in data ? data.flags : 0).freeze();

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -8,7 +8,7 @@ const Util = require('../util/Util');
  * Keeps track of mentions in a {@link Message}.
  */
 class MessageMentions {
-  constructor(message, users, roles, everyone, crosspostedChannels) {
+  constructor(message, users, roles, everyone, crosspostedChannels, repliedUser) {
     /**
      * The client the message is from
      * @type {Client}
@@ -125,6 +125,12 @@ class MessageMentions {
     } else {
       this.crosspostedChannels = new Collection();
     }
+
+    /**
+     * The author of the message that this message is a reply to
+     * @type {?User}
+     */
+    this.repliedUser = repliedUser ? this.client.users.add(repliedUser) : this.repliedUser ?? null;
   }
 
   /**

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -130,7 +130,7 @@ class MessageMentions {
      * The author of the message that this message is a reply to
      * @type {?User}
      */
-    this.repliedUser = repliedUser ? this.client.users.add(repliedUser) : this.repliedUser ?? null;
+    this.repliedUser = repliedUser ? this.client.users.add(repliedUser) : null;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -140,6 +140,7 @@ declare module 'discord.js' {
     APIPartialEmoji as RawEmoji,
     APIRole as RawRole,
     Snowflake as APISnowflake,
+    APIUser,
     ApplicationCommandOptionType as ApplicationCommandOptionTypes,
     ApplicationCommandPermissionType as ApplicationCommandPermissionTypes,
   } from 'discord-api-types/v8';
@@ -1467,9 +1468,10 @@ declare module 'discord.js' {
   export class MessageMentions {
     constructor(
       message: Message,
-      users: unknown[] | Collection<Snowflake, User>,
+      users: APIUser[] | Collection<Snowflake, User>,
       roles: Snowflake[] | Collection<Snowflake, Role>,
       everyone: boolean,
+      repliedUser?: APIUser,
     );
     private _channels: Collection<Snowflake, Channel> | null;
     private readonly _content: string;
@@ -1481,6 +1483,7 @@ declare module 'discord.js' {
     public readonly guild: Guild;
     public has(data: UserResolvable | RoleResolvable | ChannelResolvable, options?: MessageMentionsHasOptions): boolean;
     public readonly members: Collection<Snowflake, GuildMember> | null;
+    public repliedUser: User | null;
     public roles: Collection<Snowflake, Role>;
     public users: Collection<Snowflake, User>;
     public crosspostedChannels: Collection<Snowflake, CrosspostedChannel>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1471,7 +1471,7 @@ declare module 'discord.js' {
       users: APIUser[] | Collection<Snowflake, User>,
       roles: Snowflake[] | Collection<Snowflake, Role>,
       everyone: boolean,
-      repliedUser?: APIUser,
+      repliedUser?: APIUser | User,
     );
     private _channels: Collection<Snowflake, Channel> | null;
     private readonly _content: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds a `repliedUser` property to the message mentions so that users can more quickly see which user was replied to.

**Status and versioning classification:**

- Code changes have been tested against the Discord API
- I know how to update typings and have done so
- This PR changes the library's interface (methods or parameters added)