### PR TITLE
types(*): revert incorrect unknown type changes

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -173,9 +173,9 @@ export class BaseClient extends EventEmitter {
   public clearTimeout(timeout: NodeJS.Timeout): void;
   public clearImmediate(timeout: NodeJS.Immediate): void;
   public destroy(): void;
-  public setInterval(fn: (...args: unknown[]) => void, delay: number, ...args: unknown[]): NodeJS.Timeout;
-  public setTimeout(fn: (...args: unknown[]) => void, delay: number, ...args: unknown[]): NodeJS.Timeout;
-  public setImmediate(fn: (...args: unknown[]) => void, ...args: unknown[]): NodeJS.Immediate;
+  public setInterval<T extends any[]>(fn: (...args: T) => Awaited<void>, delay: number, ...args: T): NodeJS.Timeout;
+  public setTimeout<T extends any[]>(fn: (...args: T) => Awaited<void>, delay: number, ...args: T): NodeJS.Timeout;
+  public setImmediate<T extends any[]>(fn: (...args: T) => Awaited<void>, ...args: T): NodeJS.Immediate;
   public toJSON(...props: Record<string, boolean | string>[]): unknown;
 }
 
@@ -303,13 +303,13 @@ export class Client extends BaseClient {
   public on<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => Awaited<void>): this;
   public on<S extends string | symbol>(
     event: Exclude<S, keyof ClientEvents>,
-    listener: (...args: unknown[]) => Awaited<void>,
+    listener: (...args: any[]) => Awaited<void>,
   ): this;
 
   public once<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => Awaited<void>): this;
   public once<S extends string | symbol>(
     event: Exclude<S, keyof ClientEvents>,
-    listener: (...args: unknown[]) => Awaited<void>,
+    listener: (...args: any[]) => Awaited<void>,
   ): this;
 
   public emit<K extends keyof ClientEvents>(event: K, ...args: ClientEvents[K]): boolean;
@@ -318,7 +318,7 @@ export class Client extends BaseClient {
   public off<K extends keyof ClientEvents>(event: K, listener: (...args: ClientEvents[K]) => Awaited<void>): this;
   public off<S extends string | symbol>(
     event: Exclude<S, keyof ClientEvents>,
-    listener: (...args: unknown[]) => Awaited<void>,
+    listener: (...args: any[]) => Awaited<void>,
   ): this;
 
   public removeAllListeners<K extends keyof ClientEvents>(event?: K): this;
@@ -387,7 +387,7 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
   public [Symbol.asyncIterator](): AsyncIterableIterator<V>;
   public toJSON(): unknown;
 
-  protected listener: (...args: unknown[]) => void;
+  protected listener: (...args: any[]) => void;
   public abstract collect(...args: unknown[]): K | null | Promise<K | null>;
   public abstract dispose(...args: unknown[]): K | null;
 
@@ -850,11 +850,11 @@ export class InteractionCollector<T extends Interaction> extends Collector<Snowf
   public dispose(interaction: Interaction): Snowflake;
   public on(event: 'collect' | 'dispose', listener: (interaction: T) => Awaited<void>): this;
   public on(event: 'end', listener: (collected: Collection<Snowflake, T>, reason: string) => Awaited<void>): this;
-  public on(event: string, listener: (...args: unknown[]) => Awaited<void>): this;
+  public on(event: string, listener: (...args: any[]) => Awaited<void>): this;
 
   public once(event: 'collect' | 'dispose', listener: (interaction: T) => Awaited<void>): this;
   public once(event: 'end', listener: (collected: Collection<Snowflake, T>, reason: string) => Awaited<void>): this;
-  public once(event: string, listener: (...args: unknown[]) => Awaited<void>): this;
+  public once(event: string, listener: (...args: any[]) => Awaited<void>): this;
 }
 
 export class InteractionWebhook extends PartialWebhookMixin() {
@@ -1305,14 +1305,14 @@ export class ReactionCollector extends Collector<Snowflake | string, MessageReac
 
   public on(event: 'collect' | 'dispose' | 'remove', listener: (reaction: MessageReaction, user: User) => void): this;
   public on(event: 'end', listener: (collected: Collection<Snowflake, MessageReaction>, reason: string) => void): this;
-  public on(event: string, listener: (...args: unknown[]) => void): this;
+  public on(event: string, listener: (...args: any[]) => void): this;
 
   public once(event: 'collect' | 'dispose' | 'remove', listener: (reaction: MessageReaction, user: User) => void): this;
   public once(
     event: 'end',
     listener: (collected: Collection<Snowflake, MessageReaction>, reason: string) => void,
   ): this;
-  public once(event: string, listener: (...args: unknown[]) => void): this;
+  public once(event: string, listener: (...args: any[]) => void): this;
 }
 
 export class ReactionEmoji extends Emoji {
@@ -1375,7 +1375,7 @@ export class SelectMenuInteraction extends MessageComponentInteraction {
 export class Shard extends EventEmitter {
   public constructor(manager: ShardingManager, id: number);
   private _evals: Map<string, Promise<unknown>>;
-  private _exitListener: (...args: unknown[]) => void;
+  private _exitListener: (...args: any[]) => void;
   private _fetches: Map<string, Promise<unknown>>;
   private _handleExit(respawn?: boolean): void;
   private _handleMessage(message: unknown): void;
@@ -1399,14 +1399,14 @@ export class Shard extends EventEmitter {
   public on(event: 'spawn' | 'death', listener: (child: ChildProcess) => Awaited<void>): this;
   public on(event: 'disconnect' | 'ready' | 'reconnecting', listener: () => Awaited<void>): this;
   public on(event: 'error', listener: (error: Error) => Awaited<void>): this;
-  public on(event: 'message', listener: (message: unknown) => Awaited<void>): this;
-  public on(event: string, listener: (...args: unknown[]) => Awaited<void>): this;
+  public on(event: 'message', listener: (message: any) => Awaited<void>): this;
+  public on(event: string, listener: (...args: any[]) => Awaited<void>): this;
 
   public once(event: 'spawn' | 'death', listener: (child: ChildProcess) => Awaited<void>): this;
   public once(event: 'disconnect' | 'ready' | 'reconnecting', listener: () => Awaited<void>): this;
   public once(event: 'error', listener: (error: Error) => Awaited<void>): this;
-  public once(event: 'message', listener: (message: unknown) => Awaited<void>): this;
-  public once(event: string, listener: (...args: unknown[]) => Awaited<void>): this;
+  public once(event: 'message', listener: (message: any) => Awaited<void>): this;
+  public once(event: string, listener: (...args: any[]) => Awaited<void>): this;
 }
 
 export class ShardClientUtil {
@@ -1815,8 +1815,8 @@ export class WebSocketManager extends EventEmitter {
   public status: Status;
   public readonly ping: number;
 
-  public on(event: WSEventType, listener: (data: unknown, shardId: number) => void): this;
-  public once(event: WSEventType, listener: (data: unknown, shardId: number) => void): this;
+  public on(event: WSEventType, listener: (data: any, shardId: number) => void): this;
+  public once(event: WSEventType, listener: (data: any, shardId: number) => void): this;
 
   private debug(message: string, shard?: WebSocketShard): void;
   private connect(): Promise<void>;
@@ -1874,12 +1874,12 @@ export class WebSocketShard extends EventEmitter {
   public on(event: 'ready' | 'resumed' | 'invalidSession', listener: () => Awaited<void>): this;
   public on(event: 'close', listener: (event: CloseEvent) => Awaited<void>): this;
   public on(event: 'allReady', listener: (unavailableGuilds?: Set<Snowflake>) => Awaited<void>): this;
-  public on(event: string, listener: (...args: unknown[]) => Awaited<void>): this;
+  public on(event: string, listener: (...args: any[]) => Awaited<void>): this;
 
   public once(event: 'ready' | 'resumed' | 'invalidSession', listener: () => Awaited<void>): this;
   public once(event: 'close', listener: (event: CloseEvent) => Awaited<void>): this;
   public once(event: 'allReady', listener: (unavailableGuilds?: Set<Snowflake>) => Awaited<void>): this;
-  public once(event: string, listener: (...args: unknown[]) => Awaited<void>): this;
+  public once(event: string, listener: (...args: any[]) => Awaited<void>): this;
 }
 
 export class Widget extends Base {
@@ -3914,7 +3914,7 @@ export type Partialize<T, O extends string> = {
   [K in keyof Omit<
     T,
     'client' | 'createdAt' | 'createdTimestamp' | 'id' | 'partial' | 'fetch' | 'deleted' | O
-  >]: T[K] extends (...args: unknown[]) => void ? T[K] : T[K] | null;
+  >]: T[K] extends (...args: any[]) => void ? T[K] : T[K] | null;
 };
 
 export interface PartialDMChannel
@@ -4307,7 +4307,7 @@ export type WSEventType =
   | 'STAGE_INSTANCE_UPDATE'
   | 'STAGE_INSTANCE_DELETE';
 
-export type Serialized<T> = T extends symbol | bigint | (() => unknown)
+export type Serialized<T> = T extends symbol | bigint | (() => any)
   ? never
   : T extends number | string | boolean | undefined
   ? T


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the types for all arguments from spread functions from `unknown` to `any`, introduced in #6047. This meant that  any conditions that relied on these functions would return false and break certain things (like Partials)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
