### PR TITLE
refactor(CommandInteractionOptionResolver): add readonly data property

### DIFF
--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -52,7 +52,7 @@ class CommandInteraction extends Interaction {
      */
     this.options = new CommandInteractionOptionResolver(
       this.client,
-      data.data.options?.map(option => this.transformOption(option, data.data.resolved)),
+      data.data.options?.map(option => this.transformOption(option, data.data.resolved)) ?? [],
     );
 
     /**

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -16,13 +16,6 @@ class CommandInteractionOptionResolver {
     Object.defineProperty(this, 'client', { value: client });
 
     /**
-     * The interaction options array.
-     * @type {CommandInteractionOption[]}
-     * @private
-     */
-    this._options = options ?? [];
-
-    /**
      * The name of the sub-command group.
      * @type {?string}
      * @private
@@ -35,14 +28,24 @@ class CommandInteractionOptionResolver {
      * @private
      */
     this._subCommand = null;
-    if (this._options[0]?.type === 'SUB_COMMAND_GROUP') {
-      this._group = this._options[0].name;
-      this._options = this._options[0].options ?? [];
+
+    let data = options;
+    if (data[0]?.type === 'SUB_COMMAND_GROUP') {
+      this._group = data[0].name;
+      data = data[0].options ?? [];
     }
-    if (this._options[0]?.type === 'SUB_COMMAND') {
-      this._subCommand = this._options[0].name;
-      this._options = this._options[0].options ?? [];
+    if (data[0]?.type === 'SUB_COMMAND') {
+      this._subCommand = data[0].name;
+      data = data[0].options ?? [];
     }
+
+    /**
+     * The interaction options array.
+     * @name CommandInteractionOptionResolver#data
+     * @type {ReadonlyArray<CommandInteractionOption>}
+     * @readonly
+     */
+    Object.defineProperty(this, 'data', { value: Object.freeze(data) });
   }
 
   /**
@@ -52,7 +55,7 @@ class CommandInteractionOptionResolver {
    * @returns {?CommandInteractionOption} The option, if found.
    */
   get(name, required = false) {
-    const option = this._options.find(opt => opt.name === name);
+    const option = this.data.find(opt => opt.name === name);
     if (!option) {
       if (required) {
         throw new TypeError('COMMAND_INTERACTION_OPTION_NOT_FOUND', name);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -427,7 +427,7 @@ export class CommandInteraction extends Interaction {
 export class CommandInteractionOptionResolver {
   public constructor(client: Client, options: CommandInteractionOption[]);
   public readonly client: Client;
-  private _options: CommandInteractionOption[];
+  public readonly data: readonly CommandInteractionOption[];
   private _group: string | null;
   private _subCommand: string | null;
   private _getTypedOption(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -429,6 +429,7 @@ export class CommandInteractionOptionResolver {
   public readonly client: Client;
   public readonly data: readonly CommandInteractionOption[];
   private _group: string | null;
+  private _hoistedOptions: CommandInteractionOption[];
   private _subCommand: string | null;
   private _getTypedOption(
     name: string,

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -656,6 +656,7 @@ client.on('interactionCreate', async interaction => {
   if (interaction.isCommand()) {
     assertType<CommandInteraction>(interaction);
     assertType<CommandInteractionOptionResolver>(interaction.options);
+    assertType<readonly CommandInteractionOption[]>(interaction.options.data);
 
     const optionalOption = interaction.options.get('name');
     const requiredOption = interaction.options.get('name', true);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This moves the `_options` property to the public `data` property as a read-only array, which allows custom usage of options.

This closes #6143.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- Code changes have been tested against the Discord API, or there are no code changes
