### PR TITLE
types: fix remaining Raw type references, update discord-api-types dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sapphire/async-queue": "^1.1.2",
         "@types/ws": "^7.4.4",
         "abort-controller": "^3.0.0",
-        "discord-api-types": "^0.18.1",
+        "discord-api-types": "^0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e",
         "node-fetch": "^2.6.1",
         "ws": "^7.4.6"
       },
@@ -1532,6 +1532,15 @@
         "prism-media": "^1.2.9",
         "tiny-typed-emitter": "^2.0.3",
         "ws": "^7.4.4"
+      }
+    },
+    "node_modules/@discordjs/voice/node_modules/discord-api-types": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
+      "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -3787,9 +3796,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
-      "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==",
+      "version": "0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e.tgz",
+      "integrity": "sha512-ttRA/8e/WKHDbGFfED5WlS7gID+kalmNr6iMiWBCvkphQ7kFHiTOVbnj/zX9ksaRaYXp/I38SCQ+qZvLu8DJZg==",
       "engines": {
         "node": ">=12"
       }
@@ -12654,6 +12663,14 @@
         "prism-media": "^1.2.9",
         "tiny-typed-emitter": "^2.0.3",
         "ws": "^7.4.4"
+      },
+      "dependencies": {
+        "discord-api-types": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
+          "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==",
+          "dev": true
+        }
       }
     },
     "@eslint/eslintrc": {
@@ -14433,9 +14450,9 @@
       "dev": true
     },
     "discord-api-types": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
-      "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg=="
+      "version": "0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e.tgz",
+      "integrity": "sha512-ttRA/8e/WKHDbGFfED5WlS7gID+kalmNr6iMiWBCvkphQ7kFHiTOVbnj/zX9ksaRaYXp/I38SCQ+qZvLu8DJZg=="
     },
     "dmd": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@sapphire/async-queue": "^1.1.2",
     "@types/ws": "^7.4.4",
     "abort-controller": "^3.0.0",
-    "discord-api-types": "^0.18.1",
+    "discord-api-types": "^0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e",
     "node-fetch": "^2.6.1",
     "ws": "^7.4.6"
   },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1185,7 +1185,7 @@ declare module 'discord.js' {
   export class InteractionWebhook extends PartialWebhookMixin() {
     constructor(client: Client, id: Snowflake, token: string);
     public token: string;
-    public send(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | RawMessage>;
+    public send(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
   }
 
   export class Invite extends Base {
@@ -1372,7 +1372,7 @@ declare module 'discord.js' {
 
   export class MessageComponentInteraction extends Interaction {
     public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | null;
-    public readonly component: MessageActionRowComponent | Exclude<RawMessageComponent, RawActionRowComponent> | null;
+    public readonly component: MessageActionRowComponent | Exclude<APIMessageComponent, APIActionRowComponent> | null;
     public componentType: MessageComponentType;
     public customID: string;
     public deferred: boolean;
@@ -2123,9 +2123,9 @@ declare module 'discord.js' {
     public editMessage(
       message: MessageResolvable,
       options: string | MessagePayload | WebhookEditMessageOptions,
-    ): Promise<RawMessage>;
-    public fetchMessage(message: Snowflake, cache?: boolean): Promise<RawMessage>;
-    public send(options: string | MessagePayload | WebhookMessageOptions): Promise<RawMessage>;
+    ): Promise<APIMessage>;
+    public fetchMessage(message: Snowflake, cache?: boolean): Promise<APIMessage>;
+    public send(options: string | MessagePayload | WebhookMessageOptions): Promise<APIMessage>;
   }
 
   export class WebSocketManager extends EventEmitter {
@@ -2624,9 +2624,9 @@ declare module 'discord.js' {
     editMessage(
       message: MessageResolvable | '@original',
       options: string | MessagePayload | WebhookEditMessageOptions,
-    ): Promise<Message | RawMessage>;
-    fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | RawMessage>;
-    send(options: string | MessagePayload | WebhookMessageOptions): Promise<Message | RawMessage>;
+    ): Promise<Message | APIMessage>;
+    fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | APIMessage>;
+    send(options: string | MessagePayload | WebhookMessageOptions): Promise<Message | APIMessage>;
   }
 
   interface WebhookFields extends PartialWebhookFields {


### PR DESCRIPTION
This replaces the remaining instances of Raw typings after they had been renamed.
It also updates the discord-api-types dependency to the -next release to support the component typings

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
