### PR TITLE
fix(GuildChannel): only fetch invites for the specific channel

### DIFF
--- a/src/managers/GuildInviteManager.js
+++ b/src/managers/GuildInviteManager.js
@@ -146,8 +146,8 @@ class GuildInviteManager extends CachedManager {
     return data.reduce((col, invite) => col.set(invite.code, this._add(invite, cache)), new Collection());
   }
 
-  async _fetchChannelMany(channelID, cache) {
-    const data = await this.client.api.channels(channelID).invites.get();
+  async _fetchChannelMany(channelId, cache) {
+    const data = await this.client.api.channels(channelId).invites.get();
     return data.reduce((col, invite) => col.set(invite.code, this._add(invite, cache)), new Collection());
   }
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -497,7 +497,7 @@ class GuildChannel extends Channel {
    * @returns {Promise<Collection<string, Invite>>}
    */
   fetchInvites(cache = true) {
-    return this.guild.invites.fetch({ channelID: this.id, cache });
+    return this.guild.invites.fetch({ channelId: this.id, cache });
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Following the renaming of `ID` properties to `Id` (#6036), this particular instance was missed, which cases `GuildChannel#fetchInvites` to fetch all invites from the guild rather than just the specific channel.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
