### PR TITLE
docs(ClientUser): fix shardId nullable

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -103,7 +103,7 @@ class ClientUser extends User {
    * @property {PresenceStatusData} [status] Status of the user
    * @property {boolean} [afk] Whether the user is AFK
    * @property {ActivitiesOptions[]} [activities] Activity the user is playing
-   * @property {number|number[]} [shardId] Shard Id(s) to have the activity set on
+   * @property {number|number[]} [shardId] Shard id(s) to have the activity set on
    */
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -103,7 +103,7 @@ class ClientUser extends User {
    * @property {PresenceStatusData} [status] Status of the user
    * @property {boolean} [afk] Whether the user is AFK
    * @property {ActivitiesOptions[]} [activities] Activity the user is playing
-   * @property {?(number|number[])} [shardId] Shard Id(s) to have the activity set on
+   * @property {number|number[]} [shardId] Shard Id(s) to have the activity set on
    */
 
   /**
@@ -130,7 +130,7 @@ class ClientUser extends User {
   /**
    * Sets the status of the client user.
    * @param {PresenceStatusData} status Status to change to
-   * @param {?(number|number[])} [shardId] Shard id(s) to have the activity set on
+   * @param {number|number[]} [shardId] Shard id(s) to have the activity set on
    * @returns {Presence}
    * @example
    * // Set the client user's status


### PR DESCRIPTION
fix #6020 

**Please describe the changes this PR makes and why it should be merged:**

This PR fixes some jsdocs where `shardId` was showed as nullable while it isn't, in fact, passing `null` as `shardId` throws a TypeError. However, it's still marked as optional and types are ok.

**Status and versioning classification:**


- This PR **only** includes non-code changes, like changes to documentation, README, etc.
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating