### PR TITLE
docs(ThreadManager): fix reason prop of ThreadCreateOptions

### DIFF
--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -78,7 +78,7 @@ class ThreadManager extends BaseManager {
    * creates a private thread if not provided
    * @property {ThreadChannelType|number} [type='public_thread'] The type of thread to create
    * <warn>When creating threads in a `news` channel this is ignored and is always `news_thread`</warn>
-   * @param {string} [reason] Reason for creating the thread
+   * @property {string} [reason] Reason for creating the thread
    */
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the jsdoc for `ThreadCreateOptions`

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
