### PR TITLE
docs(Channel): make the type news_thread an inline code-block

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -22,7 +22,7 @@ class Channel extends Base {
      * * `category` - a guild category channel
      * * `news` - a guild news channel
      * * `store` - a guild store channel
-     * * 'news_thread` - a guild news channels' public thread channel
+     * * `news_thread` - a guild news channels' public thread channel
      * * `public_thread` - a guild text channels' public thread channel
      * * `private_thread` - a guild text channels' private thread channel
      * * `stage` - a guild stage channel


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a small visual bug in the documentation causing `news_thread` to not render like the others (as an inline code-block).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
