### PR TITLE
types(*): create mention types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -439,7 +439,7 @@ declare module 'discord.js' {
     public fetch(force?: boolean): Promise<Channel>;
     public isText(): this is TextChannel | DMChannel | NewsChannel | ThreadChannel;
     public isThread(): this is ThreadChannel;
-    public toString(): string;
+    public toString(): ChannelMention;
   }
 
   export class Client extends BaseClient {
@@ -1103,7 +1103,7 @@ declare module 'discord.js' {
     public permissionsIn(channel: GuildChannelResolvable): Readonly<Permissions>;
     public setNickname(nickname: string | null, reason?: string): Promise<GuildMember>;
     public toJSON(): unknown;
-    public toString(): string;
+    public toString(): MemberMention;
     public valueOf(): string;
   }
 
@@ -1757,7 +1757,7 @@ declare module 'discord.js' {
     public setPermissions(permissions: PermissionResolvable, reason?: string): Promise<Role>;
     public setPosition(position: number, options?: SetRolePositionOptions): Promise<Role>;
     public toJSON(): unknown;
-    public toString(): string;
+    public toString(): RoleMention;
 
     public static comparePositions(role1: Role, role2: Role): number;
   }
@@ -2052,7 +2052,7 @@ declare module 'discord.js' {
     public equals(user: User): boolean;
     public fetch(force?: boolean): Promise<User>;
     public fetchFlags(force?: boolean): Promise<UserFlags>;
-    public toString(): string;
+    public toString(): UserMention;
     public typingDurationIn(channel: ChannelResolvable): number;
     public typingIn(channel: ChannelResolvable): boolean;
     public typingSinceIn(channel: ChannelResolvable): Date;
@@ -3027,6 +3027,11 @@ declare module 'discord.js' {
     after?: Snowflake;
     around?: Snowflake;
   }
+
+  type ChannelMention = `<#${Snowflake}>`;
+  type UserMention = `<@${Snowflake}>`;
+  type MemberMention = UserMention | `<@!${Snowflake}>`;
+  type RoleMention = '@everyone' | `<@&${Snowflake}>`;
 
   interface ChannelPosition {
     channel: ChannelResolvable;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3029,9 +3029,9 @@ declare module 'discord.js' {
   }
 
   type ChannelMention = `<#${Snowflake}>`;
-  type UserMention = `<@${Snowflake}>`;
   type MemberMention = UserMention | `<@!${Snowflake}>`;
   type RoleMention = '@everyone' | `<@&${Snowflake}>`;
+  type UserMention = `<@${Snowflake}>`;
 
   interface ChannelPosition {
     channel: ChannelResolvable;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3029,9 +3029,6 @@ declare module 'discord.js' {
   }
 
   type ChannelMention = `<#${Snowflake}>`;
-  type MemberMention = UserMention | `<@!${Snowflake}>`;
-  type RoleMention = '@everyone' | `<@&${Snowflake}>`;
-  type UserMention = `<@${Snowflake}>`;
 
   interface ChannelPosition {
     channel: ChannelResolvable;
@@ -3714,6 +3711,8 @@ declare module 'discord.js' {
     stack: string;
   }
 
+  type MemberMention = UserMention | `<@!${Snowflake}>`;
+
   type MembershipState = keyof typeof MembershipStates;
 
   type MessageActionRowComponent = MessageButton | MessageSelectMenu;
@@ -4213,6 +4212,8 @@ declare module 'discord.js' {
     mentionable?: boolean;
   }
 
+  type RoleMention = '@everyone' | `<@&${Snowflake}>`;
+
   interface RolePosition {
     role: RoleResolvable;
     position: number;
@@ -4341,6 +4342,8 @@ declare module 'discord.js' {
     | 'VERIFIED_BOT'
     | 'EARLY_VERIFIED_BOT_DEVELOPER'
     | 'DISCORD_CERTIFIED_MODERATOR';
+
+  type UserMention = `<@${Snowflake}>`;
 
   type UserResolvable = User | Snowflake | Message | GuildMember | ThreadMember;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds more specific typings for mentions like the example below:
```ts
type UserMention = `<@${Snowflake}>`;
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.