### PR TITLE
feat(Guild): add fetchWidget() for getting widget data

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -404,8 +404,8 @@ class Client extends BaseClient {
   }
 
   /**
-   * Obtains the widget of a guild from Discord, available for guilds with the widget enabled.
-   * @param {GuildResolvable} guild The guild to fetch the widget for
+   * Obtains the widget data of a guild from Discord, available for guilds with the widget enabled.
+   * @param {GuildResolvable} guild The guild to fetch the widget data for
    * @returns {Promise<Widget>}
    */
   async fetchWidget(guild) {

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -408,7 +408,7 @@ class Client extends BaseClient {
    * @param {GuildResolvable} guild The guild to fetch the widget data for
    * @returns {Promise<Widget>}
    */
-  async fetchWidget(guild) {
+  async fetchGuildWidget(guild) {
     const id = this.guilds.resolveId(guild);
     if (!id) throw new TypeError('INVALID_TYPE', 'guild', 'GuildResolvable');
     const data = await this.api.guilds(id, 'widget.json').get();

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -678,7 +678,7 @@ class Guild extends AnonymousGuild {
    *   .catch(console.error);
    */
   fetchWidget() {
-    return this.client.fetchWidget(this.id);
+    return this.client.fetchGuildWidget(this.id);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -669,29 +669,42 @@ class Guild extends AnonymousGuild {
   }
 
   /**
-   * Data for the Guild Widget object
-   * @typedef {Object} GuildWidget
-   * @property {boolean} enabled Whether the widget is enabled
-   * @property {?GuildChannel} channel The widget channel
-   */
-
-  /**
-   * The Guild Widget object
-   * @typedef {Object} GuildWidgetData
-   * @property {boolean} enabled Whether the widget is enabled
-   * @property {?GuildChannelResolvable} channel The widget channel
-   */
-
-  /**
-   * Fetches the guild widget.
-   * @returns {Promise<GuildWidget>}
+   * Fetches the guild widget data, requires the widget to be enabled.
+   * @returns {Promise<Widget>}
    * @example
-   * // Fetches the guild widget
+   * // Fetches the guild widget data
    * guild.fetchWidget()
+   *   .then(widget => console.log(`The widget shows ${widget.channels.size} channels`))
+   *   .catch(console.error);
+   */
+  fetchWidget() {
+    return this.client.fetchWidget(this.id);
+  }
+
+  /**
+   * Data for the Guild Widget Settings object
+   * @typedef {Object} GuildWidgetSettings
+   * @property {boolean} enabled Whether the widget is enabled
+   * @property {?GuildChannel} channel The widget invite channel
+   */
+
+  /**
+   * The Guild Widget Settings object
+   * @typedef {Object} GuildWidgetSettingsData
+   * @property {boolean} enabled Whether the widget is enabled
+   * @property {?GuildChannelResolvable} channel The widget invite channel
+   */
+
+  /**
+   * Fetches the guild widget settings.
+   * @returns {Promise<GuildWidgetSettings>}
+   * @example
+   * // Fetches the guild widget settings
+   * guild.fetchWidgetSettings()
    *   .then(widget => console.log(`The widget is ${widget.enabled ? 'enabled' : 'disabled'}`))
    *   .catch(console.error);
    */
-  async fetchWidget() {
+  async fetchWidgetSettings() {
     const data = await this.client.api.guilds(this.id).widget.get();
     this.widgetEnabled = data.enabled;
     this.widgetChannelId = data.channel_id;
@@ -1234,18 +1247,18 @@ class Guild extends AnonymousGuild {
   }
 
   /**
-   * Edits the guild's widget.
-   * @param {GuildWidgetData} widget The widget for the guild
-   * @param {string} [reason] Reason for changing the guild's widget
+   * Edits the guild's widget settings.
+   * @param {GuildWidgetSettingsData} settings The widget settings for the guild
+   * @param {string} [reason] Reason for changing the guild's widget settings
    * @returns {Promise<Guild>}
    */
-  setWidget(widget, reason) {
+  setWidgetSettings(settings, reason) {
     return this.client.api
       .guilds(this.id)
       .widget.patch({
         data: {
-          enabled: widget.enabled,
-          channel_id: this.channels.resolveId(widget.channel),
+          enabled: settings.enabled,
+          channel_id: this.channels.resolveId(settings.channel),
         },
         reason,
       })

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -298,7 +298,7 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
   public fetchSticker(id: Snowflake): Promise<Sticker>;
   public fetchPremiumStickerPacks(): Promise<Collection<Snowflake, StickerPack>>;
   public fetchWebhook(id: Snowflake, token?: string): Promise<Webhook>;
-  public fetchWidget(guild: GuildResolvable): Promise<Widget>;
+  public fetchGuildWidget(guild: GuildResolvable): Promise<Widget>;
   public generateInvite(options?: InviteGenerationOptions): string;
   public login(token?: string): Promise<string>;
   public isReady(): this is Client<true>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -589,7 +589,8 @@ export class Guild extends AnonymousGuild {
   public fetchVanityData(): Promise<Vanity>;
   public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
   public fetchWelcomeScreen(): Promise<WelcomeScreen>;
-  public fetchWidget(): Promise<GuildWidget>;
+  public fetchWidget(): Promise<Widget>;
+  public fetchWidgetSettings(): Promise<GuildWidgetSettings>;
   public leave(): Promise<Guild>;
   public setAFKChannel(afkChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
   public setAFKTimeout(afkTimeout: number, reason?: string): Promise<Guild>;
@@ -615,7 +616,7 @@ export class Guild extends AnonymousGuild {
   public setSystemChannel(systemChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
   public setSystemChannelFlags(systemChannelFlags: SystemChannelFlagsResolvable, reason?: string): Promise<Guild>;
   public setVerificationLevel(verificationLevel: VerificationLevel | number, reason?: string): Promise<Guild>;
-  public setWidget(widget: GuildWidgetData, reason?: string): Promise<Guild>;
+  public setWidgetSettings(settings: GuildWidgetSettingsData, reason?: string): Promise<Guild>;
   public toJSON(): unknown;
 }
 
@@ -3525,7 +3526,7 @@ export interface GuildCreateOptions {
   verificationLevel?: VerificationLevel | number;
 }
 
-export interface GuildWidget {
+export interface GuildWidgetSettings {
   enabled: boolean;
   channel: GuildChannel | null;
 }
@@ -3616,7 +3617,7 @@ export interface GuildPruneMembersOptions {
   roles?: RoleResolvable[];
 }
 
-export interface GuildWidgetData {
+export interface GuildWidgetSettingsData {
   enabled: boolean;
   channel: GuildChannelResolvable | null;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently, you can fetch a guild's widget data with Client#fetchWidget(guild), but you can't do it from the guild object. Now, you can use Guild#fetchWidget() as a shortcut. The old fetchWidget and setWidget methods have been renamed to fetchWidgetSettings and setWidgetSettings to more accurately explain their functionality.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
