### PR TITLE
refactor: use guild-wide route for fetching active threads

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -182,17 +182,16 @@ class GuildChannelManager extends CachedManager {
   /**
    * Obtains all active thread channels in the guild from Discord
    * @param {boolean} [cache=true] Whether to cache the fetched data
-   * @param {boolean} [returnRaw=false] Whether to return the raw data
-   * @returns {Promise<FetchedThreads>|Promise<APIActiveThreadsList>}
+   * @returns {Promise<FetchedThreads>}
    * @example
    * // Fetch all threads from the guild
    * message.guild.channels.fetchActiveThreads()
    *   .then(fetched => console.log(`There are ${fetched.threads.size} threads.`))
    *   .catch(console.error);
    */
-  async fetchActiveThreads(cache = true, returnRaw = false) {
+  async fetchActiveThreads(cache = true) {
     const raw = await this.client.api.guilds(this.guild.id).threads.active.get();
-    return returnRaw ? raw : ThreadManager._mapThreads(raw, this.client, { guild: this.guild, cache });
+    return ThreadManager._mapThreads(raw, this.client, { guild: this.guild, cache });
   }
 }
 

--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -220,7 +220,7 @@ class ThreadManager extends CachedManager {
     const raw = await path.threads
       .archived(type)
       .get({ query: { before: type === 'private' && !fetchAll ? id : timestamp, limit } });
-    return this._mapThreads(raw, cache);
+    return this.constructor._mapThreads(raw, this.client, { parent: this.channel, cache });
   }
 
   /**
@@ -229,20 +229,21 @@ class ThreadManager extends CachedManager {
    * @returns {Promise<FetchedThreads>}
    */
   async fetchActive(cache = true) {
-    const raw = await this.client.api.channels(this.channel.id).threads.active.get();
-    return this._mapThreads(raw, cache);
+    const raw = await this.channel.guild.channels.fetchActiveThreads(cache, true);
+    return this.constructor._mapThreads(raw, this.client, { parent: this.channel, cache });
   }
 
-  _mapThreads(rawThreads, cache) {
+  static _mapThreads(rawThreads, client, { parent, guild, cache }) {
     const threads = rawThreads.threads.reduce((coll, raw) => {
-      const thread = this.client.channels._add(raw, null, { cache });
+      const thread = client.channels._add(raw, guild ?? parent?.guild, { cache });
+      if (parent && thread.parentId !== parent.id) return coll;
       return coll.set(thread.id, thread);
     }, new Collection());
     // Discord sends the thread id as id in this object
-    for (const rawMember of rawThreads.members) threads.get(rawMember.id)?.members._add(rawMember);
+    for (const rawMember of rawThreads.members) client.channels.cache.get(rawMember.id)?.members._add(rawMember);
     return {
       threads,
-      hasMore: rawThreads.has_more,
+      hasMore: rawThreads.has_more ?? false,
     };
   }
 }

--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -229,7 +229,7 @@ class ThreadManager extends CachedManager {
    * @returns {Promise<FetchedThreads>}
    */
   async fetchActive(cache = true) {
-    const raw = await this.channel.guild.channels.fetchActiveThreads(cache, true);
+    const raw = await this.client.api.guilds(this.channel.guild.id).threads.active.get();
     return this.constructor._mapThreads(raw, this.client, { parent: this.channel, cache });
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -28,6 +28,7 @@ import {
   APISticker,
   APIStickerItem,
   APIStickerPack,
+  APIThreadList,
   APIUser,
   GatewayVoiceServerUpdateDispatchData,
   GatewayVoiceStateUpdateDispatchData,
@@ -2292,6 +2293,8 @@ export class GuildChannelManager extends CachedManager<
   ): Promise<
     Collection<Snowflake, TextChannel | VoiceChannel | CategoryChannel | NewsChannel | StoreChannel | StageChannel>
   >;
+  public fetchActiveThreads(cache?: boolean): Promise<FetchedThreads>;
+  public fetchActiveThreads(cache: boolean, returnRaw: true): Promise<APIThreadList>;
 }
 
 export class GuildEmojiManager extends BaseGuildEmojiManager {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -28,7 +28,6 @@ import {
   APISticker,
   APIStickerItem,
   APIStickerPack,
-  APIThreadList,
   APIUser,
   GatewayVoiceServerUpdateDispatchData,
   GatewayVoiceStateUpdateDispatchData,
@@ -2294,7 +2293,6 @@ export class GuildChannelManager extends CachedManager<
     Collection<Snowflake, TextChannel | VoiceChannel | CategoryChannel | NewsChannel | StoreChannel | StageChannel>
   >;
   public fetchActiveThreads(cache?: boolean): Promise<FetchedThreads>;
-  public fetchActiveThreads(cache: boolean, returnRaw: true): Promise<APIThreadList>;
 }
 
 export class GuildEmojiManager extends BaseGuildEmojiManager {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Guild wide route for fetching active threads! And since channel wide route its being removed in v10, already based the per channel fetch on guild wide.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
