### PR TITLE
refactor(Presences): remove from User, nullable on GuildMember

### DIFF
--- a/src/client/actions/PresenceUpdate.js
+++ b/src/client/actions/PresenceUpdate.js
@@ -16,7 +16,7 @@ class PresenceUpdateAction extends Action {
     const guild = this.client.guilds.cache.get(data.guild_id);
     if (!guild) return;
 
-    const oldPresence = guild.presences.cache.get(user.id)?._clone();
+    const oldPresence = guild.presences.cache.get(user.id)?._clone() ?? null;
     let member = guild.members.cache.get(user.id);
     if (!member && data.status !== 'offline') {
       member = guild.members.add({

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Base = require('./Base');
-const { Presence } = require('./Presence');
 const VoiceState = require('./VoiceState');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { Error } = require('../errors');
@@ -133,19 +132,11 @@ class GuildMember extends Base {
 
   /**
    * The presence of this guild member
-   * @type {Presence}
+   * @type {?Presence}
    * @readonly
    */
   get presence() {
-    return (
-      this.guild.presences.cache.get(this.id) ??
-      new Presence(this.client, {
-        user: {
-          id: this.id,
-        },
-        guild: this.guild,
-      })
-    );
+    return this.guild.presences.resolve(this.id);
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Base = require('./Base');
-const { Presence } = require('./Presence');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { Error } = require('../errors');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
@@ -120,18 +119,6 @@ class User extends Base {
    */
   get createdAt() {
     return new Date(this.createdTimestamp);
-  }
-
-  /**
-   * The presence of this user
-   * @type {Presence}
-   * @readonly
-   */
-  get presence() {
-    for (const guild of this.client.guilds.cache.values()) {
-      if (guild.presences.cache.has(this.id)) return guild.presences.cache.get(this.id);
-    }
-    return new Presence(this.client, { user: { id: this.id } });
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -687,7 +687,7 @@ export class GuildMember extends PartialTextBasedChannel(Base) {
   public readonly permissions: Readonly<Permissions>;
   public readonly premiumSince: Date | null;
   public premiumSinceTimestamp: number | null;
-  public readonly presence: Presence;
+  public readonly presence: Presence | null;
   public readonly roles: GuildMemberRoleManager;
   public user: User;
   public readonly voice: VoiceState;
@@ -1648,7 +1648,6 @@ export class User extends PartialTextBasedChannel(Base) {
   public flags: Readonly<UserFlags> | null;
   public id: Snowflake;
   public readonly partial: false;
-  public readonly presence: Presence;
   public system: boolean;
   public readonly tag: string;
   public username: string;
@@ -2931,7 +2930,7 @@ export interface ClientEvents {
   messageReactionAdd: [message: MessageReaction, user: User | PartialUser];
   messageReactionRemove: [reaction: MessageReaction, user: User | PartialUser];
   messageUpdate: [oldMessage: Message | PartialMessage, newMessage: Message | PartialMessage];
-  presenceUpdate: [oldPresence: Presence | undefined, newPresence: Presence];
+  presenceUpdate: [oldPresence: Presence | null, newPresence: Presence];
   rateLimit: [rateLimitData: RateLimitData];
   invalidRequestWarning: [invalidRequestWarningData: InvalidRequestWarningData];
   ready: [];


### PR DESCRIPTION
as well as on Client#presenceUpdate

**Please describe the changes this PR makes and why it should be merged:**

This PR:
- removes `User#presence` as it was a hack traversing the guild cache in order to find a presence of any member representing the given user.
- makes `GuildMember#presence` nullable. That way you can distinguish between "This member is offline" and "The presence of this member is unknown" without having to check the cache yourself, rendering this getter pointless.
  Additionally this was confusing when you did not enable the presence intent in the first place: "Why do I know this member is offline? I am not supposed to know!" (Despite you actually having no idea)
- makes `Client#presenceUpdate` first parameter `null` instead of `undefined`, because we don't do this in other places and an explicit null makes more sense than undefined.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

