### PR TITLE
feat(User): support user banners

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -281,7 +281,7 @@ class User extends Base {
   }
 
   /**
-   * Checks if the user is equal to another. It compares ID, username, discriminator, avatar, and bot flags.
+   * Checks if the user is equal to another. It compares ID, username, discriminator, avatar, banner, and bot flags.
    * It is recommended to compare equality by using `user.id === user2.id` unless you want to compare all properties.
    * @param {User} user User to compare with
    * @returns {boolean}
@@ -292,7 +292,8 @@ class User extends Base {
       this.id === user.id &&
       this.username === user.username &&
       this.discriminator === user.discriminator &&
-      this.avatar === user.avatar;
+      this.avatar === user.avatar &&
+      this.banner === user.banner;
 
     return equal;
   }
@@ -342,6 +343,7 @@ class User extends Base {
     );
     json.avatarURL = this.avatarURL();
     json.displayAvatarURL = this.displayAvatarURL();
+    json.bannerURL = this.bannerURL();
     return json;
   }
 

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -83,6 +83,16 @@ class User extends Base {
     } else if (typeof this.avatar !== 'string') {
       this.avatar = null;
     }
+    
+    if ('banner' in data) {
+      /**
+       * The ID of the user's banner
+       * @type {?string}
+       */
+      this.banner = data.banner;
+    } else if (typeof this.banner !== 'string') {
+      this.banner = null;
+    }
 
     if ('system' in data) {
       /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -83,7 +83,7 @@ class User extends Base {
     } else if (typeof this.avatar !== 'string') {
       this.avatar = null;
     }
-    
+
     if ('banner' in data) {
       /**
        * The ID of the user's banner

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -192,6 +192,16 @@ class User extends Base {
   }
 
   /**
+   * A link to the user's banner.
+   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @returns {?string}
+   */
+  bannerURL({ format, size, dynamic } = {}) {
+    if (!this.banner) return null;
+    return this.client.rest.cdn.Banner(this.id, this.banner, format, size, dynamic);
+  }
+
+  /**
    * The Discord "tag" (e.g. `hydrabolt#0001`) for this user
    * @type {?string}
    * @readonly

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -86,7 +86,7 @@ class User extends Base {
 
     if ('banner' in data) {
       /**
-       * The ID of the user's banner
+       * The user banner's hash
        * @type {?string}
        */
       this.banner = data.banner;
@@ -281,7 +281,7 @@ class User extends Base {
   }
 
   /**
-   * Checks if the user is equal to another. It compares ID, username, discriminator, avatar, banner, and bot flags.
+   * Checks if the user is equal to another. It compares id, username, discriminator, avatar, banner, and bot flags.
    * It is recommended to compare equality by using `user.id === user2.id` unless you want to compare all properties.
    * @param {User} user User to compare with
    * @returns {boolean}

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -159,7 +159,7 @@ exports.Endpoints = {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/avatars/${userID}/${hash}`, { format, size });
       },
-      Banner: (id, hash, format = 'webp', size) => {
+      Banner: (id, hash, format = 'webp', size, dynamic = false) => {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/banners/${id}/${hash}`, { format, size });
       },

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -159,8 +159,10 @@ exports.Endpoints = {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/avatars/${userID}/${hash}`, { format, size });
       },
-      Banner: (guildID, hash, format = 'webp', size) =>
-        makeImageUrl(`${root}/banners/${guildID}/${hash}`, { format, size }),
+      Banner: (id, hash, format = 'webp', size) => {
+        if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
+        return makeImageUrl(`${root}/banners/${id}/${hash}`, { format, size });
+      },
       Icon: (guildID, hash, format = 'webp', size, dynamic = false) => {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size });

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -570,7 +570,7 @@ declare module 'discord.js' {
           format: 'default' | AllowedImageFormat,
           size: number,
         ) => string;
-        Banner: (guildID: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
+        Banner: (id: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
         Icon: (
           userID: Snowflake | number,
           hash: string,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -569,13 +569,21 @@ declare module 'discord.js' {
           hash: string,
           format: 'default' | AllowedImageFormat,
           size: number,
+          dynamic: boolean,
         ) => string;
-        Banner: (id: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
+        Banner: (
+          id: Snowflake | number,
+          hash: string,
+          format: AllowedImageFormat,
+          size: number,
+          dynamic: boolean,
+        ) => string;
         Icon: (
           userID: Snowflake | number,
           hash: string,
           format: 'default' | AllowedImageFormat,
           size: number,
+          dynamic: boolean,
         ) => string;
         AppIcon: (userID: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
         AppAsset: (userID: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1973,6 +1973,7 @@ declare module 'discord.js' {
   export class User extends PartialTextBasedChannel(Base) {
     constructor(client: Client, data: unknown);
     public avatar: string | null;
+    public banner: string | null;
     public bot: boolean;
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
@@ -1988,6 +1989,7 @@ declare module 'discord.js' {
     public readonly tag: string;
     public username: string;
     public avatarURL(options?: ImageURLOptions): string | null;
+    public bannerURL(options?: ImageURLOptions): string | null;
     public createDM(): Promise<DMChannel>;
     public deleteDM(): Promise<DMChannel>;
     public displayAvatarURL(options?: ImageURLOptions): string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
With the recent releases of user banners for everyone, Discord confirmed they will add the banner image hash to the user object.
See https://github.com/discord/discord-api-docs/issues/3095#issuecomment-868817186

This PR supports the banner field.

Do not merge until the field is accessible via the API.


**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
