### PR TITLE
feat(CommandInteraction): add CommandInteractionOptionResolver

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -138,6 +138,8 @@ const Messages = {
     `Option "${name}" is of type: ${type}; expected one of: ${expected.join(', ')}`,
   COMMAND_INTERACTION_OPTION_EMPTY: (name, type) =>
     `Required option "${name}" is of type: ${type}; expected a non-empty value.`,
+  COMMAND_INTERACTION_OPTION_NO_SUB_COMMAND: 'No sub-command specified for interaction.',
+  COMMAND_INTERACTION_OPTION_NO_SUB_COMMAND_GROUP: 'No sub-command group specified for interaction.',
 
   INVITE_MISSING_SCOPES: 'At least one valid scope must be provided for the invite',
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -133,6 +133,12 @@ const Messages = {
   INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be fetched or deleted.',
   INTERACTION_FETCH_EPHEMERAL: 'Ephemeral responses cannot be fetched.',
 
+  COMMAND_INTERACTION_OPTION_NOT_FOUND: name => `Required option "${name}" not found.`,
+  COMMAND_INTERACTION_OPTION_TYPE: (name, type, expected) =>
+    `Option "${name}" is of type: ${type}; expected one of: ${expected.join(', ')}`,
+  COMMAND_INTERACTION_OPTION_EMPTY: (name, type) =>
+    `Required option "${name}" is of type: ${type}; expected a non-empty value.`,
+
   INVITE_MISSING_SCOPES: 'At least one valid scope must be provided for the invite',
 
   NOT_IMPLEMENTED: (what, name) => `Method ${what} not implemented on ${name}.`,

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -1,9 +1,9 @@
 'use strict';
 
+const CommandInteractionOptionResolver = require('./CommandInteractionOptionResolver');
 const Interaction = require('./Interaction');
 const InteractionWebhook = require('./InteractionWebhook');
 const InteractionResponses = require('./interfaces/InteractionResponses');
-const Collection = require('../util/Collection');
 const { ApplicationCommandOptionTypes } = require('../util/Constants');
 
 /**
@@ -48,9 +48,11 @@ class CommandInteraction extends Interaction {
 
     /**
      * The options passed to the command.
-     * @type {Collection<string, CommandInteractionOption>}
+     * @type {CommandInteractionOptionResolver}
      */
-    this.options = this._createOptionsCollection(data.data.options, data.data.resolved);
+    this.options = new CommandInteractionOptionResolver(
+      this._createOptionsArray(data.data.options, data.data.resolved),
+    );
 
     /**
      * Whether this interaction has already been replied to
@@ -108,7 +110,7 @@ class CommandInteraction extends Interaction {
     };
 
     if ('value' in option) result.value = option.value;
-    if ('options' in option) result.options = this._createOptionsCollection(option.options, resolved);
+    if ('options' in option) result.options = this._createOptionsArray(option.options, resolved);
 
     if (resolved) {
       const user = resolved.users?.[option.value];
@@ -128,19 +130,19 @@ class CommandInteraction extends Interaction {
   }
 
   /**
-   * Creates a collection of options from the received options array.
+   * Creates an array of options from the received API options array.
    * @param {APIApplicationCommandOption[]} options The received options
    * @param {APIApplicationCommandOptionResolved} resolved The resolved interaction data
-   * @returns {Collection<string, CommandInteractionOption>}
+   * @returns {CommandInteractionOption[]}
    * @private
    */
-  _createOptionsCollection(options, resolved) {
-    const optionsCollection = new Collection();
-    if (typeof options === 'undefined') return optionsCollection;
+  _createOptionsArray(options, resolved) {
+    const optionsArray = [];
+    if (typeof options === 'undefined') return optionsArray;
     for (const option of options) {
-      optionsCollection.set(option.name, this.transformOption(option, resolved));
+      optionsArray.push(this.transformOption(option, resolved));
     }
-    return optionsCollection;
+    return optionsArray;
   }
 
   // These are here only for documentation purposes - they are implemented by InteractionResponses

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -51,7 +51,8 @@ class CommandInteraction extends Interaction {
      * @type {CommandInteractionOptionResolver}
      */
     this.options = new CommandInteractionOptionResolver(
-      this._createOptionsArray(data.data.options, data.data.resolved),
+      this.client,
+      data.data.options?.map(option => this.transformOption(option, data.data.resolved)),
     );
 
     /**
@@ -110,7 +111,7 @@ class CommandInteraction extends Interaction {
     };
 
     if ('value' in option) result.value = option.value;
-    if ('options' in option) result.options = this._createOptionsArray(option.options, resolved);
+    if ('options' in option) result.options = option.options.map(opt => this.transformOption(opt, resolved));
 
     if (resolved) {
       const user = resolved.users?.[option.value];
@@ -127,22 +128,6 @@ class CommandInteraction extends Interaction {
     }
 
     return result;
-  }
-
-  /**
-   * Creates an array of options from the received API options array.
-   * @param {APIApplicationCommandOption[]} options The received options
-   * @param {APIApplicationCommandOptionResolved} resolved The resolved interaction data
-   * @returns {CommandInteractionOption[]}
-   * @private
-   */
-  _createOptionsArray(options, resolved) {
-    const optionsArray = [];
-    if (typeof options === 'undefined') return optionsArray;
-    for (const option of options) {
-      optionsArray.push(this.transformOption(option, resolved));
-    }
-    return optionsArray;
   }
 
   // These are here only for documentation purposes - they are implemented by InteractionResponses

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -43,14 +43,12 @@ class CommandInteractionOptionResolver {
     const option = this.get(name, required);
     if (option) {
       if (!types.includes(option.type)) {
-        throw new Error(`Option "${name}" is of type "${option.type}" but expected: ${types.join('|')}.`);
+        throw new Error(`Option "${name}" is of type "${option.type}"; expected ${types.join('|')}.`);
       } else if (required && properties.every(prop => option[prop] === null || typeof option[prop] === 'undefined')) {
-        throw new Error(`Option "${name}" of type "${option.type}" is marked as required, but is null.`);
+        throw new Error(`Option "${name}" of type "${option.type}" is required, but is empty.`);
       } else {
         return option;
       }
-    } else if (required) {
-      throw new Error(`Missing required option "${name}"`);
     } else {
       return option;
     }

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -188,7 +188,8 @@ class CommandInteractionOptionResolver {
    * Gets a mentionable option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?(User|GuildMember|Role)} The value of the option, or null if not set and not required.
+   * @returns {?(User|GuildMember|APIInteractionDataResolvedGuildMember|Role|APIRole)}
+   * The value of the option, or null if not set and not required.
    */
   getMentionable(name, required = false) {
     const option = this._getTypedOption(name, ['MENTIONABLE'], ['user', 'member', 'role'], required);

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -28,7 +28,7 @@ class CommandInteractionOptionResolver {
      * @private
      */
     this._group = null;
-    
+
     /**
      * The name of the sub-command.
      * @type {?string}

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -96,11 +96,10 @@ class CommandInteractionOptionResolver {
 
   /**
    * Gets the selected sub-command group.
-   * @param {boolean} [required=false] Whether to throw an error if there is no sub-command group.
-   * @returns {?string} The name of the selected sub-command group, or null if not set and not required.
+   * @returns {string} The name of the selected sub-command group, or null if not set and not required.
    */
-  getSubCommandGroup(required = false) {
-    if (required && !this._group) {
+  getSubCommandGroup() {
+    if (!this._group) {
       throw new TypeError('COMMAND_INTERACTION_OPTION_NO_SUB_COMMAND_GROUP');
     }
     return this._group;

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -96,7 +96,7 @@ class CommandInteractionOptionResolver {
 
   /**
    * Gets the selected sub-command group.
-   * @returns {string} The name of the selected sub-command group, or null if not set and not required.
+   * @returns {string} The name of the selected sub-command group.
    */
   getSubCommandGroup() {
     if (!this._group) {

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -1,0 +1,160 @@
+'use strict';
+
+/**
+ * A resolver for command interaction options.
+ */
+class CommandInteractionOptionResolver {
+  constructor(options) {
+    /**
+     * The raw interaction options array.
+     * @type {CommandInteractionOption[]}
+     * @private
+     */
+    this.options = options ?? [];
+  }
+
+  /**
+   * Gets an option by its name.
+   * @param {string} name The name of the option.
+   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @returns {?CommandInteractionOption} The option, if found.
+   */
+  get(name, required = false) {
+    const option = this.options.find(opt => opt.name === name);
+    if (option) {
+      return option;
+    } else if (required) {
+      throw new Error(`Missing required option "${name}"`);
+    } else {
+      return null;
+    }
+  }
+
+  /**
+   * Gets an option by name and property and checks its type.
+   * @param {string} name The name of the option.
+   * @param {ApplicationCommandOptionType[]} types The type of the option.
+   * @param {string[]} properties The property to check for for `required`.
+   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @returns {?|null} The value of `property`.
+   * @private
+   */
+  _getTypedOption(name, types, properties, required) {
+    const option = this.get(name, required);
+    if (option) {
+      if (!types.includes(option.type)) {
+        throw new Error(`Option "${name}" is of type "${option.type}" but expected: ${types.join('|')}.`);
+      } else if (required && properties.every(prop => option[prop] === null)) {
+        throw new Error(`Option "${name}" of type "${option.type}" is marked as required, but is null.`);
+      } else {
+        return option;
+      }
+    } else if (required) {
+      throw new Error(`Missing required option "${name}"`);
+    } else {
+      return option;
+    }
+  }
+
+  /**
+   * Gets a sub-command or sub-command group.
+   * @param {string} name The name of the sub-command or sub-command group.
+   * @returns {CommandInteractionOptionResolver|null}
+   */
+  getSubCommand(name) {
+    const option = this._getTypedOption(name, ['SUB_COMMAND', 'SUB_COMMAND_GROUP'], ['options'], false);
+    return option ? new CommandInteractionOptionResolver(option.options) : null;
+  }
+
+  /**
+   * Gets a boolean option.
+   * @param {string} name The name of the option.
+   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @returns {boolean|null} The value of the option, or null if not set and not required.
+   */
+  getBoolean(name, required = false) {
+    const option = this._getTypedOption(name, ['BOOLEAN'], ['value'], required);
+    return option?.value ?? null;
+  }
+
+  /**
+   * Gets a channel option.
+   * @param {string} name The name of the option.
+   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @returns {GuildChannel|APIInteractionDataResolvedChannel|null}
+   * The value of the option, or null if not set and not required.
+   */
+  getChannel(name, required = false) {
+    const option = this._getTypedOption(name, ['CHANNEL'], ['channel'], required);
+    return option?.channel ?? null;
+  }
+
+  /**
+   * Gets a string option.
+   * @param {string} name The name of the option.
+   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @returns {string|null} The value of the option, or null if not set and not required.
+   */
+  getString(name, required = false) {
+    const option = this._getTypedOption(name, ['STRING'], ['value'], required);
+    return option?.value ?? null;
+  }
+
+  /**
+   * Gets a integer option.
+   * @param {string} name The name of the option.
+   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @returns {number|null} The value of the option, or null if not set and not required.
+   */
+  getInteger(name, required = false) {
+    const option = this._getTypedOption(name, ['INTEGER'], ['value'], required);
+    return option?.value ?? null;
+  }
+
+  /**
+   * Gets a user option.
+   * @param {string} name The name of the option.
+   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @returns {User|null} The value of the option, or null if not set and not required.
+   */
+  getUser(name, required = false) {
+    const option = this._getTypedOption(name, ['USER'], ['user'], required);
+    return option?.user ?? null;
+  }
+
+  /**
+   * Gets a member option.
+   * @param {string} name The name of the option.
+   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @returns {GuildMember|APIInteractionDataResolvedGuildMember|null}
+   * The value of the option, or null if not set and not required.
+   */
+  getMember(name, required = false) {
+    const option = this._getTypedOption(name, ['MEMBER'], ['member'], required);
+    return option?.member ?? null;
+  }
+
+  /**
+   * Gets a role option.
+   * @param {string} name The name of the option.
+   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @returns {Role|APIRole|null} The value of the option, or null if not set and not required.
+   */
+  getRole(name, required = false) {
+    const option = this._getTypedOption(name, ['ROLE'], ['role'], required);
+    return option?.role ?? null;
+  }
+
+  /**
+   * Gets a mentionable option.
+   * @param {string} name The name of the option.
+   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @returns {User|GuildMember|Role|null} The value of the option, or null if not set and not required.
+   */
+  getMentionable(name, required = false) {
+    const option = this._getTypedOption(name, ['MENTIONABLE'], ['user', 'member', 'role'], required);
+    return option?.user ?? option?.member ?? option?.role ?? null;
+  }
+}
+
+module.exports = CommandInteractionOptionResolver;

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -21,6 +21,27 @@ class CommandInteractionOptionResolver {
      * @private
      */
     this._options = options ?? [];
+
+    /**
+     * The name of the sub-command group.
+     * @type {?string}
+     * @private
+     */
+    this._group = null;
+    /**
+     * The name of the sub-command.
+     * @type {?string}
+     * @private
+     */
+    this._subCommand = null;
+    if (this._options[0]?.type === 'SUB_COMMAND_GROUP') {
+      this._group = this._options[0].name;
+      this._options = this._options[0].options ?? [];
+    }
+    if (this._options[0]?.type === 'SUB_COMMAND') {
+      this._subCommand = this._options[0].name;
+      this._options = this._options[0].options ?? [];
+    }
   }
 
   /**
@@ -62,14 +83,26 @@ class CommandInteractionOptionResolver {
   }
 
   /**
-   * Gets a sub-command or sub-command group.
-   * @param {string} name The name of the sub-command or sub-command group.
-   * @returns {?CommandInteractionOptionResolver}
-   * A new resolver for the sub-command/group's options, or null if empty
+   * Gets the selected sub-command.
+   * @returns {string} The name of the selected sub-command.
    */
-  getSubCommand(name) {
-    const option = this._getTypedOption(name, ['SUB_COMMAND', 'SUB_COMMAND_GROUP'], ['options'], false);
-    return option && new CommandInteractionOptionResolver(this.client, option.options);
+  getSubCommand() {
+    if (!this._subCommand) {
+      throw new TypeError('COMMAND_INTERACTION_OPTION_NO_SUB_COMMAND');
+    }
+    return this._subCommand;
+  }
+
+  /**
+   * Gets the selected sub-command group.
+   * @param {boolean} [required=false] Whether to throw an error if there is no sub-command group.
+   * @returns {?string} The name of the selected sub-command group, or null if not set and not required.
+   */
+  getSubCommandGroup(required = false) {
+    if (required && !this._group) {
+      throw new TypeError('COMMAND_INTERACTION_OPTION_NO_SUB_COMMAND_GROUP');
+    }
+    return this._group;
   }
 
   /**

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -90,7 +90,7 @@ class CommandInteractionOptionResolver {
    * Gets a channel option.
    * @param {string} name The name of the option.
    * @param {boolean} required Whether to throw an error if the option is not found.
-   * @returns {?GuildChannel|APIInteractionDataResolvedChannel}
+   * @returns {?(GuildChannel|APIInteractionDataResolvedChannel)}
    * The value of the option, or null if not set and not required.
    */
   getChannel(name, required = false) {
@@ -135,7 +135,7 @@ class CommandInteractionOptionResolver {
    * Gets a member option.
    * @param {string} name The name of the option.
    * @param {boolean} required Whether to throw an error if the option is not found.
-   * @returns {?GuildMember|APIInteractionDataResolvedGuildMember}
+   * @returns {?(GuildMember|APIInteractionDataResolvedGuildMember)}
    * The value of the option, or null if not set and not required.
    */
   getMember(name, required = false) {
@@ -147,7 +147,7 @@ class CommandInteractionOptionResolver {
    * Gets a role option.
    * @param {string} name The name of the option.
    * @param {boolean} required Whether to throw an error if the option is not found.
-   * @returns {?Role|APIRole} The value of the option, or null if not set and not required.
+   * @returns {?(Role|APIRole)} The value of the option, or null if not set and not required.
    */
   getRole(name, required = false) {
     const option = this._getTypedOption(name, ['ROLE'], ['role'], required);
@@ -158,7 +158,7 @@ class CommandInteractionOptionResolver {
    * Gets a mentionable option.
    * @param {string} name The name of the option.
    * @param {boolean} required Whether to throw an error if the option is not found.
-   * @returns {?User|GuildMember|Role} The value of the option, or null if not set and not required.
+   * @returns {?(User|GuildMember|Role)} The value of the option, or null if not set and not required.
    */
   getMentionable(name, required = false) {
     const option = this._getTypedOption(name, ['MENTIONABLE'], ['user', 'member', 'role'], required);

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -26,18 +26,18 @@ class CommandInteractionOptionResolver {
   /**
    * Gets an option by its name.
    * @param {string} name The name of the option.
-   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
    * @returns {?CommandInteractionOption} The option, if found.
    */
   get(name, required = false) {
     const option = this._options.find(opt => opt.name === name);
-    if (option) {
-      return option;
-    } else if (required) {
-      throw new TypeError('COMMAND_INTERACTION_OPTION_NOT_FOUND', name);
-    } else {
+    if (!option) {
+      if (required) {
+        throw new TypeError('COMMAND_INTERACTION_OPTION_NOT_FOUND', name);
+      }
       return null;
     }
+    return option;
   }
 
   /**
@@ -51,17 +51,14 @@ class CommandInteractionOptionResolver {
    */
   _getTypedOption(name, types, properties, required) {
     const option = this.get(name, required);
-    if (option) {
-      if (!types.includes(option.type)) {
-        throw new TypeError('COMMAND_INTERACTION_OPTION_TYPE', name, option.type, types);
-      } else if (required && properties.every(prop => option[prop] === null || typeof option[prop] === 'undefined')) {
-        throw new TypeError('COMMAND_INTERACTION_OPTION_EMPTY', name, option.type);
-      } else {
-        return option;
-      }
-    } else {
-      return option;
+    if (!option) {
+      return null;
+    } else if (!types.includes(option.type)) {
+      throw new TypeError('COMMAND_INTERACTION_OPTION_TYPE', name, option.type, types);
+    } else if (required && properties.every(prop => option[prop] === null || typeof option[prop] === 'undefined')) {
+      throw new TypeError('COMMAND_INTERACTION_OPTION_EMPTY', name, option.type);
     }
+    return option;
   }
 
   /**
@@ -72,13 +69,13 @@ class CommandInteractionOptionResolver {
    */
   getSubCommand(name) {
     const option = this._getTypedOption(name, ['SUB_COMMAND', 'SUB_COMMAND_GROUP'], ['options'], false);
-    return option ? new CommandInteractionOptionResolver(this.client, option.options) : null;
+    return option && new CommandInteractionOptionResolver(this.client, option.options);
   }
 
   /**
    * Gets a boolean option.
    * @param {string} name The name of the option.
-   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
    * @returns {?boolean} The value of the option, or null if not set and not required.
    */
   getBoolean(name, required = false) {
@@ -89,7 +86,7 @@ class CommandInteractionOptionResolver {
   /**
    * Gets a channel option.
    * @param {string} name The name of the option.
-   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
    * @returns {?(GuildChannel|APIInteractionDataResolvedChannel)}
    * The value of the option, or null if not set and not required.
    */
@@ -101,7 +98,7 @@ class CommandInteractionOptionResolver {
   /**
    * Gets a string option.
    * @param {string} name The name of the option.
-   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
    * @returns {?string} The value of the option, or null if not set and not required.
    */
   getString(name, required = false) {
@@ -112,7 +109,7 @@ class CommandInteractionOptionResolver {
   /**
    * Gets an integer option.
    * @param {string} name The name of the option.
-   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
    * @returns {?number} The value of the option, or null if not set and not required.
    */
   getInteger(name, required = false) {
@@ -123,7 +120,7 @@ class CommandInteractionOptionResolver {
   /**
    * Gets a user option.
    * @param {string} name The name of the option.
-   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
    * @returns {?User} The value of the option, or null if not set and not required.
    */
   getUser(name, required = false) {
@@ -134,7 +131,7 @@ class CommandInteractionOptionResolver {
   /**
    * Gets a member option.
    * @param {string} name The name of the option.
-   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
    * @returns {?(GuildMember|APIInteractionDataResolvedGuildMember)}
    * The value of the option, or null if not set and not required.
    */
@@ -146,7 +143,7 @@ class CommandInteractionOptionResolver {
   /**
    * Gets a role option.
    * @param {string} name The name of the option.
-   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
    * @returns {?(Role|APIRole)} The value of the option, or null if not set and not required.
    */
   getRole(name, required = false) {
@@ -157,7 +154,7 @@ class CommandInteractionOptionResolver {
   /**
    * Gets a mentionable option.
    * @param {string} name The name of the option.
-   * @param {boolean} required Whether to throw an error if the option is not found.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
    * @returns {?(User|GuildMember|Role)} The value of the option, or null if not set and not required.
    */
   getMentionable(name, required = false) {

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -28,6 +28,7 @@ class CommandInteractionOptionResolver {
      * @private
      */
     this._group = null;
+    
     /**
      * The name of the sub-command.
      * @type {?string}

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -58,6 +58,7 @@ class CommandInteractionOptionResolver {
    * Gets a sub-command or sub-command group.
    * @param {string} name The name of the sub-command or sub-command group.
    * @returns {CommandInteractionOptionResolver|null}
+   * A new resolver for the sub-command/group's options, or null if empty
    */
   getSubCommand(name) {
     const option = this._getTypedOption(name, ['SUB_COMMAND', 'SUB_COMMAND_GROUP'], ['options'], false);

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -6,7 +6,7 @@
 class CommandInteractionOptionResolver {
   constructor(options) {
     /**
-     * The raw interaction options array.
+     * The interaction options array.
      * @type {CommandInteractionOption[]}
      * @private
      */
@@ -36,7 +36,7 @@ class CommandInteractionOptionResolver {
    * @param {ApplicationCommandOptionType[]} types The type of the option.
    * @param {string[]} properties The property to check for for `required`.
    * @param {boolean} required Whether to throw an error if the option is not found.
-   * @returns {?|null} The value of `property`.
+   * @returns {*|null} The value of `property`.
    * @private
    */
   _getTypedOption(name, types, properties, required) {
@@ -44,7 +44,7 @@ class CommandInteractionOptionResolver {
     if (option) {
       if (!types.includes(option.type)) {
         throw new Error(`Option "${name}" is of type "${option.type}" but expected: ${types.join('|')}.`);
-      } else if (required && properties.every(prop => option[prop] === null)) {
+      } else if (required && properties.every(prop => option[prop] === null || typeof option[prop] === 'undefined')) {
         throw new Error(`Option "${name}" of type "${option.type}" is marked as required, but is null.`);
       } else {
         return option;
@@ -101,7 +101,7 @@ class CommandInteractionOptionResolver {
   }
 
   /**
-   * Gets a integer option.
+   * Gets an integer option.
    * @param {string} name The name of the option.
    * @param {boolean} required Whether to throw an error if the option is not found.
    * @returns {number|null} The value of the option, or null if not set and not required.

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -44,7 +44,7 @@ class CommandInteractionOptionResolver {
    * Gets an option by name and property and checks its type.
    * @param {string} name The name of the option.
    * @param {ApplicationCommandOptionType[]} types The type of the option.
-   * @param {string[]} properties The property to check for for `required`.
+   * @param {string[]} properties The properties to check for for `required`.
    * @param {boolean} required Whether to throw an error if the option is not found.
    * @returns {?CommandInteractionOption} The option, if found.
    * @private

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -453,8 +453,7 @@ export class CommandInteractionOptionResolver {
   public get(name: string, required: true): CommandInteractionOption;
   public get(name: string, required?: boolean): CommandInteractionOption | null;
   public getSubCommand(): string;
-  public getSubCommandGroup(required: true): string;
-  public getSubCommandGroup(required?: boolean): string | null;
+  public getSubCommandGroup(): string;
   public getBoolean(name: string, required: true): boolean;
   public getBoolean(name: string, required?: boolean): boolean | null;
   public getChannel(name: string, required: true): NonNullable<CommandInteractionOption['channel']>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -432,13 +432,11 @@ export class CommandInteraction extends Interaction {
 }
 
 export class CommandInteractionOptionResolver {
-  private options: CommandInteractionOption[];
-
   constructor(options: CommandInteractionOption[]);
+  private options: CommandInteractionOption[];
 
   public get(name: string, required: true): CommandInteractionOption;
   public get(name: string, required: boolean): CommandInteractionOption | null;
-
   private _getTypedOption(
     name: string,
     types: ApplicationCommandOptionType[],
@@ -453,28 +451,20 @@ export class CommandInteractionOptionResolver {
   ): CommandInteractionOption | null;
 
   public getSubCommand(name: string): CommandInteractionOptionResolver | null;
-
   public getBoolean(name: string, required: true): boolean;
   public getBoolean(name: string, required?: boolean): boolean | null;
-
   public getChannel(name: string, required: true): NonNullable<CommandInteractionOption['channel']>;
   public getChannel(name: string, required?: boolean): NonNullable<CommandInteractionOption['channel']> | null;
-
   public getString(name: string, required: true): string;
   public getString(name: string, required?: boolean): string | null;
-
   public getInteger(name: string, required: true): number;
   public getInteger(name: string, required?: boolean): number | null;
-
   public getUser(name: string, required: true): NonNullable<CommandInteractionOption['user']>;
   public getUser(name: string, required?: boolean): NonNullable<CommandInteractionOption['user']> | null;
-
   public getMember(name: string, required: true): NonNullable<CommandInteractionOption['member']>;
   public getMember(name: string, required?: boolean): NonNullable<CommandInteractionOption['member']> | null;
-
   public getRole(name: string, required: true): NonNullable<CommandInteractionOption['role']>;
   public getRole(name: string, required?: boolean): NonNullable<CommandInteractionOption['role']> | null;
-
   public getMentionable(
     name: string,
     required: true,
@@ -482,7 +472,6 @@ export class CommandInteractionOptionResolver {
     | NonNullable<CommandInteractionOption['member']>
     | NonNullable<CommandInteractionOption['role']>
     | NonNullable<CommandInteractionOption['user']>;
-
   public getMentionable(
     name: string,
     required?: boolean,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -432,8 +432,9 @@ export class CommandInteraction extends Interaction {
 }
 
 export class CommandInteractionOptionResolver {
-  constructor(options: CommandInteractionOption[]);
-  private options: CommandInteractionOption[];
+  public constructor(client: Client, options: CommandInteractionOption[]);
+  public readonly client: Client;
+  private _options: CommandInteractionOption[];
   private _getTypedOption(
     name: string,
     types: ApplicationCommandOptionType[],
@@ -467,18 +468,11 @@ export class CommandInteractionOptionResolver {
   public getMentionable(
     name: string,
     required: true,
-  ):
-    | NonNullable<CommandInteractionOption['member']>
-    | NonNullable<CommandInteractionOption['role']>
-    | NonNullable<CommandInteractionOption['user']>;
+  ): NonNullable<CommandInteractionOption['member' | 'role' | 'user']>;
   public getMentionable(
     name: string,
     required?: boolean,
-  ):
-    | NonNullable<CommandInteractionOption['member']>
-    | NonNullable<CommandInteractionOption['role']>
-    | NonNullable<CommandInteractionOption['user']>
-    | null;
+  ): NonNullable<CommandInteractionOption['member' | 'role' | 'user']> | null;
 }
 
 export class DataResolver extends null {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -435,6 +435,8 @@ export class CommandInteractionOptionResolver {
   public constructor(client: Client, options: CommandInteractionOption[]);
   public readonly client: Client;
   private _options: CommandInteractionOption[];
+  private _group: string | null;
+  private _subCommand: string | null;
   private _getTypedOption(
     name: string,
     types: ApplicationCommandOptionType[],
@@ -450,7 +452,9 @@ export class CommandInteractionOptionResolver {
 
   public get(name: string, required: true): CommandInteractionOption;
   public get(name: string, required?: boolean): CommandInteractionOption | null;
-  public getSubCommand(name: string): CommandInteractionOptionResolver | null;
+  public getSubCommand(): string;
+  public getSubCommandGroup(required: true): string;
+  public getSubCommandGroup(required?: boolean): string | null;
   public getBoolean(name: string, required: true): boolean;
   public getBoolean(name: string, required?: boolean): boolean | null;
   public getChannel(name: string, required: true): NonNullable<CommandInteractionOption['channel']>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -416,7 +416,7 @@ export class CommandInteraction extends Interaction {
   public commandName: string;
   public deferred: boolean;
   public ephemeral: boolean | null;
-  public options: Collection<string, CommandInteractionOption>;
+  public options: CommandInteractionOptionResolver;
   public replied: boolean;
   public webhook: InteractionWebhook;
   public defer(options?: InteractionDeferOptions & { fetchReply: true }): Promise<Message | APIMessage>;
@@ -429,6 +429,68 @@ export class CommandInteraction extends Interaction {
   public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
   private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
   private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
+}
+
+export class CommandInteractionOptionResolver {
+  private options: CommandInteractionOption[];
+
+  constructor(options: CommandInteractionOption[]);
+
+  public get(name: string, required: true): CommandInteractionOption;
+  public get(name: string, required: boolean): CommandInteractionOption | null;
+
+  private _getTypedOption(
+    name: string,
+    types: string[],
+    properties: string[],
+    required: true,
+  ): CommandInteractionOption;
+  private _getTypedOption(
+    name: string,
+    types: string[],
+    properties: string[],
+    required: boolean,
+  ): CommandInteractionOption | null;
+
+  public getSubCommand(name: string): CommandInteractionOptionResolver | null;
+
+  public getBoolean(name: string, required: true): boolean;
+  public getBoolean(name: string, required?: boolean): boolean | null;
+
+  public getChannel(name: string, required: true): NonNullable<CommandInteractionOption['channel']>;
+  public getChannel(name: string, required?: boolean): NonNullable<CommandInteractionOption['channel']> | null;
+
+  public getString(name: string, required: true): string;
+  public getString(name: string, required?: boolean): string | null;
+
+  public getInteger(name: string, required: true): number;
+  public getInteger(name: string, required?: boolean): number | null;
+
+  public getUser(name: string, required: true): NonNullable<CommandInteractionOption['user']>;
+  public getUser(name: string, required?: boolean): NonNullable<CommandInteractionOption['user']> | null;
+
+  public getMember(name: string, required: true): NonNullable<CommandInteractionOption['member']>;
+  public getMember(name: string, required?: boolean): NonNullable<CommandInteractionOption['member']> | null;
+
+  public getRole(name: string, required: true): NonNullable<CommandInteractionOption['role']>;
+  public getRole(name: string, required?: boolean): NonNullable<CommandInteractionOption['role']> | null;
+
+  public getMentionable(
+    name: string,
+    required: true,
+  ):
+    | NonNullable<CommandInteractionOption['member']>
+    | NonNullable<CommandInteractionOption['role']>
+    | NonNullable<CommandInteractionOption['user']>;
+
+  public getMentionable(
+    name: string,
+    required?: boolean,
+  ):
+    | NonNullable<CommandInteractionOption['member']>
+    | NonNullable<CommandInteractionOption['role']>
+    | NonNullable<CommandInteractionOption['user']>
+    | null;
 }
 
 export class DataResolver extends null {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -441,14 +441,14 @@ export class CommandInteractionOptionResolver {
 
   private _getTypedOption(
     name: string,
-    types: string[],
-    properties: string[],
+    types: ApplicationCommandOptionType[],
+    properties: (keyof ApplicationCommandOption)[],
     required: true,
   ): CommandInteractionOption;
   private _getTypedOption(
     name: string,
-    types: string[],
-    properties: string[],
+    types: ApplicationCommandOptionType[],
+    properties: (keyof ApplicationCommandOption)[],
     required: boolean,
   ): CommandInteractionOption | null;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -448,7 +448,7 @@ export class CommandInteractionOptionResolver {
   ): CommandInteractionOption | null;
 
   public get(name: string, required: true): CommandInteractionOption;
-  public get(name: string, required: boolean): CommandInteractionOption | null;
+  public get(name: string, required?: boolean): CommandInteractionOption | null;
   public getSubCommand(name: string): CommandInteractionOptionResolver | null;
   public getBoolean(name: string, required: true): boolean;
   public getBoolean(name: string, required?: boolean): boolean | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -434,9 +434,6 @@ export class CommandInteraction extends Interaction {
 export class CommandInteractionOptionResolver {
   constructor(options: CommandInteractionOption[]);
   private options: CommandInteractionOption[];
-
-  public get(name: string, required: true): CommandInteractionOption;
-  public get(name: string, required: boolean): CommandInteractionOption | null;
   private _getTypedOption(
     name: string,
     types: ApplicationCommandOptionType[],
@@ -450,6 +447,8 @@ export class CommandInteractionOptionResolver {
     required: boolean,
   ): CommandInteractionOption | null;
 
+  public get(name: string, required: true): CommandInteractionOption;
+  public get(name: string, required: boolean): CommandInteractionOption | null;
   public getSubCommand(name: string): CommandInteractionOptionResolver | null;
   public getBoolean(name: string, required: true): boolean;
   public getBoolean(name: string, required?: boolean): boolean | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR creates a new structure, `CommandInteractionOptionResolver`, which acts as a resolver for `CommandInteraction` options. This replaces the existing `Collection<string, CommandInteractionOption>` on `CommandInteraction#options` with the new class.

The new class will allow for easier usage and validation of command options. It also will serve as an additional check against users having mismatches between their option types and their execution code. This also allows for TypeScript users to access the properties in a cleaner and type-safe way without custom parsers or casting.

Example:
```typescript
import { Client, Snowflake } from "discord.js";

const client = new Client({ intents: [] });

client.on("ready", async () => {
  const guild = await client.guilds.fetch(process.env.DISCORD_GUILD_ID as Snowflake);
  await guild.commands.create({
    name: "test",
    description: "test",
    options: [
      {
        name: "sub",
        description: "sub",
        type: "SUB_COMMAND",
        options: [
          {
            name: "bar",
            description: "bar",
            type: "INTEGER",
            required: true,
          },
          {
            name: "baz",
            description: "baz",
            type: "USER",
            required: false,
          },
        ],
      },
    ],
  });
});

client.on("interactionCreate", async (interaction) => {
  if (interaction.isCommand() && interaction.commandName === "test") {
    const sub = interaction.options.getSubCommand("sub");
    if (sub) {
      const bar = sub.getInteger("bar", true);
      const baz = sub.getUser("baz");
      await interaction.reply((bar * 2).toString() + " " + baz?.id);
    } else {
      await interaction.reply("Error: Invalid subcommand!");
    }
  }
});

client.login(process.env.DISCORD_TOKEN);
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
