### PR TITLE
feat(Rest): expose https.Agent options

### DIFF
--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -31,9 +31,7 @@ class APIRequest {
   }
 
   make() {
-    if (!agent) {
-      agent = new https.Agent({ ...this.client.options.http.agent, keepAlive: true });
-    }
+    agent ??= new https.Agent({ ...this.client.options.http.agent, keepAlive: true });
 
     const API =
       this.options.versioned === false

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -6,7 +6,7 @@ const AbortController = require('abort-controller');
 const fetch = require('node-fetch');
 const { UserAgent } = require('../util/Constants');
 
-const agent = new https.Agent({ keepAlive: true });
+let agent = null;
 
 class APIRequest {
   constructor(rest, method, path, options) {
@@ -31,6 +31,10 @@ class APIRequest {
   }
 
   make() {
+    if (!agent) {
+      agent = new https.Agent({ ...this.client.options.http.agent, keepAlive: true });
+    }
+
     const API =
       this.options.versioned === false
         ? this.client.options.http.api

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -78,9 +78,17 @@
  */
 
 /**
+ * HTTPS Agent options.
+ * @typedef {import('https').AgentOptions} AgentOptions
+ * @see {@link https://nodejs.org/api/https.html#https_class_https_agent}
+ * @see {@link https://nodejs.org/api/http.html#http_new_agent_options}
+ */
+
+/**
  * HTTP options
  * @typedef {Object} HTTPOptions
  * @property {number} [version=9] API version to use
+ * @property {AgentOptions} [agent={}] HTTPS Agent options
  * @property {string} [api='https://discord.com/api'] Base url of the API
  * @property {string} [cdn='https://cdn.discordapp.com'] Base url of the CDN
  * @property {string} [invite='https://discord.gg'] Base url of invites

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -79,7 +79,7 @@
 
 /**
  * HTTPS Agent options.
- * @typedef {import('https').AgentOptions} AgentOptions
+ * @typedef {Object} AgentOptions
  * @see {@link https://nodejs.org/api/https.html#https_class_https_agent}
  * @see {@link https://nodejs.org/api/http.html#http_new_agent_options}
  */

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -124,6 +124,7 @@ class Options extends null {
         version: 9,
       },
       http: {
+        agent: {},
         version: 9,
         api: 'https://discord.com/api',
         cdn: 'https://cdn.discordapp.com',

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -34,6 +34,7 @@ import {
   Snowflake,
 } from 'discord-api-types/v9';
 import { EventEmitter } from 'events';
+import * as https from 'https';
 import { Stream } from 'stream';
 import * as WebSocket from 'ws';
 import {
@@ -3639,6 +3640,7 @@ export interface HTTPErrorData {
 }
 
 export interface HTTPOptions {
+  agent?: Omit<https.AgentOptions, 'keepAlive'>;
   api?: string;
   version?: number;
   host?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -34,7 +34,7 @@ import {
   Snowflake,
 } from 'discord-api-types/v9';
 import { EventEmitter } from 'events';
-import * as https from 'https';
+import { AgentOptions } from 'https';
 import { Stream } from 'stream';
 import * as WebSocket from 'ws';
 import {
@@ -3640,7 +3640,7 @@ export interface HTTPErrorData {
 }
 
 export interface HTTPOptions {
-  agent?: Omit<https.AgentOptions, 'keepAlive'>;
+  agent?: Omit<AgentOptions, 'keepAlive'>;
   api?: string;
   version?: number;
   host?: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This exposes the `https.Agent` options object for `APIRequest` as a client option (`HTTPOptions#agent?: https.AgentOptions`). I am currently working on mock integration testing for discord.js applications, involving a mock REST API and gateway, but to work with a local server and x509 certificates, it is necessary to change some agent options (`rejectUnauthorized: false`). 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
