### PR TITLE
revert(BitField): ⏪ Bring back-compatibility after BitField serialization

### DIFF
--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -147,7 +147,7 @@ class BitField {
     if (Array.isArray(bit)) return bit.map(p => this.resolve(p)).reduce((prev, p) => prev | p, defaultBit);
     if (typeof bit === 'string') {
       if (typeof this.FLAGS[bit] !== 'undefined') return this.FLAGS[bit];
-      if (!isNaN(bit)) return BigInt(bit);
+      if (!isNaN(bit)) return typeof defaultBit === 'bigint' ? BigInt(bit) : Number(bit);
     }
     throw new RangeError('BITFIELD_INVALID', bit);
   }

--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -129,9 +129,10 @@ class BitField {
   /**
    * Data that can be resolved to give a bitfield. This can be:
    * * A bit number (this can be a number literal or a value taken from {@link BitField.FLAGS})
+   * * A string bit number
    * * An instance of BitField
    * * An Array of BitFieldResolvable
-   * @typedef {number|bigint|BitField|BitFieldResolvable[]} BitFieldResolvable
+   * @typedef {number|string|bigint|BitField|BitFieldResolvable[]} BitFieldResolvable
    */
 
   /**
@@ -144,7 +145,10 @@ class BitField {
     if (typeof defaultBit === typeof bit && bit >= defaultBit) return bit;
     if (bit instanceof BitField) return bit.bitfield;
     if (Array.isArray(bit)) return bit.map(p => this.resolve(p)).reduce((prev, p) => prev | p, defaultBit);
-    if (typeof bit === 'string' && typeof this.FLAGS[bit] !== 'undefined') return this.FLAGS[bit];
+    if (typeof bit === 'string') {
+      if (typeof this.FLAGS[bit] !== 'undefined') return this.FLAGS[bit];
+      if (!isNaN(bit)) return BigInt(bit);
+    }
     throw new RangeError('BITFIELD_INVALID', bit);
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2702,9 +2702,10 @@ declare module 'discord.js' {
   }
 
   type BitFieldResolvable<T extends string, N extends number | bigint> =
-    | RecursiveReadonlyArray<T | N | Readonly<BitField<T, N>>>
+    | RecursiveReadonlyArray<T | N | `${bigint}` | Readonly<BitField<T, N>>>
     | T
     | N
+    | `${bigint}`
     | Readonly<BitField<T, N>>;
 
   type BufferResolvable = Buffer | string;
@@ -3616,7 +3617,7 @@ declare module 'discord.js' {
 
   interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> {}
 
-  type PermissionResolvable = BitFieldResolvable<PermissionString, string, bigint>;
+  type PermissionResolvable = BitFieldResolvable<PermissionString, bigint>;
 
   type PermissionString =
     | 'CREATE_INSTANT_INVITE'

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -355,7 +355,7 @@ declare module 'discord.js' {
     public valueOf(): N;
     public [Symbol.iterator](): IterableIterator<S>;
     public static FLAGS: unknown;
-    public static resolve(bit?: BitFieldResolvable<any, number | bigint>): number | bigint;
+    public static resolve(bit?: BitFieldResolvable<S, N>): number | bigint;
   }
 
   export class ButtonInteraction extends MessageComponentInteraction {
@@ -3616,7 +3616,7 @@ declare module 'discord.js' {
 
   interface PermissionOverwriteOptions extends Partial<Record<PermissionString, boolean | null>> {}
 
-  type PermissionResolvable = BitFieldResolvable<PermissionString, bigint>;
+  type PermissionResolvable = BitFieldResolvable<PermissionString, string, bigint>;
 
   type PermissionString =
     | 'CREATE_INSTANT_INVITE'


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

In #4879, some modifications were made to permissions and bitfield methods.
Especially on the type of bitfields that moves from **number** to **BigInt**.

This move has some impact on serialization and deserialization.
Take the example of a simple `JSON.stringify` and `JSON.parse`.
The method `toJSON()` (provided by BitField class) will be called and the type (BigInt in the case of Permissions) will be transformed into a string:
> `8n` => `"8"`

In the past, this type changing was not needed because a number remains a number.
In the actual Bitfield class if you try to pass permissions that went through serialization and deserialization you get the beautiful error `BITFIELD_INVALID`.
So a simple role or channel creation bring you to a crash of your action.

This PR is here to provide compatibility between Bigint stringified and BitFields.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating