### PR TITLE
types(ThreadChannel): make locked and archived param optional

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2010,7 +2010,7 @@ declare module 'discord.js' {
       autoArchiveDuration: ThreadAutoArchiveDuration,
       reason?: string,
     ): Promise<ThreadChannel>;
-    public setLocked(locked: boolean, reason?: string): Promise<ThreadChannel>;
+    public setLocked(locked?: boolean, reason?: string): Promise<ThreadChannel>;
     public setName(name: string, reason?: string): Promise<ThreadChannel>;
     public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<ThreadChannel>;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2005,7 +2005,7 @@ declare module 'discord.js' {
     public leave(): Promise<ThreadChannel>;
     public permissionsFor(memberOrRole: GuildMember | Role): Readonly<Permissions>;
     public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
-    public setArchived(archived: boolean, reason?: string): Promise<ThreadChannel>;
+    public setArchived(archived?: boolean, reason?: string): Promise<ThreadChannel>;
     public setAutoArchiveDuration(
       autoArchiveDuration: ThreadAutoArchiveDuration,
       reason?: string,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR just fixes typings for parameters `locked` in `ThreadChannel#setLocked` and `archived` in `ThreadChannel#setArchived` to be optional as showed in [docs](https://discord.js.org/#/docs/main/master/class/ThreadChannel?scrollTo=setLocked) and in the source code.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.