### PR TITLE
types(PartialWebhookFields): add APIMessage to deleteMessage union

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2447,7 +2447,7 @@ export function WebhookMixin<T>(Base?: Constructable<T>): Constructable<T & Webh
 export interface PartialWebhookFields {
   id: Snowflake;
   readonly url: string;
-  deleteMessage(message: MessageResolvable | '@original'): Promise<void>;
+  deleteMessage(message: MessageResolvable | APIMessage | '@original'): Promise<void>;
   editMessage(
     message: MessageResolvable | '@original',
     options: string | MessagePayload | WebhookEditMessageOptions,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Without this change the following code does not compile:
```ts
const client = new Client();

(async function() {
  const webhook = new Webhook(client, {id: '123', token: '456abc'});
  const msg = await webhook.send({ content: 'Test' });

  await webhook.deleteMessage(msg);  // Argument of type 'Message | APIMessage' is not assignable to parameter of type 'MessageResolvable | "@original"'.
})();
```

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating