### PR TITLE
fix(CommandInteractionOptionResolver): type should be USER

### DIFF
--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -169,7 +169,7 @@ class CommandInteractionOptionResolver {
    * The value of the option, or null if not set and not required.
    */
   getMember(name, required = false) {
-    const option = this._getTypedOption(name, ['MEMBER'], ['member'], required);
+    const option = this._getTypedOption(name, ['USER'], ['member'], required);
     return option?.member ?? null;
   }
 


### PR DESCRIPTION
`MEMBER` isn't an option type, it should be `USER`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating