### PR TITLE
fix: Use `string` instead of `Snowflake` for invites

### DIFF
--- a/src/managers/GuildInviteManager.js
+++ b/src/managers/GuildInviteManager.js
@@ -23,7 +23,7 @@ class GuildInviteManager extends CachedManager {
 
   /**
    * The cache of this Manager
-   * @type {Collection<Snowflake, Invite>}
+   * @type {Collection<string, Invite>}
    * @name GuildInviteManager#cache
    */
 
@@ -74,7 +74,7 @@ class GuildInviteManager extends CachedManager {
   /**
    * Fetches invite(s) from Discord.
    * @param {InviteResolvable|FetchInviteOptions|FetchInvitesOptions} [options] Options for fetching guild invite(s)
-   * @returns {Promise<Invite|Collection<Snowflake, Invite>>}
+   * @returns {Promise<Invite|Collection<string, Invite>>}
    * @example
    * // Fetch all invites from a guild
    * guild.invites.fetch()

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2351,7 +2351,7 @@ export class GuildBanManager extends CachedManager<Snowflake, GuildBan, GuildBan
   public remove(user: UserResolvable, reason?: string): Promise<User>;
 }
 
-export class GuildInviteManager extends DataManager<Snowflake, Invite, InviteResolvable> {
+export class GuildInviteManager extends DataManager<string, Invite, InviteResolvable> {
   public constructor(guild: Guild, iterable?: Iterable<unknown>);
   public guild: Guild;
   public create(channel: GuildChannelResolvable, options?: CreateInviteOptions): Promise<Invite>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The typings and documentation both detailed a `Snowflake` to be used for `GuildInviteManager#cache` and `GuildInviteManager#fetch()` instead of a `string` (invite code). This pull request should resolve this!

Resolves #6199 also.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
