### PR TITLE
types(MessageOptions): improved component typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3887,7 +3887,7 @@ declare module 'discord.js' {
     nonce?: string | number;
     content?: string | null;
     embeds?: (MessageEmbed | MessageEmbedOptions)[];
-    components?: MessageActionRow[] | MessageActionRowOptions[] | MessageActionRowComponentResolvable[][];
+    components?: (MessageActionRow | MessageActionRowOptions | MessageActionRowComponentResolvable[])[];
     allowedMentions?: MessageMentionOptions;
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
     reply?: ReplyOptions;


### PR DESCRIPTION
Fixes an issue with `MessageOptions#components` typing that prevented users from combining different types due to the way the union was written.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating