### PR TITLE
fix: Remove `connection.url` from open debug message

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -265,7 +265,7 @@ class WebSocketShard extends EventEmitter {
    * @private
    */
   onOpen() {
-    this.debug(`[CONNECTED] ${this.connection.url} in ${Date.now() - this.connectedAt}ms`);
+    this.debug(`[CONNECTED] Took ${Date.now() - this.connectedAt}ms`);
     this.status = Status.NEARLY;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #5590 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
