### PR TITLE
fix(Webhook): resolve non-string avatars too

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -224,7 +224,7 @@ class Webhook {
    * @returns {Promise<Webhook>}
    */
   async edit({ name = this.name, avatar, channel }, reason) {
-    if (avatar && typeof avatar === 'string' && !avatar.startsWith('data:')) {
+    if (avatar && !(typeof avatar === 'string' && avatar.startsWith('data:'))) {
       avatar = await DataResolver.resolveImage(avatar);
     }
     if (channel) channel = channel instanceof Channel ? channel.id : channel;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes `Webhook#edit` to also resolve non-string avatars (read: buffers) into the required data uris.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

