### PR TITLE
fix(TeamMember): Fixed incorrect return types.

### DIFF
--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -36,7 +36,7 @@ class Team extends Base {
 
     /**
      * The Team's owner id
-     * @type {?string}
+     * @type {?Snowflake}
      */
     this.ownerId = data.owner_user_id ?? null;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1884,11 +1884,11 @@ declare module 'discord.js' {
     public ownerId: Snowflake | null;
     public members: Collection<Snowflake, TeamMember>;
 
-    public readonly owner: TeamMember;
+    public readonly owner: TeamMember | null;
     public readonly createdAt: Date;
     public readonly createdTimestamp: number;
 
-    public iconURL(options?: StaticImageURLOptions): string;
+    public iconURL(options?: StaticImageURLOptions): string | null;
     public toJSON(): unknown;
     public toString(): string;
   }
@@ -1901,7 +1901,7 @@ declare module 'discord.js' {
     public membershipState: MembershipState;
     public user: User;
 
-    public toString(): string;
+    public toString(): UserMention;
   }
 
   export class TextChannel extends TextBasedChannel(GuildChannel) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes the typings for
Team#owner - the return type was missing null
Team#iconURL - the return type was missing null
TeamMember#toString - changed the return type to UserMention as for PR #6003

and changed the JSDOC for Team#ownerId to be type {?Snowflake} instead of {?string}.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating