### PR TITLE
types(MessageSelectMenu): fix addOptions parameter

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1586,7 +1586,7 @@ declare module 'discord.js' {
     public options: MessageSelectOption[];
     public placeholder: string | null;
     public type: 'SELECT_MENU';
-    public addOptions(options: MessageSelectOptionData[] | MessageSelectOptionData[][]): this;
+    public addOptions(...options: MessageSelectOptionData[] | MessageSelectOptionData[][]): this;
     public setCustomID(customID: string): this;
     public setDisabled(disabled: boolean): this;
     public setMaxValues(maxValues: number): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Seems like the typings for MessageSelectMenu.addOptions() weren't correct as they didn't support spread syntax and thus didn't match the docs. This PR fixes that.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
