### PR TITLE
types(ApplicationCommand): fix option name

### DIFF
--- a/src/managers/ApplicationCommandPermissionsManager.js
+++ b/src/managers/ApplicationCommandPermissionsManager.js
@@ -347,7 +347,7 @@ class ApplicationCommandPermissionsManager extends BaseManager {
     const { guildId, commandId } = this._validateOptions(guild, command);
     if (!commandId) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
 
-    if (!permissionId) throw new TypeError('INVALID_TYPE', 'permissionsId', 'UserResolvable or RoleResolvable');
+    if (!permissionId) throw new TypeError('INVALID_TYPE', 'permissionId', 'UserResolvable or RoleResolvable');
     let resolvedId = permissionId;
     if (typeof permissionId !== 'string') {
       resolvedId = this.client.users.resolveId(permissionId);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2235,7 +2235,7 @@ export class ApplicationCommandPermissionsManager<
   public add(
     options: FetchSingleOptions & { permissions: ApplicationCommandPermissionData[] },
   ): Promise<ApplicationCommandPermissions[]>;
-  public has(options: FetchSingleOptions & { permissionsId: UserResolvable | RoleResolvable }): Promise<boolean>;
+  public has(options: FetchSingleOptions & { permissionId: UserResolvable | RoleResolvable }): Promise<boolean>;
   public fetch(options: FetchSingleOptions): Promise<ApplicationCommandPermissions[]>;
   public fetch(options: BaseOptions): Promise<Collection<Snowflake, ApplicationCommandPermissions[]>>;
   public remove(

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -59,7 +59,7 @@ client.on('ready', async () => {
     guild: testGuildId,
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
-  await globalPermissionsManager?.has({ command: globalCommandId, guild: testGuildId, permissionsId: testGuildId });
+  await globalPermissionsManager?.has({ command: globalCommandId, guild: testGuildId, permissionId: testGuildId });
   await globalPermissionsManager?.fetch({ guild: testGuildId });
   await globalPermissionsManager?.fetch({ command: globalCommandId, guild: testGuildId });
   await globalPermissionsManager?.remove({ command: globalCommandId, guild: testGuildId, roles: [testGuildId] });
@@ -86,7 +86,7 @@ client.on('ready', async () => {
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await globalPermissionsManager?.has({ command: globalCommandId, permissionsId: testGuildId });
+  await globalPermissionsManager?.has({ command: globalCommandId, permissionId: testGuildId });
   // @ts-expect-error
   await globalPermissionsManager?.fetch();
   // @ts-expect-error
@@ -119,7 +119,7 @@ client.on('ready', async () => {
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await globalPermissionsManager?.has({ guild: testGuildId, permissionsId: testGuildId });
+  await globalPermissionsManager?.has({ guild: testGuildId, permissionId: testGuildId });
   // @ts-expect-error
   await globalPermissionsManager?.remove({ guild: testGuildId, roles: [testGuildId] });
   // @ts-expect-error
@@ -137,7 +137,7 @@ client.on('ready', async () => {
     command: globalCommandId,
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
-  await guildPermissionsManager?.has({ command: globalCommandId, permissionsId: testGuildId });
+  await guildPermissionsManager?.has({ command: globalCommandId, permissionId: testGuildId });
   await guildPermissionsManager?.fetch({});
   await guildPermissionsManager?.fetch({ command: globalCommandId });
   await guildPermissionsManager?.remove({ command: globalCommandId, roles: [testGuildId] });
@@ -158,7 +158,7 @@ client.on('ready', async () => {
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await guildPermissionsManager?.has({ command: globalCommandId, guild: testGuildId, permissionsId: testGuildId });
+  await guildPermissionsManager?.has({ command: globalCommandId, guild: testGuildId, permissionId: testGuildId });
   // @ts-expect-error
   await guildPermissionsManager?.fetch({ guild: testGuildId });
   // @ts-expect-error
@@ -189,7 +189,7 @@ client.on('ready', async () => {
   // @ts-expect-error
   await guildPermissionsManager?.add({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
   // @ts-expect-error
-  await guildPermissionsManager?.has({ permissionsId: testGuildId });
+  await guildPermissionsManager?.has({ permissionId: testGuildId });
   // @ts-expect-error
   await guildPermissionsManager?.remove({ roles: [testGuildId] });
   // @ts-expect-error
@@ -209,7 +209,7 @@ client.on('ready', async () => {
     guild: testGuildId,
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
-  await globalCommand?.permissions.has({ guild: testGuildId, permissionsId: testGuildId });
+  await globalCommand?.permissions.has({ guild: testGuildId, permissionId: testGuildId });
   await globalCommand?.permissions.fetch({ guild: testGuildId });
   await globalCommand?.permissions.remove({ guild: testGuildId, roles: [testGuildId] });
   await globalCommand?.permissions.remove({ guild: testGuildId, users: [testUserId] });
@@ -226,7 +226,7 @@ client.on('ready', async () => {
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await globalCommand?.permissions.has({ command: globalCommandId, guild: testGuildId, permissionsId: testGuildId });
+  await globalCommand?.permissions.has({ command: globalCommandId, guild: testGuildId, permissionId: testGuildId });
   // @ts-expect-error
   await globalCommand?.permissions.fetch({ command: globalCommandId, guild: testGuildId });
   // @ts-expect-error
@@ -250,7 +250,7 @@ client.on('ready', async () => {
   // @ts-expect-error
   await globalCommand?.permissions.add({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
   // @ts-expect-error
-  await globalCommand?.permissions.has({ permissionsId: testGuildId });
+  await globalCommand?.permissions.has({ permissionId: testGuildId });
   // @ts-expect-error
   await globalCommand?.permissions.fetch({});
   // @ts-expect-error
@@ -264,7 +264,7 @@ client.on('ready', async () => {
 
   // Permissions from cached guild ApplicationCommand
   await guildCommandFromGlobal?.permissions.add({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
-  await guildCommandFromGlobal?.permissions.has({ permissionsId: testGuildId });
+  await guildCommandFromGlobal?.permissions.has({ permissionId: testGuildId });
   await guildCommandFromGlobal?.permissions.fetch({});
   await guildCommandFromGlobal?.permissions.remove({ roles: [testGuildId] });
   await guildCommandFromGlobal?.permissions.remove({ users: [testUserId] });
@@ -277,7 +277,7 @@ client.on('ready', async () => {
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await guildCommandFromGlobal?.permissions.has({ command: guildCommandId, permissionsId: testGuildId });
+  await guildCommandFromGlobal?.permissions.has({ command: guildCommandId, permissionId: testGuildId });
   // @ts-expect-error
   await guildCommandFromGlobal?.permissions.remove({ command: guildCommandId, roles: [testGuildId] });
   // @ts-expect-error
@@ -300,7 +300,7 @@ client.on('ready', async () => {
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await guildCommandFromGlobal?.permissions.has({ guild: testGuildId, permissionsId: testGuildId });
+  await guildCommandFromGlobal?.permissions.has({ guild: testGuildId, permissionId: testGuildId });
   // @ts-expect-error
   await guildCommandFromGlobal?.permissions.remove({ guild: testGuildId, roles: [testGuildId] });
   // @ts-expect-error
@@ -314,7 +314,7 @@ client.on('ready', async () => {
   });
 
   await guildCommandFromGuild?.permissions.add({ permissions: [{ type: 'ROLE', id: testGuildId, permission: true }] });
-  await guildCommandFromGuild?.permissions.has({ permissionsId: testGuildId });
+  await guildCommandFromGuild?.permissions.has({ permissionId: testGuildId });
   await guildCommandFromGuild?.permissions.fetch({});
   await guildCommandFromGuild?.permissions.remove({ roles: [testGuildId] });
   await guildCommandFromGuild?.permissions.remove({ users: [testUserId] });
@@ -327,7 +327,7 @@ client.on('ready', async () => {
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await guildCommandFromGuild?.permissions.has({ command: guildCommandId, permissionsId: testGuildId });
+  await guildCommandFromGuild?.permissions.has({ command: guildCommandId, permissionId: testGuildId });
   // @ts-expect-error
   await guildCommandFromGuild?.permissions.remove({ command: guildCommandId, roles: [testGuildId] });
   // @ts-expect-error
@@ -350,7 +350,7 @@ client.on('ready', async () => {
     permissions: [{ type: 'ROLE', id: testGuildId, permission: true }],
   });
   // @ts-expect-error
-  await guildCommandFromGuild?.permissions.has({ guild: testGuildId, permissionsId: testGuildId });
+  await guildCommandFromGuild?.permissions.has({ guild: testGuildId, permissionId: testGuildId });
   // @ts-expect-error
   await guildCommandFromGuild?.permissions.remove({ guild: testGuildId, roles: [testGuildId] });
   // @ts-expect-error


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR just fixes an error in typings where the option `permissionId` was typed as `permissionsId`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.