### PR TITLE
feat(REST): append additional information to the required User Agent

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -511,6 +511,9 @@ class Client extends BaseClient {
     if (typeof options.failIfNotExists !== 'boolean') {
       throw new TypeError('CLIENT_INVALID_OPTION', 'failIfNotExists', 'a boolean');
     }
+    if (!Array.isArray(options.userAgentSuffix)) {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'userAgentSuffix', 'an array of strings');
+    }
     if (
       typeof options.rejectOnRateLimit !== 'undefined' &&
       !(typeof options.rejectOnRateLimit === 'function' || Array.isArray(options.rejectOnRateLimit))

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -18,7 +18,7 @@ class APIRequest {
     this.retries = 0;
 
     const userAgentSuffix = this.client.options.userAgentSuffix;
-    this.fullUserAgent = `${UserAgent}${userAgentSuffix.length && `, ${userAgentSuffix.join(', ')}`}`;
+    this.fullUserAgent = `${UserAgent}${userAgentSuffix.length ? `, ${userAgentSuffix.join(', ')}` : ''}`;
 
     let queryString = '';
     if (options.query) {

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -17,6 +17,9 @@ class APIRequest {
     this.options = options;
     this.retries = 0;
 
+    const userAgentSuffix = this.client.options.userAgentSuffix;
+    this.fullUserAgent = `${UserAgent}${userAgentSuffix.length && `, ${userAgentSuffix.join(", ")}`}`;
+
     let queryString = '';
     if (options.query) {
       const query = Object.entries(options.query)
@@ -33,11 +36,14 @@ class APIRequest {
         ? this.client.options.http.api
         : `${this.client.options.http.api}/v${this.client.options.http.version}`;
     const url = API + this.path;
-    let headers = { ...this.client.options.http.headers };
+
+    let headers = {
+      ...this.client.options.http.headers,
+      'User-Agent': this.fullUserAgent
+    };
 
     if (this.options.auth !== false) headers.Authorization = this.rest.getAuth();
     if (this.options.reason) headers['X-Audit-Log-Reason'] = encodeURIComponent(this.options.reason);
-    headers['User-Agent'] = UserAgent;
     if (this.options.headers) headers = Object.assign(headers, this.options.headers);
 
     let body;

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -17,7 +17,7 @@ class APIRequest {
     this.options = options;
     this.retries = 0;
 
-    const userAgentSuffix = this.client.options.userAgentSuffix;
+    const { userAgentSuffix } = this.client.options;
     this.fullUserAgent = `${UserAgent}${userAgentSuffix.length ? `, ${userAgentSuffix.join(', ')}` : ''}`;
 
     let queryString = '';

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -18,7 +18,7 @@ class APIRequest {
     this.retries = 0;
 
     const userAgentSuffix = this.client.options.userAgentSuffix;
-    this.fullUserAgent = `${UserAgent}${userAgentSuffix.length && `, ${userAgentSuffix.join(", ")}`}`;
+    this.fullUserAgent = `${UserAgent}${userAgentSuffix.length && `, ${userAgentSuffix.join(', ')}`}`;
 
     let queryString = '';
     if (options.query) {
@@ -39,7 +39,7 @@ class APIRequest {
 
     let headers = {
       ...this.client.options.http.headers,
-      'User-Agent': this.fullUserAgent
+      'User-Agent': this.fullUserAgent,
     };
 
     if (this.options.auth !== false) headers.Authorization = this.rest.getAuth();

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -63,6 +63,8 @@
  * {@link RateLimitError} will be thrown. Otherwise the request will be queued for later
  * @property {number} [retryLimit=1] How many times to retry on 5XX errors (Infinity for indefinite amount of retries)
  * @property {boolean} [failIfNotExists=true] Default value for {@link ReplyMessageOptions#failIfNotExists}
+ * @property {string[]} [userAgentSuffix] An array of additional bot info to be appended to the end of the required
+ * [User Agent](https://discord.com/developers/docs/reference#user-agent) header
  * @property {PresenceData} [presence={}] Presence data to use upon login
  * @property {IntentsResolvable} intents Intents to enable for this connection
  * @property {WebsocketOptions} [ws] Options for the WebSocket
@@ -110,6 +112,7 @@ class Options extends null {
       restTimeOffset: 500,
       restSweepInterval: 60,
       failIfNotExists: true,
+      userAgentSuffix: [],
       presence: {},
       ws: {
         large_threshold: 50,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2865,6 +2865,7 @@ export interface ClientOptions {
   restSweepInterval?: number;
   retryLimit?: number;
   failIfNotExists?: boolean;
+  userAgentSuffix?: string[];
   presence?: PresenceData;
   intents: BitFieldResolvable<IntentsString, number>;
   ws?: WebSocketOptions;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR allows you to append information about the bot (like a website, version) to the end of the (already required) user agent. As specified in the [API documentations](https://discord.com/developers/docs/reference#user-agent), users should be able to do so and are encouraged to do it.

Discord.js users could alternatively modify the constants file, where the user agent string is defined, but it can lead to them not following the API specifications.

After having a talk with a few people, I decided to implement a `userAgentSuffix` option to `ClientOptions` for people to do this. Types are already updated. An example of the usage is down below.

```js
const { Client } = require("discord.js");
const botClient = new Client({
    userAgentSuffix: [`MyBot/${/* botversion */}`]
});
```

The implementation of this PR would append the array, joined by `, `, to the end of the already-default user agent.

* Default: `DiscordBot ($djsurl, $djsversion) Node.js/$nodeversion`
* With suffix: `DiscordBot ($djsurl, $djsversion) Node.js/$nodeversion, MyBot/$botversion`

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
