### PR TITLE
feat(Client): enforce passing scopes to generateInvite

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -379,7 +379,7 @@ class Client extends BaseClient {
    * @property {PermissionResolvable} [permissions] Permissions to request
    * @property {GuildResolvable} [guild] Guild to preselect
    * @property {boolean} [disableGuildSelect] Whether to disable the guild selection
-   * @property {InviteScope[]} [additionalScopes] Whether any additional scopes should be requested
+   * @property {InviteScope[]} [scopes=['bot']] Scopes that should be requested
    */
 
   /**
@@ -393,6 +393,7 @@ class Client extends BaseClient {
    *     Permissions.FLAGS.MANAGE_GUILD,
    *     Permissions.FLAGS.MENTION_EVERYONE,
    *   ],
+   *   scope: ['bot'],
    * });
    * console.log(`Generated bot invite link: ${link}`);
    */
@@ -420,16 +421,18 @@ class Client extends BaseClient {
       query.set('guild_id', guildID);
     }
 
-    if (options.additionalScopes) {
-      const scopes = options.additionalScopes;
+    if (options.scopes) {
+      const scopes = options.scopes;
       if (!Array.isArray(scopes)) {
-        throw new TypeError('INVALID_TYPE', 'additionalScopes', 'Array of Invite Scopes', true);
+        throw new TypeError('INVALID_TYPE', 'scopes', 'Array of Invite Scopes', true);
       }
       const invalidScope = scopes.find(scope => !InviteScopes.includes(scope));
       if (invalidScope) {
-        throw new TypeError('INVALID_ELEMENT', 'Array', 'additionalScopes', invalidScope);
+        throw new TypeError('INVALID_ELEMENT', 'Array', 'scopes', invalidScope);
       }
-      query.set('scope', ['bot', ...scopes].join(' '));
+      query.set('scope', [...scopes].join(' '));
+    } else {
+      query.set('scope', 'bot');
     }
 
     return `${this.options.http.api}${this.api.oauth2.authorize}?${query}`;

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -425,7 +425,7 @@ class Client extends BaseClient {
     if (invalidScope) {
       throw new TypeError('INVALID_ELEMENT', 'Array', 'scopes', invalidScope);
     }
-    query.set('scope', [...scopes].join(' '));
+    query.set('scope', scopes.join(' '));
 
     if (options.permissions && options.scopes) {
       const permissions = Permissions.resolve(options.permissions);

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -410,15 +410,14 @@ class Client extends BaseClient {
       client_id: this.application.id,
     });
 
-    const scopes = options.scopes;
+    const { scopes } = options;
     if (typeof scopes === 'undefined') {
       throw new TypeError('INVITE_MISSING_SCOPES');
     }
     if (!Array.isArray(scopes)) {
       throw new TypeError('INVALID_TYPE', 'scopes', 'Array of Invite Scopes', true);
     }
-    const requiredScope = scopes.find(scope => scope === 'bot' || scope === 'applications.commands');
-    if (!requiredScope) {
+    if (!scopes.some(scope => ['bot', 'applications.commands'].includes(scope))) {
       throw new TypeError('INVITE_MISSING_SCOPES');
     }
     const invalidScope = scopes.find(scope => !InviteScopes.includes(scope));

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -426,7 +426,7 @@ class Client extends BaseClient {
     }
     query.set('scope', scopes.join(' '));
 
-    if (options.permissions && options.scopes) {
+    if (options.permissions) {
       const permissions = Permissions.resolve(options.permissions);
       if (permissions) query.set('permissions', permissions);
     }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -406,6 +406,10 @@ class Client extends BaseClient {
     if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
     if (!this.application) throw new Error('CLIENT_NOT_READY', 'generate an invite link');
 
+    const query = new URLSearchParams({
+      client_id: this.application.id,
+    });
+
     const scopes = options.scopes;
     if (typeof scopes === 'undefined') {
       throw new TypeError('INVITE_MISSING_SCOPES');
@@ -422,11 +426,6 @@ class Client extends BaseClient {
       throw new TypeError('INVALID_ELEMENT', 'Array', 'scopes', invalidScope);
     }
     query.set('scope', [...scopes].join(' '));
-
-    const query = new URLSearchParams({
-      client_id: this.application.id,
-      scope: 'bot',
-    });
 
     if (options.permissions && options.scopes) {
       const permissions = Permissions.resolve(options.permissions);

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -388,12 +388,17 @@ class Client extends BaseClient {
    * @returns {string}
    * @example
    * const link = client.generateInvite({
+   *   scopes: ['applications.commands'],
+   * });
+   * console.log(`Generated application invite link: ${link}`);
+   * @example
+   * const link = client.generateInvite({
    *   permissions: [
    *     Permissions.FLAGS.SEND_MESSAGES,
    *     Permissions.FLAGS.MANAGE_GUILD,
    *     Permissions.FLAGS.MENTION_EVERYONE,
    *   ],
-   *   scope: ['bot'],
+   *   scopes: ['bot'],
    * });
    * console.log(`Generated bot invite link: ${link}`);
    */

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -402,7 +402,7 @@ class Client extends BaseClient {
     if (!this.application) throw new Error('CLIENT_NOT_READY', 'generate an invite link');
 
     const scopes = options.scopes;
-    if (!scopes) {
+    if (typeof scopes === 'undefined') {
       throw new TypeError('INVITE_MISSING_SCOPES');
     }
     if (!Array.isArray(scopes)) {

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -128,6 +128,8 @@ const Messages = {
   INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be fetched or deleted.',
   INTERACTION_FETCH_EPHEMERAL: 'Ephemeral responses cannot be fetched.',
 
+  INVITE_MISSING_SCOPES: 'A valid scope must be provided for the invite',
+
   NOT_IMPLEMENTED: (what, name) => `Method ${what} not implemented on ${name}.`,
 };
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -128,7 +128,7 @@ const Messages = {
   INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be fetched or deleted.',
   INTERACTION_FETCH_EPHEMERAL: 'Ephemeral responses cannot be fetched.',
 
-  INVITE_MISSING_SCOPES: 'A valid scope must be provided for the invite',
+  INVITE_MISSING_SCOPES: 'At least one valid scope must be provided for the invite',
 
   NOT_IMPLEMENTED: (what, name) => `Method ${what} not implemented on ${name}.`,
 };

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -328,6 +328,7 @@ exports.InviteScopes = [
   'applications.commands',
   'applications.entitlements',
   'applications.store.update',
+  'bot',
   'connections',
   'email',
   'identity',

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3725,7 +3725,7 @@ declare module 'discord.js' {
     permissions?: PermissionResolvable;
     guild?: GuildResolvable;
     disableGuildSelect?: boolean;
-    additionalScopes?: InviteScope[];
+    scopes?: InviteScope[];
   }
 
   interface CreateInviteOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3725,7 +3725,7 @@ declare module 'discord.js' {
     permissions?: PermissionResolvable;
     guild?: GuildResolvable;
     disableGuildSelect?: boolean;
-    scopes?: InviteScope[];
+    scopes: InviteScope[];
   }
 
   interface CreateInviteOptions {


### PR DESCRIPTION
Previously this method would automatically include the bot scope - it's now required that the user provide scopes in the options, including one of either bot or applications.commands.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
