### PR TITLE
fix(Permissions): allow admin to override in the missing method

### DIFF
--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -25,6 +25,16 @@ class Permissions extends BitField {
    */
 
   /**
+   * Gets all given bits that are missing from the bitfield.
+   * @param {BitFieldResolvable} bits Bit(s) to check for
+   * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override
+   * @returns {string[]}
+   */
+  missing(bits, checkAdmin = true) {
+    return checkAdmin && this.has(this.constructor.FLAGS.ADMINISTRATOR) ? [] : super.missing(bits, checkAdmin);
+  }
+
+  /**
    * Checks whether the bitfield has a permission, or any of multiple permissions.
    * @param {PermissionResolvable} permission Permission(s) to check for
    * @param {boolean} [checkAdmin=true] Whether to allow the administrator permission to override


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR ensures that calling `Permissions#missing` on an instance with `ADMINISTRATOR` always returns an empty array, except when `checkAdmin` is `false`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
