### PR TITLE
types(Voice): move types to the library's definitions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -152,25 +152,6 @@ declare enum WebhookTypes {
 
 type Awaited<T> = T | PromiseLike<T>;
 
-declare module '@discordjs/voice' {
-  import { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v8';
-
-  export interface DiscordGatewayAdapterLibraryMethods {
-    onVoiceServerUpdate(data: GatewayVoiceServerUpdateDispatchData): void;
-    onVoiceStateUpdate(data: GatewayVoiceStateUpdateDispatchData): void;
-    destroy(): void;
-  }
-
-  export interface DiscordGatewayAdapterImplementerMethods {
-    sendPayload(payload: any): boolean;
-    destroy(): void;
-  }
-
-  export type DiscordGatewayAdapterCreator = (
-    methods: DiscordGatewayAdapterLibraryMethods,
-  ) => DiscordGatewayAdapterImplementerMethods;
-}
-
 declare module 'discord.js' {
   import {
     blockQuote,
@@ -188,7 +169,6 @@ declare module 'discord.js' {
     underscore,
   } from '@discordjs/builders';
   import BaseCollection from '@discordjs/collection';
-  import { DiscordGatewayAdapterCreator, DiscordGatewayAdapterLibraryMethods } from '@discordjs/voice';
   import { ChildProcess } from 'child_process';
   import {
     APIActionRowComponent,
@@ -201,6 +181,8 @@ declare module 'discord.js' {
     APIPartialEmoji,
     APIRole,
     APIUser,
+    GatewayVoiceServerUpdateDispatchData,
+    GatewayVoiceStateUpdateDispatchData,
     Snowflake as APISnowflake,
   } from 'discord-api-types/v8';
   import { EventEmitter } from 'events';
@@ -536,7 +518,7 @@ declare module 'discord.js' {
   export class ClientVoiceManager {
     constructor(client: Client);
     public readonly client: Client;
-    public adapters: Map<Snowflake, DiscordGatewayAdapterLibraryMethods>;
+    public adapters: Map<Snowflake, InternalDiscordGatewayAdapterLibraryMethods>;
   }
 
   export abstract class Collector<K, V, F extends any[] = []> extends EventEmitter {
@@ -909,7 +891,7 @@ declare module 'discord.js' {
     public systemChannelFlags: Readonly<SystemChannelFlags>;
     public systemChannelID: Snowflake | null;
     public vanityURLUses: number | null;
-    public readonly voiceAdapterCreator: DiscordGatewayAdapterCreator;
+    public readonly voiceAdapterCreator: InternalDiscordGatewayAdapterCreator;
     public readonly voiceStates: VoiceStateManager;
     public readonly widgetChannel: TextChannel | null;
     public widgetChannelID: Snowflake | null;
@@ -4495,5 +4477,31 @@ declare module 'discord.js' {
     ? {}
     : { [K in keyof T]: Serialized<T[K]> };
 
+  //#endregion
+
+  //#region voice
+  /**
+   * @internal Use `DiscordGatewayAdapterLibraryMethods` from `@discordjs/voice` instead.
+   */
+  interface InternalDiscordGatewayAdapterLibraryMethods {
+    onVoiceServerUpdate(data: GatewayVoiceServerUpdateDispatchData): void;
+    onVoiceStateUpdate(data: GatewayVoiceStateUpdateDispatchData): void;
+    destroy(): void;
+  }
+
+  /**
+   * @internal Use `DiscordGatewayAdapterImplementerMethods` from `@discordjs/voice` instead.
+   */
+  interface InternalDiscordGatewayAdapterImplementerMethods {
+    sendPayload(payload: any): boolean;
+    destroy(): void;
+  }
+
+  /**
+   * @internal Use `DiscordGatewayAdapterCreator` from `@discordjs/voice` instead.
+   */
+  type InternalDiscordGatewayAdapterCreator = (
+    methods: InternalDiscordGatewayAdapterLibraryMethods,
+  ) => InternalDiscordGatewayAdapterImplementerMethods;
   //#endregion
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4480,6 +4480,7 @@ declare module 'discord.js' {
   //#endregion
 
   //#region voice
+
   /**
    * @internal Use `DiscordGatewayAdapterLibraryMethods` from `@discordjs/voice` instead.
    */
@@ -4503,5 +4504,6 @@ declare module 'discord.js' {
   type InternalDiscordGatewayAdapterCreator = (
     methods: InternalDiscordGatewayAdapterLibraryMethods,
   ) => InternalDiscordGatewayAdapterImplementerMethods;
+
   //#endregion
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

At first, we used module augmentation so the types could be linked with the actual library's types, however, that ended up not working correctly (and I suspect it's because the `type` definition, which unlike `interface`s, they can't be augmented).

I moved the definitions into discord.js and prefixed them with `Internal` to not conflict with the /voice's definitions, as well as marked them as `@internal` with a description via TSDocs.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
