### PR TITLE
docs(Collector): properly document endReason

### DIFF
--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -89,6 +89,11 @@ class MessageCollector extends Collector {
     return message.channel.id === this.channel.id ? message.id : null;
   }
 
+  /**
+   * The reason this collector has ended with, or null if it hasn't ended yet
+   * @type {?string}
+   * @readonly
+   */
   get endReason() {
     if (this.options.max && this.collected.size >= this.options.max) return 'limit';
     if (this.options.maxProcessed && this.received === this.options.maxProcessed) return 'processedLimit';

--- a/src/structures/MessageComponentInteractionCollector.js
+++ b/src/structures/MessageComponentInteractionCollector.js
@@ -130,6 +130,11 @@ class MessageComponentInteractionCollector extends Collector {
     this.checkEnd();
   }
 
+  /**
+   * The reason this collector has ended with, or null if it hasn't ended yet
+   * @type {?string}
+   * @readonly
+   */
   get endReason() {
     if (this.options.max && this.total >= this.options.max) return 'limit';
     if (this.options.maxComponents && this.collected.size >= this.options.maxComponents) return 'componentLimit';

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -145,6 +145,11 @@ class ReactionCollector extends Collector {
     this.checkEnd();
   }
 
+  /**
+   * The reason this collector has ended with, or null if it hasn't ended yet
+   * @type {?string}
+   * @readonly
+   */
   get endReason() {
     if (this.options.max && this.total >= this.options.max) return 'limit';
     if (this.options.maxEmojis && this.collected.size >= this.options.maxEmojis) return 'emojiLimit';

--- a/src/structures/interfaces/Collector.js
+++ b/src/structures/interfaces/Collector.js
@@ -265,6 +265,14 @@ class Collector extends EventEmitter {
 
   /* eslint-disable no-empty-function */
   /**
+   * The reason this collector has ended with, or null if it hasn't ended yet
+   * @type {?string}
+   * @readonly
+   * @abstract
+   */
+  get endReason() {}
+
+  /**
    * Handles incoming events from the `handleCollect` function. Returns null if the event should not
    * be collected, or returns an object describing the data that should be stored.
    * @see Collector#handleCollect
@@ -284,13 +292,6 @@ class Collector extends EventEmitter {
    */
   dispose() {}
   /* eslint-enable no-empty-function */
-
-  /**
-   * The reason this collector has ended with, or null if it hasn't ended yet
-   * @name Collector#endReason
-   * @type {?string}
-   * @abstract
-   */
 }
 
 module.exports = Collector;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -538,7 +538,7 @@ declare module 'discord.js' {
     public readonly client: Client;
     public collected: Collection<K, V>;
     public ended: boolean;
-    public abstract endReason: string | null;
+    public abstract readonly endReason: string | null;
     public filter: CollectorFilter<[V, ...F]>;
     public readonly next: Promise<V>;
     public options: CollectorOptions<[V, ...F]>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I stumbled upon `Collector#endReason` not appearing in the documentation, so here is a fix.
(Something about the parser not picking up `@name`'d properties after the last method?)

I added jsdocs to the deriving classes so the now implement property is no longer `abstract`.
I also marked `Collector#endReason` as `readonly` in the typings, all deriving classes do that themselves already however.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
