### PR TITLE
fix(Sticker): replace 'this.guildID' (undefined) by 'this.guildId' in fetchUser

### DIFF
--- a/src/structures/Sticker.js
+++ b/src/structures/Sticker.js
@@ -156,7 +156,7 @@ class Sticker extends Base {
    */
   async fetchUser() {
     if (this.partial) await this.fetch();
-    if (!this.guildID) throw new Error('NOT_GUILD_STICKER');
+    if (!this.guildId) throw new Error('NOT_GUILD_STICKER');
 
     const data = await this.client.api.guilds(this.guildId).stickers(this.id).get();
     this._patch(data);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fix a bug due the change of all xID into xId. In this function, the change has not been made resulting in an error all the time since ```!this.guildID``` is always true.
Bug report in Discord - https://discord.com/channels/222078108977594368/682166281826598932/867014005016756244


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
