### PR TITLE
types(Interactions): fix function overloads

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1071,7 +1071,7 @@ export class MessageComponentInteraction extends Interaction {
   public webhook: InteractionWebhook;
   public defer(options: InteractionDeferOptions & { fetchReply: true }): Promise<Message | APIMessage>;
   public defer(options?: InteractionDeferOptions): Promise<void>;
-  public deferUpdate(options?: InteractionDeferUpdateOptions & { fetchReply: true }): Promise<Message | APIMessage>;
+  public deferUpdate(options: InteractionDeferUpdateOptions & { fetchReply: true }): Promise<Message | APIMessage>;
   public deferUpdate(options?: InteractionDeferUpdateOptions): Promise<void>;
   public deleteReply(): Promise<void>;
   public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1071,7 +1071,7 @@ export class MessageComponentInteraction extends Interaction {
   public webhook: InteractionWebhook;
   public defer(options: InteractionDeferOptions & { fetchReply: true }): Promise<Message | APIMessage>;
   public defer(options?: InteractionDeferOptions): Promise<void>;
-  public deferUpdate(options: InteractionDeferUpdateOptions & { fetchReply: true }): Promise<Message | APIMessage>;
+  public deferUpdate(options?: InteractionDeferUpdateOptions & { fetchReply: true }): Promise<Message | APIMessage>;
   public deferUpdate(options?: InteractionDeferUpdateOptions): Promise<void>;
   public deleteReply(): Promise<void>;
   public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -419,7 +419,7 @@ export class CommandInteraction extends Interaction {
   public options: Collection<string, CommandInteractionOption>;
   public replied: boolean;
   public webhook: InteractionWebhook;
-  public defer(options?: InteractionDeferOptions & { fetchReply: true }): Promise<Message | APIMessage>;
+  public defer(options: InteractionDeferOptions & { fetchReply: true }): Promise<Message | APIMessage>;
   public defer(options?: InteractionDeferOptions): Promise<void>;
   public deleteReply(): Promise<void>;
   public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;
@@ -1069,7 +1069,7 @@ export class MessageComponentInteraction extends Interaction {
   public message: Message | APIMessage;
   public replied: boolean;
   public webhook: InteractionWebhook;
-  public defer(options?: InteractionDeferOptions & { fetchReply: true }): Promise<Message | APIMessage>;
+  public defer(options: InteractionDeferOptions & { fetchReply: true }): Promise<Message | APIMessage>;
   public defer(options?: InteractionDeferOptions): Promise<void>;
   public deferUpdate(options?: InteractionDeferUpdateOptions & { fetchReply: true }): Promise<Message | APIMessage>;
   public deferUpdate(options?: InteractionDeferUpdateOptions): Promise<void>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes an issue with `Interaction#defer` and `MessageComponentInteraction#deferUpdate`, due to the overload types the return type would default to `Promise<Message | APIMessage>` when no parameter was passed.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
