### PR TITLE
types(ClientUser): updated `setAFK` signature

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -517,7 +517,7 @@ declare module 'discord.js' {
     public edit(data: ClientUserEditData): Promise<this>;
     public setActivity(options?: ActivityOptions): Presence;
     public setActivity(name: string, options?: ActivityOptions): Presence;
-    public setAFK(afk: boolean): Promise<Presence>;
+    public setAFK(afk: boolean, shardID?: number | number[]): Presence;
     public setAvatar(avatar: BufferResolvable | Base64Resolvable): Promise<this>;
     public setPresence(data: PresenceData): Presence;
     public setStatus(status: PresenceStatusData, shardID?: number | number[]): Presence;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR Fixes the ClientUser#setAFK typing where the return type was still set as Promise<Presence> and was missing the shardID argument.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating