### PR TITLE
docs: WebSocketShard#send and TextBasedChannel#send

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -106,7 +106,7 @@ class TextBasedChannel {
   /**
    * Sends a message to this channel.
    * @param {string|MessagePayload|MessageOptions} options The options to provide
-   * @returns {Promise<Message|Message[]>}
+   * @returns {Promise<Message>}
    * @example
    * // Send a basic message
    * channel.send('hello!')

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2277,7 +2277,7 @@ declare module 'discord.js' {
     private _cleanupConnection(): void;
     private _emitDestroyed(): void;
 
-    public send(data: unknown): void;
+    public send(data: unknown, important?: boolean): void;
 
     public on(event: 'ready' | 'resumed' | 'invalidSession', listener: () => Awaited<void>): this;
     public on(event: 'close', listener: (event: CloseEvent) => Awaited<void>): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since PR #5918 the TextBasedChannel#send method shouldn't return an array since it only did when using the split option.
and WebSocketShard#send was missing the `important` argument in the typings.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating