### PR TITLE
docs(InteractionResponses): generalize wording in update to fit other component interaction types

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -177,13 +177,13 @@ class InteractionResponses {
   }
 
   /**
-   * Updates the original message whose button was pressed.
-   * @param {string|MessagePayload|WebhookEditMessageOptions} options The options for the reply
+   * Updates the original message of the component on which the interaction was received on.
+   * @param {string|MessagePayload|WebhookEditMessageOptions} options The options for the updated message
    * @returns {Promise<Message|void>}
    * @example
    * // Remove the components from the message
    * interaction.update({
-   *   content: "A button was clicked",
+   *   content: "A component interaction was received",
    *   components: []
    * })
    *   .then(console.log)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently in `InteractionResponses#update`, the description and example refers to a button interaction, so this also gets displayed in e.g. `SelectMenuInteraction#update` on the docs. This is not done by any other methods on the interface. This PR generalizes the wording to a general component interaction, also probably making it future proof in case more component interactions will be added in the future. 
Also changed the description for the options param to be more accurate. 


**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

