### PR TITLE
fix(Sharding): strict type context and return

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -133,7 +133,7 @@ declare enum WebhookTypes {
   'Channel Follower' = 2,
 }
 
-type Awaited<T> = T | Promise<T>;
+type Awaited<T> = T | PromiseLike<T>;
 
 declare module 'discord.js' {
   import BaseCollection from '@discordjs/collection';
@@ -1756,14 +1756,14 @@ declare module 'discord.js' {
     public readonly ids: number[];
     public mode: ShardingManagerMode;
     public parentPort: any | null;
-    public broadcastEval<T>(fn: (client: Client) => T): Promise<Serialized<T>[]>;
-    public broadcastEval<T>(fn: (client: Client) => T, options: { shard: number }): Promise<Serialized<T>>;
+    public broadcastEval<T>(fn: (client: Client) => Awaited<T>): Promise<Serialized<T>[]>;
+    public broadcastEval<T>(fn: (client: Client) => Awaited<T>, options: { shard: number }): Promise<Serialized<T>>;
     public broadcastEval<T, P>(
-      fn: (client: Client, context: Serialized<P>) => T,
+      fn: (client: Client, context: Serialized<P>) => Awaited<T>,
       options: { context: P },
     ): Promise<Serialized<T>[]>;
     public broadcastEval<T, P>(
-      fn: (client: Client, context: Serialized<P>) => T,
+      fn: (client: Client, context: Serialized<P>) => Awaited<T>,
       options: { context: P; shard: number },
     ): Promise<Serialized<T>>;
     public fetchClientValues(prop: string): Promise<any[]>;
@@ -1788,14 +1788,14 @@ declare module 'discord.js' {
     public totalShards: number | 'auto';
     public shardList: number[] | 'auto';
     public broadcast(message: any): Promise<Shard[]>;
-    public broadcastEval<T>(fn: (client: Client) => T): Promise<Serialized<T>[]>;
-    public broadcastEval<T>(fn: (client: Client) => T, options: { shard: number }): Promise<Serialized<T>>;
+    public broadcastEval<T>(fn: (client: Client) => Awaited<T>): Promise<Serialized<T>[]>;
+    public broadcastEval<T>(fn: (client: Client) => Awaited<T>, options: { shard: number }): Promise<Serialized<T>>;
     public broadcastEval<T, P>(
-      fn: (client: Client, context: Serialized<P>) => T,
+      fn: (client: Client, context: Serialized<P>) => Awaited<T>,
       options: { context: P },
     ): Promise<Serialized<T>[]>;
     public broadcastEval<T, P>(
-      fn: (client: Client, context: Serialized<P>) => T,
+      fn: (client: Client, context: Serialized<P>) => Awaited<T>,
       options: { context: P; shard: number },
     ): Promise<Serialized<T>>;
     public createShard(id: number): Shard;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1756,13 +1756,16 @@ declare module 'discord.js' {
     public readonly ids: number[];
     public mode: ShardingManagerMode;
     public parentPort: any | null;
-    public broadcastEval<T>(fn: (client: Client) => T): Promise<T[]>;
-    public broadcastEval<T>(fn: (client: Client) => T, options: { shard: number }): Promise<T>;
-    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, options: { context: P }): Promise<T[]>;
+    public broadcastEval<T>(fn: (client: Client) => T): Promise<Serialized<T>[]>;
+    public broadcastEval<T>(fn: (client: Client) => T, options: { shard: number }): Promise<Serialized<T>>;
     public broadcastEval<T, P>(
-      fn: (client: Client, context: P) => T,
+      fn: (client: Client, context: Serialized<P>) => T,
+      options: { context: P },
+    ): Promise<Serialized<T>[]>;
+    public broadcastEval<T, P>(
+      fn: (client: Client, context: Serialized<P>) => T,
       options: { context: P; shard: number },
-    ): Promise<T>;
+    ): Promise<Serialized<T>>;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
     public respawnAll(options?: MultipleShardRespawnOptions): Promise<void>;
@@ -1785,13 +1788,16 @@ declare module 'discord.js' {
     public totalShards: number | 'auto';
     public shardList: number[] | 'auto';
     public broadcast(message: any): Promise<Shard[]>;
-    public broadcastEval<T>(fn: (client: Client) => T): Promise<T[]>;
-    public broadcastEval<T>(fn: (client: Client) => T, options: { shard: number }): Promise<T>;
-    public broadcastEval<T, P>(fn: (client: Client, context: P) => T, options: { context: P }): Promise<T[]>;
+    public broadcastEval<T>(fn: (client: Client) => T): Promise<Serialized<T>[]>;
+    public broadcastEval<T>(fn: (client: Client) => T, options: { shard: number }): Promise<Serialized<T>>;
     public broadcastEval<T, P>(
-      fn: (client: Client, context: P) => T,
+      fn: (client: Client, context: Serialized<P>) => T,
+      options: { context: P },
+    ): Promise<Serialized<T>[]>;
+    public broadcastEval<T, P>(
+      fn: (client: Client, context: Serialized<P>) => T,
       options: { context: P; shard: number },
-    ): Promise<T>;
+    ): Promise<Serialized<T>>;
     public createShard(id: number): Shard;
     public fetchClientValues(prop: string): Promise<any[]>;
     public fetchClientValues(prop: string, shard: number): Promise<any>;
@@ -4320,6 +4326,18 @@ declare module 'discord.js' {
     | 'STAGE_INSTANCE_CREATE'
     | 'STAGE_INSTANCE_UPDATE'
     | 'STAGE_INSTANCE_DELETE';
+
+  type Serialized<T> = T extends symbol | bigint | (() => unknown)
+    ? never
+    : T extends number | string | boolean | undefined
+    ? T
+    : T extends { toJSON(): infer R }
+    ? R
+    : T extends ReadonlyArray<infer V>
+    ? Serialized<V>[]
+    : T extends ReadonlyMap<unknown, unknown> | ReadonlySet<unknown>
+    ? {}
+    : { [K in keyof T]: Serialized<T[K]> };
 
   //#endregion
 }

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,6 +1,15 @@
 /// <reference path="index.d.ts" />
 
-import { Client, Intents, Message, MessageAttachment, MessageEmbed } from 'discord.js';
+import {
+  Client,
+  Collection,
+  Intents,
+  Message,
+  MessageAttachment,
+  MessageEmbed,
+  Permissions,
+  Serialized,
+} from 'discord.js';
 
 const client: Client = new Client({
   intents: Intents.NON_PRIVILEGED,
@@ -48,3 +57,32 @@ client.on('message', ({ channel }) => {
 });
 
 client.login('absolutely-valid-token');
+
+declare const assertType: <T>(value: T) => asserts value is T;
+declare const serialize: <T>(value: T) => Serialized<T>;
+
+assertType<undefined>(serialize(undefined));
+assertType<null>(serialize(null));
+assertType<number[]>(serialize([1, 2, 3]));
+assertType<{}>(serialize(new Set([1, 2, 3])));
+assertType<{}>(
+  serialize(
+    new Map([
+      [1, '2'],
+      [2, '4'],
+    ]),
+  ),
+);
+assertType<string>(serialize(new Permissions(Permissions.FLAGS.ATTACH_FILES)));
+assertType<number>(serialize(new Intents(Intents.FLAGS.GUILDS)));
+assertType<unknown>(
+  serialize(
+    new Collection([
+      [1, '2'],
+      [2, '4'],
+    ]),
+  ),
+);
+assertType<never>(serialize(Symbol('a')));
+assertType<never>(serialize(() => {}));
+assertType<never>(serialize(BigInt(42)));

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -9,6 +9,8 @@ import {
   MessageEmbed,
   Permissions,
   Serialized,
+  ShardClientUtil,
+  ShardingManager,
 } from 'discord.js';
 
 const client: Client = new Client({
@@ -58,6 +60,7 @@ client.on('message', ({ channel }) => {
 
 client.login('absolutely-valid-token');
 
+// Test type transformation:
 declare const assertType: <T>(value: T) => asserts value is T;
 declare const serialize: <T>(value: T) => Serialized<T>;
 
@@ -86,3 +89,12 @@ assertType<unknown>(
 assertType<never>(serialize(Symbol('a')));
 assertType<never>(serialize(() => {}));
 assertType<never>(serialize(BigInt(42)));
+
+// Test type return of broadcastEval:
+declare const shardClientUtil: ShardClientUtil;
+declare const shardingManager: ShardingManager;
+
+assertType<Promise<number[]>>(shardingManager.broadcastEval(() => 1));
+assertType<Promise<number[]>>(shardClientUtil.broadcastEval(() => 1));
+assertType<Promise<number[]>>(shardingManager.broadcastEval(async () => 1));
+assertType<Promise<number[]>>(shardClientUtil.broadcastEval(async () => 1));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Right now, `ShardClientUtil#broadcastEval` and `ShardingManager#broadcastEval`'s return types are the same as the callback's, as well as the context passed, however, the context data is serialized, and so is the return type.

This PR implements `Serialized`, which fixes this issue by converting rich types into their serialized counterpart.

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
