### PR TITLE
ci: deprecate old dev releases on publish

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm ci --ignore-scripts --no-optional
 
       - name: Deprecate old versions
-        run: npm deprecate discord.js@"~13.0.0-dev" "No longer supported" || true
+        run: npm deprecate discord.js@"~13.0.0-dev" "no longer supported" || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -21,6 +21,11 @@ jobs:
         # Remove --no-optional after Node 16 upgrade
         run: npm ci --ignore-scripts --no-optional
 
+      - name: Deprecate old versions
+        run: npm deprecate discord.js@">13.0.0-dev" "A newer release is available and this version is no longer supported."
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+
       - name: Publish
         run: |
           npm version --git-tag-version=false $(jq --raw-output '.version' package.json).$(git rev-parse --short HEAD).$(date +%s)

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -22,7 +22,7 @@ jobs:
         run: npm ci --ignore-scripts --no-optional
 
       - name: Deprecate old versions
-        run: npm deprecate discord.js@">13.0.0-dev" "A newer release is available and this version is no longer supported."
+        run: npm deprecate discord.js@"~13.0.0-dev" "No longer supported" || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a step to the publish dev CI that automatically deprecates all dev versions before publishing a new one so that you don't have to manually do that yourselves every 12 hours. Here are the npm docs on [npm-deprecate](https://docs.npmjs.com/cli/v7/commands/npm-deprecate) and you can test the version range [here](https://semver.npmjs.com/)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
