### PR TITLE
feat(MessageEmbed): add setFields method

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -304,7 +304,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   setFields(...fields) {
-    this.spliceFields(0, this.fields.length, this.constructor.normalizeFields(fields));
+    this.spliceFields(0, this.fields.length, fields);
     return this;
   }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -304,7 +304,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   setFields(...fields) {
-    this.fields = this.constructor.normalizeFields(fields);
+    this.spliceFields(0, this.fields.length, this.constructor.normalizeFields(fields));
     return this;
   }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -299,6 +299,16 @@ class MessageEmbed {
   }
 
   /**
+   * Sets the embed's fields (max 25).
+   * @param {...EmbedFieldData|EmbedFieldData[]} fields The fields to set
+   * @returns {MessageEmbed}
+   */
+  setFields(...fields) {
+    this.fields = this.constructor.normalizeFields(fields);
+    return this;
+  }
+
+  /**
    * Sets the author of this embed.
    * @param {string} name The name of the author
    * @param {string} [iconURL] The icon URL of the author

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1156,6 +1156,7 @@ export class MessageEmbed {
   public readonly video: MessageEmbedVideo | null;
   public addField(name: string, value: string, inline?: boolean): this;
   public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
+  public setFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
   public setAuthor(name: string, iconURL?: string, url?: string): this;
   public setColor(color: ColorResolvable): this;
   public setDescription(description: string): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a setFields method to MessageEmbed that overwrites the current fields in the MessageEmbed with the provided ones.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
