### PR TITLE
fix(Message): Make author of referenced message nullable

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -332,7 +332,7 @@ class Message extends Base {
       'mention_roles' in data ? data.mention_roles : this.mentions.roles,
       'mention_everyone' in data ? data.mention_everyone : this.mentions.everyone,
       'mention_channels' in data ? data.mention_channels : this.mentions.crosspostedChannels,
-      'referenced_message' in data ? data.referenced_message?.author ?? null : this.mentions.repliedUser,
+      data.referenced_message ? data.referenced_message.author : this.mentions.repliedUser,
     );
 
     this.flags = new MessageFlags('flags' in data ? data.flags : 0).freeze();

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -332,7 +332,7 @@ class Message extends Base {
       'mention_roles' in data ? data.mention_roles : this.mentions.roles,
       'mention_everyone' in data ? data.mention_everyone : this.mentions.everyone,
       'mention_channels' in data ? data.mention_channels : this.mentions.crosspostedChannels,
-      'referenced_message' in data ? (data.referenced_message?.author ?? null) : this.mentions.repliedUser,
+      'referenced_message' in data ? data.referenced_message?.author ?? null : this.mentions.repliedUser,
     );
 
     this.flags = new MessageFlags('flags' in data ? data.flags : 0).freeze();

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -332,7 +332,7 @@ class Message extends Base {
       'mention_roles' in data ? data.mention_roles : this.mentions.roles,
       'mention_everyone' in data ? data.mention_everyone : this.mentions.everyone,
       'mention_channels' in data ? data.mention_channels : this.mentions.crosspostedChannels,
-      'referenced_message' in data ? data.referenced_message.author : this.mentions.repliedUser,
+      'referenced_message' in data ? (data.referenced_message?.author ?? null) : this.mentions.repliedUser,
     );
 
     this.flags = new MessageFlags('flags' in data ? data.flags : 0).freeze();

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -332,7 +332,7 @@ class Message extends Base {
       'mention_roles' in data ? data.mention_roles : this.mentions.roles,
       'mention_everyone' in data ? data.mention_everyone : this.mentions.everyone,
       'mention_channels' in data ? data.mention_channels : this.mentions.crosspostedChannels,
-      data.referenced_message?.author ?? : this.mentions.repliedUser,
+      data.referenced_message?.author ?? this.mentions.repliedUser,
     );
 
     this.flags = new MessageFlags('flags' in data ? data.flags : 0).freeze();

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -332,7 +332,7 @@ class Message extends Base {
       'mention_roles' in data ? data.mention_roles : this.mentions.roles,
       'mention_everyone' in data ? data.mention_everyone : this.mentions.everyone,
       'mention_channels' in data ? data.mention_channels : this.mentions.crosspostedChannels,
-      data.referenced_message ? data.referenced_message.author : this.mentions.repliedUser,
+      data.referenced_message?.author ?? : this.mentions.repliedUser,
     );
 
     this.flags = new MessageFlags('flags' in data ? data.flags : 0).freeze();

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1486,7 +1486,7 @@ declare module 'discord.js' {
       users: APIUser[] | Collection<Snowflake, User>,
       roles: Snowflake[] | Collection<Snowflake, Role>,
       everyone: boolean,
-      repliedUser?: APIUser | User | null,
+      repliedUser?: APIUser | User,
     );
     private _channels: Collection<Snowflake, Channel> | null;
     private readonly _content: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1486,7 +1486,7 @@ declare module 'discord.js' {
       users: APIUser[] | Collection<Snowflake, User>,
       roles: Snowflake[] | Collection<Snowflake, Role>,
       everyone: boolean,
-      repliedUser?: APIUser | User,
+      repliedUser?: APIUser | User | null,
     );
     private _channels: Collection<Snowflake, Channel> | null;
     private readonly _content: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
After #5905 PR, `data.referenced_message` property has been added to Message class (optional, non-nullable). Actually, however, the property is also nullable. This PR makes that nullable, and fixes issue caused by non-nullable property.


![2021-06-26 20251409](https://user-images.githubusercontent.com/79850607/123511515-ad065080-d6bc-11eb-8a65-2ecbf19740d3.png)

p.s. My english is not good. please understand if you find any wrong grammar..

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating