### PR TITLE
types(MessageOptions): fix components being optional

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3724,7 +3724,7 @@ declare module 'discord.js' {
   type MessageActionRowComponentResolvable = MessageActionRowComponent | MessageActionRowComponentOptions;
 
   interface MessageActionRowOptions extends BaseMessageComponentOptions {
-    components?: MessageActionRowComponentResolvable[];
+    components: MessageActionRowComponentResolvable[];
   }
 
   interface MessageActivity {

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -385,21 +385,21 @@ client.on('message', ({ channel }) => {
 client.on('interaction', async interaction => {
   if (!interaction.isCommand()) return;
 
-  const row = new MessageActionRow();
-
-  //@ts-expect-error
-  const badRow = new MessageActionRow({});
+  void new MessageActionRow();
 
   const button = new MessageButton();
 
-  const buttonRow = new MessageActionRow({ components: [button] });
+  const actionRow = new MessageActionRow({ components: [button] });
 
-  await interaction.reply({ content: 'Hi!', components: [buttonRow] });
-
-  //@ts-expect-error
-  await interaction.reply({ content: 'Hi!', components: [button] });
+  await interaction.reply({ content: 'Hi!', components: [actionRow] });
 
   await interaction.reply({ content: 'Hi!', components: [[button]] });
+
+  // @ts-expect-error
+  void new MessageActionRow({});
+
+  // @ts-expect-error
+  await interaction.reply({ content: 'Hi!', components: [button] });
 });
 
 client.login('absolutely-valid-token');

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -5,7 +5,9 @@ import {
   Collection,
   Intents,
   Message,
+  MessageActionRow,
   MessageAttachment,
+  MessageButton,
   MessageEmbed,
   Permissions,
   Serialized,
@@ -378,6 +380,26 @@ client.on('message', ({ channel }) => {
   channel.send();
   // @ts-expect-error
   channel.send({ another: 'property' });
+});
+
+client.on('interaction', async interaction => {
+  if (!interaction.isCommand()) return;
+
+  const row = new MessageActionRow();
+
+  //@ts-expect-error
+  const badRow = new MessageActionRow({});
+
+  const button = new MessageButton();
+
+  const buttonRow = new MessageActionRow({ components: [button] });
+
+  await interaction.reply({ content: 'Hi!', components: [buttonRow] });
+
+  //@ts-expect-error
+  await interaction.reply({ content: 'Hi!', components: [button] });
+
+  await interaction.reply({ content: 'Hi!', components: [[button]] });
 });
 
 client.login('absolutely-valid-token');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes an issue where you'd be able to pass an array of MessageComponents in the components property for MessageOptions where, in fact, you need to pass an array of arrays of MessageComponents. This also makes it so that initializing a MessageActionRow with an empty object in the constructor will now throw an error.
These scenarios will still work:
```ts
new MessageActionRow();
new MessageActionRow({ components: [MessageButton] });
message.channel.send({ content, components: [[MessageButton]]})
```
And these scenarios will now throw an error:
```ts
new MessageActionRow({});
message.channel.send({ content, components: [MessageButton] })
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
