### PR TITLE
ci: add UNIX timestamp to version number

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Publish
         run: |
-          npm version --git-tag-version=false $(jq --raw-output '.version' package.json).$(git rev-parse --short=7 --verify HEAD).$(date +%s)
+          npm version --git-tag-version=false $(jq --raw-output '.version' package.json).$(git rev-parse --short HEAD).$(date +%s)
           npm publish --tag dev || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Publish
         run: |
-          npm version --git-tag-version=false $(jq --raw-output '.version' package.json).$(git rev-parse --verify HEAD)
+          npm version --git-tag-version=false $(jq --raw-output '.version' package.json).$(git rev-parse --short=7 --verify HEAD).$(date +%s)
           npm publish --tag dev || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Changed the git sha to only include the first 7 characters and added a UNIX timestamp in seconds. This should prevent issues with `npm update` and dependabot being stuck on older versions.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
