### PR TITLE
docs(InteractionResponses): reply docs example

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -63,7 +63,7 @@ class InteractionResponses {
    * const embed = new MessageEmbed().setDescription('Pong!');
    *
    * interaction.reply({ embeds: [embed] })
-   *   .then('Reply sent.')
+   *   .then(() => console.log('Reply sent.'))
    *   .catch(console.error);
    * @example
    * // Create an ephemeral reply

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -63,7 +63,7 @@ class InteractionResponses {
    * const embed = new MessageEmbed().setDescription('Pong!');
    *
    * interaction.reply({ embeds: [embed] })
-   *   .then(console.log)
+   *   .then('Reply sent.')
    *   .catch(console.error);
    * @example
    * // Create an ephemeral reply

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -68,7 +68,7 @@ class InteractionResponses {
    * @example
    * // Create an ephemeral reply
    * interaction.reply({ content: 'Pong!', ephemeral: true })
-   *   .then(console.log)
+   *   .then(() => console.log('Reply sent.'))
    *   .catch(console.error);
    */
   async reply(options) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `reply` method returns `Promise<void>`, so `.then(console.log)` is pointless.  This replaces the log with a simple string to acknowledge success.  I left other methods that potentially resolve into `void` (`defer`, `followUp`, etc) alone.

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
