### PR TITLE
fix(GuildAuditLog): Assert `target` to null upon not finding invite codes

### DIFF
--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -490,7 +490,7 @@ class GuildAuditLogsEntry {
           let change = this.changes.find(c => c.key === 'code');
           change = change.new ?? change.old;
           return guild.invites.fetch().then(invites => {
-            this.target = invites.find(i => i.code === change);
+            this.target = invites.find(i => i.code === change) ?? null;
           });
         } else {
           this.target = this.changes.reduce((o, c) => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Hi there!

Upon running `<Guild>.fetchAuditLogs({ type })` where `type` is 40 (`INVITE_CREATE`), 41 (`INVITE_UPDATE`) or 42 (`INVITE_DELETE`), there is a possibility that `target` on the returned `GuildAuditLogsEntry` will be `undefined`.

One case where this is easily reproducible is by simply creating and then deleting an invite and then running `<Guild>.fetchAuditLogs({ type: 40 })`.

I've simply added the nullish coalescing operator after that check to ensure that if an invite code cannot be found, it will default to `null` and not `undefined`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
