### PR TITLE
docs(MessageSelectMenu): add link to Discord docs

### DIFF
--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -58,8 +58,15 @@ class MessageComponentInteraction extends Interaction {
   }
 
   /**
+   * Raw message components from the API
+   * * APIMessageButton
+   * * APIMessageSelectMenu
+   * @typedef {APIMessageButton|APIMessageSelectMenu} APIMessageActionRowComponent
+   */
+
+  /**
    * The component which was interacted with
-   * @type {?(MessageActionRowComponent|Object)}
+   * @type {?(MessageActionRowComponent|APIMessageActionRowComponent)}
    * @readonly
    */
   get component() {
@@ -95,3 +102,13 @@ class MessageComponentInteraction extends Interaction {
 InteractionResponses.applyToClass(MessageComponentInteraction);
 
 module.exports = MessageComponentInteraction;
+
+/**
+ * @external APIMessageSelectMenu
+ * @see {@link https://discord.com/developers/docs/interactions/message-components#select-menu-object}
+ */
+
+/**
+ * @external APIMessageButton
+ * @see {@link https://discord.com/developers/docs/interactions/message-components#button-object}
+ */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds links to Discord's documentation regarding MessageSelectMenus where they're needed. Also created a typedef for the current raw components from the API that includes the 2 new links I added.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
