### PR TITLE
refactor(ApplicationCommandManager): remove unused assignment

### DIFF
--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -83,7 +83,7 @@ class ApplicationCommandManager extends CachedManager {
    */
   async fetch(id, { guildId, cache = true, force = false } = {}) {
     if (typeof id === 'object') {
-      ({ guildId, cache = true, force = false } = id);
+      ({ guildId, cache = true } = id);
     } else if (id) {
       if (!force) {
         const existing = this.cache.get(id);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `force` parameter is used only in line 88:

https://github.com/discordjs/discord.js/blob/2e078e44883c1ef5f85ef973d61a305ce2a34251/src/managers/ApplicationCommandManager.js#L88

Which is always unreachable for line 86, where this assignment is at.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
