### PR TITLE
docs: drop string from MessageButtonStyleResolvable

### DIFF
--- a/src/structures/MessageButton.js
+++ b/src/structures/MessageButton.js
@@ -147,9 +147,8 @@ class MessageButton extends BaseMessageComponent {
   /**
    * Data that can be resolved to a MessageButtonStyle. This can be
    * * MessageButtonStyle
-   * * string
    * * number
-   * @typedef {string|number|MessageButtonStyle} MessageButtonStyleResolvable
+   * @typedef {number|MessageButtonStyle} MessageButtonStyleResolvable
    */
 
   /**


### PR DESCRIPTION
MessageButtonStyle resolvable was incorrectly documented as accepting any string

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
