### PR TITLE
fix(Typings): type attachments to InteractionUpdateOptions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3810,7 +3810,7 @@ export type MessageComponentType = keyof typeof MessageComponentTypes;
 export type MessageComponentTypeResolvable = MessageComponentType | MessageComponentTypes;
 
 export interface MessageEditOptions {
-  attachments?: Array<MessageAttachment | never>;
+  attachments?: (MessageAttachment | never)[];
   content?: string | null;
   embeds?: (MessageEmbed | MessageEmbedOptions)[] | null;
   files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3694,7 +3694,7 @@ export type InteractionResponseType = keyof typeof InteractionResponseTypes;
 
 export type InteractionType = keyof typeof InteractionTypes;
 
-export type InteractionUpdateOptions = Omit<InteractionReplyOptions, 'ephemeral'>;
+export type InteractionUpdateOptions = MessageEditOptions;
 
 export type IntentsString =
   | 'GUILDS'
@@ -3810,7 +3810,7 @@ export type MessageComponentType = keyof typeof MessageComponentTypes;
 export type MessageComponentTypeResolvable = MessageComponentType | MessageComponentTypes;
 
 export interface MessageEditOptions {
-  attachments?: (MessageAttachment | never)[];
+  attachments?: MessageAttachment[];
   content?: string | null;
   embeds?: (MessageEmbed | MessageEmbedOptions)[] | null;
   files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3810,7 +3810,7 @@ export type MessageComponentType = keyof typeof MessageComponentTypes;
 export type MessageComponentTypeResolvable = MessageComponentType | MessageComponentTypes;
 
 export interface MessageEditOptions {
-  attachments?: MessageAttachment[];
+  attachments?: Array<MessageAttachment | never>;
   content?: string | null;
   embeds?: (MessageEmbed | MessageEmbedOptions)[] | null;
   files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3694,7 +3694,9 @@ export type InteractionResponseType = keyof typeof InteractionResponseTypes;
 
 export type InteractionType = keyof typeof InteractionTypes;
 
-export type InteractionUpdateOptions = MessageEditOptions;
+export interface InteractionUpdateOptions extends MessageEditOptions {
+  fetchReply?: boolean;
+}
 
 export type IntentsString =
   | 'GUILDS'


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently, if you want to remove attachments from a message you have to use `message.removeAttachments()`, and if you need to edit the content as well that is 2 API calls. Assigning `attachments: []` does work, but sparks errors in TypeScript that require `// @ts-ignore` - which is generally considered a bad practice. This PR fixes the typings allowing you to assign `attachments: []` without having to use ts-ignore.

**Status and versioning classification:**

I know how to update typings and have done so, or typings don't need updating