### PR TITLE
feat(FetchRecommendedShardsOptions): account for large bot sharding

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -255,14 +255,21 @@ class Util extends null {
   }
 
   /**
+   * @typedef {Object} FetchRecommendedShardsOptions
+   * @property {number} [guildsPerShard=1000] Number of guilds per shard
+   * @property {boolean} [largeBotSharding=false] Whether or not to round for large bot sharding
+   */
+
+  /**
    * Gets the recommended shard count from Discord.
    * @param {string} token Discord auth token
-   * @param {number} [guildsPerShard=1000] Number of guilds per shard
+   * @param {FetchRecommendedShardsOptions} [options] Options for fetching recommended shard count
    * @returns {Promise<number>} The recommended number of shards
    */
-  static fetchRecommendedShards(token, guildsPerShard = 1000) {
+  static fetchRecommendedShards(token, { guildsPerShard = 1000, largeBotSharding = false } = {}) {
     if (!token) throw new DiscordError('TOKEN_MISSING');
     const defaults = Options.createDefault();
+    const multiple = largeBotSharding ? 16 : 1;
     return fetch(`${defaults.http.api}/v${defaults.http.version}${Endpoints.botGateway}`, {
       method: 'GET',
       headers: { Authorization: `Bot ${token.replace(/^Bot\s*/i, '')}` },
@@ -272,7 +279,7 @@ class Util extends null {
         if (res.status === 401) throw new DiscordError('TOKEN_INVALID');
         throw res;
       })
-      .then(data => data.shards * (1000 / guildsPerShard));
+      .then(data => Math.ceil(data.shards * (1000 / guildsPerShard), multiple) * multiple);
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -256,7 +256,7 @@ class Util extends null {
 
   /**
    * @typedef {Object} FetchRecommendedShardsOptions
-   * @property {number} [guildsPerShard=1000] Number of guilds per shard
+   * @property {number} [guildsPerShard=1000] Number of guilds assigned per shard
    * @property {boolean} [largeBotSharding=false] Whether or not to round for large bot sharding
    */
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -257,7 +257,7 @@ class Util extends null {
   /**
    * @typedef {Object} FetchRecommendedShardsOptions
    * @property {number} [guildsPerShard=1000] Number of guilds assigned per shard
-   * @property {boolean} [multipleOf=1] The multiple the shard count should round up to. (16 for large bot sharding)
+   * @property {number} [multipleOf=1] The multiple the shard count should round up to. (16 for large bot sharding)
    */
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -257,7 +257,7 @@ class Util extends null {
   /**
    * @typedef {Object} FetchRecommendedShardsOptions
    * @property {number} [guildsPerShard=1000] Number of guilds assigned per shard
-   * @property {boolean} [largeBotSharding=false] Whether or not to round for large bot sharding
+   * @property {boolean} [multipleOf=1] The multiple the shard count should round up to. (16 for large bot sharding)
    */
 
   /**
@@ -266,10 +266,9 @@ class Util extends null {
    * @param {FetchRecommendedShardsOptions} [options] Options for fetching the recommended shard count
    * @returns {Promise<number>} The recommended number of shards
    */
-  static fetchRecommendedShards(token, { guildsPerShard = 1000, largeBotSharding = false } = {}) {
+  static fetchRecommendedShards(token, { guildsPerShard = 1000, multipleOf = 1 } = {}) {
     if (!token) throw new DiscordError('TOKEN_MISSING');
     const defaults = Options.createDefault();
-    const multiple = largeBotSharding ? 16 : 1;
     return fetch(`${defaults.http.api}/v${defaults.http.version}${Endpoints.botGateway}`, {
       method: 'GET',
       headers: { Authorization: `Bot ${token.replace(/^Bot\s*/i, '')}` },
@@ -279,7 +278,7 @@ class Util extends null {
         if (res.status === 401) throw new DiscordError('TOKEN_INVALID');
         throw res;
       })
-      .then(data => Math.ceil((data.shards * (1000 / guildsPerShard)) / multiple) * multiple);
+      .then(data => Math.ceil((data.shards * (1000 / guildsPerShard)) / multipleOf) * multipleOf);
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -263,7 +263,7 @@ class Util extends null {
   /**
    * Gets the recommended shard count from Discord.
    * @param {string} token Discord auth token
-   * @param {FetchRecommendedShardsOptions} [options] Options for fetching recommended shard count
+   * @param {FetchRecommendedShardsOptions} [options] Options for fetching the recommended shard count
    * @returns {Promise<number>} The recommended number of shards
    */
   static fetchRecommendedShards(token, { guildsPerShard = 1000, largeBotSharding = false } = {}) {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -279,7 +279,7 @@ class Util extends null {
         if (res.status === 401) throw new DiscordError('TOKEN_INVALID');
         throw res;
       })
-      .then(data => Math.ceil(data.shards * (1000 / guildsPerShard), multiple) * multiple);
+      .then(data => Math.ceil((data.shards * (1000 / guildsPerShard)) / multiple) * multiple);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1531,6 +1531,11 @@ export class ShardingManager extends EventEmitter {
   public once(event: 'shardCreate', listener: (shard: Shard) => Awaited<void>): this;
 }
 
+export interface FetchRecommendedShardsOptions {
+  guildsPerShard?: number;
+  largeBotSharding?: boolean;
+}
+
 export class SnowflakeUtil extends null {
   private constructor();
   public static deconstruct(snowflake: Snowflake): DeconstructedSnowflake;
@@ -1791,7 +1796,7 @@ export class Util extends null {
   public static escapeStrikethrough(text: string): string;
   public static escapeSpoiler(text: string): string;
   public static cleanCodeBlockContent(text: string): string;
-  public static fetchRecommendedShards(token: string, guildsPerShard?: number): Promise<number>;
+  public static fetchRecommendedShards(token: string, options?: FetchRecommendedShardsOptions): Promise<number>;
   public static flatten(obj: unknown, ...props: Record<string, boolean | string>[]): unknown;
   public static idToBinary(num: Snowflake): string;
   public static makeError(obj: MakeErrorOptions): Error;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1533,7 +1533,7 @@ export class ShardingManager extends EventEmitter {
 
 export interface FetchRecommendedShardsOptions {
   guildsPerShard?: number;
-  largeBotSharding?: boolean;
+  multipleOf?: number;
 }
 
 export class SnowflakeUtil extends null {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Implements the changes described in #5672. This changes Util.fetchRecommendedShards to take in a FetchRecommendedShardsOption which includes guildsPerShard which is the number of guilds per shard the user wants and a boolean largeBotSharding option which decides if discord.js will round their shards up to a multiple of 16 which is [required for large bot sharding.](https://discord.com/developers/docs/topics/gateway#sharding-for-very-large-bots)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)