### PR TITLE
docs(*): add class links to isX() methods

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -103,7 +103,8 @@ class Channel extends Base {
   }
 
   /**
-   * Indicates whether this channel is text-based.
+   * Indicates whether this channel is text-based
+   * ({@link TextChannel}, {@link DMChannel}, {@link NewsChannel} or {@link ThreadChannel}).
    * @returns {boolean}
    */
   isText() {
@@ -111,7 +112,7 @@ class Channel extends Base {
   }
 
   /**
-   * Indicates whether this channel is a thread channel.
+   * Indicates whether this channel is a {@link ThreadChannel}.
    * @returns {boolean}
    */
   isThread() {

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -114,7 +114,7 @@ class Interaction extends Base {
   }
 
   /**
-   * Indicates whether this interaction is a command interaction.
+   * Indicates whether this interaction is a {@link CommandInteraction}.
    * @returns {boolean}
    */
   isCommand() {
@@ -122,7 +122,7 @@ class Interaction extends Base {
   }
 
   /**
-   * Indicates whether this interaction is a message component interaction.
+   * Indicates whether this interaction is a {@link MessageComponentInteraction}.
    * @returns {boolean}
    */
   isMessageComponent() {
@@ -130,7 +130,7 @@ class Interaction extends Base {
   }
 
   /**
-   * Indicates whether this interaction is a button interaction.
+   * Indicates whether this interaction is a {@link ButtonInteraction}.
    * @returns {boolean}
    */
   isButton() {
@@ -141,7 +141,7 @@ class Interaction extends Base {
   }
 
   /**
-   * Indicates whether this interaction is a select menu interaction.
+   * Indicates whether this interaction is a {@link SelectMenuInteraction}.
    * @returns {boolean}
    */
   isSelectMenu() {

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -62,7 +62,7 @@ class InteractionResponses {
    * // Reply to the interaction with an embed
    * const embed = new MessageEmbed().setDescription('Pong!');
    *
-   * interaction.reply(embed)
+   * interaction.reply({ embeds: [embed] })
    *   .then(console.log)
    *   .catch(console.error);
    * @example


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds `@link`s to the isX() methods (isText, isThread, isButton, isSelectMenu, isMessageComponent, isCommand) and also fixes one outdated example in interaction.reply()

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
