### PR TITLE
feat(WebhookClient): allow creation of clients via URLs

### DIFF
--- a/src/client/WebhookClient.js
+++ b/src/client/WebhookClient.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseClient = require('./BaseClient');
+const { Error } = require('../errors');
 const Webhook = require('../structures/Webhook');
 
 /**
@@ -10,19 +11,40 @@ const Webhook = require('../structures/Webhook');
  */
 class WebhookClient extends BaseClient {
   /**
-   * @param {Snowflake} id The webhook's id
-   * @param {string} token Token of the webhook
+   * The data for the webhook client
+   * @typedef {Object} WebhookClientData
+   * @property {Snowflake} [id] The webhook's id
+   * @property {string} [token] Token of the webhook
+   * @property {string} [url] The full URL of the webhook
+   */
+
+  /**
+   * @param {WebhookClientData} data The data of the webhook
    * @param {ClientOptions} [options] Options for the client
    * @example
    * // Create a new webhook and send a message
-   * const hook = new Discord.WebhookClient('1234', 'abcdef');
+   * const hook = new Discord.WebhookClient({ id: '1234', token: 'abcdef' });
    * hook.send('This will send a message').catch(console.error);
    */
-  constructor(id, token, options) {
+  constructor(data, options) {
     super(options);
     Object.defineProperty(this, 'client', { value: this });
-    this.id = id;
-    Object.defineProperty(this, 'token', { value: token, writable: true, configurable: true });
+    let id, token;
+
+    if ('url' in data) {
+      const url = data.url.match(
+        // eslint-disable-next-line no-useless-escape
+        /^https?:\/\/(?:discord|discordapp)\.com\/api\/webhooks(?:\/v[0-9]\d*)?\/([^\/]+)\/([^\/]+)/i,
+      );
+
+      if (!url || url.length <= 1) throw new Error('WEBHOOK_URL_INVALID');
+
+      id = url[1];
+      token = url[2];
+    }
+
+    this.id = id ?? data.id;
+    Object.defineProperty(this, 'token', { value: token ?? data.id, writable: true, configurable: true });
   }
 
   // These are here only for documentation purposes - they are implemented by Webhook

--- a/src/client/WebhookClient.js
+++ b/src/client/WebhookClient.js
@@ -11,11 +11,11 @@ const Webhook = require('../structures/Webhook');
  */
 class WebhookClient extends BaseClient {
   /**
-   * The data for the webhook client
+   * The data for the webhook client containing either an id and token or just a URL
    * @typedef {Object} WebhookClientData
-   * @property {Snowflake} [id] The webhook's id
-   * @property {string} [token] Token of the webhook
-   * @property {string} [url] The full URL of the webhook
+   * @property {Snowflake} [id] The id of the webhook
+   * @property {string} [token] The token of the webhook
+   * @property {string} [url] The full url for the webhook client
    */
 
   /**
@@ -29,22 +29,21 @@ class WebhookClient extends BaseClient {
   constructor(data, options) {
     super(options);
     Object.defineProperty(this, 'client', { value: this });
-    let id, token;
+    let { id, token } = data;
 
     if ('url' in data) {
       const url = data.url.match(
         // eslint-disable-next-line no-useless-escape
-        /^https?:\/\/(?:discord|discordapp)\.com\/api\/webhooks(?:\/v[0-9]\d*)?\/([^\/]+)\/([^\/]+)/i,
+        /^https?:\/\/(?:canary|ptb)?\.?discord\.com\/api\/webhooks(?:\/v[0-9]\d*)?\/([^\/]+)\/([^\/]+)/i,
       );
 
       if (!url || url.length <= 1) throw new Error('WEBHOOK_URL_INVALID');
 
-      id = url[1];
-      token = url[2];
+      [, id, token] = url;
     }
 
-    this.id = id ?? data.id;
-    Object.defineProperty(this, 'token', { value: token ?? data.id, writable: true, configurable: true });
+    this.id = id;
+    Object.defineProperty(this, 'token', { value: token, writable: true, configurable: true });
   }
 
   // These are here only for documentation purposes - they are implemented by Webhook

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -101,6 +101,7 @@ const Messages = {
 
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
   WEBHOOK_TOKEN_UNAVAILABLE: 'This action requires a webhook token, but none is available.',
+  WEBHOOK_URL_INVALID: 'The provided webhook URL is not valid.',
   MESSAGE_REFERENCE_MISSING: 'The message does not reference another message',
 
   EMOJI_TYPE: 'Emoji must be a string or GuildEmoji/ReactionEmoji',

--- a/test/webhooktest.js
+++ b/test/webhooktest.js
@@ -97,7 +97,7 @@ client.on('messageCreate', async message => {
   if (message.author.id !== owner) return;
   const match = message.content.match(/^do (.+)$/);
   const hooks = [
-    { type: 'WebhookClient', hook: new WebhookClient(webhookChannel, webhookToken) },
+    { type: 'WebhookClient', hook: new WebhookClient({ id: webhookChannel, token: webhookToken }) },
     { type: 'TextChannel#fetchWebhooks', hook: await message.channel.fetchWebhooks().then(x => x.first()) },
     { type: 'Guild#fetchWebhooks', hook: await message.guild.fetchWebhooks().then(x => x.first()) },
   ];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1894,7 +1894,7 @@ export class Webhook extends WebhookMixin() {
 }
 
 export class WebhookClient extends WebhookMixin(BaseClient) {
-  public constructor(id: Snowflake, token: string, options?: WebhookClientOptions);
+  public constructor(data: WebhookClientData, options?: WebhookClientOptions);
   public client: this;
   public options: WebhookClientOptions;
   public token: string;
@@ -4339,6 +4339,17 @@ export interface Vanity {
 export type VerificationLevel = keyof typeof VerificationLevels;
 
 export type VoiceBasedChannelTypes = 'GUILD_VOICE' | 'GUILD_STAGE_VOICE';
+
+export type WebhookClientData = WebhookClientDataIdWithToken | WebhookClientDataURL;
+
+export interface WebhookClientDataIdWithToken {
+  id: Snowflake;
+  token: string;
+}
+
+export interface WebhookClientDataURL {
+  url: string;
+}
 
 export type WebhookClientOptions = Pick<
   ClientOptions,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This allows `WebhookClient`'s to be made with URLs, without the need of removing it or doing any type of parsing. This is useful for pass-through services like Webhook senders, etc., allowing a more convenient time for developers who don't want to use IDs and tokens. Example:
```ts
import { WebhookClient } from 'discord.js';

const webhook = new WebhookClient({ url: 'https://discord.com/api/webhooks/1234567890/abc' });

webhook.send({ content: 'Hi.' });
```

This PR also updates:
* Typings.
* Errors (URLs are passed to a RegEx and validated, although 100% perfection is not possible).
* Tests.

It now mandates initializing Webhook clients should have *one* object parameter, that can contain either ID + token or just a URL (this isn't validated so all 3 are optional).

If I do anything wrong, please forgive me, or if this isn't needed, feel free to give the right feedback/review, I appreciate it.

Fixes #6164

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
