### PR TITLE
fix(PresenceUpdate): use added presence over nullable getter

### DIFF
--- a/src/client/actions/PresenceUpdate.js
+++ b/src/client/actions/PresenceUpdate.js
@@ -27,7 +27,7 @@ class PresenceUpdateAction extends Action {
       this.client.emit(Events.GUILD_MEMBER_AVAILABLE, member);
     }
     const newPresence = guild.presences._add(Object.assign(data, { guild }));
-    if (this.client.listenerCount(Events.PRESENCE_UPDATE) && newPresence.equals(oldPresence)) {
+    if (this.client.listenerCount(Events.PRESENCE_UPDATE) && !newPresence.equals(oldPresence)) {
       /**
        * Emitted whenever a guild member's presence (e.g. status, activity) is changed.
        * @event Client#presenceUpdate

--- a/src/client/actions/PresenceUpdate.js
+++ b/src/client/actions/PresenceUpdate.js
@@ -26,15 +26,15 @@ class PresenceUpdateAction extends Action {
       });
       this.client.emit(Events.GUILD_MEMBER_AVAILABLE, member);
     }
-    guild.presences._add(Object.assign(data, { guild }));
-    if (this.client.listenerCount(Events.PRESENCE_UPDATE) && member && !member.presence.equals(oldPresence)) {
+    const newPresence = guild.presences._add(Object.assign(data, { guild }));
+    if (this.client.listenerCount(Events.PRESENCE_UPDATE) && newPresence.equals(oldPresence)) {
       /**
        * Emitted whenever a guild member's presence (e.g. status, activity) is changed.
        * @event Client#presenceUpdate
        * @param {?Presence} oldPresence The presence before the update, if one at all
        * @param {Presence} newPresence The presence after the update
        */
-      this.client.emit(Events.PRESENCE_UPDATE, oldPresence, member.presence);
+      this.client.emit(Events.PRESENCE_UPDATE, oldPresence, newPresence);
     }
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #6075 by using the presence returned from `PresenceManager#add`.

The cause for this is a combined effort of #6013 and #6055:
The first would discard the presence on insertion (as intended when not caching them), causing the getter to return a default presence here.
With the second the default presence was removed, causing the getter to now return `null`, causing this crash.
~~I should have spotted that.~~

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
