### PR TITLE
feat(GuildPreview): add createdAt & createdTimestamp

### DIFF
--- a/src/structures/GuildPreview.js
+++ b/src/structures/GuildPreview.js
@@ -91,7 +91,6 @@ class GuildPreview extends Base {
       this.emojis.set(emoji.id, new GuildPreviewEmoji(this.client, emoji, this));
     }
   }
-  
   /**
    * The timestamp this guild was created at
    * @type {number}

--- a/src/structures/GuildPreview.js
+++ b/src/structures/GuildPreview.js
@@ -3,6 +3,7 @@
 const Base = require('./Base');
 const GuildPreviewEmoji = require('./GuildPreviewEmoji');
 const Collection = require('../util/Collection');
+const SnowflakeUtil = require('../util/SnowflakeUtil');
 
 /**
  * Represents the data about the guild any bot can preview, connected to the specified guild.
@@ -89,6 +90,24 @@ class GuildPreview extends Base {
     for (const emoji of data.emojis) {
       this.emojis.set(emoji.id, new GuildPreviewEmoji(this.client, emoji, this));
     }
+  }
+  
+  /**
+   * The timestamp this guild was created at
+   * @type {number}
+   * @readonly
+   */
+  get createdTimestamp() {
+    return SnowflakeUtil.deconstruct(this.id).timestamp;
+  }
+
+  /**
+   * The time this guild was created at
+   * @type {Date}
+   * @readonly
+   */
+  get createdAt() {
+    return new Date(this.createdTimestamp);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -711,6 +711,8 @@ export class GuildPreview extends Base {
   public constructor(client: Client, data: unknown);
   public approximateMemberCount: number;
   public approximatePresenceCount: number;
+  public readonly createdAt: Date;
+  public readonly createdTimestamp: number;
   public description: string | null;
   public discoverySplash: string | null;
   public emojis: Collection<Snowflake, GuildPreviewEmoji>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
GuildPreview is missing the `createdAt` & `createdTimestamp` fields since it doesn't extend the BaseGuild class, so this PR adds it.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
