### PR TITLE
feat(CommandInteractionOptionResolver): add sub-command required option

### DIFF
--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -98,7 +98,6 @@ class CommandInteractionOptionResolver {
   /**
    * Gets the selected sub-command.
    * @param {boolean} [required=true] Whether to throw an error if there is no sub-command.
-   * Note that this defaults to true, unlike the other `getX()` methods.
    * @returns {?string} The name of the selected sub-command, or null if not set and not required.
    */
   getSubCommand(required = true) {
@@ -111,7 +110,6 @@ class CommandInteractionOptionResolver {
   /**
    * Gets the selected sub-command group.
    * @param {boolean} [required=true] Whether to throw an error if there is no sub-command group.
-   * Note that this defaults to true, unlike the other `getX()` methods.
    * @returns {?string} The name of the selected sub-command group, or null if not set and not required.
    */
   getSubCommandGroup(required = true) {

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -99,7 +99,7 @@ class CommandInteractionOptionResolver {
    * Gets the selected sub-command.
    * @param {boolean} [required=true] Whether to throw an error if there is no sub-command.
    * Note that this defaults to true, unlike the other `getX()` methods.
-   * @returns {string} The name of the selected sub-command.
+   * @returns {?string} The name of the selected sub-command, or null if not set and not required.
    */
   getSubCommand(required = true) {
     if (required && !this._subCommand) {
@@ -112,7 +112,7 @@ class CommandInteractionOptionResolver {
    * Gets the selected sub-command group.
    * @param {boolean} [required=true] Whether to throw an error if there is no sub-command group.
    * Note that this defaults to true, unlike the other `getX()` methods.
-   * @returns {string} The name of the selected sub-command group.
+   * @returns {?string} The name of the selected sub-command group, or null if not set and not required.
    */
   getSubCommandGroup(required = true) {
     if (required && !this._group) {

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -97,10 +97,12 @@ class CommandInteractionOptionResolver {
 
   /**
    * Gets the selected sub-command.
+   * @param {boolean} [required=true] Whether to throw an error if there is no sub-command.
+   * Note that this defaults to true, unlike the other `getX()` methods.
    * @returns {string} The name of the selected sub-command.
    */
-  getSubCommand() {
-    if (!this._subCommand) {
+  getSubCommand(required = true) {
+    if (required && !this._subCommand) {
       throw new TypeError('COMMAND_INTERACTION_OPTION_NO_SUB_COMMAND');
     }
     return this._subCommand;
@@ -108,10 +110,12 @@ class CommandInteractionOptionResolver {
 
   /**
    * Gets the selected sub-command group.
+   * @param {boolean} [required=true] Whether to throw an error if there is no sub-command group.
+   * Note that this defaults to true, unlike the other `getX()` methods.
    * @returns {string} The name of the selected sub-command group.
    */
-  getSubCommandGroup() {
-    if (!this._group) {
+  getSubCommandGroup(required = true) {
+    if (required && !this._group) {
       throw new TypeError('COMMAND_INTERACTION_OPTION_NO_SUB_COMMAND_GROUP');
     }
     return this._group;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -451,7 +451,6 @@ export class CommandInteractionOptionResolver {
   public getSubCommand(required: boolean): string | null;
   public getSubCommandGroup(required?: true): string;
   public getSubCommandGroup(required: boolean): string | null;
-
   public getBoolean(name: string, required: true): boolean;
   public getBoolean(name: string, required?: boolean): boolean | null;
   public getChannel(name: string, required: true): NonNullable<CommandInteractionOption['channel']>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -446,8 +446,12 @@ export class CommandInteractionOptionResolver {
 
   public get(name: string, required: true): CommandInteractionOption;
   public get(name: string, required?: boolean): CommandInteractionOption | null;
-  public getSubCommand(): string;
-  public getSubCommandGroup(): string;
+
+  public getSubCommand(required?: true): string;
+  public getSubCommand(required: boolean): string | null;
+  public getSubCommandGroup(required?: true): string;
+  public getSubCommandGroup(required: boolean): string | null;
+
   public getBoolean(name: string, required: true): boolean;
   public getBoolean(name: string, required?: boolean): boolean | null;
   public getChannel(name: string, required: true): NonNullable<CommandInteractionOption['channel']>;

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -669,6 +669,13 @@ client.on('interactionCreate', async interaction => {
     assertType<string>(interaction.options.getString('name', true));
 
     assertType<string>(interaction.options.getSubCommand());
+    assertType<string>(interaction.options.getSubCommand(true));
+    assertType<string | null>(interaction.options.getSubCommand(booleanValue));
+    assertType<string | null>(interaction.options.getSubCommand(false));
+
     assertType<string>(interaction.options.getSubCommandGroup());
+    assertType<string>(interaction.options.getSubCommandGroup(true));
+    assertType<string | null>(interaction.options.getSubCommandGroup(booleanValue));
+    assertType<string | null>(interaction.options.getSubCommandGroup(false));
   }
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This adds a `required` parameter to the `getSubCommand()` and `getSubCommandGroup()` methods, defaulted to `true` (as opposed to `false` in option getters), to allow for optional checking of sub-commands if needed (e.g. logging) without changing the current default behavior that enforces strict command definitions.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
