### PR TITLE
refactor: removed `code` and `split` options

### DIFF
--- a/src/structures/APIMessage.js
+++ b/src/structures/APIMessage.js
@@ -104,7 +104,7 @@ class APIMessage {
 
   /**
    * Makes the content of this message.
-   * @returns {?(string|string[])}
+   * @returns {?string}
    */
   makeContent() {
     let content;
@@ -112,27 +112,6 @@ class APIMessage {
       content = '';
     } else if (typeof this.options.content !== 'undefined') {
       content = Util.verifyString(this.options.content, RangeError, 'MESSAGE_CONTENT_TYPE', false);
-    }
-
-    if (typeof content !== 'string') return content;
-
-    const isSplit = typeof this.options.split !== 'undefined' && this.options.split !== false;
-    const isCode = typeof this.options.code !== 'undefined' && this.options.code !== false;
-    const splitOptions = isSplit ? { ...this.options.split } : undefined;
-
-    if (content) {
-      if (isCode) {
-        const codeName = typeof this.options.code === 'string' ? this.options.code : '';
-        content = `\`\`\`${codeName}\n${Util.cleanCodeBlockContent(content)}\n\`\`\``;
-        if (isSplit) {
-          splitOptions.prepend = `${splitOptions.prepend || ''}\`\`\`${codeName}\n`;
-          splitOptions.append = `\n\`\`\`${splitOptions.append || ''}`;
-        }
-      }
-
-      if (isSplit) {
-        content = Util.splitMessage(content, splitOptions);
-      }
     }
 
     return content;
@@ -230,37 +209,6 @@ class APIMessage {
 
     this.files = await Promise.all(this.options.files?.map(file => this.constructor.resolveFile(file)) ?? []);
     return this;
-  }
-
-  /**
-   * Converts this APIMessage into an array of APIMessages for each split content
-   * @returns {APIMessage[]}
-   */
-  split() {
-    if (!this.data) this.resolveData();
-
-    if (!Array.isArray(this.data.content)) return [this];
-
-    const apiMessages = [];
-
-    for (let i = 0; i < this.data.content.length; i++) {
-      let data;
-      let opt;
-
-      if (i === this.data.content.length - 1) {
-        data = { ...this.data, content: this.data.content[i] };
-        opt = { ...this.options, content: this.data.content[i] };
-      } else {
-        data = { content: this.data.content[i], tts: this.data.tts, allowed_mentions: this.options.allowedMentions };
-        opt = { content: this.data.content[i], tts: this.data.tts, allowedMentions: this.options.allowedMentions };
-      }
-
-      const apiMessage = new APIMessage(this.target, opt);
-      apiMessage.data = data;
-      apiMessages.push(apiMessage);
-    }
-
-    return apiMessages;
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -549,7 +549,6 @@ class Message extends Base {
    * @typedef {Object} MessageEditOptions
    * @property {?string} [content] Content to be edited
    * @property {MessageEmbed[]|APIEmbed[]} [embeds] Embeds to be added/edited
-   * @property {string|boolean} [code] Language for optional codeblock formatting to apply
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * @property {MessageFlags} [flags] Which flags to set for the message. Only `SUPPRESS_EMBEDS` can be edited.
    * @property {MessageAttachment[]} [attachments] An array of attachments to keep,

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -166,10 +166,6 @@ class Webhook {
       apiMessage = APIMessage.create(this, options).resolveData();
     }
 
-    if (Array.isArray(apiMessage.data.content)) {
-      return Promise.all(apiMessage.split().map(this.send.bind(this)));
-    }
-
     const { data, files } = await apiMessage.resolveFiles();
     return this.client.api
       .webhooks(this.id, this.token)

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -62,9 +62,6 @@ class TextBasedChannel {
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to send with the message
-   * @property {string|boolean} [code] Language for optional codeblock formatting to apply
-   * @property {boolean|SplitOptions} [split=false] Whether or not the message should be split into multiple messages if
-   * it exceeds the character limit. If an object is provided, these are the options for splitting the message
    * @property {MessageActionRow[]|MessageActionRowOptions[]|MessageActionRowComponentResolvable[][]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */
@@ -96,16 +93,6 @@ class TextBasedChannel {
    * @typedef {Object} FileOptions
    * @property {BufferResolvable} attachment File to attach
    * @property {string} [name='file.jpg'] Filename of the attachment
-   */
-
-  /**
-   * Options for splitting a message.
-   * @typedef {Object} SplitOptions
-   * @property {number} [maxLength=2000] Maximum character length per message piece
-   * @property {string|string[]|RegExp|RegExp[]} [char='\n'] Character(s) or Regex(s) to split the message with,
-   * an array can be used to split multiple times
-   * @property {string} [prepend=''] Text to prepend to every piece except the first
-   * @property {string} [append=''] Text to append to every piece except the last
    */
 
   /**
@@ -175,10 +162,6 @@ class TextBasedChannel {
       apiMessage = options.resolveData();
     } else {
       apiMessage = APIMessage.create(this, options).resolveData();
-    }
-
-    if (Array.isArray(apiMessage.data.content)) {
-      return Promise.all(apiMessage.split().map(this.send.bind(this)));
     }
 
     const { data, files } = await apiMessage.resolveFiles();

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -56,6 +56,16 @@ class Util {
   }
 
   /**
+   * Options for splitting a message.
+   * @typedef {Object} SplitOptions
+   * @property {number} [maxLength=2000] Maximum character length per message piece
+   * @property {string|string[]|RegExp|RegExp[]} [char='\n'] Character(s) or Regex(s) to split the message with,
+   * an array can be used to split multiple times
+   * @property {string} [prepend=''] Text to prepend to every piece except the first
+   * @property {string} [append=''] Text to append to every piece except the last
+   */
+
+  /**
    * Splits a string into multiple chunks at a designated character that do not exceed a specific length.
    * @param {string} text Content to split
    * @param {SplitOptions} [options] Options controlling the behavior of the split

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -225,10 +225,9 @@ declare module 'discord.js' {
     ): APIMessage;
     public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | MessageAttachment): Promise<unknown>;
 
-    public makeContent(): string | string[] | undefined;
+    public makeContent(): string | undefined;
     public resolveData(): this;
     public resolveFiles(): Promise<this>;
-    public split(): APIMessage[];
   }
 
   export abstract class Application {
@@ -1183,12 +1182,7 @@ declare module 'discord.js' {
   export class InteractionWebhook extends PartialWebhookMixin() {
     constructor(client: Client, id: Snowflake, token: string);
     public token: string;
-    public send(
-      options: string | APIMessage | (InteractionReplyOptions & { split?: false }),
-    ): Promise<Message | RawMessage>;
-    public send(
-      options: APIMessage | (InteractionReplyOptions & { split: true | SplitOptions }),
-    ): Promise<(Message | RawMessage)[]>;
+    public send(options: string | APIMessage | InteractionReplyOptions): Promise<Message | RawMessage>;
   }
 
   export class Invite extends Base {
@@ -1303,8 +1297,7 @@ declare module 'discord.js' {
     public pin(): Promise<Message>;
     public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
     public removeAttachments(): Promise<Message>;
-    public reply(options: string | APIMessage | (ReplyMessageOptions & { split?: false })): Promise<Message>;
-    public reply(options: APIMessage | (ReplyMessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
+    public reply(options: string | APIMessage | ReplyMessageOptions): Promise<Message>;
     public startThread(
       name: string,
       autoArchiveDuration: ThreadAutoArchiveDuration,
@@ -2139,8 +2132,7 @@ declare module 'discord.js' {
       options: string | APIMessage | WebhookEditMessageOptions,
     ): Promise<RawMessage>;
     public fetchMessage(message: Snowflake, cache?: boolean): Promise<RawMessage>;
-    public send(options: string | APIMessage | (WebhookMessageOptions & { split?: false })): Promise<RawMessage>;
-    public send(options: APIMessage | (WebhookMessageOptions & { split: true | SplitOptions })): Promise<RawMessage[]>;
+    public send(options: string | APIMessage | WebhookMessageOptions): Promise<RawMessage>;
   }
 
   export class WebSocketManager extends EventEmitter {
@@ -2600,8 +2592,7 @@ declare module 'discord.js' {
   interface PartialTextBasedChannelFields {
     lastMessageID: Snowflake | null;
     readonly lastMessage: Message | null;
-    send(options: string | APIMessage | (MessageOptions & { split?: false })): Promise<Message>;
-    send(options: APIMessage | (MessageOptions & { split: true | SplitOptions })): Promise<Message[]>;
+    send(options: string | APIMessage | MessageOptions): Promise<Message>;
   }
 
   interface TextBasedChannelFields extends PartialTextBasedChannelFields {
@@ -2645,10 +2636,7 @@ declare module 'discord.js' {
       options: string | APIMessage | WebhookEditMessageOptions,
     ): Promise<Message | RawMessage>;
     fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | RawMessage>;
-    send(
-      options: APIMessage | (WebhookMessageOptions & { split: true | SplitOptions }),
-    ): Promise<(Message | RawMessage)[]>;
-    send(options: string | APIMessage | (WebhookMessageOptions & { split?: false })): Promise<Message | RawMessage>;
+    send(options: string | APIMessage | WebhookMessageOptions): Promise<Message | RawMessage>;
   }
 
   interface WebhookFields extends PartialWebhookFields {
@@ -3660,7 +3648,6 @@ declare module 'discord.js' {
     attachments?: MessageAttachment[];
     content?: string | null;
     embeds?: (MessageEmbed | MessageEmbedOptions)[] | null;
-    code?: string | boolean;
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
     flags?: BitFieldResolvable<MessageFlagsString, number>;
     allowedMentions?: MessageMentionOptions;
@@ -3761,13 +3748,11 @@ declare module 'discord.js' {
   interface MessageOptions {
     tts?: boolean;
     nonce?: string | number;
-    content?: string;
+    content?: string | null;
     embeds?: (MessageEmbed | MessageEmbedOptions)[];
     components?: MessageActionRow[] | MessageActionRowOptions[] | MessageActionRowComponentResolvable[][];
     allowedMentions?: MessageMentionOptions;
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
-    code?: string | boolean;
-    split?: boolean | SplitOptions;
     reply?: ReplyOptions;
   }
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -27,9 +27,8 @@ client.on('messageReactionRemoveAll', async message => {
   console.log(`messageReactionRemoveAll - content: ${message.content}`);
 });
 
-// These are to check that stuff is the right type
+// This is to check that stuff is the right type
 declare const assertIsMessage: (m: Promise<Message>) => void;
-declare const assertIsMessageArray: (m: Promise<Message[]>) => void;
 
 client.on('message', ({ channel }) => {
   assertIsMessage(channel.send('string'));
@@ -41,8 +40,6 @@ client.on('message', ({ channel }) => {
   assertIsMessage(channel.send({ files: [attachment] }));
   assertIsMessage(channel.send({ embeds: [embed] }));
   assertIsMessage(channel.send({ embeds: [embed], files: [attachment] }));
-
-  assertIsMessageArray(channel.send({ split: true }));
 
   // @ts-expect-error
   channel.send();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

:broom: clean-up service here, removing old remnants from old versions of discord.js

:warning: Removed `APIMessage#split`
:warning: Removed `MessageEditOptions#code`
:warning: Removed `BaseMessageOptions#code`
:warning: Removed `BaseMessageOptions#split`

- **Why?**
  No other method in the entire library does two requests to the same path. This method was an exception for many years, and is something that should always been done by the user.
- **How do I restore this feature?**
  You can still use the `Util.splitMessage` utility, and then with given array, send all the messages as you desire.
  As for `code`, simply wrap the content into \`\`\`js\n${content}\`\`\`​. We're releasing an utility later in the future too, so you can do `codeblock('js', content)`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)