### PR TITLE
feat: allow channels from uncached guilds to be returned from fetch

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -90,6 +90,7 @@ const Messages = {
   GUILD_CHANNEL_RESOLVE: 'Could not resolve channel to a guild channel.',
   GUILD_VOICE_CHANNEL_RESOLVE: 'Could not resolve channel to a guild voice channel.',
   GUILD_CHANNEL_ORPHAN: 'Could not find a parent to this guild channel.',
+  GUILD_CHANNEL_UNOWNED: 'The fetched channel does not belong to this managers guild',
   GUILD_OWNED: 'Guild is owned by the client.',
   GUILD_MEMBERS_TIMEOUT: "Members didn't arrive in time.",
   GUILD_UNCACHED_ME: 'The client user as a member of this guild is uncached.',

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -90,7 +90,7 @@ const Messages = {
   GUILD_CHANNEL_RESOLVE: 'Could not resolve channel to a guild channel.',
   GUILD_VOICE_CHANNEL_RESOLVE: 'Could not resolve channel to a guild voice channel.',
   GUILD_CHANNEL_ORPHAN: 'Could not find a parent to this guild channel.',
-  GUILD_CHANNEL_UNOWNED: 'The fetched channel does not belong to this managers guild',
+  GUILD_CHANNEL_UNOWNED: "The fetched channel does not belong to this manager's guild.",
   GUILD_OWNED: 'Guild is owned by the client.',
   GUILD_MEMBERS_TIMEOUT: "Members didn't arrive in time.",
   GUILD_UNCACHED_ME: 'The client user as a member of this guild is uncached.',

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -127,7 +127,7 @@ class Channel extends Base {
     return ThreadChannelTypes.includes(this.type);
   }
 
-  static create(client, data, guild) {
+  static create(client, data, guild, allowUnknownGuild) {
     if (!CategoryChannel) CategoryChannel = require('./CategoryChannel');
     if (!DMChannel) DMChannel = require('./DMChannel');
     if (!NewsChannel) NewsChannel = require('./NewsChannel');
@@ -148,41 +148,41 @@ class Channel extends Base {
     } else {
       if (!guild) guild = client.guilds.cache.get(data.guild_id);
 
-      if (guild) {
+      if (guild || allowUnknownGuild) {
         switch (data.type) {
           case ChannelTypes.TEXT: {
-            channel = new TextChannel(guild, data);
+            channel = new TextChannel(guild, data, client);
             break;
           }
           case ChannelTypes.VOICE: {
-            channel = new VoiceChannel(guild, data);
+            channel = new VoiceChannel(guild, data, client);
             break;
           }
           case ChannelTypes.CATEGORY: {
-            channel = new CategoryChannel(guild, data);
+            channel = new CategoryChannel(guild, data, client);
             break;
           }
           case ChannelTypes.NEWS: {
-            channel = new NewsChannel(guild, data);
+            channel = new NewsChannel(guild, data, client);
             break;
           }
           case ChannelTypes.STORE: {
-            channel = new StoreChannel(guild, data);
+            channel = new StoreChannel(guild, data, client);
             break;
           }
           case ChannelTypes.STAGE: {
-            channel = new StageChannel(guild, data);
+            channel = new StageChannel(guild, data, client);
             break;
           }
           case ChannelTypes.NEWS_THREAD:
           case ChannelTypes.PUBLIC_THREAD:
           case ChannelTypes.PRIVATE_THREAD: {
-            channel = new ThreadChannel(guild, data);
-            channel.parent?.threads.cache.set(channel.id, channel);
+            channel = new ThreadChannel(guild, data, client);
+            if (!allowUnknownGuild) channel.parent?.threads.cache.set(channel.id, channel);
             break;
           }
         }
-        if (channel) guild.channels?.cache.set(channel.id, channel);
+        if (channel && !allowUnknownGuild) guild.channels?.cache.set(channel.id, channel);
       }
     }
     return channel;

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -24,15 +24,22 @@ class GuildChannel extends Channel {
   /**
    * @param {Guild} guild The guild the guild channel is part of
    * @param {APIChannel} data The data for the guild channel
+   * @param {Client} [client] A safety parameter for the client that instantiated this
    */
-  constructor(guild, data) {
-    super(guild.client, data, false);
+  constructor(guild, data, client) {
+    super(guild?.client ?? client, data, false);
 
     /**
      * The guild the channel is in
      * @type {Guild}
      */
     this.guild = guild;
+
+    /**
+     * The id of the guild the channel is in
+     * @type {Snowflake}
+     */
+    this.guildId = guild?.id ?? data.guild_id;
 
     this.parentId = this.parentId ?? null;
     /**
@@ -61,6 +68,10 @@ class GuildChannel extends Channel {
        * @type {number}
        */
       this.rawPosition = data.position;
+    }
+
+    if ('guild_id' in data) {
+      this.guildId = data.guild_id;
     }
 
     if ('parent_id' in data) {

--- a/src/structures/StoreChannel.js
+++ b/src/structures/StoreChannel.js
@@ -8,11 +8,12 @@ const GuildChannel = require('./GuildChannel');
  */
 class StoreChannel extends GuildChannel {
   /**
-   * @param {*} guild The guild the store channel is part of
-   * @param {*} data The data for the store channel
+   * @param {Guild} guild The guild the store channel is part of
+   * @param {APIChannel} data The data for the store channel
+   * @param {Client} [client] A safety parameter for the client that instantiated this
    */
-  constructor(guild, data) {
-    super(guild, data);
+  constructor(guild, data, client) {
+    super(guild, data, client);
 
     /**
      * If the guild considers this channel NSFW

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -17,9 +17,10 @@ class TextChannel extends GuildChannel {
   /**
    * @param {Guild} guild The guild the text channel is part of
    * @param {APIChannel} data The data for the text channel
+   * @param {Client} [client] A safety parameter for the client that instantiated this
    */
-  constructor(guild, data) {
-    super(guild, data);
+  constructor(guild, data, client) {
+    super(guild, data, client);
     /**
      * A manager of the messages sent to this channel
      * @type {MessageManager}

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -15,15 +15,22 @@ class ThreadChannel extends Channel {
   /**
    * @param {Guild} guild The guild the thread channel is part of
    * @param {APIChannel} data The data for the thread channel
+   * @param {Client} [client] A safety parameter for the client that instantiated this
    */
-  constructor(guild, data) {
-    super(guild.client, data, false);
+  constructor(guild, data, client) {
+    super(guild?.client ?? client, data, false);
 
     /**
      * The guild the thread is in
      * @type {Guild}
      */
     this.guild = guild;
+
+    /**
+     * The id of the guild the channel is in
+     * @type {Snowflake}
+     */
+    this.guildId = guild?.id ?? data.guild_id;
 
     /**
      * A manager of the messages sent to this thread
@@ -49,6 +56,10 @@ class ThreadChannel extends Channel {
      * @type {string}
      */
     this.name = data.name;
+
+    if ('guild_id' in data) {
+      this.guildId = data.guild_id;
+    }
 
     if ('parent_id' in data) {
       /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -619,13 +619,14 @@ export class GuildBan extends Base {
 }
 
 export class GuildChannel extends Channel {
-  public constructor(guild: Guild, data?: unknown);
+  public constructor(guild: Guild, data?: unknown, client?: Client);
   private memberPermissions(member: GuildMember): Readonly<Permissions>;
   private rolePermissions(role: Role): Readonly<Permissions>;
 
   public readonly calculatedPosition: number;
   public readonly deletable: boolean;
   public guild: Guild;
+  public guildId: Snowflake;
   public readonly manageable: boolean;
   public readonly members: Collection<Snowflake, GuildMember>;
   public name: string;
@@ -1519,7 +1520,7 @@ export class Sticker extends Base {
 }
 
 export class StoreChannel extends GuildChannel {
-  public constructor(guild: Guild, data?: unknown);
+  public constructor(guild: Guild, data?: unknown, client?: Client);
   public nsfw: boolean;
   public type: 'store';
 }
@@ -1558,7 +1559,7 @@ export class TeamMember extends Base {
 }
 
 export class TextChannel extends TextBasedChannel(GuildChannel) {
-  public constructor(guild: Guild, data?: unknown);
+  public constructor(guild: Guild, data?: unknown, client?: Client);
   public defaultAutoArchiveDuration?: ThreadAutoArchiveDuration;
   public messages: MessageManager;
   public nsfw: boolean;
@@ -1578,13 +1579,14 @@ export class TextChannel extends TextBasedChannel(GuildChannel) {
 }
 
 export class ThreadChannel extends TextBasedChannel(Channel) {
-  public constructor(guild: Guild, data?: object);
+  public constructor(guild: Guild, data?: object, client?: Client);
   public archived: boolean;
   public readonly archivedAt: Date;
   public archiveTimestamp: number;
   public autoArchiveDuration: ThreadAutoArchiveDuration;
   public readonly editable: boolean;
   public guild: Guild;
+  public guildId: Snowflake;
   public readonly guildMembers: Collection<Snowflake, GuildMember>;
   public readonly joinable: boolean;
   public readonly joined: boolean;
@@ -2266,7 +2268,7 @@ export class BaseGuildEmojiManager extends CachedManager<Snowflake, GuildEmoji, 
 
 export class ChannelManager extends CachedManager<Snowflake, Channel, ChannelResolvable> {
   public constructor(client: Client, iterable: Iterable<unknown>);
-  public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<Channel | null>;
+  public fetch(id: Snowflake, options?: FetchChannelOptions): Promise<Channel | null>;
 }
 
 export class GuildApplicationCommandManager extends ApplicationCommandManager<ApplicationCommand, {}, Guild> {
@@ -3156,6 +3158,10 @@ export interface FetchBanOptions extends BaseFetchOptions {
 
 export interface FetchBansOptions {
   cache: boolean;
+}
+
+export interface FetchChannelOptions extends BaseFetchOptions {
+  allowUnknownGuild?: boolean;
 }
 
 export interface FetchedThreads {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR allows fetching channels from guilds that do not exist in the client cache (applicable mostly when sharding, but also possible to have guilds uncached via intents limiting or the new collection based limiting)

A big red flag warning here: channels obviously rely on guild internally a lot, however I did not want to change types when the majority of times the values will be present. I would expect people using this option to know exactly what they are doing and which properties can be accessed.

This also fixes up fetching single channels from the guild channel manager, making it cleaner and throwing when trying to fetch a channel from a  different guild (this is the only breaking change)

closes: #4929

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
