### PR TITLE
types(Guild): remove fetchVoiceRegions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -541,7 +541,6 @@ export class Guild extends AnonymousGuild {
   public fetchPreview(): Promise<GuildPreview>;
   public fetchTemplates(): Promise<Collection<GuildTemplate['code'], GuildTemplate>>;
   public fetchVanityData(): Promise<Vanity>;
-  public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
   public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
   public fetchWelcomeScreen(): Promise<WelcomeScreen>;
   public fetchWidget(): Promise<GuildWidget>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Guild#fetchVoiceRegions` was removed in https://github.com/discordjs/discord.js/pull/5766, but wasn't removed from the typings. This PR fixes that.


**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
