### PR TITLE
fix(ApplicationCommand): stringType isn't supposed to be sent to the API

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -212,7 +212,7 @@ class ApplicationCommand extends Base {
   static transformOption(option, received) {
     const stringType = typeof option.type === 'string' ? option.type : ApplicationCommandOptionTypes[option.type];
     return {
-      type: typeof option.type === 'number' && !received ? option.type : stringType,
+      type: typeof option.type === 'number' && !received ? option.type : ApplicationCommandOptionTypes[option.type],
       name: option.name,
       description: option.description,
       required:


### PR DESCRIPTION
Fixes a bug introduced in #5862 which could send strings to the API instead of integers when creating slash commands

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
