### PR TITLE
docs: fix some missed MessageComponent collector methods

### DIFF
--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -91,8 +91,8 @@ class DMChannel extends Channel {
   get typingCount() {}
   createMessageCollector() {}
   awaitMessages() {}
-  createMessageComponentInteractionCollector() {}
-  awaitMessageComponentInteraction() {}
+  createMessageComponentCollector() {}
+  awaitMessageComponent() {}
   // Doesn't work on DM channels; bulkDelete() {}
 }
 

--- a/src/structures/InteractionCollector.js
+++ b/src/structures/InteractionCollector.js
@@ -25,7 +25,7 @@ const { InteractionTypes, MessageComponentTypes } = require('../util/Constants')
  */
 class InteractionCollector extends Collector {
   /**
-   * @param {Client} client The client on which to collect message component interactions
+   * @param {Client} client The client on which to collect interactions
    * @param {InteractionCollectorOptions} [options={}] The options to apply to this collector
    */
   constructor(client, options = {}) {
@@ -68,7 +68,7 @@ class InteractionCollector extends Collector {
         : options.componentType ?? null;
 
     /**
-     * The users which have interacted to components on this collector
+     * The users which have interacted to this collector
      * @type {Collection}
      */
     this.users = new Collection();
@@ -122,7 +122,7 @@ class InteractionCollector extends Collector {
   collect(interaction) {
     /**
      * Emitted whenever a interaction is collected.
-     * @event MessageComponentInteractionCollector#collect
+     * @event InteractionCollector#collect
      * @param {Interaction} interaction The interaction that was collected
      */
     if (this.interactionType && interaction.type !== this.interactionType) return null;
@@ -142,7 +142,7 @@ class InteractionCollector extends Collector {
   dispose(interaction) {
     /**
      * Emitted whenever an interaction is disposed of.
-     * @event MessageComponentInteractionCollector#dispose
+     * @event InteractionCollector#dispose
      * @param {Interaction} interaction The interaction that was disposed of
      */
     if (this.type && interaction.type !== this.type) return null;
@@ -155,7 +155,7 @@ class InteractionCollector extends Collector {
   }
 
   /**
-   * Empties this message component collector.
+   * Empties this interaction collector.
    */
   empty() {
     this.total = 0;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -454,7 +454,7 @@ class Message extends Base {
    * @example
    * // Create a message component interaction collector
    * const filter = (interaction) => interaction.customID === 'button' && interaction.user.id === 'someID';
-   * const collector = message.createMessageComponentInteractionCollector({ filter, time: 15000 });
+   * const collector = message.createMessageComponentCollector({ filter, time: 15000 });
    * collector.on('collect', i => console.log(`Collected ${i.customID}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
@@ -482,7 +482,7 @@ class Message extends Base {
    * @example
    * // Collect a message component interaction
    * const filter = (interaction) => interaction.customID === 'button' && interaction.user.id === 'someID';
-   * message.awaitMessageComponentInteraction({ filter, time: 15000 })
+   * message.awaitMessageComponent({ filter, time: 15000 })
    *   .then(interaction => console.log(`${interaction.customID} was clicked!`))
    *   .catch(console.error);
    */

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -198,8 +198,8 @@ class TextChannel extends GuildChannel {
   get typingCount() {}
   createMessageCollector() {}
   awaitMessages() {}
-  createMessageComponentInteractionCollector() {}
-  awaitMessageComponentInteraction() {}
+  createMessageComponentCollector() {}
+  awaitMessageComponent() {}
   bulkDelete() {}
 }
 

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -405,8 +405,8 @@ class ThreadChannel extends Channel {
   get typingCount() {}
   createMessageCollector() {}
   awaitMessages() {}
-  createMessageComponentInteractionCollector() {}
-  awaitMessageComponentInteractions() {}
+  createMessageComponentCollector() {}
+  awaitMessageComponent() {}
   bulkDelete() {}
 }
 

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -310,7 +310,7 @@ class TextBasedChannel {
    * @example
    * // Create a button interaction collector
    * const filter = (interaction) => interaction.customID === 'button' && interaction.user.id === 'someID';
-   * const collector = channel.createMessageComponentInteractionCollector({ filter, time: 15000 });
+   * const collector = channel.createMessageComponentCollector({ filter, time: 15000 });
    * collector.on('collect', i => console.log(`Collected ${i.customID}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
@@ -330,7 +330,7 @@ class TextBasedChannel {
    * @example
    * // Collect a message component interaction
    * const filter = (interaction) => interaction.customID === 'button' && interaction.user.id === 'someID';
-   * channel.awaitMessageComponentInteraction({ filter, time: 15000 })
+   * channel.awaitMessageComponent({ filter, time: 15000 })
    *   .then(interaction => console.log(`${interaction.customID} was clicked!`))
    *   .catch(console.error);
    */


### PR DESCRIPTION
Missed renaming the MessageComponent methods in a few places so they weren't being documented properly.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
