### PR TITLE
fix(Collector): docs and types

### DIFF
--- a/src/structures/MessageComponentInteractionCollector.js
+++ b/src/structures/MessageComponentInteractionCollector.js
@@ -82,7 +82,7 @@ class MessageComponentInteractionCollector extends Collector {
   /**
    * Handles an incoming interaction for possible collection.
    * @param {Interaction} interaction The interaction to possibly collect
-   * @returns {?(Snowflake|string)}
+   * @returns {?Snowflake}
    * @private
    */
   collect(interaction) {

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -81,7 +81,7 @@ class ReactionCollector extends Collector {
    * Handles an incoming reaction for possible collection.
    * @param {MessageReaction} reaction The reaction to possibly collect
    * @param {User} user The user that added the reaction
-   * @returns {Promise<Snowflake|string>}
+   * @returns {Promise<?(Snowflake|string)>}
    * @private
    */
   async collect(reaction, user) {

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -95,7 +95,7 @@ class Collector extends EventEmitter {
    * @emits Collector#collect
    */
   async handleCollect(...args) {
-    const collect = this.collect(...args);
+    const collect = await this.collect(...args);
 
     if (collect && (await this.filter(...args, this.collected))) {
       this.collected.set(collect, args[0]);
@@ -269,7 +269,7 @@ class Collector extends EventEmitter {
    * be collected, or returns an object describing the data that should be stored.
    * @see Collector#handleCollect
    * @param {...*} args Any args the event listener emits
-   * @returns {?{key, value}} Data to insert into collection, if any
+   * @returns {?(*|Promise<?*>)} Data to insert into collection, if any
    * @abstract
    */
   collect() {}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -480,8 +480,8 @@ declare module 'discord.js' {
     public adapters: Map<Snowflake, DiscordGatewayAdapterLibraryMethods>;
   }
 
-  export abstract class Collector<K, V> extends EventEmitter {
-    constructor(client: Client, options?: CollectorOptions<[V]>);
+  export abstract class Collector<K, V, F extends any[] = []> extends EventEmitter {
+    constructor(client: Client, options?: CollectorOptions<[V, ...F]>);
     private _timeout: NodeJS.Timeout | null;
     private _idletimeout: NodeJS.Timeout | null;
 
@@ -489,9 +489,9 @@ declare module 'discord.js' {
     public collected: Collection<K, V>;
     public ended: boolean;
     public abstract endReason: string | null;
-    public filter: CollectorFilter<[V]>;
+    public filter: CollectorFilter<[V, ...F]>;
     public readonly next: Promise<V>;
-    public options: CollectorOptions<[V]>;
+    public options: CollectorOptions<[V, ...F]>;
     public checkEnd(): void;
     public handleCollect(...args: any[]): Promise<void>;
     public handleDispose(...args: any[]): Promise<void>;
@@ -501,8 +501,8 @@ declare module 'discord.js' {
     public toJSON(): unknown;
 
     protected listener: (...args: any[]) => void;
-    public abstract collect(...args: any[]): K;
-    public abstract dispose(...args: any[]): K;
+    public abstract collect(...args: any[]): K | null | Promise<K | null>;
+    public abstract dispose(...args: any[]): K | null;
 
     public on(event: 'collect' | 'dispose', listener: (...args: any[]) => Awaited<void>): this;
     public on(event: 'end', listener: (collected: Collection<K, V>, reason: string) => Awaited<void>): this;
@@ -1366,8 +1366,8 @@ declare module 'discord.js' {
     public options: MessageCollectorOptions;
     public received: number;
 
-    public collect(message: Message): Snowflake;
-    public dispose(message: Message): Snowflake;
+    public collect(message: Message): Snowflake | null;
+    public dispose(message: Message): Snowflake | null;
   }
 
   export class MessageComponentInteraction extends Interaction {
@@ -1408,8 +1408,8 @@ declare module 'discord.js' {
     public total: number;
     public users: Collection<Snowflake, User>;
 
-    public collect(interaction: Interaction): Snowflake;
-    public dispose(interaction: Interaction): Snowflake;
+    public collect(interaction: Interaction): Snowflake | null;
+    public dispose(interaction: Interaction): Snowflake | null;
     public on(
       event: 'collect' | 'dispose',
       listener: (interaction: MessageComponentInteraction) => Awaited<void>,
@@ -1616,7 +1616,7 @@ declare module 'discord.js' {
     public equals(presence: Presence): boolean;
   }
 
-  export class ReactionCollector extends Collector<Snowflake | string, MessageReaction> {
+  export class ReactionCollector extends Collector<Snowflake | string, MessageReaction, [User]> {
     constructor(message: Message, options?: ReactionCollectorOptions);
     private _handleChannelDeletion(channel: GuildChannel): void;
     private _handleGuildDeletion(guild: Guild): void;
@@ -1630,8 +1630,8 @@ declare module 'discord.js' {
 
     public static key(reaction: MessageReaction): Snowflake | string;
 
-    public collect(reaction: MessageReaction): Promise<Snowflake | string>;
-    public dispose(reaction: MessageReaction, user: User): Snowflake | string;
+    public collect(reaction: MessageReaction, user: User): Promise<Snowflake | string | null>;
+    public dispose(reaction: MessageReaction, user: User): Snowflake | string | null;
     public empty(): void;
 
     public on(event: 'collect' | 'dispose' | 'remove', listener: (reaction: MessageReaction, user: User) => void): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR is smaller than it sounds but I'm explaining every change in detail here because I don't want to open yet another fix PR lol

Docs:
- The return type of `MessageComponentInteractionCollector#collect()` was changed from `?(Snowflake|string)` to just `?Snowflake` because it only returns either null or the interaction ID
- The return type of `ReactionCollector#collect()` was changed from `Promise<Snowflake|string>` to `Promise<?(Snowflake|string)>` because it can return null as well
- The return type of `Collector#collect()` was changed from... whatever that was before to `?(*|Promise<?*>)` so that extended classes can specify whether it returns a promise or not

Types:
- `Collector` got another type parameter for additional filter parameters
- `Collector#collect()` can now return a promise, which should be specified on extended classes as explained above
- All `collect()` and `dispose()` methods got null added to their return type (probably an oversight)
- A `user` parameter was added to `ReactionCollector#collect()` (probably another oversight)

Miscellaneous:
- An `await` keyword was added in `Collector#handleCollect()` because `this.collect()` is asynchronous for reaction collectors

**Status and versioning classification:**

- I know how to update typings and have done so