### PR TITLE
types(VoiceState): fix optional params

### DIFF
--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -149,7 +149,7 @@ class VoiceState extends Base {
 
   /**
    * Moves the member to a different channel, or disconnects them from the one they're in.
-   * @param {ChannelResolvable|null} [channel] Channel to move the member to, or `null` if you want to disconnect them
+   * @param {ChannelResolvable|null} channel Channel to move the member to, or `null` if you want to disconnect them
    * from voice.
    * @param {string} [reason] Reason for moving member to another channel or disconnecting
    * @returns {Promise<GuildMember>}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2160,14 +2160,14 @@ declare module 'discord.js' {
     public serverMute: boolean | null;
     public sessionID: string | null;
     public streaming: boolean;
-    public selfVideo: boolean;
+    public selfVideo: boolean | null;
     public suppress: boolean;
     public requestToSpeakTimestamp: number | null;
 
     public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;
     public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
     public kick(reason?: string): Promise<GuildMember>;
-    public setChannel(channel: ChannelResolvable | null, reason?: string): Promise<GuildMember>;
+    public setChannel(channel?: ChannelResolvable | null, reason?: string): Promise<GuildMember>;
     public setRequestToSpeak(request: boolean): Promise<void>;
     public setSuppressed(suppressed: boolean): Promise<void>;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2167,7 +2167,7 @@ declare module 'discord.js' {
     public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;
     public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
     public kick(reason?: string): Promise<GuildMember>;
-    public setChannel(channel?: ChannelResolvable | null, reason?: string): Promise<GuildMember>;
+    public setChannel(channel: ChannelResolvable | null, reason?: string): Promise<GuildMember>;
     public setRequestToSpeak(request: boolean): Promise<void>;
     public setSuppressed(suppressed: boolean): Promise<void>;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

https://discord.js.org/#/docs/main/master/class/VoiceState

1. VoiceState.selfVideo can be null.
2. VoiceState.setChannel(channel, reason): Channel can be optional, as default is none. (according to docs on master)

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
