### PR TITLE
docs(Partials): add link to the guide

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -41,7 +41,7 @@ const { Error, RangeError } = require('../errors');
  * 401, 403, or 429) in a 10 minute window between emitted warnings (0 for no warnings). That is, if set to 500,
  * warnings will be emitted at invalid request number 500, 1000, 1500, and so on.
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
- * they're missing all the data for a particular structure. See the "Partials" topic on the
+ * they're missing all the data for a particular structure. See the "Partial Structures" topic on the
  * [guide](https://discordjs.guide/popular-topics/partials.html) for some
  * important usage information, as partials require you to put checks in place when handling data.
  * @property {number} [restWsBridgeTimeout=5000] Maximum time permitted between REST responses and their
@@ -307,7 +307,7 @@ exports.ShardEvents = {
  * * GUILD_MEMBER
  * * MESSAGE
  * * REACTION
- * <warn>Partials require you to put checks in place when handling data, read the Partials topic on the
+ * <warn>Partials require you to put checks in place when handling data. See the "Partial Structures" topic on the
  * [guide](https://discordjs.guide/popular-topics/partials.html) for more information.</warn>
  * @typedef {string} PartialType
  */

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -41,7 +41,8 @@ const { Error, RangeError } = require('../errors');
  * 401, 403, or 429) in a 10 minute window between emitted warnings (0 for no warnings). That is, if set to 500,
  * warnings will be emitted at invalid request number 500, 1000, 1500, and so on.
  * @property {PartialType[]} [partials] Structures allowed to be partial. This means events can be emitted even when
- * they're missing all the data for a particular structure. See the "Partials" topic listed in the sidebar for some
+ * they're missing all the data for a particular structure. See the "Partials" topic on the
+ * [guide](https://discordjs.guide/popular-topics/partials.html) for some
  * important usage information, as partials require you to put checks in place when handling data.
  * @property {number} [restWsBridgeTimeout=5000] Maximum time permitted between REST responses and their
  * corresponding websocket events
@@ -306,8 +307,8 @@ exports.ShardEvents = {
  * * GUILD_MEMBER
  * * MESSAGE
  * * REACTION
- * <warn>Partials require you to put checks in place when handling data, read the Partials topic listed in the
- * sidebar for more information.</warn>
+ * <warn>Partials require you to put checks in place when handling data, read the Partials topic on the
+ * [guide](https://discordjs.guide/popular-topics/partials.html) for more information.</warn>
  * @typedef {string} PartialType
  */
 exports.PartialTypes = keyMirror(['USER', 'CHANNEL', 'GUILD_MEMBER', 'MESSAGE', 'REACTION']);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
On #5820, all guides present in this repo were removed in favor of the ones in https://discordjs.guide. This PR removes a reference to an article on the "sidebar" and adds the proper link to the guide.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
