### PR TITLE
types(Options): should extend null

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -509,7 +509,7 @@ declare module 'discord.js' {
     public setUsername(username: string): Promise<this>;
   }
 
-  export class Options {
+  export class Options extends null {
     public static createDefaultOptions(): ClientOptions;
     public static cacheWithLimits(limits?: Record<string, number>): CacheFactory;
     public static cacheEverything(): CacheFactory;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -510,6 +510,7 @@ declare module 'discord.js' {
   }
 
   export class Options extends null {
+    private constructor();
     public static createDefaultOptions(): ClientOptions;
     public static cacheWithLimits(limits?: Record<string, number>): CacheFactory;
     public static cacheEverything(): CacheFactory;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The Options class extends null in the javascript file, but not in the typings.
https://github.com/discordjs/discord.js/blob/185e37602b0fabf6f06a02886128aead9239c5d9/src/util/Options.js#L92
https://github.com/discordjs/discord.js/blob/185e37602b0fabf6f06a02886128aead9239c5d9/typings/index.d.ts#L512

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating