### PR TITLE
types: define ApplicationCommand enums in lib

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -7,6 +7,23 @@ declare enum ActivityTypes {
   COMPETING = 5,
 }
 
+declare enum ApplicationCommandOptionTypes {
+  SUB_COMMAND = 1,
+  SUB_COMMAND_GROUP = 2,
+  STRING = 3,
+  INTEGER = 4,
+  BOOLEAN = 5,
+  USER = 6,
+  CHANNEL = 7,
+  ROLE = 8,
+  MENTIONABLE = 9,
+}
+
+declare enum ApplicationCommandPermissionTypes {
+  ROLE = 1,
+  USER = 2,
+}
+
 declare enum ChannelType {
   text = 0,
   dm = 1,
@@ -150,8 +167,6 @@ declare module 'discord.js' {
     APIRole,
     APIUser,
     Snowflake as APISnowflake,
-    ApplicationCommandOptionType as ApplicationCommandOptionTypes,
-    ApplicationCommandPermissionType as ApplicationCommandPermissionTypes,
   } from 'discord-api-types/v8';
   import { EventEmitter } from 'events';
   import { PathLike } from 'fs';


### PR DESCRIPTION
Two enums that were imported from discord-api-types are no longer compatible after updating that dependency.
This creates them in discord.js own types instead.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
