### PR TITLE
refactor(PresenceManager): have Presence extend Base and simplify add

### DIFF
--- a/src/managers/PresenceManager.js
+++ b/src/managers/PresenceManager.js
@@ -19,8 +19,7 @@ class PresenceManager extends CachedManager {
    */
 
   add(data, cache) {
-    const existing = this.cache.get(data.user.id);
-    return existing ? existing.patch(data) : super.add(data, cache, { id: data.user.id });
+    return super.add(data, cache, { id: data.user.id });
   }
 
   /**

--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -15,7 +15,7 @@ class ClientPresence extends Presence {
 
   set(presence) {
     const packet = this._parse(presence);
-    this.patch(packet);
+    this._patch(packet);
     if (typeof presence.shardId === 'undefined') {
       this.client.ws.broadcast({ op: OPCodes.STATUS_UPDATE, d: packet });
     } else if (Array.isArray(presence.shardId)) {

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -41,6 +41,7 @@ class Presence extends Base {
    */
   constructor(client, data = {}) {
     super(client);
+
     /**
      * The presence's user id
      * @type {Snowflake}

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Base = require('./Base');
 const Emoji = require('./Emoji');
 const ActivityFlags = require('../util/ActivityFlags');
 const { ActivityTypes } = require('../util/Constants');
@@ -31,20 +32,15 @@ const Util = require('../util/Util');
 
 /**
  * Represents a user's presence.
+ * @extends {Base}
  */
-class Presence {
+class Presence extends Base {
   /**
    * @param {Client} client The instantiating client
    * @param {APIPresence} [data={}] The data for the presence
    */
   constructor(client, data = {}) {
-    /**
-     * The client that instantiated this
-     * @name Presence#client
-     * @type {Client}
-     * @readonly
-     */
-    Object.defineProperty(this, 'client', { value: client });
+    super(client);
     /**
      * The presence's user id
      * @type {Snowflake}
@@ -57,7 +53,7 @@ class Presence {
      */
     this.guild = data.guild ?? null;
 
-    this.patch(data);
+    this._patch(data);
   }
 
   /**
@@ -78,7 +74,7 @@ class Presence {
     return this.guild.members.resolve(this.userId);
   }
 
-  patch(data) {
+  _patch(data) {
     /**
      * The status of this presence
      * @type {PresenceStatus}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1273,10 +1273,9 @@ export class Permissions extends BitField<PermissionString, bigint> {
   public static resolve(permission?: PermissionResolvable): bigint;
 }
 
-export class Presence {
+export class Presence extends Base {
   public constructor(client: Client, data?: unknown);
   public activities: Activity[];
-  public readonly client: Client;
   public clientStatus: ClientPresenceStatusData | null;
   public guild: Guild | null;
   public readonly member: GuildMember | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR brings a bit of consistency to `PresenceManager` and `Presence` with the other structures and managers.
`Presence` more or less implemented `Base`'s stuff itself in combination with `PresenceManager` patching it itself, while `CachedManager` could do that just fine.

Carefully going with `semver: patch` here, since I am not sure what making `Presence` extend `Base` could break.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

