### PR TITLE
refactor(Intents): remove computed shorts

### DIFF
--- a/src/util/Intents.js
+++ b/src/util/Intents.js
@@ -61,23 +61,4 @@ Intents.FLAGS = {
   DIRECT_MESSAGE_TYPING: 1 << 14,
 };
 
-/**
- * Bitfield representing all privileged intents
- * @type {number}
- * @see {@link https://discord.com/developers/docs/topics/gateway#privileged-intents}
- */
-Intents.PRIVILEGED = Intents.FLAGS.GUILD_MEMBERS | Intents.FLAGS.GUILD_PRESENCES;
-
-/**
- * Bitfield representing all intents combined
- * @type {number}
- */
-Intents.ALL = Object.values(Intents.FLAGS).reduce((acc, p) => acc | p, 0);
-
-/**
- * Bitfield representing all non-privileged intents
- * @type {number}
- */
-Intents.NON_PRIVILEGED = Intents.ALL & ~Intents.PRIVILEGED;
-
 module.exports = Intents;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -804,9 +804,6 @@ export class IntegrationApplication extends Application {
 
 export class Intents extends BitField<IntentsString> {
   public static FLAGS: Record<IntentsString, number>;
-  public static PRIVILEGED: number;
-  public static ALL: number;
-  public static NON_PRIVILEGED: number;
   public static resolve(bit?: BitFieldResolvable<IntentsString, number>): number;
 }
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -23,7 +23,7 @@ import {
 } from '..';
 
 const client: Client = new Client({
-  intents: Intents.NON_PRIVILEGED,
+  intents: Intents.FLAGS.GUILDS,
   makeCache: Options.cacheWithLimits({
     MessageManager: 200,
   }),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- ⚠️ remove `Intents.ALL`
- ⚠️ remove `Intents.PRIVILEGED`
- ⚠️ remove `Intents.NON_PRIVILEGED`

We currently provide static shorthands on the Intents bitfield wrapper (inspired by Permissions when implementing). This raises multiple issues:

- End users are lead to just pass `Intents.ALL` no matter what they actually need for the bot to work, as evident from library support channels
- Discord might change the grouping of which intents are privileged and which are not at any time. They don't make any promise that this will stay at member presences and guild members. Removal accordingly improves maintainability, as we do not need to push releases to change groupings going forward.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
