### PR TITLE
feat(RoleManager): added `edit` method, alias `Role#edit`

### DIFF
--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -184,7 +184,7 @@ class RoleManager extends BaseManager {
       mentionable: data.mentionable,
     };
 
-    const d = this.client.api.guilds[this.guild.id].roles[id].patch({ data: _data, reason });
+    const d = this.client.api.guilds(this.guild.id).roles(id).patch({ data: _data, reason });
 
     const clone = this.cache.get(id)?._clone();
     clone?._patch(d);

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const BaseManager = require('./BaseManager');
+const { TypeError } = require('../errors');
 const Role = require('../structures/Role');
 const Collection = require('../util/Collection');
 const Permissions = require('../util/Permissions');
-const { resolveColor } = require('../util/Util');
+const { resolveColor, setPosition } = require('../util/Util');
 
 /**
  * Manages API methods for roles and stores their cache.
@@ -141,6 +142,53 @@ class RoleManager extends BaseManager {
         if (position) return role.setPosition(position, reason);
         return role;
       });
+  }
+
+  /**
+   * Edits a role of the guild.
+   * @param {RoleResolvable} role The role to edit
+   * @param {RoleData} data The new data for the role
+   * @param {string} [reason] Reason for editing this role
+   * @returns {Promise<Role>}
+   * @example
+   * // Edit a role
+   * guild.roles.edit('222079219327434752', { name: 'buddies' })
+   *   .then(updated => console.log(`Edited role name to ${updated.name}`))
+   *   .catch(console.error);
+   */
+  async edit(role, data, reason) {
+    const id = this.resolveID(role);
+    if (!id) throw new TypeError('INVALID_TYPE', 'role', 'RoleResolvable');
+
+    if (typeof data.position === 'number') {
+      const updatedRoles = await setPosition(
+        this,
+        data.position,
+        false,
+        this.guild._sortedRoles(),
+        this.client.api.guilds(this.guild.id).roles,
+        reason,
+      );
+
+      this.client.actions.GuildRolesPositionUpdate.handle({
+        guild_id: this.guild.id,
+        roles: updatedRoles,
+      });
+    }
+
+    const _data = {
+      name: data.name,
+      color: typeof data.color === 'undefined' ? undefined : resolveColor(data.color),
+      hoist: data.hoist,
+      permissions: typeof data.permissions === 'undefined' ? undefined : new Permissions(data.permissions),
+      mentionable: data.mentionable,
+    };
+
+    const d = this.client.api.guilds[this.guild.id].roles[id].patch({ data: _data, reason });
+
+    const clone = this.cache.get(id)?._clone();
+    clone?._patch(d);
+    return clone ?? this.add(d, false);
   }
 
   /**

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -184,7 +184,7 @@ class RoleManager extends BaseManager {
       mentionable: data.mentionable,
     };
 
-    const d = this.client.api.guilds(this.guild.id).roles(id).patch({ data: _data, reason });
+    const d = await this.client.api.guilds(this.guild.id).roles(id).patch({ data: _data, reason });
 
     const clone = this.cache.get(id)?._clone();
     clone?._patch(d);

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -157,12 +157,12 @@ class RoleManager extends BaseManager {
    *   .catch(console.error);
    */
   async edit(role, data, reason) {
-    const id = this.resolveID(role);
-    if (!id) throw new TypeError('INVALID_TYPE', 'role', 'RoleResolvable');
+    role = this.resolve(role);
+    if (!role) throw new TypeError('INVALID_TYPE', 'role', 'RoleResolvable');
 
     if (typeof data.position === 'number') {
       const updatedRoles = await setPosition(
-        this,
+        role,
         data.position,
         false,
         this.guild._sortedRoles(),
@@ -184,11 +184,11 @@ class RoleManager extends BaseManager {
       mentionable: data.mentionable,
     };
 
-    const d = await this.client.api.guilds(this.guild.id).roles(id).patch({ data: _data, reason });
+    const d = await this.client.api.guilds(this.guild.id).roles(role.id).patch({ data: _data, reason });
 
-    const clone = this.cache.get(id)?._clone();
-    clone?._patch(d);
-    return clone ?? this.add(d, false);
+    const clone = role._clone();
+    clone._patch(d);
+    return clone;
   }
 
   /**

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -196,38 +196,8 @@ class Role extends Base {
    *   .then(updated => console.log(`Edited role name to ${updated.name}`))
    *   .catch(console.error);
    */
-  async edit(data, reason) {
-    if (typeof data.position !== 'undefined') {
-      await Util.setPosition(
-        this,
-        data.position,
-        false,
-        this.guild._sortedRoles(),
-        this.client.api.guilds(this.guild.id).roles,
-        reason,
-      ).then(updatedRoles => {
-        this.client.actions.GuildRolesPositionUpdate.handle({
-          guild_id: this.guild.id,
-          roles: updatedRoles,
-        });
-      });
-    }
-    return this.client.api.guilds[this.guild.id].roles[this.id]
-      .patch({
-        data: {
-          name: data.name ?? this.name,
-          color: data.color !== null ? Util.resolveColor(data.color ?? this.color) : null,
-          hoist: data.hoist ?? this.hoist,
-          permissions: typeof data.permissions !== 'undefined' ? new Permissions(data.permissions) : this.permissions,
-          mentionable: data.mentionable ?? this.mentionable,
-        },
-        reason,
-      })
-      .then(role => {
-        const clone = this._clone();
-        clone._patch(role);
-        return clone;
-      });
+  edit(data, reason) {
+    return this.guild.roles.edit(this, data, reason);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2650,6 +2650,7 @@ declare module 'discord.js' {
     public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<Role | null>;
     public fetch(id?: Snowflake, options?: BaseFetchOptions): Promise<Collection<Snowflake, Role>>;
     public create(options?: CreateRoleOptions): Promise<Role>;
+    public edit(role: RoleResolvable, options: RoleData, reason?: string): Promise<Role>;
   }
 
   export class StageInstanceManager extends BaseManager<Snowflake, StageInstance, StageInstanceResolvable> {
@@ -4230,7 +4231,7 @@ declare module 'discord.js' {
     position: number;
   }
 
-  type RoleResolvable = Role | string;
+  type RoleResolvable = Role | Snowflake;
 
   interface RoleTagData {
     botID?: Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #5634

Also implements `RoleManager#edit` to be consistent with many other managers.

- [x] Updated typings.
- [x] Tested `RoleManager#edit`.
- [x] Tested `Role#edit`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
