### PR TITLE
feat: right-clickybois (context menu support for ApplicationCommand and CommandInteraction)

### DIFF
--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -3,6 +3,7 @@
 const Action = require('./Action');
 const ButtonInteraction = require('../../structures/ButtonInteraction');
 const CommandInteraction = require('../../structures/CommandInteraction');
+const ContextMenuInteraction = require('../../structures/ContextMenuInteraction');
 const SelectMenuInteraction = require('../../structures/SelectMenuInteraction');
 const { Events, InteractionTypes, MessageComponentTypes } = require('../../util/Constants');
 
@@ -18,7 +19,11 @@ class InteractionCreateAction extends Action {
     let InteractionType;
     switch (data.type) {
       case InteractionTypes.APPLICATION_COMMAND:
-        InteractionType = CommandInteraction;
+        if (typeof data.data.target_id === 'undefined') {
+          InteractionType = CommandInteraction;
+        } else {
+          InteractionType = ContextMenuInteraction;
+        }
         break;
       case InteractionTypes.MESSAGE_COMPONENT:
         switch (data.data.component_type) {

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -5,7 +5,7 @@ const ButtonInteraction = require('../../structures/ButtonInteraction');
 const CommandInteraction = require('../../structures/CommandInteraction');
 const ContextMenuInteraction = require('../../structures/ContextMenuInteraction');
 const SelectMenuInteraction = require('../../structures/SelectMenuInteraction');
-const { Events, InteractionTypes, MessageComponentTypes } = require('../../util/Constants');
+const { Events, InteractionTypes, MessageComponentTypes, ApplicationCommandTypes } = require('../../util/Constants');
 
 let deprecationEmitted = false;
 
@@ -19,10 +19,20 @@ class InteractionCreateAction extends Action {
     let InteractionType;
     switch (data.type) {
       case InteractionTypes.APPLICATION_COMMAND:
-        if (typeof data.data.target_id === 'undefined') {
-          InteractionType = CommandInteraction;
-        } else {
-          InteractionType = ContextMenuInteraction;
+        switch (data.data.type) {
+          case ApplicationCommandTypes.APPLICATION_COMMAND:
+            InteractionType = CommandInteraction;
+            break;
+          case ApplicationCommandTypes.USER:
+          case ApplicationCommandTypes.MESSAGE:
+            InteractionType = ContextMenuInteraction;
+            break;
+          default:
+            client.emit(
+              Events.DEBUG,
+              `[INTERACTION] Received application command interaction with unknown type: ${data.data.type}`,
+            );
+            return;
         }
         break;
       case InteractionTypes.MESSAGE_COMPONENT:

--- a/src/client/actions/InteractionCreate.js
+++ b/src/client/actions/InteractionCreate.js
@@ -20,7 +20,7 @@ class InteractionCreateAction extends Action {
     switch (data.type) {
       case InteractionTypes.APPLICATION_COMMAND:
         switch (data.data.type) {
-          case ApplicationCommandTypes.APPLICATION_COMMAND:
+          case ApplicationCommandTypes.CHAT_INPUT:
             InteractionType = CommandInteraction;
             break;
           case ApplicationCommandTypes.USER:

--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -5,6 +5,7 @@ const ApplicationCommandPermissionsManager = require('./ApplicationCommandPermis
 const CachedManager = require('./CachedManager');
 const { TypeError } = require('../errors');
 const ApplicationCommand = require('../structures/ApplicationCommand');
+const { ApplicationCommandTypes } = require('../util/Constants');
 
 /**
  * Manages API methods for application commands and stores their cache.
@@ -207,6 +208,7 @@ class ApplicationCommandManager extends CachedManager {
     return {
       name: command.name,
       description: command.description,
+      type: typeof command.type === 'number' ? command.type : ApplicationCommandTypes[command.type],
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
       default_permission: command.defaultPermission,
     };

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -13,7 +13,6 @@ class ApplicationCommand extends Base {
   constructor(client, data, guild, guildId) {
     super(client);
 
-    console.log(data);
     /**
      * The command's id
      * @type {Snowflake}

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -105,6 +105,7 @@ class ApplicationCommand extends Base {
    * @typedef {Object} ApplicationCommandData
    * @property {string} name The name of the command
    * @property {string} description The description of the command
+   * @property {ApplicationCommandTypes} [type] The type of the command
    * @property {ApplicationCommandOptionData[]} [options] Options for the command
    * @property {boolean} [defaultPermission] Whether the command is enabled by default when the app is added to a guild
    */

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -2,7 +2,7 @@
 
 const Base = require('./Base');
 const ApplicationCommandPermissionsManager = require('../managers/ApplicationCommandPermissionsManager');
-const { ApplicationCommandOptionTypes } = require('../util/Constants');
+const { ApplicationCommandOptionTypes, ApplicationCommandTypes } = require('../util/Constants');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
 
 /**
@@ -13,6 +13,7 @@ class ApplicationCommand extends Base {
   constructor(client, data, guild, guildId) {
     super(client);
 
+    console.log(data);
     /**
      * The command's id
      * @type {Snowflake}
@@ -43,6 +44,12 @@ class ApplicationCommand extends Base {
      * @type {ApplicationCommandPermissionsManager}
      */
     this.permissions = new ApplicationCommandPermissionsManager(this);
+
+    /**
+     * The type of this application command
+     * @type {ApplicationCommandType}
+     */
+    this.type = ApplicationCommandTypes[data.type];
 
     this._patch(data);
   }

--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -82,7 +82,7 @@ class BaseCommandInteraction extends Interaction {
    * @property {string|number|boolean} [value] The value of the option
    * @property {CommandInteractionOption[]} [options] Additional options if this option is a
    * subcommand (group)
-   * @property {User|APIUser} [user] The resolved user
+   * @property {User} [user] The resolved user
    * @property {GuildMember|APIGuildMember} [member] The resolved member
    * @property {GuildChannel|APIChannel} [channel] The resolved channel
    * @property {Role|APIRole} [role] The resolved role

--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -17,7 +17,7 @@ class BaseCommandInteraction extends Interaction {
 
     /**
      * The channel this interaction was sent in
-     * @type {?(TextChannel|NewsChannel|DMChannel)}
+     * @type {?TextBasedChannels}
      * @name BaseCommandInteraction#channel
      * @readonly
      */

--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -80,9 +80,9 @@ class BaseCommandInteraction extends Interaction {
    * @property {string} name The name of the option
    * @property {ApplicationCommandOptionType} type The type of the option
    * @property {string|number|boolean} [value] The value of the option
-   * @property {Collection<string, CommandInteractionOption>} [options] Additional options if this option is a
+   * @property {CommandInteractionOption[]} [options] Additional options if this option is a
    * subcommand (group)
-   * @property {User} [user] The resolved user
+   * @property {User|APIUser} [user] The resolved user
    * @property {GuildMember|APIGuildMember} [member] The resolved member
    * @property {GuildChannel|APIChannel} [channel] The resolved channel
    * @property {Role|APIRole} [role] The resolved role
@@ -91,7 +91,7 @@ class BaseCommandInteraction extends Interaction {
   /**
    * Transforms an option received from the API.
    * @param {APIApplicationCommandOption} option The received option
-   * @param {APIApplicationCommandInteractionData.resolved} resolved The resolved interaction data
+   * @param {APIInteractionDataResolved} resolved The resolved interaction data
    * @returns {CommandInteractionOption}
    * @private
    */
@@ -137,11 +137,6 @@ module.exports = BaseCommandInteraction;
 
 /* eslint-disable max-len */
 /**
- * @external APIApplicationCommandOptionResolved
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-applicationcommandinteractiondataresolved}
- */
-
-/**
- * @external APIInteractionDataResolvedOption
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#sample-application-command-interaction-application-command-interaction-data-resolved-structure}
+ * @external APIInteractionDataResolved
+ * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure}
  */

--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -1,0 +1,147 @@
+'use strict';
+
+const Interaction = require('./Interaction');
+const InteractionWebhook = require('./InteractionWebhook');
+const InteractionResponses = require('./interfaces/InteractionResponses');
+const { ApplicationCommandOptionTypes } = require('../util/Constants');
+
+/**
+ * Represents a command interaction.
+ * @extends {Interaction}
+ * @implements {InteractionResponses}
+ * @abstract
+ */
+class BaseCommandInteraction extends Interaction {
+  constructor(client, data) {
+    super(client, data);
+
+    /**
+     * The channel this interaction was sent in
+     * @type {?(TextChannel|NewsChannel|DMChannel)}
+     * @name BaseCommandInteraction#channel
+     * @readonly
+     */
+
+    /**
+     * The id of the channel this interaction was sent in
+     * @type {Snowflake}
+     * @name BaseCommandInteraction#channelId
+     */
+
+    /**
+     * The invoked application command's id
+     * @type {Snowflake}
+     */
+    this.commandId = data.data.id;
+
+    /**
+     * The invoked application command's name
+     * @type {string}
+     */
+    this.commandName = data.data.name;
+
+    /**
+     * Whether the reply to this interaction has been deferred
+     * @type {boolean}
+     */
+    this.deferred = false;
+
+    /**
+     * Whether this interaction has already been replied to
+     * @type {boolean}
+     */
+    this.replied = false;
+
+    /**
+     * Whether the reply to this interaction is ephemeral
+     * @type {?boolean}
+     */
+    this.ephemeral = null;
+
+    /**
+     * An associated interaction webhook, can be used to further interact with this interaction
+     * @type {InteractionWebhook}
+     */
+    this.webhook = new InteractionWebhook(this.client, this.applicationId, this.token);
+  }
+
+  /**
+   * The invoked application command, if it was fetched before
+   * @type {?ApplicationCommand}
+   */
+  get command() {
+    const id = this.commandId;
+    return this.guild?.commands.cache.get(id) ?? this.client.application.commands.cache.get(id) ?? null;
+  }
+
+  /**
+   * Represents an option of a received command interaction.
+   * @typedef {Object} CommandInteractionOption
+   * @property {string} name The name of the option
+   * @property {ApplicationCommandOptionType} type The type of the option
+   * @property {string|number|boolean} [value] The value of the option
+   * @property {Collection<string, CommandInteractionOption>} [options] Additional options if this option is a
+   * subcommand (group)
+   * @property {User} [user] The resolved user
+   * @property {GuildMember|APIGuildMember} [member] The resolved member
+   * @property {GuildChannel|APIChannel} [channel] The resolved channel
+   * @property {Role|APIRole} [role] The resolved role
+   */
+
+  /**
+   * Transforms an option received from the API.
+   * @param {APIApplicationCommandOption} option The received option
+   * @param {APIApplicationCommandInteractionData.resolved} resolved The resolved interaction data
+   * @returns {CommandInteractionOption}
+   * @private
+   */
+  transformOption(option, resolved) {
+    const result = {
+      name: option.name,
+      type: ApplicationCommandOptionTypes[option.type],
+    };
+
+    if ('value' in option) result.value = option.value;
+    if ('options' in option) result.options = option.options.map(opt => this.transformOption(opt, resolved));
+
+    if (resolved) {
+      const user = resolved.users?.[option.value];
+      if (user) result.user = this.client.users._add(user);
+
+      const member = resolved.members?.[option.value];
+      if (member) result.member = this.guild?.members._add({ user, ...member }) ?? member;
+
+      const channel = resolved.channels?.[option.value];
+      if (channel) result.channel = this.client.channels._add(channel, this.guild) ?? channel;
+
+      const role = resolved.roles?.[option.value];
+      if (role) result.role = this.guild?.roles._add(role) ?? role;
+    }
+
+    return result;
+  }
+
+  // These are here only for documentation purposes - they are implemented by InteractionResponses
+  /* eslint-disable no-empty-function */
+  defer() {}
+  reply() {}
+  fetchReply() {}
+  editReply() {}
+  deleteReply() {}
+  followUp() {}
+}
+
+InteractionResponses.applyToClass(BaseCommandInteraction, ['deferUpdate', 'update']);
+
+module.exports = BaseCommandInteraction;
+
+/* eslint-disable max-len */
+/**
+ * @external APIApplicationCommandOptionResolved
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-applicationcommandinteractiondataresolved}
+ */
+
+/**
+ * @external APIInteractionDataResolvedOption
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#sample-application-command-interaction-application-command-interaction-data-resolved-structure}
+ */

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -52,7 +52,7 @@ class CommandInteraction extends Interaction {
      */
     this.options = new CommandInteractionOptionResolver(
       this.client,
-      data.data.target_id
+      typeof data.data.target_id !== 'undefined'
         ? this.resolveContextMenuOptions(data.data)
         : data.data.options?.map(option => this.transformOption(option, data.data.resolved)) ?? [],
     );

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -1,50 +1,15 @@
 'use strict';
 
+const BaseCommandInteraction = require('./BaseCommandInteraction');
 const CommandInteractionOptionResolver = require('./CommandInteractionOptionResolver');
-const Interaction = require('./Interaction');
-const InteractionWebhook = require('./InteractionWebhook');
-const InteractionResponses = require('./interfaces/InteractionResponses');
-const { ApplicationCommandOptionTypes } = require('../util/Constants');
 
 /**
  * Represents a command interaction.
- * @extends {Interaction}
- * @implements {InteractionResponses}
+ * @extends {BaseCommandInteraction}
  */
-class CommandInteraction extends Interaction {
+class CommandInteraction extends BaseCommandInteraction {
   constructor(client, data) {
     super(client, data);
-
-    /**
-     * The channel this interaction was sent in
-     * @type {?TextBasedChannels}
-     * @name CommandInteraction#channel
-     * @readonly
-     */
-
-    /**
-     * The id of the channel this interaction was sent in
-     * @type {Snowflake}
-     * @name CommandInteraction#channelId
-     */
-
-    /**
-     * The invoked application command's id
-     * @type {Snowflake}
-     */
-    this.commandId = data.data.id;
-
-    /**
-     * The invoked application command's name
-     * @type {string}
-     */
-    this.commandName = data.data.name;
-
-    /**
-     * Whether the reply to this interaction has been deferred
-     * @type {boolean}
-     */
-    this.deferred = false;
 
     /**
      * The options passed to the command.
@@ -52,136 +17,9 @@ class CommandInteraction extends Interaction {
      */
     this.options = new CommandInteractionOptionResolver(
       this.client,
-      typeof data.data.target_id !== 'undefined'
-        ? this.resolveContextMenuOptions(data.data)
-        : data.data.options?.map(option => this.transformOption(option, data.data.resolved)) ?? [],
+      data.data.options?.map(option => this.transformOption(option, data.data.resolved)) ?? [],
     );
-
-    /**
-     * Whether this interaction has already been replied to
-     * @type {boolean}
-     */
-    this.replied = false;
-
-    /**
-     * Whether the reply to this interaction is ephemeral
-     * @type {?boolean}
-     */
-    this.ephemeral = null;
-
-    /**
-     * An associated interaction webhook, can be used to further interact with this interaction
-     * @type {InteractionWebhook}
-     */
-    this.webhook = new InteractionWebhook(this.client, this.applicationId, this.token);
   }
-
-  /**
-   * The invoked application command, if it was fetched before
-   * @type {?ApplicationCommand}
-   */
-  get command() {
-    const id = this.commandId;
-    return this.guild?.commands.cache.get(id) ?? this.client.application.commands.cache.get(id) ?? null;
-  }
-
-  /**
-   * Represents an option of a received command interaction.
-   * @typedef {Object} CommandInteractionOption
-   * @property {string} name The name of the option
-   * @property {ApplicationCommandOptionType} type The type of the option
-   * @property {string|number|boolean} [value] The value of the option
-   * @property {CommandInteractionOption[]} [options] Additional options if this option is a
-   * subcommand (group)
-   * @property {User} [user] The resolved user
-   * @property {GuildMember|APIInteractionDataResolvedOption} [member] The resolved member
-   * @property {GuildChannel|APIInteractionDataResolvedOption} [channel] The resolved channel
-   * @property {Role|APIRole} [role] The resolved role
-   */
-
-  /**
-   * Transforms an option received from the API.
-   * @param {APIApplicationCommandOption} option The received option
-   * @param {APIApplicationCommandOptionResolved} resolved The resolved interaction data
-   * @returns {CommandInteractionOption}
-   * @private
-   */
-  transformOption(option, resolved) {
-    const result = {
-      name: option.name,
-      type: ApplicationCommandOptionTypes[option.type],
-    };
-
-    if ('value' in option) result.value = option.value;
-    if ('options' in option) result.options = option.options.map(opt => this.transformOption(opt, resolved));
-
-    if (resolved) {
-      const user = resolved.users?.[option.value];
-      if (user) result.user = this.client.users._add(user);
-
-      const member = resolved.members?.[option.value];
-      if (member) result.member = this.guild?.members._add({ user, ...member }) ?? member;
-
-      const channel = resolved.channels?.[option.value];
-      if (channel) {
-        result.channel = this.client.channels._add(channel, this.guild, { fromInteraction: true }) ?? channel;
-      }
-
-      const role = resolved.roles?.[option.value];
-      if (role) result.role = this.guild?.roles._add(role) ?? role;
-    }
-
-    return result;
-  }
-
-  /**
-   * Resolves and transforms options received from the API for a context menu interaction.
-   * @param {APIApplicationCommandInteractionData} data The interaction data
-   * @returns {CommandInteractionOption[]}
-   * @private
-   */
-  resolveContextMenuOptions({ target_id, resolved }) {
-    const result = [];
-
-    if (resolved.users?.[target_id]) {
-      result.push(
-        this.transformOption({ name: 'user', type: ApplicationCommandOptionTypes.USER, value: target_id }, resolved),
-      );
-    }
-
-    if (resolved.messages?.[target_id]) {
-      result.push({
-        name: 'message',
-        type: '_MESSAGE',
-        value: target_id,
-        message: this.channel?.messages._add(resolved.messages[target_id]),
-      });
-    }
-
-    return result;
-  }
-
-  // These are here only for documentation purposes - they are implemented by InteractionResponses
-  /* eslint-disable no-empty-function */
-  deferReply() {}
-  reply() {}
-  fetchReply() {}
-  editReply() {}
-  deleteReply() {}
-  followUp() {}
 }
 
-InteractionResponses.applyToClass(CommandInteraction, ['deferUpdate', 'update']);
-
 module.exports = CommandInteraction;
-
-/* eslint-disable max-len */
-/**
- * @external APIApplicationCommandOptionResolved
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-applicationcommandinteractiondataresolved}
- */
-
-/**
- * @external APIInteractionDataResolvedOption
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#sample-application-command-interaction-application-command-interaction-data-resolved-structure}
- */

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -220,6 +220,18 @@ class CommandInteractionOptionResolver {
     const option = this._getTypedOption(name, 'MENTIONABLE', ['user', 'member', 'role'], required);
     return option?.member ?? option?.user ?? option?.role ?? null;
   }
+
+  /**
+   * Gets a message option.
+   * @param {string} name The name of the option.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
+   * @returns {?(Message|APIMessage)}
+   * The value of the option, or null if not set and not required.
+   */
+  getMessage(name, required = false) {
+    const option = this._getTypedOption(name, '_MESSAGE', ['message'], required);
+    return option?.message ?? null;
+  }
 }
 
 module.exports = CommandInteractionOptionResolver;

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -179,7 +179,7 @@ class CommandInteractionOptionResolver {
    * Gets a user option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?User|APIUser} The value of the option, or null if not set and not required.
+   * @returns {?User} The value of the option, or null if not set and not required.
    */
   getUser(name, required = false) {
     const option = this._getTypedOption(name, 'USER', ['user'], required);
@@ -213,7 +213,7 @@ class CommandInteractionOptionResolver {
    * Gets a mentionable option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?(User|APIUser|GuildMember|APIGuildMember|Role|APIRole)}
+   * @returns {?(User|GuildMember|APIGuildMember|Role|APIRole)}
    * The value of the option, or null if not set and not required.
    */
   getMentionable(name, required = false) {

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -134,7 +134,7 @@ class CommandInteractionOptionResolver {
    * Gets a channel option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?(GuildChannel|APIInteractionDataResolvedOption)}
+   * @returns {?(GuildChannel|APIGuildChannel)}
    * The value of the option, or null if not set and not required.
    */
   getChannel(name, required = false) {
@@ -179,7 +179,7 @@ class CommandInteractionOptionResolver {
    * Gets a user option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?User} The value of the option, or null if not set and not required.
+   * @returns {?User|APIUser} The value of the option, or null if not set and not required.
    */
   getUser(name, required = false) {
     const option = this._getTypedOption(name, 'USER', ['user'], required);
@@ -190,7 +190,7 @@ class CommandInteractionOptionResolver {
    * Gets a member option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?(GuildMember|APIInteractionDataResolvedOption)}
+   * @returns {?(GuildMember|APIGuildMember)}
    * The value of the option, or null if not set and not required.
    */
   getMember(name, required = false) {
@@ -213,7 +213,7 @@ class CommandInteractionOptionResolver {
    * Gets a mentionable option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?(User|GuildMember|APIInteractionDataResolvedOption|Role|APIRole)}
+   * @returns {?(User|APIUser|GuildMember|APIGuildMember|Role|APIRole)}
    * The value of the option, or null if not set and not required.
    */
   getMentionable(name, required = false) {

--- a/src/structures/ContextMenuInteraction.js
+++ b/src/structures/ContextMenuInteraction.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const BaseCommandInteraction = require('./BaseCommandInteraction');
+const CommandInteractionOptionResolver = require('./CommandInteractionOptionResolver');
+const { ApplicationCommandOptionTypes } = require('../util/Constants');
+
+/**
+ * Represents a context menu interaction.
+ * @extends {BaseCommandInteraction}
+ */
+class ContextMenuInteraction extends BaseCommandInteraction {
+  constructor(client, data) {
+    super(client, data);
+    /**
+     * The target of the interaction, parsed into an option
+     * @type {CommandInteractionOptionResolver}
+     */
+    this.options = new CommandInteractionOptionResolver(this.client, this.resolveContextMenuOptions(data.data));
+
+    /**
+     * The target of the interaction
+     * @type {Snowflake}
+     */
+    this.targetId = data.data.target_id;
+  }
+
+  /**
+   * Resolves and transforms options received from the API for a context menu interaction.
+   * @param {APIApplicationCommandInteractionData} data The interaction data
+   * @returns {CommandInteractionOption[]}
+   * @private
+   */
+  resolveContextMenuOptions({ target_id, resolved }) {
+    const result = [];
+
+    if (resolved.users?.[target_id]) {
+      result.push(
+        this.transformOption({ name: 'user', type: ApplicationCommandOptionTypes.USER, value: target_id }, resolved),
+      );
+    }
+
+    if (resolved.messages?.[target_id]) {
+      result.push({
+        name: 'message',
+        type: '_MESSAGE',
+        value: target_id,
+        message: this.channel?.messages._add(resolved.messages[target_id]),
+      });
+    }
+
+    return result;
+  }
+}
+
+module.exports = ContextMenuInteraction;

--- a/src/structures/ContextMenuInteraction.js
+++ b/src/structures/ContextMenuInteraction.js
@@ -18,7 +18,7 @@ class ContextMenuInteraction extends BaseCommandInteraction {
     this.options = new CommandInteractionOptionResolver(this.client, this.resolveContextMenuOptions(data.data));
 
     /**
-     * The target of the interaction
+     * The id of the target of the interaction
      * @type {Snowflake}
      */
     this.targetId = data.data.target_id;

--- a/src/structures/ContextMenuInteraction.js
+++ b/src/structures/ContextMenuInteraction.js
@@ -2,7 +2,7 @@
 
 const BaseCommandInteraction = require('./BaseCommandInteraction');
 const CommandInteractionOptionResolver = require('./CommandInteractionOptionResolver');
-const { ApplicationCommandOptionTypes } = require('../util/Constants');
+const { ApplicationCommandOptionTypes, ApplicationCommandTypes } = require('../util/Constants');
 
 /**
  * Represents a context menu interaction.
@@ -12,7 +12,7 @@ class ContextMenuInteraction extends BaseCommandInteraction {
   constructor(client, data) {
     super(client, data);
     /**
-     * The target of the interaction, parsed into an option
+     * The target of the interaction, parsed into options
      * @type {CommandInteractionOptionResolver}
      */
     this.options = new CommandInteractionOptionResolver(this.client, this.resolveContextMenuOptions(data.data));
@@ -22,6 +22,12 @@ class ContextMenuInteraction extends BaseCommandInteraction {
      * @type {Snowflake}
      */
     this.targetId = data.data.target_id;
+
+    /**
+     * The type of the target of the interaction; either USER or MESSAGE
+     * @type {ApplicationCommandType}
+     */
+    this.targetType = ApplicationCommandTypes[data.data.type];
   }
 
   /**

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -118,7 +118,15 @@ class Interaction extends Base {
    * @returns {boolean}
    */
   isCommand() {
-    return InteractionTypes[this.type] === InteractionTypes.APPLICATION_COMMAND;
+    return InteractionTypes[this.type] === InteractionTypes.APPLICATION_COMMAND && typeof this.targetId === 'undefined';
+  }
+
+  /**
+   * Indicates whether this interaction is a {@link ContextMenuInteraction}
+   * @returns {boolean}
+   */
+  isContextMenu() {
+    return InteractionTypes[this.type] === InteractionTypes.APPLICATION_COMMAND && typeof this.targetId !== 'undefined';
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -888,6 +888,15 @@ exports.OverwriteTypes = createEnum(['role', 'member']);
 
 /* eslint-disable max-len */
 /**
+ * The type of an {@link ApplicationCommand} object:
+ * * CHAT_INPUT
+ * * USER
+ * * MESSAGE
+ * @typedef {string} ApplicationCommandType
+ */
+exports.ApplicationCommandTypes = createEnum([null, 'CHAT_INPUT', 'USER', 'MESSAGE']);
+
+/**
  * The type of an {@link ApplicationCommandOption} object:
  * * SUB_COMMAND
  * * SUB_COMMAND_GROUP

--- a/typings/enums.d.ts
+++ b/typings/enums.d.ts
@@ -10,6 +10,12 @@ export enum ActivityTypes {
   COMPETING = 5,
 }
 
+export enum ApplicationCommandTypes {
+  CHAT_INPUT = 1,
+  USER = 2,
+  MESSAGE = 3,
+}
+
 export enum ApplicationCommandOptionTypes {
   SUB_COMMAND = 1,
   SUB_COMMAND_GROUP = 2,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2256,11 +2256,11 @@ export abstract class CachedManager<K, Holds, R> extends DataManager<K, Holds, R
 }
 
 export class ApplicationCommandManager<
-  ApplicationCommandType = ApplicationCommand<{ guild: GuildResolvable }>,
+  ApplicationCommandScope = ApplicationCommand<{ guild: GuildResolvable }>,
   PermissionsOptionsExtras = { guild: GuildResolvable },
   PermissionsGuildType = null,
-> extends CachedManager<Snowflake, ApplicationCommandType, ApplicationCommandResolvable> {
-  public constructor(client: Client, iterable?: Iterable<RawApplicationCommandData>);
+> extends CachedManager<Snowflake, ApplicationCommandScope, ApplicationCommandResolvable> {
+  public constructor(client: Client, iterable?: Iterable<unknown>);
   public permissions: ApplicationCommandPermissionsManager<
     { command?: ApplicationCommandResolvable } & PermissionsOptionsExtras,
     { command: ApplicationCommandResolvable } & PermissionsOptionsExtras,
@@ -2269,10 +2269,10 @@ export class ApplicationCommandManager<
     null
   >;
   private commandPath({ id, guildId }: { id?: Snowflake; guildId?: Snowflake }): unknown;
-  public create(command: ApplicationCommandData): Promise<ApplicationCommandType>;
+  public create(command: ApplicationCommandData): Promise<ApplicationCommandScope>;
   public create(command: ApplicationCommandData, guildId: Snowflake): Promise<ApplicationCommand>;
-  public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<ApplicationCommandType | null>;
-  public edit(command: ApplicationCommandResolvable, data: ApplicationCommandData): Promise<ApplicationCommandType>;
+  public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<ApplicationCommandScope | null>;
+  public edit(command: ApplicationCommandResolvable, data: ApplicationCommandData): Promise<ApplicationCommandScope>;
   public edit(
     command: ApplicationCommandResolvable,
     data: ApplicationCommandData,
@@ -2282,12 +2282,12 @@ export class ApplicationCommandManager<
     id: Snowflake,
     options: FetchApplicationCommandOptions & { guildId: Snowflake },
   ): Promise<ApplicationCommand>;
-  public fetch(id: Snowflake, options?: FetchApplicationCommandOptions): Promise<ApplicationCommandType>;
+  public fetch(id: Snowflake, options?: FetchApplicationCommandOptions): Promise<ApplicationCommandScope>;
   public fetch(
     id?: Snowflake,
     options?: FetchApplicationCommandOptions,
-  ): Promise<Collection<Snowflake, ApplicationCommandType>>;
-  public set(commands: ApplicationCommandData[]): Promise<Collection<Snowflake, ApplicationCommandType>>;
+  ): Promise<Collection<Snowflake, ApplicationCommandScope>>;
+  public set(commands: ApplicationCommandData[]): Promise<Collection<Snowflake, ApplicationCommandScope>>;
   public set(
     commands: ApplicationCommandData[],
     guildId: Snowflake,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -572,6 +572,8 @@ export class CommandInteractionOptionResolver {
     name: string,
     required?: boolean,
   ): NonNullable<CommandInteractionOption['member' | 'role' | 'user']> | null;
+  public getMessage(name: string, required: true): NonNullable<CommandInteractionOption['message']>;
+  public getMessage(name: string, required?: boolean): NonNullable<CommandInteractionOption['message']> | null;
 }
 
 export class DataResolver extends null {
@@ -3238,6 +3240,7 @@ export interface CommandInteractionOption {
   member?: GuildMember | APIInteractionDataResolvedGuildMember;
   channel?: GuildChannel | APIInteractionDataResolvedChannel;
   role?: Role | APIRole;
+  message?: Message | APIMessage;
 }
 
 export interface ConstantsClientApplicationAssetTypes {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2881,7 +2881,7 @@ export interface ApplicationAsset {
 
 export interface ApplicationCommandData {
   name: string;
-  description: string;
+  description?: string;
   type?: ApplicationCommandType | ApplicationCommandTypes;
   options?: ApplicationCommandOptionData[];
   defaultPermission?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -244,7 +244,7 @@ export class BaseClient extends EventEmitter {
 
 export abstract class BaseCommandInteraction extends Interaction {
   public readonly command: ApplicationCommand | ApplicationCommand<{ guild: GuildResolvable }> | null;
-  public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | ThreadChannel | null;
+  public readonly channel: TextBasedChannels | null;
   public channelId: Snowflake;
   public commandId: Snowflake;
   public commandName: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -48,6 +48,7 @@ import {
   ActivityTypes,
   ApplicationCommandOptionTypes,
   ApplicationCommandPermissionTypes,
+  ApplicationCommandTypes,
   ChannelTypes,
   DefaultMessageNotificationLevels,
   ExplicitContentFilterLevels,
@@ -2891,6 +2892,8 @@ export interface ApplicationCommandOptionChoice {
   name: string;
   value: string | number;
 }
+
+export type ApplicationCommandType = keyof typeof ApplicationCommandTypes;
 
 export type ApplicationCommandOptionType = keyof typeof ApplicationCommandOptionTypes;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2870,6 +2870,7 @@ export interface ApplicationAsset {
 export interface ApplicationCommandData {
   name: string;
   description: string;
+  type?: ApplicationCommandType | ApplicationCommandTypes;
   options?: ApplicationCommandOptionData[];
   defaultPermission?: boolean;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -582,6 +582,7 @@ export class CommandInteractionOptionResolver {
 export class ContextMenuInteraction extends BaseCommandInteraction {
   public options: CommandInteractionOptionResolver;
   public targetId: Snowflake;
+  public targetType: Exclude<ApplicationCommandType, 'CHAT_INPUT'>;
   private resolveContextMenuOptions(data: APIApplicationCommandInteractionData): CommandInteractionOption[];
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -211,6 +211,7 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
     Guild | null,
     Snowflake
   >;
+  public type: ApplicationCommandType;
   public delete(): Promise<ApplicationCommand<PermissionsFetchType>>;
   public edit(data: ApplicationCommandData): Promise<ApplicationCommand<PermissionsFetchType>>;
   private static transformOption(option: ApplicationCommandOptionData, received?: boolean): unknown;

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -610,17 +610,17 @@ declare const applicationCommandData: ApplicationCommandData;
 declare const applicationCommandResolvable: ApplicationCommandResolvable;
 declare const applicationCommandManager: ApplicationCommandManager;
 {
-  type ApplicationCommandType = ApplicationCommand<{ guild: GuildResolvable }>;
+  type ApplicationCommandScope = ApplicationCommand<{ guild: GuildResolvable }>;
 
-  assertType<Promise<ApplicationCommandType>>(applicationCommandManager.create(applicationCommandData));
+  assertType<Promise<ApplicationCommandScope>>(applicationCommandManager.create(applicationCommandData));
   assertType<Promise<ApplicationCommand>>(applicationCommandManager.create(applicationCommandData, '0'));
-  assertType<Promise<ApplicationCommandType>>(
+  assertType<Promise<ApplicationCommandScope>>(
     applicationCommandManager.edit(applicationCommandResolvable, applicationCommandData),
   );
   assertType<Promise<ApplicationCommand>>(
     applicationCommandManager.edit(applicationCommandResolvable, applicationCommandData, '0'),
   );
-  assertType<Promise<Collection<Snowflake, ApplicationCommandType>>>(
+  assertType<Promise<Collection<Snowflake, ApplicationCommandScope>>>(
     applicationCommandManager.set([applicationCommandData]),
   );
   assertType<Promise<Collection<Snowflake, ApplicationCommand>>>(


### PR DESCRIPTION
This adds support for creating Application Commands in right-click context menus, and receiving the interactions.

The received data is parsed into the CommandOptionResolver as seamlessly as possible:
- A command acting on a user creates a `USER` type option: `getUser('user)` / `getMember('user')`
- A command acting on a message creates a fake `_MESSAGE` type option for the new `getMessage('message')`

The type of application command is yet to be included in the interaction data, but when it is this will be updated to use that rather than relying on the existence of `target_id`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)