### PR TITLE
fix(Presence) missing client property definition

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1276,6 +1276,7 @@ export class Permissions extends BitField<PermissionString, bigint> {
 export class Presence {
   public constructor(client: Client, data?: unknown);
   public activities: Activity[];
+  public readonly client: Client;
   public clientStatus: ClientPresenceStatusData | null;
   public guild: Guild | null;
   public readonly member: GuildMember | null;


### PR DESCRIPTION
Readonly property "client" was missing from type definitions for class Presence.

**Please describe the changes this PR makes and why it should be merged:**

Seeing as the client property is still being defined and is also still listed in the docs, this looks like it was missing. Feedback on PR is welcome, as I'd like to continue to contribute/do so properly. Thanks!

https://github.com/discordjs/discord.js/blob/master/src/structures/Presence.js#L41

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating