### PR TITLE
fix(InviteScope): added missing 'bot' scope

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -314,6 +314,7 @@ exports.WSEvents = keyMirror([
  * * `applications.commands`: allows this bot to create commands in the server
  * * `applications.entitlements`: allows reading entitlements for a users applications
  * * `applications.store.update`: allows reading and updating of store data for a users applications
+ * * `bot`: makes the bot join the selected guild
  * * `connections`: makes the endpoint for getting a users connections available
  * * `email`: allows the `/users/@me` endpoint return with an email
  * * `identify`: allows the `/users/@me` endpoint without an email

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3556,6 +3556,7 @@ export type InviteScope =
   | 'applications.commands'
   | 'applications.entitlements'
   | 'applications.store.update'
+  | 'bot'
   | 'connections'
   | 'email'
   | 'identity'


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `bot` invite scope was missing from the typings and from the docs.
The description of the bot scope on the docs might not be the best, let me know.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
