### PR TITLE
refactor(Message): combine patch methods

### DIFF
--- a/src/client/actions/MessageUpdate.js
+++ b/src/client/actions/MessageUpdate.js
@@ -9,7 +9,7 @@ class MessageUpdateAction extends Action {
       const { id, channel_id, guild_id, author, timestamp, type } = data;
       const message = this.getMessage({ id, channel_id, guild_id, author, timestamp, type }, channel);
       if (message) {
-        const old = message.patch(data);
+        const old = message._update(data, true);
         return {
           old,
           updated: message,

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -47,7 +47,7 @@ class Message extends Base {
     if (data) this._patch(data);
   }
 
-  _patch(data) {
+  _patch(data, partial = false) {
     /**
      * The message's id
      * @type {Snowflake}
@@ -127,25 +127,27 @@ class Message extends Base {
      * lost if re-fetched</warn>
      * @type {?string}
      */
-    this.nonce = 'nonce' in data ? data.nonce : null;
+    this.nonce = partial ? this.nonce : 'nonce' in data ? data.nonce : null;
 
     /**
      * A list of embeds in the message - e.g. YouTube Player
      * @type {MessageEmbed[]}
      */
-    this.embeds = data.embeds?.map(e => new Embed(e, true)) ?? [];
+    this.embeds = data.embeds?.map(e => new Embed(e, true)) ?? (partial ? this.embeds.slice() : []);
 
     /**
      * A list of MessageActionRows in the message
      * @type {MessageActionRow[]}
      */
-    this.components = data.components?.map(c => BaseMessageComponent.create(c, this.client)) ?? [];
+    this.components =
+      data.components?.map(c => BaseMessageComponent.create(c, this.client)) ??
+      (partial ? this.components.slice() : []);
 
     /**
      * A collection of attachments in the message - e.g. Pictures - mapped by their ids
      * @type {Collection<Snowflake, MessageAttachment>}
      */
-    this.attachments = new Collection();
+    this.attachments = partial && this.attachments ? new Collection(this.attachments) : new Collection();
     if (data.attachments) {
       for (const attachment of data.attachments) {
         this.attachments.set(attachment.id, new MessageAttachment(attachment.url, attachment.filename, attachment));
@@ -176,54 +178,73 @@ class Message extends Base {
      * A manager of the reactions belonging to this message
      * @type {ReactionManager}
      */
-    this.reactions = new ReactionManager(this);
+    this.reactions = partial && this.reactions ? this.reactions : new ReactionManager(this);
     if (data.reactions?.length > 0) {
       for (const reaction of data.reactions) {
         this.reactions._add(reaction);
       }
     }
 
-    /**
-     * All valid mentions that the message contains
-     * @type {MessageMentions}
-     */
-    this.mentions = new Mentions(
-      this,
-      data.mentions,
-      data.mention_roles,
-      data.mention_everyone,
-      data.mention_channels,
-      data.referenced_message?.author,
-    );
+    if (partial) {
+      this.mentions = new Mentions(
+        this,
+        data.mentions ?? this.mentions.users,
+        data.mention_roles ?? this.mentions.roles,
+        data.mention_everyone ?? this.mentions.everyone,
+        data.mention_channels ?? this.mentions.crosspostedChannels,
+        data.referenced_message?.author ?? this.mentions.repliedUser,
+      );
+    } else {
+      /**
+       * All valid mentions that the message contains
+       * @type {MessageMentions}
+       */
+      this.mentions = new Mentions(
+        this,
+        data.mentions,
+        data.mention_roles,
+        data.mention_everyone,
+        data.mention_channels,
+        data.referenced_message?.author,
+      );
+    }
 
     /**
      * The id of the webhook that sent the message, if applicable
      * @type {?Snowflake}
      */
-    this.webhookId = data.webhook_id ?? null;
+    this.webhookId = partial && this.webhookId ? this.webhookId : data.webhook_id ?? null;
 
     /**
      * Supplemental application information for group activities
      * @type {?ClientApplication}
      */
-    this.groupActivityApplication = data.application ? new ClientApplication(this.client, data.application) : null;
+    this.groupActivityApplication =
+      partial && this.groupActivityApplication
+        ? this.groupActivityApplication
+        : data.application
+        ? new ClientApplication(this.client, data.application)
+        : null;
 
     /**
      * The id of the application of the interaction that sent this message, if any
      * @type {?Snowflake}
      */
-    this.applicationId = data.application_id ?? null;
+    this.applicationId = partial && this.applicationId ? this.applicationId : data.application_id ?? null;
 
     /**
      * Group activity
      * @type {?MessageActivity}
      */
-    this.activity = data.activity
-      ? {
-          partyId: data.activity.party_id,
-          type: data.activity.type,
-        }
-      : null;
+    this.activity =
+      partial && this.activity
+        ? this.activity
+        : data.activity
+        ? {
+            partyId: data.activity.party_id,
+            type: data.activity.type,
+          }
+        : null;
 
     if (this.member && data.member) {
       this.member._patch(data.member);
@@ -235,7 +256,7 @@ class Message extends Base {
      * Flags that are applied to the message
      * @type {Readonly<MessageFlags>}
      */
-    this.flags = new MessageFlags(data.flags).freeze();
+    this.flags = new MessageFlags(partial ? data.flags ?? 0 : data.flags).freeze();
 
     /**
      * Reference data sent in a message that contains ids identifying the referenced message
@@ -249,13 +270,16 @@ class Message extends Base {
      * Message reference data
      * @type {?MessageReference}
      */
-    this.reference = data.message_reference
-      ? {
-          channelId: data.message_reference.channel_id,
-          guildId: data.message_reference.guild_id,
-          messageId: data.message_reference.message_id,
-        }
-      : null;
+    this.reference =
+      partial && this.reference
+        ? this.reference
+        : data.message_reference
+        ? {
+            channelId: data.message_reference.channel_id,
+            guildId: data.message_reference.guild_id,
+            messageId: data.message_reference.message_id,
+          }
+        : null;
 
     if (data.referenced_message) {
       this.channel.messages._add(data.referenced_message);
@@ -286,6 +310,12 @@ class Message extends Base {
     }
   }
 
+  _update(data, partial = false) {
+    const clone = this._clone();
+    this._patch(data, partial);
+    return clone;
+  }
+
   /**
    * Whether or not this message is a partial
    * @type {boolean}
@@ -293,47 +323,6 @@ class Message extends Base {
    */
   get partial() {
     return typeof this.content !== 'string' || !this.author;
-  }
-
-  /**
-   * Updates the message and returns the old message.
-   * @param {APIMessage} data Raw Discord message update data
-   * @returns {Message}
-   * @private
-   */
-  patch(data) {
-    const clone = this._clone();
-
-    if (data.edited_timestamp) this.editedTimestamp = new Date(data.edited_timestamp).getTime();
-    if ('content' in data) this.content = data.content;
-    if ('pinned' in data) this.pinned = data.pinned;
-    if ('tts' in data) this.tts = data.tts;
-    if ('thread' in data) this.thread = this.client.channels._add(data.thread);
-
-    if ('attachments' in data) {
-      this.attachments = new Collection();
-      for (const attachment of data.attachments) {
-        this.attachments.set(attachment.id, new MessageAttachment(attachment.url, attachment.filename, attachment));
-      }
-    } else {
-      this.attachments = new Collection(this.attachments);
-    }
-
-    this.embeds = data.embeds?.map(e => new Embed(e, true)) ?? this.embeds.slice();
-    this.components = data.components?.map(c => BaseMessageComponent.create(c, this.client)) ?? this.components.slice();
-
-    this.mentions = new Mentions(
-      this,
-      data.mentions ?? this.mentions.users,
-      data.mention_roles ?? this.mentions.roles,
-      data.mention_everyone ?? this.mentions.everyone,
-      data.mention_channels ?? this.mentions.crosspostedChannels,
-      data.referenced_message?.author ?? this.mentions.repliedUser,
-    );
-
-    this.flags = new MessageFlags(data.flags ?? 0).freeze();
-
-    return clone;
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -147,7 +147,8 @@ class Message extends Base {
      * A collection of attachments in the message - e.g. Pictures - mapped by their ids
      * @type {Collection<Snowflake, MessageAttachment>}
      */
-    this.attachments = partial && this.attachments ? new Collection(this.attachments) : new Collection();
+    this.attachments =
+      partial && !data.attachments && this.attachments ? new Collection(this.attachments) : new Collection();
     if (data.attachments) {
       for (const attachment of data.attachments) {
         this.attachments.set(attachment.id, new MessageAttachment(attachment.url, attachment.filename, attachment));
@@ -256,7 +257,7 @@ class Message extends Base {
      * Flags that are applied to the message
      * @type {Readonly<MessageFlags>}
      */
-    this.flags = new MessageFlags(partial ? data.flags ?? 0 : data.flags).freeze();
+    this.flags = new MessageFlags(partial ? data.flags ?? this.flags : data.flags).freeze();
 
     /**
      * Reference data sent in a message that contains ids identifying the referenced message

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -969,7 +969,8 @@ export class LimitedCollection<K, V> extends Collection<K, V> {
 
 export class Message extends Base {
   public constructor(client: Client, data: unknown, channel: TextChannel | DMChannel | NewsChannel | ThreadChannel);
-  private patch(data: unknown): Message;
+  private _patch(data: unknown, partial?: boolean): Message;
+  private _update(data: unknown, partial?: boolean): Message;
 
   public activity: MessageActivity | null;
   public applicationId: Snowflake | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Two patch methods, both private, second often gets missed during changes. No more!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
