### PR TITLE
refactor: remove `lastMessage` properties from `User` and `GuildMember`

### DIFF
--- a/src/client/actions/MessageCreate.js
+++ b/src/client/actions/MessageCreate.js
@@ -13,17 +13,7 @@ class MessageCreateAction extends Action {
       const existing = channel.messages.cache.get(data.id);
       if (existing) return { message: existing };
       const message = channel.messages.add(data);
-      const user = message.author;
-      const member = message.member;
       channel.lastMessageId = data.id;
-      if (user) {
-        user.lastMessageId = data.id;
-        user.lastMessageChannelId = channel.id;
-      }
-      if (member) {
-        member.lastMessageId = data.id;
-        member.lastMessageChannelId = channel.id;
-      }
 
       /**
        * Emitted whenever a message is created.

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -35,18 +35,6 @@ class GuildMember extends Base {
     this.joinedTimestamp = null;
 
     /**
-     * The member's last message id, if one was sent
-     * @type {?Snowflake}
-     */
-    this.lastMessageId = null;
-
-    /**
-     * The id of the channel for the last message sent by the member in their guild, if one was sent
-     * @type {?Snowflake}
-     */
-    this.lastMessageChannelId = null;
-
-    /**
      * The timestamp of when the member used their Nitro boost on the guild, if it was used
      * @type {?number}
      */
@@ -114,15 +102,6 @@ class GuildMember extends Base {
    */
   get roles() {
     return new GuildMemberRoleManager(this);
-  }
-
-  /**
-   * The Message object of the last message sent by the member in their guild, if one was sent
-   * @type {?Message}
-   * @readonly
-   */
-  get lastMessage() {
-    return this.guild.channels.resolve(this.lastMessageChannelId)?.messages.resolve(this.lastMessageId) ?? null;
   }
 
   /**
@@ -352,8 +331,6 @@ class GuildMember extends Base {
       this.partial === member.partial &&
       this.guild.id === member.guild.id &&
       this.joinedTimestamp === member.joinedTimestamp &&
-      this.lastMessageId === member.lastMessageId &&
-      this.lastMessageChannelId === member.lastMessageChannelId &&
       this.nickname === member.nickname &&
       this.pending === member.pending &&
       (this._roles === member._roles ||
@@ -377,8 +354,6 @@ class GuildMember extends Base {
       guild: 'guildId',
       user: 'userId',
       displayName: true,
-      lastMessage: false,
-      lastMessageId: false,
       roles: true,
     });
   }

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -32,18 +32,6 @@ class User extends Base {
 
     this.flags = null;
 
-    /**
-     * The user's last message id, if one was sent
-     * @type {?Snowflake}
-     */
-    this.lastMessageId = null;
-
-    /**
-     * The channel in which the last message was sent by the user, if one was sent
-     * @type {?Snowflake}
-     */
-    this.lastMessageChannelId = null;
-
     this._patch(data);
   }
 
@@ -132,15 +120,6 @@ class User extends Base {
    */
   get createdAt() {
     return new Date(this.createdTimestamp);
-  }
-
-  /**
-   * The Message object of the last message sent by the user, if one was sent
-   * @type {?Message}
-   * @readonly
-   */
-  get lastMessage() {
-    return this.client.channels.resolve(this.lastMessageChannelId)?.messages.resolve(this.lastMessageId) ?? null;
   }
 
   /**
@@ -316,8 +295,6 @@ class User extends Base {
         createdTimestamp: true,
         defaultAvatarURL: true,
         tag: true,
-        lastMessage: false,
-        lastMessageId: false,
       },
       ...props,
     );

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -681,7 +681,6 @@ export class GuildMember extends PartialTextBasedChannel(Base) {
   public readonly joinedAt: Date | null;
   public joinedTimestamp: number | null;
   public readonly kickable: boolean;
-  public lastMessageChannelId: Snowflake | null;
   public readonly manageable: boolean;
   public nickname: string | null;
   public readonly partial: false;
@@ -1646,7 +1645,6 @@ export class User extends PartialTextBasedChannel(Base) {
   public readonly dmChannel: DMChannel | null;
   public flags: Readonly<UserFlags> | null;
   public id: Snowflake;
-  public lastMessageId: Snowflake | null;
   public readonly partial: false;
   public readonly presence: Presence;
   public system: boolean;
@@ -2531,13 +2529,13 @@ export function TextBasedChannel<T, I extends keyof TextBasedChannelFields = nev
 ): Constructable<T & Omit<TextBasedChannelFields, I>>;
 
 export interface PartialTextBasedChannelFields {
-  lastMessageId: Snowflake | null;
-  readonly lastMessage: Message | null;
   send(options: string | MessagePayload | MessageOptions): Promise<Message>;
 }
 
 export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
   _typing: Map<string, TypingData>;
+  lastMessageId: Snowflake | null;
+  readonly lastMessage: Message | null;
   lastPinTimestamp: number | null;
   readonly lastPinAt: Date | null;
   typing: boolean;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,17 +1,25 @@
 import {
   Client,
   Collection,
+  DMChannel,
+  GuildMember,
   Intents,
   Message,
   MessageActionRow,
   MessageAttachment,
   MessageButton,
   MessageEmbed,
+  NewsChannel,
   Options,
+  PartialTextBasedChannelFields,
   Permissions,
   Serialized,
   ShardClientUtil,
   ShardingManager,
+  TextBasedChannelFields,
+  TextChannel,
+  ThreadChannel,
+  User,
 } from '..';
 
 const client: Client = new Client({
@@ -455,3 +463,27 @@ assertType<Promise<number[]>>(shardingManager.broadcastEval(() => 1));
 assertType<Promise<number[]>>(shardClientUtil.broadcastEval(() => 1));
 assertType<Promise<number[]>>(shardingManager.broadcastEval(async () => 1));
 assertType<Promise<number[]>>(shardClientUtil.broadcastEval(async () => 1));
+
+declare const dmChannel: DMChannel;
+declare const threadChannel: ThreadChannel;
+declare const newsChannel: NewsChannel;
+declare const textChannel: TextChannel;
+declare const user: User;
+declare const guildMember: GuildMember;
+
+// Test whether the structures implement send
+assertType<TextBasedChannelFields['send']>(dmChannel.send);
+assertType<TextBasedChannelFields>(threadChannel);
+assertType<TextBasedChannelFields>(newsChannel);
+assertType<TextBasedChannelFields>(textChannel);
+assertType<PartialTextBasedChannelFields>(user);
+assertType<PartialTextBasedChannelFields>(guildMember);
+
+assertType<Message | null>(dmChannel.lastMessage);
+assertType<Message | null>(threadChannel.lastMessage);
+assertType<Message | null>(newsChannel.lastMessage);
+assertType<Message | null>(textChannel.lastMessage);
+// @ts-expect-error
+assertType<never>(user.lastMessage);
+// @ts-expect-error
+assertType<never>(guildMember.lastMessage);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Only `TextBasedChannel#lastMessageId` is given by Discord (`data.last_message_id`), `User`'s and `GuildMember`'s were extensions from our side.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
