### PR TITLE
docs(Constants): document the Constants object for enum-like usage

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -1016,5 +1016,5 @@ function createEnum(keys) {
  * @property {StickerType} StickerTypes The value set for a sticker's type.
  * @property {VerificationLevel} VerificationLevels The value set for the verification levels for a guild.
  * @property {WebhookType} WebhookTypes The value set for a webhook's type.
- * @property {WSEvents} WSEventType The type of a websocket message event.
+ * @property {WSEventType} WSEvents The type of a websocket message event.
  */

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -986,3 +986,35 @@ function createEnum(keys) {
   }
   return obj;
 }
+
+/**
+ * @typedef {Object} Constants Constants that can be used in an enum or object-like way.
+ * @property {ActivityType} ActivityTypes The type of an activity of a users presence.
+ * @property {APIError} APIErrors An error encountered while performing an API request.
+ * @property {ApplicationCommandOptionType} ApplicationCommandOptionTypes
+ * The type of an {@link ApplicationCommandOption} object.
+ * @property {ApplicationCommandPermissionType} ApplicationCommandPermissionTypes
+ * The type of an {@link ApplicationCommandPermissions} object.
+ * @property {ChannelType} ChannelTypes All available channel types.
+ * @property {DefaultMessageNotificationLevel} DefaultMessageNotificationLevels
+ * The value set for a guild's default message notifications.
+ * @property {ExplicitContentFilterLevel} ExplicitContentFilterLevels
+ * The value set for the explicit content filter levels for a guild.
+ * @property {InteractionResponseType} InteractionResponseTypes The type of an interaction response.
+ * @property {InteractionType} InteractionTypes The type of an {@link Interaction} object.
+ * @property {MembershipState} MembershipStates The value set for a team members's membership state.
+ * @property {MessageButtonStyle} MessageButtonStyles The style of a message button.
+ * @property {MessageComponentType} MessageComponentTypes The type of a message component.
+ * @property {MFALevel} MFALevels The required MFA level for a guild.
+ * @property {NSFWLevel} NSFWLevels NSFW level of a guild.
+ * @property {OverwriteType} OverwriteTypes An overwrite type.
+ * @property {PartialType} PartialTypes The type of Structure allowed to be a partial.
+ * @property {PremiumTier} PremiumTiers The premium tier (Server Boost level) of a guild.
+ * @property {PrivacyLevel} PrivacyLevels Privacy level of a {@link StageInstance} object.
+ * @property {Status} Status The available statuses of the client.
+ * @property {StickerFormatType} StickerFormatTypes The value set for a sticker's format type.
+ * @property {StickerType} StickerTypes The value set for a sticker's type.
+ * @property {VerificationLevel} VerificationLevels The value set for the verification levels for a guild.
+ * @property {WebhookType} WebhookTypes The value set for a webhook's type.
+ * @property {WSEvents} WSEventType The type of a websocket message event.
+ */


### PR DESCRIPTION
This documents the exported and separately documented typedef values in `util/Constants.js` as one parent object, covering all of the ones that can be used in an enum-like way, e.g. `Constants.MessageButtonStyles.PRIMARY`. As discord.js doesn't export the TS enums in its packaged typings, this alternative allows us to support the usage of Constants instead of relying on magic strings.

I'm not sure if I've done it correctly, since this definition is referencing the enum/object/whatever of all the available types rather than just one singular selected value from the typedef. Open to feedback on this.

Constants that are just an array of string values such as `Constants.MessageTypes` are not documented here to avoid confusion, as they can't be property-accessed like the other. Not sure how to go about including those if necessary. `MessageType[]`?

The definitions of the types are largely copy-pasted from their respective typedefs. I don't consider changing the description of the typing to be in scope of this PR, so any issues should be a new PR changing both locations.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.