### PR TITLE
refactor: remove typing caching

### DIFF
--- a/src/client/actions/ChannelUpdate.js
+++ b/src/client/actions/ChannelUpdate.js
@@ -15,8 +15,6 @@ class ChannelUpdateAction extends Action {
       if (ChannelTypes[channel.type] !== data.type) {
         const newChannel = Channel.create(this.client, data, channel.guild);
         for (const [id, message] of channel.messages.cache) newChannel.messages.cache.set(id, message);
-        newChannel._typing = new Map(channel._typing);
-        channel = newChannel;
         this.client.channels.cache.set(channel.id, channel);
       }
 

--- a/src/client/actions/GuildDelete.js
+++ b/src/client/actions/GuildDelete.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Action = require('./Action');
-const { Events, TextBasedChannelTypes } = require('../../util/Constants');
+const { Events } = require('../../util/Constants');
 
 class GuildDeleteAction extends Action {
   constructor(client) {
@@ -14,10 +14,6 @@ class GuildDeleteAction extends Action {
 
     let guild = client.guilds.cache.get(data.id);
     if (guild) {
-      for (const channel of guild.channels.cache.values()) {
-        if (TextBasedChannelTypes.includes(channel.type)) channel.stopTyping(true);
-      }
-
       if (data.unavailable) {
         // Guild is unavailable
         guild.available = false;

--- a/src/client/actions/TypingStart.js
+++ b/src/client/actions/TypingStart.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Action = require('./Action');
+const Typing = require('../../structures/Typing');
 const { Events, TextBasedChannelTypes } = require('../../util/Constants');
 
 class TypingStart extends Action {
@@ -15,42 +16,14 @@ class TypingStart extends Action {
     }
 
     const user = this.getUserFromMember(data);
-    const timestamp = new Date(data.timestamp * 1000);
-
     if (channel && user) {
-      if (channel._typing.has(user.id)) {
-        const typing = channel._typing.get(user.id);
-
-        typing.lastTimestamp = timestamp;
-        typing.elapsedTime = Date.now() - typing.since;
-        this.client.clearTimeout(typing.timeout);
-        typing.timeout = this.tooLate(channel, user);
-      } else {
-        const since = new Date();
-        const lastTimestamp = new Date();
-        channel._typing.set(user.id, {
-          user,
-          since,
-          lastTimestamp,
-          elapsedTime: Date.now() - since,
-          timeout: this.tooLate(channel, user),
-        });
-
-        /**
-         * Emitted whenever a user starts typing in a channel.
-         * @event Client#typingStart
-         * @param {DMChannel|TextChannel|NewsChannel} channel The channel the user started typing in
-         * @param {User} user The user that started typing
-         */
-        this.client.emit(Events.TYPING_START, channel, user);
-      }
+      /**
+       * Emitted whenever a user starts typing in a channel.
+       * @event Client#typingStart
+       * @param {Typing} typing The typing state
+       */
+      this.client.emit(Events.TYPING_START, new Typing(channel, user, data));
     }
-  }
-
-  tooLate(channel, user) {
-    return channel.client.setTimeout(() => {
-      channel._typing.delete(user.id);
-    }, 10000);
   }
 }
 

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -78,8 +78,6 @@ const Messages = {
   MESSAGE_NONCE_TYPE: 'Message nonce must be an integer or a string.',
   MESSAGE_CONTENT_TYPE: 'Message content must be a non-empty string.',
 
-  TYPING_COUNT: 'Count must be at least 1',
-
   SPLIT_MAX_LEN: 'Chunk exceeds the max length and contains no split characters.',
 
   BAN_RESOLVE_ID: (ban = false) => `Couldn't resolve the user id to ${ban ? 'ban' : 'unban'}.`,

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -8,11 +8,6 @@ const DataResolver = require('../util/DataResolver');
  * @extends {User}
  */
 class ClientUser extends User {
-  constructor(client, data) {
-    super(client, data);
-    this._typing = new Map();
-  }
-
   _patch(data) {
     super._patch(data);
 

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -25,7 +25,6 @@ class DMChannel extends Channel {
      * @type {MessageManager}
      */
     this.messages = new MessageManager(this);
-    this._typing = new Map();
   }
 
   _patch(data) {
@@ -87,10 +86,7 @@ class DMChannel extends Channel {
   get lastMessage() {}
   get lastPinAt() {}
   send() {}
-  startTyping() {}
-  stopTyping() {}
-  get typing() {}
-  get typingCount() {}
+  sendTyping() {}
   createMessageCollector() {}
   awaitMessages() {}
   createMessageComponentCollector() {}

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -38,7 +38,6 @@ class TextChannel extends GuildChannel {
      * @type {boolean}
      */
     this.nsfw = Boolean(data.nsfw);
-    this._typing = new Map();
   }
 
   _patch(data) {
@@ -193,10 +192,7 @@ class TextChannel extends GuildChannel {
   get lastMessage() {}
   get lastPinAt() {}
   send() {}
-  startTyping() {}
-  stopTyping() {}
-  get typing() {}
-  get typingCount() {}
+  sendTyping() {}
   createMessageCollector() {}
   awaitMessages() {}
   createMessageComponentCollector() {}

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -43,8 +43,6 @@ class ThreadChannel extends Channel {
      * @type {ThreadMemberManager}
      */
     this.members = new ThreadMemberManager(this);
-
-    this._typing = new Map();
     if (data) this._patch(data);
   }
 
@@ -413,10 +411,7 @@ class ThreadChannel extends Channel {
   get lastMessage() {}
   get lastPinAt() {}
   send() {}
-  startTyping() {}
-  stopTyping() {}
-  get typing() {}
-  get typingCount() {}
+  sendTyping() {}
   createMessageCollector() {}
   awaitMessages() {}
   createMessageComponentCollector() {}

--- a/src/structures/Typing.js
+++ b/src/structures/Typing.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const Base = require('./Base');
+
+/**
+ * Represents a typing state for a user in a channel.
+ * @extends {Base}
+ */
+class Typing extends Base {
+  /**
+   * @param {TextChannel|DMChannel|NewsChannel|ThreadChannel} channel The channel this typing came from
+   * @param {User} user The user that started typing
+   * @param {APITypingStart} data The raw data received
+   */
+  constructor(channel, user, data) {
+    super(channel.client);
+
+    /**
+     * The channel the status is from
+     * @type {TextChannel|DMChannel|NewsChannel|ThreadChannel}
+     */
+    this.channel = channel;
+
+    /**
+     * The user who is typing
+     * @type {User}
+     */
+    this.user = user;
+
+    this._patch(data);
+  }
+
+  _patch(data) {
+    /**
+     * The UNIX timestamp in milliseconds the user started typing at
+     * @type {number}
+     */
+    this.startedTimestamp = data.timestamp * 1000;
+  }
+
+  /**
+   * Indicates whether the status is received from a guild.
+   * @returns {boolean}
+   */
+  inGuild() {
+    return this.guild !== null;
+  }
+
+  /**
+   * The time the user started typing at
+   * @type {Date}
+   * @readonly
+   */
+  get startedAt() {
+    return new Date(this.startedTimestamp);
+  }
+
+  /**
+   * The guild the status is from
+   * @type {?Guild}
+   * @readonly
+   */
+  get guild() {
+    return this.channel.guild ?? null;
+  }
+
+  /**
+   * The member who is typing
+   * @type {?GuildMember}
+   * @readonly
+   */
+  get member() {
+    return this.guild?.members.resolve(this.user) ?? null;
+  }
+}
+
+module.exports = Typing;
+
+/**
+ * @external APITypingStart
+ * @see {@link https://discord.com/developers/docs/topics/gateway#typing-start-typing-start-event-fields}
+ */

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -160,34 +160,6 @@ class User extends Base {
   }
 
   /**
-   * Checks whether the user is typing in a channel.
-   * @param {ChannelResolvable} channel The channel to check in
-   * @returns {boolean}
-   */
-  typingIn(channel) {
-    return this.client.channels.resolve(channel)._typing.has(this.id);
-  }
-
-  /**
-   * Gets the time that the user started typing.
-   * @param {ChannelResolvable} channel The channel to get the time in
-   * @returns {?Date}
-   */
-  typingSinceIn(channel) {
-    channel = this.client.channels.resolve(channel);
-    return channel._typing.has(this.id) ? new Date(channel._typing.get(this.id).since) : null;
-  }
-
-  /**
-   * Gets the amount of time the user has been typing in a channel for (in milliseconds), or -1 if they're not typing.
-   * @param {ChannelResolvable} channel The channel to get the time in
-   * @returns {number}
-   */
-  typingDurationIn(channel) {
-    return this.client.channels.resolve(channel)._typing.get(this.id)?.elapsedTime ?? -1;
-  }
-
-  /**
    * The DM between the client's user and this user
    * @type {?DMChannel}
    * @readonly

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2448,7 +2448,7 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     options?: InteractionCollectorOptions<T>,
   ): InteractionCollector<T>;
   createMessageCollector(options?: MessageCollectorOptions): MessageCollector;
-  sendTyping(count?: number): Promise<void>;
+  sendTyping(): Promise<void>;
 }
 
 export function PartialWebhookMixin<T>(Base?: Constructable<T>): Constructable<T & PartialWebhookFields>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1661,7 +1661,6 @@ export class Typing extends Base {
   public inGuild(): this is this & {
     channel: TextChannel | NewsChannel | ThreadChannel;
     readonly guild: Guild;
-    readonly member: GuildMember;
   };
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1646,6 +1646,25 @@ export class ThreadMemberFlags extends BitField<ThreadMemberFlagsString> {
   public static resolve(bit?: BitFieldResolvable<ThreadMemberFlagsString, number>): number;
 }
 
+export class Typing extends Base {
+  public constructor(
+    channel: TextChannel | PartialDMChannel | NewsChannel | ThreadChannel,
+    user: PartialUser,
+    data?: object,
+  );
+  public channel: TextChannel | PartialDMChannel | NewsChannel | ThreadChannel;
+  public user: PartialUser;
+  public startedTimestamp: number;
+  public readonly startedAt: Date;
+  public readonly guild: Guild | null;
+  public readonly member: GuildMember | null;
+  public inGuild(): this is this & {
+    channel: TextChannel | NewsChannel | ThreadChannel;
+    readonly guild: Guild;
+    readonly member: GuildMember;
+  };
+}
+
 export class User extends PartialTextBasedChannel(Base) {
   public constructor(client: Client, data: unknown);
   public avatar: string | null;
@@ -1669,9 +1688,6 @@ export class User extends PartialTextBasedChannel(Base) {
   public fetch(force?: boolean): Promise<User>;
   public fetchFlags(force?: boolean): Promise<UserFlags>;
   public toString(): UserMention;
-  public typingDurationIn(channel: ChannelResolvable): number;
-  public typingIn(channel: ChannelResolvable): boolean;
-  public typingSinceIn(channel: ChannelResolvable): Date;
 }
 
 export class UserFlags extends BitField<UserFlagsString> {
@@ -2417,13 +2433,10 @@ export interface PartialTextBasedChannelFields {
 }
 
 export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
-  _typing: Map<string, TypingData>;
   lastMessageId: Snowflake | null;
   readonly lastMessage: Message | null;
   lastPinTimestamp: number | null;
   readonly lastPinAt: Date | null;
-  typing: boolean;
-  typingCount: number;
   awaitMessageComponent<T extends MessageComponentInteraction = MessageComponentInteraction>(
     options?: AwaitMessageComponentOptions<T>,
   ): Promise<T>;
@@ -2436,8 +2449,7 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     options?: InteractionCollectorOptions<T>,
   ): InteractionCollector<T>;
   createMessageCollector(options?: MessageCollectorOptions): MessageCollector;
-  startTyping(count?: number): Promise<void>;
-  stopTyping(force?: boolean): void;
+  sendTyping(count?: number): Promise<void>;
 }
 
 export function PartialWebhookMixin<T>(Base?: Constructable<T>): Constructable<T & PartialWebhookFields>;
@@ -2832,7 +2844,7 @@ export interface ClientEvents {
     mewMembers: Collection<Snowflake, ThreadMember>,
   ];
   threadUpdate: [oldThread: ThreadChannel, newThread: ThreadChannel];
-  typingStart: [channel: Channel | PartialDMChannel, user: User | PartialUser];
+  typingStart: [typing: Typing];
   userUpdate: [oldUser: User | PartialUser, newUser: User];
   voiceStateUpdate: [oldState: VoiceState, newState: VoiceState];
   webhookUpdate: [channel: TextChannel];
@@ -3958,14 +3970,6 @@ export type SystemChannelFlagsString =
 export type SystemChannelFlagsResolvable = BitFieldResolvable<SystemChannelFlagsString, number>;
 
 export type SystemMessageType = Exclude<MessageType, 'DEFAULT' | 'REPLY' | 'APPLICATION_COMMAND'>;
-
-export interface TypingData {
-  user: User | PartialUser;
-  since: Date;
-  lastTimestamp: Date;
-  elapsedTime: number;
-  timeout: NodeJS.Timeout;
-}
 
 export interface StageInstanceEditOptions {
   topic?: string;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -8,6 +8,7 @@ import {
   Collection,
   Constants,
   DMChannel,
+  Guild,
   GuildApplicationCommandManager,
   GuildChannelManager,
   GuildEmoji,
@@ -24,7 +25,9 @@ import {
   MessageReaction,
   NewsChannel,
   Options,
+  PartialDMChannel,
   PartialTextBasedChannelFields,
+  PartialUser,
   Permissions,
   ReactionCollector,
   Role,
@@ -38,6 +41,7 @@ import {
   TextBasedChannelFields,
   TextChannel,
   ThreadChannel,
+  Typing,
   User,
   VoiceChannel,
 } from '..';
@@ -583,13 +587,23 @@ assertType<Promise<Collection<Snowflake, GuildEmoji>>>(guildEmojiManager.fetch()
 assertType<Promise<Collection<Snowflake, GuildEmoji>>>(guildEmojiManager.fetch(undefined, {}));
 assertType<Promise<GuildEmoji | null>>(guildEmojiManager.fetch('0'));
 
-// Test partials structures
-client.on('typingStart', (channel, user) => {
-  if (channel.partial) assertType<undefined>(channel.lastMessageId);
-  if (user.partial) return assertType<null>(user.username);
-  assertType<string>(user.username);
-});
+declare const typing: Typing;
+assertType<PartialUser>(typing.user);
+if (typing.user.partial) assertType<null>(typing.user.username);
 
+assertType<TextChannel | PartialDMChannel | NewsChannel | ThreadChannel>(typing.channel);
+if (typing.channel.partial) assertType<undefined>(typing.channel.lastMessageId);
+
+assertType<GuildMember | null>(typing.member);
+assertType<Guild | null>(typing.guild);
+
+if (typing.inGuild()) {
+  assertType<GuildMember>(typing.member);
+  assertType<Guild>(typing.channel.guild);
+  assertType<Guild>(typing.guild);
+}
+
+// Test partials structures
 client.on('guildMemberRemove', member => {
   if (member.partial) return assertType<null>(member.joinedAt);
   assertType<Date | null>(member.joinedAt);

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -598,7 +598,6 @@ assertType<GuildMember | null>(typing.member);
 assertType<Guild | null>(typing.guild);
 
 if (typing.inGuild()) {
-  assertType<GuildMember>(typing.member);
   assertType<Guild>(typing.channel.guild);
   assertType<Guild>(typing.guild);
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Added `Typing` structure.
- Renamed `TextBasedChannel#startTyping` to `sendTyping`.
  Additionally, this will not longer run a 9s interval sending additional requests, but instead, it will do so only once without any internal tracking.
- Removed `TextBasedChannel#stopTyping` as it relied on internal tracking.
- Removed `TextBasedChannel#typing` as it relied on internal tracking.
- Removed `TextBasedChannel#typingCount` as it relied on internal tracking.
- Removed `TextBasedChannel#_typing`.
- Changed `typingStart` event to take a `Typing` structure.
- Removed many timers, making typing events more scalable than ever.
- Removed `User#typingIn` as it relied on internal tracking.
- Removed `User#typingSinceIn` as it relied on internal tracking.
- Removed `User#typingDurationIn` as it relied on internal tracking.
- Removed `TypingData` type.

This PR complements #6113 by removing sparse timers, which will allow `Client#destroy` to work as intended.

As a side note, this PR makes channel instances a lot lighter, reducing memory usage by 140 MB per 1 million channels while also reducing the main thread's load by not registering potentially thousands of timers, which results on large delays in when user timers start running, promises start resolving/rejecting, etc.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
