### PR TITLE
fix(Message): #patch throws if referenced message was deleted

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -332,7 +332,7 @@ class Message extends Base {
       'mention_roles' in data ? data.mention_roles : this.mentions.roles,
       'mention_everyone' in data ? data.mention_everyone : this.mentions.everyone,
       'mention_channels' in data ? data.mention_channels : this.mentions.crosspostedChannels,
-      'referenced_message' in data ? data.referenced_message.author : this.mentions.repliedUser,
+      data.referenced_message ? data.referenced_message.author : this.mentions.repliedUser,
     );
 
     this.flags = new MessageFlags('flags' in data ? data.flags : 0).freeze();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes an issue where patching a message will throw error if the message it replied to has been deleted. This happens because the lib only checks for the presence of `referenced_message` and not whether its `null` or not.

Thanks, @toastersticks for the 🕵️ work

**Status and versioning classification:**
- Code changes have been tested against the Discord API
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
