### PR TITLE
docs(Util): methods removed on the base object

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -8,7 +8,7 @@ const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
 const isObject = d => typeof d === 'object' && d !== null;
 
 /**
- * Contains various general-purpose utility methods. These functions are also available on the base `Discord` object.
+ * Contains various general-purpose utility methods.
  */
 class Util {
   constructor() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Util methods were removed from the base Discord object in #5904 but docs have not been updated. This PR only removes the phrase "*These functions are also available on the base `Discord` object.*" phrase in the js comment.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.