### PR TITLE
feat(CategoryChannel): ✨ Return name with 'CategoryChannel#toString'

### DIFF
--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -17,6 +17,17 @@ class CategoryChannel extends GuildChannel {
   }
 
   /**
+   * When concatenated with a string, this automatically returns the channel's name instead of the Category object.
+   * @returns {string}
+   * @example
+   * // Logs: Hello from General chit-chat !
+   * console.log(`Hello from ${category}!`);
+   */
+  toString() {
+    return this.name;
+  }
+
+  /**
    * Sets the category parent of this channel.
    * <warn>It is not currently possible to set the parent of a CategoryChannel.</warn>
    * @method setParent


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently, the stringification leads to a mention of vocal and textual salons but not for categories.
![image](https://user-images.githubusercontent.com/29425008/123617200-4c375f00-d807-11eb-9c2c-e470f191e99c.png)

The mention simply indicates the name of the category and prefixes it with a `#` which is the prefix of the textual channels.

The objective of this PR would be to extend the `CategoryChannel#toString` method to return the name of the channel.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
