### PR TITLE
feat(Util): added formatters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "13.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {
+        "@discordjs/builders": "^0.1.0",
         "@discordjs/collection": "^0.1.6",
         "@discordjs/form-data": "^3.0.1",
         "@sapphire/async-queue": "^1.1.4",
@@ -978,6 +979,26 @@
       "dev": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.1.0.tgz",
+      "integrity": "sha512-x9wwMeBdgll3zqzG0c1d+z67Fg4Feg222bNAzzzP4o4FUzxhFW5biUIPQP08nEHmXhuwPSiyiknu20zZgr0otg==",
+      "dependencies": {
+        "discord-api-types": "^0.18.1"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
+      "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@discordjs/collection": {
@@ -12179,6 +12200,21 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
+        }
+      }
+    },
+    "@discordjs/builders": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.1.0.tgz",
+      "integrity": "sha512-x9wwMeBdgll3zqzG0c1d+z67Fg4Feg222bNAzzzP4o4FUzxhFW5biUIPQP08nEHmXhuwPSiyiknu20zZgr0otg==",
+      "requires": {
+        "discord-api-types": "^0.18.1"
+      },
+      "dependencies": {
+        "discord-api-types": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
+          "integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "homepage": "https://github.com/discordjs/discord.js#readme",
   "dependencies": {
+    "@discordjs/builders": "^0.1.0",
     "@discordjs/collection": "^0.1.6",
     "@discordjs/form-data": "^3.0.1",
     "@sapphire/async-queue": "^1.1.4",

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ module.exports = {
   Collection: require('./util/Collection'),
   Constants: require('./util/Constants'),
   DataResolver: require('./util/DataResolver'),
+  Formatters: require('./util/Formatters'),
   BaseManager: require('./managers/BaseManager'),
   DiscordAPIError: require('./rest/DiscordAPIError'),
   HTTPError: require('./rest/HTTPError'),

--- a/src/util/Formatters.js
+++ b/src/util/Formatters.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const {
+  TimestampStyles,
+  blockQuote,
+  bold,
+  codeBlock,
+  inlineCode,
+  italic,
+  quote,
+  strikethrough,
+  time,
+  underscore,
+} = require('@discordjs/builders');
+
+exports.TimestampStyles = TimestampStyles;
+exports.blockQuote = blockQuote;
+exports.bold = bold;
+exports.codeBlock = codeBlock;
+exports.inlineCode = inlineCode;
+exports.italic = italic;
+exports.quote = quote;
+exports.strikethrough = strikethrough;
+exports.time = time;
+exports.underscore = underscore;

--- a/src/util/Formatters.js
+++ b/src/util/Formatters.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const {
-  TimestampStyles,
   blockQuote,
   bold,
   codeBlock,
@@ -10,10 +9,10 @@ const {
   quote,
   strikethrough,
   time,
+  TimestampStyles,
   underscore,
 } = require('@discordjs/builders');
 
-exports.TimestampStyles = TimestampStyles;
 exports.blockQuote = blockQuote;
 exports.bold = bold;
 exports.codeBlock = codeBlock;
@@ -22,4 +21,5 @@ exports.italic = italic;
 exports.quote = quote;
 exports.strikethrough = strikethrough;
 exports.time = time;
+exports.TimestampStyles = TimestampStyles;
 exports.underscore = underscore;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2110,8 +2110,6 @@ declare module 'discord.js' {
 
   export namespace Formatters {
     export {
-      TimestampStyles,
-      TimestampStylesString,
       blockQuote,
       bold,
       codeBlock,
@@ -2120,6 +2118,8 @@ declare module 'discord.js' {
       quote,
       strikethrough,
       time,
+      TimestampStyles,
+      TimestampStylesString,
       underscore,
     };
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -172,7 +172,21 @@ declare module '@discordjs/voice' {
 }
 
 declare module 'discord.js' {
+  import {
+    blockQuote,
+    bold,
+    codeBlock,
+    inlineCode,
+    italic,
+    quote,
+    strikethrough,
+    time,
+    TimestampStyles,
+    TimestampStylesString,
+    underscore,
+  } from '@discordjs/builders';
   import BaseCollection from '@discordjs/collection';
+  import { DiscordGatewayAdapterCreator, DiscordGatewayAdapterLibraryMethods } from '@discordjs/voice';
   import { ChildProcess } from 'child_process';
   import {
     APIActionRowComponent,
@@ -189,8 +203,7 @@ declare module 'discord.js' {
   } from 'discord-api-types/v8';
   import { EventEmitter } from 'events';
   import { PathLike } from 'fs';
-  import { Readable, Stream, Writable } from 'stream';
-  import { DiscordGatewayAdapterCreator, DiscordGatewayAdapterLibraryMethods } from '@discordjs/voice';
+  import { Stream } from 'stream';
   import * as WebSocket from 'ws';
 
   export const version: string;
@@ -2093,6 +2106,22 @@ declare module 'discord.js' {
       reason?: string,
     ): Promise<{ id: Snowflake; position: number }[]>;
     public static splitMessage(text: string, options?: SplitOptions): string[];
+  }
+
+  export namespace Formatters {
+    export {
+      TimestampStyles,
+      TimestampStylesString,
+      blockQuote,
+      bold,
+      codeBlock,
+      inlineCode,
+      italic,
+      quote,
+      strikethrough,
+      time,
+      underscore,
+    };
   }
 
   export class VoiceChannel extends BaseGuildVoiceChannel {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

ref: https://github.com/discordjs/discord.js/pull/5918

**Usage:**

```javascript
const { Formatters } = require('discord.js');

Formatters.bold('Hello there');
// **Hello there**
```

```javascript
const { Formatters: { bold, italic } } = require('discord.js');

bold(italic('General Kenobi!'));
// **_General Kenobi!_**
```

Or with TypeScript / ESM:

```typescript
import { Formatters } from 'discord.js';

Formatters.codeBlock('You are a bold one.');
// ```\nYou are a bold one.```
```

> **Note**: A namespace was used because it's the equivalent of `export * as Formatters from './util/Formatters';` in TypeScript.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
