### PR TITLE
types(*): make hex color types compatible with ColorResolvable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1141,8 +1141,6 @@ declare module 'discord.js' {
     public roles: Snowflake[];
   }
 
-  type HexColorString = `#${string}`;
-
   export class HTTPError extends Error {
     constructor(message: string, name: string, code: number, request: unknown);
     public code: number;
@@ -3558,6 +3556,8 @@ declare module 'discord.js' {
   }
 
   type GuildTemplateResolvable = string;
+
+  type HexColorString = `#${string}`;
 
   interface HTTPAttachmentData {
     attachment: string | Buffer | Stream;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1059,7 +1059,7 @@ declare module 'discord.js' {
     public readonly bannable: boolean;
     public deleted: boolean;
     public readonly displayColor: number;
-    public readonly displayHexColor: string;
+    public readonly displayHexColor: `#${string}`;
     public readonly displayName: string;
     public guild: Guild;
     public readonly id: Snowflake;
@@ -1475,7 +1475,7 @@ declare module 'discord.js' {
     public description: string | null;
     public fields: EmbedField[];
     public footer: MessageEmbedFooter | null;
-    public readonly hexColor: string | null;
+    public readonly hexColor: `#${string}` | null;
     public image: MessageEmbedImage | null;
     public readonly length: number;
     public provider: MessageEmbedProvider | null;
@@ -1712,7 +1712,7 @@ declare module 'discord.js' {
     public deleted: boolean;
     public readonly editable: boolean;
     public guild: Guild;
-    public readonly hexColor: string;
+    public readonly hexColor: `#${string}`;
     public hoist: boolean;
     public id: Snowflake;
     public managed: boolean;
@@ -4056,7 +4056,7 @@ declare module 'discord.js' {
     > {
     readonly bannable: boolean;
     readonly displayColor: number;
-    readonly displayHexColor: string;
+    readonly displayHexColor: `#${string}`;
     readonly displayName: string;
     guild: Guild;
     readonly manageable: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1059,7 +1059,7 @@ declare module 'discord.js' {
     public readonly bannable: boolean;
     public deleted: boolean;
     public readonly displayColor: number;
-    public readonly displayHexColor: `#${string}`;
+    public readonly displayHexColor: HexColorString;
     public readonly displayName: string;
     public guild: Guild;
     public readonly id: Snowflake;
@@ -1140,6 +1140,8 @@ declare module 'discord.js' {
     public guild: GuildPreview;
     public roles: Snowflake[];
   }
+
+  type HexColorString = `#${string}`;
 
   export class HTTPError extends Error {
     constructor(message: string, name: string, code: number, request: unknown);
@@ -1475,7 +1477,7 @@ declare module 'discord.js' {
     public description: string | null;
     public fields: EmbedField[];
     public footer: MessageEmbedFooter | null;
-    public readonly hexColor: `#${string}` | null;
+    public readonly hexColor: HexColorString | null;
     public image: MessageEmbedImage | null;
     public readonly length: number;
     public provider: MessageEmbedProvider | null;
@@ -1712,7 +1714,7 @@ declare module 'discord.js' {
     public deleted: boolean;
     public readonly editable: boolean;
     public guild: Guild;
-    public readonly hexColor: `#${string}`;
+    public readonly hexColor: HexColorString;
     public hoist: boolean;
     public id: Snowflake;
     public managed: boolean;
@@ -3170,7 +3172,7 @@ declare module 'discord.js' {
     | 'RANDOM'
     | [number, number, number]
     | number
-    | `#${string}`;
+    | HexColorString;
 
   interface CommandInteractionOption {
     name: string;
@@ -4056,7 +4058,7 @@ declare module 'discord.js' {
     > {
     readonly bannable: boolean;
     readonly displayColor: number;
-    readonly displayHexColor: `#${string}`;
+    readonly displayHexColor: HexColorString;
     readonly displayName: string;
     guild: Guild;
     readonly manageable: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In #5950 the type for ColorResolvable was changed from `string` to `#${string}`. This meant that assigning a hexColor from the library to a ColorResolvable parameter would error out, so this PR fixes that.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
