### PR TITLE
docs(Widget): Add the typedef WidgetChannel

### DIFF
--- a/src/structures/Widget.js
+++ b/src/structures/Widget.js
@@ -20,9 +20,9 @@ class Widget extends Base {
   /**
    * Represents a channel in a Widget
    * @typedef {Object} WidgetChannel
-   * @property {Snowflake} [id] Id of the channel
-   * @property {string} [name] Name of the channel
-   * @property {number} [position] Position of the channel
+   * @property {Snowflake} id Id of the channel
+   * @property {string} name Name of the channel
+   * @property {number} position Position of the channel
    */
 
   /**

--- a/src/structures/Widget.js
+++ b/src/structures/Widget.js
@@ -18,6 +18,14 @@ class Widget extends Base {
   }
 
   /**
+   * Represents a channel in a Widget
+   * @typedef {Object} WidgetChannel
+   * @property {Snowflake} [id] Id of the channel
+   * @property {string} [name] Name of the channel
+   * @property {number} [position] Position of the channel
+   */
+
+  /**
    * Builds the widget with the provided data.
    * @param {*} data The raw data of the widget
    * @private


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Just a correction of docs, the typedef was not include in the first place 

![image](https://user-images.githubusercontent.com/42680097/126886010-0cfd86c4-7557-439b-9fce-48082dc3ccdf.png)

(typings are already done btw)

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
- This PR **only** includes non-code changes, like changes to documentation, README, etc.