### PR TITLE
feat(StageChannel): add createStageInstance method & use better naming convention

### DIFF
--- a/src/managers/StageInstanceManager.js
+++ b/src/managers/StageInstanceManager.js
@@ -35,7 +35,7 @@ class StageInstanceManager extends BaseManager {
 
   /**
    * Creates a new stage instance.
-   * @param {StageChannel|Snowflake} channel The stage channel whose instance is to be created
+   * @param {StageChannel|Snowflake} channel The stage channel to associate the created instance to
    * @param {StageInstanceCreateOptions} options The options to create the stage instance
    * @returns {Promise<StageInstance>}
    * @example

--- a/src/managers/StageInstanceManager.js
+++ b/src/managers/StageInstanceManager.js
@@ -35,7 +35,7 @@ class StageInstanceManager extends BaseManager {
 
   /**
    * Creates a new stage instance.
-   * @param {StageChannel|Snowflake} channel The stage channel to associate the created instance to
+   * @param {StageChannel|Snowflake} channel The stage channel to associate the created stage instance to
    * @param {StageInstanceCreateOptions} options The options to create the stage instance
    * @returns {Promise<StageInstance>}
    * @example
@@ -68,7 +68,7 @@ class StageInstanceManager extends BaseManager {
 
   /**
    * Fetches the stage instance associated with a stage channel, if it exists.
-   * @param {StageChannel|Snowflake} channel The stage channel whose instance is to be fetched
+   * @param {StageChannel|Snowflake} channel The stage channel whose associated stage instance is to be fetched
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<StageInstance>}
    * @example
@@ -99,7 +99,7 @@ class StageInstanceManager extends BaseManager {
 
   /**
    * Edits an existing stage instance.
-   * @param {StageChannel|Snowflake} channel The stage channel whose instance is to be edited
+   * @param {StageChannel|Snowflake} channel The stage channel whose associated stage instance is to be edited
    * @param {StageInstanceEditOptions} options The options to edit the stage instance
    * @returns {Promise<StageInstance>}
    * @example
@@ -135,7 +135,7 @@ class StageInstanceManager extends BaseManager {
 
   /**
    * Deletes an existing stage instance.
-   * @param {StageChannel|Snowflake} channel The stage channel whose instance is to be deleted
+   * @param {StageChannel|Snowflake} channel The stage channel whose associated stage instance is to be deleted
    * @returns {Promise<void>}
    */
   async delete(channel) {

--- a/src/managers/StageInstanceManager.js
+++ b/src/managers/StageInstanceManager.js
@@ -28,31 +28,30 @@ class StageInstanceManager extends BaseManager {
 
   /**
    * Options used to create a stage instance.
-   * @typedef {Object} CreateStageInstanceOptions
-   * @property {StageChannel|Snowflake} channel The stage channel whose instance is to be created
+   * @typedef {Object} StageInstanceCreateOptions
    * @property {string} topic The topic of the stage instance
    * @property {PrivacyLevel|number} [privacyLevel] The privacy level of the stage instance
    */
 
   /**
    * Creates a new stage instance.
-   * @param {CreateStageInstanceOptions} options The options to create the stage instance
+   * @param {StageChannel|Snowflake} channel The stage channel whose instance is to be created
+   * @param {StageInstanceCreateOptions} options The options to create the stage instance
    * @returns {Promise<StageInstance>}
    * @example
    * // Create a stage instance
-   * guild.stageInstances.create({
-   *  channel: '1234567890123456789',
+   * guild.stageInstances.create('1234567890123456789', {
    *  topic: 'A very creative topic',
    *  privacyLevel: 'GUILD_ONLY'
    * })
    *  .then(stageInstance => console.log(stageInstance))
    *  .catch(console.error);
    */
-  async create(options) {
-    if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
-    let { channel, topic, privacyLevel } = options;
+  async create(channel, options) {
     const channelID = this.guild.channels.resolveID(channel);
     if (!channelID) throw new Error('STAGE_CHANNEL_RESOLVE');
+    if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
+    let { topic, privacyLevel } = options;
 
     if (privacyLevel) privacyLevel = typeof privacyLevel === 'number' ? privacyLevel : PrivacyLevels[privacyLevel];
 

--- a/src/structures/StageChannel.js
+++ b/src/structures/StageChannel.js
@@ -29,6 +29,15 @@ class StageChannel extends BaseGuildVoiceChannel {
   }
 
   /**
+   * Creates an instance of this stage channel.
+   * @param {StageInstanceCreateOptions} options The options to create the stage instance
+   * @returns {Promise<StageInstance>}
+   */
+  createStageInstance(options) {
+    return this.guild.stageInstances.create(this.id, options);
+  }
+
+  /**
    * Sets the RTC region of the channel.
    * @name StageChannel#setRTCRegion
    * @param {?string} region The new region of the channel. Set to `null` to remove a specific region for the channel

--- a/src/structures/StageChannel.js
+++ b/src/structures/StageChannel.js
@@ -20,20 +20,20 @@ class StageChannel extends BaseGuildVoiceChannel {
   }
 
   /**
-   * The instance of this stage channel, if it exists
+   * The stage instance of this stage channel, if it exists
    * @type {?StageInstance}
    * @readonly
    */
-  get instance() {
+  get stageInstance() {
     return this.guild.stageInstances.cache.find(stageInstance => stageInstance.channelID === this.id) ?? null;
   }
 
   /**
-   * Creates an instance associated to this stage channel.
+   * Creates a stage instance associated to this stage channel.
    * @param {StageInstanceCreateOptions} options The options to create the stage instance
    * @returns {Promise<StageInstance>}
    */
-  createInstance(options) {
+  createStageInstance(options) {
     return this.guild.stageInstances.create(this.id, options);
   }
 

--- a/src/structures/StageChannel.js
+++ b/src/structures/StageChannel.js
@@ -29,7 +29,7 @@ class StageChannel extends BaseGuildVoiceChannel {
   }
 
   /**
-   * Creates an instance of this stage channel.
+   * Creates an instance associated to this stage channel.
    * @param {StageInstanceCreateOptions} options The options to create the stage instance
    * @returns {Promise<StageInstance>}
    */

--- a/src/structures/StageChannel.js
+++ b/src/structures/StageChannel.js
@@ -33,7 +33,7 @@ class StageChannel extends BaseGuildVoiceChannel {
    * @param {StageInstanceCreateOptions} options The options to create the stage instance
    * @returns {Promise<StageInstance>}
    */
-  createStageInstance(options) {
+  createInstance(options) {
     return this.guild.stageInstances.create(this.id, options);
   }
 

--- a/src/structures/StageInstance.js
+++ b/src/structures/StageInstance.js
@@ -60,7 +60,7 @@ class StageInstance extends Base {
   }
 
   /**
-   * The stage channel associated with this instance
+   * The stage channel associated with this stage instance
    * @type {?StageChannel}
    * @readonly
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1827,8 +1827,8 @@ declare module 'discord.js' {
   export class StageChannel extends BaseGuildVoiceChannel {
     public topic: string | null;
     public type: 'stage';
-    public readonly instance: StageInstance | null;
-    public createInstance(options: StageInstanceCreateOptions): Promise<StageInstance>;
+    public readonly stageInstance: StageInstance | null;
+    public createStageInstance(options: StageInstanceCreateOptions): Promise<StageInstance>;
   }
 
   export class StageInstance extends Base {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1828,7 +1828,7 @@ declare module 'discord.js' {
     public topic: string | null;
     public type: 'stage';
     public readonly instance: StageInstance | null;
-    public createStageInstance(options: StageInstanceCreateOptions): Promise<StageInstance>;
+    public createInstance(options: StageInstanceCreateOptions): Promise<StageInstance>;
   }
 
   export class StageInstance extends Base {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1828,6 +1828,7 @@ declare module 'discord.js' {
     public topic: string | null;
     public type: 'stage';
     public readonly instance: StageInstance | null;
+    public createStageInstance(options: StageInstanceCreateOptions): Promise<StageInstance>;
   }
 
   export class StageInstance extends Base {
@@ -2539,7 +2540,7 @@ declare module 'discord.js' {
   export class StageInstanceManager extends BaseManager<Snowflake, StageInstance, StageInstanceResolvable> {
     constructor(guild: Guild, iterable?: Iterable<any>);
     public guild: Guild;
-    public create(options: CreateStageInstanceOptions): Promise<StageInstance>;
+    public create(channel: StageChannel | Snowflake, options: StageInstanceCreateOptions): Promise<StageInstance>;
     public fetch(channel: StageChannel | Snowflake, options?: BaseFetchOptions): Promise<StageInstance>;
     public edit(channel: StageChannel | Snowflake, options: StageInstanceEditOptions): Promise<StageInstance>;
     public delete(channel: StageChannel | Snowflake): Promise<void>;
@@ -3120,8 +3121,7 @@ declare module 'discord.js' {
     reason?: string;
   }
 
-  interface CreateStageInstanceOptions {
-    channel: StageChannel | Snowflake;
+  interface StageInstanceCreateOptions {
     topic: string;
     privacyLevel?: PrivacyLevel | number;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds a new `createStageInstance` method on `StageChannel` that lets the user create a stage instance associated to it. It also refactors the options typedef to keep it consistent with rest of the lib:

1) `CreateStageInstanceOptions` is now `StageInstanceCreateOptions`
2) The `channel` field is a seperate param now instead of being inside the options object

⚠️ As pointed out by @SpaceEEC, the term **"instance"** makes it sound like it is an instance of a Stage Channel which it isn't. This PR removes this ambiguity by using the complete term i.e. **"Stage Instance"** in all places. 

**Status and versioning classification:**
- Code changes have been tested against the Discord API
- I know how to update typings and have done so
- This PR changes the library's interface
- This PR includes breaking changes
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
