### PR TITLE
fix(Guild): add invite manager property, extend CachedManager

### DIFF
--- a/src/managers/GuildInviteManager.js
+++ b/src/managers/GuildInviteManager.js
@@ -8,7 +8,7 @@ const DataResolver = require('../util/DataResolver');
 
 /**
  * Manages API methods for GuildInvites and stores their cache.
- * @extends {BaseManager}
+ * @extends {CachedManager}
  */
 class GuildInviteManager extends CachedManager {
   constructor(guild, iterable) {

--- a/src/managers/GuildInviteManager.js
+++ b/src/managers/GuildInviteManager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const BaseManager = require('./BaseManager');
+const CachedManager = require('./CachedManager');
 const { Error } = require('../errors');
 const Invite = require('../structures/Invite');
 const Collection = require('../util/Collection');
@@ -10,9 +10,9 @@ const DataResolver = require('../util/DataResolver');
  * Manages API methods for GuildInvites and stores their cache.
  * @extends {BaseManager}
  */
-class GuildInviteManager extends BaseManager {
+class GuildInviteManager extends CachedManager {
   constructor(guild, iterable) {
-    super(guild.client, iterable, Invite);
+    super(guild.client, Invite, iterable);
 
     /**
      * The guild this Manager belongs to

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -12,6 +12,7 @@ const GuildApplicationCommandManager = require('../managers/GuildApplicationComm
 const GuildBanManager = require('../managers/GuildBanManager');
 const GuildChannelManager = require('../managers/GuildChannelManager');
 const GuildEmojiManager = require('../managers/GuildEmojiManager');
+const GuildInviteManager = require('../managers/GuildInviteManager');
 const GuildMemberManager = require('../managers/GuildMemberManager');
 const PresenceManager = require('../managers/PresenceManager');
 const RoleManager = require('../managers/RoleManager');
@@ -89,6 +90,12 @@ class Guild extends AnonymousGuild {
      * @type {StageInstanceManager}
      */
     this.stageInstances = new StageInstanceManager(this);
+
+    /**
+     * A manager of the invites of this guild
+     * @type {GuildInviteManager}
+     */
+    this.invites = new GuildInviteManager(this);
 
     /**
      * Whether the bot has been removed from the guild

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -859,7 +859,6 @@ declare module 'discord.js' {
     public approximatePresenceCount: number | null;
     public available: boolean;
     public bans: GuildBanManager;
-    public invites: GuildInviteManager;
     public channels: GuildChannelManager;
     public commands: GuildApplicationCommandManager;
     public defaultMessageNotifications: DefaultMessageNotificationLevel | number;
@@ -867,6 +866,7 @@ declare module 'discord.js' {
     public discoverySplash: string | null;
     public emojis: GuildEmojiManager;
     public explicitContentFilter: ExplicitContentFilterLevel;
+    public invites: GuildInviteManager;
     public readonly joinedAt: Date;
     public joinedTimestamp: number;
     public large: boolean;


### PR DESCRIPTION
Adds the new `GuildInviteManager` to `Guild` as `Guild#invites` since #5889 didnt, and extend the new `CachedManager`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)