### PR TITLE
types(Message): mark `#thread` as nullable

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -950,7 +950,7 @@ export class Message extends Base {
   public reactions: ReactionManager;
   public stickers: Collection<Snowflake, Sticker>;
   public system: boolean;
-  public thread: ThreadChannel;
+  public thread: ThreadChannel | null;
   public tts: boolean;
   public type: MessageType;
   public readonly url: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Message#thread` is marked as nullable in JSDocs, but not in the typings.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
