### PR TITLE
docs(MessageManager): document options param for #edit as required

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -116,7 +116,7 @@ class MessageManager extends CachedManager {
   /**
    * Edits a message, even if it's not cached.
    * @param {MessageResolvable} message The message to edit
-   * @param {MessageEditOptions|MessagePayload} [options] The options to provide
+   * @param {MessageEditOptions|MessagePayload} options The options to edit the message
    * @returns {Promise<Message>}
    */
   async edit(message, options) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `options` param for `MessageManager#edit` is documented as optional, which isn't correct as the [typings](https://github.com/discordjs/discord.js/blob/610b0b4dd6b6e66c05c22eb852d2a752b99d07ba/typings/index.d.ts#L2591) for it states that it is a required param. Also, the said method calls `MessagePayload#create`, which requires the second param to be always defined, which is `options` in this case.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
