### PR TITLE
fix(PermissionsOverwrites): only convert type if number

### DIFF
--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -36,7 +36,7 @@ class PermissionOverwrites extends Base {
      * The type of this overwrite
      * @type {OverwriteType}
      */
-    this.type = OverwriteTypes[data.type];
+    this.type = typeof data.type === 'number' ? OverwriteTypes[data.type] : data.type;
 
     /**
      * The permissions that are denied for the user or role.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

In some situations `PermissionsOverwrites#_patch` was being called with an existing `PermissionsOverwrites` object rather than raw packet data from Discord (I observed this locally when an overwrite was removed from a channel). This meant that `type` was already a string, and so the enum conversion was resulting in it incorrectly being stored as a number.

This PR tweaks the patch logic in `PermissionsOverwrites` to ensure that the enum conversion only occurs if the data provided is a number. If it is not, it is assumed that it is already a valid string type. This ensures that `PermissionsOverwrites#type` is always actually a string, as documented.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating