### PR TITLE
refactor: improve typings and docs related to threads

### DIFF
--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -77,8 +77,9 @@ class ThreadManager extends BaseManager {
    * should automatically archive in case of no recent activity
    * @property {MessageResolvable} [startMessage] The message to start a thread from. <warn>If this is defined then type
    * of thread gets automatically defined and cannot be changed. The provided `type` field will be ignored</warn>
-   * @property {ThreadChannelType|number} [type] The type of thread to create. <warn>When creating threads in a
-   * {@link NewsChannel} this is ignored and is always `news_thread`</warn>
+   * @property {ThreadChannelType|number} [type] The type of thread to create. Defaults to `public_thread` if created in
+   * a {@link TextChannel} <warn>When creating threads in a {@link NewsChannel} this is ignored and is always
+   * `news_thread`</warn>
    * @property {string} [reason] Reason for creating the thread
    */
 

--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -7,7 +7,7 @@ const Collection = require('../util/Collection');
 const { ChannelTypes } = require('../util/Constants');
 
 /**
- * Manages API methods for ThreadChannels and stores their cache.
+ * Manages API methods for {@link ThreadChannel} objects and stores their cache.
  * @extends {BaseManager}
  */
 class ThreadManager extends BaseManager {
@@ -35,7 +35,7 @@ class ThreadManager extends BaseManager {
   }
 
   /**
-   * Data that can be resolved to give a Thread Channel object. This can be:
+   * Data that can be resolved to a Thread Channel object. This can be:
    * * A ThreadChannel object
    * * A Snowflake
    * @typedef {ThreadChannel|Snowflake} ThreadChannelResolvable
@@ -60,7 +60,8 @@ class ThreadManager extends BaseManager {
    */
 
   /**
-   * A number that is allowed to be the duration in minutes before a thread is automatically archived. This can be:
+   * A number that is allowed to be the duration (in minutes) of inactivity after which a thread is automatically
+   * archived. This can be:
    * * `60` (1 hour)
    * * `1440` (1 day)
    * * `4320` (3 days) <warn>This is only available when the guild has the `THREE_DAY_THREAD_ARCHIVE` feature.</warn>
@@ -69,20 +70,21 @@ class ThreadManager extends BaseManager {
    */
 
   /**
-   * Options for creating a thread <warn>Only one of `startMessage` or `type` can be defined.
-   * If `startMessage` is defined, `type` is automatically defined and cannot be changed.</warn>
+   * Options for creating a thread. <warn>Only one of `startMessage` or `type` can be defined.</warn>
    * @typedef {Object} ThreadCreateOptions
-   * @property {string} name The name of the new Thread
-   * @property {ThreadAutoArchiveDuration} autoArchiveDuration How long before the thread is automatically archived
-   * @property {MessageResolvable} [startMessage] The message to start a thread from
-   * @property {ThreadChannelType|number} [type='public_thread'] The type of thread to create
-   * <warn>When creating threads in a `news` channel this is ignored and is always `news_thread`</warn>
+   * @property {string} name The name of the new thread
+   * @property {ThreadAutoArchiveDuration} autoArchiveDuration The amount of time (in minutes) after which the thread
+   * should automatically archive in case of no recent activity
+   * @property {MessageResolvable} [startMessage] The message to start a thread from. <warn>If this is defined then type
+   * of thread gets automatically defined and cannot be changed. The provided `type` field will be ignored</warn>
+   * @property {ThreadChannelType|number} [type] The type of thread to create. <warn>When creating threads in a
+   * {@link NewsChannel} this is ignored and is always `news_thread`</warn>
    * @property {string} [reason] Reason for creating the thread
    */
 
   /**
    * Creates a new thread in the channel.
-   * @param {ThreadCreateOptions} [options] Options
+   * @param {ThreadCreateOptions} [options] Options to create a new thread
    * @returns {Promise<ThreadChannel>}
    * @example
    * // Create a new public thread
@@ -92,7 +94,7 @@ class ThreadManager extends BaseManager {
    *     autoArchiveDuration: 60,
    *     reason: 'Needed a separate thread for food',
    *   })
-   *   .then(console.log)
+   *   .then(threadChannel => console.log(threadChannel))
    *   .catch(console.error);
    * @example
    * // Create a new private thread
@@ -103,7 +105,7 @@ class ThreadManager extends BaseManager {
    *      type: 'private_thread',
    *      reason: 'Needed a separate thread for moderation',
    *    })
-   *   .then(console.log)
+   *   .then(threadChannel => console.log(threadChannel))
    *   .catch(console.error);
    */
   async create({ name, autoArchiveDuration, startMessage, type, reason } = {}) {
@@ -141,11 +143,10 @@ class ThreadManager extends BaseManager {
 
   /**
    * Obtains a thread from Discord, or the channel cache if it's already available.
-   * @param {ThreadChannelResolvable|FetchThreadsOptions} [options] If a ThreadChannelResolvable, the thread to fetch.
-   * If undefined, fetches all active threads.
-   * If an Object, fetches the specified threads.
-   * @param {BaseFetchOptions} [cacheOptions] Additional options for this fetch
-   * only applies when fetching a single thread
+   * @param {ThreadChannelResolvable|FetchThreadsOptions} [options] The options to fetch threads. If it is a
+   * ThreadChannelResolvable then the specified thread will be fetched. Fetches all active threads if `undefined`
+   * @param {BaseFetchOptions} [cacheOptions] Additional options for this fetch. <warn>The `force` field gets ignored
+   * if `options` is not a ThreadChannelResolvable</warn>
    * @returns {Promise<?(ThreadChannel|FetchedThreads)>}
    * @example
    * // Fetch a thread by its id
@@ -164,10 +165,10 @@ class ThreadManager extends BaseManager {
   }
 
   /**
-   * Data that can be resolved to give a Date object. This can be:
+   * Data that can be resolved to a Date object. This can be:
    * * A Date object
    * * A number representing a timestamp
-   * * An ISO8601 string
+   * * An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) string
    * @typedef {Date|number|string} DateResolvable
    */
 
@@ -175,24 +176,23 @@ class ThreadManager extends BaseManager {
    * The options used to fetch archived threads.
    * @typedef {Object} FetchArchivedThreadOptions
    * @property {string} [type='public'] The type of threads to fetch, either `public` or `private`
-   * @property {boolean} [fetchAll=false] When type is `private` whether to fetch **all** archived threads,
-   * requires `MANAGE_THREADS` if true
-   * @property {DateResolvable|ThreadChannelResolvable} [before] Identifier for a Date or Snowflake
-   * to get threads that were created before it,
-   * must be a ThreadChannelResolvable when type is `private` and fetchAll is `false`
+   * @property {boolean} [fetchAll=false] Whether to fetch **all** archived threads when type is `private`.
+   * Requires `MANAGE_THREADS` if true
+   * @property {DateResolvable|ThreadChannelResolvable} [before] Only return threads that were created before this Date
+   * or Snowflake. <warn>Must be a {@link ThreadChannelResolvable} when type is `private` and fetchAll is `false`</warn>
    * @property {number} [limit] Maximum number of threads to return
    */
 
   /**
    * The data returned from a thread fetch that returns multiple threads.
    * @typedef {Object} FetchedThreads
-   * @property {Collection<Snowflake, ThreadChannel>} threads The threads fetched, with any members returned
+   * @property {Collection<Snowflake, ThreadChannel>} threads The threads that were fetched, with any members returned
    * @property {?boolean} hasMore Whether there are potentially additional threads that require a subsequent call
    */
 
   /**
    * Obtains a set of archived threads from Discord, requires `READ_MESSAGE_HISTORY` in the parent channel.
-   * @param {FetchArchivedThreadOptions} [options] The options to use when fetch archived threads
+   * @param {FetchArchivedThreadOptions} [options] The options to fetch archived threads
    * @param {boolean} [cache=true] Whether to cache the new thread objects if they aren't already
    * @returns {Promise<FetchedThreads>}
    */

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -66,7 +66,7 @@ class ThreadChannel extends Channel {
       this.locked = data.thread_metadata.locked ?? false;
 
       /**
-       * The id of the member who created this thread
+       * Whether the thread is archived
        * @type {boolean}
        */
       this.archived = data.thread_metadata.archived;
@@ -88,7 +88,7 @@ class ThreadChannel extends Channel {
 
     if ('owner_id' in data) {
       /**
-       * The id of the member that created this thread
+       * The id of the member who created this thread
        * @type {?Snowflake}
        */
       this.ownerID = data.owner_id;

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -287,7 +287,7 @@ class ThreadChannel extends Channel {
    * @param {string} [reason] Reason for changing the thread's name
    * @returns {Promise<ThreadChannel>}
    * @example
-   * // Change thread's name
+   * // Change the thread's name
    * thread.setName('not_general')
    *   .then(newThread => console.log(`Thread's new name is ${newThread.name}`))
    *   .catch(console.error);

--- a/src/structures/ThreadMember.js
+++ b/src/structures/ThreadMember.js
@@ -47,7 +47,7 @@ class ThreadMember extends Base {
   }
 
   /**
-   * The guild member that this thread member instance represents
+   * The guild member associated with this thread member
    * @type {?GuildMember}
    * @readonly
    */
@@ -65,7 +65,7 @@ class ThreadMember extends Base {
   }
 
   /**
-   * The user that this thread member instance represents
+   * The user associated with this thread member
    * @type {?User}
    * @readonly
    */
@@ -83,7 +83,7 @@ class ThreadMember extends Base {
   }
 
   /**
-   * Remove this member from the thread.
+   * Removes this member from the thread.
    * @param {string} [reason] Reason for removing the member
    * @returns {ThreadMember}
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2654,11 +2654,8 @@ declare module 'discord.js' {
     constructor(channel: TextChannel | NewsChannel, iterable?: Iterable<any>);
     public channel: TextChannel | NewsChannel;
     public create(options: ThreadCreateOptions<AllowedThreadType>): Promise<ThreadChannel>;
-    public fetch(options: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<ThreadChannel | null>;
-    public fetch(
-      options?: { archived?: FetchArchivedThreadOptions; active?: boolean },
-      cacheOptions?: { cache?: boolean },
-    ): Promise<FetchedThreads>;
+    public fetch(options?: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<ThreadChannel | null>;
+    public fetch(options?: FetchThreadsOptions, cacheOptions?: BaseFetchOptions): Promise<FetchedThreads>;
     public fetchArchived(options?: FetchArchivedThreadOptions, cache?: boolean): Promise<FetchedThreads>;
     public fetchActive(cache?: boolean): Promise<FetchedThreads>;
   }
@@ -3368,6 +3365,11 @@ declare module 'discord.js' {
   interface FetchReactionUsersOptions {
     limit?: number;
     after?: Snowflake;
+  }
+
+  interface FetchThreadsOptions {
+    archived?: FetchArchivedThreadOptions;
+    active?: boolean;
   }
 
   interface FileOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1611,7 +1611,7 @@ declare module 'discord.js' {
     public defaultAutoArchiveDuration?: ThreadAutoArchiveDuration;
     public messages: MessageManager;
     public nsfw: boolean;
-    public threads: ThreadManager;
+    public threads: ThreadManager<AllowedThreadTypeForNewsChannel>;
     public topic: string | null;
     public type: 'news';
     public createWebhook(name: string, options?: ChannelWebhookCreateOptions): Promise<Webhook>;
@@ -1963,7 +1963,7 @@ declare module 'discord.js' {
     public nsfw: boolean;
     public type: 'text';
     public rateLimitPerUser: number;
-    public threads: ThreadManager;
+    public threads: ThreadManager<AllowedThreadTypeForTextChannel>;
     public topic: string | null;
     public createWebhook(name: string, options?: ChannelWebhookCreateOptions): Promise<Webhook>;
     public setDefaultAutoArchiveDuration(
@@ -2650,16 +2650,10 @@ declare module 'discord.js' {
     public delete(channel: StageChannel | Snowflake): Promise<void>;
   }
 
-  export class ThreadManager extends BaseManager<Snowflake, ThreadChannel, ThreadChannelResolvable> {
+  export class ThreadManager<AllowedThreadType> extends BaseManager<Snowflake, ThreadChannel, ThreadChannelResolvable> {
     constructor(channel: TextChannel | NewsChannel, iterable?: Iterable<any>);
     public channel: TextChannel | NewsChannel;
-    public create(options: {
-      name: string;
-      autoArchiveDuration: ThreadAutoArchiveDuration;
-      startMessage?: MessageResolvable;
-      type?: ThreadChannelType | number;
-      reason?: string;
-    }): Promise<ThreadChannel>;
+    public create(options: ThreadCreateOptions<AllowedThreadType>): Promise<ThreadChannel>;
     public fetch(options: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<ThreadChannel | null>;
     public fetch(
       options?: { archived?: FetchArchivedThreadOptions; active?: boolean },
@@ -2784,6 +2778,10 @@ declare module 'discord.js' {
     mute?: boolean;
     deaf?: boolean;
   }
+
+  type AllowedThreadTypeForNewsChannel = 'news_thread' | 10;
+
+  type AllowedThreadTypeForTextChannel = 'public_thread' | 'private_thread' | 11 | 12;
 
   interface APIErrors {
     UNKNOWN_ACCOUNT: 10001;
@@ -4314,6 +4312,14 @@ declare module 'discord.js' {
   type ThreadChannelResolvable = ThreadChannel | Snowflake;
 
   type ThreadChannelType = 'news_thread' | 'public_thread' | 'private_thread';
+
+  interface ThreadCreateOptions<AllowedThreadType> {
+    name: string;
+    autoArchiveDuration: ThreadAutoArchiveDuration;
+    startMessage?: MessageResolvable;
+    type?: AllowedThreadType;
+    reason?: string;
+  }
 
   interface ThreadEditData {
     name?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2654,7 +2654,7 @@ declare module 'discord.js' {
     constructor(channel: TextChannel | NewsChannel, iterable?: Iterable<any>);
     public channel: TextChannel | NewsChannel;
     public create(options: ThreadCreateOptions<AllowedThreadType>): Promise<ThreadChannel>;
-    public fetch(options?: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<ThreadChannel | null>;
+    public fetch(options: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<ThreadChannel | null>;
     public fetch(options?: FetchThreadsOptions, cacheOptions?: BaseFetchOptions): Promise<FetchedThreads>;
     public fetchArchived(options?: FetchArchivedThreadOptions, cache?: boolean): Promise<FetchedThreads>;
     public fetchActive(cache?: boolean): Promise<FetchedThreads>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2655,7 +2655,7 @@ declare module 'discord.js' {
     public channel: TextChannel | NewsChannel;
     public create(options: ThreadCreateOptions<AllowedThreadType>): Promise<ThreadChannel>;
     public fetch(options: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<ThreadChannel | null>;
-    public fetch(options?: FetchThreadsOptions, cacheOptions?: BaseFetchOptions): Promise<FetchedThreads>;
+    public fetch(options?: FetchThreadsOptions, cacheOptions?: { cache?: boolean }): Promise<FetchedThreads>;
     public fetchArchived(options?: FetchArchivedThreadOptions, cache?: boolean): Promise<FetchedThreads>;
     public fetchActive(cache?: boolean): Promise<FetchedThreads>;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

1) This PR improves the typings by:

- Restricting values for `type` in `ThreadManager#create` depending on what type of channel the manager belongs to. This will provide better and valid autocompletion
- Adding interfaces where they were needed to make the typings look clean and tidy
- Fixing a TS bug in `ThreadManager#fetch` where it will never suggest `force` field for `cacheOptions` (the fact that it gets ignored in some specific circumstances has been documented too)

2) This PR also improves the documentation for threads by:
- Adding typedef for `ThreadEditData`
- Adding more detailed information where it was required
- Doing a little bit of sentence restructuring here and there
- Addressing caveats

**Status and versioning classification:**
- I know how to update typings and have done so
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
