### PR TITLE
fix(Webhook): return void from #delete for consistency.

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -293,10 +293,10 @@ class Webhook {
   /**
    * Deletes the webhook.
    * @param {string} [reason] Reason for deleting this webhook
-   * @returns {Promise}
+   * @returns {Promise<void>}
    */
-  delete(reason) {
-    return this.client.api.webhooks(this.id, this.token).delete({ reason });
+  async delete(reason) {
+    await this.client.api.webhooks(this.id, this.token).delete({ reason });
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The typings for Webhook#delete says it returns `Promise<void>` but it really returns `Promise<Buffer>` with the buffer being an empty buffer because as https://discord.com/developers/docs/resources/webhook#delete-webhook states the route returns a 204 with no content. Webhook#deleteMessage has the same result from the route so to keep it consistent with that method and the typings this PR removes the return from the delete method.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating