### PR TITLE
revert: support for nested arrays of components, fix error handling

### DIFF
--- a/src/structures/BaseMessageComponent.js
+++ b/src/structures/BaseMessageComponent.js
@@ -57,7 +57,7 @@ class BaseMessageComponent {
    * @returns {?MessageComponent}
    * @private
    */
-  static create(data, client, skipValidation = false) {
+  static create(data, client) {
     let component;
     let type = data.type;
 
@@ -66,7 +66,7 @@ class BaseMessageComponent {
     switch (type) {
       case MessageComponentTypes.ACTION_ROW: {
         const MessageActionRow = require('./MessageActionRow');
-        component = new MessageActionRow(data);
+        component = new MessageActionRow(data, client);
         break;
       }
       case MessageComponentTypes.BUTTON: {
@@ -82,7 +82,7 @@ class BaseMessageComponent {
       default:
         if (client) {
           client.emit(Events.DEBUG, `[BaseMessageComponent] Received component with unknown type: ${data.type}`);
-        } else if (!skipValidation) {
+        } else {
           throw new TypeError('INVALID_TYPE', 'data.type', 'valid MessageComponentType');
         }
     }

--- a/src/structures/BaseMessageComponent.js
+++ b/src/structures/BaseMessageComponent.js
@@ -53,7 +53,6 @@ class BaseMessageComponent {
    * Constructs a MessageComponent based on the type of the incoming data
    * @param {MessageComponentOptions} data Data for a MessageComponent
    * @param {Client|WebhookClient} [client] Client constructing this component
-   * @param {boolean} [skipValidation=false] Whether or not to validate the component type
    * @returns {?MessageComponent}
    * @private
    */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -572,7 +572,7 @@ class Message extends Base {
    * @property {MessageAttachment[]} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to add to the message
-   * @property {MessageActionRow[]|MessageActionRowOptions[]|MessageActionRowComponentResolvable[][]} [components]
+   * @property {MessageActionRow[]|MessageActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */
 

--- a/src/structures/MessageActionRow.js
+++ b/src/structures/MessageActionRow.js
@@ -37,15 +37,16 @@ class MessageActionRow extends BaseMessageComponent {
 
   /**
    * @param {MessageActionRow|MessageActionRowOptions} [data={}] MessageActionRow to clone or raw data
+   * @param {Client} [client] The client constructing this MessageActionRow, if provided
    */
-  constructor(data = {}) {
+  constructor(data = {}, client = null) {
     super({ type: 'ACTION_ROW' });
 
     /**
      * The components in this action row
      * @type {MessageActionRowComponent[]}
      */
-    this.components = data.components?.map(c => BaseMessageComponent.create(c, null, true)) ?? [];
+    this.components = data.components?.map(c => BaseMessageComponent.create(c, client)) ?? [];
   }
 
   /**
@@ -54,7 +55,7 @@ class MessageActionRow extends BaseMessageComponent {
    * @returns {MessageActionRow}
    */
   addComponents(...components) {
-    this.components.push(...components.flat(Infinity).map(c => BaseMessageComponent.create(c, null, true)));
+    this.components.push(...components.flat(Infinity).map(c => BaseMessageComponent.create(c)));
     return this;
   }
 
@@ -66,11 +67,7 @@ class MessageActionRow extends BaseMessageComponent {
    * @returns {MessageActionRow}
    */
   spliceComponents(index, deleteCount, ...components) {
-    this.components.splice(
-      index,
-      deleteCount,
-      ...components.flat(Infinity).map(c => BaseMessageComponent.create(c, null, true)),
-    );
+    this.components.splice(index, deleteCount, ...components.flat(Infinity).map(c => BaseMessageComponent.create(c)));
     return this;
   }
 

--- a/src/structures/MessagePayload.js
+++ b/src/structures/MessagePayload.js
@@ -3,7 +3,6 @@
 const BaseMessageComponent = require('./BaseMessageComponent');
 const MessageEmbed = require('./MessageEmbed');
 const { RangeError } = require('../errors');
-const { MessageComponentTypes } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const MessageFlags = require('../util/MessageFlags');
 const Util = require('../util/Util');
@@ -138,11 +137,7 @@ class MessagePayload {
       }
     }
 
-    const components = this.options.components?.map(c =>
-      BaseMessageComponent.create(
-        Array.isArray(c) ? { type: MessageComponentTypes.ACTION_ROW, components: c } : c,
-      ).toJSON(),
-    );
+    const components = this.options.components?.map(c => BaseMessageComponent.create(c).toJSON());
 
     let username;
     let avatarURL;

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -103,7 +103,7 @@ class Webhook {
    * @property {string} [content] See {@link BaseMessageOptions#content}
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
-   * @property {MessageActionRow[]|MessageActionRowOptions[]|MessageActionRowComponentResolvable[][]} [components]
+   * @property {MessageActionRow[]|MessageActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */
 

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -63,7 +63,7 @@ class TextBasedChannel {
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to send with the message
-   * @property {MessageActionRow[]|MessageActionRowOptions[]|MessageActionRowComponentResolvable[][]} [components]
+   * @property {MessageActionRow[]|MessageActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3518,7 +3518,7 @@ export interface MessageEditOptions {
   files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
   flags?: BitFieldResolvable<MessageFlagsString, number>;
   allowedMentions?: MessageMentionOptions;
-  components?: (MessageActionRow | MessageActionRowOptions | MessageActionRowComponentResolvable[])[];
+  components?: (MessageActionRow | MessageActionRowOptions)[];
 }
 
 export interface MessageEmbedAuthor {
@@ -3617,7 +3617,7 @@ export interface MessageOptions {
   nonce?: string | number;
   content?: string | null;
   embeds?: (MessageEmbed | MessageEmbedOptions)[];
-  components?: (MessageActionRow | MessageActionRowOptions | MessageActionRowComponentResolvable[])[];
+  components?: (MessageActionRow | MessageActionRowOptions)[];
   allowedMentions?: MessageMentionOptions;
   files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
   reply?: ReplyOptions;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -434,6 +434,7 @@ client.on('interaction', async interaction => {
 
   await interaction.reply({ content: 'Hi!', components: [actionRow] });
 
+  // @ts-expect-error
   await interaction.reply({ content: 'Hi!', components: [[button]] });
 
   // @ts-expect-error


### PR DESCRIPTION
As nice as this was for the user interface, as per internal discussion it was considered not future proof should there ever be a different type of Row component.

This removes support for sending a nested array of components, e.g. no more:
`message.channel.send({ content, components: [[button]] })`

I also noticed that the way component types were being checked didn't work in some scenarios - this simplifies that process to ensure `client` is passed where it should be a debug event, and isn't everywhere else that it should throw.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)