### PR TITLE
fix(CommandInteraction): change options type from Collection to array

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -416,7 +416,6 @@ export class CommandInteraction extends Interaction {
   public reply(options: InteractionReplyOptions & { fetchReply: true }): Promise<Message | APIMessage>;
   public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
   private transformOption(option: unknown, resolved: unknown): CommandInteractionOption;
-  private _createOptionsCollection(options: unknown, resolved: unknown): Collection<string, CommandInteractionOption>;
 }
 
 export class CommandInteractionOptionResolver {
@@ -3024,7 +3023,7 @@ export interface CommandInteractionOption {
   name: string;
   type: ApplicationCommandOptionType;
   value?: string | number | boolean;
-  options?: Collection<string, CommandInteractionOption>;
+  options?: CommandInteractionOption[];
   user?: User;
   member?: GuildMember | APIInteractionDataResolvedGuildMember;
   channel?: GuildChannel | APIInteractionDataResolvedChannel;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -8,6 +8,9 @@ import {
   ClientApplication,
   ClientUser,
   Collection,
+  CommandInteraction,
+  CommandInteractionOption,
+  CommandInteractionOptionResolver,
   Constants,
   DMChannel,
   Guild,
@@ -646,4 +649,25 @@ client.on('messageReactionAdd', async reaction => {
 
 // Test interactions
 declare const interaction: Interaction;
+declare const booleanValue: boolean;
 if (interaction.inGuild()) assertType<Snowflake>(interaction.guildId);
+
+client.on('interactionCreate', async interaction => {
+  if (interaction.isCommand()) {
+    assertType<CommandInteraction>(interaction);
+    assertType<CommandInteractionOptionResolver>(interaction.options);
+
+    const optionalOption = interaction.options.get('name');
+    const requiredOption = interaction.options.get('name', true);
+    assertType<CommandInteractionOption | null>(optionalOption);
+    assertType<CommandInteractionOption>(requiredOption);
+    assertType<CommandInteractionOption[] | undefined>(requiredOption.options);
+
+    assertType<string | null>(interaction.options.getString('name', booleanValue));
+    assertType<string | null>(interaction.options.getString('name', false));
+    assertType<string>(interaction.options.getString('name', true));
+
+    assertType<string>(interaction.options.getSubCommand());
+    assertType<string>(interaction.options.getSubCommandGroup());
+  }
+});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes a typings issue on `CommandInteractionOption#options` which still referenced the `Collection` logic that was removed in f293132345294e33e80866272feaedf2e4a70d45. This PR updates the type to an array, as it is in the code. This PR also adds test cases for related typings and removes a removed method from `CommandInteraction`.

**Status and versioning classification:**
-    Code changes have been tested against the Discord API, or there are no code changes
-    I know how to update typings and have done so, or typings don't need updating

