### PR TITLE
types(Interactions): fix function overload types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1443,9 +1443,7 @@ declare module 'discord.js' {
     public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
     public reply(options: InteractionReplyOptions & { fetchReply: true }): Promise<Message | APIMessage>;
     public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
-    public update(
-      content: string | MessagePayload | (InteractionUpdateOptions & { fetchReply: true }),
-    ): Promise<Message | APIMessage>;
+    public update(content: InteractionUpdateOptions & { fetchReply: true }): Promise<Message | APIMessage>;
     public update(content: string | MessagePayload | InteractionUpdateOptions): Promise<void>;
 
     public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -578,10 +578,10 @@ declare module 'discord.js' {
     public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;
     public fetchReply(): Promise<Message | APIMessage>;
     public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
+    public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
     public reply(
       options: string | MessagePayload | (InteractionReplyOptions & { fetchReply: true }),
     ): Promise<Message | APIMessage>;
-    public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
     private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
   }
@@ -1443,10 +1443,10 @@ declare module 'discord.js' {
     public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;
     public fetchReply(): Promise<Message | APIMessage>;
     public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
+    public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
     public reply(
       options: string | MessagePayload | (InteractionReplyOptions & { fetchReply: true }),
     ): Promise<Message | APIMessage>;
-    public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
     public update(
       content: string | MessagePayload | (InteractionUpdateOptions & { fetchReply: true }),
     ): Promise<Message | APIMessage>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -578,10 +578,8 @@ declare module 'discord.js' {
     public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;
     public fetchReply(): Promise<Message | APIMessage>;
     public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
+    public reply(options: InteractionReplyOptions & { fetchReply: true }): Promise<Message | APIMessage>;
     public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
-    public reply(
-      options: string | MessagePayload | (InteractionReplyOptions & { fetchReply: true }),
-    ): Promise<Message | APIMessage>;
     private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
     private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
   }
@@ -1443,10 +1441,8 @@ declare module 'discord.js' {
     public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;
     public fetchReply(): Promise<Message | APIMessage>;
     public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
+    public reply(options: InteractionReplyOptions & { fetchReply: true }): Promise<Message | APIMessage>;
     public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
-    public reply(
-      options: string | MessagePayload | (InteractionReplyOptions & { fetchReply: true }),
-    ): Promise<Message | APIMessage>;
     public update(
       content: string | MessagePayload | (InteractionUpdateOptions & { fetchReply: true }),
     ): Promise<Message | APIMessage>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes issues with `Interaction#reply` and `MessageComponentInteraction#update`, due to the overload types the return type would default to `Promise<Message | APIMessage>` if only a string was specified as the content.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
