### PR TITLE
docs(ThreadChannel): fix documentation for setLocked method

### DIFF
--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -268,7 +268,7 @@ class ThreadChannel extends Channel {
 
   /**
    * Sets whether the thread can be **unarchived** by anyone with `SEND_MESSAGES` permission.
-   * When the thread is locked only members with `MANAGE_THREADS` can unarchive it.
+   * When a thread is locked only members with `MANAGE_THREADS` can unarchive it.
    * @param {boolean} [locked=true] Whether the thread is locked
    * @param {string} [reason] Reason for locking or unlocking the thread
    * @returns {Promise<ThreadChannel>}

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -267,9 +267,10 @@ class ThreadChannel extends Channel {
   }
 
   /**
-   * Sets whether the thread can be archived by anyone or just mods.
+   * Sets whether the thread can be **unarchived** by anyone with `SEND_MESSAGES` permission.
+   * When the thread is locked only members with `MANAGE_THREADS` can unarchive it.
    * @param {boolean} [locked=true] Whether the thread is locked
-   * @param {string} [reason] Reason for archiving or unarchiving
+   * @param {string} [reason] Reason for locking or unlocking the thread
    * @returns {Promise<ThreadChannel>}
    * @example
    * // Set the thread to locked


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the docs for `ThreadChannel#setLocked` 🧵 🔒 

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
