### PR TITLE
refactor(Util): make class extend `null`

### DIFF
--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -11,11 +11,7 @@ const Invite = require('../structures/Invite');
  * The DataResolver identifies different objects and tries to resolve a specific piece of information from them.
  * @private
  */
-class DataResolver {
-  constructor() {
-    throw new Error(`The ${this.constructor.name} class may not be instantiated.`);
-  }
-
+class DataResolver extends null {
   /**
    * Data that can be resolved to give an invite code. This can be:
    * * An invite code

--- a/src/util/SnowflakeUtil.js
+++ b/src/util/SnowflakeUtil.js
@@ -9,11 +9,7 @@ let INCREMENT = 0;
 /**
  * A container for useful snowflake-related methods.
  */
-class SnowflakeUtil {
-  constructor() {
-    throw new Error(`The ${this.constructor.name} class may not be instantiated.`);
-  }
-
+class SnowflakeUtil extends null {
   /**
    * A Twitter snowflake, except the epoch is 2015-01-01T00:00:00.000Z
    * ```

--- a/src/util/Structures.js
+++ b/src/util/Structures.js
@@ -31,11 +31,7 @@
 /**
  * Allows for the extension of built-in Discord.js structures that are instantiated by {@link BaseManager Managers}.
  */
-class Structures {
-  constructor() {
-    throw new Error(`The ${this.constructor.name} class may not be instantiated.`);
-  }
-
+class Structures extends null {
   /**
    * Retrieves a structure class.
    * @param {string} structure Name of the structure to retrieve

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -10,11 +10,7 @@ const isObject = d => typeof d === 'object' && d !== null;
 /**
  * Contains various general-purpose utility methods.
  */
-class Util {
-  constructor() {
-    throw new Error(`The ${this.constructor.name} class may not be instantiated.`);
-  }
-
+class Util extends null {
   /**
    * Flatten an object. Any properties that are collections will get converted to an array of keys.
    * @param {Object} obj The object to flatten.

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -811,6 +811,7 @@ declare module 'discord.js' {
   };
 
   export class DataResolver extends null {
+    private constructor();
     public static resolveBase64(data: Base64Resolvable): string;
     public static resolveCode(data: string, regx: RegExp): string;
     public static resolveFile(resource: BufferResolvable | Stream): Promise<Buffer | Stream>;
@@ -1868,6 +1869,7 @@ declare module 'discord.js' {
   }
 
   export class SnowflakeUtil extends null {
+    private constructor();
     public static deconstruct(snowflake: Snowflake): DeconstructedSnowflake;
     public static generate(timestamp?: number | Date): Snowflake;
     public static readonly EPOCH: number;
@@ -1905,6 +1907,7 @@ declare module 'discord.js' {
   }
 
   export class Structures extends null {
+    private constructor();
     public static get<K extends keyof Extendable>(structure: K): Extendable[K];
     public static get(structure: string): (...args: any[]) => void;
     public static extend<K extends keyof Extendable, T extends Extendable[K]>(
@@ -2064,6 +2067,7 @@ declare module 'discord.js' {
   }
 
   export class Util extends null {
+    private constructor();
     public static basename(path: string, ext?: string): string;
     public static binaryToID(num: string): Snowflake;
     public static cleanContent(str: string, channel: Channel): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2063,7 +2063,7 @@ declare module 'discord.js' {
     public static resolve(bit?: BitFieldResolvable<UserFlagsString, number>): number;
   }
 
-  export class Util {
+  export class Util extends null {
     public static basename(path: string, ext?: string): string;
     public static binaryToID(num: string): Snowflake;
     public static cleanContent(str: string, channel: Channel): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -810,7 +810,7 @@ declare module 'discord.js' {
     PremiumTiers: typeof PremiumTiers;
   };
 
-  export class DataResolver {
+  export class DataResolver extends null {
     public static resolveBase64(data: Base64Resolvable): string;
     public static resolveCode(data: string, regx: RegExp): string;
     public static resolveFile(resource: BufferResolvable | Stream): Promise<Buffer | Stream>;
@@ -1867,7 +1867,7 @@ declare module 'discord.js' {
     public once(event: 'shardCreate', listener: (shard: Shard) => Awaited<void>): this;
   }
 
-  export class SnowflakeUtil {
+  export class SnowflakeUtil extends null {
     public static deconstruct(snowflake: Snowflake): DeconstructedSnowflake;
     public static generate(timestamp?: number | Date): Snowflake;
     public static readonly EPOCH: number;
@@ -1904,7 +1904,7 @@ declare module 'discord.js' {
     public type: 'store';
   }
 
-  export class Structures {
+  export class Structures extends null {
     public static get<K extends keyof Extendable>(structure: K): Extendable[K];
     public static get(structure: string): (...args: any[]) => void;
     public static extend<K extends keyof Extendable, T extends Extendable[K]>(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When constructing a class extending null, the following error is thrown:

```javascript
TypeError: Super constructor null of Util is not a constructor
```

Which lets us skip a constructor, as well as it stops other static members from the Object class from being inherited.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
