### PR TITLE
fix(Util): splitMessage not working with array

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -81,7 +81,7 @@ class Util {
         if (currentChar instanceof RegExp) {
           splitText = splitText.flatMap(chunk => chunk.match(currentChar));
         } else {
-          splitText = splitText.map(chunk => chunk.split(currentChar)).flat(1);
+          splitText = splitText.flatMap(chunk => chunk.split(currentChar));
         }
       }
     } else {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -79,7 +79,7 @@ class Util {
       while (char.length > 0 && splitText.some(elem => elem.length > maxLength)) {
         const currentChar = char.shift();
         if (currentChar instanceof RegExp) {
-          splitText = splitText.map(chunk => chunk.match(currentChar)).flat(1);
+          splitText = splitText.flatMap(chunk => chunk.match(currentChar));
         } else {
           splitText = splitText.map(chunk => chunk.split(currentChar)).flat(1);
         }

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -79,9 +79,9 @@ class Util {
       while (char.length > 0 && splitText.some(elem => elem.length > maxLength)) {
         const currentChar = char.shift();
         if (currentChar instanceof RegExp) {
-          splitText = splitText.map(chunk => chunk.match(currentChar));
+          splitText = splitText.map(chunk => chunk.match(currentChar)).flat(1);
         } else {
-          splitText = splitText.map(chunk => chunk.split(currentChar));
+          splitText = splitText.map(chunk => chunk.split(currentChar)).flat(1);
         }
       }
     } else {


### PR DESCRIPTION
fix #6006 

**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a problem with Util.splitMessage which doesn't work when the `char` option is set to an array. This is because the array of messages is mapped and messages splitted again causing the creation of an array of arrays. This PR adds a `.flat(1)` to prevent this from happening. I also tested this with all options but let me know if there are still problems.

*Sorry for too many commits but I accidentally pushed the content of another PR into my master branch*

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating