### PR TITLE
docs(Webhook): fix thread example in send method

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -118,7 +118,7 @@ class Webhook {
    *   .catch(console.error);
    * @example
    * // Send a basic message in a thread
-   * webhook.send('hello!', { threadID: '836856309672348295' })
+   * webhook.send({ content: 'hello!', threadID: '836856309672348295' })
    *   .then(message => console.log(`Sent message: ${message.content}`))
    *   .catch(console.error);
    * @example


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

One example in `Webhook#send` still uses the old way of sending messages with multiple parameters, which got removed as of #5758. This PR fixes that and uses a single param.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.