### PR TITLE
test(Types): add `notPropertyOf` type-only utility

### DIFF
--- a/typings/index.ts
+++ b/typings/index.ts
@@ -428,6 +428,7 @@ client.login('absolutely-valid-token');
 // Test type transformation:
 declare const assertType: <T>(value: T) => asserts value is T;
 declare const serialize: <T>(value: T) => Serialized<T>;
+declare const notPropertyOf: <T, P extends string>(value: T, property: P & Exclude<P, keyof T>) => void;
 
 assertType<undefined>(serialize(undefined));
 assertType<null>(serialize(null));
@@ -483,7 +484,8 @@ assertType<Message | null>(dmChannel.lastMessage);
 assertType<Message | null>(threadChannel.lastMessage);
 assertType<Message | null>(newsChannel.lastMessage);
 assertType<Message | null>(textChannel.lastMessage);
-// @ts-expect-error
-assertType<never>(user.lastMessage);
-// @ts-expect-error
-assertType<never>(guildMember.lastMessage);
+
+notPropertyOf(user, 'lastMessage');
+notPropertyOf(user, 'lastMessageId');
+notPropertyOf(guildMember, 'lastMessage');
+notPropertyOf(guildMember, 'lastMessageId');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This utility is useful for checking whether classes that use mixins don't get any unintended property.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
