### PR TITLE
chore(Deps): update `discord-api-types` to 0.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@sapphire/async-queue": "^1.1.4",
         "@types/ws": "^7.4.5",
         "abort-controller": "^3.0.0",
-        "discord-api-types": "^0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e",
+        "discord-api-types": "^0.19.0",
         "node-fetch": "^2.6.1",
         "ws": "^7.5.1"
       },
@@ -3858,9 +3858,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e.tgz",
-      "integrity": "sha512-ttRA/8e/WKHDbGFfED5WlS7gID+kalmNr6iMiWBCvkphQ7kFHiTOVbnj/zX9ksaRaYXp/I38SCQ+qZvLu8DJZg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.19.0.tgz",
+      "integrity": "sha512-t2HKLd43Lbe+rf+ffYfKVv9Kk5f6p7sFqvO6CMV55ZB0PgZv8WigCkt9FoJciYo5S3Q6CGYK+WnE/ZG+6vkBDQ==",
       "engines": {
         "node": ">=12"
       }
@@ -14474,9 +14474,9 @@
       "dev": true
     },
     "discord-api-types": {
-      "version": "0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e.tgz",
-      "integrity": "sha512-ttRA/8e/WKHDbGFfED5WlS7gID+kalmNr6iMiWBCvkphQ7kFHiTOVbnj/zX9ksaRaYXp/I38SCQ+qZvLu8DJZg=="
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.19.0.tgz",
+      "integrity": "sha512-t2HKLd43Lbe+rf+ffYfKVv9Kk5f6p7sFqvO6CMV55ZB0PgZv8WigCkt9FoJciYo5S3Q6CGYK+WnE/ZG+6vkBDQ=="
     },
     "dmd": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@sapphire/async-queue": "^1.1.4",
     "@types/ws": "^7.4.5",
     "abort-controller": "^3.0.0",
-    "discord-api-types": "^0.19.0-next.f393ba520d7d6d2aacaca7b3ca5d355fab614f6e",
+    "discord-api-types": "^0.19.0",
     "node-fetch": "^2.6.1",
     "ws": "^7.5.1"
   },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,7 +29,7 @@ import {
   GatewayVoiceServerUpdateDispatchData,
   GatewayVoiceStateUpdateDispatchData,
   Snowflake,
-} from 'discord-api-types/v8';
+} from 'discord-api-types/v9';
 import { EventEmitter } from 'events';
 import { Stream } from 'stream';
 import * as WebSocket from 'ws';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Forgot to write here, updates discord-api-types from the now-deprecated `-next` versions

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
