### PR TITLE
docs(*): wrap optional properties with union types in parentheses

### DIFF
--- a/src/structures/ClientApplication.js
+++ b/src/structures/ClientApplication.js
@@ -55,7 +55,7 @@ class ClientApplication extends Application {
 
     /**
      * The owner of this OAuth application
-     * @type {?User|Team}
+     * @type {?(User|Team)}
      */
     this.owner = data.team
       ? new Team(this.client, data.team)

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -103,7 +103,7 @@ class ClientUser extends Structures.get('User') {
    * @property {PresenceStatusData} [status] Status of the user
    * @property {boolean} [afk] Whether the user is AFK
    * @property {ActivitiesOptions[]} [activities] Activity the user is playing
-   * @property {?number|number[]} [shardID] Shard Id(s) to have the activity set on
+   * @property {?(number|number[])} [shardID] Shard Id(s) to have the activity set on
    */
 
   /**
@@ -130,7 +130,7 @@ class ClientUser extends Structures.get('User') {
   /**
    * Sets the status of the client user.
    * @param {PresenceStatusData} status Status to change to
-   * @param {?number|number[]} [shardID] Shard ID(s) to have the activity set on
+   * @param {?(number|number[])} [shardID] Shard ID(s) to have the activity set on
    * @returns {Presence}
    * @example
    * // Set the client user's status

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -17,7 +17,7 @@ class CommandInteraction extends Interaction {
 
     /**
      * The channel this interaction was sent in
-     * @type {?TextChannel|NewsChannel|DMChannel}
+     * @type {?(TextChannel|NewsChannel|DMChannel)}
      * @name CommandInteraction#channel
      * @readonly
      */

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -354,7 +354,7 @@ class GuildAuditLogsEntry {
 
     /**
      * Specific property changes
-     * @type {?(AuditLogChange[])}
+     * @type {?AuditLogChange[]}
      */
     this.changes = data.changes?.map(c => ({ key: c.key, old: c.old_value, new: c.new_value })) ?? null;
 

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -58,7 +58,7 @@ class Interaction extends Base {
 
     /**
      * If this interaction was sent in a guild, the member which sent it
-     * @type {?GuildMember|APIGuildMember}
+     * @type {?(GuildMember|APIGuildMember)}
      */
     this.member = data.member ? this.guild?.members.add(data.member) ?? data.member : null;
 

--- a/src/structures/InteractionCollector.js
+++ b/src/structures/InteractionCollector.js
@@ -39,7 +39,7 @@ class InteractionCollector extends Collector {
 
     /**
      * The channel from which to collect interactions, if provided
-     * @type {?TextChannel|DMChannel|NewsChannel}
+     * @type {?(TextChannel|DMChannel|NewsChannel)}
      */
     this.channel = this.message?.channel ?? options.channel ?? null;
 

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -68,13 +68,13 @@ class Webhook {
 
     /**
      * The owner of the webhook
-     * @type {?User|APIUser}
+     * @type {?(User|APIUser)}
      */
     this.owner = data.user ? this.client.users?.add(data.user) ?? data.user : null;
 
     /**
      * The source guild of the webhook
-     * @type {?Guild|APIGuild}
+     * @type {?(Guild|APIGuild)}
      */
     this.sourceGuild = data.source_guild
       ? this.client.guilds?.add(data.source_guild, false) ?? data.source_guild
@@ -82,7 +82,7 @@ class Webhook {
 
     /**
      * The source channel of the webhook
-     * @type {?Channel|APIChannel}
+     * @type {?(Channel|APIChannel)}
      */
     this.sourceChannel = this.client.channels?.resolve(data.source_channel?.id) ?? data.source_channel ?? null;
   }

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -42,7 +42,7 @@ class WelcomeChannel extends Base {
 
   /**
    * The channel of this welcome channel
-   * @type {?TextChannel|NewsChannel}
+   * @type {?(TextChannel|NewsChannel)}
    */
   get channel() {
     return this.client.channels.resolve(this.channelID);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
## Why the parentheses are required:
*Let's use `ClientApplication#owner` as an example of a union type without parentheses*

https://github.com/discordjs/discord.js/blob/39db95352c91faf175c2fd8ed365f293f965a0e4/src/structures/ClientApplication.js#L58

Instead of the type being shown as "**?User** or **?Team**", it's shown as "**User** or **Team**"

![image](https://user-images.githubusercontent.com/42935195/124364005-8ef99c80-dc36-11eb-9794-b233f9657cf0.png)

*On the other hand, let's use `GuildChannelManager#resolve` as an example of a union type with parentheses:*

https://github.com/discordjs/discord.js/blob/39db95352c91faf175c2fd8ed365f293f965a0e4/src/managers/GuildChannelManager.js#L62

![image](https://user-images.githubusercontent.com/42935195/124364094-2e1e9400-dc37-11eb-9894-842ec4f9f05e.png)

*** 

I removed the parentheses from `GuildAuditLogs#changes` as they are not necessary.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
