### PR TITLE
feat(Client): add conditional ready typings

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -158,13 +158,6 @@ class Client extends BaseClient {
      */
     this.readyAt = null;
 
-    /**
-     * The ready state of the client - This will be true once the websocket initially connects.
-     * @type {boolean}
-     * @private
-     */
-    this.ready = false;
-
     if (this.options.messageSweepInterval > 0) {
       this.setInterval(this.sweepMessages.bind(this), this.options.messageSweepInterval * 1000);
     }
@@ -181,6 +174,15 @@ class Client extends BaseClient {
       if (guild.available) for (const emoji of guild.emojis.cache.values()) emojis.cache.set(emoji.id, emoji);
     }
     return emojis;
+  }
+
+  /**
+   * The ready state of the client - This will be true once the websocket initially connects.
+   * @type {boolean}
+   * @private
+   */
+  get ready() {
+    return this.ws.status === 0;
   }
 
   /**
@@ -227,7 +229,6 @@ class Client extends BaseClient {
 
     try {
       await this.ws.connect();
-      this.ready = true;
       return this.token;
     } catch (error) {
       this.destroy();

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -177,15 +177,6 @@ class Client extends BaseClient {
   }
 
   /**
-   * The ready state of the client - This will be true once the websocket initially connects.
-   * @type {boolean}
-   * @private
-   */
-  get ready() {
-    return this.ws.status === 0;
-  }
-
-  /**
    * Timestamp of the time the client was last `READY` at
    * @type {?number}
    * @readonly
@@ -242,7 +233,7 @@ class Client extends BaseClient {
    * @returns {boolean}
    */
   isReady() {
-    return this.ready;
+    return this.ws.status === 0;
   }
 
   /**

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -158,6 +158,13 @@ class Client extends BaseClient {
      */
     this.readyAt = null;
 
+    /**
+     * The ready state of the client - This will be true once the websocket initially connects.
+     * @type {boolean}
+     * @private
+     */
+    this.ready = false;
+
     if (this.options.messageSweepInterval > 0) {
       this.setInterval(this.sweepMessages.bind(this), this.options.messageSweepInterval * 1000);
     }
@@ -220,11 +227,21 @@ class Client extends BaseClient {
 
     try {
       await this.ws.connect();
+      this.ready = true;
       return this.token;
     } catch (error) {
       this.destroy();
       throw error;
     }
+  }
+
+  /**
+   * Returns whether the client has logged in, indicative of being able to access
+   * properties such as `user` and `application`.
+   * @returns {boolean}
+   */
+  isReady() {
+    return this.ready;
   }
 
   /**

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -18,7 +18,7 @@ const VoiceRegion = require('../structures/VoiceRegion');
 const Webhook = require('../structures/Webhook');
 const Widget = require('../structures/Widget');
 const Collection = require('../util/Collection');
-const { Events, InviteScopes } = require('../util/Constants');
+const { Events, InviteScopes, Status } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const Intents = require('../util/Intents');
 const Options = require('../util/Options');
@@ -233,7 +233,7 @@ class Client extends BaseClient {
    * @returns {boolean}
    */
   isReady() {
-    return this.ws.status === 0;
+    return this.ws.status === Status.READY;
   }
 
   /**

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -373,8 +373,9 @@ class WebSocketManager extends EventEmitter {
     /**
      * Emitted when the client becomes ready to start working.
      * @event Client#ready
+     * @param {Client} client The client
      */
-    this.client.emit(Events.CLIENT_READY);
+    this.client.emit(Events.CLIENT_READY, this.client);
 
     this.handlePacket();
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -111,7 +111,7 @@ export abstract class AnonymousGuild extends BaseGuild {
   public splashURL(options?: StaticImageURLOptions): string | null;
 }
 
