### PR TITLE
feat(InteractionCreate): move to an Action handler

### DIFF
--- a/src/client/actions/ActionsManager.js
+++ b/src/client/actions/ActionsManager.js
@@ -17,6 +17,7 @@ class ActionsManager {
     this.register(require('./ChannelUpdate'));
     this.register(require('./GuildDelete'));
     this.register(require('./GuildUpdate'));
+    this.register(require('./InteractionCreate'));
     this.register(require('./InviteCreate'));
     this.register(require('./InviteDelete'));
     this.register(require('./GuildMemberRemove'));

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -7,6 +7,8 @@ const Structures = require('../../util/Structures');
 class InteractionCreateAction extends Action {
   handle(data) {
     const client = this.client;
+
+    // Resolve and cache partial channels for Interaction#channel getter
     this.getChannel(data);
 
     let InteractionType;

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const Action = require('./Action');
+const { Events, InteractionTypes, MessageComponentTypes } = require('../../../util/Constants');
+const Structures = require('../../../util/Structures');
+
+class InteractionCreateAction extends Action {
+  handle(data) {
+    const client = this.client;
+    this.getChannel(data);
+
+    let InteractionType;
+    switch (data.type) {
+      case InteractionTypes.APPLICATION_COMMAND:
+        InteractionType = Structures.get('CommandInteraction');
+        break;
+      case InteractionTypes.MESSAGE_COMPONENT:
+        switch (data.data.component_type) {
+          case MessageComponentTypes.BUTTON:
+            InteractionType = Structures.get('ButtonInteraction');
+            break;
+          default:
+            client.emit(
+              Events.DEBUG,
+              `[INTERACTION] Received component interaction with unknown type: ${data.data.component_type}`,
+            );
+            return;
+        }
+        break;
+      default:
+        client.emit(Events.DEBUG, `[INTERACTION] Received interaction with unknown type: ${data.type}`);
+        return;
+    }
+
+    /**
+     * Emitted when an interaction is created.
+     * @event Client#interaction
+     * @param {Interaction} interaction The interaction which was created
+     */
+    client.emit(Events.INTERACTION_CREATE, new InteractionType(client, data));
+  }
+}
+
+module.exports = InteractionCreateAction;

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const Action = require('./Action');
-const { Events, InteractionTypes, MessageComponentTypes } = require('../../../util/Constants');
-const Structures = require('../../../util/Structures');
+const { Events, InteractionTypes, MessageComponentTypes } = require('../../util/Constants');
+const Structures = require('../../util/Structures');
 
 class InteractionCreateAction extends Action {
   handle(data) {

--- a/src/client/websocket/handlers/INTERACTION_CREATE.js
+++ b/src/client/websocket/handlers/INTERACTION_CREATE.js
@@ -1,36 +1,5 @@
 'use strict';
 
-const { Events, InteractionTypes, MessageComponentTypes } = require('../../../util/Constants');
-const Structures = require('../../../util/Structures');
-
-module.exports = (client, { d: data }) => {
-  let InteractionType;
-  switch (data.type) {
-    case InteractionTypes.APPLICATION_COMMAND:
-      InteractionType = Structures.get('CommandInteraction');
-      break;
-    case InteractionTypes.MESSAGE_COMPONENT:
-      switch (data.data.component_type) {
-        case MessageComponentTypes.BUTTON:
-          InteractionType = Structures.get('ButtonInteraction');
-          break;
-        default:
-          client.emit(
-            Events.DEBUG,
-            `[INTERACTION] Received component interaction with unknown type: ${data.data.component_type}`,
-          );
-          return;
-      }
-      break;
-    default:
-      client.emit(Events.DEBUG, `[INTERACTION] Received interaction with unknown type: ${data.type}`);
-      return;
-  }
-
-  /**
-   * Emitted when an interaction is created.
-   * @event Client#interaction
-   * @param {Interaction} interaction The interaction which was created
-   */
-  client.emit(Events.INTERACTION_CREATE, new InteractionType(client, data));
+module.exports = (client, packet) => {
+  client.actions.InteractionCreate.handle(packet.d);
 };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -503,7 +503,7 @@ declare module 'discord.js' {
 
   export class CommandInteraction extends Interaction {
     public readonly command: ApplicationCommand | null;
-    public channel: TextChannel | DMChannel | NewsChannel;
+    public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | null;
     public channelID: Snowflake;
     public commandID: Snowflake;
     public commandName: string;
@@ -1364,6 +1364,7 @@ declare module 'discord.js' {
   }
 
   export class MessageComponentInteraction extends Interaction {
+    public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | null;
     public componentType: MessageComponentType;
     public customID: string;
     public deferred: boolean;


### PR DESCRIPTION
Ignoring the much larger issues about Websocket and Action handlers still being separate, this moves the INTERACTION_CREATE logic over to an Action handler.

This allows `Action#getChannel` to be used for caching a partial DMChannel, preventing `Interaction#channel` from returning null with the CHANNEL partial enabled

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating