### PR TITLE
feat(ThreadChannel): add fetchOwner() method

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -458,7 +458,7 @@ class Guild extends AnonymousGuild {
   }
 
   /**
-   * Options used to fetch the owner of guild.
+   * Options used to fetch the owner of a guild or a thread.
    * @typedef {Object} FetchOwnerOptions
    * @property {boolean} [cache=true] Whether or not to cache the fetched member
    * @property {boolean} [force=false] Whether to skip the cache check and request the API

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -247,7 +247,7 @@ class ThreadChannel extends Channel {
 
     // We cannot fetch a single thread member, as of this commit's date, Discord API responds with 405
     const members = await this.members.fetch(cache);
-    return members.get(this.ownerId);
+    return members.get(this.ownerId) ?? null;
   }
 
   /**

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -189,6 +189,15 @@ class ThreadChannel extends Channel {
   }
 
   /**
+   * The {@link ThreadMember} object of the owner of this thread
+   * @type {?ThreadMember}
+   * @readonly
+   */
+  get owner() {
+    return this.members.cache.get(this.ownerId);
+  }
+
+  /**
    * The time at which this thread's archive status was last changed
    * <info>If the thread was never archived or unarchived, this is the time at which the thread was created</info>
    * @type {?Date}
@@ -232,6 +241,15 @@ class ThreadChannel extends Channel {
    */
   permissionsFor(memberOrRole) {
     return this.parent?.permissionsFor(memberOrRole) ?? null;
+  }
+
+  /**
+   * Fetches the owner of this thread
+   * @param {FetchOwnerOptions} [options] The options for fetching the member
+   * @returns {Promise<GuildMember>}
+   */
+  fetchOwner(options) {
+    return this.guild.members.fetch({ ...options, user: this.ownerId });
   }
 
   /**

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -237,7 +237,7 @@ class ThreadChannel extends Channel {
   /**
    * Fetches the owner of this thread
    * @param {FetchOwnerOptions} [options] The options for fetching the member
-   * @returns {Promise<ThreadMember>}
+   * @returns {Promise<?ThreadMember>}
    */
   async fetchOwner({ cache = true, force = false } = {}) {
     if (!force) {

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -241,7 +241,7 @@ class ThreadChannel extends Channel {
    */
   async fetchOwner({ cache = true, force = false } = {}) {
     if (!force) {
-      const existing = this.cache.get(this.ownerId);
+      const existing = this.members.cache.get(this.ownerId);
       if (existing) return existing;
     }
 

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -245,10 +245,9 @@ class ThreadChannel extends Channel {
       if (existing) return existing;
     }
 
-    // We cannot fetch a single thread member, as of this commit's date, Discord API throws with 405
-    const data = await this.client.api.channels(this.thread.id, 'thread-members').get();
-    const owner = data.find(member => member.user_id === this.ownerId);
-    return this._add(owner, cache);
+    // We cannot fetch a single thread member, as of this commit's date, Discord API responds with 405
+    const members = await this.members.fetch(cache);
+    return members.get(this.ownerId);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1688,6 +1688,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
   public members: ThreadMemberManager;
   public name: string;
   public ownerId: Snowflake | null;
+  public readonly owner: ThreadMember | null;
   public readonly parent: TextChannel | NewsChannel | null;
   public parentId: Snowflake | null;
   public rateLimitPerUser: number | null;
@@ -1699,6 +1700,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
   public leave(): Promise<ThreadChannel>;
   public permissionsFor(memberOrRole: GuildMember | Role): Readonly<Permissions>;
   public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
+  public fetchOwner(options?: FetchOwnerOptions): Promise<GuildMember>;
   public setArchived(archived?: boolean, reason?: string): Promise<ThreadChannel>;
   public setAutoArchiveDuration(
     autoArchiveDuration: ThreadAutoArchiveDuration,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1688,7 +1688,6 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
   public members: ThreadMemberManager;
   public name: string;
   public ownerId: Snowflake | null;
-  public readonly owner: ThreadMember | null;
   public readonly parent: TextChannel | NewsChannel | null;
   public parentId: Snowflake | null;
   public rateLimitPerUser: number | null;
@@ -1700,7 +1699,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
   public leave(): Promise<ThreadChannel>;
   public permissionsFor(memberOrRole: GuildMember | Role): Readonly<Permissions>;
   public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
-  public fetchOwner(options?: FetchOwnerOptions): Promise<GuildMember>;
+  public fetchOwner(options?: FetchOwnerOptions): Promise<ThreadMember>;
   public setArchived(archived?: boolean, reason?: string): Promise<ThreadChannel>;
   public setAutoArchiveDuration(
     autoArchiveDuration: ThreadAutoArchiveDuration,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1699,7 +1699,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
   public leave(): Promise<ThreadChannel>;
   public permissionsFor(memberOrRole: GuildMember | Role): Readonly<Permissions>;
   public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
-  public fetchOwner(options?: FetchOwnerOptions): Promise<ThreadMember>;
+  public fetchOwner(options?: FetchOwnerOptions): Promise<ThreadMember | null>;
   public setArchived(archived?: boolean, reason?: string): Promise<ThreadChannel>;
   public setAutoArchiveDuration(
     autoArchiveDuration: ThreadAutoArchiveDuration,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a fetchOwner() method that returns the ThreadMember object corresponding to the Owner of the thread

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
