### PR TITLE
typings(GuildInviteManager): FetchInvitesOptions

### DIFF
--- a/src/managers/GuildInviteManager.js
+++ b/src/managers/GuildInviteManager.js
@@ -67,8 +67,8 @@ class GuildInviteManager extends CachedManager {
   /**
    * Options used to fetch all invites from a guild.
    * @typedef {Object} FetchInvitesOptions
-   * @property {boolean} cache Whether or not to cache the fetched invites
    * @property {GuildChannelResolvable} [channelId] The channel to fetch all invites from
+   * @property {boolean} [cache=true] Whether or not to cache the fetched invites
    */
 
   /**

--- a/src/managers/GuildInviteManager.js
+++ b/src/managers/GuildInviteManager.js
@@ -68,6 +68,7 @@ class GuildInviteManager extends CachedManager {
    * Options used to fetch all invites from a guild.
    * @typedef {Object} FetchInvitesOptions
    * @property {boolean} cache Whether or not to cache the fetched invites
+   * @property {GuildChannelResolvable} [channelId] The channel to fetch all invites from
    */
 
   /**
@@ -86,7 +87,7 @@ class GuildInviteManager extends CachedManager {
    *   .catch(console.error);
    * @example
    * // Fetch all invites from a channel
-   * guild.invites.fetch({ channelID, '222197033908436994' })
+   * guild.invites.fetch({ channelId: '222197033908436994' })
    *   .then(console.log)
    *   .catch(console.error);
    * @example

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3062,7 +3062,7 @@ interface FetchInviteOptions extends BaseFetchOptions {
 }
 
 interface FetchInvitesOptions {
-  channelID?: Snowflake;
+  channelId?: GuildChannelResolvable;
   cache?: boolean;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the jsdocs and typings for GuildInviteManager's FetchInvitesOptions, since #6036 the fetch methods channelID param was changed to channelId which the casing wasn't fixed in the type declarations file, and channelId was missing completely from the JSDoc. The JSDoc was also inconsistent with what was in the typings file.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating