### PR TITLE
docs(ThreadManager): fix FetchedThreads typedef and startMessage

### DIFF
--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -74,8 +74,7 @@ class ThreadManager extends BaseManager {
    * @typedef {Object} ThreadCreateOptions
    * @property {string} name The name of the new Thread
    * @property {ThreadAutoArchiveDuration} autoArchiveDuration How long before the thread is automatically archived
-   * @property {MessageResolvable} [startMessage] The message to start a public or news thread from,
-   * creates a private thread if not provided
+   * @property {MessageResolvable} [startMessage] The message to start a thread from
    * @property {ThreadChannelType|number} [type='public_thread'] The type of thread to create
    * <warn>When creating threads in a `news` channel this is ignored and is always `news_thread`</warn>
    * @param {string} [reason] Reason for creating the thread
@@ -186,7 +185,7 @@ class ThreadManager extends BaseManager {
 
   /**
    * The data returned from a thread fetch that returns multiple threads.
-   * @typedef {FetchedThreads}
+   * @typedef {Object} FetchedThreads
    * @property {Collection<Snowflake, ThreadChannel>} threads The threads fetched, with any members returned
    * @property {?boolean} hasMore Whether there are potentially additional threads that require a subsequent call
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR correctly defines the `FetchedThreads` typedef.

It also changes the description for `ThreadCreateOptions#startMessage`. Thread created without a message does default to private if no type was provided but we have `type` set to `public_thread` as default in the lib. So, it is not going to be a private thread if no `startMessage` was provided.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
