### PR TITLE
fix(Typings): Improve components typings in MessageEditOptions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3771,7 +3771,7 @@ declare module 'discord.js' {
     files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
     flags?: BitFieldResolvable<MessageFlagsString, number>;
     allowedMentions?: MessageMentionOptions;
-    components?: MessageActionRow[] | MessageActionRowOptions[] | MessageActionRowComponentResolvable[][];
+    components?: (MessageActionRow | MessageActionRowOptions | MessageActionRowComponentResolvable[])[];
   }
 
   interface MessageEmbedAuthor {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

#5987 Updated the component typings for MessageOptions but not for MessageEditOptions, causing compilation issues when trying to pass a MessageOptions type to `message.edit()`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
