### PR TITLE
docs(Thread): add links to discord api docs

### DIFF
--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -14,7 +14,7 @@ const Permissions = require('../util/Permissions');
 class ThreadChannel extends Channel {
   /**
    * @param {Guild} guild The guild the thread channel is part of
-   * @param {Object} data The data for the thread channel
+   * @param {APIChannel} data The data for the thread channel
    */
   constructor(guild, data) {
     super(guild.client, data, false);
@@ -179,7 +179,7 @@ class ThreadChannel extends Channel {
 
   /**
    * Edits the thread.
-   * @param {Object} data The new data for the thread
+   * @param {APIChannel} data The new data for the thread
    * @param {string} [data.name] The new name for the trhead
    * @param {boolean} [data.archived] Whether the thread is archived
    * @param {number} [data.autoArchiveDuration] How long in minutes before the thread is automatically archived,

--- a/src/structures/ThreadMember.js
+++ b/src/structures/ThreadMember.js
@@ -10,7 +10,7 @@ const ThreadMemberFlags = require('../util/ThreadMemberFlags');
 class ThreadMember extends Base {
   /**
    * @param {ThreadChannel} thread The thread that this member is associated with
-   * @param {Object} data The data for the thread member
+   * @param {APIThreadMember} data The data for the thread member
    */
   constructor(thread, data) {
     super(thread.client);
@@ -93,3 +93,8 @@ class ThreadMember extends Base {
 }
 
 module.exports = ThreadMember;
+
+/**
+ * @external APIThreadMember
+ * @see {@link https://discord.com/developers/docs/resources/channel#thread-member-object}
+ */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds links to the new APIThreadMember object as well as the existing APIChannel link to thread channels

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
