### PR TITLE
docs(MessageMentions): fix documentation for members property

### DIFF
--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -134,7 +134,7 @@ class MessageMentions {
   }
 
   /**
-   * Any members that were mentioned (only in {@link TextChannel}s)
+   * Any members that were mentioned (only in {@link TextChannel}s and {@link ThreadChannel}s)
    * <info>Order as received from the API, not as they appear in the message content</info>
    * @type {?Collection<Snowflake, GuildMember>}
    * @readonly

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -134,7 +134,7 @@ class MessageMentions {
   }
 
   /**
-   * Any members that were mentioned (only in {@link TextChannel}s and {@link ThreadChannel}s)
+   * Any members that were mentioned (only in {@link Guild}s)
    * <info>Order as received from the API, not as they appear in the message content</info>
    * @type {?Collection<Snowflake, GuildMember>}
    * @readonly


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`MessageMentions#members` works also in a ThreadChannel

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
