### PR TITLE
feat(Channel): add isThread typeguard for better TS support

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Base = require('./Base');
-const { ChannelTypes } = require('../util/Constants');
+const { ChannelTypes, ThreadChannelTypes } = require('../util/Constants');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
 
 /**
@@ -115,7 +115,7 @@ class Channel extends Base {
    * @returns {boolean}
    */
   isThread() {
-    return ['news_thread', 'public_thread', 'private_thread'].includes(this.type);
+    return ThreadChannelTypes.includes(this.type);
   }
 
   static create(client, data, guild) {

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -110,6 +110,14 @@ class Channel extends Base {
     return 'messages' in this;
   }
 
+  /**
+   * Indicates whether this channel is a thread channel.
+   * @returns {boolean}
+   */
+  isThread() {
+    return ['news_thread', 'public_thread', 'private_thread'].includes(this.type);
+  }
+
   static create(client, data, guild) {
     const Structures = require('../util/Structures');
     let channel;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -438,6 +438,7 @@ declare module 'discord.js' {
     public delete(reason?: string): Promise<Channel>;
     public fetch(force?: boolean): Promise<Channel>;
     public isText(): this is TextChannel | DMChannel | NewsChannel | ThreadChannel;
+    public isThread(): this is ThreadChannel;
     public toString(): string;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds `Channel#isThread` method to help TS users narrow down a generic channel into a `ThreadChannel`

**Status and versioning classification:**
- Code changes have been tested against the Discord API
- I know how to update typings and have done so
- This PR changes the library's interface (method added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
