### PR TITLE
types(ColorResolvable): change `string` to `#${string}`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3103,7 +3103,7 @@ declare module 'discord.js' {
     | 'RANDOM'
     | [number, number, number]
     | number
-    | string;
+    | `#${string}`;
 
   interface CommandInteractionOption {
     name: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently, when using `ColorResolvable`, you wouldn't get the color names from IntelliSense because they merge with the `string` type. By changing this to a templated string, the strings don't merge and the names show up.

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
