### PR TITLE
types(DataManager): add 'K' to type parameter of 'resolveId'

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2136,7 +2136,7 @@ export abstract class DataManager<K, Holds, R> extends BaseManager {
   public readonly cache: Collection<K, Holds>;
   public resolve(resolvable: Holds): Holds;
   public resolve(resolvable: R): Holds | null;
-  public resolveId(resolvable: Holds): K;
+  public resolveId(resolvable: K | Holds): K;
   public resolveId(resolvable: R): K | null;
   public valueOf(): Collection<K, Holds>;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When you provide a parameter of type K to ```DataManager.resolveId(...)```, the typing consider that the result can be 'null' or 'K' type however, it will never be the case given the code of the function. So, this PR adds the type K for the parameter of the resolveId function which has as return type 'K' only.
More information here : https://discord.com/channels/222078108977594368/682166281826598932/866797061001052200

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->