### PR TITLE
types(ThreadManager): add type to ThreadManager#create options

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2625,6 +2625,7 @@ declare module 'discord.js' {
       name: string;
       autoArchiveDuration: ThreadAutoArchiveDuration;
       startMessage?: MessageResolvable;
+      type?: ThreadChannelType | number;
       reason?: string;
     }): Promise<ThreadChannel>;
     public fetch(options: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<ThreadChannel | null>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the lack of the type parameter in ThreadManager#create's options

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.