### PR TITLE
feat(MessageBuilder): refactor and expand on APIMessage

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -115,6 +115,9 @@ const Messages = {
     "or from a guild's application command manager.",
 
   INTERACTION_ALREADY_REPLIED: 'This interaction has already been deferred or replied to.',
+
+  TARGET_NOT_WEBHOOK: 'Cannot set username/avatarURL property if target is not a Webhook',
+  TARGET_NOT_INTERACTION: 'Cannot set the ephemeral flag if target is not an Interaction',
 };
 
 for (const [name, message] of Object.entries(Messages)) register(name, message);

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ module.exports = {
   ApplicationCommand: require('./structures/ApplicationCommand'),
   Base: require('./structures/Base'),
   Activity: require('./structures/Presence').Activity,
-  APIMessage: require('./structures/APIMessage'),
+  MessageBuilder: require('./structures/MessageBuilder'),
   BaseGuild: require('./structures/BaseGuild'),
   BaseGuildEmoji: require('./structures/BaseGuildEmoji'),
   BaseGuildVoiceChannel: require('./structures/BaseGuildVoiceChannel'),

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -2,8 +2,8 @@
 
 const BaseManager = require('./BaseManager');
 const { TypeError } = require('../errors');
-const APIMessage = require('../structures/APIMessage');
 const Message = require('../structures/Message');
+const MessageBuilder = require('../structures/MessageBuilder');
 const Collection = require('../util/Collection');
 const LimitedCollection = require('../util/LimitedCollection');
 
@@ -116,14 +116,14 @@ class MessageManager extends BaseManager {
   /**
    * Edits a message, even if it's not cached.
    * @param {MessageResolvable} message The message to edit
-   * @param {MessageEditOptions|APIMessage} [options] The options to provide
+   * @param {MessageEditOptions|MessageBuilder} [options] The options to provide
    * @returns {Promise<Message>}
    */
   async edit(message, options) {
     message = this.resolveID(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
-    const { data, files } = await (options instanceof APIMessage ? options : APIMessage.create(this, options))
+    const { data, files } = await (options instanceof MessageBuilder ? options : MessageBuilder.create(this, options))
       .resolveData()
       .resolveFiles();
     const d = await this.client.api.channels[this.channel.id].messages[message].patch({ data, files });

--- a/src/structures/InteractionWebhook.js
+++ b/src/structures/InteractionWebhook.js
@@ -28,7 +28,7 @@ class InteractionWebhook {
   /* eslint-disable no-empty-function, valid-jsdoc */
   /**
    * Sends a message with this webhook.
-   * @param {string|APIMessage|InteractionReplyOptions} options The content for the reply
+   * @param {string|MessageBuilder|InteractionReplyOptions} options The content for the reply
    * @returns {Promise<Message|Object>}
    */
   send() {}

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const APIMessage = require('./APIMessage');
 const Base = require('./Base');
 const BaseMessageComponent = require('./BaseMessageComponent');
 const ClientApplication = require('./ClientApplication');
 const MessageAttachment = require('./MessageAttachment');
+const MessageBuilder = require('./MessageBuilder');
 const MessageComponentInteractionCollector = require('./MessageComponentInteractionCollector');
 const Embed = require('./MessageEmbed');
 const Mentions = require('./MessageMentions');
@@ -550,7 +550,7 @@ class Message extends Base {
 
   /**
    * Edits the content of the message.
-   * @param {string|APIMessage|MessageEditOptions} options The options to provide
+   * @param {string|MessageBuilder|MessageEditOptions} options The options to provide
    * @returns {Promise<Message>}
    * @example
    * // Update the content of a message
@@ -652,7 +652,7 @@ class Message extends Base {
 
   /**
    * Send an inline reply to this message.
-   * @param {string|APIMessage|ReplyMessageOptions} options The options to provide
+   * @param {string|MessageBuilder|ReplyMessageOptions} options The options to provide
    * @returns {Promise<Message|Message[]>}
    * @example
    * // Reply to a message
@@ -663,10 +663,10 @@ class Message extends Base {
   reply(options) {
     let data;
 
-    if (options instanceof APIMessage) {
+    if (options instanceof MessageBuilder) {
       data = options;
     } else {
-      data = APIMessage.create(this, options, {
+      data = MessageBuilder.create(this, options, {
         reply: {
           messageReference: this,
           failIfNotExists: options?.failIfNotExists ?? true,

--- a/src/structures/MessageBuilder.js
+++ b/src/structures/MessageBuilder.js
@@ -237,9 +237,10 @@ class MessageBuilder {
     return apiMessages;
   }
 
+  // eslint-disable-next-line valid-jsdoc
   /**
    * Add components to this message
-   * @param {MessageActionRow[]|MessageActionRowOptions[]|(MessageActionRowComponentResolvable[])[]} components
+   * @param {MessageActionRow|MessageActionRowOptions|MessageActionRowComponentResolvable[][]} components
    * Action rows containing interactive components for the message (buttons, select menus)
    * @returns {MessageBuilder}
    */
@@ -383,11 +384,12 @@ class MessageBuilder {
     return this;
   }
 
+  // eslint-disable-next-line valid-jsdoc
   /**
    * Removes, replaces and inserts components for this message
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of components to remove
-   * @param {MessageActionRow[]|MessageActionRowOptions[]|(MessageActionRowComponentResolvable[])[]} components
+   * @param {MessageActionRow[]|MessageActionRowOptions[]|MessageActionRowComponentResolvable[][]} components
    * Action rows containing interactive components for the message (buttons, select menus)
    * @returns {MessageBuilder}
    */

--- a/src/structures/MessageBuilder.js
+++ b/src/structures/MessageBuilder.js
@@ -14,9 +14,9 @@ const Util = require('../util/Util');
 class MessageBuilder {
   /**
    * @param {MessageTarget} target - The target for this message to be sent to
-   * @param {MessageOptions|WebhookMessageOptions} options - Options passed in from send
+   * @param {MessageOptions|WebhookMessageOptions} [options={}] - Options passed in from send
    */
-  constructor(target, options) {
+  constructor(target, options = {}) {
     /**
      * The target for this message to be sent to
      * @type {MessageTarget}
@@ -90,7 +90,9 @@ class MessageBuilder {
    * @returns {?(string|string[])}
    */
   makeContent() {
-    let { content } = this.setContent(this.options.content);
+    let {
+      options: { content },
+    } = this.setContent(this.options.content);
     if (typeof content !== 'string') return content;
 
     const isSplit = typeof this.options.split !== 'undefined' && this.options.split !== false;
@@ -127,7 +129,9 @@ class MessageBuilder {
     const content = this.makeContent();
     const tts = Boolean(this.options.tts);
 
-    const { nonce } = this.setNonce(this.options.nonce);
+    const {
+      options: { nonce },
+    } = this.setNonce(this.options.nonce);
 
     const components = this.options.components?.map(c =>
       BaseMessageComponent.create(
@@ -240,7 +244,7 @@ class MessageBuilder {
    * @returns {MessageBuilder}
    */
   addComponents(components) {
-    this.options.components = (this.options.components ?? []).push(...components);
+    this.options.components = [...(this.options.components ?? []), ...components];
     return this;
   }
 
@@ -250,7 +254,7 @@ class MessageBuilder {
    * @returns {MessageBuilder}
    */
   addEmbeds(embeds) {
-    this.options.embeds = (this.options.embeds ?? []).push(...embeds);
+    this.options.embeds = [...(this.options.embeds ?? []), ...embeds];
     return this;
   }
 
@@ -260,7 +264,7 @@ class MessageBuilder {
    * @returns {MessageBuilder}
    */
   addFiles(files) {
-    this.options.files = (this.options.files ?? []).push(...files);
+    this.options.files = [...(this.options.files ?? []), ...files];
     return this;
   }
 

--- a/src/structures/MessageBuilder.js
+++ b/src/structures/MessageBuilder.js
@@ -11,7 +11,7 @@ const Util = require('../util/Util');
 /**
  * Represents a message to be sent to the API.
  */
-class APIMessage {
+class MessageBuilder {
   /**
    * @param {MessageTarget} target - The target for this message to be sent to
    * @param {MessageOptions|WebhookMessageOptions} options - Options passed in from send
@@ -123,7 +123,7 @@ class APIMessage {
 
   /**
    * Resolves data.
-   * @returns {APIMessage}
+   * @returns {MessageBuilder}
    */
   resolveData() {
     if (this.data) return this;
@@ -206,7 +206,7 @@ class APIMessage {
 
   /**
    * Resolves files.
-   * @returns {Promise<APIMessage>}
+   * @returns {Promise<MessageBuilder>}
    */
   async resolveFiles() {
     if (this.files) return this;
@@ -216,8 +216,8 @@ class APIMessage {
   }
 
   /**
-   * Converts this APIMessage into an array of APIMessages for each split content
-   * @returns {APIMessage[]}
+   * Converts this MessageBuilder into an array of MessageBuilders for each split content
+   * @returns {MessageBuilder[]}
    */
   split() {
     if (!this.data) this.resolveData();
@@ -238,7 +238,7 @@ class APIMessage {
         opt = { content: this.data.content[i], tts: this.data.tts, allowedMentions: this.options.allowedMentions };
       }
 
-      const apiMessage = new APIMessage(this.target, opt);
+      const apiMessage = new MessageBuilder(this.target, opt);
       apiMessage.data = data;
       apiMessages.push(apiMessage);
     }
@@ -282,7 +282,7 @@ class APIMessage {
   }
 
   /**
-   * Creates an `APIMessage` from user-level arguments.
+   * Creates a `MessageBuilder` from user-level arguments.
    * @param {MessageTarget} target Target to send to
    * @param {string|MessageOptions|WebhookMessageOptions} options Options or content to use
    * @param {MessageOptions|WebhookMessageOptions} [extra={}] - Extra options to add onto specified options
@@ -296,7 +296,7 @@ class APIMessage {
   }
 }
 
-module.exports = APIMessage;
+module.exports = MessageBuilder;
 
 /**
  * A target for a message.

--- a/src/structures/MessageBuilder.js
+++ b/src/structures/MessageBuilder.js
@@ -404,7 +404,7 @@ class MessageBuilder {
    * Removes, replaces and inserts embeds for this message (max 10).
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of embeds to remove
-   * @param  {MessageEmbed[]|MessageEmbedOptions[]} embeds The replacing embed objects
+   * @param {MessageEmbed[]|MessageEmbedOptions[]} embeds The replacing embed objects
    * @returns {MessageBuilder}
    */
   spliceEmbeds(index, deleteCount, embeds) {

--- a/src/structures/MessageBuilder.js
+++ b/src/structures/MessageBuilder.js
@@ -247,6 +247,156 @@ class MessageBuilder {
   }
 
   /**
+   * Add components to this message
+   * @param {MessageActionRow[]|MessageActionRowOptions[]|(MessageActionRowComponentResolvable[])[]} components
+   * Action rows containing interactive components for the message (buttons, select menus)
+   * @returns {MessageBuilder}
+   */
+  addComponents(components) {
+    this.options.components = (this.options.components ?? []).push(...components);
+    return this;
+  }
+
+  /**
+   * Add embeds to this message (max 10).
+   * @param {MessageEmbed[]|MessageEmbedOptions[]} embeds The embeds for the message
+   * @returns {MessageBuilder}
+   */
+  addEmbeds(embeds) {
+    this.options.embeds = (this.options.embeds ?? []).push(...embeds);
+    return this;
+  }
+
+  /**
+   * Adds file attachments to this message
+   * @param {FileOptions[]|BufferResolvable[]|MessageAttachment[]} files Files to send with the message
+   * @returns {MessageBuilder}
+   */
+  addFiles(files) {
+    this.options.files = (this.options.files ?? []).push(...files);
+    return this;
+  }
+
+  /**
+   * Set the mentions that should be parsed for this message
+   * @param {MessageMentionOptions} options Which mentions should be parsed from the message content
+   * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
+   * @returns {MessageBuilder}
+   */
+  setAllowedMentions(options) {
+    this.options.allowedMentions = options;
+    return this;
+  }
+
+  /**
+   * For webhooks, set the avatar override for this message
+   * @param {string} avatar The avatar URL to be used
+   * @returns {MessageBuilder}
+   */
+  setAvatarURL(avatar) {
+    this.options.avatarURL = avatar;
+    return this;
+  }
+
+  /**
+   * Set this message to be wrapped in a codeblock, with optional language formatting
+   * @param {string|boolean} code Language for optional codeblock formatting to apply
+   * @returns {MessageBuilder}
+   */
+  setCode(code) {
+    this.options.code = code;
+    return this;
+  }
+
+  /**
+   * Set the content for this message
+   * @param {string} content The content for the message
+   * @returns {MessageBuilder}
+   */
+  setContent(content) {
+    this.options.content = content;
+    return this;
+  }
+
+  /**
+   * Set this message to be a reply to another message
+   * @param {ReplyOptions} options The options for replying to a message
+   * @returns {MessageBuilder}
+   */
+  setReply(options) {
+    this.options.reply = options;
+    return this;
+  }
+
+  /**
+   * Sets whether or not the message should be split into multiple messages if
+   * it exceeds the character limit. If an object is provided, these are the options for splitting the message
+   * @param {boolean|SplitOptions} options Boolean, or ptions to split the message by
+   * @returns {MessageBuilder}
+   */
+  setSplitOptions(options) {
+    this.options.split = options;
+    return this;
+  }
+
+  /**
+   * Sets whether or not the message should be spoken aloud
+   * @param {boolean} tts Whether or not the message should be spoken aloud
+   * @returns {MessageBuilder}
+   */
+  setTTS(tts) {
+    this.options.tts = tts;
+    return this;
+  }
+
+  /**
+   * For webhooks, set the username override for this message
+   * @param {string} username The username to be used
+   * @returns {MessageBuilder}
+   */
+  setUsername(username) {
+    this.options.username = username;
+    return this;
+  }
+
+  /**
+   * Removes, replaces and inserts components for this message
+   * @param {number} index The index to start at
+   * @param {number} deleteCount The number of components to remove
+   * @param {MessageActionRow[]|MessageActionRowOptions[]|(MessageActionRowComponentResolvable[])[]} components
+   * Action rows containing interactive components for the message (buttons, select menus)
+   * @returns {MessageBuilder}
+   */
+  spliceComponents(index, deleteCount, components) {
+    this.options.components?.splice(index, deleteCount, ...components);
+    return this;
+  }
+
+  /**
+   * Removes, replaces and inserts embeds for this message (max 10).
+   * @param {number} index The index to start at
+   * @param {number} deleteCount The number of embeds to remove
+   * @param  {MessageEmbed[]|MessageEmbedOptions[]} embeds The replacing embed objects
+   * @returns {MessageBuilder}
+   */
+  spliceEmbeds(index, deleteCount, embeds) {
+    this.options.embeds?.splice(index, deleteCount, ...embeds);
+    return this;
+  }
+
+  /**
+   * Remove, replaces and inserts file attachments for this message.
+   * @param {number} index The index to start at
+   * @param {number} deleteCount The number of files to remove
+   * @param {FileOptions[]|BufferResolvable[]|MessageAttachment[]} files The replacing file objects
+   * @returns {MessageBuilder}
+   */
+  spliceFiles(index, deleteCount, files) {
+    this.options.files?.splice(index, deleteCount, ...files);
+    return this;
+  }
+
+  /**
    * Resolves a single file into an object sendable to the API.
    * @param {BufferResolvable|Stream|FileOptions|MessageAttachment} fileLike Something that could be resolved to a file
    * @returns {Object}

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const APIMessage = require('./APIMessage');
 const Channel = require('./Channel');
+const MessageBuilder = require('./MessageBuilder');
 const { Error } = require('../errors');
 const { WebhookTypes } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
@@ -107,7 +107,7 @@ class Webhook {
 
   /**
    * Sends a message with this webhook.
-   * @param {string|APIMessage|WebhookMessageOptions} options The options to provide
+   * @param {string|MessageBuilder|WebhookMessageOptions} options The options to provide
    * @returns {Promise<Message|Object>}
    * @example
    * // Send a basic message
@@ -153,10 +153,10 @@ class Webhook {
 
     let apiMessage;
 
-    if (options instanceof APIMessage) {
+    if (options instanceof MessageBuilder) {
       apiMessage = options.resolveData();
     } else {
-      apiMessage = APIMessage.create(this, options).resolveData();
+      apiMessage = MessageBuilder.create(this, options).resolveData();
     }
 
     if (Array.isArray(apiMessage.data.content)) {
@@ -256,7 +256,7 @@ class Webhook {
   /**
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable|'@original'} message The message to edit
-   * @param {string|APIMessage|WebhookEditMessageOptions} options The options to provide
+   * @param {string|MessageBuilder|WebhookEditMessageOptions} options The options to provide
    * @returns {Promise<Message|Object>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */
@@ -265,8 +265,8 @@ class Webhook {
 
     let apiMessage;
 
-    if (options instanceof APIMessage) apiMessage = options;
-    else apiMessage = APIMessage.create(this, options);
+    if (options instanceof MessageBuilder) apiMessage = options;
+    else apiMessage = MessageBuilder.create(this, options);
 
     const { data, files } = await apiMessage.resolveData().resolveFiles();
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -3,7 +3,7 @@
 const { Error } = require('../../errors');
 const { InteractionResponseTypes } = require('../../util/Constants');
 const MessageFlags = require('../../util/MessageFlags');
-const APIMessage = require('../APIMessage');
+const MessageBuilder = require('../MessageBuilder');
 
 /**
  * Interface for classes that support shared interaction response types.
@@ -52,7 +52,7 @@ class InteractionResponses {
 
   /**
    * Creates a reply to this interaction.
-   * @param {string|APIMessage|InteractionReplyOptions} options The options for the reply
+   * @param {string|MessageBuilder|InteractionReplyOptions} options The options for the reply
    * @returns {Promise<void>}
    * @example
    * // Reply to the interaction with an embed
@@ -71,8 +71,8 @@ class InteractionResponses {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
 
     let apiMessage;
-    if (options instanceof APIMessage) apiMessage = options;
-    else apiMessage = APIMessage.create(this, options);
+    if (options instanceof MessageBuilder) apiMessage = options;
+    else apiMessage = MessageBuilder.create(this, options);
 
     const { data, files } = await apiMessage.resolveData().resolveFiles();
 
@@ -103,7 +103,7 @@ class InteractionResponses {
   /**
    * Edits the initial reply to this interaction.
    * @see Webhook#editMessage
-   * @param {string|APIMessage|WebhookEditMessageOptions} options The new options for the message
+   * @param {string|MessageBuilder|WebhookEditMessageOptions} options The new options for the message
    * @returns {Promise<Message|Object>}
    * @example
    * // Edit the reply to this interaction
@@ -131,7 +131,7 @@ class InteractionResponses {
 
   /**
    * Send a follow-up message to this interaction.
-   * @param {string|APIMessage|InteractionReplyOptions} options The options for the reply
+   * @param {string|MessageBuilder|InteractionReplyOptions} options The options for the reply
    * @returns {Promise<Message|Object>}
    */
   followUp(options) {
@@ -159,7 +159,7 @@ class InteractionResponses {
 
   /**
    * Updates the original message whose button was pressed
-   * @param {string|APIMessage|WebhookEditMessageOptions} options The options for the reply
+   * @param {string|MessageBuilder|WebhookEditMessageOptions} options The options for the reply
    * @returns {Promise<void>}
    * @example
    * // Remove the components from the message
@@ -174,8 +174,8 @@ class InteractionResponses {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
 
     let apiMessage;
-    if (options instanceof APIMessage) apiMessage = options;
-    else apiMessage = APIMessage.create(this, options);
+    if (options instanceof MessageBuilder) apiMessage = options;
+    else apiMessage = MessageBuilder.create(this, options);
 
     const { data, files } = await apiMessage.resolveData().resolveFiles();
 

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -2,7 +2,7 @@
 
 /* eslint-disable import/order */
 const MessageCollector = require('../MessageCollector');
-const APIMessage = require('../APIMessage');
+const MessageBuilder = require('../MessageBuilder');
 const SnowflakeUtil = require('../../util/SnowflakeUtil');
 const Collection = require('../../util/Collection');
 const { RangeError, TypeError, Error } = require('../../errors');
@@ -118,7 +118,7 @@ class TextBasedChannel {
 
   /**
    * Sends a message to this channel.
-   * @param {string|APIMessage|MessageOptions} options The options to provide
+   * @param {string|MessageBuilder|MessageOptions} options The options to provide
    * @returns {Promise<Message|Message[]>}
    * @example
    * // Send a basic message
@@ -171,10 +171,10 @@ class TextBasedChannel {
 
     let apiMessage;
 
-    if (options instanceof APIMessage) {
+    if (options instanceof MessageBuilder) {
       apiMessage = options.resolveData();
     } else {
-      apiMessage = APIMessage.create(this, options).resolveData();
+      apiMessage = MessageBuilder.create(this, options).resolveData();
     }
 
     if (Array.isArray(apiMessage.data.content)) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1331,7 +1331,9 @@ declare module 'discord.js' {
     public setAllowedMentions(options: MessageMentionOptions): this;
     public setAvatarURL(avatar: string): this;
     public setCode(code: string | boolean): this;
-    public setContent(contentL: string): this;
+    public setContent(content: string | null): this;
+    public setEphemeral(ephemeral: boolean): this;
+    public setNonce(nonce: string | number): this;
     public setReply(options: ReplyOptions): this;
     public setSplitOptions(options: boolean | SplitOptions): this;
     public setTTS(tts: boolean): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1303,7 +1303,7 @@ declare module 'discord.js' {
   }
 
   export class MessageBuilder {
-    constructor(target: MessageTarget, options: MessageOptions | WebhookMessageOptions);
+    constructor(target: MessageTarget, options?: MessageOptions | WebhookMessageOptions);
     public data: unknown | null;
     public readonly isUser: boolean;
     public readonly isWebhook: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1320,9 +1320,33 @@ declare module 'discord.js' {
     ): MessageBuilder;
     public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | MessageAttachment): Promise<unknown>;
 
+    public addComponents(
+      components: (MessageActionRow | MessageActionRowOptions | MessageActionRowComponentResolvable[])[],
+    ): this;
+    public addEmbeds(embeds: (MessageEmbed | MessageEmbedOptions)[]): this;
+    public addFiles(files: (FileOptions | BufferResolvable | Stream | MessageAttachment)[]): this;
     public makeContent(): string | string[] | undefined;
     public resolveData(): this;
     public resolveFiles(): Promise<this>;
+    public setAllowedMentions(options: MessageMentionOptions): this;
+    public setAvatarURL(avatar: string): this;
+    public setCode(code: string | boolean): this;
+    public setContent(contentL: string): this;
+    public setReply(options: ReplyOptions): this;
+    public setSplitOptions(options: boolean | SplitOptions): this;
+    public setTTS(tts: boolean): this;
+    public setUsername(username: string): this;
+    public spliceComponents(
+      index: number,
+      deleteCount: number,
+      components: MessageActionRow[] | MessageActionRowOptions[] | MessageActionRowComponentResolvable[][],
+    ): this;
+    public spliceEmbeds(index: number, deleteCount: number, embeds: (MessageEmbed | MessageEmbedOptions)[]): this;
+    public spliceFiles(
+      index: number,
+      deleteCount: number,
+      files: (FileOptions | BufferResolvable | Stream | MessageAttachment)[],
+    ): this;
     public split(): MessageBuilder[];
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -199,30 +199,6 @@ declare module 'discord.js' {
     public splashURL(options?: StaticImageURLOptions): string | null;
   }
 
-  export class APIMessage {
-    constructor(target: MessageTarget, options: MessageOptions | WebhookMessageOptions);
-    public data: unknown | null;
-    public readonly isUser: boolean;
-    public readonly isWebhook: boolean;
-    public readonly isMessage: boolean;
-    public readonly isInteraction: boolean;
-    public files: unknown[] | null;
-    public options: MessageOptions | WebhookMessageOptions;
-    public target: MessageTarget;
-
-    public static create(
-      target: MessageTarget,
-      options: string | MessageOptions | WebhookMessageOptions,
-      extra?: MessageOptions | WebhookMessageOptions,
-    ): APIMessage;
-    public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | MessageAttachment): Promise<unknown>;
-
-    public makeContent(): string | string[] | undefined;
-    public resolveData(): this;
-    public resolveFiles(): Promise<this>;
-    public split(): APIMessage[];
-  }
-
   export abstract class Application {
     constructor(client: Client, data: unknown);
     public readonly createdAt: Date;
@@ -513,10 +489,10 @@ declare module 'discord.js' {
     public webhook: InteractionWebhook;
     public defer(options?: InteractionDeferOptions): Promise<void>;
     public deleteReply(): Promise<void>;
-    public editReply(options: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage>;
+    public editReply(options: string | MessageBuilder | WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
-    public followUp(options: string | APIMessage | InteractionReplyOptions): Promise<Message | RawMessage>;
-    public reply(options: string | APIMessage | InteractionReplyOptions): Promise<void>;
+    public followUp(options: string | MessageBuilder | InteractionReplyOptions): Promise<Message | RawMessage>;
+    public reply(options: string | MessageBuilder | InteractionReplyOptions): Promise<void>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
     private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
   }
@@ -1167,10 +1143,10 @@ declare module 'discord.js' {
     constructor(client: Client, id: Snowflake, token: string);
     public token: string;
     public send(
-      options: string | APIMessage | (InteractionReplyOptions & { split?: false }),
+      options: string | MessageBuilder | (InteractionReplyOptions & { split?: false }),
     ): Promise<Message | RawMessage>;
     public send(
-      options: APIMessage | (InteractionReplyOptions & { split: true | SplitOptions }),
+      options: MessageBuilder | (InteractionReplyOptions & { split: true | SplitOptions }),
     ): Promise<(Message | RawMessage)[]>;
   }
 
@@ -1276,7 +1252,7 @@ declare module 'discord.js' {
       options?: MessageComponentInteractionCollectorOptions,
     ): MessageComponentInteractionCollector;
     public delete(): Promise<Message>;
-    public edit(content: string | MessageEditOptions | APIMessage): Promise<Message>;
+    public edit(content: string | MessageEditOptions | MessageBuilder): Promise<Message>;
     public equals(message: Message, rawData: unknown): boolean;
     public fetchReference(): Promise<Message>;
     public fetchWebhook(): Promise<Webhook>;
@@ -1285,8 +1261,8 @@ declare module 'discord.js' {
     public pin(): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public removeAttachments(): Promise<Message>;
-    public reply(options: string | APIMessage | (ReplyMessageOptions & { split?: false })): Promise<Message>;
-    public reply(options: APIMessage | (ReplyMessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
+    public reply(options: string | MessageBuilder | (ReplyMessageOptions & { split?: false })): Promise<Message>;
+    public reply(options: MessageBuilder | (ReplyMessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
     public suppressEmbeds(suppress?: boolean): Promise<Message>;
     public toJSON(): unknown;
     public toString(): string;
@@ -1324,6 +1300,30 @@ declare module 'discord.js' {
     public setFile(attachment: BufferResolvable | Stream, name?: string): this;
     public setName(name: string): this;
     public toJSON(): unknown;
+  }
+
+  export class MessageBuilder {
+    constructor(target: MessageTarget, options: MessageOptions | WebhookMessageOptions);
+    public data: unknown | null;
+    public readonly isUser: boolean;
+    public readonly isWebhook: boolean;
+    public readonly isMessage: boolean;
+    public readonly isInteraction: boolean;
+    public files: unknown[] | null;
+    public options: MessageOptions | WebhookMessageOptions;
+    public target: MessageTarget;
+
+    public static create(
+      target: MessageTarget,
+      options: string | MessageOptions | WebhookMessageOptions,
+      extra?: MessageOptions | WebhookMessageOptions,
+    ): MessageBuilder;
+    public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | MessageAttachment): Promise<unknown>;
+
+    public makeContent(): string | string[] | undefined;
+    public resolveData(): this;
+    public resolveFiles(): Promise<this>;
+    public split(): MessageBuilder[];
   }
 
   export class MessageButton extends BaseMessageComponent {
@@ -1373,11 +1373,11 @@ declare module 'discord.js' {
     public defer(options?: InteractionDeferOptions): Promise<void>;
     public deferUpdate(): Promise<void>;
     public deleteReply(): Promise<void>;
-    public editReply(options: string | APIMessage | WebhookEditMessageOptions): Promise<Message | RawMessage>;
+    public editReply(options: string | MessageBuilder | WebhookEditMessageOptions): Promise<Message | RawMessage>;
     public fetchReply(): Promise<Message | RawMessage>;
-    public followUp(options: string | APIMessage | InteractionReplyOptions): Promise<Message | RawMessage>;
-    public reply(options: string | APIMessage | InteractionReplyOptions): Promise<void>;
-    public update(content: string | APIMessage | WebhookEditMessageOptions): Promise<void>;
+    public followUp(options: string | MessageBuilder | InteractionReplyOptions): Promise<Message | RawMessage>;
+    public reply(options: string | MessageBuilder | InteractionReplyOptions): Promise<void>;
+    public update(content: string | MessageBuilder | WebhookEditMessageOptions): Promise<void>;
     public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
   }
 
@@ -2013,11 +2013,13 @@ declare module 'discord.js' {
     public token: string;
     public editMessage(
       message: MessageResolvable,
-      options: string | APIMessage | WebhookEditMessageOptions,
+      options: string | MessageBuilder | WebhookEditMessageOptions,
     ): Promise<RawMessage>;
     public fetchMessage(message: Snowflake, cache?: boolean): Promise<RawMessage>;
-    public send(options: string | APIMessage | (WebhookMessageOptions & { split?: false })): Promise<RawMessage>;
-    public send(options: APIMessage | (WebhookMessageOptions & { split: true | SplitOptions })): Promise<RawMessage[]>;
+    public send(options: string | MessageBuilder | (WebhookMessageOptions & { split?: false })): Promise<RawMessage>;
+    public send(
+      options: MessageBuilder | (WebhookMessageOptions & { split: true | SplitOptions }),
+    ): Promise<RawMessage[]>;
   }
 
   export class WebSocketManager extends EventEmitter {
@@ -2371,7 +2373,7 @@ declare module 'discord.js' {
     public cache: Collection<Snowflake, Message>;
     public crosspost(message: MessageResolvable): Promise<Message>;
     public delete(message: MessageResolvable): Promise<void>;
-    public edit(message: MessageResolvable, options: APIMessage | MessageEditOptions): Promise<Message>;
+    public edit(message: MessageResolvable, options: MessageBuilder | MessageEditOptions): Promise<Message>;
     public fetch(message: Snowflake, options?: BaseFetchOptions): Promise<Message>;
     public fetch(
       options?: ChannelLogsQueryOptions,
@@ -2449,8 +2451,8 @@ declare module 'discord.js' {
   interface PartialTextBasedChannelFields {
     lastMessageID: Snowflake | null;
     readonly lastMessage: Message | null;
-    send(options: string | APIMessage | (MessageOptions & { split?: false })): Promise<Message>;
-    send(options: APIMessage | (MessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
+    send(options: string | MessageBuilder | (MessageOptions & { split?: false })): Promise<Message>;
+    send(options: MessageBuilder | (MessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
   }
 
   interface TextBasedChannelFields extends PartialTextBasedChannelFields {
@@ -2491,13 +2493,13 @@ declare module 'discord.js' {
     deleteMessage(message: MessageResolvable | '@original'): Promise<void>;
     editMessage(
       message: MessageResolvable | '@original',
-      options: string | APIMessage | WebhookEditMessageOptions,
+      options: string | MessageBuilder | WebhookEditMessageOptions,
     ): Promise<Message | RawMessage>;
     fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | RawMessage>;
     send(
-      options: APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
+      options: MessageBuilder | (WebhookMessageOptions & { split: true | SplitOptions }),
     ): Promise<(Message | RawMessage)[]>;
-    send(options: string | APIMessage | (WebhookMessageOptions & { split?: false })): Promise<Message | RawMessage>;
+    send(options: string | MessageBuilder | (WebhookMessageOptions & { split?: false })): Promise<Message | RawMessage>;
   }
 
   interface WebhookFields extends PartialWebhookFields {


### PR DESCRIPTION
Did someone say scope creep?

In order to address a single misleading typing where the discord-api-types `APIMessage` naming overlaps with the discord.js `APIMessage` class in VSC's Intellisense, the entire class has been refactored into a `MessageBuilder`.

**Changes:**
- Rename APIMessage (the class) to MessageBuilder throughout the library.
- Make the `options` constructor parameter optional
- Add builder methods for each option
- Move validation to builder methods where appropriate, and call internally
- New validation error messages

This is likely to need plenty of review and testing.

NOTE: There appears to be a bug in the eslint valid-jsdoc rule, where changes I made to make eslint see the rule as valid actually caused the docgen to fail. The jsdoc *is* correct and I've told the rule to ignore it.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)