### PR TITLE
types(ColorResolvable): readonly tuple

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3080,7 +3080,7 @@ export type ColorResolvable =
   | 'DARK_BUT_NOT_BLACK'
   | 'NOT_QUITE_BLACK'
   | 'RANDOM'
-  | [number, number, number]
+  | readonly [number, number, number]
   | number
   | HexColorString;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Add the `readonly` keyword on the tuple of `ColorResolvable`.

Since the tuple don't have to be mutated, make it `readonly` make `ColorResolvable` type wider.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
