### PR TITLE
docs(InteractionResponses): Document missing properties

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -31,6 +31,12 @@ class InteractionResponses {
    */
 
   /**
+   * Options for updating the message received from a {@link ButtonInteraction}.
+   * @typedef {MessageEditOptions} InteractionUpdateOptions
+   * @property {boolean} [fetchReply] Whether to fetch the reply
+   */
+
+  /**
    * Defers the reply to this interaction.
    * @param {InteractionDeferOptions} [options] Options for deferring the reply to this interaction
    * @returns {Promise<Message|void>}

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -14,12 +14,20 @@ class InteractionResponses {
    * Options for deferring the reply to an {@link Interaction}.
    * @typedef {Object} InteractionDeferOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
+   * @property {boolean} [fetchReply] Whether to return the replied interaction
+   */
+
+  /**
+   * Options for deferring and updating the reply to a {@link ButtonInteraction}.
+   * @typedef {Object} InteractionDeferUpdateOptions
+   * @property {boolean} [fetchReply] Whether to return the replied interaction
    */
 
   /**
    * Options for a reply to an {@link Interaction}.
    * @typedef {BaseMessageOptions} InteractionReplyOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
+   * @property {boolean} [fetchReply] Whether to return the replied interaction
    */
 
   /**
@@ -178,7 +186,7 @@ class InteractionResponses {
 
   /**
    * Updates the original message of the component on which the interaction was received on.
-   * @param {string|MessagePayload|WebhookEditMessageOptions} options The options for the updated message
+   * @param {string|MessagePayload|InteractionUpdateOptions} options The options for the updated message
    * @returns {Promise<Message|void>}
    * @example
    * // Remove the components from the message

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -14,20 +14,20 @@ class InteractionResponses {
    * Options for deferring the reply to an {@link Interaction}.
    * @typedef {Object} InteractionDeferOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
-   * @property {boolean} [fetchReply] Whether to return the replied interaction
+   * @property {boolean} [fetchReply] Whether to fetch the reply
    */
 
   /**
    * Options for deferring and updating the reply to a {@link ButtonInteraction}.
    * @typedef {Object} InteractionDeferUpdateOptions
-   * @property {boolean} [fetchReply] Whether to return the replied interaction
+   * @property {boolean} [fetchReply] Whether to fetch the reply
    */
 
   /**
    * Options for a reply to an {@link Interaction}.
    * @typedef {BaseMessageOptions} InteractionReplyOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
-   * @property {boolean} [fetchReply] Whether to return the replied interaction
+   * @property {boolean} [fetchReply] Whether to fetch the reply
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1125,8 +1125,8 @@ export class MessageComponentInteraction extends Interaction {
   public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message | APIMessage>;
   public reply(options: InteractionReplyOptions & { fetchReply: true }): Promise<Message | APIMessage>;
   public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
-  public update(content: InteractionUpdateOptions & { fetchReply: true }): Promise<Message | APIMessage>;
-  public update(content: string | MessagePayload | InteractionUpdateOptions): Promise<void>;
+  public update(options: InteractionUpdateOptions & { fetchReply: true }): Promise<Message | APIMessage>;
+  public update(options: string | MessagePayload | InteractionUpdateOptions): Promise<void>;
 
   public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
 }
@@ -3696,7 +3696,9 @@ export type InteractionResponseType = keyof typeof InteractionResponseTypes;
 
 export type InteractionType = keyof typeof InteractionTypes;
 
-export type InteractionUpdateOptions = Omit<InteractionReplyOptions, 'ephemeral'>;
+export interface InteractionUpdateOptions extends WebhookEditMessageOptions {
+  fetchReply?: boolean;
+}
 
 export type IntentsString =
   | 'GUILDS'


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Hey!

`InteractionResponses` did not document a few `fetchReply` properties to the methods, so I've gone ahead and added those in.

The documentation for the type definition `InteractionDeferUpdateOptions` was completely missing, so I've added that in too!

I also noticed that the `.update()` method documented `WebhookEditMessageOptions` to be sent across. This didn't include the `fetchReply` property, but I did see an interesting `InteractionUpdateOptions` type that wasn't being used _anywhere_ other than itself being defined. It looks a bit wrong though, because it extended `WebhookMessageOptions` which allowed properties like `tts` to be sent through when it wouldn't do anything, ~~so I adjusted this to extend `WebhookEditMessageOptions` instead~~ so I applied the fix from #6162 after reading through it. My attempted fix of this changed `content` to `options` here, so I might as well leave that in for some consistency with the other methods.

This should resolve #6157!

Please check through the wording and typings and stuff and let me know if anything seems amiss!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
