### PR TITLE
types(ButtonMessageOptions): make button/link button typings more specific

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3799,11 +3799,11 @@ export interface BaseButtonOptions extends BaseMessageComponentOptions {
 export type MessageButtonOptions = BaseButtonOptions &
   (
     | {
-        style: Exclude<MessageButtonStyle, 'LINK'>;
+        style: Exclude<MessageButtonStyleResolvable, 'LINK' | MessageButtonStyles.LINK>;
         customId: string;
       }
     | {
-        style: 'LINK';
+        style: 'LINK' | MessageButtonStyles.LINK;
         url: string;
       }
   );

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3790,14 +3790,23 @@ export interface MessageActivity {
 
 export type MessageAdditions = MessageEmbed | MessageAttachment | (MessageEmbed | MessageAttachment)[];
 
-export interface MessageButtonOptions extends BaseMessageComponentOptions {
-  customId?: string;
+export interface BaseButtonOptions extends BaseMessageComponentOptions {
   disabled?: boolean;
   emoji?: EmojiIdentifierResolvable;
   label?: string;
-  style: MessageButtonStyleResolvable;
-  url?: string;
 }
+
+export type MessageButtonOptions = BaseButtonOptions &
+  (
+    | {
+        style: Exclude<MessageButtonStyle, 'LINK'>;
+        customId: string;
+      }
+    | {
+        style: 'LINK';
+        url: string;
+      }
+  );
 
 export type MessageButtonStyle = keyof typeof MessageButtonStyles;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

With discord buttons and link button components, there are certain property combinations that aren't allowed. Basically, You can't use a `customID` property for buttons with the `LINK` style, for non-link buttons you can't use the `url` property. The issue is that it is only presented at runtime:

```
DiscordAPIError: Invalid Form Body
components[0].components[0].custom_id: A custom id and url cannot both be specified
```

With this PR it adjusts the `ButtonMessageOptions` type to provide a compile-time error, if an invalid `ButtonMessageOptions` combination is provided.


**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
