### PR TITLE
fix(User): fix bot and system properties being incorrect in some cases

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -59,13 +59,13 @@ class User extends Base {
       this.username = null;
     }
 
-    if ('bot' in data || typeof this.bot === 'boolean') {
+    if ('bot' in data) {
       /**
        * Whether or not the user is a bot
        * @type {?boolean}
        */
-      this.bot = Boolean(data.bot ?? this.bot);
-    } else if (!this.partial) {
+      this.bot = Boolean(data.bot);
+    } else if (!this.partial && typeof this.bot !== 'boolean') {
       this.bot = false;
     }
 
@@ -89,13 +89,13 @@ class User extends Base {
       this.avatar = null;
     }
 
-    if ('system' in data || typeof this.system === 'boolean') {
+    if ('system' in data) {
       /**
        * Whether the user is an Official Discord System user (part of the urgent message system)
        * @type {?boolean}
        */
-      this.system = Boolean(data.system ?? this.system);
-    } else if (!this.partial) {
+      this.system = Boolean(data.system);
+    } else if (!this.partial && typeof this.system !== 'boolean') {
       this.system = false;
     }
 

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -27,7 +27,10 @@ class User extends Base {
      */
     this.id = data.id;
 
+    this.bot = null;
+
     this.system = null;
+
     this.flags = null;
 
     /**
@@ -56,12 +59,14 @@ class User extends Base {
       this.username = null;
     }
 
-    if ('bot' in data || typeof this.bot !== 'boolean') {
+    if ('bot' in data) {
       /**
        * Whether or not the user is a bot
        * @type {boolean}
        */
       this.bot = Boolean(data.bot);
+    } else if (!this.partial) {
+      this.bot = false;
     }
 
     if ('discriminator' in data) {
@@ -90,6 +95,8 @@ class User extends Base {
        * @type {?boolean}
        */
       this.system = Boolean(data.system);
+    } else if (!this.partial) {
+      this.system = false;
     }
 
     if ('public_flags' in data) {

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -62,7 +62,7 @@ class User extends Base {
     if ('bot' in data) {
       /**
        * Whether or not the user is a bot
-       * @type {boolean}
+       * @type {?boolean}
        */
       this.bot = Boolean(data.bot);
     } else if (!this.partial) {

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -59,12 +59,12 @@ class User extends Base {
       this.username = null;
     }
 
-    if ('bot' in data) {
+    if ('bot' in data || typeof this.bot === 'boolean') {
       /**
        * Whether or not the user is a bot
        * @type {?boolean}
        */
-      this.bot = Boolean(data.bot);
+      this.bot = Boolean(data.bot ?? this.bot);
     } else if (!this.partial) {
       this.bot = false;
     }
@@ -89,12 +89,12 @@ class User extends Base {
       this.avatar = null;
     }
 
-    if ('system' in data) {
+    if ('system' in data || typeof this.system === 'boolean') {
       /**
        * Whether the user is an Official Discord System user (part of the urgent message system)
        * @type {?boolean}
        */
-      this.system = Boolean(data.system);
+      this.system = Boolean(data.system ?? this.system);
     } else if (!this.partial) {
       this.system = false;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1857,7 +1857,7 @@ declare module 'discord.js' {
   export class User extends PartialTextBasedChannel(Base) {
     constructor(client: Client, data: unknown);
     public avatar: string | null;
-    public bot: boolean | null;
+    public bot: boolean;
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
     public discriminator: string;
@@ -1868,7 +1868,7 @@ declare module 'discord.js' {
     public lastMessageID: Snowflake | null;
     public readonly partial: false;
     public readonly presence: Presence;
-    public system: boolean | null;
+    public system: boolean;
     public readonly tag: string;
     public username: string;
     public avatarURL(options?: ImageURLOptions): string | null;
@@ -3777,9 +3777,9 @@ declare module 'discord.js' {
   type PartialTypes = 'USER' | 'CHANNEL' | 'GUILD_MEMBER' | 'MESSAGE' | 'REACTION';
 
   interface PartialUser extends Omit<Partialize<User, 'bot' | 'flags' | 'system' | 'tag' | 'username'>, 'deleted'> {
-    bot: User['bot'];
+    bot: null;
     flags: User['flags'];
-    system: User['system'];
+    system: null;
     readonly tag: null;
     username: null;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1857,7 +1857,7 @@ declare module 'discord.js' {
   export class User extends PartialTextBasedChannel(Base) {
     constructor(client: Client, data: unknown);
     public avatar: string | null;
-    public bot: boolean;
+    public bot: boolean | null;
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
     public discriminator: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Due to the system property only being present in user objects when the user is a system user, it would end up always being null instead of false like it should be. This PR fixes that so that it's true for system users, false for non-system users and null for partial users (regardless of whether they're system or not, since we don't know that)
Another issue in the User class was that the bot property would always be false for partial users due to the check `typeof this.bot !== 'boolean'` which would return true since this.bot was set to null previously. This fixes that so that it's null for partial users, true for bots and false for regular users.

⚠️ I did test these changes but only by creating partial objects myself since I couldn't find a way to easily obtain an actual partial user object. Please let me know if there's something that could go wrong that I didn't pick up in my tests.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
