### PR TITLE
refactor(Presence): remove second assignment of `syncID`

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -234,8 +234,6 @@ class Activity {
      */
     this.assets = data.assets ? new RichPresenceAssets(this, data.assets) : null;
 
-    this.syncID = data.sync_id;
-
     /**
      * Flags that describe the activity
      * @type {Readonly<ActivityFlags>}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In the `Activity` class, the syncID property was defined twice in the constructor.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating