### PR TITLE
feat(Collector): better types for events

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -391,10 +391,10 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
   public abstract collect(...args: unknown[]): K | null | Promise<K | null>;
   public abstract dispose(...args: unknown[]): K | null;
 
-  public on(event: 'collect' | 'dispose', listener: (...args: unknown[]) => Awaited<void>): this;
+  public on(event: 'collect' | 'dispose', listener: (...args: [V, ...F]) => Awaited<void>): this;
   public on(event: 'end', listener: (collected: Collection<K, V>, reason: string) => Awaited<void>): this;
 
-  public once(event: 'collect' | 'dispose', listener: (...args: unknown[]) => Awaited<void>): this;
+  public once(event: 'collect' | 'dispose', listener: (...args: [V, ...F]) => Awaited<void>): this;
   public once(event: 'end', listener: (collected: Collection<K, V>, reason: string) => Awaited<void>): this;
 }
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -494,12 +494,12 @@ notPropertyOf(guildMember, 'lastMessage');
 notPropertyOf(guildMember, 'lastMessageId');
 
 // Test collector event parameters
-declare const mc: MessageCollector;
-mc.on('collect', (...args) => {
+declare const messageCollector: MessageCollector;
+messageCollector.on('collect', (...args) => {
   assertType<[Message]>(args);
 });
 
-declare const rc: ReactionCollector;
-rc.on('dispose', (...args) => {
+declare const reactionCollector: ReactionCollector;
+reactionCollector.on('dispose', (...args) => {
   assertType<[MessageReaction, User]>(args);
 });

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -8,11 +8,14 @@ import {
   MessageActionRow,
   MessageAttachment,
   MessageButton,
+  MessageCollector,
   MessageEmbed,
+  MessageReaction,
   NewsChannel,
   Options,
   PartialTextBasedChannelFields,
   Permissions,
+  ReactionCollector,
   Serialized,
   ShardClientUtil,
   ShardingManager,
@@ -489,3 +492,14 @@ notPropertyOf(user, 'lastMessage');
 notPropertyOf(user, 'lastMessageId');
 notPropertyOf(guildMember, 'lastMessage');
 notPropertyOf(guildMember, 'lastMessageId');
+
+// Test collector event parameters
+declare const mc: MessageCollector;
+mc.on('collect', (...args) => {
+  assertType<[Message]>(args);
+});
+
+declare const rc: ReactionCollector;
+rc.on('dispose', (...args) => {
+  assertType<[MessageReaction, User]>(args);
+});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This changes the type of the collector event parameters from `unknown` to something actually helpful.

**Status and versioning classification:**

- There are no code changes
- I know how to update typings and have done so