### PR TITLE
Fixed typos from commit #5570

### DIFF
--- a/src/client/actions/ThreadListSync.js
+++ b/src/client/actions/ThreadListSync.js
@@ -11,7 +11,7 @@ class ThreadListSyncAction extends Action {
     const guild = client.guilds.cache.get(data.guild_id);
     if (!guild) return {};
 
-    if (data.channels_ids) {
+    if (data.channel_ids) {
       for (const id of data.channel_ids) {
         const channel = client.channels.resolve(id);
         if (channel) this.removeStale(channel);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4147,7 +4147,7 @@ declare module 'discord.js' {
     name?: string;
     archived?: boolean;
     autoArchiveDuration?: ThreadAutoArchiveDuration;
-    rateLimitPeruser?: number;
+    rateLimitPerUser?: number;
     locked?: boolean;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes a couple of typos added with the PR #5570
Such as in the ThreadListSync actions file where `channels_ids` was used instead of `channel_ids`
and in the typings file where rateLimitPeruser was used instead of rateLimitPerUser.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating