### PR TITLE
fix(Thread): make archive_timestamp not nullable

### DIFF
--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -99,12 +99,10 @@ class ThreadChannel extends Channel {
     this.rateLimitPerUser = data.rate_limit_per_user ?? 0;
 
     /**
-     * The timestamp the thread was last archived or unarchived at
-     * @type {?number}
+     * The timestamp when the thread's archive status was last changed
+     * @type {number}
      */
-    this.archiveTimestamp = data.thread_metadata.archive_timestamp
-      ? new Date(data.thread_metadata.archive_timestamp).getTime()
-      : null;
+    this.archiveTimestamp = new Date(data.thread_metadata.archive_timestamp).getTime();
 
     /**
      * The approximate count of messages in this thread
@@ -135,12 +133,12 @@ class ThreadChannel extends Channel {
   }
 
   /**
-   * The time the thread was last archived or unarchived at
-   * @type {?Date}
+   * The time when the thread's archive status was last changed
+   * @type {Date}
    * @readonly
    */
   get archivedAt() {
-    return this.archiveTimestamp ? new Date(this.archiveTimestamp) : null;
+    return new Date(this.archiveTimestamp);
   }
 
   /**

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -100,8 +100,7 @@ class ThreadChannel extends Channel {
 
     /**
      * The timestamp when the thread's archive status was last changed
-     * <info>If the thread was never archived or unarchived,
-     * this is the same as {@link ThreadChannel#createdTimestamp}</info>
+     * <info>If the thread was never archived or unarchived, this is set when it's created</info>
      * @type {number}
      */
     this.archiveTimestamp = new Date(data.thread_metadata.archive_timestamp).getTime();
@@ -136,7 +135,7 @@ class ThreadChannel extends Channel {
 
   /**
    * The time when the thread's archive status was last changed
-   * <info>If the thread was never archived or unarchived, this is the same as {@link ThreadChannel#createdAt}</info>
+   * <info>If the thread was never archived or unarchived, this is set when it's created</info>
    * @type {Date}
    * @readonly
    */

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -100,6 +100,8 @@ class ThreadChannel extends Channel {
 
     /**
      * The timestamp when the thread's archive status was last changed
+     * <info>If the thread was never archived or unarchived,
+     * this is the same as {@link ThreadChannel#createdTimestamp}</info>
      * @type {number}
      */
     this.archiveTimestamp = new Date(data.thread_metadata.archive_timestamp).getTime();
@@ -134,6 +136,7 @@ class ThreadChannel extends Channel {
 
   /**
    * The time when the thread's archive status was last changed
+   * <info>If the thread was never archived or unarchived, this is the same as {@link ThreadChannel#createdAt}</info>
    * @type {Date}
    * @readonly
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1923,8 +1923,8 @@ declare module 'discord.js' {
   export class ThreadChannel extends TextBasedChannel(Channel) {
     constructor(guild: Guild, data?: object);
     public archived: boolean;
-    public readonly archivedAt: Date | null;
-    public archiveTimestamp: number | null;
+    public readonly archivedAt: Date;
+    public archiveTimestamp: number;
     public autoArchiveDuration: ThreadAutoArchiveDuration;
     public readonly editable: boolean;
     public guild: Guild;


### PR DESCRIPTION
fix #5964

**Please describe the changes this PR makes and why it should be merged:**
This PR makes `archivedTimestamp` and `archivedAt` not nullable as shown in [Discord API docs](https://discord.com/developers/docs/resources/channel#thread-metadata-object).

Since these properties indicate the date of the last archive status change and not only the last archived/unarchive date maybe we can change their actual names, but for now, I'll keep them.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating