### PR TITLE
types(Interaction): change inGuild return type

### DIFF
--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -106,14 +106,6 @@ class Interaction extends Base {
   }
 
   /**
-   * Indicates whether this interaction is received from a guild.
-   * @returns {boolean}
-   */
-  inGuild() {
-    return Boolean(this.guildId && this.member);
-  }
-
-  /**
    * Indicates whether this interaction is a {@link CommandInteraction}.
    * @returns {boolean}
    */

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -106,6 +106,14 @@ class Interaction extends Base {
   }
 
   /**
+   * Indicates whether this interaction is received from a guild.
+   * @returns {boolean}
+   */
+  inGuild() {
+    return Boolean(this.guildId && this.member);
+  }
+
+  /**
    * Indicates whether this interaction is a {@link CommandInteraction}.
    * @returns {boolean}
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -831,6 +831,7 @@ export class Interaction extends Base {
   public type: InteractionType;
   public user: User;
   public version: number;
+  public inGuild(): this is this & { guildId: Snowflake; member: GuildMember | APIInteractionGuildMember };
   public isButton(): this is ButtonInteraction;
   public isCommand(): this is CommandInteraction;
   public isMessageComponent(): this is MessageComponentInteraction;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -832,7 +832,6 @@ export class Interaction extends Base {
   public type: InteractionType;
   public user: User;
   public version: number;
-  public inGuild(): boolean;
   public isButton(): this is ButtonInteraction;
   public isCommand(): this is CommandInteraction;
   public isMessageComponent(): this is MessageComponentInteraction;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,4 +1,3 @@
-import { S_IFDIR } from 'constants';
 import {
   ApplicationCommand,
   ApplicationCommandData,

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -1,3 +1,4 @@
+import { S_IFDIR } from 'constants';
 import {
   ApplicationCommand,
   ApplicationCommandData,
@@ -15,6 +16,7 @@ import {
   GuildMember,
   GuildResolvable,
   Intents,
+  Interaction,
   Message,
   MessageActionRow,
   MessageAttachment,
@@ -604,3 +606,7 @@ client.on('messageReactionAdd', async reaction => {
   if (reaction.message.partial) return assertType<string | null>(reaction.message.content);
   assertType<string>(reaction.message.content);
 });
+
+// Test interactions
+declare const interaction: Interaction;
+if (interaction.inGuild()) assertType<Snowflake>(interaction.guildId);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes the `inGuild` method in `Interaction`, because, as discussed in the [Discord server](https://canary.discord.com/channels/222078108977594368/682166281826598932/863179005350903858), it's used only in this structure (not in any other `Structure` like Message or `Channel`) and doesn't provide any type guard for TS users so it's useless, as shown below:
```ts
client.on("interactionCreate", (interaction) => {
    if (interaction.inGuild()) console.log(interaction.client.guilds.fetch(interaction.guildId));
})
```
```ts
client.on("interactionCreate", (interaction) => {
    if (interaction.guildId) console.log(interaction.client.guilds.fetch(interaction.guildId));
})
```
These two codes are pretty much the same and should return the same result so, for a JS user there's no difference, but they might choose the second, as there's no need to call a function; For a TS user, the first will show an error like `guildId is possibly null`, while the second will work as expected.

For those who used this method, it can easily be replaced:
```diff
- interaction.inGuild()
+ interaction.guildId // Or `!!interaction.guildId`, or `Boolean(interaction.guildId)`
```

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)