### PR TITLE
refactor: change `xID` to `xId`

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -98,20 +98,20 @@ class Client extends BaseClient {
       : null;
 
     /**
-     * All of the {@link User} objects that have been cached at any point, mapped by their IDs
+     * All of the {@link User} objects that have been cached at any point, mapped by their ids
      * @type {UserManager}
      */
     this.users = new UserManager(this);
 
     /**
-     * All of the guilds the client is currently handling, mapped by their IDs -
+     * All of the guilds the client is currently handling, mapped by their ids -
      * as long as sharding isn't being used, this will be *every* guild the bot is a member of
      * @type {GuildManager}
      */
     this.guilds = new GuildManager(this);
 
     /**
-     * All of the {@link Channel}s that the client is currently handling, mapped by their IDs -
+     * All of the {@link Channel}s that the client is currently handling, mapped by their ids -
      * as long as sharding isn't being used, this will be *every* channel in *every* guild the bot
      * is a member of. Note that DM channels will not be initially cached, and thus not be present
      * in the Manager without their explicit fetching or use.
@@ -164,7 +164,7 @@ class Client extends BaseClient {
   }
 
   /**
-   * All custom emojis that the client has access to, mapped by their IDs
+   * All custom emojis that the client has access to, mapped by their ids
    * @type {BaseGuildEmojiManager}
    * @readonly
    */
@@ -273,7 +273,7 @@ class Client extends BaseClient {
 
   /**
    * Obtains a webhook from Discord.
-   * @param {Snowflake} id ID of the webhook
+   * @param {Snowflake} id The webhook's id
    * @param {string} [token] Token for the webhook
    * @returns {Promise<Webhook>}
    * @example
@@ -352,7 +352,7 @@ class Client extends BaseClient {
    * @returns {Promise<GuildPreview>}
    */
   fetchGuildPreview(guild) {
-    const id = this.guilds.resolveID(guild);
+    const id = this.guilds.resolveId(guild);
     if (!id) throw new TypeError('INVALID_TYPE', 'guild', 'GuildResolvable');
     return this.api
       .guilds(id)
@@ -366,7 +366,7 @@ class Client extends BaseClient {
    * @returns {Promise<Widget>}
    */
   async fetchWidget(guild) {
-    const id = this.guilds.resolveID(guild);
+    const id = this.guilds.resolveId(guild);
     if (!id) throw new TypeError('INVALID_TYPE', 'guild', 'GuildResolvable');
     const data = await this.api.guilds(id, 'widget.json').get();
     return new Widget(this, data);
@@ -414,9 +414,9 @@ class Client extends BaseClient {
     }
 
     if (options.guild) {
-      const guildID = this.guilds.resolveID(options.guild);
-      if (!guildID) throw new TypeError('INVALID_TYPE', 'options.guild', 'GuildResolvable');
-      query.set('guild_id', guildID);
+      const guildId = this.guilds.resolveId(options.guild);
+      if (!guildId) throw new TypeError('INVALID_TYPE', 'options.guild', 'GuildResolvable');
+      query.set('guild_id', guildId);
     }
 
     if (options.additionalScopes) {

--- a/src/client/WebhookClient.js
+++ b/src/client/WebhookClient.js
@@ -10,7 +10,7 @@ const Webhook = require('../structures/Webhook');
  */
 class WebhookClient extends BaseClient {
   /**
-   * @param {Snowflake} id ID of the webhook
+   * @param {Snowflake} id The webhook's id
    * @param {string} token Token of the webhook
    * @param {ClientOptions} [options] Options for the client
    * @example

--- a/src/client/actions/MessageCreate.js
+++ b/src/client/actions/MessageCreate.js
@@ -15,14 +15,14 @@ class MessageCreateAction extends Action {
       const message = channel.messages.add(data);
       const user = message.author;
       const member = message.member;
-      channel.lastMessageID = data.id;
+      channel.lastMessageId = data.id;
       if (user) {
-        user.lastMessageID = data.id;
-        user.lastMessageChannelID = channel.id;
+        user.lastMessageId = data.id;
+        user.lastMessageChannelId = channel.id;
       }
       if (member) {
-        member.lastMessageID = data.id;
-        member.lastMessageChannelID = channel.id;
+        member.lastMessageId = data.id;
+        member.lastMessageChannelId = channel.id;
       }
 
       /**

--- a/src/client/actions/MessageDeleteBulk.js
+++ b/src/client/actions/MessageDeleteBulk.js
@@ -31,7 +31,7 @@ class MessageDeleteBulkAction extends Action {
       /**
        * Emitted whenever messages are deleted in bulk.
        * @event Client#messageDeleteBulk
-       * @param {Collection<Snowflake, Message>} messages The deleted messages, mapped by their ID
+       * @param {Collection<Snowflake, Message>} messages The deleted messages, mapped by their id
        */
       if (messages.size > 0) client.emit(Events.MESSAGE_BULK_DELETE, messages);
       return { messages };

--- a/src/client/voice/ClientVoiceManager.js
+++ b/src/client/voice/ClientVoiceManager.js
@@ -16,14 +16,14 @@ class ClientVoiceManager {
     Object.defineProperty(this, 'client', { value: client });
 
     /**
-     * Maps guild IDs to voice adapters created for use with @discordjs/voice.
+     * Maps guild ids to voice adapters created for use with @discordjs/voice.
      * @type {Map<Snowflake, Object>}
      */
     this.adapters = new Map();
 
-    client.on(Events.SHARD_DISCONNECT, (_, shardID) => {
-      for (const [guildID, adapter] of this.adapters.entries()) {
-        if (client.guilds.cache.get(guildID)?.shardID === shardID) {
+    client.on(Events.SHARD_DISCONNECT, (_, shardId) => {
+      for (const [guildId, adapter] of this.adapters.entries()) {
+        if (client.guilds.cache.get(guildId)?.shardId === shardId) {
           adapter.destroy();
         }
       }

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -174,8 +174,8 @@ class WebSocketManager extends EventEmitter {
         /**
          * Emitted when a shard turns ready.
          * @event Client#shardReady
-         * @param {number} id The shard ID that turned ready
-         * @param {?Set<string>} unavailableGuilds Set of unavailable guild IDs, if any
+         * @param {number} id The shard id that turned ready
+         * @param {?Set<string>} unavailableGuilds Set of unavailable guild ids, if any
          */
         this.client.emit(Events.SHARD_READY, shard.id, unavailableGuilds);
 
@@ -189,7 +189,7 @@ class WebSocketManager extends EventEmitter {
            * Emitted when a shard's WebSocket disconnects and will no longer reconnect.
            * @event Client#shardDisconnect
            * @param {CloseEvent} event The WebSocket close event
-           * @param {number} id The shard ID that disconnected
+           * @param {number} id The shard id that disconnected
            */
           this.client.emit(Events.SHARD_DISCONNECT, event, shard.id);
           this.debug(WSCodes[event.code], shard);
@@ -198,20 +198,20 @@ class WebSocketManager extends EventEmitter {
 
         if (UNRESUMABLE_CLOSE_CODES.includes(event.code)) {
           // These event codes cannot be resumed
-          shard.sessionID = null;
+          shard.sessionId = null;
         }
 
         /**
          * Emitted when a shard is attempting to reconnect or re-identify.
          * @event Client#shardReconnecting
-         * @param {number} id The shard ID that is attempting to reconnect
+         * @param {number} id The shard id that is attempting to reconnect
          */
         this.client.emit(Events.SHARD_RECONNECTING, shard.id);
 
         this.shardQueue.add(shard);
 
-        if (shard.sessionID) {
-          this.debug(`Session ID is present, attempting an immediate reconnect...`, shard);
+        if (shard.sessionId) {
+          this.debug(`Session id is present, attempting an immediate reconnect...`, shard);
           this.reconnect();
         } else {
           shard.destroy({ reset: true, emit: false, log: false });

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -28,7 +28,7 @@ class WebSocketShard extends EventEmitter {
     this.manager = manager;
 
     /**
-     * The ID of the shard
+     * The shard's id
      * @type {number}
      */
     this.id = id;
@@ -54,11 +54,11 @@ class WebSocketShard extends EventEmitter {
     this.closeSequence = 0;
 
     /**
-     * The current session ID of the shard
+     * The current session id of the shard
      * @type {?string}
      * @private
      */
-    this.sessionID = null;
+    this.sessionId = null;
 
     /**
      * The previous heartbeat ping of the shard
@@ -134,7 +134,7 @@ class WebSocketShard extends EventEmitter {
     Object.defineProperty(this, 'eventsAttached', { value: false, writable: true });
 
     /**
-     * A set of guild IDs this shard expects to receive
+     * A set of guild ids this shard expects to receive
      * @name WebSocketShard#expectedGuilds
      * @type {?Set<string>}
      * @private
@@ -313,7 +313,7 @@ class WebSocketShard extends EventEmitter {
      * Emitted whenever a shard's WebSocket encounters a connection error.
      * @event Client#shardError
      * @param {Error} error The encountered error
-     * @param {number} shardID The shard that encountered this error
+     * @param {number} shardId The shard that encountered this error
      */
     this.manager.client.emit(Events.SHARD_ERROR, error, this.id);
   }
@@ -382,10 +382,10 @@ class WebSocketShard extends EventEmitter {
          */
         this.emit(ShardEvents.READY);
 
-        this.sessionID = packet.d.session_id;
+        this.sessionId = packet.d.session_id;
         this.expectedGuilds = new Set(packet.d.guilds.map(d => d.id));
         this.status = Status.WAITING_FOR_GUILDS;
-        this.debug(`[READY] Session ${this.sessionID}.`);
+        this.debug(`[READY] Session ${this.sessionId}.`);
         this.lastHeartbeatAcked = true;
         this.sendHeartbeat('ReadyHeartbeat');
         break;
@@ -398,7 +398,7 @@ class WebSocketShard extends EventEmitter {
 
         this.status = Status.READY;
         const replayed = packet.s - this.closeSequence;
-        this.debug(`[RESUMED] Session ${this.sessionID} | Replayed ${replayed} events.`);
+        this.debug(`[RESUMED] Session ${this.sessionId} | Replayed ${replayed} events.`);
         this.lastHeartbeatAcked = true;
         this.sendHeartbeat('ResumeHeartbeat');
         break;
@@ -426,8 +426,8 @@ class WebSocketShard extends EventEmitter {
         }
         // Reset the sequence
         this.sequence = -1;
-        // Reset the session ID as it's invalid
-        this.sessionID = null;
+        // Reset the session id as it's invalid
+        this.sessionId = null;
         // Set the status to reconnecting
         this.status = Status.RECONNECTING;
         // Finally, emit the INVALID_SESSION event
@@ -576,7 +576,7 @@ class WebSocketShard extends EventEmitter {
    * @returns {void}
    */
   identify() {
-    return this.sessionID ? this.identifyResume() : this.identifyNew();
+    return this.sessionId ? this.identifyResume() : this.identifyNew();
   }
 
   /**
@@ -609,19 +609,19 @@ class WebSocketShard extends EventEmitter {
    * @private
    */
   identifyResume() {
-    if (!this.sessionID) {
-      this.debug('[RESUME] No session ID was present; identifying as a new session.');
+    if (!this.sessionId) {
+      this.debug('[RESUME] No session id was present; identifying as a new session.');
       this.identifyNew();
       return;
     }
 
     this.status = Status.RESUMING;
 
-    this.debug(`[RESUME] Session ${this.sessionID}, sequence ${this.closeSequence}`);
+    this.debug(`[RESUME] Session ${this.sessionId}, sequence ${this.closeSequence}`);
 
     const d = {
       token: this.manager.client.token,
-      session_id: this.sessionID,
+      session_id: this.sessionId,
       seq: this.closeSequence,
     };
 
@@ -731,10 +731,10 @@ class WebSocketShard extends EventEmitter {
     // Step 4: Cache the old sequence (use to attempt a resume)
     if (this.sequence !== -1) this.closeSequence = this.sequence;
 
-    // Step 5: Reset the sequence and session ID if requested
+    // Step 5: Reset the sequence and session id if requested
     if (reset) {
       this.sequence = -1;
-      this.sessionID = null;
+      this.sessionId = null;
     }
 
     // Step 6: reset the ratelimit data

--- a/src/client/websocket/handlers/GUILD_CREATE.js
+++ b/src/client/websocket/handlers/GUILD_CREATE.js
@@ -11,7 +11,7 @@ module.exports = (client, { d: data }, shard) => {
     }
   } else {
     // A new guild
-    data.shardID = shard.id;
+    data.shardId = shard.id;
     guild = client.guilds.add(data);
     if (client.ws.status === Status.READY) {
       /**

--- a/src/client/websocket/handlers/READY.js
+++ b/src/client/websocket/handlers/READY.js
@@ -13,7 +13,7 @@ module.exports = (client, { d: data }, shard) => {
   }
 
   for (const guild of data.guilds) {
-    guild.shardID = shard.id;
+    guild.shardId = shard.id;
     client.guilds.add(guild);
   }
 

--- a/src/client/websocket/handlers/RESUMED.js
+++ b/src/client/websocket/handlers/RESUMED.js
@@ -7,7 +7,7 @@ module.exports = (client, packet, shard) => {
   /**
    * Emitted when a shard resumes successfully.
    * @event Client#shardResume
-   * @param {number} id The shard ID that resumed
+   * @param {number} id The shard id that resumed
    * @param {number} replayedEvents The amount of replayed events
    */
   client.emit(Events.SHARD_RESUME, shard.id, replayed);

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -48,9 +48,9 @@ const Messages = {
 
   BUTTON_LABEL: 'MessageButton label must be a string',
   BUTTON_URL: 'MessageButton url must be a string',
-  BUTTON_CUSTOM_ID: 'MessageButton customID must be a string',
+  BUTTON_CUSTOM_ID: 'MessageButton customId must be a string',
 
-  SELECT_MENU_CUSTOM_ID: 'MessageSelectMenu customID must be a string',
+  SELECT_MENU_CUSTOM_ID: 'MessageSelectMenu customId must be a string',
   SELECT_MENU_PLACEHOLDER: 'MessageSelectMenu placeholder must be a string',
   SELECT_OPTION_LABEL: 'MessageSelectOption label must be a string',
   SELECT_OPTION_VALUE: 'MessageSelectOption value must be a string',
@@ -82,8 +82,8 @@ const Messages = {
 
   SPLIT_MAX_LEN: 'Chunk exceeds the max length and contains no split characters.',
 
-  BAN_RESOLVE_ID: (ban = false) => `Couldn't resolve the user ID to ${ban ? 'ban' : 'unban'}.`,
-  FETCH_BAN_RESOLVE_ID: "Couldn't resolve the user ID to fetch the ban.",
+  BAN_RESOLVE_ID: (ban = false) => `Couldn't resolve the user id to ${ban ? 'ban' : 'unban'}.`,
+  FETCH_BAN_RESOLVE_ID: "Couldn't resolve the user id to fetch the ban.",
 
   PRUNE_DAYS_TYPE: 'Days must be a number',
 
@@ -109,7 +109,7 @@ const Messages = {
   MISSING_MANAGE_EMOJIS_PERMISSION: guild =>
     `Client must have Manage Emoji permission in guild ${guild} to see emoji authors.`,
 
-  REACTION_RESOLVE_USER: "Couldn't resolve the user ID to remove from the reaction.",
+  REACTION_RESOLVE_USER: "Couldn't resolve the user id to remove from the reaction.",
 
   VANITY_URL: 'This guild does not have the VANITY_URL feature enabled.',
 
@@ -121,7 +121,7 @@ const Messages = {
   GLOBAL_COMMAND_PERMISSIONS:
     'Permissions for global commands may only be fetched or modified by providing a GuildResolvable ' +
     "or from a guild's application command manager.",
-  GUILD_UNCACHED_ROLE_RESOLVE: 'Cannot resolve roles from an arbitrary guild, provide an ID instead',
+  GUILD_UNCACHED_ROLE_RESOLVE: 'Cannot resolve roles from an arbitrary guild, provide an id instead',
 
   INTERACTION_ALREADY_REPLIED: 'This interaction has already been deferred or replied to.',
   INTERACTION_NOT_REPLIED: 'This interaction has not been deferred or replied to.',

--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -27,21 +27,21 @@ class ApplicationCommandManager extends CachedManager {
    * @name ApplicationCommandManager#cache
    */
 
-  add(data, cache, guildID) {
-    return super.add(data, cache, { extras: [this.guild, guildID] });
+  add(data, cache, guildId) {
+    return super.add(data, cache, { extras: [this.guild, guildId] });
   }
 
   /**
    * The APIRouter path to the commands
-   * @param {Snowflake} [options.id] ID of the application command
-   * @param {Snowflake} [options.guildID] ID of the guild to use in the path,
+   * @param {Snowflake} [options.id] The application command's id
+   * @param {Snowflake} [options.guildId] The guild's id to use in the path,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Object}
    * @private
    */
-  commandPath({ id, guildID } = {}) {
+  commandPath({ id, guildId } = {}) {
     let path = this.client.api.applications(this.client.application.id);
-    if (this.guild ?? guildID) path = path.guilds(this.guild?.id ?? guildID);
+    if (this.guild ?? guildId) path = path.guilds(this.guild?.id ?? guildId);
     return id ? path.commands(id) : path.commands;
   }
 
@@ -62,12 +62,12 @@ class ApplicationCommandManager extends CachedManager {
   /**
    * Options used to fetch Application Commands from discord
    * @typedef {BaseFetchOptions} FetchApplicationCommandOptions
-   * @property {Snowflake} [guildID] ID of the guild to fetch commands for, for when the guild is not cached
+   * @property {Snowflake} [guildId] The guild's id to fetch commands for, for when the guild is not cached
    */
 
   /**
    * Obtains one or multiple application commands from Discord, or the cache if it's already available.
-   * @param {Snowflake} [id] ID of the application command
+   * @param {Snowflake} [id] The application command's id
    * @param {FetchApplicationCommandOptions} [options] Additional options for this fetch
    * @returns {Promise<ApplicationCommand|Collection<Snowflake, ApplicationCommand>>}
    * @example
@@ -81,26 +81,26 @@ class ApplicationCommandManager extends CachedManager {
    *   .then(commands => console.log(`Fetched ${commands.size} commands`))
    *   .catch(console.error);
    */
-  async fetch(id, { guildID, cache = true, force = false } = {}) {
+  async fetch(id, { guildId, cache = true, force = false } = {}) {
     if (typeof id === 'object') {
-      ({ guildID, cache = true, force = false } = id);
+      ({ guildId, cache = true, force = false } = id);
     } else if (id) {
       if (!force) {
         const existing = this.cache.get(id);
         if (existing) return existing;
       }
-      const command = await this.commandPath({ id, guildID }).get();
+      const command = await this.commandPath({ id, guildId }).get();
       return this.add(command, cache);
     }
 
-    const data = await this.commandPath({ guildID }).get();
-    return data.reduce((coll, command) => coll.set(command.id, this.add(command, cache, guildID)), new Collection());
+    const data = await this.commandPath({ guildId }).get();
+    return data.reduce((coll, command) => coll.set(command.id, this.add(command, cache, guildId)), new Collection());
   }
 
   /**
    * Creates an application command.
    * @param {ApplicationCommandData} command The command
-   * @param {Snowflake} [guildID] ID of the guild to create this command in,
+   * @param {Snowflake} [guildId] The guild's id to create this command in,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Promise<ApplicationCommand>}
    * @example
@@ -112,17 +112,17 @@ class ApplicationCommandManager extends CachedManager {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async create(command, guildID) {
-    const data = await this.commandPath({ guildID }).post({
+  async create(command, guildId) {
+    const data = await this.commandPath({ guildId }).post({
       data: this.constructor.transformCommand(command),
     });
-    return this.add(data, undefined, guildID);
+    return this.add(data, undefined, guildId);
   }
 
   /**
    * Sets all the commands for this application or guild.
    * @param {ApplicationCommandData[]} commands The commands
-   * @param {Snowflake} [guildID] ID of the guild to create the commands in,
+   * @param {Snowflake} [guildId] The guild's id to create the commands in,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Promise<Collection<Snowflake, ApplicationCommand>>}
    * @example
@@ -141,12 +141,12 @@ class ApplicationCommandManager extends CachedManager {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async set(commands, guildID) {
-    const data = await this.commandPath({ guildID }).put({
+  async set(commands, guildId) {
+    const data = await this.commandPath({ guildId }).put({
       data: commands.map(c => this.constructor.transformCommand(c)),
     });
     return data.reduce(
-      (coll, command) => coll.set(command.id, this.add(command, undefined, guildID)),
+      (coll, command) => coll.set(command.id, this.add(command, undefined, guildId)),
       new Collection(),
     );
   }
@@ -155,7 +155,7 @@ class ApplicationCommandManager extends CachedManager {
    * Edits an application command.
    * @param {ApplicationCommandResolvable} command The command to edit
    * @param {ApplicationCommandData} data The data to update the command with
-   * @param {Snowflake} [guildID] ID of the guild where the command registered,
+   * @param {Snowflake} [guildId] The guild's id where the command registered,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Promise<ApplicationCommand>}
    * @example
@@ -166,18 +166,18 @@ class ApplicationCommandManager extends CachedManager {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async edit(command, data, guildID) {
-    const id = this.resolveID(command);
+  async edit(command, data, guildId) {
+    const id = this.resolveId(command);
     if (!id) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
 
-    const patched = await this.commandPath({ id, guildID }).patch({ data: this.constructor.transformCommand(data) });
-    return this.add(patched, undefined, guildID);
+    const patched = await this.commandPath({ id, guildId }).patch({ data: this.constructor.transformCommand(data) });
+    return this.add(patched, undefined, guildId);
   }
 
   /**
    * Deletes an application command.
    * @param {ApplicationCommandResolvable} command The command to delete
-   * @param {Snowflake} [guildID] ID of the guild where the command is registered,
+   * @param {Snowflake} [guildId] The guild's id where the command is registered,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Promise<?ApplicationCommand>}
    * @example
@@ -186,11 +186,11 @@ class ApplicationCommandManager extends CachedManager {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async delete(command, guildID) {
-    const id = this.resolveID(command);
+  async delete(command, guildId) {
+    const id = this.resolveId(command);
     if (!id) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
 
-    await this.commandPath({ id, guildID }).delete();
+    await this.commandPath({ id, guildId }).delete();
 
     const cached = this.cache.get(id);
     this.cache.delete(id);

--- a/src/managers/ApplicationCommandPermissionsManager.js
+++ b/src/managers/ApplicationCommandPermissionsManager.js
@@ -29,30 +29,30 @@ class ApplicationCommandPermissionsManager extends BaseManager {
      * The id of the guild that this manager acts on
      * @type {?Snowflake}
      */
-    this.guildID = manager.guildID ?? manager.guild?.id ?? null;
+    this.guildId = manager.guildId ?? manager.guild?.id ?? null;
 
     /**
      * The id of the command this manager acts on
      * @type {?Snowflake}
      */
-    this.commandID = manager.id ?? null;
+    this.commandId = manager.id ?? null;
   }
 
   /**
    * The APIRouter path to the commands
-   * @param {Snowflake} guildID ID of the guild to use in the path,
-   * @param {Snowflake} [commandID] ID of the application command
+   * @param {Snowflake} guildId The guild's id to use in the path,
+   * @param {Snowflake} [commandId] The application command's id
    * @returns {Object}
    * @private
    */
-  permissionsPath(guildID, commandID) {
-    return this.client.api.applications(this.client.application.id).guilds(guildID).commands(commandID).permissions;
+  permissionsPath(guildId, commandId) {
+    return this.client.api.applications(this.client.application.id).guilds(guildId).commands(commandId).permissions;
   }
 
   /**
    * Data for setting the permissions of an application command.
    * @typedef {Object} ApplicationCommandPermissionData
-   * @property {Snowflake} id The ID of the role or user
+   * @property {Snowflake} id The role or user's id
    * @property {ApplicationCommandPermissionType|number} type Whether this permission is for a role or a user
    * @property {boolean} permission Whether the role or user has the permission to use this command
    */
@@ -60,20 +60,20 @@ class ApplicationCommandPermissionsManager extends BaseManager {
   /**
    * The object returned when fetching permissions for an application command.
    * @typedef {Object} ApplicationCommandPermissions
-   * @property {Snowflake} id The ID of the role or user
+   * @property {Snowflake} id The role or user's id
    * @property {ApplicationCommandPermissionType} type Whether this permission is for a role or a user
    * @property {boolean} permission Whether the role or user has the permission to use this command
    */
 
   /**
    * Options for managing permissions for one or more Application Commands
-   * <warn>When passing these options to a manager where `guildID` is `null`,
+   * <warn>When passing these options to a manager where `guildId` is `null`,
    * `guild` is a required parameter</warn>
    * @typedef {Object} BaseApplicationCommandPermissionsOptions
    * @param {GuildResolvable} [guild] The guild to modify / check permissions for
-   * <warn>Ignored when the manager has a non-null `guildID` property</warn>
+   * <warn>Ignored when the manager has a non-null `guildId` property</warn>
    * @param {ApplicationCommandResolvable} [command] The command to modify / check permissions for
-   * <warn>Ignored when the manager has a non-null `commandID` property</warn>
+   * <warn>Ignored when the manager has a non-null `commandId` property</warn>
    */
 
   /**
@@ -92,13 +92,13 @@ class ApplicationCommandPermissionsManager extends BaseManager {
    *   .catch(console.error);
    */
   async fetch({ guild, command } = {}) {
-    const { guildID, commandID } = this._validateOptions(guild, command);
-    if (commandID) {
-      const data = await this.permissionsPath(guildID, commandID).get();
+    const { guildId, commandId } = this._validateOptions(guild, command);
+    if (commandId) {
+      const data = await this.permissionsPath(guildId, commandId).get();
       return data.permissions.map(perm => this.constructor.transformPermissions(perm, true));
     }
 
-    const data = await this.permissionsPath(guildID).get();
+    const data = await this.permissionsPath(guildId).get();
     return data.reduce(
       (coll, perm) =>
         coll.set(
@@ -112,14 +112,14 @@ class ApplicationCommandPermissionsManager extends BaseManager {
   /**
    * Data used for overwriting the permissions for all application commands in a guild.
    * @typedef {Object} GuildApplicationCommandPermissionData
-   * @property {Snowflake} id The ID of the command
+   * @property {Snowflake} id The command's id
    * @property {ApplicationCommandPermissionData[]} permissions The permissions for this command
    */
 
   /**
    * Options used to set permissions for one or more Application Commands in a guild
    * <warn>One of `command` AND `permissions`, OR `fullPermissions` is required.
-   * `fullPermissions` is not a valid option when passing to a manager where `commandID` is non-null</warn>
+   * `fullPermissions` is not a valid option when passing to a manager where `commandId` is non-null</warn>
    * @typedef {BaseApplicationCommandPermissionsOptions} SetApplicationCommandPermissionsOptions
    * @param {ApplicationCommandPermissionData[]} [permissions] The new permissions for the command
    * @param {GuildApplicationCommandPermissionData[]} [fullPermissions] The new permissions for all commands
@@ -157,13 +157,13 @@ class ApplicationCommandPermissionsManager extends BaseManager {
    *   .catch(console.error);
    */
   async set({ guild, command, permissions, fullPermissions } = {}) {
-    const { guildID, commandID } = this._validateOptions(guild, command);
+    const { guildId, commandId } = this._validateOptions(guild, command);
 
-    if (commandID) {
+    if (commandId) {
       if (!Array.isArray(permissions)) {
         throw new TypeError('INVALID_TYPE', 'permissions', 'Array of ApplicationCommandPermissionData', true);
       }
-      const data = await this.permissionsPath(guildID, commandID).put({
+      const data = await this.permissionsPath(guildId, commandId).put({
         data: { permissions: permissions.map(perm => this.constructor.transformPermissions(perm)) },
       });
       return data.permissions.map(perm => this.constructor.transformPermissions(perm, true));
@@ -181,7 +181,7 @@ class ApplicationCommandPermissionsManager extends BaseManager {
         permissions: perm.permissions.map(p => this.constructor.transformPermissions(p)),
       });
     }
-    const data = await this.permissionsPath(guildID).put({
+    const data = await this.permissionsPath(guildId).put({
       data: APIPermissions,
     });
     return data.reduce(
@@ -196,7 +196,7 @@ class ApplicationCommandPermissionsManager extends BaseManager {
 
   /**
    * Options used to add permissions to a command
-   * <warn>The `command` parameter is not optional when the managers `commandID` is `null`</warn>
+   * <warn>The `command` parameter is not optional when the managers `commandId` is `null`</warn>
    * @typedef {BaseApplicationCommandPermissionsOptions} AddApplicationCommandPermissionsOptions
    * @param {ApplicationCommandPermissionData[]} permissions The permissions to add to the command
    */
@@ -218,15 +218,15 @@ class ApplicationCommandPermissionsManager extends BaseManager {
    *   .catch(console.error);
    */
   async add({ guild, command, permissions }) {
-    const { guildID, commandID } = this._validateOptions(guild, command);
-    if (!commandID) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
+    const { guildId, commandId } = this._validateOptions(guild, command);
+    if (!commandId) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
     if (!Array.isArray(permissions)) {
       throw new TypeError('INVALID_TYPE', 'permissions', 'Array of ApplicationCommandPermissionData', true);
     }
 
     let existing = [];
     try {
-      existing = await this.fetch({ guild: guildID, command: commandID });
+      existing = await this.fetch({ guild: guildId, command: commandId });
     } catch (error) {
       if (error.code !== APIErrors.UNKNOWN_APPLICATION_COMMAND_PERMISSIONS) throw error;
     }
@@ -238,12 +238,12 @@ class ApplicationCommandPermissionsManager extends BaseManager {
       }
     }
 
-    return this.set({ guild: guildID, command: commandID, permissions: newPermissions });
+    return this.set({ guild: guildId, command: commandId, permissions: newPermissions });
   }
 
   /**
    * Options used to remove permissions from a command
-   * <warn>The `command` parameter is not optional when the managers `commandID` is `null`</warn>
+   * <warn>The `command` parameter is not optional when the managers `commandId` is `null`</warn>
    * @typedef {BaseApplicationCommandPermissionsOptions} RemoveApplicationCommandPermissionsOptions
    * @param {UserResolvable|UserResolvable[]} [users] The user(s) to remove from the command permissions
    * <warn>One of `users` or `roles` is required</warn>
@@ -269,67 +269,67 @@ class ApplicationCommandPermissionsManager extends BaseManager {
    *    .catch(console.error);
    */
   async remove({ guild, command, users, roles }) {
-    const { guildID, commandID } = this._validateOptions(guild, command);
-    if (!commandID) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
+    const { guildId, commandId } = this._validateOptions(guild, command);
+    if (!commandId) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
 
     if (!users && !roles) throw new TypeError('INVALID_TYPE', 'users OR roles', 'Array or Resolvable', true);
 
-    let resolvedIDs = [];
+    let resolvedIds = [];
     if (Array.isArray(users)) {
       users.forEach(user => {
-        const userID = this.client.users.resolveID(user);
-        if (!userID) throw new TypeError('INVALID_ELEMENT', 'Array', 'users', user);
-        resolvedIDs.push(userID);
+        const userId = this.client.users.resolveId(user);
+        if (!userId) throw new TypeError('INVALID_ELEMENT', 'Array', 'users', user);
+        resolvedIds.push(userId);
       });
     } else if (users) {
-      const userID = this.client.users.resolveID(users);
-      if (!userID) {
+      const userId = this.client.users.resolveId(users);
+      if (!userId) {
         throw new TypeError('INVALID_TYPE', 'users', 'Array or UserResolvable');
       }
-      resolvedIDs.push(userID);
+      resolvedIds.push(userId);
     }
 
     if (Array.isArray(roles)) {
       roles.forEach(role => {
         if (typeof role === 'string') {
-          resolvedIDs.push(role);
+          resolvedIds.push(role);
           return;
         }
         if (!this.guild) throw new Error('GUILD_UNCACHED_ROLE_RESOLVE');
-        const roleID = this.guild.roles.resolveID(role);
-        if (!roleID) throw new TypeError('INVALID_ELEMENT', 'Array', 'users', role);
-        resolvedIDs.push(roleID);
+        const roleId = this.guild.roles.resolveId(role);
+        if (!roleId) throw new TypeError('INVALID_ELEMENT', 'Array', 'users', role);
+        resolvedIds.push(roleId);
       });
     } else if (roles) {
       if (typeof roles === 'string') {
-        resolvedIDs.push(roles);
+        resolvedIds.push(roles);
       } else {
         if (!this.guild) throw new Error('GUILD_UNCACHED_ROLE_RESOLVE');
-        const roleID = this.guild.roles.resolveID(roles);
-        if (!roleID) {
+        const roleId = this.guild.roles.resolveId(roles);
+        if (!roleId) {
           throw new TypeError('INVALID_TYPE', 'users', 'Array or RoleResolvable');
         }
-        resolvedIDs.push(roleID);
+        resolvedIds.push(roleId);
       }
     }
 
     let existing = [];
     try {
-      existing = await this.fetch({ guild: guildID, command: commandID });
+      existing = await this.fetch({ guild: guildId, command: commandId });
     } catch (error) {
       if (error.code !== APIErrors.UNKNOWN_APPLICATION_COMMAND_PERMISSIONS) throw error;
     }
 
-    const permissions = existing.filter(perm => !resolvedIDs.includes(perm.id));
+    const permissions = existing.filter(perm => !resolvedIds.includes(perm.id));
 
-    return this.set({ guild: guildID, command: commandID, permissions });
+    return this.set({ guild: guildId, command: commandId, permissions });
   }
 
   /**
    * Options used to check existance of permissions on a command
-   * <warn>The `command` parameter is not optional when the managers `commandID` is `null`</warn>
+   * <warn>The `command` parameter is not optional when the managers `commandId` is `null`</warn>
    * @typedef {BaseApplicationCommandPermissionsOptions} HasApplicationCommandPermissionsOptions
-   * @param {UserResolvable|RoleResolvable} permissionID The user or role to check if a permission exists for
+   * @param {UserResolvable|RoleResolvable} permissionId The user or role to check if a permission exists for
    * on this command.
    */
 
@@ -339,54 +339,54 @@ class ApplicationCommandPermissionsManager extends BaseManager {
    * @returns {Promise<boolean>}
    * @example
    * // Check whether a user has permission to use a command
-   * guild.commands.permissions.has({ command: '123456789012345678', permissionID: '876543210123456789' })
+   * guild.commands.permissions.has({ command: '123456789012345678', permissionId: '876543210123456789' })
    *  .then(console.log)
    *  .catch(console.error);
    */
-  async has({ guild, command, permissionID }) {
-    const { guildID, commandID } = this._validateOptions(guild, command);
-    if (!commandID) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
+  async has({ guild, command, permissionId }) {
+    const { guildId, commandId } = this._validateOptions(guild, command);
+    if (!commandId) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
 
-    if (!permissionID) throw new TypeError('INVALID_TYPE', 'permissionsID', 'UserResolvable or RoleResolvable');
-    let resolvedID = permissionID;
-    if (typeof permissionID !== 'string') {
-      resolvedID = this.client.users.resolveID(permissionID);
-      if (!resolvedID) {
+    if (!permissionId) throw new TypeError('INVALID_TYPE', 'permissionsId', 'UserResolvable or RoleResolvable');
+    let resolvedId = permissionId;
+    if (typeof permissionId !== 'string') {
+      resolvedId = this.client.users.resolveId(permissionId);
+      if (!resolvedId) {
         if (!this.guild) throw new Error('GUILD_UNCACHED_ROLE_RESOLVE');
-        resolvedID = this.guild.roles.resolveID(permissionID);
+        resolvedId = this.guild.roles.resolveId(permissionId);
       }
-      if (!resolvedID) {
-        throw new TypeError('INVALID_TYPE', 'permissionID', 'UserResolvable or RoleResolvable');
+      if (!resolvedId) {
+        throw new TypeError('INVALID_TYPE', 'permissionId', 'UserResolvable or RoleResolvable');
       }
     }
 
     let existing = [];
     try {
-      existing = await this.fetch({ guild: guildID, command: commandID });
+      existing = await this.fetch({ guild: guildId, command: commandId });
     } catch (error) {
       if (error.code !== APIErrors.UNKNOWN_APPLICATION_COMMAND_PERMISSIONS) throw error;
     }
 
-    return existing.some(perm => perm.id === resolvedID);
+    return existing.some(perm => perm.id === resolvedId);
   }
 
   _validateOptions(guild, command) {
-    const guildID = this.guildID ?? this.client.guilds.resolveID(guild);
-    if (!guildID) throw new Error('GLOBAL_COMMAND_PERMISSIONS');
-    let commandID = this.commandID;
-    if (command && !commandID) {
-      commandID = this.manager.resolveID?.(command);
-      if (!commandID && this.guild) {
-        commandID = this.guild.commands.resolveID(command);
+    const guildId = this.guildId ?? this.client.guilds.resolveId(guild);
+    if (!guildId) throw new Error('GLOBAL_COMMAND_PERMISSIONS');
+    let commandId = this.commandId;
+    if (command && !commandId) {
+      commandId = this.manager.resolveId?.(command);
+      if (!commandId && this.guild) {
+        commandId = this.guild.commands.resolveId(command);
       }
-      if (!commandID) {
-        commandID = this.client.application?.commands.resolveID(command);
+      if (!commandId) {
+        commandId = this.client.application?.commands.resolveId(command);
       }
-      if (!commandID) {
+      if (!commandId) {
         throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable', true);
       }
     }
-    return { guildID, commandID };
+    return { guildId, commandId };
   }
 
   /**

--- a/src/managers/BaseGuildEmojiManager.js
+++ b/src/managers/BaseGuildEmojiManager.js
@@ -22,7 +22,7 @@ class BaseGuildEmojiManager extends CachedManager {
 
   /**
    * Data that can be resolved into a GuildEmoji object. This can be:
-   * * A custom emoji ID
+   * * A custom emoji identifier
    * * A GuildEmoji object
    * * A ReactionEmoji object
    * @typedef {Snowflake|GuildEmoji|ReactionEmoji} EmojiResolvable
@@ -39,13 +39,13 @@ class BaseGuildEmojiManager extends CachedManager {
   }
 
   /**
-   * Resolves an EmojiResolvable to an Emoji ID string.
+   * Resolves an EmojiResolvable to an Emoji id string.
    * @param {EmojiResolvable} emoji The Emoji resolvable to identify
    * @returns {?Snowflake}
    */
-  resolveID(emoji) {
+  resolveId(emoji) {
     if (emoji instanceof ReactionEmoji) return emoji.id;
-    return super.resolveID(emoji);
+    return super.resolveId(emoji);
   }
 
   /**

--- a/src/managers/ChannelManager.js
+++ b/src/managers/ChannelManager.js
@@ -66,8 +66,8 @@ class ChannelManager extends CachedManager {
    */
 
   /**
-   * Resolves a ChannelResolvable to a channel ID string.
-   * @method resolveID
+   * Resolves a ChannelResolvable to a channel id string.
+   * @method resolveId
    * @memberof ChannelManager
    * @instance
    * @param {ChannelResolvable} channel The channel resolvable to resolve
@@ -76,7 +76,7 @@ class ChannelManager extends CachedManager {
 
   /**
    * Obtains a channel from Discord, or the channel cache if it's already available.
-   * @param {Snowflake} id ID of the channel
+   * @param {Snowflake} id The channel's id
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<?Channel>}
    * @example

--- a/src/managers/DataManager.js
+++ b/src/managers/DataManager.js
@@ -43,11 +43,11 @@ class DataManager extends BaseManager {
   }
 
   /**
-   * Resolves a data entry to an instance ID.
+   * Resolves a data entry to an instance id.
    * @param {string|Object} idOrInstance The id or instance of something in this Manager
    * @returns {?Snowflake}
    */
-  resolveID(idOrInstance) {
+  resolveId(idOrInstance) {
     if (idOrInstance instanceof this.holds) return idOrInstance.id;
     if (typeof idOrInstance === 'string') return idOrInstance;
     return null;

--- a/src/managers/GuildBanManager.js
+++ b/src/managers/GuildBanManager.js
@@ -44,7 +44,7 @@ class GuildBanManager extends CachedManager {
    * @returns {?GuildBan}
    */
   resolve(ban) {
-    return super.resolve(ban) ?? super.resolve(this.client.users.resolveID(ban));
+    return super.resolve(ban) ?? super.resolve(this.client.users.resolveId(ban));
   }
 
   /**
@@ -91,10 +91,10 @@ class GuildBanManager extends CachedManager {
    */
   fetch(options) {
     if (!options) return this._fetchMany();
-    const user = this.client.users.resolveID(options);
+    const user = this.client.users.resolveId(options);
     if (user) return this._fetchSingle({ user, cache: true });
     if (options.user) {
-      options.user = this.client.users.resolveID(options.user);
+      options.user = this.client.users.resolveId(options.user);
     }
     if (!options.user) {
       if ('cache' in options) return this._fetchMany(options.cache);
@@ -131,16 +131,16 @@ class GuildBanManager extends CachedManager {
    * @param {BanOptions} [options] Options for the ban
    * @returns {Promise<GuildMember|User|Snowflake>} Result object will be resolved as specifically as possible.
    * If the GuildMember cannot be resolved, the User will instead be attempted to be resolved. If that also cannot
-   * be resolved, the user ID will be the result.
+   * be resolved, the user id will be the result.
    * @example
-   * // Ban a user by ID (or with a user/guild member object)
+   * // Ban a user by id (or with a user/guild member object)
    * guild.bans.create('84484653687267328')
    *   .then(user => console.log(`Banned ${user.username ?? user.id ?? user} from ${guild.name}`))
    *   .catch(console.error);
    */
   async create(user, options = { days: 0 }) {
     if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
-    const id = this.client.users.resolveID(user);
+    const id = this.client.users.resolveId(user);
     if (!id) throw new Error('BAN_RESOLVE_ID', true);
     await this.client.api
       .guilds(this.guild.id)
@@ -165,13 +165,13 @@ class GuildBanManager extends CachedManager {
    * @param {string} [reason] Reason for unbanning user
    * @returns {Promise<User>}
    * @example
-   * // Unban a user by ID (or with a user/guild member object)
+   * // Unban a user by id (or with a user/guild member object)
    * guild.bans.remove('84484653687267328')
    *   .then(user => console.log(`Unbanned ${user.username} from ${guild.name}`))
    *   .catch(console.error);
    */
   async remove(user, reason) {
-    const id = this.client.users.resolveID(user);
+    const id = this.client.users.resolveId(user);
     if (!id) throw new Error('BAN_RESOLVE_ID');
     await this.client.api.guilds(this.guild.id).bans(id).delete({ reason });
     return this.client.users.resolve(user);

--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -67,13 +67,13 @@ class GuildChannelManager extends CachedManager {
   }
 
   /**
-   * Resolves a GuildChannelResolvable to a channel ID string.
+   * Resolves a GuildChannelResolvable to a channel id.
    * @param {GuildChannelResolvable} channel The GuildChannel resolvable to resolve
    * @returns {?Snowflake}
    */
-  resolveID(channel) {
-    if (channel instanceof ThreadChannel) return super.resolveID(channel.id);
-    return super.resolveID(channel);
+  resolveId(channel) {
+    if (channel instanceof ThreadChannel) return super.resolveId(channel.id);
+    return super.resolveId(channel);
   }
 
   /**
@@ -119,7 +119,7 @@ class GuildChannelManager extends CachedManager {
     name,
     { type, topic, nsfw, bitrate, userLimit, parent, permissionOverwrites, position, rateLimitPerUser, reason } = {},
   ) {
-    if (parent) parent = this.client.channels.resolveID(parent);
+    if (parent) parent = this.client.channels.resolveId(parent);
     if (permissionOverwrites) {
       permissionOverwrites = permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
     }
@@ -144,7 +144,7 @@ class GuildChannelManager extends CachedManager {
 
   /**
    * Obtains one or more guild channels from Discord, or the channel cache if they're already available.
-   * @param {Snowflake} [id] ID of the channel
+   * @param {Snowflake} [id] The channel's id
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<?GuildChannel|Collection<Snowflake, GuildChannel>>}
    * @example

--- a/src/managers/GuildEmojiManager.js
+++ b/src/managers/GuildEmojiManager.js
@@ -59,7 +59,7 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
       }
       data.roles = [];
       for (const role of roles.values()) {
-        const resolvedRole = this.guild.roles.resolveID(role);
+        const resolvedRole = this.guild.roles.resolveId(role);
         if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role);
         data.roles.push(resolvedRole);
       }
@@ -73,7 +73,7 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
 
   /**
    * Obtains one or more emojis from Discord, or the emoji cache if they're already available.
-   * @param {Snowflake} [id] ID of the emoji
+   * @param {Snowflake} [id] The emoji's id
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<GuildEmoji|Collection<Snowflake, GuildEmoji>>}
    * @example

--- a/src/managers/GuildEmojiRoleManager.js
+++ b/src/managers/GuildEmojiRoleManager.js
@@ -44,7 +44,7 @@ class GuildEmojiRoleManager extends DataManager {
 
     const resolvedRoles = [];
     for (const role of roleOrRoles.values()) {
-      const resolvedRole = this.guild.roles.resolveID(role);
+      const resolvedRole = this.guild.roles.resolveId(role);
       if (!resolvedRole) {
         return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
       }
@@ -63,22 +63,22 @@ class GuildEmojiRoleManager extends DataManager {
   remove(roleOrRoles) {
     if (!Array.isArray(roleOrRoles) && !(roleOrRoles instanceof Collection)) roleOrRoles = [roleOrRoles];
 
-    const resolvedRoleIDs = [];
+    const resolvedRoleIds = [];
     for (const role of roleOrRoles.values()) {
-      const roleID = this.guild.roles.resolveID(role);
-      if (!roleID) {
+      const roleId = this.guild.roles.resolveId(role);
+      if (!roleId) {
         return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role));
       }
-      resolvedRoleIDs.push(roleID);
+      resolvedRoleIds.push(roleId);
     }
 
-    const newRoles = this.cache.keyArray().filter(id => !resolvedRoleIDs.includes(id));
+    const newRoles = this.cache.keyArray().filter(id => !resolvedRoleIds.includes(id));
     return this.set(newRoles);
   }
 
   /**
    * Sets the role(s) that can use this emoji.
-   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles The roles or role IDs to apply
+   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles The roles or role ids to apply
    * @returns {Promise<GuildEmoji>}
    * @example
    * // Set the emoji's roles to a single role

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -50,7 +50,7 @@ class GuildManager extends CachedManager {
   /**
    * Partial data for a Role.
    * @typedef {Object} PartialRoleData
-   * @property {Snowflake|number} [id] The ID for this role, used to set channel overrides,
+   * @property {Snowflake|number} [id] The role's id, used to set channel overrides,
    * this is a placeholder and will be replaced by the API after consumption
    * @property {string} [name] The name of the role
    * @property {ColorResolvable} [color] The color of the role, either a hex string or a base 10 number
@@ -63,7 +63,7 @@ class GuildManager extends CachedManager {
   /**
    * Partial overwrite data.
    * @typedef {Object} PartialOverwriteData
-   * @property {Snowflake|number} id The Role or User ID for this overwrite
+   * @property {Snowflake|number} id The {@link Role} or {@link User} id for this overwrite
    * @property {string} [type] The type of this overwrite
    * @property {PermissionResolvable} [allow] The permissions to allow
    * @property {PermissionResolvable} [deny] The permissions to deny
@@ -72,9 +72,9 @@ class GuildManager extends CachedManager {
   /**
    * Partial data for a Channel.
    * @typedef {Object} PartialChannelData
-   * @property {Snowflake|number} [id] The ID for this channel, used to set its parent,
+   * @property {Snowflake|number} [id] The channel's id, used to set its parent,
    * this is a placeholder and will be replaced by the API after consumption
-   * @property {Snowflake|number} [parentID] The parent ID for this channel
+   * @property {Snowflake|number} [parentId] The parent id for this channel
    * @property {string} [type] The type of the channel
    * @property {string} name The name of the channel
    * @property {string} [topic] The topic of the text channel
@@ -108,14 +108,14 @@ class GuildManager extends CachedManager {
   }
 
   /**
-   * Resolves a GuildResolvable to a Guild ID string.
-   * @method resolveID
+   * Resolves a {@link GuildResolvable} to a {@link Guild} id string.
+   * @method resolveId
    * @memberof GuildManager
    * @instance
    * @param {GuildResolvable} guild The guild resolvable to identify
    * @returns {?Snowflake}
    */
-  resolveID(guild) {
+  resolveId(guild) {
     if (
       guild instanceof GuildChannel ||
       guild instanceof GuildMember ||
@@ -123,15 +123,15 @@ class GuildManager extends CachedManager {
       guild instanceof Role ||
       (guild instanceof Invite && guild.guild)
     ) {
-      return super.resolveID(guild.guild.id);
+      return super.resolveId(guild.guild.id);
     }
-    return super.resolveID(guild);
+    return super.resolveId(guild);
   }
 
   /**
    * Options used to create a guild.
    * @typedef {Object} GuildCreateOptions
-   * @property {Snowflake|number} [afkChannelID] The ID of the AFK channel
+   * @property {Snowflake|number} [afkChannelId] The AFK channel's id
    * @property {number} [afkTimeout] The AFK timeout in seconds
    * @property {PartialChannelData[]} [channels=[]] The channels for this guild
    * @property {DefaultMessageNotifications} [defaultMessageNotifications] The default message notifications
@@ -140,7 +140,7 @@ class GuildManager extends CachedManager {
    * @property {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild
    * @property {PartialRoleData[]} [roles=[]] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.
-   * @property {Snowflake|number} [systemChannelID] The ID of the system channel
+   * @property {Snowflake|number} [systemChannelId] The system channel's id
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel
    * @property {VerificationLevel} [verificationLevel] The verification level for the guild
    */
@@ -155,14 +155,14 @@ class GuildManager extends CachedManager {
   async create(
     name,
     {
-      afkChannelID,
+      afkChannelId,
       afkTimeout,
       channels = [],
       defaultMessageNotifications,
       explicitContentFilter,
       icon = null,
       roles = [],
-      systemChannelID,
+      systemChannelId,
       systemChannelFlags,
       verificationLevel,
     } = {},
@@ -179,8 +179,8 @@ class GuildManager extends CachedManager {
     }
     for (const channel of channels) {
       if (channel.type) channel.type = ChannelTypes[channel.type.toUpperCase()];
-      channel.parent_id = channel.parentID;
-      delete channel.parentID;
+      channel.parent_id = channel.parentId;
+      delete channel.parentId;
       if (!channel.permissionOverwrites) continue;
       for (const overwrite of channel.permissionOverwrites) {
         if (overwrite.allow) overwrite.allow = Permissions.resolve(overwrite.allow).toString();
@@ -206,9 +206,9 @@ class GuildManager extends CachedManager {
             explicit_content_filter: explicitContentFilter,
             roles,
             channels,
-            afk_channel_id: afkChannelID,
+            afk_channel_id: afkChannelId,
             afk_timeout: afkTimeout,
-            system_channel_id: systemChannelID,
+            system_channel_id: systemChannelId,
             system_channel_flags: systemChannelFlags,
           },
         })
@@ -245,18 +245,18 @@ class GuildManager extends CachedManager {
   /**
    * Options used to fetch multiple guilds.
    * @typedef {Object} FetchGuildsOptions
-   * @property {Snowflake} [before] Get guilds before this guild ID
-   * @property {Snowflake} [after] Get guilds after this guild ID
+   * @property {Snowflake} [before] Get guilds before this guild id
+   * @property {Snowflake} [after] Get guilds after this guild id
    * @property {number} [limit=100] Maximum number of guilds to request (1-100)
    */
 
   /**
    * Obtains one or multiple guilds from Discord, or the guild cache if it's already available.
-   * @param {GuildResolvable|FetchGuildOptions|FetchGuildsOptions} [options] ID of the guild or options
+   * @param {GuildResolvable|FetchGuildOptions|FetchGuildsOptions} [options] The guild's id or options
    * @returns {Promise<Guild|Collection<Snowflake, OAuth2Guild>>}
    */
   async fetch(options = {}) {
-    const id = this.resolveID(options) ?? this.resolveID(options.guild);
+    const id = this.resolveId(options) ?? this.resolveId(options.guild);
 
     if (id) {
       if (!options.force) {

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -42,27 +42,27 @@ class GuildMemberManager extends CachedManager {
    */
 
   /**
-   * Resolves a GuildMemberResolvable to a GuildMember object.
+   * Resolves a {@link GuildMemberResolvable} to a {@link GuildMember} object.
    * @param {GuildMemberResolvable} member The user that is part of the guild
    * @returns {?GuildMember}
    */
   resolve(member) {
     const memberResolvable = super.resolve(member);
     if (memberResolvable) return memberResolvable;
-    const userResolvable = this.client.users.resolveID(member);
+    const userResolvable = this.client.users.resolveId(member);
     if (userResolvable) return super.resolve(userResolvable);
     return null;
   }
 
   /**
-   * Resolves a GuildMemberResolvable to a member ID string.
+   * Resolves a {@link GuildMemberResolvable} to a member id.
    * @param {GuildMemberResolvable} member The user that is part of the guild
    * @returns {?Snowflake}
    */
-  resolveID(member) {
-    const memberResolvable = super.resolveID(member);
+  resolveId(member) {
+    const memberResolvable = super.resolveId(member);
     if (memberResolvable) return memberResolvable;
-    const userResolvable = this.client.users.resolveID(member);
+    const userResolvable = this.client.users.resolveId(member);
     return this.cache.has(userResolvable) ? userResolvable : null;
   }
 
@@ -123,14 +123,14 @@ class GuildMemberManager extends CachedManager {
    */
   fetch(options) {
     if (!options) return this._fetchMany();
-    const user = this.client.users.resolveID(options);
+    const user = this.client.users.resolveId(options);
     if (user) return this._fetchSingle({ user, cache: true });
     if (options.user) {
       if (Array.isArray(options.user)) {
-        options.user = options.user.map(u => this.client.users.resolveID(u));
+        options.user = options.user.map(u => this.client.users.resolveId(u));
         return this._fetchMany(options);
       } else {
-        options.user = this.client.users.resolveID(options.user);
+        options.user = this.client.users.resolveId(options.user);
       }
       if (!options.limit && !options.withPresences) return this._fetchSingle(options);
     }
@@ -164,7 +164,7 @@ class GuildMemberManager extends CachedManager {
    * @returns {Promise<GuildMember>}
    */
   async edit(user, data, reason) {
-    const id = this.client.users.resolveID(user);
+    const id = this.client.users.resolveId(user);
     if (!id) throw new TypeError('INVALID_TYPE', 'user', 'UserResolvable');
 
     // Clone the data object for immutability
@@ -234,7 +234,7 @@ class GuildMemberManager extends CachedManager {
     const resolvedRoles = [];
 
     for (const role of roles) {
-      const resolvedRole = this.guild.roles.resolveID(role);
+      const resolvedRole = this.guild.roles.resolveId(role);
       if (!resolvedRole) {
         return Promise.reject(new TypeError('INVALID_ELEMENT', 'Array', 'options.roles', role));
       }
@@ -266,15 +266,15 @@ class GuildMemberManager extends CachedManager {
    * @param {string} [reason] Reason for kicking
    * @returns {Promise<GuildMember|User|Snowflake>} Result object will be resolved as specifically as possible.
    * If the GuildMember cannot be resolved, the User will instead be attempted to be resolved. If that also cannot
-   * be resolved, the user ID will be the result.
+   * be resolved, the user's id will be the result.
    * @example
-   * // Kick a user by ID (or with a user/guild member object)
+   * // Kick a user by id (or with a user/guild member object)
    * guild.members.kick('84484653687267328')
    *   .then(user => console.log(`Kicked ${user.username ?? user.id ?? user} from ${guild.name}`))
    *   .catch(console.error);
    */
   async kick(user, reason) {
-    const id = this.client.users.resolveID(user);
+    const id = this.client.users.resolveId(user);
     if (!id) return Promise.reject(new TypeError('INVALID_TYPE', 'user', 'UserResolvable'));
 
     await this.client.api.guilds(this.guild.id).members(id).delete({ reason });
@@ -288,10 +288,10 @@ class GuildMemberManager extends CachedManager {
    * @param {BanOptions} [options] Options for the ban
    * @returns {Promise<GuildMember|User|Snowflake>} Result object will be resolved as specifically as possible.
    * If the GuildMember cannot be resolved, the User will instead be attempted to be resolved. If that also cannot
-   * be resolved, the user ID will be the result.
+   * be resolved, the user id will be the result.
    * Internally calls the GuildBanManager#create method.
    * @example
-   * // Ban a user by ID (or with a user/guild member object)
+   * // Ban a user by id (or with a user/guild member object)
    * guild.members.ban('84484653687267328')
    *   .then(user => console.log(`Banned ${user.username ?? user.id ?? user} from ${guild.name}`))
    *   .catch(console.error);
@@ -307,7 +307,7 @@ class GuildMemberManager extends CachedManager {
    * @returns {Promise<User>}
    * Internally calls the GuildBanManager#remove method.
    * @example
-   * // Unban a user by ID (or with a user/guild member object)
+   * // Unban a user by id (or with a user/guild member object)
    * guild.members.unban('84484653687267328')
    *   .then(user => console.log(`Unbanned ${user.username} from ${guild.name}`))
    *   .catch(console.error);

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -84,7 +84,7 @@ class GuildMemberRoleManager extends DataManager {
    */
   get botRole() {
     if (!this.member.user.bot) return null;
-    return this.cache.find(role => role.tags?.botID === this.member.user.id) ?? null;
+    return this.cache.find(role => role.tags?.botId === this.member.user.id) ?? null;
   }
 
   /**
@@ -97,7 +97,7 @@ class GuildMemberRoleManager extends DataManager {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
       const resolvedRoles = [];
       for (const role of roleOrRoles.values()) {
-        const resolvedRole = this.guild.roles.resolveID(role);
+        const resolvedRole = this.guild.roles.resolveId(role);
         if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role);
         resolvedRoles.push(resolvedRole);
       }
@@ -105,7 +105,7 @@ class GuildMemberRoleManager extends DataManager {
       const newRoles = [...new Set(resolvedRoles.concat(...this.cache.values()))];
       return this.set(newRoles, reason);
     } else {
-      roleOrRoles = this.guild.roles.resolveID(roleOrRoles);
+      roleOrRoles = this.guild.roles.resolveId(roleOrRoles);
       if (roleOrRoles === null) {
         throw new TypeError('INVALID_TYPE', 'roles', 'Role, Snowflake or Array or Collection of Roles or Snowflakes');
       }
@@ -128,7 +128,7 @@ class GuildMemberRoleManager extends DataManager {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
       const resolvedRoles = [];
       for (const role of roleOrRoles.values()) {
-        const resolvedRole = this.guild.roles.resolveID(role);
+        const resolvedRole = this.guild.roles.resolveId(role);
         if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'roles', role);
         resolvedRoles.push(resolvedRole);
       }
@@ -136,7 +136,7 @@ class GuildMemberRoleManager extends DataManager {
       const newRoles = this.cache.filter(role => !resolvedRoles.includes(role.id));
       return this.set(newRoles, reason);
     } else {
-      roleOrRoles = this.guild.roles.resolveID(roleOrRoles);
+      roleOrRoles = this.guild.roles.resolveId(roleOrRoles);
       if (roleOrRoles === null) {
         throw new TypeError('INVALID_TYPE', 'roles', 'Role, Snwoflake or Array or Collection of Roles or Snowflakes');
       }
@@ -152,7 +152,7 @@ class GuildMemberRoleManager extends DataManager {
 
   /**
    * Sets the roles applied to the member.
-   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles The roles or role IDs to apply
+   * @param {Collection<Snowflake, Role>|RoleResolvable[]} roles The roles or role ids to apply
    * @param {string} [reason] Reason for applying the roles
    * @returns {Promise<GuildMember>}
    * @example

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -36,16 +36,16 @@ class MessageManager extends CachedManager {
    * `after` are mutually exclusive. All the parameters are optional.
    * @typedef {Object} ChannelLogsQueryOptions
    * @property {number} [limit=50] Number of messages to acquire
-   * @property {Snowflake} [before] ID of a message to get the messages that were posted before it
-   * @property {Snowflake} [after] ID of a message to get the messages that were posted after it
-   * @property {Snowflake} [around] ID of a message to get the messages that were posted around it
+   * @property {Snowflake} [before] THe message's id to get the messages that were posted before it
+   * @property {Snowflake} [after] THe message's id to get the messages that were posted after it
+   * @property {Snowflake} [around] THe message's id to get the messages that were posted around it
    */
 
   /**
    * Gets a message, or messages, from this channel.
    * <info>The returned Collection does not contain reaction users of the messages if they were not cached.
    * Those need to be fetched separately in such a case.</info>
-   * @param {Snowflake|ChannelLogsQueryOptions} [message] The ID of the message to fetch, or query parameters.
+   * @param {Snowflake|ChannelLogsQueryOptions} [message] The id of the message to fetch, or query parameters.
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<Message>|Promise<Collection<Snowflake, Message>>}
    * @example
@@ -59,7 +59,7 @@ class MessageManager extends CachedManager {
    *   .then(messages => console.log(`Received ${messages.size} messages`))
    *   .catch(console.error);
    * @example
-   * // Get messages and filter by user ID
+   * // Get messages and filter by user id
    * channel.messages.fetch()
    *   .then(messages => console.log(`${messages.filter(m => m.author.id === '84484653687267328').size} messages`))
    *   .catch(console.error);
@@ -96,7 +96,7 @@ class MessageManager extends CachedManager {
    */
 
   /**
-   * Resolves a MessageResolvable to a Message object.
+   * Resolves a {@link MessageResolvable} to a {@link Message} object.
    * @method resolve
    * @memberof MessageManager
    * @instance
@@ -105,8 +105,8 @@ class MessageManager extends CachedManager {
    */
 
   /**
-   * Resolves a MessageResolvable to a Message ID string.
-   * @method resolveID
+   * Resolves a {@link MessageResolvable} to a {@link Message} id.
+   * @method resolveId
    * @memberof MessageManager
    * @instance
    * @param {MessageResolvable} message The message resolvable to resolve
@@ -120,8 +120,8 @@ class MessageManager extends CachedManager {
    * @returns {Promise<Message>}
    */
   async edit(message, options) {
-    const messageID = this.resolveID(message);
-    if (!messageID) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
+    const messageId = this.resolveId(message);
+    if (!messageId) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
     const { data, files } = await (options instanceof MessagePayload
       ? options
@@ -129,9 +129,9 @@ class MessageManager extends CachedManager {
     )
       .resolveData()
       .resolveFiles();
-    const d = await this.client.api.channels[this.channel.id].messages[messageID].patch({ data, files });
+    const d = await this.client.api.channels[this.channel.id].messages[messageId].patch({ data, files });
 
-    const existing = this.cache.get(messageID);
+    const existing = this.cache.get(messageId);
     if (existing) {
       const clone = existing._clone();
       clone._patch(d);
@@ -146,7 +146,7 @@ class MessageManager extends CachedManager {
    * @returns {Promise<Message>}
    */
   async crosspost(message) {
-    message = this.resolveID(message);
+    message = this.resolveId(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
     const data = await this.client.api.channels(this.channel.id).messages(message).crosspost.post();
@@ -159,7 +159,7 @@ class MessageManager extends CachedManager {
    * @returns {Promise<void>}
    */
   async pin(message) {
-    message = this.resolveID(message);
+    message = this.resolveId(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
     await this.client.api.channels(this.channel.id).pins(message).put();
@@ -171,7 +171,7 @@ class MessageManager extends CachedManager {
    * @returns {Promise<void>}
    */
   async unpin(message) {
-    message = this.resolveID(message);
+    message = this.resolveId(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
     await this.client.api.channels(this.channel.id).pins(message).delete();
@@ -184,7 +184,7 @@ class MessageManager extends CachedManager {
    * @returns {Promise<void>}
    */
   async react(message, emoji) {
-    message = this.resolveID(message);
+    message = this.resolveId(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
     emoji = this.client.emojis.resolveIdentifier(emoji);
@@ -200,19 +200,19 @@ class MessageManager extends CachedManager {
    * @returns {Promise<void>}
    */
   async delete(message) {
-    message = this.resolveID(message);
+    message = this.resolveId(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
     await this.client.api.channels(this.channel.id).messages(message).delete();
   }
 
-  async _fetchId(messageID, cache, force) {
+  async _fetchId(messageId, cache, force) {
     if (!force) {
-      const existing = this.cache.get(messageID);
+      const existing = this.cache.get(messageId);
       if (existing && !existing.partial) return existing;
     }
 
-    const data = await this.client.api.channels[this.channel.id].messages[messageID].get();
+    const data = await this.client.api.channels[this.channel.id].messages[messageId].get();
     return this.add(data, cache);
   }
 

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -36,9 +36,9 @@ class MessageManager extends CachedManager {
    * `after` are mutually exclusive. All the parameters are optional.
    * @typedef {Object} ChannelLogsQueryOptions
    * @property {number} [limit=50] Number of messages to acquire
-   * @property {Snowflake} [before] THe message's id to get the messages that were posted before it
-   * @property {Snowflake} [after] THe message's id to get the messages that were posted after it
-   * @property {Snowflake} [around] THe message's id to get the messages that were posted around it
+   * @property {Snowflake} [before] The message's id to get the messages that were posted before it
+   * @property {Snowflake} [after] The message's id to get the messages that were posted after it
+   * @property {Snowflake} [around] The message's id to get the messages that were posted around it
    */
 
   /**

--- a/src/managers/PermissionOverwriteManager.js
+++ b/src/managers/PermissionOverwriteManager.js
@@ -71,7 +71,7 @@ class PermissionOverwriteManager extends CachedManager {
    * @private
    */
   async upsert(userOrRole, options, overwriteOptions = {}, existing) {
-    let userOrRoleID = this.channel.guild.roles.resolveID(userOrRole) ?? this.client.users.resolveID(userOrRole);
+    let userOrRoleId = this.channel.guild.roles.resolveId(userOrRole) ?? this.client.users.resolveId(userOrRole);
     let { type, reason } = overwriteOptions;
     if (typeof type !== 'number') {
       userOrRole = this.channel.guild.roles.resolve(userOrRole) ?? this.client.users.resolve(userOrRole);
@@ -83,9 +83,9 @@ class PermissionOverwriteManager extends CachedManager {
 
     await this.client.api
       .channels(this.channel.id)
-      .permissions(userOrRoleID)
+      .permissions(userOrRoleId)
       .put({
-        data: { id: userOrRoleID, type, allow, deny },
+        data: { id: userOrRoleId, type, allow, deny },
         reason,
       });
     return this.channel;
@@ -124,7 +124,7 @@ class PermissionOverwriteManager extends CachedManager {
    *   .catch(console.error);
    */
   edit(userOrRole, options, overwriteOptions) {
-    userOrRole = this.channel.guild.roles.resolveID(userOrRole) ?? this.client.users.resolveID(userOrRole);
+    userOrRole = this.channel.guild.roles.resolveId(userOrRole) ?? this.client.users.resolveId(userOrRole);
     const existing = this.cache.get(userOrRole);
     return this.upsert(userOrRole, options, overwriteOptions, existing);
   }
@@ -136,10 +136,10 @@ class PermissionOverwriteManager extends CachedManager {
    * @returns {GuildChannel}
    */
   async delete(userOrRole, reason) {
-    const userOrRoleID = this.channel.guild.roles.resolveID(userOrRole) ?? this.client.users.resolveID(userOrRole);
-    if (!userOrRoleID) throw new TypeError('INVALID_TYPE', 'parameter', 'User nor a Role');
+    const userOrRoleId = this.channel.guild.roles.resolveId(userOrRole) ?? this.client.users.resolveId(userOrRole);
+    if (!userOrRoleId) throw new TypeError('INVALID_TYPE', 'parameter', 'User nor a Role');
 
-    await this.client.api.channels(this.channel.id).permissions(userOrRoleID).delete({ reason });
+    await this.client.api.channels(this.channel.id).permissions(userOrRoleId).delete({ reason });
     return this.channel;
   }
 }

--- a/src/managers/PresenceManager.js
+++ b/src/managers/PresenceManager.js
@@ -32,26 +32,26 @@ class PresenceManager extends CachedManager {
    */
 
   /**
-   * Resolves a PresenceResolvable to a Presence object.
+   * Resolves a {@link PresenceResolvable} to a {@link Presence} object.
    * @param {PresenceResolvable} presence The presence resolvable to resolve
    * @returns {?Presence}
    */
   resolve(presence) {
     const presenceResolvable = super.resolve(presence);
     if (presenceResolvable) return presenceResolvable;
-    const UserResolvable = this.client.users.resolveID(presence);
+    const UserResolvable = this.client.users.resolveId(presence);
     return super.resolve(UserResolvable);
   }
 
   /**
-   * Resolves a PresenceResolvable to a Presence ID string.
+   * Resolves a {@link PresenceResolvable} to a {@link Presence} id.
    * @param {PresenceResolvable} presence The presence resolvable to resolve
    * @returns {?Snowflake}
    */
-  resolveID(presence) {
-    const presenceResolvable = super.resolveID(presence);
+  resolveId(presence) {
+    const presenceResolvable = super.resolveId(presence);
     if (presenceResolvable) return presenceResolvable;
-    const userResolvable = this.client.users.resolveID(presence);
+    const userResolvable = this.client.users.resolveId(presence);
     return this.cache.has(userResolvable) ? userResolvable : null;
   }
 }

--- a/src/managers/ReactionManager.js
+++ b/src/managers/ReactionManager.js
@@ -36,7 +36,7 @@ class ReactionManager extends CachedManager {
    */
 
   /**
-   * Resolves a MessageReactionResolvable to a MessageReaction object.
+   * Resolves a {@link MessageReactionResolvable} to a {@link MessageReaction} object.
    * @method resolve
    * @memberof ReactionManager
    * @instance
@@ -45,8 +45,8 @@ class ReactionManager extends CachedManager {
    */
 
   /**
-   * Resolves a MessageReactionResolvable to a MessageReaction ID string.
-   * @method resolveID
+   * Resolves a {@link MessageReactionResolvable} to a {@link MessageReaction} id.
+   * @method resolveId
    * @memberof ReactionManager
    * @instance
    * @param {MessageReactionResolvable} reaction The MessageReaction to resolve

--- a/src/managers/ReactionUserManager.js
+++ b/src/managers/ReactionUserManager.js
@@ -34,7 +34,7 @@ class ReactionUserManager extends CachedManager {
    */
 
   /**
-   * Fetches all the users that gave this reaction. Resolves with a collection of users, mapped by their IDs.
+   * Fetches all the users that gave this reaction. Resolves with a collection of users, mapped by their ids.
    * @param {FetchReactionUsersOptions} [options] Options for fetching the users
    * @returns {Promise<Collection<Snowflake, User>>}
    */
@@ -58,11 +58,11 @@ class ReactionUserManager extends CachedManager {
    * @returns {Promise<MessageReaction>}
    */
   remove(user = this.client.user) {
-    const userID = this.client.users.resolveID(user);
-    if (!userID) return Promise.reject(new Error('REACTION_RESOLVE_USER'));
+    const userId = this.client.users.resolveId(user);
+    if (!userId) return Promise.reject(new Error('REACTION_RESOLVE_USER'));
     const message = this.reaction.message;
     return this.client.api.channels[message.channel.id].messages[message.id].reactions[this.reaction.emoji.identifier][
-      userID === this.client.user.id ? '@me' : userID
+      userId === this.client.user.id ? '@me' : userId
     ]
       .delete()
       .then(() => this.reaction);

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -34,7 +34,7 @@ class RoleManager extends CachedManager {
 
   /**
    * Obtains a role from Discord, or the role cache if they're already available.
-   * @param {Snowflake} [id] ID of the role
+   * @param {Snowflake} [id] The role's id
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<?Role|Collection<Snowflake, Role>>}
    * @example
@@ -69,7 +69,7 @@ class RoleManager extends CachedManager {
    */
 
   /**
-   * Resolves a RoleResolvable to a Role object.
+   * Resolves a {@link RoleResolvable} to a {@link Role} object.
    * @method resolve
    * @memberof RoleManager
    * @instance
@@ -78,8 +78,8 @@ class RoleManager extends CachedManager {
    */
 
   /**
-   * Resolves a RoleResolvable to a role ID string.
-   * @method resolveID
+   * Resolves a {@link RoleResolvable} to a {@link Role} id.
+   * @method resolveId
    * @memberof RoleManager
    * @instance
    * @param {RoleResolvable} role The role resolvable to resolve
@@ -199,9 +199,9 @@ class RoleManager extends CachedManager {
    * @returns {?Role}
    */
   botRoleFor(user) {
-    const userID = this.client.users.resolveID(user);
-    if (!userID) return null;
-    return this.cache.find(role => role.tags?.botID === userID) ?? null;
+    const userId = this.client.users.resolveId(user);
+    if (!userId) return null;
+    return this.cache.find(role => role.tags?.botId === userId) ?? null;
   }
 
   /**

--- a/src/managers/StageInstanceManager.js
+++ b/src/managers/StageInstanceManager.js
@@ -48,8 +48,8 @@ class StageInstanceManager extends CachedManager {
    *  .catch(console.error);
    */
   async create(channel, options) {
-    const channelID = this.guild.channels.resolveID(channel);
-    if (!channelID) throw new Error('STAGE_CHANNEL_RESOLVE');
+    const channelId = this.guild.channels.resolveId(channel);
+    if (!channelId) throw new Error('STAGE_CHANNEL_RESOLVE');
     if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
     let { topic, privacyLevel } = options;
 
@@ -57,7 +57,7 @@ class StageInstanceManager extends CachedManager {
 
     const data = await this.client.api['stage-instances'].post({
       data: {
-        channel_id: channelID,
+        channel_id: channelId,
         topic,
         privacy_level: privacyLevel,
       },
@@ -78,15 +78,15 @@ class StageInstanceManager extends CachedManager {
    *  .catch(console.error);
    */
   async fetch(channel, { cache = true, force = false } = {}) {
-    const channelID = this.guild.channels.resolveID(channel);
-    if (!channelID) throw new Error('STAGE_CHANNEL_RESOLVE');
+    const channelId = this.guild.channels.resolveId(channel);
+    if (!channelId) throw new Error('STAGE_CHANNEL_RESOLVE');
 
     if (!force) {
-      const existing = this.cache.find(stageInstance => stageInstance.channelID === channelID);
+      const existing = this.cache.find(stageInstance => stageInstance.channelId === channelId);
       if (existing) return existing;
     }
 
-    const data = await this.client.api('stage-instances', channelID).get();
+    const data = await this.client.api('stage-instances', channelId).get();
     return this.add(data, cache);
   }
 
@@ -110,14 +110,14 @@ class StageInstanceManager extends CachedManager {
    */
   async edit(channel, options) {
     if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
-    const channelID = this.guild.channels.resolveID(channel);
-    if (!channelID) throw new Error('STAGE_CHANNEL_RESOLVE');
+    const channelId = this.guild.channels.resolveId(channel);
+    if (!channelId) throw new Error('STAGE_CHANNEL_RESOLVE');
 
     let { topic, privacyLevel } = options;
 
     if (privacyLevel) privacyLevel = typeof privacyLevel === 'number' ? privacyLevel : PrivacyLevels[privacyLevel];
 
-    const data = await this.client.api('stage-instances', channelID).patch({
+    const data = await this.client.api('stage-instances', channelId).patch({
       data: {
         topic,
         privacy_level: privacyLevel,
@@ -139,10 +139,10 @@ class StageInstanceManager extends CachedManager {
    * @returns {Promise<void>}
    */
   async delete(channel) {
-    const channelID = this.guild.channels.resolveID(channel);
-    if (!channelID) throw new Error('STAGE_CHANNEL_RESOLVE');
+    const channelId = this.guild.channels.resolveId(channel);
+    if (!channelId) throw new Error('STAGE_CHANNEL_RESOLVE');
 
-    await this.client.api('stage-instances', channelID).delete();
+    await this.client.api('stage-instances', channelId).delete();
   }
 }
 

--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -42,7 +42,7 @@ class ThreadManager extends CachedManager {
    */
 
   /**
-   * Resolves a ThreadChannelResolvable to a Thread Channel object.
+   * Resolves a {@link ThreadChannelResolvable} to a {@link ThreadChannel} object.
    * @method resolve
    * @memberof ThreadManager
    * @instance
@@ -51,8 +51,8 @@ class ThreadManager extends CachedManager {
    */
 
   /**
-   * Resolves a ThreadChannelResolvable to a thread channel ID string.
-   * @method resolveID
+   * Resolves a {@link ThreadChannelResolvable} to a {@link ThreadChannel} id.
+   * @method resolveId
    * @memberof ThreadManager
    * @instance
    * @param {ThreadChannelResolvable} thread The ThreadChannel resolvable to resolve
@@ -116,9 +116,9 @@ class ThreadManager extends CachedManager {
     }
     let resolvedType = this.channel.type === 'news' ? ChannelTypes.NEWS_THREAD : ChannelTypes.PUBLIC_THREAD;
     if (startMessage) {
-      const startMessageID = this.channel.messages.resolveID(startMessage);
-      if (!startMessageID) throw new TypeError('INVALID_TYPE', 'startMessage', 'MessageResolvable');
-      path = path.messages(startMessageID);
+      const startMessageId = this.channel.messages.resolveId(startMessage);
+      if (!startMessageId) throw new TypeError('INVALID_TYPE', 'startMessage', 'MessageResolvable');
+      path = path.messages(startMessageId);
     } else if (this.channel.type !== 'news') {
       resolvedType = typeof type === 'string' ? ChannelTypes[type.toUpperCase()] : type ?? resolvedType;
     }
@@ -157,7 +157,7 @@ class ThreadManager extends CachedManager {
    */
   fetch(options, { cache = true, force = false } = {}) {
     if (!options) return this.fetchActive(cache);
-    const channel = this.client.channels.resolveID(options);
+    const channel = this.client.channels.resolveId(options);
     if (channel) return this.client.channels.fetch(channel, cache, force);
     if (options.archived) {
       return this.fetchArchived(options.archived, cache);
@@ -206,7 +206,7 @@ class ThreadManager extends CachedManager {
     let id;
     if (typeof before !== 'undefined') {
       if (before instanceof ThreadChannel || /^\d{16,19}$/.test(String(before))) {
-        id = this.resolveID(before);
+        id = this.resolveId(before);
         timestamp = this.resolve(before)?.archivedAt?.toISOString();
       } else {
         try {

--- a/src/managers/ThreadMemberManager.js
+++ b/src/managers/ThreadMemberManager.js
@@ -44,27 +44,27 @@ class ThreadMemberManager extends CachedManager {
    */
 
   /**
-   * Resolves a ThreadMemberResolvable to a ThreadMember object.
+   * Resolves a {@link ThreadMemberResolvable} to a {@link ThreadMember} object.
    * @param {ThreadMemberResolvable} member The user that is part of the thread
    * @returns {?GuildMember}
    */
   resolve(member) {
     const memberResolvable = super.resolve(member);
     if (memberResolvable) return memberResolvable;
-    const userResolvable = this.client.users.resolveID(member);
+    const userResolvable = this.client.users.resolveId(member);
     if (userResolvable) return super.resolve(userResolvable);
     return null;
   }
 
   /**
-   * Resolves a ThreadMemberResolvable to a thread member ID string.
+   * Resolves a {@link ThreadMemberResolvable} to a {@link ThreadMember} id string.
    * @param {ThreadMemberResolvable} member The user that is part of the guild
    * @returns {?Snowflake}
    */
-  resolveID(member) {
-    const memberResolvable = super.resolveID(member);
+  resolveId(member) {
+    const memberResolvable = super.resolveId(member);
     if (memberResolvable) return memberResolvable;
-    const userResolvable = this.client.users.resolveID(member);
+    const userResolvable = this.client.users.resolveId(member);
     return this.cache.has(userResolvable) ? userResolvable : null;
   }
 
@@ -75,7 +75,7 @@ class ThreadMemberManager extends CachedManager {
    * @returns {Promise<Snowflake>}
    */
   add(member, reason) {
-    const id = member === '@me' ? member : this.client.users.resolveID(member);
+    const id = member === '@me' ? member : this.client.users.resolveId(member);
     if (!id) return Promise.reject(new TypeError('INVALID_TYPE', 'member', 'UserResolvable'));
     return this.client.api
       .channels(this.thread.id, 'thread-members', id)

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -32,7 +32,7 @@ class UserManager extends CachedManager {
    */
 
   /**
-   * Resolves a UserResolvable to a User object.
+   * Resolves a {@link UserResolvable} to a {@link User} object.
    * @param {UserResolvable} user The UserResolvable to identify
    * @returns {?User}
    */
@@ -43,20 +43,20 @@ class UserManager extends CachedManager {
   }
 
   /**
-   * Resolves a UserResolvable to a user ID string.
+   * Resolves a {@link UserResolvable} to a {@link User} id.
    * @param {UserResolvable} user The UserResolvable to identify
    * @returns {?Snowflake}
    */
-  resolveID(user) {
+  resolveId(user) {
     if (user instanceof ThreadMember) return user.id;
     if (user instanceof GuildMember) return user.user.id;
     if (user instanceof Message) return user.author.id;
-    return super.resolveID(user);
+    return super.resolveId(user);
   }
 
   /**
    * Obtains a user from Discord, or the user cache if it's already available.
-   * @param {Snowflake} id ID of the user
+   * @param {Snowflake} id The user's id
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<User>}
    */

--- a/src/rest/APIRouter.js
+++ b/src/rest/APIRouter.js
@@ -21,7 +21,7 @@ function buildRoute(manager) {
         for (let i = 0; i < route.length; i++) {
           // Reactions routes and sub-routes all share the same bucket
           if (route[i - 1] === 'reactions') break;
-          // Literal IDs should only be taken account if they are the Major ID (the Channel/Guild ID)
+          // Literal ids should only be taken account if they are the Major id (the Channel/Guild id)
           if (/\d{16,19}/g.test(route[i]) && !/channels|guilds/.test(route[i - 1])) routeBucket.push(':id');
           // All other parts of the route should be considered as part of the bucket identifier
           else routeBucket.push(route[i]);

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -16,7 +16,7 @@ let Worker = null;
 class Shard extends EventEmitter {
   /**
    * @param {ShardingManager} manager Manager that is creating this shard
-   * @param {number} id ID of this shard
+   * @param {number} id The shard's id
    */
   constructor(manager, id) {
     super();
@@ -31,7 +31,7 @@ class Shard extends EventEmitter {
     this.manager = manager;
 
     /**
-     * ID of the shard in the manager
+     * The shard's id in the manager
      * @type {number}
      */
     this.id = id;

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -59,7 +59,7 @@ class ShardClientUtil {
   }
 
   /**
-   * Array of shard IDs of this client
+   * Array of shard ids of this client
    * @type {number[]}
    * @readonly
    */
@@ -230,14 +230,14 @@ class ShardClientUtil {
   }
 
   /**
-   * Get the shard ID for a given guild ID.
-   * @param {Snowflake} guildID Snowflake guild ID to get shard ID for
+   * Get the shard id for a given guild id.
+   * @param {Snowflake} guildId Snowflake guild id to get shard id for
    * @param {number} shardCount Number of shards
    * @returns {number}
    */
-  static shardIDForGuildID(guildID, shardCount) {
-    const shard = Number(BigInt(guildID) >> 22n) % shardCount;
-    if (shard < 0) throw new Error('SHARDING_SHARD_MISCALCULATION', shard, guildID, shardCount);
+  static shardIdForGuildId(guildId, shardCount) {
+    const shard = Number(BigInt(guildId) >> 22n) % shardCount;
+    if (shard < 0) throw new Error('SHARDING_SHARD_MISCALCULATION', shard, guildId, shardCount);
     return shard;
   }
 }

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -76,10 +76,10 @@ class ShardingManager extends EventEmitter {
         throw new TypeError('CLIENT_INVALID_OPTION', 'shardList', 'an array.');
       }
       this.shardList = [...new Set(this.shardList)];
-      if (this.shardList.length < 1) throw new RangeError('CLIENT_INVALID_OPTION', 'shardList', 'at least 1 ID.');
+      if (this.shardList.length < 1) throw new RangeError('CLIENT_INVALID_OPTION', 'shardList', 'at least 1 id.');
       if (
         this.shardList.some(
-          shardID => typeof shardID !== 'number' || isNaN(shardID) || !Number.isInteger(shardID) || shardID < 0,
+          shardId => typeof shardId !== 'number' || isNaN(shardId) || !Number.isInteger(shardId) || shardId < 0,
         )
       ) {
         throw new TypeError('CLIENT_INVALID_OPTION', 'shardList', 'an array of positive integers.');
@@ -148,7 +148,7 @@ class ShardingManager extends EventEmitter {
   /**
    * Creates a single shard.
    * <warn>Using this method is usually not necessary if you use the spawn method.</warn>
-   * @param {number} [id=this.shards.size] ID of the shard to create
+   * @param {number} [id=this.shards.size] Id of the shard to create
    * <info>This is usually not necessary to manually specify.</info>
    * @returns {Shard} Note that the created shard needs to be explicitly spawned using its spawn method.
    */
@@ -200,18 +200,18 @@ class ShardingManager extends EventEmitter {
       this.totalShards = amount;
     }
 
-    if (this.shardList.some(shardID => shardID >= amount)) {
+    if (this.shardList.some(shardId => shardId >= amount)) {
       throw new RangeError(
         'CLIENT_INVALID_OPTION',
         'Amount of shards',
-        'bigger than the highest shardID in the shardList option.',
+        'bigger than the highest shardId in the shardList option.',
       );
     }
 
     // Spawn the shards
-    for (const shardID of this.shardList) {
+    for (const shardId of this.shardList) {
       const promises = [];
-      const shard = this.createShard(shardID);
+      const shard = this.createShard(shardId);
       promises.push(shard.spawn(timeout));
       if (delay > 0 && this.shards.size !== this.shardList.length) promises.push(Util.delayFor(delay));
       await Promise.all(promises); // eslint-disable-line no-await-in-loop

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -10,11 +10,11 @@ const SnowflakeUtil = require('../util/SnowflakeUtil');
  * @extends {Base}
  */
 class ApplicationCommand extends Base {
-  constructor(client, data, guild, guildID) {
+  constructor(client, data, guild, guildId) {
     super(client);
 
     /**
-     * The ID of this command
+     * The command's id
      * @type {Snowflake}
      */
     this.id = data.id;
@@ -26,11 +26,11 @@ class ApplicationCommand extends Base {
     this.guild = guild ?? null;
 
     /**
-     * The guild ID this command is part of, this may be non-null when `guild` is `null` if the command
+     * The guild's id this command is part of, this may be non-null when `guild` is `null` if the command
      * was fetched from the `ApplicationCommandManager`
      * @type {?Snowflake}
      */
-    this.guildID = guild?.id ?? guildID ?? null;
+    this.guildId = guild?.id ?? guildId ?? null;
 
     /**
      * The manager for permissions of this command on its guild or arbitrary guilds when the command is global
@@ -127,7 +127,7 @@ class ApplicationCommand extends Base {
    *   .catch(console.error);
    */
   edit(data) {
-    return this.manager.edit(this, data, this.guildID);
+    return this.manager.edit(this, data, this.guildId);
   }
 
   /**
@@ -140,7 +140,7 @@ class ApplicationCommand extends Base {
    *   .catch(console.error);
    */
   delete() {
-    return this.manager.delete(this, this.guildID);
+    return this.manager.delete(this, this.guildId);
   }
 
   /**

--- a/src/structures/BaseGuild.js
+++ b/src/structures/BaseGuild.js
@@ -13,7 +13,7 @@ class BaseGuild extends Base {
     super(client);
 
     /**
-     * The ID of this guild
+     * The guild's id
      * @type {Snowflake}
      */
     this.id = data.id;

--- a/src/structures/BaseGuildVoiceChannel.js
+++ b/src/structures/BaseGuildVoiceChannel.js
@@ -39,7 +39,7 @@ class BaseGuildVoiceChannel extends GuildChannel {
   get members() {
     const coll = new Collection();
     for (const state of this.guild.voiceStates.cache.values()) {
-      if (state.channelID === this.id && state.member) {
+      if (state.channelId === this.id && state.member) {
         coll.set(state.id, state.member);
       }
     }

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -13,7 +13,7 @@ class CategoryChannel extends GuildChannel {
    * @readonly
    */
   get children() {
-    return this.guild.channels.cache.filter(c => c.parentID === this.id);
+    return this.guild.channels.cache.filter(c => c.parentId === this.id);
   }
 
   /**

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -50,7 +50,7 @@ class Channel extends Base {
 
   _patch(data) {
     /**
-     * The unique ID of the channel
+     * The channel's id
      * @type {Snowflake}
      */
     this.id = data.id;

--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -16,14 +16,14 @@ class ClientPresence extends Presence {
   set(presence) {
     const packet = this._parse(presence);
     this.patch(packet);
-    if (typeof presence.shardID === 'undefined') {
+    if (typeof presence.shardId === 'undefined') {
       this.client.ws.broadcast({ op: OPCodes.STATUS_UPDATE, d: packet });
-    } else if (Array.isArray(presence.shardID)) {
-      for (const shardID of presence.shardID) {
-        this.client.ws.shards.get(shardID).send({ op: OPCodes.STATUS_UPDATE, d: packet });
+    } else if (Array.isArray(presence.shardId)) {
+      for (const shardId of presence.shardId) {
+        this.client.ws.shards.get(shardId).send({ op: OPCodes.STATUS_UPDATE, d: packet });
       }
     } else {
-      this.client.ws.shards.get(presence.shardID).send({ op: OPCodes.STATUS_UPDATE, d: packet });
+      this.client.ws.shards.get(presence.shardId).send({ op: OPCodes.STATUS_UPDATE, d: packet });
     }
     return this;
   }

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -103,7 +103,7 @@ class ClientUser extends User {
    * @property {PresenceStatusData} [status] Status of the user
    * @property {boolean} [afk] Whether the user is AFK
    * @property {ActivitiesOptions[]} [activities] Activity the user is playing
-   * @property {?(number|number[])} [shardID] Shard Id(s) to have the activity set on
+   * @property {?(number|number[])} [shardId] Shard Id(s) to have the activity set on
    */
 
   /**
@@ -130,14 +130,14 @@ class ClientUser extends User {
   /**
    * Sets the status of the client user.
    * @param {PresenceStatusData} status Status to change to
-   * @param {?(number|number[])} [shardID] Shard ID(s) to have the activity set on
+   * @param {?(number|number[])} [shardId] Shard id(s) to have the activity set on
    * @returns {Presence}
    * @example
    * // Set the client user's status
    * client.user.setStatus('idle');
    */
-  setStatus(status, shardID) {
-    return this.setPresence({ status, shardID });
+  setStatus(status, shardId) {
+    return this.setPresence({ status, shardId });
   }
 
   /**
@@ -146,7 +146,7 @@ class ClientUser extends User {
    * @property {string} [name] Name of the activity
    * @property {string} [url] Twitch / YouTube stream URL
    * @property {ActivityType|number} [type] Type of the activity
-   * @property {number|number[]} [shardID] Shard Id(s) to have the activity set on
+   * @property {number|number[]} [shardId] Shard Id(s) to have the activity set on
    */
 
   /**
@@ -159,20 +159,20 @@ class ClientUser extends User {
    * client.user.setActivity('discord.js', { type: 'WATCHING' });
    */
   setActivity(name, options = {}) {
-    if (!name) return this.setPresence({ activities: [], shardID: options.shardID });
+    if (!name) return this.setPresence({ activities: [], shardId: options.shardId });
 
     const activity = Object.assign({}, options, typeof name === 'object' ? name : { name });
-    return this.setPresence({ activities: [activity], shardID: activity.shardID });
+    return this.setPresence({ activities: [activity], shardId: activity.shardId });
   }
 
   /**
    * Sets/removes the AFK flag for the client user.
    * @param {boolean} afk Whether or not the user is AFK
-   * @param {number|number[]} [shardID] Shard Id(s) to have the AFK flag set on
+   * @param {number|number[]} [shardId] Shard Id(s) to have the AFK flag set on
    * @returns {Presence}
    */
-  setAFK(afk, shardID) {
-    return this.setPresence({ afk, shardID });
+  setAFK(afk, shardId) {
+    return this.setPresence({ afk, shardId });
   }
 }
 

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -23,19 +23,19 @@ class CommandInteraction extends Interaction {
      */
 
     /**
-     * The ID of the channel this interaction was sent in
+     * The id of the channel this interaction was sent in
      * @type {Snowflake}
-     * @name CommandInteraction#channelID
+     * @name CommandInteraction#channelId
      */
 
     /**
-     * The ID of the invoked application command
+     * The invoked application command's id
      * @type {Snowflake}
      */
-    this.commandID = data.data.id;
+    this.commandId = data.data.id;
 
     /**
-     * The name of the invoked application command
+     * The invoked application command's name
      * @type {string}
      */
     this.commandName = data.data.name;
@@ -68,7 +68,7 @@ class CommandInteraction extends Interaction {
      * An associated interaction webhook, can be used to further interact with this interaction
      * @type {InteractionWebhook}
      */
-    this.webhook = new InteractionWebhook(this.client, this.applicationID, this.token);
+    this.webhook = new InteractionWebhook(this.client, this.applicationId, this.token);
   }
 
   /**
@@ -76,7 +76,7 @@ class CommandInteraction extends Interaction {
    * @type {?ApplicationCommand}
    */
   get command() {
-    const id = this.commandID;
+    const id = this.commandId;
     return this.guild?.commands.cache.get(id) ?? this.client.application.commands.cache.get(id) ?? null;
   }
 

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -38,10 +38,10 @@ class DMChannel extends Channel {
     }
 
     /**
-     * The ID of the last message in the channel, if one was sent
+     * The channel's last message id, if one was sent
      * @type {?Snowflake}
      */
-    this.lastMessageID = data.last_message_id;
+    this.lastMessageId = data.last_message_id;
 
     /**
      * The timestamp when the last pinned message was pinned, if there was one
@@ -56,7 +56,7 @@ class DMChannel extends Channel {
    * @readonly
    */
   get partial() {
-    return typeof this.lastMessageID === 'undefined';
+    return typeof this.lastMessageId === 'undefined';
   }
 
   /**

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -6,9 +6,9 @@ const SnowflakeUtil = require('../util/SnowflakeUtil');
 /**
  * Represents raw emoji data from the API
  * @typedef {APIEmoji} RawEmoji
- * @property {?Snowflake} id ID of this emoji
- * @property {?string} name Name of this emoji
- * @property {?boolean} animated Whether this emoji is animated
+ * @property {?Snowflake} id The emoji's id
+ * @property {?string} name The emoji's name
+ * @property {?boolean} animated Whether the emoji is animated
  */
 
 /**
@@ -19,19 +19,19 @@ class Emoji extends Base {
   constructor(client, emoji) {
     super(client);
     /**
-     * Whether this emoji is animated
+     * Whether or not the emoji is animated
      * @type {?boolean}
      */
     this.animated = emoji.animated ?? null;
 
     /**
-     * The name of this emoji
+     * The emoji's name
      * @type {?string}
      */
     this.name = emoji.name ?? null;
 
     /**
-     * The ID of this emoji
+     * The emoji's id
      * @type {?Snowflake}
      */
     this.id = emoji.id;
@@ -98,7 +98,7 @@ class Emoji extends Base {
 
   toJSON() {
     return super.toJSON({
-      guild: 'guildID',
+      guild: 'guildId',
       createdTimestamp: true,
       url: true,
       identifier: true,

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -113,7 +113,7 @@ class Guild extends AnonymousGuild {
      * The id of the shard this Guild belongs to.
      * @type {number}
      */
-    this.shardID = data.shardID;
+    this.shardId = data.shardId;
   }
 
   /**
@@ -122,7 +122,7 @@ class Guild extends AnonymousGuild {
    * @readonly
    */
   get shard() {
-    return this.client.ws.shards.get(this.shardID);
+    return this.client.ws.shards.get(this.shardId);
   }
 
   /**
@@ -183,10 +183,10 @@ class Guild extends AnonymousGuild {
      */
 
     /**
-     * The ID of the application that created this guild (if applicable)
+     * The id of the application that created this guild (if applicable)
      * @type {?Snowflake}
      */
-    this.applicationID = data.application_id;
+    this.applicationId = data.application_id;
 
     /**
      * The time in seconds before a user is counted as "away from keyboard"
@@ -195,16 +195,16 @@ class Guild extends AnonymousGuild {
     this.afkTimeout = data.afk_timeout;
 
     /**
-     * The ID of the voice channel where AFK members are moved
+     * The id of the voice channel where AFK members are moved
      * @type {?Snowflake}
      */
-    this.afkChannelID = data.afk_channel_id;
+    this.afkChannelId = data.afk_channel_id;
 
     /**
-     * The ID of the system channel
+     * The system channel's id
      * @type {?Snowflake}
      */
-    this.systemChannelID = data.system_channel_id;
+    this.systemChannelId = data.system_channel_id;
 
     /**
      * The premium tier of this guild
@@ -230,10 +230,10 @@ class Guild extends AnonymousGuild {
 
     if (typeof data.widget_channel_id !== 'undefined') {
       /**
-       * The widget channel ID, if enabled
+       * The widget channel's id, if enabled
        * @type {?string}
        */
-      this.widgetChannelID = data.widget_channel_id;
+      this.widgetChannelId = data.widget_channel_id;
     }
 
     /**
@@ -317,16 +317,16 @@ class Guild extends AnonymousGuild {
     this.vanityURLUses = null;
 
     /**
-     * The ID of the rules channel for the guild
+     * The rules channel's id for the guild
      * @type {?Snowflake}
      */
-    this.rulesChannelID = data.rules_channel_id;
+    this.rulesChannelId = data.rules_channel_id;
 
     /**
-     * The ID of the community updates channel for the guild
+     * The community updates channel's id for the guild
      * @type {?Snowflake}
      */
-    this.publicUpdatesChannelID = data.public_updates_channel_id;
+    this.publicUpdatesChannelId = data.public_updates_channel_id;
 
     /**
      * The preferred locale of the guild, defaults to `en-US`
@@ -359,10 +359,10 @@ class Guild extends AnonymousGuild {
 
     if (data.owner_id) {
       /**
-       * The user ID of this guild's owner
+       * The user id of this guild's owner
        * @type {Snowflake}
        */
-      this.ownerID = data.owner_id;
+      this.ownerId = data.owner_id;
     }
 
     if (data.presences) {
@@ -445,12 +445,12 @@ class Guild extends AnonymousGuild {
 
   /**
    * Fetches the owner of the guild.
-   * If the member object isn't needed, use {@link Guild#ownerID} instead.
+   * If the member object isn't needed, use {@link Guild#ownerId} instead.
    * @param {FetchOwnerOptions} [options] The options for fetching the member
    * @returns {Promise<GuildMember>}
    */
   fetchOwner(options) {
-    return this.members.fetch({ ...options, user: this.ownerID });
+    return this.members.fetch({ ...options, user: this.ownerId });
   }
 
   /**
@@ -459,7 +459,7 @@ class Guild extends AnonymousGuild {
    * @readonly
    */
   get afkChannel() {
-    return this.client.channels.resolve(this.afkChannelID);
+    return this.client.channels.resolve(this.afkChannelId);
   }
 
   /**
@@ -468,7 +468,7 @@ class Guild extends AnonymousGuild {
    * @readonly
    */
   get systemChannel() {
-    return this.client.channels.resolve(this.systemChannelID);
+    return this.client.channels.resolve(this.systemChannelId);
   }
 
   /**
@@ -477,7 +477,7 @@ class Guild extends AnonymousGuild {
    * @readonly
    */
   get widgetChannel() {
-    return this.client.channels.resolve(this.widgetChannelID);
+    return this.client.channels.resolve(this.widgetChannelId);
   }
 
   /**
@@ -486,7 +486,7 @@ class Guild extends AnonymousGuild {
    * @readonly
    */
   get rulesChannel() {
-    return this.client.channels.resolve(this.rulesChannelID);
+    return this.client.channels.resolve(this.rulesChannelId);
   }
 
   /**
@@ -495,7 +495,7 @@ class Guild extends AnonymousGuild {
    * @readonly
    */
   get publicUpdatesChannel() {
-    return this.client.channels.resolve(this.publicUpdatesChannelID);
+    return this.client.channels.resolve(this.publicUpdatesChannelId);
   }
 
   /**
@@ -702,7 +702,7 @@ class Guild extends AnonymousGuild {
   async fetchWidget() {
     const data = await this.client.api.guilds(this.id).widget.get();
     this.widgetEnabled = data.enabled;
-    this.widgetChannelID = data.channel_id;
+    this.widgetChannelId = data.channel_id;
     return {
       enabled: data.enabled,
       channel: data.channel_id ? this.channels.cache.get(data.channel_id) : null,
@@ -738,7 +738,7 @@ class Guild extends AnonymousGuild {
         query: {
           before: options.before,
           limit: options.limit,
-          user_id: this.client.users.resolveID(options.user),
+          user_id: this.client.users.resolveId(options.user),
           action_type: options.type,
         },
       })
@@ -764,7 +764,7 @@ class Guild extends AnonymousGuild {
    * @returns {Promise<GuildMember>}
    */
   async addMember(user, options) {
-    user = this.client.users.resolveID(user);
+    user = this.client.users.resolveId(user);
     if (!user) throw new TypeError('INVALID_TYPE', 'user', 'UserResolvable');
     if (this.members.cache.has(user)) return this.members.cache.get(user);
     options.access_token = options.accessToken;
@@ -774,7 +774,7 @@ class Guild extends AnonymousGuild {
       }
       const resolvedRoles = [];
       for (const role of options.roles.values()) {
-        const resolvedRole = this.roles.resolveID(role);
+        const resolvedRole = this.roles.resolveId(role);
         if (!role) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role);
         resolvedRoles.push(resolvedRole);
       }
@@ -832,14 +832,14 @@ class Guild extends AnonymousGuild {
           : VerificationLevels[data.verificationLevel];
     }
     if (typeof data.afkChannel !== 'undefined') {
-      _data.afk_channel_id = this.client.channels.resolveID(data.afkChannel);
+      _data.afk_channel_id = this.client.channels.resolveId(data.afkChannel);
     }
     if (typeof data.systemChannel !== 'undefined') {
-      _data.system_channel_id = this.client.channels.resolveID(data.systemChannel);
+      _data.system_channel_id = this.client.channels.resolveId(data.systemChannel);
     }
     if (data.afkTimeout) _data.afk_timeout = Number(data.afkTimeout);
     if (typeof data.icon !== 'undefined') _data.icon = data.icon;
-    if (data.owner) _data.owner_id = this.client.users.resolveID(data.owner);
+    if (data.owner) _data.owner_id = this.client.users.resolveId(data.owner);
     if (data.splash) _data.splash = data.splash;
     if (data.discoverySplash) _data.discovery_splash = data.discoverySplash;
     if (data.banner) _data.banner = data.banner;
@@ -859,10 +859,10 @@ class Guild extends AnonymousGuild {
       _data.system_channel_flags = SystemChannelFlags.resolve(data.systemChannelFlags);
     }
     if (typeof data.rulesChannel !== 'undefined') {
-      _data.rules_channel_id = this.client.channels.resolveID(data.rulesChannel);
+      _data.rules_channel_id = this.client.channels.resolveId(data.rulesChannel);
     }
     if (typeof data.publicUpdatesChannel !== 'undefined') {
-      _data.public_updates_channel_id = this.client.channels.resolveID(data.publicUpdatesChannel);
+      _data.public_updates_channel_id = this.client.channels.resolveId(data.publicUpdatesChannel);
     }
     if (typeof data.features !== 'undefined') {
       _data.features = data.features;
@@ -916,7 +916,7 @@ class Guild extends AnonymousGuild {
       return {
         emoji_id: emoji && emoji.id,
         emoji_name: emoji?.name ?? welcomeChannelData.emoji,
-        channel_id: this.channels.resolveID(welcomeChannelData.channel),
+        channel_id: this.channels.resolveId(welcomeChannelData.channel),
         description: welcomeChannelData.description,
       };
     });
@@ -1179,16 +1179,16 @@ class Guild extends AnonymousGuild {
    * @param {ChannelPosition[]} channelPositions Channel positions to update
    * @returns {Promise<Guild>}
    * @example
-   * guild.setChannelPositions([{ channel: channelID, position: newChannelIndex }])
+   * guild.setChannelPositions([{ channel: channelId, position: newChannelIndex }])
    *   .then(guild => console.log(`Updated channel positions for ${guild}`))
    *   .catch(console.error);
    */
   setChannelPositions(channelPositions) {
     const updatedChannels = channelPositions.map(r => ({
-      id: this.client.channels.resolveID(r.channel),
+      id: this.client.channels.resolveId(r.channel),
       position: r.position,
       lock_permissions: r.lockPermissions,
-      parent_id: typeof r.parent !== 'undefined' ? this.channels.resolveID(r.parent) : undefined,
+      parent_id: typeof r.parent !== 'undefined' ? this.channels.resolveId(r.parent) : undefined,
     }));
 
     return this.client.api
@@ -1206,7 +1206,7 @@ class Guild extends AnonymousGuild {
   /**
    * The data needed for updating a guild role's position
    * @typedef {Object} GuildRolePosition
-   * @property {RoleResolveable} role The ID of the role
+   * @property {RoleResolveable} role The role's id
    * @property {number} position The position to update
    */
 
@@ -1215,14 +1215,14 @@ class Guild extends AnonymousGuild {
    * @param {GuildRolePosition[]} rolePositions Role positions to update
    * @returns {Promise<Guild>}
    * @example
-   * guild.setRolePositions([{ role: roleID, position: updatedRoleIndex }])
+   * guild.setRolePositions([{ role: roleId, position: updatedRoleIndex }])
    *  .then(guild => console.log(`Role positions updated for ${guild}`))
    *  .catch(console.error);
    */
   setRolePositions(rolePositions) {
     // Make sure rolePositions are prepared for API
     rolePositions = rolePositions.map(o => ({
-      id: this.roles.resolveID(o.role),
+      id: this.roles.resolveId(o.role),
       position: o.position,
     }));
 
@@ -1253,7 +1253,7 @@ class Guild extends AnonymousGuild {
       .widget.patch({
         data: {
           enabled: widget.enabled,
-          channel_id: this.channels.resolveID(widget.channel),
+          channel_id: this.channels.resolveId(widget.channel),
         },
         reason,
       })
@@ -1270,7 +1270,7 @@ class Guild extends AnonymousGuild {
    *   .catch(console.error);
    */
   leave() {
-    if (this.ownerID === this.client.user.id) return Promise.reject(new Error('GUILD_OWNED'));
+    if (this.ownerId === this.client.user.id) return Promise.reject(new Error('GUILD_OWNED'));
     return this.client.api
       .users('@me')
       .guilds(this.id)
@@ -1313,7 +1313,7 @@ class Guild extends AnonymousGuild {
       this.memberCount === guild.memberCount &&
       this.large === guild.large &&
       this.icon === guild.icon &&
-      this.ownerID === guild.ownerID &&
+      this.ownerId === guild.ownerId &&
       this.verificationLevel === guild.verificationLevel &&
       (this.features === guild.features ||
         (this.features.length === guild.features.length &&
@@ -1366,7 +1366,7 @@ class Guild extends AnonymousGuild {
   }
 
   /**
-   * Creates a collection of this guild's roles, sorted by their position and IDs.
+   * Creates a collection of this guild's roles, sorted by their position and ids.
    * @returns {Collection<Snowflake, Role>}
    * @private
    */
@@ -1375,7 +1375,7 @@ class Guild extends AnonymousGuild {
   }
 
   /**
-   * Creates a collection of this guild's or a specific category's channels, sorted by their position and IDs.
+   * Creates a collection of this guild's or a specific category's channels, sorted by their position and ids.
    * @param {GuildChannel} [channel] Category to get the channels of
    * @returns {Collection<Snowflake, GuildChannel>}
    * @private

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -359,7 +359,7 @@ class GuildAuditLogsEntry {
     this.changes = data.changes?.map(c => ({ key: c.key, old: c.old_value, new: c.new_value })) ?? null;
 
     /**
-     * The ID of this entry
+     * The entry's id
      * @type {Snowflake}
      */
     this.id = data.id;
@@ -390,7 +390,7 @@ class GuildAuditLogsEntry {
       case Actions.MESSAGE_UNPIN:
         this.extra = {
           channel: guild.client.channels.cache.get(data.options.channel_id) ?? { id: data.options.channel_id },
-          messageID: data.options.message_id,
+          messageId: data.options.message_id,
         };
         break;
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -35,7 +35,7 @@ class GuildChannel extends Channel {
      */
     this.guild = guild;
 
-    this.parentID = this.parentID ?? null;
+    this.parentId = this.parentId ?? null;
     /**
      * A manager of permission overwrites that belong to this channel
      * @type {PermissionOverwriteManager}
@@ -66,10 +66,10 @@ class GuildChannel extends Channel {
 
     if ('parent_id' in data) {
       /**
-       * The ID of the category parent of this channel
+       * The id of the category parent of this channel
        * @type {?Snowflake}
        */
-      this.parentID = data.parent_id;
+      this.parentId = data.parent_id;
     }
 
     if ('permission_overwrites' in data) {
@@ -86,7 +86,7 @@ class GuildChannel extends Channel {
    * @readonly
    */
   get parent() {
-    return this.guild.channels.resolve(this.parentID);
+    return this.guild.channels.resolve(this.parentId);
   }
 
   /**
@@ -185,7 +185,7 @@ class GuildChannel extends Channel {
    * @private
    */
   memberPermissions(member) {
-    if (member.id === this.guild.ownerID) return new Permissions(Permissions.ALL).freeze();
+    if (member.id === this.guild.ownerId) return new Permissions(Permissions.ALL).freeze();
 
     const roles = member.roles.cache;
     const permissions = new Permissions(roles.map(role => role.permissions));
@@ -235,7 +235,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * A collection of cached members of this channel, mapped by their ID.
+   * A collection of cached members of this channel, mapped by their ids.
    * Members that can view this channel, if the channel is text based.
    * Members in the channel, if the channel is voice based.
    * @type {Collection<Snowflake, GuildMember>}
@@ -261,7 +261,7 @@ class GuildChannel extends Channel {
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the voice channel
-   * @property {?Snowflake} [parentID] The parent ID of the channel
+   * @property {?Snowflake} [parentId] The parent's id of the channel
    * @property {boolean} [lockPermissions]
    * Lock the permissions of the channel to what the parent's permissions are
    * @property {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [permissionOverwrites]
@@ -307,8 +307,8 @@ class GuildChannel extends Channel {
     }
 
     if (data.lockPermissions) {
-      if (data.parentID) {
-        const newParent = this.guild.channels.resolve(data.parentID);
+      if (data.parentId) {
+        const newParent = this.guild.channels.resolve(data.parentId);
         if (newParent?.type === 'category') {
           permission_overwrites = newParent.permissionOverwrites.cache.map(o =>
             PermissionOverwrites.resolve(o, this.guild),
@@ -330,7 +330,7 @@ class GuildChannel extends Channel {
         bitrate: data.bitrate ?? this.bitrate,
         user_limit: data.userLimit ?? this.userLimit,
         rtc_region: data.rtcRegion ?? this.rtcRegion,
-        parent_id: data.parentID,
+        parent_id: data.parentId,
         lock_permissions: data.lockPermissions,
         rate_limit_per_user: data.rateLimitPerUser,
         default_auto_archive_duration: data.defaultAutoArchiveDuration,
@@ -379,7 +379,7 @@ class GuildChannel extends Channel {
     return this.edit(
       {
         // eslint-disable-next-line no-prototype-builtins
-        parentID: channel?.id ?? channel ?? null,
+        parentId: channel?.id ?? channel ?? null,
         lockPermissions,
       },
       reason,
@@ -488,8 +488,8 @@ class GuildChannel extends Channel {
           max_age: maxAge,
           max_uses: maxUses,
           unique,
-          target_user_id: this.client.users.resolveID(targetUser),
-          target_application_id: targetApplication?.id ?? targetApplication?.applicationID ?? targetApplication,
+          target_user_id: this.client.users.resolveId(targetUser),
+          target_application_id: targetApplication?.id ?? targetApplication?.applicationId ?? targetApplication,
           target_type: targetType,
         },
         reason,
@@ -540,7 +540,7 @@ class GuildChannel extends Channel {
   }
 
   /**
-   * Checks if this channel has the same type, topic, position, name, overwrites and ID as another channel.
+   * Checks if this channel has the same type, topic, position, name, overwrites, and id as another channel.
    * In most cases, a simple `channel.id === channel2.id` will do, and is much faster too.
    * @param {GuildChannel} channel Channel to compare with
    * @returns {boolean}
@@ -573,8 +573,8 @@ class GuildChannel extends Channel {
   get deletable() {
     return (
       this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false) &&
-      this.guild.rulesChannelID !== this.id &&
-      this.guild.publicUpdatesChannelID !== this.id
+      this.guild.rulesChannelId !== this.id &&
+      this.guild.publicUpdatesChannelId !== this.id
     );
   }
 
@@ -584,7 +584,7 @@ class GuildChannel extends Channel {
    * @readonly
    */
   get manageable() {
-    if (this.client.user.id === this.guild.ownerID) return true;
+    if (this.client.user.id === this.guild.ownerId) return true;
     if (this.type === 'voice' || this.type === 'stage') {
       if (!this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false)) {
         return false;
@@ -601,7 +601,7 @@ class GuildChannel extends Channel {
    * @readonly
    */
   get viewable() {
-    if (this.client.user.id === this.guild.ownerID) return true;
+    if (this.client.user.id === this.guild.ownerId) return true;
     const permissions = this.permissionsFor(this.client.user);
     if (!permissions) return false;
     return permissions.has(Permissions.FLAGS.VIEW_CHANNEL, false);

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -35,16 +35,16 @@ class GuildMember extends Base {
     this.joinedTimestamp = null;
 
     /**
-     * The ID of the last message sent by the member in their guild, if one was sent
+     * The member's last message id, if one was sent
      * @type {?Snowflake}
      */
-    this.lastMessageID = null;
+    this.lastMessageId = null;
 
     /**
-     * The ID of the channel for the last message sent by the member in their guild, if one was sent
+     * The id of the channel for the last message sent by the member in their guild, if one was sent
      * @type {?Snowflake}
      */
-    this.lastMessageChannelID = null;
+    this.lastMessageChannelId = null;
 
     /**
      * The timestamp of when the member used their Nitro boost on the guild, if it was used
@@ -122,7 +122,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get lastMessage() {
-    return this.guild.channels.resolve(this.lastMessageChannelID)?.messages.resolve(this.lastMessageID) ?? null;
+    return this.guild.channels.resolve(this.lastMessageChannelId)?.messages.resolve(this.lastMessageId) ?? null;
   }
 
   /**
@@ -188,7 +188,7 @@ class GuildMember extends Base {
   }
 
   /**
-   * The ID of this member
+   * The member's id
    * @type {Snowflake}
    * @readonly
    */
@@ -211,7 +211,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get permissions() {
-    if (this.user.id === this.guild.ownerID) return new Permissions(Permissions.ALL).freeze();
+    if (this.user.id === this.guild.ownerId) return new Permissions(Permissions.ALL).freeze();
     return new Permissions(this.roles.cache.map(role => role.permissions)).freeze();
   }
 
@@ -222,9 +222,9 @@ class GuildMember extends Base {
    * @readonly
    */
   get manageable() {
-    if (this.user.id === this.guild.ownerID) return false;
+    if (this.user.id === this.guild.ownerId) return false;
     if (this.user.id === this.client.user.id) return false;
-    if (this.client.user.id === this.guild.ownerID) return true;
+    if (this.client.user.id === this.guild.ownerId) return true;
     if (!this.guild.me) throw new Error('GUILD_UNCACHED_ME');
     return this.guild.me.roles.highest.comparePositionTo(this.roles.highest) > 0;
   }
@@ -263,7 +263,7 @@ class GuildMember extends Base {
    * The data for editing a guild member.
    * @typedef {Object} GuildMemberEditData
    * @property {?string} [nick] The nickname to set for the member
-   * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles or role IDs to apply
+   * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles or role ids to apply
    * @property {boolean} [mute] Whether or not the member should be muted
    * @property {boolean} [deaf] Whether or not the member should be deafened
    * @property {ChannelResolvable|null} [channel] Channel to move member to (if they are connected to voice), or `null`
@@ -352,8 +352,8 @@ class GuildMember extends Base {
       this.partial === member.partial &&
       this.guild.id === member.guild.id &&
       this.joinedTimestamp === member.joinedTimestamp &&
-      this.lastMessageID === member.lastMessageID &&
-      this.lastMessageChannelID === member.lastMessageChannelID &&
+      this.lastMessageId === member.lastMessageId &&
+      this.lastMessageChannelId === member.lastMessageChannelId &&
       this.nickname === member.nickname &&
       this.pending === member.pending &&
       (this._roles === member._roles ||
@@ -374,11 +374,11 @@ class GuildMember extends Base {
 
   toJSON() {
     return super.toJSON({
-      guild: 'guildID',
-      user: 'userID',
+      guild: 'guildId',
+      user: 'userId',
       displayName: true,
       lastMessage: false,
-      lastMessageID: false,
+      lastMessageId: false,
       roles: true,
     });
   }

--- a/src/structures/GuildTemplate.js
+++ b/src/structures/GuildTemplate.js
@@ -50,10 +50,10 @@ class GuildTemplate extends Base {
     this.usageCount = data.usage_count;
 
     /**
-     * The ID of the user that created this template
+     * The id of the user that created this template
      * @type {Snowflake}
      */
-    this.creatorID = data.creator_id;
+    this.creatorId = data.creator_id;
 
     /**
      * The user that created this template
@@ -74,10 +74,10 @@ class GuildTemplate extends Base {
     this.updatedAt = new Date(data.updated_at);
 
     /**
-     * The ID of the guild that this template belongs to
+     * The id of the guild that this template belongs to
      * @type {Snowflake}
      */
-    this.guildID = data.source_guild_id;
+    this.guildId = data.source_guild_id;
 
     /**
      * The data of the guild that this template would create
@@ -148,7 +148,7 @@ class GuildTemplate extends Base {
    */
   edit({ name, description } = {}) {
     return this.client.api
-      .guilds(this.guildID)
+      .guilds(this.guildId)
       .templates(this.code)
       .patch({ data: { name, description } })
       .then(data => this._patch(data));
@@ -160,7 +160,7 @@ class GuildTemplate extends Base {
    */
   delete() {
     return this.client.api
-      .guilds(this.guildID)
+      .guilds(this.guildId)
       .templates(this.code)
       .delete()
       .then(() => this);
@@ -172,7 +172,7 @@ class GuildTemplate extends Base {
    */
   sync() {
     return this.client.api
-      .guilds(this.guildID)
+      .guilds(this.guildId)
       .templates(this.code)
       .put()
       .then(data => this._patch(data));
@@ -202,7 +202,7 @@ class GuildTemplate extends Base {
    * @readonly
    */
   get guild() {
-    return this.client.guilds.resolve(this.guildID);
+    return this.client.guilds.resolve(this.guildId);
   }
 
   /**

--- a/src/structures/Integration.js
+++ b/src/structures/Integration.js
@@ -90,7 +90,7 @@ class Integration extends Base {
    */
   get roles() {
     const roles = this.guild.roles.cache;
-    return roles.filter(role => role.tags?.integrationID === this.id);
+    return roles.filter(role => role.tags?.integrationId === this.id);
   }
 
   _patch(data) {
@@ -186,9 +186,9 @@ class Integration extends Base {
 
   toJSON() {
     return super.toJSON({
-      role: 'roleID',
-      guild: 'guildID',
-      user: 'userID',
+      role: 'roleId',
+      guild: 'guildId',
+      user: 'userId',
     });
   }
 }

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -13,19 +13,19 @@ class Interaction extends Base {
     super(client);
 
     /**
-     * The type of this interaction
+     * The interaction's type
      * @type {InteractionType}
      */
     this.type = InteractionTypes[data.type];
 
     /**
-     * The ID of this interaction
+     * The interaction's id
      * @type {Snowflake}
      */
     this.id = data.id;
 
     /**
-     * The token of this interaction
+     * The interaction's token
      * @type {string}
      * @name Interaction#token
      * @readonly
@@ -33,22 +33,22 @@ class Interaction extends Base {
     Object.defineProperty(this, 'token', { value: data.token });
 
     /**
-     * The ID of the application
+     * The application's id
      * @type {Snowflake}
      */
-    this.applicationID = data.application_id;
+    this.applicationId = data.application_id;
 
     /**
-     * The ID of the channel this interaction was sent in
+     * The id of the channel this interaction was sent in
      * @type {?Snowflake}
      */
-    this.channelID = data.channel_id ?? null;
+    this.channelId = data.channel_id ?? null;
 
     /**
-     * The ID of the guild this interaction was sent in
+     * The id of the guild this interaction was sent in
      * @type {?Snowflake}
      */
-    this.guildID = data.guild_id ?? null;
+    this.guildId = data.guild_id ?? null;
 
     /**
      * The user which sent this interaction
@@ -93,7 +93,7 @@ class Interaction extends Base {
    * @readonly
    */
   get channel() {
-    return this.client.channels.cache.get(this.channelID) ?? null;
+    return this.client.channels.cache.get(this.channelId) ?? null;
   }
 
   /**
@@ -102,7 +102,7 @@ class Interaction extends Base {
    * @readonly
    */
   get guild() {
-    return this.client.guilds.cache.get(this.guildID) ?? null;
+    return this.client.guilds.cache.get(this.guildId) ?? null;
   }
 
   /**
@@ -110,7 +110,7 @@ class Interaction extends Base {
    * @returns {boolean}
    */
   inGuild() {
-    return Boolean(this.guildID && this.member);
+    return Boolean(this.guildId && this.member);
   }
 
   /**

--- a/src/structures/InteractionCollector.js
+++ b/src/structures/InteractionCollector.js
@@ -128,8 +128,8 @@ class InteractionCollector extends Collector {
     if (this.interactionType && interaction.type !== this.interactionType) return null;
     if (this.componentType && interaction.componentType !== this.componentType) return null;
     if (this.message && interaction.message?.id !== this.message.id) return null;
-    if (this.channel && interaction.channelID !== this.channel.id) return null;
-    if (this.guild && interaction.guildID !== this.guild.id) return null;
+    if (this.channel && interaction.channelId !== this.channel.id) return null;
+    if (this.guild && interaction.guildId !== this.guild.id) return null;
 
     return interaction.id;
   }
@@ -148,8 +148,8 @@ class InteractionCollector extends Collector {
     if (this.type && interaction.type !== this.type) return null;
     if (this.componentType && interaction.componentType !== this.componentType) return null;
     if (this.message && interaction.message?.id !== this.message.id) return null;
-    if (this.channel && interaction.channelID !== this.channel.id) return null;
-    if (this.guild && interaction.guildID !== this.guild.id) return null;
+    if (this.channel && interaction.channelId !== this.channel.id) return null;
+    if (this.guild && interaction.guildId !== this.guild.id) return null;
 
     return interaction.id;
   }

--- a/src/structures/InteractionWebhook.js
+++ b/src/structures/InteractionWebhook.js
@@ -9,8 +9,8 @@ const Webhook = require('./Webhook');
 class InteractionWebhook {
   /**
    * @param {Client} client The instantiating client
-   * @param {Snowflake} id ID of the application
-   * @param {string} token Token of the interaction
+   * @param {Snowflake} id The application's id
+   * @param {string} token The interaction's token
    */
   constructor(client, id, token) {
     /**

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -211,9 +211,9 @@ class Invite extends Base {
       presenceCount: false,
       memberCount: false,
       uses: false,
-      channel: 'channelID',
-      inviter: 'inviterID',
-      guild: 'guildID',
+      channel: 'channelId',
+      inviter: 'inviterId',
+      guild: 'guildId',
     });
   }
 

--- a/src/structures/InviteStageInstance.js
+++ b/src/structures/InviteStageInstance.js
@@ -8,20 +8,20 @@ const Collection = require('../util/Collection');
  * @extends {Base}
  */
 class InviteStageInstance extends Base {
-  constructor(client, data, channelID, guildID) {
+  constructor(client, data, channelId, guildId) {
     super(client);
 
     /**
-     * The ID of the stage channel this invite is for
+     * The id of the stage channel this invite is for
      * @type {Snowflake}
      */
-    this.channelID = channelID;
+    this.channelId = channelId;
 
     /**
-     * The guild ID of the stage channel
+     * The stage channel's guild id
      * @type {Snowflake}
      */
-    this.guildID = guildID;
+    this.guildId = guildId;
 
     /**
      * The members speaking in the stage channel
@@ -64,7 +64,7 @@ class InviteStageInstance extends Base {
    * @readonly
    */
   get channel() {
-    return this.client.channels.resolve(this.channelID);
+    return this.client.channels.resolve(this.channelId);
   }
 
   /**
@@ -73,7 +73,7 @@ class InviteStageInstance extends Base {
    * @readonly
    */
   get guild() {
-    return this.client.guilds.resolve(this.guildID);
+    return this.client.guilds.resolve(this.guildId);
   }
 }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -49,7 +49,7 @@ class Message extends Base {
 
   _patch(data) {
     /**
-     * The ID of the message
+     * The message's id
      * @type {Snowflake}
      */
     this.id = data.id;
@@ -142,7 +142,7 @@ class Message extends Base {
     this.components = data.components?.map(c => BaseMessageComponent.create(c, this.client)) ?? [];
 
     /**
-     * A collection of attachments in the message - e.g. Pictures - mapped by their ID
+     * A collection of attachments in the message - e.g. Pictures - mapped by their ids
      * @type {Collection<Snowflake, MessageAttachment>}
      */
     this.attachments = new Collection();
@@ -200,10 +200,10 @@ class Message extends Base {
     );
 
     /**
-     * ID of the webhook that sent the message, if applicable
+     * The id of the webhook that sent the message, if applicable
      * @type {?Snowflake}
      */
-    this.webhookID = data.webhook_id ?? null;
+    this.webhookId = data.webhook_id ?? null;
 
     /**
      * Supplemental application information for group activities
@@ -212,10 +212,10 @@ class Message extends Base {
     this.groupActivityApplication = data.application ? new ClientApplication(this.client, data.application) : null;
 
     /**
-     * ID of the application of the interaction that sent this message, if any
+     * The id of the application of the interaction that sent this message, if any
      * @type {?Snowflake}
      */
-    this.applicationID = data.application_id ?? null;
+    this.applicationId = data.application_id ?? null;
 
     /**
      * Group activity
@@ -223,7 +223,7 @@ class Message extends Base {
      */
     this.activity = data.activity
       ? {
-          partyID: data.activity.party_id,
+          partyId: data.activity.party_id,
           type: data.activity.type,
         }
       : null;
@@ -241,11 +241,11 @@ class Message extends Base {
     this.flags = new MessageFlags(data.flags).freeze();
 
     /**
-     * Reference data sent in a message that contains IDs identifying the referenced message
+     * Reference data sent in a message that contains ids identifying the referenced message
      * @typedef {Object} MessageReference
-     * @property {string} channelID ID of the channel the message was referenced
-     * @property {?string} guildID ID of the guild the message was referenced
-     * @property {?string} messageID ID of the message that was referenced
+     * @property {string} channelId The channel's id the message was referenced
+     * @property {?string} guildId The guild's id the message was referenced
+     * @property {?string} messageId The message's id that was referenced
      */
 
     /**
@@ -254,9 +254,9 @@ class Message extends Base {
      */
     this.reference = data.message_reference
       ? {
-          channelID: data.message_reference.channel_id,
-          guildID: data.message_reference.guild_id,
-          messageID: data.message_reference.message_id,
+          channelId: data.message_reference.channel_id,
+          guildId: data.message_reference.guild_id,
+          messageId: data.message_reference.message_id,
         }
       : null;
 
@@ -267,7 +267,7 @@ class Message extends Base {
     /**
      * Partial data of the interaction that a message is a reply to
      * @typedef {Object} MessageInteraction
-     * @property {Snowflake} id The ID of the interaction
+     * @property {Snowflake} id The interaction's id
      * @property {InteractionType} type The type of the interaction
      * @property {string} commandName The name of the interaction's application command
      * @property {User} user The user that invoked the interaction
@@ -402,7 +402,7 @@ class Message extends Base {
    * @returns {ReactionCollector}
    * @example
    * // Create a reaction collector
-   * const filter = (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someID';
+   * const filter = (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someId';
    * const collector = message.createReactionCollector({ filter, time: 15000 });
    * collector.on('collect', r => console.log(`Collected ${r.emoji.name}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
@@ -424,7 +424,7 @@ class Message extends Base {
    * @returns {Promise<Collection<string, MessageReaction>>}
    * @example
    * // Create a reaction collector
-   * const filter = (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someID'
+   * const filter = (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someId'
    * message.awaitReactions({ filter, time: 15000 })
    *   .then(collected => console.log(`Collected ${collected.size} reactions`))
    *   .catch(console.error);
@@ -453,9 +453,9 @@ class Message extends Base {
    * @returns {InteractionCollector}
    * @example
    * // Create a message component interaction collector
-   * const filter = (interaction) => interaction.customID === 'button' && interaction.user.id === 'someID';
+   * const filter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
    * const collector = message.createMessageComponentCollector({ filter, time: 15000 });
-   * collector.on('collect', i => console.log(`Collected ${i.customID}`));
+   * collector.on('collect', i => console.log(`Collected ${i.customId}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
   createMessageComponentCollector(options = {}) {
@@ -481,9 +481,9 @@ class Message extends Base {
    * @returns {Promise<MessageComponentInteraction>}
    * @example
    * // Collect a message component interaction
-   * const filter = (interaction) => interaction.customID === 'button' && interaction.user.id === 'someID';
+   * const filter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
    * message.awaitMessageComponent({ filter, time: 15000 })
-   *   .then(interaction => console.log(`${interaction.customID} was clicked!`))
+   *   .then(interaction => console.log(`${interaction.customId} was clicked!`))
    *   .catch(console.error);
    */
   awaitMessageComponent(options = {}) {
@@ -538,10 +538,10 @@ class Message extends Base {
    */
   async fetchReference() {
     if (!this.reference) throw new Error('MESSAGE_REFERENCE_MISSING');
-    const { channelID, messageID } = this.reference;
-    const channel = this.client.channels.resolve(channelID);
+    const { channelId, messageId } = this.reference;
+    const channel = this.client.channels.resolve(channelId);
     if (!channel) throw new Error('GUILD_CHANNEL_RESOLVE');
-    const message = await channel.messages.fetch(messageID);
+    const message = await channel.messages.fetch(messageId);
     return message;
   }
 
@@ -733,8 +733,8 @@ class Message extends Base {
    * @returns {Promise<?Webhook>}
    */
   fetchWebhook() {
-    if (!this.webhookID) return Promise.reject(new Error('WEBHOOK_MESSAGE'));
-    return this.client.fetchWebhook(this.webhookID);
+    if (!this.webhookId) return Promise.reject(new Error('WEBHOOK_MESSAGE'));
+    return this.client.fetchWebhook(this.webhookId);
   }
 
   /**
@@ -807,10 +807,10 @@ class Message extends Base {
 
   toJSON() {
     return super.toJSON({
-      channel: 'channelID',
-      author: 'authorID',
-      groupActivityApplication: 'groupActivityApplicationID',
-      guild: 'guildID',
+      channel: 'channelId',
+      author: 'authorId',
+      groupActivityApplication: 'groupActivityApplicationId',
+      guild: 'guildId',
       cleanContent: true,
       member: false,
       reactions: false,

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -45,7 +45,7 @@ class MessageAttachment {
 
   _patch(data) {
     /**
-     * The ID of this attachment
+     * The attachment's id
      * @type {Snowflake}
      */
     this.id = data.id;

--- a/src/structures/MessageButton.js
+++ b/src/structures/MessageButton.js
@@ -13,7 +13,7 @@ class MessageButton extends BaseMessageComponent {
   /**
    * @typedef {BaseMessageComponentOptions} MessageButtonOptions
    * @property {string} [label] The text to be displayed on this button
-   * @property {string} [customID] A unique string to be sent in the interaction when clicked
+   * @property {string} [customId] A unique string to be sent in the interaction when clicked
    * @property {MessageButtonStyleResolvable} [style] The style of this button
    * @property {EmojiIdentifierResolvable} [emoji] The emoji to be displayed to the left of the text
    * @property {string} [url] Optional URL for link-style buttons
@@ -40,7 +40,7 @@ class MessageButton extends BaseMessageComponent {
      * A unique string to be sent in the interaction when clicked
      * @type {?string}
      */
-    this.customID = data.custom_id ?? data.customID ?? null;
+    this.customId = data.custom_id ?? data.customId ?? null;
 
     /**
      * The style of this button
@@ -68,12 +68,12 @@ class MessageButton extends BaseMessageComponent {
   }
 
   /**
-   * Sets the custom ID of this button
-   * @param {string} customID A unique string to be sent in the interaction when clicked
+   * Sets the custom id for this button
+   * @param {string} customId A unique string to be sent in the interaction when clicked
    * @returns {MessageButton}
    */
-  setCustomID(customID) {
-    this.customID = Util.verifyString(customID, RangeError, 'BUTTON_CUSTOM_ID');
+  setCustomId(customId) {
+    this.customId = Util.verifyString(customId, RangeError, 'BUTTON_CUSTOM_ID');
     return this;
   }
 
@@ -134,7 +134,7 @@ class MessageButton extends BaseMessageComponent {
    */
   toJSON() {
     return {
-      custom_id: this.customID,
+      custom_id: this.customId,
       disabled: this.disabled,
       emoji: this.emoji,
       label: this.label,

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -21,10 +21,10 @@ class MessageComponentInteraction extends Interaction {
     this.message = this.channel?.messages.add(data.message) ?? data.message;
 
     /**
-     * The custom ID of the component which was interacted with
+     * The custom id of the component which was interacted with
      * @type {string}
      */
-    this.customID = data.data.custom_id;
+    this.customId = data.data.custom_id;
 
     /**
      * The type of component which was interacted with
@@ -54,7 +54,7 @@ class MessageComponentInteraction extends Interaction {
      * An associated interaction webhook, can be used to further interact with this interaction
      * @type {InteractionWebhook}
      */
-    this.webhook = new InteractionWebhook(this.client, this.applicationID, this.token);
+    this.webhook = new InteractionWebhook(this.client, this.applicationId, this.token);
   }
 
   /**
@@ -73,7 +73,7 @@ class MessageComponentInteraction extends Interaction {
     return (
       this.message.components
         .flatMap(row => row.components)
-        .find(component => (component.customID ?? component.custom_id) === this.customID) ?? null
+        .find(component => (component.customId ?? component.custom_id) === this.customId) ?? null
     );
   }
 

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -95,10 +95,10 @@ class MessageMentions {
     /**
      * Crossposted channel data.
      * @typedef {Object} CrosspostedChannel
-     * @property {string} channelID ID of the mentioned channel
-     * @property {string} guildID ID of the guild that has the channel
-     * @property {string} type Type of the channel
-     * @property {string} name The name of the channel
+     * @property {string} channelId The mentioned channel's id
+     * @property {string} guildId The id of the guild that has the channel
+     * @property {string} type The channel's type
+     * @property {string} name The channel's name
      */
 
     if (crosspostedChannels) {
@@ -115,8 +115,8 @@ class MessageMentions {
         for (const d of crosspostedChannels) {
           const type = channelTypes[d.type];
           this.crosspostedChannels.set(d.id, {
-            channelID: d.id,
-            guildID: d.guild_id,
+            channelId: d.id,
+            guildId: d.guild_id,
             type: type?.toLowerCase() ?? 'unknown',
             name: d.name,
           });
@@ -191,7 +191,7 @@ class MessageMentions {
 
     if (!ignoreDirect) {
       const id =
-        this.guild?.roles.resolveID(data) ?? this.client.channels.resolveID(data) ?? this.client.users.resolveID(data);
+        this.guild?.roles.resolveId(data) ?? this.client.channels.resolveId(data) ?? this.client.users.resolveId(data);
 
       return typeof id === 'string' && (this.users.has(id) || this.channels.has(id) || this.roles.has(id));
     }

--- a/src/structures/MessagePayload.js
+++ b/src/structures/MessagePayload.js
@@ -173,8 +173,8 @@ class MessagePayload {
     let message_reference;
     if (typeof this.options.reply === 'object') {
       const message_id = this.isMessage
-        ? this.target.channel.messages.resolveID(this.options.reply.messageReference)
-        : this.target.messages.resolveID(this.options.reply.messageReference);
+        ? this.target.channel.messages.resolveId(this.options.reply.messageReference)
+        : this.target.messages.resolveId(this.options.reply.messageReference);
       if (message_id) {
         message_reference = {
           message_id,

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -113,7 +113,7 @@ class MessageReaction {
   }
 
   toJSON() {
-    return Util.flatten(this, { emoji: 'emojiID', message: 'messageID' });
+    return Util.flatten(this, { emoji: 'emojiId', message: 'messageId' });
   }
 
   _add(user) {

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -11,7 +11,7 @@ const Util = require('../util/Util');
 class MessageSelectMenu extends BaseMessageComponent {
   /**
    * @typedef {BaseMessageComponentOptions} MessageSelectMenuOptions
-   * @property {string} [customID] A unique string to be sent in the interaction when clicked
+   * @property {string} [customId] A unique string to be sent in the interaction when clicked
    * @property {string} [placeholder] Custom placeholder text to display when nothing is selected
    * @property {number} [minValues] The minimum number of selections required
    * @property {number} [maxValues] The maximum number of selections allowed
@@ -51,7 +51,7 @@ class MessageSelectMenu extends BaseMessageComponent {
      * A unique string to be sent in the interaction when clicked
      * @type {?string}
      */
-    this.customID = data.custom_id ?? data.customID ?? null;
+    this.customId = data.custom_id ?? data.customId ?? null;
 
     /**
      * Custom placeholder text to display when nothing is selected
@@ -85,12 +85,12 @@ class MessageSelectMenu extends BaseMessageComponent {
   }
 
   /**
-   * Sets the custom ID of this select menu
-   * @param {string} customID A unique string to be sent in the interaction when clicked
+   * Sets the custom id of this select menu
+   * @param {string} customId A unique string to be sent in the interaction when clicked
    * @returns {MessageSelectMenu}
    */
-  setCustomID(customID) {
-    this.customID = Util.verifyString(customID, RangeError, 'SELECT_MENU_CUSTOM_ID');
+  setCustomId(customId) {
+    this.customId = Util.verifyString(customId, RangeError, 'SELECT_MENU_CUSTOM_ID');
     return this;
   }
 
@@ -163,7 +163,7 @@ class MessageSelectMenu extends BaseMessageComponent {
    */
   toJSON() {
     return {
-      custom_id: this.customID,
+      custom_id: this.customId,
       disabled: this.disabled,
       placeholder: this.placeholder,
       min_values: this.minValues,

--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -28,9 +28,9 @@ class NewsChannel extends TextChannel {
    * }
    */
   async addFollower(channel, reason) {
-    const channelID = this.guild.channels.resolveID(channel);
-    if (!channelID) throw new Error('GUILD_CHANNEL_RESOLVE');
-    await this.client.api.channels(this.id).followers.post({ data: { webhook_channel_id: channelID }, reason });
+    const channelId = this.guild.channels.resolveId(channel);
+    if (!channelId) throw new Error('GUILD_CHANNEL_RESOLVE');
+    await this.client.api.channels(this.id).followers.post({ data: { webhook_channel_id: channelId }, reason });
     return this;
   }
 }

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -27,7 +27,7 @@ class PermissionOverwrites extends Base {
 
   _patch(data) {
     /**
-     * The ID of this overwrite, either a user ID or a role ID
+     * The overwrite's id, either a {@link User} or a {@link Role} id
      * @type {Snowflake}
      */
     this.id = data.id;

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -8,7 +8,7 @@ const Util = require('../util/Util');
 /**
  * Activity sent in a message.
  * @typedef {Object} MessageActivity
- * @property {string} [partyID] Id of the party represented in activity
+ * @property {string} [partyId] Id of the party represented in activity
  * @property {number} [type] Type of activity sent
  */
 
@@ -46,13 +46,13 @@ class Presence {
      */
     Object.defineProperty(this, 'client', { value: client });
     /**
-     * The user ID of this presence
+     * The presence's user id
      * @type {Snowflake}
      */
-    this.userID = data.user.id;
+    this.userId = data.user.id;
 
     /**
-     * The guild of this presence
+     * The guild this presence is in
      * @type {?Guild}
      */
     this.guild = data.guild ?? null;
@@ -66,7 +66,7 @@ class Presence {
    * @readonly
    */
   get user() {
-    return this.client.users.resolve(this.userID);
+    return this.client.users.resolve(this.userId);
   }
 
   /**
@@ -75,7 +75,7 @@ class Presence {
    * @readonly
    */
   get member() {
-    return this.guild.members.resolve(this.userID);
+    return this.guild.members.resolve(this.userId);
   }
 
   patch(data) {
@@ -148,19 +148,19 @@ class Activity {
     Object.defineProperty(this, 'presence', { value: presence });
 
     /**
-     * The ID of the activity
+     * The activity's id
      * @type {string}
      */
     this.id = data.id;
 
     /**
-     * The name of the activity
+     * The activity's name
      * @type {string}
      */
     this.name = data.name;
 
     /**
-     * The type of the activity status
+     * The activity status's type
      * @type {ActivityType}
      */
     this.type = typeof data.type === 'number' ? ActivityTypes[data.type] : data.type;
@@ -184,10 +184,10 @@ class Activity {
     this.state = data.state ?? null;
 
     /**
-     * Application ID associated with this activity
+     * The id of the application associated with this activity
      * @type {?Snowflake}
      */
-    this.applicationID = data.application_id ?? null;
+    this.applicationId = data.application_id ?? null;
 
     /**
      * Timestamps for the activity
@@ -203,10 +203,10 @@ class Activity {
       : null;
 
     /**
-     * The ID of the song on Spotify
+     * The Spotify song's id
      * @type {?string}
      */
-    this.syncID = data.sync_id ?? null;
+    this.syncId = data.sync_id ?? null;
 
     /**
      * The platform the game is being played on
@@ -217,7 +217,7 @@ class Activity {
     /**
      * Party of the activity
      * @type {?Object}
-     * @property {?string} id ID of the party
+     * @property {?string} id The party's id
      * @property {number[]} size Size of the party as `[current, max]`
      */
     this.party = data.party ?? null;
@@ -241,10 +241,10 @@ class Activity {
     this.emoji = data.emoji ? new Emoji(presence.client, data.emoji) : null;
 
     /**
-     * The ID of the game or Spotify session
+     * The game's or Spotify session's id
      * @type {?string}
      */
-    this.sessionID = data.session_id ?? null;
+    this.sessionId = data.session_id ?? null;
 
     /**
      * The labels of the buttons of this rich presence
@@ -318,13 +318,13 @@ class RichPresenceAssets {
     this.smallText = assets.small_text ?? null;
 
     /**
-     * ID of the large image asset
+     * The large image asset's id
      * @type {?Snowflake}
      */
     this.largeImage = assets.large_image ?? null;
 
     /**
-     * ID of the small image asset
+     * The small image asset's id
      * @type {?Snowflake}
      */
     this.smallImage = assets.small_image ?? null;
@@ -338,7 +338,7 @@ class RichPresenceAssets {
   smallImageURL({ format, size } = {}) {
     return (
       this.smallImage &&
-      this.activity.presence.client.rest.cdn.AppAsset(this.activity.applicationID, this.smallImage, {
+      this.activity.presence.client.rest.cdn.AppAsset(this.activity.applicationId, this.smallImage, {
         format,
         size,
       })
@@ -357,7 +357,7 @@ class RichPresenceAssets {
     } else if (/^twitch:/.test(this.largeImage)) {
       return `https://static-cdn.jtvnw.net/previews-ttv/live_user_${this.largeImage.slice(7)}.png`;
     }
-    return this.activity.presence.client.rest.cdn.AppAsset(this.activity.applicationID, this.largeImage, {
+    return this.activity.presence.client.rest.cdn.AppAsset(this.activity.applicationId, this.largeImage, {
       format,
       size,
     });

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -30,7 +30,7 @@ class Role extends Base {
 
   _patch(data) {
     /**
-     * The ID of the role (unique to the guild it is part of)
+     * The role's id (unique to the guild it is part of)
      * @type {Snowflake}
      */
     this.id = data.id;
@@ -86,17 +86,17 @@ class Role extends Base {
     /**
      * The tags this role has
      * @type {?Object}
-     * @property {Snowflake} [botID] The id of the bot this role belongs to
-     * @property {Snowflake} [integrationID] The id of the integration this role belongs to
+     * @property {Snowflake} [botId] The id of the bot this role belongs to
+     * @property {Snowflake} [integrationId] The id of the integration this role belongs to
      * @property {true} [premiumSubscriberRole] Whether this is the guild's premium subscription role
      */
     this.tags = data.tags ? {} : null;
     if (data.tags) {
       if ('bot_id' in data.tags) {
-        this.tags.botID = data.tags.bot_id;
+        this.tags.botId = data.tags.bot_id;
       }
       if ('integration_id' in data.tags) {
-        this.tags.integrationID = data.tags.integration_id;
+        this.tags.integrationId = data.tags.integration_id;
       }
       if ('premium_subscriber' in data.tags) {
         this.tags.premiumSubscriberRole = true;

--- a/src/structures/StageChannel.js
+++ b/src/structures/StageChannel.js
@@ -25,7 +25,7 @@ class StageChannel extends BaseGuildVoiceChannel {
    * @readonly
    */
   get stageInstance() {
-    return this.guild.stageInstances.cache.find(stageInstance => stageInstance.channelID === this.id) ?? null;
+    return this.guild.stageInstances.cache.find(stageInstance => stageInstance.channelId === this.id) ?? null;
   }
 
   /**

--- a/src/structures/StageInstance.js
+++ b/src/structures/StageInstance.js
@@ -13,7 +13,7 @@ class StageInstance extends Base {
     super(client);
 
     /**
-     * The ID of this stage instance
+     * The stage instance's id
      * @type {Snowflake}
      */
     this.id = data.id;
@@ -29,16 +29,16 @@ class StageInstance extends Base {
 
   _patch(data) {
     /**
-     * The guild ID of the associated stage channel
+     * The id of the guild associated with the stage channel
      * @type {Snowflake}
      */
-    this.guildID = data.guild_id;
+    this.guildId = data.guild_id;
 
     /**
-     * The ID of the associated stage channel
+     * The id of the channel associated with the stage channel
      * @type {Snowflake}
      */
-    this.channelID = data.channel_id;
+    this.channelId = data.channel_id;
 
     /**
      * The topic of the stage instance
@@ -65,7 +65,7 @@ class StageInstance extends Base {
    * @readonly
    */
   get channel() {
-    return this.client.channels.resolve(this.channelID);
+    return this.client.channels.resolve(this.channelId);
   }
 
   /**
@@ -74,7 +74,7 @@ class StageInstance extends Base {
    * @readonly
    */
   get guild() {
-    return this.client.guilds.resolve(this.guildID);
+    return this.client.guilds.resolve(this.guildId);
   }
 
   /**
@@ -88,7 +88,7 @@ class StageInstance extends Base {
    *  .catch(console.error)
    */
   edit(options) {
-    return this.guild.stageInstances.edit(this.channelID, options);
+    return this.guild.stageInstances.edit(this.channelId, options);
   }
 
   /**
@@ -101,7 +101,7 @@ class StageInstance extends Base {
    *  .catch(console.error);
    */
   async delete() {
-    await this.guild.stageInstances.delete(this.channelID);
+    await this.guild.stageInstances.delete(this.channelId);
     const clone = this._clone();
     clone.deleted = true;
     return clone;
@@ -118,7 +118,7 @@ class StageInstance extends Base {
    *  .catch(console.error);
    */
   setTopic(topic) {
-    return this.guild.stageInstances.edit(this.channelID, { topic });
+    return this.guild.stageInstances.edit(this.channelId, { topic });
   }
 
   /**

--- a/src/structures/Sticker.js
+++ b/src/structures/Sticker.js
@@ -12,13 +12,13 @@ class Sticker extends Base {
   constructor(client, sticker) {
     super(client);
     /**
-     * The ID of the sticker
+     * The sticker's id
      * @type {Snowflake}
      */
     this.id = sticker.id;
 
     /**
-     * The ID of the sticker's image
+     * The sticker image's id
      * @type {string}
      */
     this.asset = sticker.asset;
@@ -42,10 +42,10 @@ class Sticker extends Base {
     this.name = sticker.name;
 
     /**
-     * The ID of the pack the sticker is from
+     * The id of the pack the sticker is from
      * @type {Snowflake}
      */
-    this.packID = sticker.pack_id;
+    this.packId = sticker.pack_id;
 
     /**
      * An array of tags for the sticker, if any

--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -17,7 +17,7 @@ class Team extends Base {
 
   _patch(data) {
     /**
-     * The ID of the Team
+     * The Team's id
      * @type {Snowflake}
      */
     this.id = data.id;
@@ -38,7 +38,7 @@ class Team extends Base {
      * The Team's owner id
      * @type {?string}
      */
-    this.ownerID = data.owner_user_id ?? null;
+    this.ownerId = data.owner_user_id ?? null;
 
     /**
      * The Team's members
@@ -58,7 +58,7 @@ class Team extends Base {
    * @readonly
    */
   get owner() {
-    return this.members.get(this.ownerID) ?? null;
+    return this.members.get(this.ownerId) ?? null;
   }
 
   /**

--- a/src/structures/TeamMember.js
+++ b/src/structures/TeamMember.js
@@ -41,7 +41,7 @@ class TeamMember extends Base {
   }
 
   /**
-   * The ID of the Team Member
+   * The Team Member's id
    * @type {Snowflake}
    * @readonly
    */

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -57,10 +57,10 @@ class TextChannel extends GuildChannel {
 
     if ('last_message_id' in data) {
       /**
-       * The ID of the last message sent in this channel, if one was sent
+       * The last message id sent in the channel, if one was sent
        * @type {?Snowflake}
        */
-      this.lastMessageID = data.last_message_id;
+      this.lastMessageId = data.last_message_id;
     }
 
     if ('rate_limit_per_user' in data) {

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -52,10 +52,10 @@ class ThreadChannel extends Channel {
 
     if ('parent_id' in data) {
       /**
-       * The ID of the parent channel of this thread
+       * The id of the parent channel of this thread
        * @type {Snowflake}
        */
-      this.parentID = data.parent_id;
+      this.parentId = data.parent_id;
     }
 
     if ('thread_metadata' in data) {
@@ -91,15 +91,15 @@ class ThreadChannel extends Channel {
        * The id of the member who created this thread
        * @type {?Snowflake}
        */
-      this.ownerID = data.owner_id;
+      this.ownerId = data.owner_id;
     }
 
     if ('last_message_id' in data) {
       /**
-       * The ID of the last message sent in this thread, if one was sent
+       * The last message id sent in this thread, if one was sent
        * @type {?Snowflake}
        */
-      this.lastMessageID = data.last_message_id;
+      this.lastMessageId = data.last_message_id;
     }
 
     if ('last_pin_timestamp' in data) {
@@ -167,7 +167,7 @@ class ThreadChannel extends Channel {
    * @readonly
    */
   get parent() {
-    return this.guild.channels.resolve(this.parentID);
+    return this.guild.channels.resolve(this.parentId);
   }
 
   /**
@@ -321,7 +321,7 @@ class ThreadChannel extends Channel {
    * @readonly
    */
   get editable() {
-    return (this.ownerID === this.client.user.id && (this.type !== 'private_thread' || this.joined)) || this.manageable;
+    return (this.ownerId === this.client.user.id && (this.type !== 'private_thread' || this.joined)) || this.manageable;
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -21,7 +21,7 @@ class User extends Base {
     super(client);
 
     /**
-     * The ID of the user
+     * The user's id
      * @type {Snowflake}
      */
     this.id = data.id;
@@ -33,16 +33,16 @@ class User extends Base {
     this.flags = null;
 
     /**
-     * The ID of the last message sent by the user, if one was sent
+     * The user's last message id, if one was sent
      * @type {?Snowflake}
      */
-    this.lastMessageID = null;
+    this.lastMessageId = null;
 
     /**
-     * The ID of the channel for the last message sent by the user, if one was sent
+     * The channel in which the last message was sent by the user, if one was sent
      * @type {?Snowflake}
      */
-    this.lastMessageChannelID = null;
+    this.lastMessageChannelId = null;
 
     this._patch(data);
   }
@@ -80,7 +80,7 @@ class User extends Base {
 
     if ('avatar' in data) {
       /**
-       * The ID of the user's avatar
+       * The user avatar's hash
        * @type {?string}
        */
       this.avatar = data.avatar;
@@ -140,7 +140,7 @@ class User extends Base {
    * @readonly
    */
   get lastMessage() {
-    return this.client.channels.resolve(this.lastMessageChannelID)?.messages.resolve(this.lastMessageID) ?? null;
+    return this.client.channels.resolve(this.lastMessageChannelId)?.messages.resolve(this.lastMessageId) ?? null;
   }
 
   /**
@@ -262,7 +262,7 @@ class User extends Base {
   }
 
   /**
-   * Checks if the user is equal to another. It compares ID, username, discriminator, avatar, and bot flags.
+   * Checks if the user is equal to another. It compares id, username, discriminator, avatar, and bot flags.
    * It is recommended to compare equality by using `user.id === user2.id` unless you want to compare all properties.
    * @param {User} user User to compare with
    * @returns {boolean}
@@ -317,7 +317,7 @@ class User extends Base {
         defaultAvatarURL: true,
         tag: true,
         lastMessage: false,
-        lastMessageID: false,
+        lastMessageId: false,
       },
       ...props,
     );

--- a/src/structures/VoiceRegion.js
+++ b/src/structures/VoiceRegion.js
@@ -8,7 +8,7 @@ const Util = require('../util/Util');
 class VoiceRegion {
   constructor(data) {
     /**
-     * The ID of the region
+     * The region's id
      * @type {string}
      */
     this.id = data.id;

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -19,7 +19,7 @@ class VoiceState extends Base {
      */
     this.guild = guild;
     /**
-     * The ID of the member of this voice state
+     * The id of the member of this voice state
      * @type {Snowflake}
      */
     this.id = data.user_id;
@@ -53,20 +53,20 @@ class VoiceState extends Base {
      */
     this.selfVideo = data.self_video ?? null;
     /**
-     * The session ID of this member's connection
+     * The session id for this member's connection
      * @type {?string}
      */
-    this.sessionID = data.session_id ?? null;
+    this.sessionId = data.session_id ?? null;
     /**
      * Whether this member is streaming using "Go Live"
      * @type {boolean}
      */
     this.streaming = data.self_stream ?? false;
     /**
-     * The ID of the voice or stage channel that this member is in
+     * The {@link VoiceChannel} or {@link StageChannel} id the member is in
      * @type {?Snowflake}
      */
-    this.channelID = data.channel_id ?? null;
+    this.channelId = data.channel_id ?? null;
     /**
      * Whether this member is suppressed from speaking. This property is specific to stage channels only.
      * @type {boolean}
@@ -97,7 +97,7 @@ class VoiceState extends Base {
    * @readonly
    */
   get channel() {
-    return this.guild.channels.cache.get(this.channelID) ?? null;
+    return this.guild.channels.cache.get(this.channelId) ?? null;
   }
 
   /**
@@ -177,7 +177,7 @@ class VoiceState extends Base {
 
     await this.client.api.guilds(this.guild.id, 'voice-states', '@me').patch({
       data: {
-        channel_id: this.channelID,
+        channel_id: this.channelId,
         request_to_speak_timestamp: request ? new Date().toISOString() : null,
       },
     });
@@ -209,7 +209,7 @@ class VoiceState extends Base {
 
     await this.client.api.guilds(this.guild.id, 'voice-states', target).patch({
       data: {
-        channel_id: this.channelID,
+        channel_id: this.channelId,
         suppress: suppressed,
       },
     });
@@ -222,8 +222,8 @@ class VoiceState extends Base {
       serverMute: true,
       selfDeaf: true,
       selfMute: true,
-      sessionID: true,
-      channelID: 'channel',
+      sessionId: true,
+      channelId: 'channel',
     });
   }
 }

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -43,7 +43,7 @@ class Webhook {
     this.avatar = data.avatar;
 
     /**
-     * The ID of the webhook
+     * The webhook's id
      * @type {Snowflake}
      */
     this.id = data.id;
@@ -58,13 +58,13 @@ class Webhook {
      * The guild the webhook belongs to
      * @type {Snowflake}
      */
-    this.guildID = data.guild_id;
+    this.guildId = data.guild_id;
 
     /**
      * The channel the webhook belongs to
      * @type {Snowflake}
      */
-    this.channelID = data.channel_id;
+    this.channelId = data.channel_id;
 
     /**
      * The owner of the webhook
@@ -92,7 +92,7 @@ class Webhook {
    * @typedef {BaseMessageOptions} WebhookMessageOptions
    * @property {string} [username=this.name] Username override for the message
    * @property {string} [avatarURL] Avatar URL override for the message
-   * @property {Snowflake} [threadID] The id of the thread in the channel to send to.
+   * @property {Snowflake} [threadId] The id of the thread in the channel to send to.
    * <info>For interaction webhooks, this property is ignored</info>
    */
 
@@ -118,7 +118,7 @@ class Webhook {
    *   .catch(console.error);
    * @example
    * // Send a basic message in a thread
-   * webhook.send({ content: 'hello!', threadID: '836856309672348295' })
+   * webhook.send({ content: 'hello!', threadId: '836856309672348295' })
    *   .then(message => console.log(`Sent message: ${message.content}`))
    *   .catch(console.error);
    * @example
@@ -172,7 +172,7 @@ class Webhook {
       .post({
         data,
         files,
-        query: { thread_id: messagePayload.options.threadID, wait: true },
+        query: { thread_id: messagePayload.options.threadId, wait: true },
         auth: false,
       })
       .then(d => this.client.channels?.cache.get(d.channel_id)?.messages.add(d, false) ?? d);
@@ -235,13 +235,13 @@ class Webhook {
 
     this.name = data.name;
     this.avatar = data.avatar;
-    this.channelID = data.channel_id;
+    this.channelId = data.channel_id;
     return this;
   }
 
   /**
    * Gets a message that was sent by this webhook.
-   * @param {Snowflake|'@original'} message The ID of the message to fetch
+   * @param {Snowflake|'@original'} message The id of the message to fetch
    * @param {boolean} [cache=true] Whether to cache the message
    * @returns {Promise<Message|APIMessage>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned

--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -37,7 +37,7 @@ class WelcomeChannel extends Base {
      * The id of this welcome channel
      * @type {Snowflake}
      */
-    this.channelID = data.channel_id;
+    this.channelId = data.channel_id;
   }
 
   /**
@@ -45,7 +45,7 @@ class WelcomeChannel extends Base {
    * @type {?(TextChannel|NewsChannel)}
    */
   get channel() {
-    return this.client.channels.resolve(this.channelID);
+    return this.client.channels.resolve(this.channelId);
   }
 
   /**

--- a/src/structures/WelcomeScreen.js
+++ b/src/structures/WelcomeScreen.js
@@ -32,7 +32,7 @@ class WelcomeScreen extends Base {
 
     for (const channel of data.welcome_channels) {
       const welcomeChannel = new WelcomeChannel(this.guild, channel);
-      this.welcomeChannels.set(welcomeChannel.channelID, welcomeChannel);
+      this.welcomeChannels.set(welcomeChannel.channelId, welcomeChannel);
     }
   }
 

--- a/src/structures/WidgetMember.js
+++ b/src/structures/WidgetMember.js
@@ -83,7 +83,7 @@ class WidgetMember extends Base {
      * The id of the voice channel the member is in, if any
      * @type {?Snowflake}
      */
-    this.channelID = data.channel_id;
+    this.channelId = data.channel_id;
 
     /**
      * The avatar URL of the member.

--- a/src/structures/interfaces/Application.js
+++ b/src/structures/interfaces/Application.js
@@ -18,7 +18,7 @@ class Application extends Base {
 
   _patch(data) {
     /**
-     * The ID of the application
+     * The application's id
      * @type {Snowflake}
      */
     this.id = data.id;
@@ -83,9 +83,9 @@ class Application extends Base {
   /**
    * Asset data.
    * @typedef {Object} ApplicationAsset
-   * @property {Snowflake} id The asset ID
-   * @property {string} name The asset name
-   * @property {string} type The asset type
+   * @property {Snowflake} id The asset's id
+   * @property {string} name The asset's name
+   * @property {string} type The asset's type
    */
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -22,10 +22,10 @@ class TextBasedChannel {
     this.messages = new MessageManager(this);
 
     /**
-     * The ID of the last message in the channel, if one was sent
+     * The channel's last message id, if one was sent
      * @type {?Snowflake}
      */
-    this.lastMessageID = null;
+    this.lastMessageId = null;
 
     /**
      * The timestamp when the last pinned message was pinned, if there was one
@@ -40,7 +40,7 @@ class TextBasedChannel {
    * @readonly
    */
   get lastMessage() {
-    return this.messages.resolve(this.lastMessageID);
+    return this.messages.resolve(this.lastMessageId);
   }
 
   /**
@@ -309,9 +309,9 @@ class TextBasedChannel {
    * @returns {InteractionCollector}
    * @example
    * // Create a button interaction collector
-   * const filter = (interaction) => interaction.customID === 'button' && interaction.user.id === 'someID';
+   * const filter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
    * const collector = channel.createMessageComponentCollector({ filter, time: 15000 });
-   * collector.on('collect', i => console.log(`Collected ${i.customID}`));
+   * collector.on('collect', i => console.log(`Collected ${i.customId}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
   createMessageComponentCollector(options = {}) {
@@ -329,9 +329,9 @@ class TextBasedChannel {
    * @returns {Promise<MessageComponentInteraction>}
    * @example
    * // Collect a message component interaction
-   * const filter = (interaction) => interaction.customID === 'button' && interaction.user.id === 'someID';
+   * const filter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
    * channel.awaitMessageComponent({ filter, time: 15000 })
-   *   .then(interaction => console.log(`${interaction.customID} was clicked!`))
+   *   .then(interaction => console.log(`${interaction.customId} was clicked!`))
    *   .catch(console.error);
    */
   awaitMessageComponent(options = {}) {
@@ -360,23 +360,23 @@ class TextBasedChannel {
    */
   async bulkDelete(messages, filterOld = false) {
     if (Array.isArray(messages) || messages instanceof Collection) {
-      let messageIDs = messages instanceof Collection ? messages.keyArray() : messages.map(m => m.id ?? m);
+      let messageIds = messages instanceof Collection ? messages.keyArray() : messages.map(m => m.id ?? m);
       if (filterOld) {
-        messageIDs = messageIDs.filter(id => Date.now() - SnowflakeUtil.deconstruct(id).timestamp < 1209600000);
+        messageIds = messageIds.filter(id => Date.now() - SnowflakeUtil.deconstruct(id).timestamp < 1209600000);
       }
-      if (messageIDs.length === 0) return new Collection();
-      if (messageIDs.length === 1) {
-        await this.client.api.channels(this.id).messages(messageIDs[0]).delete();
+      if (messageIds.length === 0) return new Collection();
+      if (messageIds.length === 1) {
+        await this.client.api.channels(this.id).messages(messageIds[0]).delete();
         const message = this.client.actions.MessageDelete.getMessage(
           {
-            message_id: messageIDs[0],
+            message_id: messageIds[0],
           },
           this,
         );
         return message ? new Collection([[message.id, message]]) : new Collection();
       }
-      await this.client.api.channels[this.id].messages['bulk-delete'].post({ data: { messages: messageIDs } });
-      return messageIDs.reduce(
+      await this.client.api.channels[this.id].messages['bulk-delete'].post({ data: { messages: messageIds } });
+      return messageIds.reduce(
         (col, id) =>
           col.set(
             id,

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -42,31 +42,31 @@ function makeImageUrl(root, { format = 'webp', size } = {}) {
 exports.Endpoints = {
   CDN(root) {
     return {
-      Emoji: (emojiID, format = 'png') => `${root}/emojis/${emojiID}.${format}`,
+      Emoji: (emojiId, format = 'png') => `${root}/emojis/${emojiId}.${format}`,
       Asset: name => `${root}/assets/${name}`,
       DefaultAvatar: discriminator => `${root}/embed/avatars/${discriminator}.png`,
-      Avatar: (userID, hash, format = 'webp', size, dynamic = false) => {
+      Avatar: (userId, hash, format = 'webp', size, dynamic = false) => {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
-        return makeImageUrl(`${root}/avatars/${userID}/${hash}`, { format, size });
+        return makeImageUrl(`${root}/avatars/${userId}/${hash}`, { format, size });
       },
-      Banner: (guildID, hash, format = 'webp', size) =>
-        makeImageUrl(`${root}/banners/${guildID}/${hash}`, { format, size }),
-      Icon: (guildID, hash, format = 'webp', size, dynamic = false) => {
+      Banner: (guildId, hash, format = 'webp', size) =>
+        makeImageUrl(`${root}/banners/${guildId}/${hash}`, { format, size }),
+      Icon: (guildId, hash, format = 'webp', size, dynamic = false) => {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
-        return makeImageUrl(`${root}/icons/${guildID}/${hash}`, { format, size });
+        return makeImageUrl(`${root}/icons/${guildId}/${hash}`, { format, size });
       },
-      AppIcon: (clientID, hash, { format = 'webp', size } = {}) =>
-        makeImageUrl(`${root}/app-icons/${clientID}/${hash}`, { size, format }),
-      AppAsset: (clientID, hash, { format = 'webp', size } = {}) =>
-        makeImageUrl(`${root}/app-assets/${clientID}/${hash}`, { size, format }),
-      GDMIcon: (channelID, hash, format = 'webp', size) =>
-        makeImageUrl(`${root}/channel-icons/${channelID}/${hash}`, { size, format }),
-      Splash: (guildID, hash, format = 'webp', size) =>
-        makeImageUrl(`${root}/splashes/${guildID}/${hash}`, { size, format }),
-      DiscoverySplash: (guildID, hash, format = 'webp', size) =>
-        makeImageUrl(`${root}/discovery-splashes/${guildID}/${hash}`, { size, format }),
-      TeamIcon: (teamID, hash, { format = 'webp', size } = {}) =>
-        makeImageUrl(`${root}/team-icons/${teamID}/${hash}`, { size, format }),
+      AppIcon: (clientId, hash, { format = 'webp', size } = {}) =>
+        makeImageUrl(`${root}/app-icons/${clientId}/${hash}`, { size, format }),
+      AppAsset: (clientId, hash, { format = 'webp', size } = {}) =>
+        makeImageUrl(`${root}/app-assets/${clientId}/${hash}`, { size, format }),
+      GDMIcon: (channelId, hash, format = 'webp', size) =>
+        makeImageUrl(`${root}/channel-icons/${channelId}/${hash}`, { size, format }),
+      Splash: (guildId, hash, format = 'webp', size) =>
+        makeImageUrl(`${root}/splashes/${guildId}/${hash}`, { size, format }),
+      DiscoverySplash: (guildId, hash, format = 'webp', size) =>
+        makeImageUrl(`${root}/discovery-splashes/${guildId}/${hash}`, { size, format }),
+      TeamIcon: (teamId, hash, { format = 'webp', size } = {}) =>
+        makeImageUrl(`${root}/team-icons/${teamId}/${hash}`, { size, format }),
     };
   },
   invite: (root, code) => `${root}/${code}`,

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -28,7 +28,7 @@
 /**
  * Options for a client.
  * @typedef {Object} ClientOptions
- * @property {number|number[]|string} [shards] ID of the shard to run, or an array of shard IDs. If not specified,
+ * @property {number|number[]|string} [shards] The shard's id to run, or an array of shard ids. If not specified,
  * the client will spawn {@link ClientOptions#shardCount} shards. If set to `auto`, it will fetch the
  * recommended amount of shards from Discord and spawn that amount
  * @property {number} [shardCount=1] The total amount of shards used by all processes of this bot

--- a/src/util/SnowflakeUtil.js
+++ b/src/util/SnowflakeUtil.js
@@ -24,7 +24,7 @@ class SnowflakeUtil extends null {
 
   /**
    * Generates a Discord snowflake.
-   * <info>This hardcodes the worker ID as 1 and the process ID as 0.</info>
+   * <info>This hardcodes the worker's id as 1 and the process's id as 0.</info>
    * @param {number|Date} [timestamp=Date.now()] Timestamp or date of the snowflake to generate
    * @returns {Snowflake} The generated snowflake
    */
@@ -39,7 +39,7 @@ class SnowflakeUtil extends null {
     const BINARY = `${(timestamp - EPOCH).toString(2).padStart(42, '0')}0000100000${(INCREMENT++)
       .toString(2)
       .padStart(12, '0')}`;
-    return Util.binaryToID(BINARY);
+    return Util.binaryToId(BINARY);
   }
 
   /**
@@ -47,8 +47,8 @@ class SnowflakeUtil extends null {
    * @typedef {Object} DeconstructedSnowflake
    * @property {number} timestamp Timestamp the snowflake was created
    * @property {Date} date Date the snowflake was created
-   * @property {number} workerID Worker ID in the snowflake
-   * @property {number} processID Process ID in the snowflake
+   * @property {number} workerId The worker's id in the snowflake
+   * @property {number} processId The process's id in the snowflake
    * @property {number} increment Increment in the snowflake
    * @property {string} binary Binary representation of the snowflake
    */
@@ -65,8 +65,8 @@ class SnowflakeUtil extends null {
       get date() {
         return new Date(this.timestamp);
       },
-      workerID: parseInt(BINARY.substring(42, 47), 2),
-      processID: parseInt(BINARY.substring(47, 52), 2),
+      workerId: parseInt(BINARY.substring(42, 47), 2),
+      processId: parseInt(BINARY.substring(47, 52), 2),
       increment: parseInt(BINARY.substring(52, 64), 2),
       binary: BINARY,
     };

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -277,8 +277,8 @@ class Util extends null {
 
   /**
    * Parses emoji info out of a string. The string must be one of:
-   * * A UTF-8 emoji (no ID)
-   * * A URL-encoded UTF-8 emoji (no ID)
+   * * A UTF-8 emoji (no id)
+   * * A URL-encoded UTF-8 emoji (no id)
    * * A Discord custom emoji (`<:name:id>` or `<a:name:id>`)
    * @param {string} text Emoji string to parse
    * @returns {APIEmoji} Object with `animated`, `name`, and `id` properties
@@ -469,7 +469,7 @@ class Util extends null {
   }
 
   /**
-   * Sorts by Discord's position and ID.
+   * Sorts by Discord's position and id.
    * @param  {Collection} collection Collection of objects to sort
    * @returns {Collection}
    */
@@ -539,7 +539,7 @@ class Util extends null {
    * @returns {Snowflake}
    * @private
    */
-  static binaryToID(num) {
+  static binaryToId(num) {
     let dec = '';
 
     while (num.length > 50) {

--- a/test/createGuild.js
+++ b/test/createGuild.js
@@ -13,9 +13,9 @@ client.on('ready', async () => {
         { name: 'afk channel', type: 'voice', id: 0 },
         { name: 'system-channel', id: 1 },
       ],
-      afkChannelID: 0,
+      afkChannelId: 0,
       afkTimeout: 60,
-      systemChannelID: 1,
+      systemChannelId: 1,
     });
     console.log(guild.id);
     assert.strictEqual(guild.afkChannel.name, 'afk channel');

--- a/test/random.js
+++ b/test/random.js
@@ -245,8 +245,8 @@ client.on('messageReactionRemove', (reaction, user) => {
 
 client.on('messageCreate', m => {
   if (m.content.startsWith('#reactions')) {
-    const mID = m.content.split(' ')[1];
-    m.channel.messages.fetch(mID).then(rM => {
+    const mId = m.content.split(' ')[1];
+    m.channel.messages.fetch(mId).then(rM => {
       for (const reaction of rM.reactions.cache.values()) {
         reaction.users.fetch().then(users => {
           m.channel.send(

--- a/test/templateCreateGuild.js
+++ b/test/templateCreateGuild.js
@@ -13,7 +13,7 @@ client
         console.log('no templates');
       } else {
         const guild = await templates.first().createGuild('guild name');
-        console.log(`created guild with ID ${guild.id}`);
+        console.log(`created guild with id ${guild.id}`);
         await guild.delete();
         console.log('deleted guild');
       }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -214,7 +214,7 @@ declare module 'discord.js' {
 
   export class Activity {
     constructor(presence: Presence, data?: unknown);
-    public applicationID: Snowflake | null;
+    public applicationId: Snowflake | null;
     public assets: RichPresenceAssets | null;
     public buttons: string[];
     public readonly createdAt: Date;
@@ -229,9 +229,9 @@ declare module 'discord.js' {
       size: [number, number];
     } | null;
     public platform: ActivityPlatform | null;
-    public sessionID: string | null;
+    public sessionId: string | null;
     public state: string | null;
-    public syncID: string | null;
+    public syncId: string | null;
     public timestamps: {
       start: Date | null;
       end: Date | null;
@@ -298,13 +298,13 @@ declare module 'discord.js' {
   }
 
   export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
-    constructor(client: Client, data: unknown, guild?: Guild, guildID?: Snowflake);
+    constructor(client: Client, data: unknown, guild?: Guild, guildId?: Snowflake);
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
     public defaultPermission: boolean;
     public description: string;
     public guild: Guild | null;
-    public guildID: Snowflake | null;
+    public guildId: Snowflake | null;
     public readonly manager: ApplicationCommandManager;
     public id: Snowflake;
     public name: string;
@@ -520,10 +520,10 @@ declare module 'discord.js' {
     public edit(data: ClientUserEditData): Promise<this>;
     public setActivity(options?: ActivityOptions): Presence;
     public setActivity(name: string, options?: ActivityOptions): Presence;
-    public setAFK(afk: boolean, shardID?: number | number[]): Presence;
+    public setAFK(afk: boolean, shardId?: number | number[]): Presence;
     public setAvatar(avatar: BufferResolvable | Base64Resolvable): Promise<this>;
     public setPresence(data: PresenceData): Presence;
-    public setStatus(status: PresenceStatusData, shardID?: number | number[]): Presence;
+    public setStatus(status: PresenceStatusData, shardId?: number | number[]): Presence;
     public setUsername(username: string): Promise<this>;
   }
 
@@ -573,8 +573,8 @@ declare module 'discord.js' {
   export class CommandInteraction extends Interaction {
     public readonly command: ApplicationCommand | ApplicationCommand<{ guild: GuildResolvable }> | null;
     public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | ThreadChannel | null;
-    public channelID: Snowflake;
-    public commandID: Snowflake;
+    public channelId: Snowflake;
+    public commandId: Snowflake;
     public commandName: string;
     public deferred: boolean;
     public ephemeral: boolean | null;
@@ -622,31 +622,31 @@ declare module 'discord.js' {
       CDN: (root: string) => {
         Asset: (name: string) => string;
         DefaultAvatar: (id: Snowflake | number) => string;
-        Emoji: (emojiID: Snowflake, format: 'png' | 'gif') => string;
+        Emoji: (emojiId: Snowflake, format: 'png' | 'gif') => string;
         Avatar: (
-          userID: Snowflake | number,
+          userId: Snowflake | number,
           hash: string,
           format: 'default' | AllowedImageFormat,
           size: number,
         ) => string;
-        Banner: (guildID: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
+        Banner: (guildId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
         Icon: (
-          userID: Snowflake | number,
+          userId: Snowflake | number,
           hash: string,
           format: 'default' | AllowedImageFormat,
           size: number,
         ) => string;
-        AppIcon: (userID: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
-        AppAsset: (userID: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
-        GDMIcon: (userID: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
-        Splash: (guildID: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
+        AppIcon: (userId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
+        AppAsset: (userId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
+        GDMIcon: (userId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
+        Splash: (guildId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
         DiscoverySplash: (
-          guildID: Snowflake | number,
+          guildId: Snowflake | number,
           hash: string,
           format: AllowedImageFormat,
           size: number,
         ) => string;
-        TeamIcon: (teamID: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
+        TeamIcon: (teamId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
       };
     };
     WSCodes: {
@@ -869,9 +869,9 @@ declare module 'discord.js' {
     private _sortedChannels(channel: Channel): Collection<Snowflake, GuildChannel>;
 
     public readonly afkChannel: VoiceChannel | null;
-    public afkChannelID: Snowflake | null;
+    public afkChannelId: Snowflake | null;
     public afkTimeout: number;
-    public applicationID: Snowflake | null;
+    public applicationId: Snowflake | null;
     public approximateMemberCount: number | null;
     public approximatePresenceCount: number | null;
     public available: boolean;
@@ -892,27 +892,27 @@ declare module 'discord.js' {
     public memberCount: number;
     public members: GuildMemberManager;
     public mfaLevel: MFALevel;
-    public ownerID: Snowflake;
+    public ownerId: Snowflake;
     public preferredLocale: string;
     public premiumSubscriptionCount: number | null;
     public premiumTier: PremiumTier;
     public presences: PresenceManager;
     public readonly publicUpdatesChannel: TextChannel | null;
-    public publicUpdatesChannelID: Snowflake | null;
+    public publicUpdatesChannelId: Snowflake | null;
     public roles: RoleManager;
     public readonly rulesChannel: TextChannel | null;
-    public rulesChannelID: Snowflake | null;
+    public rulesChannelId: Snowflake | null;
     public readonly shard: WebSocketShard;
-    public shardID: number;
+    public shardId: number;
     public stageInstances: StageInstanceManager;
     public readonly systemChannel: TextChannel | null;
     public systemChannelFlags: Readonly<SystemChannelFlags>;
-    public systemChannelID: Snowflake | null;
+    public systemChannelId: Snowflake | null;
     public vanityURLUses: number | null;
     public readonly voiceAdapterCreator: DiscordGatewayAdapterCreator;
     public readonly voiceStates: VoiceStateManager;
     public readonly widgetChannel: TextChannel | null;
-    public widgetChannelID: Snowflake | null;
+    public widgetChannelId: Snowflake | null;
     public widgetEnabled: boolean | null;
     public addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
     public createIntegration(data: IntegrationData, reason?: string): Promise<Guild>;
@@ -1027,7 +1027,7 @@ declare module 'discord.js' {
     public readonly members: Collection<Snowflake, GuildMember>;
     public name: string;
     public readonly parent: CategoryChannel | null;
-    public parentID: Snowflake | null;
+    public parentId: Snowflake | null;
     public permissionOverwrites: PermissionOverwriteManager;
     public readonly permissionsLocked: boolean | null;
     public readonly position: number;
@@ -1078,7 +1078,7 @@ declare module 'discord.js' {
     public readonly joinedAt: Date | null;
     public joinedTimestamp: number | null;
     public readonly kickable: boolean;
-    public lastMessageChannelID: Snowflake | null;
+    public lastMessageChannelId: Snowflake | null;
     public readonly manageable: boolean;
     public nickname: string | null;
     public readonly partial: false;
@@ -1132,11 +1132,11 @@ declare module 'discord.js' {
     public description: string | null;
     public usageCount: number;
     public creator: User;
-    public creatorID: Snowflake;
+    public creatorId: Snowflake;
     public createdAt: Date;
     public updatedAt: Date;
     public guild: Guild | null;
-    public guildID: Snowflake;
+    public guildId: Snowflake;
     public serializedGuild: unknown;
     public unSynced: boolean | null;
     public createGuild(name: string, icon?: BufferResolvable | Base64Resolvable): Promise<Guild>;
@@ -1210,13 +1210,13 @@ declare module 'discord.js' {
 
   export class Interaction extends Base {
     constructor(client: Client, data: unknown);
-    public applicationID: Snowflake;
+    public applicationId: Snowflake;
     public readonly channel: Channel | null;
-    public channelID: Snowflake | null;
+    public channelId: Snowflake | null;
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
     public readonly guild: Guild | null;
-    public guildID: Snowflake | null;
+    public guildId: Snowflake | null;
     public id: Snowflake;
     public member: GuildMember | APIInteractionGuildMember | null;
     public readonly token: string;
@@ -1293,9 +1293,9 @@ declare module 'discord.js' {
   }
 
   export class InviteStageInstance extends Base {
-    constructor(client: Client, data: unknown, channelID: Snowflake, guildID: Snowflake);
-    public channelID: Snowflake;
-    public guildID: Snowflake;
+    constructor(client: Client, data: unknown, channelId: Snowflake, guildId: Snowflake);
+    public channelId: Snowflake;
+    public guildId: Snowflake;
     public members: Collection<Snowflake, GuildMember>;
     public topic: string;
     public participantCount: number;
@@ -1314,7 +1314,7 @@ declare module 'discord.js' {
     private patch(data: unknown): Message;
 
     public activity: MessageActivity | null;
-    public applicationID: Snowflake | null;
+    public applicationId: Snowflake | null;
     public attachments: Collection<Snowflake, MessageAttachment>;
     public author: User;
     public channel: TextChannel | DMChannel | NewsChannel | ThreadChannel;
@@ -1347,7 +1347,7 @@ declare module 'discord.js' {
     public tts: boolean;
     public type: MessageType;
     public readonly url: string;
-    public webhookID: Snowflake | null;
+    public webhookId: Snowflake | null;
     public flags: Readonly<MessageFlags>;
     public reference: MessageReference | null;
     public awaitMessageComponent<T extends MessageComponentInteraction = MessageComponentInteraction>(
@@ -1415,14 +1415,14 @@ declare module 'discord.js' {
 
   export class MessageButton extends BaseMessageComponent {
     constructor(data?: MessageButton | MessageButtonOptions);
-    public customID: string | null;
+    public customId: string | null;
     public disabled: boolean;
     public emoji: APIPartialEmoji | null;
     public label: string | null;
     public style: MessageButtonStyle | null;
     public type: 'BUTTON';
     public url: string | null;
-    public setCustomID(customID: string): this;
+    public setCustomId(customId: string): this;
     public setDisabled(disabled: boolean): this;
     public setEmoji(emoji: EmojiIdentifierResolvable): this;
     public setLabel(label: string): this;
@@ -1450,7 +1450,7 @@ declare module 'discord.js' {
     public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | ThreadChannel | null;
     public readonly component: MessageActionRowComponent | Exclude<APIMessageComponent, APIActionRowComponent> | null;
     public componentType: MessageComponentType;
-    public customID: string;
+    public customId: string;
     public deferred: boolean;
     public ephemeral: boolean | null;
     public message: Message | APIMessage;
@@ -1562,7 +1562,7 @@ declare module 'discord.js' {
 
   class MessageSelectMenu extends BaseMessageComponent {
     constructor(data?: MessageSelectMenu | MessageSelectMenuOptions);
-    public customID: string | null;
+    public customId: string | null;
     public disabled: boolean;
     public maxValues: number | null;
     public minValues: number | null;
@@ -1570,7 +1570,7 @@ declare module 'discord.js' {
     public placeholder: string | null;
     public type: 'SELECT_MENU';
     public addOptions(...options: MessageSelectOptionData[] | MessageSelectOptionData[][]): this;
-    public setCustomID(customID: string): this;
+    public setCustomId(customId: string): this;
     public setDisabled(disabled: boolean): this;
     public setMaxValues(maxValues: number): this;
     public setMinValues(minValues: number): this;
@@ -1653,7 +1653,7 @@ declare module 'discord.js' {
     public readonly member: GuildMember | null;
     public status: PresenceStatus;
     public readonly user: User | null;
-    public userID: Snowflake;
+    public userId: Snowflake;
     public equals(presence: Presence): boolean;
   }
 
@@ -1813,7 +1813,7 @@ declare module 'discord.js' {
     public send(message: any): Promise<void>;
 
     public static singleton(client: Client, mode: ShardingManagerMode): ShardClientUtil;
-    public static shardIDForGuildID(guildID: Snowflake, shardCount: number): number;
+    public static shardIdForGuildId(guildId: Snowflake, shardCount: number): number;
   }
 
   export class ShardingManager extends EventEmitter {
@@ -1868,8 +1868,8 @@ declare module 'discord.js' {
     constructor(client: Client, data: unknown, channel: StageChannel);
     public id: Snowflake;
     public deleted: boolean;
-    public guildID: Snowflake;
-    public channelID: Snowflake;
+    public guildId: Snowflake;
+    public channelId: Snowflake;
     public topic: string;
     public privacyLevel: PrivacyLevel;
     public discoverableDisabled: boolean;
@@ -1898,7 +1898,7 @@ declare module 'discord.js' {
     public id: Snowflake;
     public name: string;
     public icon: string | null;
-    public ownerID: Snowflake | null;
+    public ownerId: Snowflake | null;
     public members: Collection<Snowflake, TeamMember>;
 
     public readonly owner: TeamMember;
@@ -1960,9 +1960,9 @@ declare module 'discord.js' {
     public messages: MessageManager;
     public members: ThreadMemberManager;
     public name: string;
-    public ownerID: Snowflake;
+    public ownerId: Snowflake;
     public readonly parent: TextChannel | NewsChannel | null;
-    public parentID: Snowflake;
+    public parentId: Snowflake;
     public rateLimitPerUser: number;
     public type: ThreadChannelType;
     public readonly unarchivable: boolean;
@@ -2011,7 +2011,7 @@ declare module 'discord.js' {
     public readonly dmChannel: DMChannel | null;
     public flags: Readonly<UserFlags> | null;
     public id: Snowflake;
-    public lastMessageID: Snowflake | null;
+    public lastMessageId: Snowflake | null;
     public readonly partial: false;
     public readonly presence: Presence;
     public system: boolean;
@@ -2038,7 +2038,7 @@ declare module 'discord.js' {
   export class Util extends null {
     private constructor();
     public static basename(path: string, ext?: string): string;
-    public static binaryToID(num: string): Snowflake;
+    public static binaryToId(num: string): Snowflake;
     public static cleanContent(str: string, channel: Channel): string;
     public static removeMentions(str: string): string;
     public static cloneObject(obj: unknown): unknown;
@@ -2115,7 +2115,7 @@ declare module 'discord.js' {
   export class VoiceState extends Base {
     constructor(guild: Guild, data: unknown);
     public readonly channel: VoiceChannel | StageChannel | null;
-    public channelID: Snowflake | null;
+    public channelId: Snowflake | null;
     public readonly deaf: boolean | null;
     public guild: Guild;
     public id: Snowflake;
@@ -2125,7 +2125,7 @@ declare module 'discord.js' {
     public selfMute: boolean | null;
     public serverDeaf: boolean | null;
     public serverMute: boolean | null;
-    public sessionID: string | null;
+    public sessionId: string | null;
     public streaming: boolean;
     public selfVideo: boolean | null;
     public suppress: boolean;
@@ -2158,9 +2158,9 @@ declare module 'discord.js' {
     constructor(client: Client, data?: unknown);
     public avatar: string;
     public avatarURL(options?: StaticImageURLOptions): string | null;
-    public channelID: Snowflake;
+    public channelId: Snowflake;
     public client: Client;
-    public guildID: Snowflake;
+    public guildId: Snowflake;
     public name: string;
     public owner: User | unknown | null;
     public sourceGuild: Guild | unknown | null;
@@ -2196,8 +2196,8 @@ declare module 'discord.js' {
     public status: Status;
     public readonly ping: number;
 
-    public on(event: WSEventType, listener: (data: any, shardID: number) => void): this;
-    public once(event: WSEventType, listener: (data: any, shardID: number) => void): this;
+    public on(event: WSEventType, listener: (data: any, shardId: number) => void): this;
+    public once(event: WSEventType, listener: (data: any, shardId: number) => void): this;
 
     private debug(message: string, shard?: WebSocketShard): void;
     private connect(): Promise<void>;
@@ -2214,7 +2214,7 @@ declare module 'discord.js' {
     constructor(manager: WebSocketManager, id: number);
     private sequence: number;
     private closeSequence: number;
-    private sessionID: string | null;
+    private sessionId: string | null;
     private lastPingTimestamp: number;
     private lastHeartbeatAcked: boolean;
     private ratelimit: { queue: unknown[]; total: number; remaining: number; time: 60e3; timer: NodeJS.Timeout | null };
@@ -2286,14 +2286,14 @@ declare module 'discord.js' {
     public selfDeaf?: boolean;
     public selfMute?: boolean;
     public suppress?: boolean;
-    public channelID?: Snowflake;
+    public channelId?: Snowflake;
     public avatarURL: string;
     public activity?: WidgetActivity;
   }
 
   export class WelcomeChannel extends Base {
     private _emoji: unknown;
-    public channelID: Snowflake;
+    public channelId: Snowflake;
     public guild: Guild | InviteGuild;
     public description: string;
     public readonly channel: TextChannel | NewsChannel | null;
@@ -2343,8 +2343,8 @@ declare module 'discord.js' {
     public readonly cache: Collection<K, Holds>;
     public resolve(resolvable: Holds): Holds;
     public resolve(resolvable: R): Holds | null;
-    public resolveID(resolvable: Holds): K;
-    public resolveID(resolvable: R): K | null;
+    public resolveId(resolvable: Holds): K;
+    public resolveId(resolvable: R): K | null;
     public valueOf(): Collection<K, Holds>;
   }
 
@@ -2366,23 +2366,23 @@ declare module 'discord.js' {
       PermissionsGuildType,
       null
     >;
-    private commandPath({ id, guildID }: { id?: Snowflake; guildID?: Snowflake }): unknown;
-    public create(command: ApplicationCommandData, guildID: Snowflake): Promise<ApplicationCommand>;
-    public create(command: ApplicationCommandData, guildID?: Snowflake): Promise<ApplicationCommandType>;
-    public delete(command: ApplicationCommandResolvable, guildID?: Snowflake): Promise<ApplicationCommandType | null>;
+    private commandPath({ id, guildId }: { id?: Snowflake; guildId?: Snowflake }): unknown;
+    public create(command: ApplicationCommandData, guildId: Snowflake): Promise<ApplicationCommand>;
+    public create(command: ApplicationCommandData, guildId?: Snowflake): Promise<ApplicationCommandType>;
+    public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<ApplicationCommandType | null>;
     public edit(
       command: ApplicationCommandResolvable,
       data: ApplicationCommandData,
-      guildID: Snowflake,
+      guildId: Snowflake,
     ): Promise<ApplicationCommand>;
     public edit(
       command: ApplicationCommandResolvable,
       data: ApplicationCommandData,
-      guildID?: Snowflake,
+      guildId?: Snowflake,
     ): Promise<ApplicationCommandType>;
     public fetch(
       id: Snowflake,
-      options: FetchApplicationCommandOptions & { guildID: Snowflake },
+      options: FetchApplicationCommandOptions & { guildId: Snowflake },
     ): Promise<ApplicationCommand>;
     public fetch(id: Snowflake, options?: FetchApplicationCommandOptions): Promise<ApplicationCommandType>;
     public fetch(
@@ -2391,11 +2391,11 @@ declare module 'discord.js' {
     ): Promise<Collection<Snowflake, ApplicationCommandType>>;
     public set(
       commands: ApplicationCommandData[],
-      guildID?: Snowflake,
+      guildId?: Snowflake,
     ): Promise<Collection<Snowflake, ApplicationCommand>>;
     public set(
       commands: ApplicationCommandData[],
-      guildID?: Snowflake,
+      guildId?: Snowflake,
     ): Promise<Collection<Snowflake, ApplicationCommandType>>;
     private static transformCommand(command: ApplicationCommandData): unknown;
   }
@@ -2405,18 +2405,18 @@ declare module 'discord.js' {
     FetchSingleOptions,
     FullPermissionsOptions,
     GuildType,
-    CommandIDType,
+    CommandIdType,
   > extends BaseManager {
     constructor(manager: ApplicationCommandManager | GuildApplicationCommandManager | ApplicationCommand);
     public client: Client;
-    public commandID: CommandIDType;
+    public commandId: CommandIdType;
     public guild: GuildType;
-    public guildID: Snowflake | null;
+    public guildId: Snowflake | null;
     public manager: ApplicationCommandManager | GuildApplicationCommandManager | ApplicationCommand;
     public add(
       options: FetchSingleOptions & { permissions: ApplicationCommandPermissionData[] },
     ): Promise<ApplicationCommandPermissions[]>;
-    public has(options: FetchSingleOptions & { permissionsID: UserResolvable | RoleResolvable }): Promise<boolean>;
+    public has(options: FetchSingleOptions & { permissionsId: UserResolvable | RoleResolvable }): Promise<boolean>;
     public fetch(options: FetchSingleOptions): Promise<ApplicationCommandPermissions[]>;
     public fetch(options: BaseOptions): Promise<Collection<Snowflake, ApplicationCommandPermissions[]>>;
     public remove(
@@ -2438,7 +2438,7 @@ declare module 'discord.js' {
         fullPermissions: GuildApplicationCommandPermissionData[];
       },
     ): Promise<Collection<Snowflake, ApplicationCommandPermissions[]>>;
-    private permissionsPath(guildID: Snowflake, commandID?: Snowflake): unknown;
+    private permissionsPath(guildId: Snowflake, commandId?: Snowflake): unknown;
     private static transformPermissions(permissions: ApplicationCommandPermissionData, received?: boolean): unknown;
   }
 
@@ -2708,7 +2708,7 @@ declare module 'discord.js' {
   ): Constructable<T & Omit<TextBasedChannelFields, I>>;
 
   interface PartialTextBasedChannelFields {
-    lastMessageID: Snowflake | null;
+    lastMessageId: Snowflake | null;
     readonly lastMessage: Message | null;
     send(options: string | MessagePayload | MessageOptions): Promise<Message>;
   }
@@ -2766,13 +2766,13 @@ declare module 'discord.js' {
 
   type ActivityFlagsString = 'INSTANCE' | 'JOIN' | 'SPECTATE' | 'JOIN_REQUEST' | 'SYNC' | 'PLAY';
 
-  type ActivitiesOptions = Omit<ActivityOptions, 'shardID'>;
+  type ActivitiesOptions = Omit<ActivityOptions, 'shardId'>;
 
   interface ActivityOptions {
     name?: string;
     url?: string;
     type?: ActivityType | number;
-    shardID?: number | readonly number[];
+    shardId?: number | readonly number[];
   }
 
   type ActivityPlatform = 'desktop' | 'samsung' | 'xbox';
@@ -3030,7 +3030,7 @@ declare module 'discord.js' {
     nsfw?: boolean;
     bitrate?: number;
     userLimit?: number;
-    parentID?: Snowflake | null;
+    parentId?: Snowflake | null;
     rateLimitPerUser?: number;
     lockPermissions?: boolean;
     permissionOverwrites?: readonly OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
@@ -3128,11 +3128,11 @@ declare module 'discord.js' {
     /** @deprecated Use interactionCreate instead */
     interaction: [interaction: Interaction];
     interactionCreate: [interaction: Interaction];
-    shardDisconnect: [closeEvent: CloseEvent, shardID: number];
-    shardError: [error: Error, shardID: number];
-    shardReady: [shardID: number, unavailableGuilds: Set<Snowflake> | undefined];
-    shardReconnecting: [shardID: number];
-    shardResume: [shardID: number, replayedEvents: number];
+    shardDisconnect: [closeEvent: CloseEvent, shardId: number];
+    shardError: [error: Error, shardId: number];
+    shardReady: [shardId: number, unavailableGuilds: Set<Snowflake> | undefined];
+    shardReconnecting: [shardId: number];
+    shardResume: [shardId: number, replayedEvents: number];
     stageInstanceCreate: [stageInstance: StageInstance];
     stageInstanceUpdate: [oldStageInstance: StageInstance | null, newStageInstance: StageInstance];
     stageInstanceDelete: [stageInstance: StageInstance];
@@ -3251,8 +3251,8 @@ declare module 'discord.js' {
   }
 
   interface CrosspostedChannel {
-    channelID: Snowflake;
-    guildID: Snowflake;
+    channelId: Snowflake;
+    guildId: Snowflake;
     type: keyof typeof ChannelType;
     name: string;
   }
@@ -3262,8 +3262,8 @@ declare module 'discord.js' {
   interface DeconstructedSnowflake {
     timestamp: number;
     readonly date: Date;
-    workerID: number;
-    processID: number;
+    workerId: number;
+    processId: number;
     increment: number;
     binary: string;
   }
@@ -3313,7 +3313,7 @@ declare module 'discord.js' {
   type ExplicitContentFilterLevel = keyof typeof ExplicitContentFilterLevels;
 
   interface FetchApplicationCommandOptions extends BaseFetchOptions {
-    guildID?: Snowflake;
+    guildId?: Snowflake;
   }
 
   interface FetchBanOptions extends BaseFetchOptions {
@@ -3496,7 +3496,7 @@ declare module 'discord.js' {
   }
 
   interface GuildCreateOptions {
-    afkChannelID?: Snowflake | number;
+    afkChannelId?: Snowflake | number;
     afkTimeout?: number;
     channels?: PartialChannelData[];
     defaultMessageNotifications?: DefaultMessageNotificationLevel | number;
@@ -3504,7 +3504,7 @@ declare module 'discord.js' {
     icon?: BufferResolvable | Base64Resolvable | null;
     roles?: PartialRoleData[];
     systemChannelFlags?: SystemChannelFlagsResolvable;
-    systemChannelID?: Snowflake | number;
+    systemChannelId?: Snowflake | number;
     verificationLevel?: VerificationLevel | number;
   }
 
@@ -3745,14 +3745,14 @@ declare module 'discord.js' {
   }
 
   interface MessageActivity {
-    partyID: string;
+    partyId: string;
     type: number;
   }
 
   type MessageAdditions = MessageEmbed | MessageAttachment | (MessageEmbed | MessageAttachment)[];
 
   interface MessageButtonOptions extends BaseMessageComponentOptions {
-    customID?: string;
+    customId?: string;
     disabled?: boolean;
     emoji?: EmojiIdentifierResolvable;
     label?: string;
@@ -3905,15 +3905,15 @@ declare module 'discord.js' {
     | string;
 
   interface MessageReference {
-    channelID: Snowflake;
-    guildID: Snowflake;
-    messageID: Snowflake | null;
+    channelId: Snowflake;
+    guildId: Snowflake;
+    messageId: Snowflake | null;
   }
 
   type MessageResolvable = Message | Snowflake;
 
   interface MessageSelectMenuOptions extends BaseMessageComponentOptions {
-    customID?: string;
+    customId?: string;
     disabled?: boolean;
     maxValues?: number;
     minValues?: number;
@@ -4060,7 +4060,7 @@ declare module 'discord.js' {
     status?: PresenceStatusData;
     afk?: boolean;
     activities?: ActivitiesOptions[];
-    shardID?: number | number[];
+    shardId?: number | number[];
   }
 
   type PresenceResolvable = Presence | UserResolvable | Snowflake;
@@ -4083,10 +4083,10 @@ declare module 'discord.js' {
   interface PartialDMChannel
     extends Partialize<
       DMChannel,
-      'lastMessage' | 'lastMessageID' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
+      'lastMessage' | 'lastMessageId' | 'messages' | 'recipient' | 'type' | 'typing' | 'typingCount'
     > {
     lastMessage: null;
-    lastMessageID: undefined;
+    lastMessageId: undefined;
     messages: MessageManager;
     recipient: User | PartialUser;
     type: 'dm';
@@ -4099,7 +4099,7 @@ declare module 'discord.js' {
     name: string;
     topic?: string;
     type?: ChannelType;
-    parentID?: Snowflake | number;
+    parentId?: Snowflake | number;
     permissionOverwrites?: PartialOverwriteData[];
   }
 
@@ -4240,8 +4240,8 @@ declare module 'discord.js' {
   type RoleResolvable = Role | Snowflake;
 
   interface RoleTagData {
-    botID?: Snowflake;
-    integrationID?: Snowflake;
+    botId?: Snowflake;
+    integrationId?: Snowflake;
     premiumSubscriberRole?: true;
   }
 
@@ -4299,7 +4299,7 @@ declare module 'discord.js' {
     public format: StickerFormatType;
     public id: Snowflake;
     public name: string;
-    public packID: Snowflake;
+    public packId: Snowflake;
     public tags: string[];
     public readonly url: string;
   }
@@ -4399,7 +4399,7 @@ declare module 'discord.js' {
   interface WebhookMessageOptions extends Omit<MessageOptions, 'reply'> {
     username?: string;
     avatarURL?: string;
-    threadID?: Snowflake;
+    threadId?: Snowflake;
   }
 
   type WebhookType = keyof typeof WebhookTypes;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -2,7 +2,6 @@
 
 import {
   Client,
-  Options,
   Collection,
   Intents,
   Message,
@@ -10,6 +9,7 @@ import {
   MessageAttachment,
   MessageButton,
   MessageEmbed,
+  Options,
   Permissions,
   Serialized,
   ShardClientUtil,
@@ -23,339 +23,339 @@ const client: Client = new Client({
   }),
 });
 
-const testGuildID = '222078108977594368'; // DJS
-const testUserID = '987654321098765432'; // example ID
-const globalCommandID = '123456789012345678'; // example ID
-const guildCommandID = '234567890123456789'; // example ID
+const testGuildId = '222078108977594368'; // DJS
+const testUserId = '987654321098765432'; // example id
+const globalCommandId = '123456789012345678'; // example id
+const guildCommandId = '234567890123456789'; // example id
 
 client.on('ready', async () => {
   console.log(`Client is logged in as ${client.user!.tag} and ready!`);
 
   // Test command manager methods
-  const globalCommand = await client.application?.commands.fetch(globalCommandID);
-  const guildCommandFromGlobal = await client.application?.commands.fetch(guildCommandID, { guildID: testGuildID });
-  const guildCommandFromGuild = await client.guilds.cache.get(testGuildID)?.commands.fetch(guildCommandID);
+  const globalCommand = await client.application?.commands.fetch(globalCommandId);
+  const guildCommandFromGlobal = await client.application?.commands.fetch(guildCommandId, { guildId: testGuildId });
+  const guildCommandFromGuild = await client.guilds.cache.get(testGuildId)?.commands.fetch(guildCommandId);
 
   // @ts-expect-error
-  await client.guilds.cache.get(testGuildID)?.commands.fetch(guildCommandID, { guildID: testGuildID });
+  await client.guilds.cache.get(testGuildId)?.commands.fetch(guildCommandId, { guildId: testGuildId });
 
   // Test command permissions
   const globalPermissionsManager = client.application?.commands.permissions;
-  const guildPermissionsManager = client.guilds.cache.get(testGuildID)?.commands.permissions;
-  const originalPermissions = await client.application?.commands.permissions.fetch({ guild: testGuildID });
+  const guildPermissionsManager = client.guilds.cache.get(testGuildId)?.commands.permissions;
+  const originalPermissions = await client.application?.commands.permissions.fetch({ guild: testGuildId });
 
   // Permissions from global manager
   await globalPermissionsManager?.add({
-    command: globalCommandID,
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
-  await globalPermissionsManager?.has({ command: globalCommandID, guild: testGuildID, permissionsID: testGuildID });
-  await globalPermissionsManager?.fetch({ guild: testGuildID });
-  await globalPermissionsManager?.fetch({ command: globalCommandID, guild: testGuildID });
-  await globalPermissionsManager?.remove({ command: globalCommandID, guild: testGuildID, roles: [testGuildID] });
-  await globalPermissionsManager?.remove({ command: globalCommandID, guild: testGuildID, users: [testUserID] });
+  await globalPermissionsManager?.has({ command: globalCommandId, guild: testGuildId, permissionsId: testGuildId });
+  await globalPermissionsManager?.fetch({ guild: testGuildId });
+  await globalPermissionsManager?.fetch({ command: globalCommandId, guild: testGuildId });
+  await globalPermissionsManager?.remove({ command: globalCommandId, guild: testGuildId, roles: [testGuildId] });
+  await globalPermissionsManager?.remove({ command: globalCommandId, guild: testGuildId, users: [testUserId] });
   await globalPermissionsManager?.remove({
-    command: globalCommandID,
-    guild: testGuildID,
-    roles: [testGuildID],
-    users: [testUserID],
+    command: globalCommandId,
+    guild: testGuildId,
+    roles: [testGuildId],
+    users: [testUserId],
   });
   await globalPermissionsManager?.set({
-    command: globalCommandID,
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   await globalPermissionsManager?.set({
-    guild: testGuildID,
-    fullPermissions: [{ id: globalCommandID, permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] }],
+    guild: testGuildId,
+    fullPermissions: [{ id: globalCommandId, permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] }],
   });
 
   // @ts-expect-error
   await globalPermissionsManager?.add({
-    command: globalCommandID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await globalPermissionsManager?.has({ command: globalCommandID, permissionsID: testGuildID });
+  await globalPermissionsManager?.has({ command: globalCommandId, permissionsId: testGuildId });
   // @ts-expect-error
   await globalPermissionsManager?.fetch();
   // @ts-expect-error
-  await globalPermissionsManager?.fetch({ command: globalCommandID });
+  await globalPermissionsManager?.fetch({ command: globalCommandId });
   // @ts-expect-error
-  await globalPermissionsManager?.remove({ command: globalCommandID, roles: [testGuildID] });
+  await globalPermissionsManager?.remove({ command: globalCommandId, roles: [testGuildId] });
   // @ts-expect-error
-  await globalPermissionsManager?.remove({ command: globalCommandID, users: [testUserID] });
+  await globalPermissionsManager?.remove({ command: globalCommandId, users: [testUserId] });
   // @ts-expect-error
-  await globalPermissionsManager?.remove({ command: globalCommandID, roles: [testGuildID], users: [testUserID] });
+  await globalPermissionsManager?.remove({ command: globalCommandId, roles: [testGuildId], users: [testUserId] });
   // @ts-expect-error
   await globalPermissionsManager?.set({
-    command: globalCommandID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
   await globalPermissionsManager?.set({
-    fullPermissions: [{ id: globalCommandID, permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] }],
+    fullPermissions: [{ id: globalCommandId, permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] }],
   });
   // @ts-expect-error
   await globalPermissionsManager?.set({
-    command: globalCommandID,
-    guild: testGuildID,
-    fullPermissions: [{ id: globalCommandID, permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] }],
+    command: globalCommandId,
+    guild: testGuildId,
+    fullPermissions: [{ id: globalCommandId, permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] }],
   });
 
   // @ts-expect-error
   await globalPermissionsManager?.add({
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await globalPermissionsManager?.has({ guild: testGuildID, permissionsID: testGuildID });
+  await globalPermissionsManager?.has({ guild: testGuildId, permissionsId: testGuildId });
   // @ts-expect-error
-  await globalPermissionsManager?.remove({ guild: testGuildID, roles: [testGuildID] });
+  await globalPermissionsManager?.remove({ guild: testGuildId, roles: [testGuildId] });
   // @ts-expect-error
-  await globalPermissionsManager?.remove({ guild: testGuildID, users: [testUserID] });
+  await globalPermissionsManager?.remove({ guild: testGuildId, users: [testUserId] });
   // @ts-expect-error
-  await globalPermissionsManager?.remove({ guild: testGuildID, roles: [testGuildID], users: [testUserID] });
+  await globalPermissionsManager?.remove({ guild: testGuildId, roles: [testGuildId], users: [testUserId] });
   // @ts-expect-error
   await globalPermissionsManager?.set({
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
 
   // Permissions from guild manager
   await guildPermissionsManager?.add({
-    command: globalCommandID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
-  await guildPermissionsManager?.has({ command: globalCommandID, permissionsID: testGuildID });
+  await guildPermissionsManager?.has({ command: globalCommandId, permissionsId: testGuildId });
   await guildPermissionsManager?.fetch({});
-  await guildPermissionsManager?.fetch({ command: globalCommandID });
-  await guildPermissionsManager?.remove({ command: globalCommandID, roles: [testGuildID] });
-  await guildPermissionsManager?.remove({ command: globalCommandID, users: [testUserID] });
-  await guildPermissionsManager?.remove({ command: globalCommandID, roles: [testGuildID], users: [testUserID] });
+  await guildPermissionsManager?.fetch({ command: globalCommandId });
+  await guildPermissionsManager?.remove({ command: globalCommandId, roles: [testGuildId] });
+  await guildPermissionsManager?.remove({ command: globalCommandId, users: [testUserId] });
+  await guildPermissionsManager?.remove({ command: globalCommandId, roles: [testGuildId], users: [testUserId] });
   await guildPermissionsManager?.set({
-    command: globalCommandID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   await guildPermissionsManager?.set({
-    fullPermissions: [{ id: globalCommandID, permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] }],
+    fullPermissions: [{ id: globalCommandId, permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] }],
   });
 
   await guildPermissionsManager?.add({
-    command: globalCommandID,
+    command: globalCommandId,
     // @ts-expect-error
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await guildPermissionsManager?.has({ command: globalCommandID, guild: testGuildID, permissionsID: testGuildID });
+  await guildPermissionsManager?.has({ command: globalCommandId, guild: testGuildId, permissionsId: testGuildId });
   // @ts-expect-error
-  await guildPermissionsManager?.fetch({ guild: testGuildID });
+  await guildPermissionsManager?.fetch({ guild: testGuildId });
   // @ts-expect-error
-  await guildPermissionsManager?.fetch({ command: globalCommandID, guild: testGuildID });
+  await guildPermissionsManager?.fetch({ command: globalCommandId, guild: testGuildId });
   // @ts-expect-error
-  await guildPermissionsManager?.remove({ command: globalCommandID, guild: testGuildID, roles: [testGuildID] });
+  await guildPermissionsManager?.remove({ command: globalCommandId, guild: testGuildId, roles: [testGuildId] });
   // @ts-expect-error
-  await guildPermissionsManager?.remove({ command: globalCommandID, guild: testGuildID, users: [testUserID] });
+  await guildPermissionsManager?.remove({ command: globalCommandId, guild: testGuildId, users: [testUserId] });
   await guildPermissionsManager?.remove({
-    command: globalCommandID,
+    command: globalCommandId,
     // @ts-expect-error
-    guild: testGuildID,
-    roles: [testGuildID],
-    users: [testUserID],
+    guild: testGuildId,
+    roles: [testGuildId],
+    users: [testUserId],
   });
   // @ts-expect-error
   await guildPermissionsManager?.set({
-    command: globalCommandID,
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   await guildPermissionsManager?.set({
     // @ts-expect-error
-    guild: testGuildID,
-    fullPermissions: [{ id: globalCommandID, permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] }],
+    guild: testGuildId,
+    fullPermissions: [{ id: globalCommandId, permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] }],
   });
 
   // @ts-expect-error
-  await guildPermissionsManager?.add({ permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] });
+  await guildPermissionsManager?.add({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
   // @ts-expect-error
-  await guildPermissionsManager?.has({ permissionsID: testGuildID });
+  await guildPermissionsManager?.has({ permissionsId: testGuildId });
   // @ts-expect-error
-  await guildPermissionsManager?.remove({ roles: [testGuildID] });
+  await guildPermissionsManager?.remove({ roles: [testGuildId] });
   // @ts-expect-error
-  await guildPermissionsManager?.remove({ users: [testUserID] });
+  await guildPermissionsManager?.remove({ users: [testUserId] });
   // @ts-expect-error
-  await guildPermissionsManager?.remove({ roles: [testGuildID], users: [testUserID] });
+  await guildPermissionsManager?.remove({ roles: [testGuildId], users: [testUserId] });
   // @ts-expect-error
-  await guildPermissionsManager?.set({ permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] });
+  await guildPermissionsManager?.set({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
   // @ts-expect-error
   await guildPermissionsManager?.set({
-    command: globalCommandID,
-    fullPermissions: [{ id: globalCommandID, permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] }],
+    command: globalCommandId,
+    fullPermissions: [{ id: globalCommandId, permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] }],
   });
 
   // Permissions from cached global ApplicationCommand
   await globalCommand?.permissions.add({
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
-  await globalCommand?.permissions.has({ guild: testGuildID, permissionsID: testGuildID });
-  await globalCommand?.permissions.fetch({ guild: testGuildID });
-  await globalCommand?.permissions.remove({ guild: testGuildID, roles: [testGuildID] });
-  await globalCommand?.permissions.remove({ guild: testGuildID, users: [testUserID] });
-  await globalCommand?.permissions.remove({ guild: testGuildID, roles: [testGuildID], users: [testUserID] });
+  await globalCommand?.permissions.has({ guild: testGuildId, permissionsId: testGuildId });
+  await globalCommand?.permissions.fetch({ guild: testGuildId });
+  await globalCommand?.permissions.remove({ guild: testGuildId, roles: [testGuildId] });
+  await globalCommand?.permissions.remove({ guild: testGuildId, users: [testUserId] });
+  await globalCommand?.permissions.remove({ guild: testGuildId, roles: [testGuildId], users: [testUserId] });
   await globalCommand?.permissions.set({
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
 
   await globalCommand?.permissions.add({
     // @ts-expect-error
-    command: globalCommandID,
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await globalCommand?.permissions.has({ command: globalCommandID, guild: testGuildID, permissionsID: testGuildID });
+  await globalCommand?.permissions.has({ command: globalCommandId, guild: testGuildId, permissionsId: testGuildId });
   // @ts-expect-error
-  await globalCommand?.permissions.fetch({ command: globalCommandID, guild: testGuildID });
+  await globalCommand?.permissions.fetch({ command: globalCommandId, guild: testGuildId });
   // @ts-expect-error
-  await globalCommand?.permissions.remove({ command: globalCommandID, guild: testGuildID, roles: [testGuildID] });
+  await globalCommand?.permissions.remove({ command: globalCommandId, guild: testGuildId, roles: [testGuildId] });
   // @ts-expect-error
-  await globalCommand?.permissions.remove({ command: globalCommandID, guild: testGuildID, users: [testUserID] });
+  await globalCommand?.permissions.remove({ command: globalCommandId, guild: testGuildId, users: [testUserId] });
   await globalCommand?.permissions.remove({
     // @ts-expect-error
-    command: globalCommandID,
-    guild: testGuildID,
-    roles: [testGuildID],
-    users: [testUserID],
+    command: globalCommandId,
+    guild: testGuildId,
+    roles: [testGuildId],
+    users: [testUserId],
   });
   await globalCommand?.permissions.set({
     // @ts-expect-error
-    command: globalCommandID,
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
 
   // @ts-expect-error
-  await globalCommand?.permissions.add({ permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] });
+  await globalCommand?.permissions.add({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
   // @ts-expect-error
-  await globalCommand?.permissions.has({ permissionsID: testGuildID });
+  await globalCommand?.permissions.has({ permissionsId: testGuildId });
   // @ts-expect-error
   await globalCommand?.permissions.fetch({});
   // @ts-expect-error
-  await globalCommand?.permissions.remove({ roles: [testGuildID] });
+  await globalCommand?.permissions.remove({ roles: [testGuildId] });
   // @ts-expect-error
-  await globalCommand?.permissions.remove({ users: [testUserID] });
+  await globalCommand?.permissions.remove({ users: [testUserId] });
   // @ts-expect-error
-  await globalCommand?.permissions.remove({ roles: [testGuildID], users: [testUserID] });
+  await globalCommand?.permissions.remove({ roles: [testGuildId], users: [testUserId] });
   // @ts-expect-error
-  await globalCommand?.permissions.set({ permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] });
+  await globalCommand?.permissions.set({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
 
   // Permissions from cached guild ApplicationCommand
-  await guildCommandFromGlobal?.permissions.add({ permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] });
-  await guildCommandFromGlobal?.permissions.has({ permissionsID: testGuildID });
+  await guildCommandFromGlobal?.permissions.add({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
+  await guildCommandFromGlobal?.permissions.has({ permissionsId: testGuildId });
   await guildCommandFromGlobal?.permissions.fetch({});
-  await guildCommandFromGlobal?.permissions.remove({ roles: [testGuildID] });
-  await guildCommandFromGlobal?.permissions.remove({ users: [testUserID] });
-  await guildCommandFromGlobal?.permissions.remove({ roles: [testGuildID], users: [testUserID] });
-  await guildCommandFromGlobal?.permissions.set({ permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] });
+  await guildCommandFromGlobal?.permissions.remove({ roles: [testGuildId] });
+  await guildCommandFromGlobal?.permissions.remove({ users: [testUserId] });
+  await guildCommandFromGlobal?.permissions.remove({ roles: [testGuildId], users: [testUserId] });
+  await guildCommandFromGlobal?.permissions.set({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
 
   await guildCommandFromGlobal?.permissions.add({
     // @ts-expect-error
-    command: globalCommandID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await guildCommandFromGlobal?.permissions.has({ command: guildCommandID, permissionsID: testGuildID });
+  await guildCommandFromGlobal?.permissions.has({ command: guildCommandId, permissionsId: testGuildId });
   // @ts-expect-error
-  await guildCommandFromGlobal?.permissions.remove({ command: guildCommandID, roles: [testGuildID] });
+  await guildCommandFromGlobal?.permissions.remove({ command: guildCommandId, roles: [testGuildId] });
   // @ts-expect-error
-  await guildCommandFromGlobal?.permissions.remove({ command: guildCommandID, users: [testUserID] });
+  await guildCommandFromGlobal?.permissions.remove({ command: guildCommandId, users: [testUserId] });
   await guildCommandFromGlobal?.permissions.remove({
     // @ts-expect-error
-    command: guildCommandID,
-    roles: [testGuildID],
-    users: [testUserID],
+    command: guildCommandId,
+    roles: [testGuildId],
+    users: [testUserId],
   });
   await guildCommandFromGlobal?.permissions.set({
     // @ts-expect-error
-    command: guildCommandID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: guildCommandId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
 
   await guildCommandFromGlobal?.permissions.add({
     // @ts-expect-error
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await guildCommandFromGlobal?.permissions.has({ guild: testGuildID, permissionsID: testGuildID });
+  await guildCommandFromGlobal?.permissions.has({ guild: testGuildId, permissionsId: testGuildId });
   // @ts-expect-error
-  await guildCommandFromGlobal?.permissions.remove({ guild: testGuildID, roles: [testGuildID] });
+  await guildCommandFromGlobal?.permissions.remove({ guild: testGuildId, roles: [testGuildId] });
   // @ts-expect-error
-  await guildCommandFromGlobal?.permissions.remove({ guild: testGuildID, users: [testUserID] });
+  await guildCommandFromGlobal?.permissions.remove({ guild: testGuildId, users: [testUserId] });
   // @ts-expect-error
-  await guildCommandFromGlobal?.permissions.remove({ guild: testGuildID, roles: [testGuildID], users: [testUserID] });
+  await guildCommandFromGlobal?.permissions.remove({ guild: testGuildId, roles: [testGuildId], users: [testUserId] });
   await guildCommandFromGlobal?.permissions.set({
     // @ts-expect-error
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
 
-  await guildCommandFromGuild?.permissions.add({ permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] });
-  await guildCommandFromGuild?.permissions.has({ permissionsID: testGuildID });
+  await guildCommandFromGuild?.permissions.add({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
+  await guildCommandFromGuild?.permissions.has({ permissionsId: testGuildId });
   await guildCommandFromGuild?.permissions.fetch({});
-  await guildCommandFromGuild?.permissions.remove({ roles: [testGuildID] });
-  await guildCommandFromGuild?.permissions.remove({ users: [testUserID] });
-  await guildCommandFromGuild?.permissions.remove({ roles: [testGuildID], users: [testUserID] });
-  await guildCommandFromGuild?.permissions.set({ permissions: [{ type: 'ROLE', id: testGuildID, permission: true }] });
+  await guildCommandFromGuild?.permissions.remove({ roles: [testGuildId] });
+  await guildCommandFromGuild?.permissions.remove({ users: [testUserId] });
+  await guildCommandFromGuild?.permissions.remove({ roles: [testGuildId], users: [testUserId] });
+  await guildCommandFromGuild?.permissions.set({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
 
   await guildCommandFromGuild?.permissions.add({
     // @ts-expect-error
-    command: globalCommandID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: globalCommandId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await guildCommandFromGuild?.permissions.has({ command: guildCommandID, permissionsID: testGuildID });
+  await guildCommandFromGuild?.permissions.has({ command: guildCommandId, permissionsId: testGuildId });
   // @ts-expect-error
-  await guildCommandFromGuild?.permissions.remove({ command: guildCommandID, roles: [testGuildID] });
+  await guildCommandFromGuild?.permissions.remove({ command: guildCommandId, roles: [testGuildId] });
   // @ts-expect-error
-  await guildCommandFromGuild?.permissions.remove({ command: guildCommandID, users: [testUserID] });
+  await guildCommandFromGuild?.permissions.remove({ command: guildCommandId, users: [testUserId] });
   await guildCommandFromGuild?.permissions.remove({
     // @ts-expect-error
-    command: guildCommandID,
-    roles: [testGuildID],
-    users: [testUserID],
+    command: guildCommandId,
+    roles: [testGuildId],
+    users: [testUserId],
   });
   await guildCommandFromGuild?.permissions.set({
     // @ts-expect-error
-    command: guildCommandID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    command: guildCommandId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
 
   await guildCommandFromGuild?.permissions.add({
     // @ts-expect-error
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await guildCommandFromGuild?.permissions.has({ guild: testGuildID, permissionsID: testGuildID });
+  await guildCommandFromGuild?.permissions.has({ guild: testGuildId, permissionsId: testGuildId });
   // @ts-expect-error
-  await guildCommandFromGuild?.permissions.remove({ guild: testGuildID, roles: [testGuildID] });
+  await guildCommandFromGuild?.permissions.remove({ guild: testGuildId, roles: [testGuildId] });
   // @ts-expect-error
-  await guildCommandFromGuild?.permissions.remove({ guild: testGuildID, users: [testUserID] });
+  await guildCommandFromGuild?.permissions.remove({ guild: testGuildId, users: [testUserId] });
   // @ts-expect-error
-  await guildCommandFromGuild?.permissions.remove({ guild: testGuildID, roles: [testGuildID], users: [testUserID] });
+  await guildCommandFromGuild?.permissions.remove({ guild: testGuildId, roles: [testGuildId], users: [testUserId] });
   await guildCommandFromGuild?.permissions.set({
     // @ts-expect-error
-    guild: testGuildID,
-    permissions: [{ type: 'ROLE', id: testGuildID, permission: true }],
+    guild: testGuildId,
+    permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
 
   client.application?.commands.permissions.set({
-    guild: testGuildID,
+    guild: testGuildId,
     fullPermissions: originalPermissions?.map((permissions, id) => ({ permissions, id })) ?? [],
   });
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Did somebody order a pizza? Well, sorry to break it for you, it's another dish of breaking changes.

| ℹ️ This Pull Request does not break every single bot using discord.js, and will for the most part, break those that use `resolveID`. |
| --- |

Barely any bot works untouched when switching from v12 to v13 ~~and Sapphire is still unaffected, even by this~~.

Basically, the gist of this PR is that all instances of `ID` have been changed to `Id`, that includes `resolveID` -> `resolveId`, `messageID` -> `messageId`, `channelID` -> `channelId`, `guildID` -> `guildId`, etc. And this has been in our backlog for around 2 years, so this change was coming out sooner or later.

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
- Code changes have been tested against the Discord API, or there are no code changes
-->
