### PR TITLE
fix(GuildChannel): clone its PermissionOverwriteManager too

### DIFF
--- a/src/managers/PermissionOverwriteManager.js
+++ b/src/managers/PermissionOverwriteManager.js
@@ -13,13 +13,19 @@ const { OverwriteTypes } = require('../util/Constants');
  */
 class PermissionOverwriteManager extends CachedManager {
   constructor(channel, iterable) {
-    super(channel.client, PermissionOverwrites, iterable);
+    super(channel.client, PermissionOverwrites);
 
     /**
      * The channel of the permission overwrite this manager belongs to
      * @type {GuildChannel}
      */
     this.channel = channel;
+
+    if (iterable) {
+      for (const item of iterable) {
+        this._add(item);
+      }
+    }
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -90,6 +90,12 @@ class GuildChannel extends Channel {
     }
   }
 
+  _clone() {
+    const clone = super._clone();
+    clone.permissionOverwrites = new PermissionOverwriteManager(clone, this.permissionOverwrites.cache.values());
+    return clone;
+  }
+
   /**
    * The category parent of this channel
    * @type {?CategoryChannel}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #6082 by cloning `GuildChannel#permissionOverwrites` when cloning the channel itself.
This PR also addresses the issue that a passed `iterable` would cause the then created `PermissionOverwrites` to be without a channel as the `channel` property would be initialized after the parent's constructor added them.
(This might be better solved with another private method to be called from the deriving classes, e.g. `this._init(iterable);` or similar)


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