-export abstract class Application extends Base {
+export abstract class Application extends Base<true> {
   public constructor(client: Client, data: unknown);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -157,9 +157,9 @@ export class ApplicationFlags extends BitField<ApplicationFlagsString> {
   public static resolve(bit?: BitFieldResolvable<ApplicationFlagsString, number>): number;
 }
 
-export class Base {
+export class Base<ClientReady extends boolean = boolean> {
   public constructor(client: Client);
-  public readonly client: Client;
+  public readonly client: Client<ClientReady>;
   public toJSON(...props: Record<string, boolean | string>[]): unknown;
   public valueOf(): string;
 }
@@ -185,7 +185,7 @@ export class BaseClient extends EventEmitter {
   public toJSON(...props: Record<string, boolean | string>[]): unknown;
 }
 
-export abstract class BaseGuild extends Base {
+export abstract class BaseGuild extends Base<true> {
   public constructor(client: Client, data: unknown);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -228,7 +228,7 @@ export class BaseMessageComponent {
   public type: MessageComponentType | null;
   private static create(
     data: MessageComponentOptions,
-    client?: Client | WebhookClient,
+    client?: Client<true> | WebhookClient,
     skipValidation?: boolean,
   ): MessageComponent | undefined;
   private static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
@@ -264,7 +264,7 @@ export class CategoryChannel extends GuildChannel {
 
 export type CategoryChannelResolvable = Snowflake | CategoryChannel;
 
-export class Channel extends Base {
+export class Channel extends Base<true> {
   public constructor(client: Client, data?: unknown, immediatePatch?: boolean);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -465,7 +465,7 @@ export class DMChannel extends TextBasedChannel(Channel, ['bulkDelete']) {
   public fetch(force?: boolean): Promise<this>;
 }
 
-export class Emoji extends Base {
+export class Emoji extends Base<true> {
   public constructor(client: Client, emoji: unknown);
   public animated: boolean | null;
   public readonly createdAt: Date | null;
@@ -622,7 +622,7 @@ export class GuildAuditLogsEntry {
   public toJSON(): unknown;
 }
 
-export class GuildBan extends Base {
+export class GuildBan extends Base<true> {
   public constructor(client: Client, data: unknown, guild: Guild);
   public guild: Guild;
   public user: User;
@@ -1145,7 +1145,7 @@ export class MessageMentions {
   private _members: Collection<Snowflake, GuildMember> | null;
 
   public readonly channels: Collection<Snowflake, Channel>;
-  public readonly client: Client;
+  public readonly client: Client<true>;
   public everyone: boolean;
   public readonly guild: Guild;
   public has(data: UserResolvable | RoleResolvable | ChannelResolvable, options?: MessageMentionsHasOptions): boolean;
@@ -1190,7 +1190,7 @@ export class MessageReaction {
   public constructor(client: Client, data: unknown, message: Message);
   private _emoji: GuildEmoji | ReactionEmoji;
 
-  public readonly client: Client;
+  public readonly client: Client<true>;
   public count: number | null;
   public readonly emoji: GuildEmoji | ReactionEmoji;
   public me: boolean;
@@ -1403,7 +1403,7 @@ export class Shard extends EventEmitter {
   public ready: boolean;
   public worker: unknown | null;
   public eval(script: string): Promise<unknown>;
-  public eval<T>(fn: (client: Client) => T): Promise<T[]>;
+  public eval<T>(fn: (client: Client<true>) => T): Promise<T[]>;
   public fetchClientValue(prop: string): Promise<unknown>;
   public kill(): void;
   public respawn(options?: { delay?: number; timeout?: number }): Promise<ChildProcess>;
@@ -1428,19 +1428,19 @@ export class ShardClientUtil {
   private _handleMessage(message: unknown): void;
   private _respond(type: string, message: unknown): void;
 
-  public client: Client;
+  public client: Client<true>;
   public readonly count: number;
   public readonly ids: number[];
   public mode: ShardingManagerMode;
   public parentPort: unknown | null;
-  public broadcastEval<T>(fn: (client: Client) => Awaited<T>): Promise<Serialized<T>[]>;
-  public broadcastEval<T>(fn: (client: Client) => Awaited<T>, options: { shard: number }): Promise<Serialized<T>>;
+  public broadcastEval<T>(fn: (client: Client<true>) => Awaited<T>): Promise<Serialized<T>[]>;
+  public broadcastEval<T>(fn: (client: Client<true>) => Awaited<T>, options: { shard: number }): Promise<Serialized<T>>;
   public broadcastEval<T, P>(
-    fn: (client: Client, context: Serialized<P>) => Awaited<T>,
+    fn: (client: Client<true>, context: Serialized<P>) => Awaited<T>,
     options: { context: P },
   ): Promise<Serialized<T>[]>;
   public broadcastEval<T, P>(
-    fn: (client: Client, context: Serialized<P>) => Awaited<T>,
+    fn: (client: Client<true>, context: Serialized<P>) => Awaited<T>,
     options: { context: P; shard: number },
   ): Promise<Serialized<T>>;
   public fetchClientValues(prop: string): Promise<unknown[]>;
@@ -1448,7 +1448,7 @@ export class ShardClientUtil {
   public respawnAll(options?: MultipleShardRespawnOptions): Promise<void>;
   public send(message: unknown): Promise<void>;
 
-  public static singleton(client: Client, mode: ShardingManagerMode): ShardClientUtil;
+  public static singleton(client: Client<true>, mode: ShardingManagerMode): ShardClientUtil;
   public static shardIdForGuildId(guildId: Snowflake, shardCount: number): number;
 }
 
@@ -1465,14 +1465,14 @@ export class ShardingManager extends EventEmitter {
   public totalShards: number | 'auto';
   public shardList: number[] | 'auto';
   public broadcast(message: unknown): Promise<Shard[]>;
-  public broadcastEval<T>(fn: (client: Client) => Awaited<T>): Promise<Serialized<T>[]>;
-  public broadcastEval<T>(fn: (client: Client) => Awaited<T>, options: { shard: number }): Promise<Serialized<T>>;
+  public broadcastEval<T>(fn: (client: Client<true>) => Awaited<T>): Promise<Serialized<T>[]>;
+  public broadcastEval<T>(fn: (client: Client<true>) => Awaited<T>, options: { shard: number }): Promise<Serialized<T>>;
   public broadcastEval<T, P>(
-    fn: (client: Client, context: Serialized<P>) => Awaited<T>,
+    fn: (client: Client<true>, context: Serialized<P>) => Awaited<T>,
     options: { context: P },
   ): Promise<Serialized<T>[]>;
   public broadcastEval<T, P>(
-    fn: (client: Client, context: Serialized<P>) => Awaited<T>,
+    fn: (client: Client<true>, context: Serialized<P>) => Awaited<T>,
     options: { context: P; shard: number },
   ): Promise<Serialized<T>>;
   public createShard(id: number): Shard;
@@ -1793,7 +1793,7 @@ export class Webhook extends WebhookMixin() {
   public avatar: string;
   public avatarURL(options?: StaticImageURLOptions): string | null;
   public channelId: Snowflake;
-  public client: Client;
+  public client: Client<true>;
   public guildId: Snowflake;
   public name: string;
   public owner: User | unknown | null;
@@ -2115,7 +2115,7 @@ export class ApplicationCommandPermissionsManager<
   CommandIdType,
 > extends BaseManager {
   public constructor(manager: ApplicationCommandManager | GuildApplicationCommandManager | ApplicationCommand);
-  public client: Client;
+  public client: Client<true>;
   public commandId: CommandIdType;
   public guild: GuildType;
   public guildId: Snowflake | null;
@@ -3797,7 +3797,7 @@ export interface PresenceData {
 export type PresenceResolvable = Presence | UserResolvable | Snowflake;
 
 export type Partialize<T, O extends string> = {
-  readonly client: Client;
+  readonly client: Client<true>;
   readonly createdAt: Date;
   readonly createdTimestamp: number;
   deleted: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -126,7 +126,7 @@ export abstract class Application extends Base<true> {
   public toString(): string | null;
 }
 
-export class ApplicationCommand<PermissionsFetchType = {}> extends Base<true> {
+export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
   public constructor(client: Client, data: unknown, guild?: Guild, guildId?: Snowflake);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -718,7 +718,7 @@ export class GuildMember extends PartialTextBasedChannel(Base) {
   public valueOf(): string;
 }
 
-export class GuildPreview extends Base<true> {
+export class GuildPreview extends Base {
   public constructor(client: Client, data: unknown);
   public approximateMemberCount: number;
   public approximatePresenceCount: number;
@@ -738,7 +738,7 @@ export class GuildPreview extends Base<true> {
   public toString(): string;
 }
 
-export class GuildTemplate extends Base<true> {
+export class GuildTemplate extends Base {
   public constructor(client: Client, data: unknown);
   public readonly createdTimestamp: number;
   public readonly updatedTimestamp: number;
@@ -784,7 +784,7 @@ export class RateLimitError extends Error {
   public name: 'RateLimitError';
 }
 
-export class Integration extends Base<true> {
+export class Integration extends Base {
   public constructor(client: Client, data: unknown, guild: Guild);
   public account: IntegrationAccount;
   public application: IntegrationApplication | null;
@@ -821,7 +821,7 @@ export class Intents extends BitField<IntentsString> {
   public static resolve(bit?: BitFieldResolvable<IntentsString, number>): number;
 }
 
-export class Interaction extends Base<true> {
+export class Interaction extends Base {
   public constructor(client: Client, data: unknown);
   public applicationId: Snowflake;
   public readonly channel: Channel | PartialDMChannel | null;
@@ -877,7 +877,7 @@ export class InteractionWebhook extends PartialWebhookMixin() {
   public send(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
 }
 
-export class Invite extends Base<true> {
+export class Invite extends Base {
   public constructor(client: Client, data: unknown);
   public channel: GuildChannel | PartialGroupDMChannel;
   public code: string;
@@ -905,7 +905,7 @@ export class Invite extends Base<true> {
   public stageInstance: InviteStageInstance | null;
 }
 
-export class InviteStageInstance extends Base<true> {
+export class InviteStageInstance extends Base {
   public constructor(client: Client, data: unknown, channelId: Snowflake, guildId: Snowflake);
   public channelId: Snowflake;
   public guildId: Snowflake;
@@ -927,7 +927,7 @@ export class LimitedCollection<K, V> extends Collection<K, V> {
   public maxSize: number;
 }
 
-export class Message extends Base<true> {
+export class Message extends Base {
   public constructor(client: Client, data: unknown, channel: TextChannel | DMChannel | NewsChannel | ThreadChannel);
   private patch(data: unknown): Message;
 
@@ -1256,7 +1256,7 @@ export class PartialGroupDMChannel extends Channel {
   public iconURL(options?: StaticImageURLOptions): string | null;
 }
 
-export class PermissionOverwrites extends Base<true> {
+export class PermissionOverwrites extends Base {
   public constructor(client: Client, data: object, channel: GuildChannel);
   public allow: Readonly<Permissions>;
   public readonly channel: GuildChannel;
@@ -1287,7 +1287,7 @@ export class Permissions extends BitField<PermissionString, bigint> {
   public static resolve(permission?: PermissionResolvable): bigint;
 }
 
-export class Presence extends Base<true> {
+export class Presence extends Base {
   public constructor(client: Client, data?: unknown);
   public activities: Activity[];
   public clientStatus: ClientPresenceStatusData | null;
@@ -1345,7 +1345,7 @@ export class RichPresenceAssets {
   public smallImageURL(options?: StaticImageURLOptions): string | null;
 }
 
-export class Role extends Base<true> {
+export class Role extends Base {
   public constructor(client: Client, data: unknown, guild: Guild);
   public color: number;
   public readonly createdAt: Date;
@@ -1500,7 +1500,7 @@ export class StageChannel extends BaseGuildVoiceChannel {
   public createStageInstance(options: StageInstanceCreateOptions): Promise<StageInstance>;
 }
 
-export class StageInstance extends Base<true> {
+export class StageInstance extends Base {
   public constructor(client: Client, data: unknown, channel: StageChannel);
   public id: Snowflake;
   public deleted: boolean;
@@ -1518,7 +1518,7 @@ export class StageInstance extends Base<true> {
   public readonly createdAt: Date;
 }
 
-export class Sticker extends Base<true> {
+export class Sticker extends Base {
   public constructor(client: Client, data: unknown);
   public asset: string;
   public readonly createdTimestamp: number;
@@ -1543,7 +1543,7 @@ export class SystemChannelFlags extends BitField<SystemChannelFlagsString> {
   public static resolve(bit?: BitFieldResolvable<SystemChannelFlagsString, number>): number;
 }
 
-export class Team extends Base<true> {
+export class Team extends Base {
   public constructor(client: Client, data: unknown);
   public id: Snowflake;
   public name: string;
@@ -1560,7 +1560,7 @@ export class Team extends Base<true> {
   public toString(): string;
 }
 
-export class TeamMember extends Base<true> {
+export class TeamMember extends Base {
   public constructor(team: Team, data: unknown);
   public team: Team;
   public readonly id: Snowflake;
@@ -1633,7 +1633,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
   public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<ThreadChannel>;
 }
 
-export class ThreadMember extends Base<true> {
+export class ThreadMember extends Base {
   public constructor(thread: ThreadChannel, data?: object);
   public flags: ThreadMemberFlags;
   public readonly guildMember: GuildMember | null;
@@ -1761,7 +1761,7 @@ export class VoiceRegion {
   public toJSON(): unknown;
 }
 
-export class VoiceState extends Base<true> {
+export class VoiceState extends Base {
   public constructor(guild: Guild, data: unknown);
   public readonly channel: VoiceChannel | StageChannel | null;
   public channelId: Snowflake | null;
@@ -1897,7 +1897,7 @@ export class WebSocketShard extends EventEmitter {
   public once(event: string, listener: (...args: any[]) => Awaited<void>): this;
 }
 
-export class Widget extends Base<true> {
+export class Widget extends Base {
   public constructor(client: Client, data: object);
   private _patch(data: object): void;
   public fetch(): Promise<Widget>;
@@ -1908,7 +1908,7 @@ export class Widget extends Base<true> {
   public presenceCount: number;
 }
 
-export class WidgetMember extends Base<true> {
+export class WidgetMember extends Base {
   public constructor(client: Client, data: object);
   public id: string;
   public username: string;
@@ -1925,7 +1925,7 @@ export class WidgetMember extends Base<true> {
   public activity?: WidgetActivity;
 }
 
-export class WelcomeChannel extends Base<true> {
+export class WelcomeChannel extends Base {
   private _emoji: unknown;
   public channelId: Snowflake;
   public guild: Guild | InviteGuild;
@@ -1934,7 +1934,7 @@ export class WelcomeChannel extends Base<true> {
   public readonly emoji: GuildEmoji | Emoji;
 }
 
-export class WelcomeScreen extends Base<true> {
+export class WelcomeScreen extends Base {
   public readonly enabled: boolean;
   public guild: Guild | InviteGuild;
   public description: string | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -278,23 +278,25 @@ export class Channel extends Base {
   public toString(): ChannelMention;
 }
 
-export class Client extends BaseClient {
+type If<T extends boolean, A, B = null> = T extends true ? A : T extends false ? B : A | B;
+
+export class Client<Ready extends boolean = boolean> extends BaseClient {
   public constructor(options: ClientOptions);
   private actions: unknown;
   private _eval(script: string): unknown;
   private _validateOptions(options: ClientOptions): void;
 
-  public application: ClientApplication | null;
+  public application: If<Ready, ClientApplication>;
   public channels: ChannelManager;
   public readonly emojis: BaseGuildEmojiManager;
   public guilds: GuildManager;
   public options: ClientOptions;
-  public readyAt: Date | null;
-  public readonly readyTimestamp: number | null;
-  public shard: ShardClientUtil | null;
-  public token: string | null;
-  public readonly uptime: number | null;
-  public user: ClientUser | null;
+  public readyAt: If<Ready, Date>;
+  public readonly readyTimestamp: If<Ready, number>;
+  public shard: If<Ready, ShardClientUtil>;
+  public token: If<Ready, string>;
+  public uptime: If<Ready, number>;
+  public user: If<Ready, ClientUser>;
   public users: UserManager;
   public voice: ClientVoiceManager;
   public ws: WebSocketManager;
@@ -307,6 +309,7 @@ export class Client extends BaseClient {
   public fetchWidget(guild: GuildResolvable): Promise<Widget>;
   public generateInvite(options?: InviteGenerationOptions): string;
   public login(token?: string): Promise<string>;
+  public isReady(): this is Client<true>;
   public sweepMessages(lifetime?: number): number;
   public toJSON(): unknown;
 
@@ -2820,7 +2823,7 @@ export interface ClientEvents {
   presenceUpdate: [oldPresence: Presence | null, newPresence: Presence];
   rateLimit: [rateLimitData: RateLimitData];
   invalidRequestWarning: [invalidRequestWarningData: InvalidRequestWarningData];
-  ready: [];
+  ready: [client: Client<true>];
   invalidated: [];
   roleCreate: [role: Role];
   roleDelete: [role: Role];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -111,7 +111,7 @@ export abstract class AnonymousGuild extends BaseGuild {
   public splashURL(options?: StaticImageURLOptions): string | null;
 }
 
-export abstract class Application extends Base<true> {
+export abstract class Application extends Base {
   public constructor(client: Client, data: unknown);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -157,9 +157,9 @@ export class ApplicationFlags extends BitField<ApplicationFlagsString> {
   public static resolve(bit?: BitFieldResolvable<ApplicationFlagsString, number>): number;
 }
 
-export class Base<ClientReady extends boolean = boolean> {
+export class Base {
   public constructor(client: Client);
-  public readonly client: Client<ClientReady>;
+  public readonly client: Client;
   public toJSON(...props: Record<string, boolean | string>[]): unknown;
   public valueOf(): string;
 }
@@ -185,7 +185,7 @@ export class BaseClient extends EventEmitter {
   public toJSON(...props: Record<string, boolean | string>[]): unknown;
 }
 
-export abstract class BaseGuild extends Base<true> {
+export abstract class BaseGuild extends Base {
   public constructor(client: Client, data: unknown);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -228,7 +228,7 @@ export class BaseMessageComponent {
   public type: MessageComponentType | null;
   private static create(
     data: MessageComponentOptions,
-    client?: Client<true> | WebhookClient,
+    client?: Client | WebhookClient,
     skipValidation?: boolean,
   ): MessageComponent | undefined;
   private static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
@@ -264,7 +264,7 @@ export class CategoryChannel extends GuildChannel {
 
 export type CategoryChannelResolvable = Snowflake | CategoryChannel;
 
-export class Channel extends Base<true> {
+export class Channel extends Base {
   public constructor(client: Client, data?: unknown, immediatePatch?: boolean);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -465,7 +465,7 @@ export class DMChannel extends TextBasedChannel(Channel, ['bulkDelete']) {
   public fetch(force?: boolean): Promise<this>;
 }
 
-export class Emoji extends Base<true> {
+export class Emoji extends Base {
   public constructor(client: Client, emoji: unknown);
   public animated: boolean | null;
   public readonly createdAt: Date | null;
@@ -622,7 +622,7 @@ export class GuildAuditLogsEntry {
   public toJSON(): unknown;
 }
 
-export class GuildBan extends Base<true> {
+export class GuildBan extends Base {
   public constructor(client: Client, data: unknown, guild: Guild);
   public guild: Guild;
   public user: User;
@@ -1145,7 +1145,7 @@ export class MessageMentions {
   private _members: Collection<Snowflake, GuildMember> | null;
 
   public readonly channels: Collection<Snowflake, Channel>;
-  public readonly client: Client<true>;
+  public readonly client: Client;
   public everyone: boolean;
   public readonly guild: Guild;
   public has(data: UserResolvable | RoleResolvable | ChannelResolvable, options?: MessageMentionsHasOptions): boolean;
@@ -1190,7 +1190,7 @@ export class MessageReaction {
   public constructor(client: Client, data: unknown, message: Message);
   private _emoji: GuildEmoji | ReactionEmoji;
 
-  public readonly client: Client<true>;
+  public readonly client: Client;
   public count: number | null;
   public readonly emoji: GuildEmoji | ReactionEmoji;
   public me: boolean;
@@ -1403,7 +1403,7 @@ export class Shard extends EventEmitter {
   public ready: boolean;
   public worker: unknown | null;
   public eval(script: string): Promise<unknown>;
-  public eval<T>(fn: (client: Client<true>) => T): Promise<T[]>;
+  public eval<T>(fn: (client: Client) => T): Promise<T[]>;
   public fetchClientValue(prop: string): Promise<unknown>;
   public kill(): void;
   public respawn(options?: { delay?: number; timeout?: number }): Promise<ChildProcess>;
@@ -1428,19 +1428,19 @@ export class ShardClientUtil {
   private _handleMessage(message: unknown): void;
   private _respond(type: string, message: unknown): void;
 
-  public client: Client<true>;
+  public client: Client;
   public readonly count: number;
   public readonly ids: number[];
   public mode: ShardingManagerMode;
   public parentPort: unknown | null;
-  public broadcastEval<T>(fn: (client: Client<true>) => Awaited<T>): Promise<Serialized<T>[]>;
-  public broadcastEval<T>(fn: (client: Client<true>) => Awaited<T>, options: { shard: number }): Promise<Serialized<T>>;
+  public broadcastEval<T>(fn: (client: Client) => Awaited<T>): Promise<Serialized<T>[]>;
+  public broadcastEval<T>(fn: (client: Client) => Awaited<T>, options: { shard: number }): Promise<Serialized<T>>;
   public broadcastEval<T, P>(
-    fn: (client: Client<true>, context: Serialized<P>) => Awaited<T>,
+    fn: (client: Client, context: Serialized<P>) => Awaited<T>,
     options: { context: P },
   ): Promise<Serialized<T>[]>;
   public broadcastEval<T, P>(
-    fn: (client: Client<true>, context: Serialized<P>) => Awaited<T>,
+    fn: (client: Client, context: Serialized<P>) => Awaited<T>,
     options: { context: P; shard: number },
   ): Promise<Serialized<T>>;
   public fetchClientValues(prop: string): Promise<unknown[]>;
@@ -1448,7 +1448,7 @@ export class ShardClientUtil {
   public respawnAll(options?: MultipleShardRespawnOptions): Promise<void>;
   public send(message: unknown): Promise<void>;
 
-  public static singleton(client: Client<true>, mode: ShardingManagerMode): ShardClientUtil;
+  public static singleton(client: Client, mode: ShardingManagerMode): ShardClientUtil;
   public static shardIdForGuildId(guildId: Snowflake, shardCount: number): number;
 }
 
@@ -1465,14 +1465,14 @@ export class ShardingManager extends EventEmitter {
   public totalShards: number | 'auto';
   public shardList: number[] | 'auto';
   public broadcast(message: unknown): Promise<Shard[]>;
-  public broadcastEval<T>(fn: (client: Client<true>) => Awaited<T>): Promise<Serialized<T>[]>;
-  public broadcastEval<T>(fn: (client: Client<true>) => Awaited<T>, options: { shard: number }): Promise<Serialized<T>>;
+  public broadcastEval<T>(fn: (client: Client) => Awaited<T>): Promise<Serialized<T>[]>;
+  public broadcastEval<T>(fn: (client: Client) => Awaited<T>, options: { shard: number }): Promise<Serialized<T>>;
   public broadcastEval<T, P>(
-    fn: (client: Client<true>, context: Serialized<P>) => Awaited<T>,
+    fn: (client: Client, context: Serialized<P>) => Awaited<T>,
     options: { context: P },
   ): Promise<Serialized<T>[]>;
   public broadcastEval<T, P>(
-    fn: (client: Client<true>, context: Serialized<P>) => Awaited<T>,
+    fn: (client: Client, context: Serialized<P>) => Awaited<T>,
     options: { context: P; shard: number },
   ): Promise<Serialized<T>>;
   public createShard(id: number): Shard;
@@ -1793,7 +1793,7 @@ export class Webhook extends WebhookMixin() {
   public avatar: string;
   public avatarURL(options?: StaticImageURLOptions): string | null;
   public channelId: Snowflake;
-  public client: Client<true>;
+  public client: Client;
   public guildId: Snowflake;
   public name: string;
   public owner: User | unknown | null;
@@ -2115,7 +2115,7 @@ export class ApplicationCommandPermissionsManager<
   CommandIdType,
 > extends BaseManager {
   public constructor(manager: ApplicationCommandManager | GuildApplicationCommandManager | ApplicationCommand);
-  public client: Client<true>;
+  public client: Client;
   public commandId: CommandIdType;
   public guild: GuildType;
   public guildId: Snowflake | null;
@@ -3797,7 +3797,7 @@ export interface PresenceData {
 export type PresenceResolvable = Presence | UserResolvable | Snowflake;
 
 export type Partialize<T, O extends string> = {
-  readonly client: Client<true>;
+  readonly client: Client;
   readonly createdAt: Date;
   readonly createdTimestamp: number;
   deleted: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -126,7 +126,7 @@ export abstract class Application extends Base<true> {
   public toString(): string | null;
 }
 
-export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
+export class ApplicationCommand<PermissionsFetchType = {}> extends Base<true> {
   public constructor(client: Client, data: unknown, guild?: Guild, guildId?: Snowflake);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -718,7 +718,7 @@ export class GuildMember extends PartialTextBasedChannel(Base) {
   public valueOf(): string;
 }
 
-export class GuildPreview extends Base {
+export class GuildPreview extends Base<true> {
   public constructor(client: Client, data: unknown);
   public approximateMemberCount: number;
   public approximatePresenceCount: number;
@@ -738,7 +738,7 @@ export class GuildPreview extends Base {
   public toString(): string;
 }
 
-export class GuildTemplate extends Base {
+export class GuildTemplate extends Base<true> {
   public constructor(client: Client, data: unknown);
   public readonly createdTimestamp: number;
   public readonly updatedTimestamp: number;
@@ -784,7 +784,7 @@ export class RateLimitError extends Error {
   public name: 'RateLimitError';
 }
 
-export class Integration extends Base {
+export class Integration extends Base<true> {
   public constructor(client: Client, data: unknown, guild: Guild);
   public account: IntegrationAccount;
   public application: IntegrationApplication | null;
@@ -821,7 +821,7 @@ export class Intents extends BitField<IntentsString> {
   public static resolve(bit?: BitFieldResolvable<IntentsString, number>): number;
 }
 
-export class Interaction extends Base {
+export class Interaction extends Base<true> {
   public constructor(client: Client, data: unknown);
   public applicationId: Snowflake;
   public readonly channel: Channel | PartialDMChannel | null;
@@ -877,7 +877,7 @@ export class InteractionWebhook extends PartialWebhookMixin() {
   public send(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
 }
 
-export class Invite extends Base {
+export class Invite extends Base<true> {
   public constructor(client: Client, data: unknown);
   public channel: GuildChannel | PartialGroupDMChannel;
   public code: string;
@@ -905,7 +905,7 @@ export class Invite extends Base {
   public stageInstance: InviteStageInstance | null;
 }
 
-export class InviteStageInstance extends Base {
+export class InviteStageInstance extends Base<true> {
   public constructor(client: Client, data: unknown, channelId: Snowflake, guildId: Snowflake);
   public channelId: Snowflake;
   public guildId: Snowflake;
@@ -927,7 +927,7 @@ export class LimitedCollection<K, V> extends Collection<K, V> {
   public maxSize: number;
 }
 
-export class Message extends Base {
+export class Message extends Base<true> {
   public constructor(client: Client, data: unknown, channel: TextChannel | DMChannel | NewsChannel | ThreadChannel);
   private patch(data: unknown): Message;
 
@@ -1256,7 +1256,7 @@ export class PartialGroupDMChannel extends Channel {
   public iconURL(options?: StaticImageURLOptions): string | null;
 }
 
-export class PermissionOverwrites extends Base {
+export class PermissionOverwrites extends Base<true> {
   public constructor(client: Client, data: object, channel: GuildChannel);
   public allow: Readonly<Permissions>;
   public readonly channel: GuildChannel;
@@ -1287,7 +1287,7 @@ export class Permissions extends BitField<PermissionString, bigint> {
   public static resolve(permission?: PermissionResolvable): bigint;
 }
 
-export class Presence extends Base {
+export class Presence extends Base<true> {
   public constructor(client: Client, data?: unknown);
   public activities: Activity[];
   public clientStatus: ClientPresenceStatusData | null;
@@ -1345,7 +1345,7 @@ export class RichPresenceAssets {
   public smallImageURL(options?: StaticImageURLOptions): string | null;
 }
 
-export class Role extends Base {
+export class Role extends Base<true> {
   public constructor(client: Client, data: unknown, guild: Guild);
   public color: number;
   public readonly createdAt: Date;
@@ -1500,7 +1500,7 @@ export class StageChannel extends BaseGuildVoiceChannel {
   public createStageInstance(options: StageInstanceCreateOptions): Promise<StageInstance>;
 }
 
-export class StageInstance extends Base {
+export class StageInstance extends Base<true> {
   public constructor(client: Client, data: unknown, channel: StageChannel);
   public id: Snowflake;
   public deleted: boolean;
@@ -1518,7 +1518,7 @@ export class StageInstance extends Base {
   public readonly createdAt: Date;
 }
 
-export class Sticker extends Base {
+export class Sticker extends Base<true> {
   public constructor(client: Client, data: unknown);
   public asset: string;
   public readonly createdTimestamp: number;
@@ -1543,7 +1543,7 @@ export class SystemChannelFlags extends BitField<SystemChannelFlagsString> {
   public static resolve(bit?: BitFieldResolvable<SystemChannelFlagsString, number>): number;
 }
 
-export class Team extends Base {
+export class Team extends Base<true> {
   public constructor(client: Client, data: unknown);
   public id: Snowflake;
   public name: string;
@@ -1560,7 +1560,7 @@ export class Team extends Base {
   public toString(): string;
 }
 
-export class TeamMember extends Base {
+export class TeamMember extends Base<true> {
   public constructor(team: Team, data: unknown);
   public team: Team;
   public readonly id: Snowflake;
@@ -1633,7 +1633,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
   public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<ThreadChannel>;
 }
 
-export class ThreadMember extends Base {
+export class ThreadMember extends Base<true> {
   public constructor(thread: ThreadChannel, data?: object);
   public flags: ThreadMemberFlags;
   public readonly guildMember: GuildMember | null;
@@ -1761,7 +1761,7 @@ export class VoiceRegion {
   public toJSON(): unknown;
 }
 
-export class VoiceState extends Base {
+export class VoiceState extends Base<true> {
   public constructor(guild: Guild, data: unknown);
   public readonly channel: VoiceChannel | StageChannel | null;
   public channelId: Snowflake | null;
@@ -1897,7 +1897,7 @@ export class WebSocketShard extends EventEmitter {
   public once(event: string, listener: (...args: any[]) => Awaited<void>): this;
 }
 
-export class Widget extends Base {
+export class Widget extends Base<true> {
   public constructor(client: Client, data: object);
   private _patch(data: object): void;
   public fetch(): Promise<Widget>;
@@ -1908,7 +1908,7 @@ export class Widget extends Base {
   public presenceCount: number;
 }
 
-export class WidgetMember extends Base {
+export class WidgetMember extends Base<true> {
   public constructor(client: Client, data: object);
   public id: string;
   public username: string;
@@ -1925,7 +1925,7 @@ export class WidgetMember extends Base {
   public activity?: WidgetActivity;
 }
 
-export class WelcomeChannel extends Base {
+export class WelcomeChannel extends Base<true> {
   private _emoji: unknown;
   public channelId: Snowflake;
   public guild: Guild | InviteGuild;
@@ -1934,7 +1934,7 @@ export class WelcomeChannel extends Base {
   public readonly emoji: GuildEmoji | Emoji;
 }
 
-export class WelcomeScreen extends Base {
+export class WelcomeScreen extends Base<true> {
   public readonly enabled: boolean;
   public guild: Guild | InviteGuild;
   public description: string | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -293,8 +293,8 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
   public options: ClientOptions;
   public readyAt: If<Ready, Date>;
   public readonly readyTimestamp: If<Ready, number>;
-  public shard: If<Ready, ShardClientUtil>;
-  public token: If<Ready, string>;
+  public shard: ShardClientUtil | null;
+  public token: If<Ready, string, string | null>;
   public uptime: If<Ready, number>;
   public user: If<Ready, ClientUser>;
   public users: UserManager;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,5 +1,7 @@
 import {
   Client,
+  ClientApplication,
+  ClientUser,
   Collection,
   Constants,
   DMChannel,
@@ -428,6 +430,29 @@ client.on('interaction', async interaction => {
 });
 
 client.login('absolutely-valid-token');
+
+// Test client conditional types
+client.on('ready', client => {
+  assertType<Client<true>>(client);
+});
+
+declare const loggedInClient: Client<true>;
+assertType<ClientApplication>(loggedInClient.application);
+assertType<Date>(loggedInClient.readyAt);
+assertType<number>(loggedInClient.readyTimestamp);
+assertType<ShardClientUtil>(loggedInClient.shard);
+assertType<string>(loggedInClient.token);
+assertType<number>(loggedInClient.uptime);
+assertType<ClientUser>(loggedInClient.user);
+
+declare const loggedOutClient: Client<false>;
+assertType<null>(loggedOutClient.application);
+assertType<null>(loggedOutClient.readyAt);
+assertType<null>(loggedOutClient.readyTimestamp);
+assertType<null>(loggedOutClient.shard);
+assertType<null>(loggedOutClient.token);
+assertType<null>(loggedOutClient.uptime);
+assertType<null>(loggedOutClient.user);
 
 // Test type transformation:
 declare const assertType: <T>(value: T) => asserts value is T;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -440,7 +440,6 @@ declare const loggedInClient: Client<true>;
 assertType<ClientApplication>(loggedInClient.application);
 assertType<Date>(loggedInClient.readyAt);
 assertType<number>(loggedInClient.readyTimestamp);
-assertType<ShardClientUtil>(loggedInClient.shard);
 assertType<string>(loggedInClient.token);
 assertType<number>(loggedInClient.uptime);
 assertType<ClientUser>(loggedInClient.user);
@@ -449,8 +448,7 @@ declare const loggedOutClient: Client<false>;
 assertType<null>(loggedOutClient.application);
 assertType<null>(loggedOutClient.readyAt);
 assertType<null>(loggedOutClient.readyTimestamp);
-assertType<null>(loggedOutClient.shard);
-assertType<null>(loggedOutClient.token);
+assertType<string | null>(loggedOutClient.token);
 assertType<null>(loggedOutClient.uptime);
 assertType<null>(loggedOutClient.user);
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds conditional typings to the `Client` class, allowing for TypeScript to infer the ready state of the client and provide access to properties that are initialized at login, such as `Client#application` and `Client#user`. This also adds a client parameter to the `Client.on("ready")` event, defined in typings as a ready client.

This will be a major quality-of-life improvement for users of TypeScript and typings users, as it allows for access to client properties without optional chaining or non-null assertions.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)