### PR TITLE
refactor: only cache commands from own user

### DIFF
--- a/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
@@ -9,7 +9,7 @@ module.exports = (client, { d: data }) => {
   const command = commandManager._add(data, data.application_id === client.application.id);
 
   /**
-   * Emitted when an application command is created.
+   * Emitted when a guild application command is created.
    * @event Client#applicationCommandCreate
    * @param {ApplicationCommand} command The command which was created
    */

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
@@ -3,15 +3,10 @@
 const { Events } = require('../../../util/Constants');
 
 module.exports = (client, { d: data }) => {
-  let command;
+  const commandManager = data.guild_id ? client.guilds.cache.get(data.guild_id)?.commands : client.application.commands;
+  if (!commandManager) return;
 
-  if (data.guild_id) {
-    const guild = client.guilds.cache.get(data.guild_id);
-    if (!guild) return;
-    command = guild.commands._add(data);
-  } else {
-    command = client.application.commands._add(data);
-  }
+  const command = commandManager._add(data, data.application_id === client.application.id);
 
   /**
    * Emitted when an application command is created.

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
@@ -3,17 +3,12 @@
 const { Events } = require('../../../util/Constants');
 
 module.exports = (client, { d: data }) => {
-  let command;
+  const commandManager = data.guild_id ? client.guilds.cache.get(data.guild_id)?.commands : client.application.commands;
+  if (!commandManager) return;
 
-  if (data.guild_id) {
-    const guild = client.guilds.cache.get(data.guild_id);
-    if (!guild) return;
-    command = guild.commands._add(data);
-    guild.commands.cache.delete(data.id);
-  } else {
-    command = client.application.commands._add(data);
-    client.application.commands.cache.delete(data.id);
-  }
+  const isOwn = data.application_id === client.application.id;
+  const command = commandManager._add(data, isOwn);
+  if (isOwn) commandManager.cache.delete(data.id);
 
   /**
    * Emitted when an application command is deleted.

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
@@ -11,7 +11,7 @@ module.exports = (client, { d: data }) => {
   if (isOwn) commandManager.cache.delete(data.id);
 
   /**
-   * Emitted when an application command is deleted.
+   * Emitted when a guild application command is deleted.
    * @event Client#applicationCommandDelete
    * @param {ApplicationCommand} command The command which was deleted
    */

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
@@ -3,18 +3,11 @@
 const { Events } = require('../../../util/Constants');
 
 module.exports = (client, { d: data }) => {
-  let oldCommand;
-  let newCommand;
+  const commandManager = data.guild_id ? client.guilds.cache.get(data.guild_id)?.commands : client.application.commands;
+  if (!commandManager) return;
 
-  if (data.guild_id) {
-    const guild = client.guilds.cache.get(data.guild_id);
-    if (!guild) return;
-    oldCommand = guild.commands.cache.get(data.id)?._clone() ?? null;
-    newCommand = guild.commands._add(data);
-  } else {
-    oldCommand = client.application.commands.cache.get(data.id)?._clone() ?? null;
-    newCommand = client.application.commands._add(data);
-  }
+  const oldCommand = commandManager.cache.get(data.id)?._clone() ?? null;
+  const newCommand = commandManager._add(data, data.application_id === client.application.id);
 
   /**
    * Emitted when an application command is updated.

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
@@ -10,7 +10,7 @@ module.exports = (client, { d: data }) => {
   const newCommand = commandManager._add(data, data.application_id === client.application.id);
 
   /**
-   * Emitted when an application command is updated.
+   * Emitted when a guild application command is updated.
    * @event Client#applicationCommandUpdate
    * @param {?ApplicationCommand} oldCommand The command before the update
    * @param {ApplicationCommand} newCommand The command after the update

--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -192,9 +192,9 @@ class ApplicationCommandManager extends CachedManager {
 
     await this.commandPath({ id, guildId }).delete();
 
+    const cached = this.cache.get(id);
     if (!guildId) this.cache.delete(id);
-
-    return this.cache.get(id) ?? null;
+    return cached ?? null;
   }
 
   /**

--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -116,7 +116,7 @@ class ApplicationCommandManager extends CachedManager {
     const data = await this.commandPath({ guildId }).post({
       data: this.constructor.transformCommand(command),
     });
-    return this._add(data, undefined, guildId);
+    return this._add(data, false, guildId);
   }
 
   /**
@@ -145,10 +145,7 @@ class ApplicationCommandManager extends CachedManager {
     const data = await this.commandPath({ guildId }).put({
       data: commands.map(c => this.constructor.transformCommand(c)),
     });
-    return data.reduce(
-      (coll, command) => coll.set(command.id, this._add(command, undefined, guildId)),
-      new Collection(),
-    );
+    return data.reduce((coll, command) => coll.set(command.id, this._add(command, false, guildId)), new Collection());
   }
 
   /**
@@ -179,7 +176,7 @@ class ApplicationCommandManager extends CachedManager {
    * @param {ApplicationCommandResolvable} command The command to delete
    * @param {Snowflake} [guildId] The guild's id where the command is registered,
    * ignored when using a {@link GuildApplicationCommandManager}
-   * @returns {Promise<?ApplicationCommand>}
+   * @returns {Promise<void>}
    * @example
    * // Delete a command
    * guild.commands.delete('123456789012345678')
@@ -191,10 +188,6 @@ class ApplicationCommandManager extends CachedManager {
     if (!id) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
 
     await this.commandPath({ id, guildId }).delete();
-
-    const cached = this.cache.get(id);
-    this.cache.delete(id);
-    return cached ?? null;
   }
 
   /**

--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -116,7 +116,7 @@ class ApplicationCommandManager extends CachedManager {
     const data = await this.commandPath({ guildId }).post({
       data: this.constructor.transformCommand(command),
     });
-    return this._add(data, false, guildId);
+    return this._add(data, !guildId, guildId);
   }
 
   /**
@@ -145,7 +145,10 @@ class ApplicationCommandManager extends CachedManager {
     const data = await this.commandPath({ guildId }).put({
       data: commands.map(c => this.constructor.transformCommand(c)),
     });
-    return data.reduce((coll, command) => coll.set(command.id, this._add(command, false, guildId)), new Collection());
+    return data.reduce(
+      (coll, command) => coll.set(command.id, this._add(command, !guildId, guildId)),
+      new Collection(),
+    );
   }
 
   /**
@@ -168,7 +171,7 @@ class ApplicationCommandManager extends CachedManager {
     if (!id) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
 
     const patched = await this.commandPath({ id, guildId }).patch({ data: this.constructor.transformCommand(data) });
-    return this._add(patched, undefined, guildId);
+    return this._add(patched, !guildId, guildId);
   }
 
   /**
@@ -176,7 +179,7 @@ class ApplicationCommandManager extends CachedManager {
    * @param {ApplicationCommandResolvable} command The command to delete
    * @param {Snowflake} [guildId] The guild's id where the command is registered,
    * ignored when using a {@link GuildApplicationCommandManager}
-   * @returns {Promise<void>}
+   * @returns {Promise<?ApplicationCommand>}
    * @example
    * // Delete a command
    * guild.commands.delete('123456789012345678')
@@ -188,6 +191,10 @@ class ApplicationCommandManager extends CachedManager {
     if (!id) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
 
     await this.commandPath({ id, guildId }).delete();
+
+    if (!guildId) this.cache.delete(id);
+
+    return this.cache.get(id) ?? null;
   }
 
   /**

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -20,7 +20,7 @@ class ApplicationCommand extends Base {
     this.id = data.id;
 
     /**
-     * The application's id
+     * The parent application's id
      * @type {Snowflake}
      */
     this.applicationId = data.application_id;

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -20,6 +20,12 @@ class ApplicationCommand extends Base {
     this.id = data.id;
 
     /**
+     * The application's id
+     * @type {Snowflake}
+     */
+    this.applicationId = data.application_id;
+
+    /**
      * The guild this command is part of
      * @type {?Guild}
      */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -125,6 +125,7 @@ export abstract class Application extends Base {
 
 export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
   public constructor(client: Client, data: unknown, guild?: Guild, guildId?: Snowflake);
+  public applicationId: Snowflake;
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
   public defaultPermission: boolean;
@@ -2162,7 +2163,7 @@ export class ApplicationCommandManager<
   private commandPath({ id, guildId }: { id?: Snowflake; guildId?: Snowflake }): unknown;
   public create(command: ApplicationCommandData): Promise<ApplicationCommandType>;
   public create(command: ApplicationCommandData, guildId: Snowflake): Promise<ApplicationCommand>;
-  public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<ApplicationCommandType | null>;
+  public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<void>;
   public edit(command: ApplicationCommandResolvable, data: ApplicationCommandData): Promise<ApplicationCommandType>;
   public edit(
     command: ApplicationCommandResolvable,
@@ -2242,7 +2243,7 @@ export class GuildApplicationCommandManager extends ApplicationCommandManager<Ap
   public constructor(guild: Guild, iterable?: Iterable<unknown>);
   public guild: Guild;
   public create(command: ApplicationCommandData): Promise<ApplicationCommand>;
-  public delete(command: ApplicationCommandResolvable): Promise<ApplicationCommand | null>;
+  public delete(command: ApplicationCommandResolvable): Promise<void>;
   public edit(command: ApplicationCommandResolvable, data: ApplicationCommandData): Promise<ApplicationCommand>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<ApplicationCommand>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, ApplicationCommand>>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2163,7 +2163,7 @@ export class ApplicationCommandManager<
   private commandPath({ id, guildId }: { id?: Snowflake; guildId?: Snowflake }): unknown;
   public create(command: ApplicationCommandData): Promise<ApplicationCommandType>;
   public create(command: ApplicationCommandData, guildId: Snowflake): Promise<ApplicationCommand>;
-  public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<ApplicationCommand | null>;
+  public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<ApplicationCommandType | null>;
   public edit(command: ApplicationCommandResolvable, data: ApplicationCommandData): Promise<ApplicationCommandType>;
   public edit(
     command: ApplicationCommandResolvable,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2163,7 +2163,7 @@ export class ApplicationCommandManager<
   private commandPath({ id, guildId }: { id?: Snowflake; guildId?: Snowflake }): unknown;
   public create(command: ApplicationCommandData): Promise<ApplicationCommandType>;
   public create(command: ApplicationCommandData, guildId: Snowflake): Promise<ApplicationCommand>;
-  public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<void>;
+  public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<ApplicationCommand | null>;
   public edit(command: ApplicationCommandResolvable, data: ApplicationCommandData): Promise<ApplicationCommandType>;
   public edit(
     command: ApplicationCommandResolvable,
@@ -2243,7 +2243,7 @@ export class GuildApplicationCommandManager extends ApplicationCommandManager<Ap
   public constructor(guild: Guild, iterable?: Iterable<unknown>);
   public guild: Guild;
   public create(command: ApplicationCommandData): Promise<ApplicationCommand>;
-  public delete(command: ApplicationCommandResolvable): Promise<void>;
+  public delete(command: ApplicationCommandResolvable): Promise<ApplicationCommand | null>;
   public edit(command: ApplicationCommandResolvable, data: ApplicationCommandData): Promise<ApplicationCommand>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<ApplicationCommand>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, ApplicationCommand>>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The applicationCommandCreate/Update/Delete events are sent when guild commands owned by _any_ bot in the server are created, updated, or deleted - and not just the commands owned by the client user. This meant that Discord.js was caching commands owned by other bots.

This PR:
- makes sure the command events only cache commands from the own bot (thanks @vladfrangu for the code suggestions)
- adds `ApplicationCommand#applicationId`
- modifies some of the `ApplicationCommandManager` methods so that they don't patch the cache in place (_this fixes a bug where the applicationCommandUpdate event would emit the oldCommand with the new data_), unless the targeted command is a global command. (The command events aren't fired for global commands, only guild commands)


**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
