### PR TITLE
refactor(Message): make thread a getter for accuracy

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -98,6 +98,7 @@ const Messages = {
   INVALID_ELEMENT: (type, name, elem) => `Supplied ${type} ${name} includes an invalid element: ${elem}`,
 
   MESSAGE_THREAD_PARENT: 'The message was not sent in a guild text or news channel',
+  MESSAGE_EXISTING_THREAD: 'The message already has a thread',
 
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
   WEBHOOK_TOKEN_UNAVAILABLE: 'This action requires a webhook token, but none is available.',

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -390,8 +390,8 @@ class Message extends Base {
 
   /**
    * The thread started by this message
-   * <info>This can be null when the message has a thread if the cache no longer has the thread.
-   * Use {@link Message#hasThread} to check whether the message has a thread.</info>
+   * <info>This property is not suitable for checking whether a message has a thread,
+   * use {@link Message#hasThread} instead.</info>
    * @type {?ThreadChannel}
    * @readonly
    */

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -101,16 +101,6 @@ class Message extends Base {
       this.pinned = null;
     }
 
-    if ('thread' in data) {
-      /**
-       * The thread started by this message
-       * @type {?ThreadChannel}
-       */
-      this.thread = this.client.channels._add(data.thread);
-    } else if (!this.thread) {
-      this.thread = null;
-    }
-
     if ('tts' in data) {
       /**
        * Whether or not the message was Text-To-Speech
@@ -267,6 +257,9 @@ class Message extends Base {
           }
         : null;
     }
+    if ('thread' in data) {
+      this.client.channels._add(data.thread, this.guild);
+    }
     if (this.member && data.member) {
       this.member._patch(data.member);
     } else if (data.member && this.guild && this.author) {
@@ -384,6 +377,26 @@ class Message extends Base {
    */
   get guild() {
     return this.channel.guild ?? null;
+  }
+
+  /**
+   * Whether this message has a thread associated with it
+   * @type {boolean}
+   * @readonly
+   */
+  get hasThread() {
+    return this.flags.has(MessageFlags.FLAGS.HAS_THREAD);
+  }
+
+  /**
+   * The thread started by this message
+   * <info>This can be null when the message has a thread if the cache no longer has the thread.
+   * Use {@link Message#hasThread} to check whether the message has a thread.</info>
+   * @type {?ThreadChannel}
+   * @readonly
+   */
+  get thread() {
+    return this.channel.threads.resolve(this.id);
   }
 
   /**
@@ -726,6 +739,7 @@ class Message extends Base {
     if (!['GUILD_TEXT', 'GUILD_NEWS'].includes(this.channel.type)) {
       return Promise.reject(new Error('MESSAGE_THREAD_PARENT'));
     }
+    if (this.hasThread) return Promise.reject(new Error('MESSAGE_EXISTING_THREAD'));
     return this.channel.threads.create({ name, autoArchiveDuration, startMessage: this, reason });
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -999,6 +999,7 @@ export class Message extends Base {
   public embeds: MessageEmbed[];
   public groupActivityApplication: ClientApplication | null;
   public readonly guild: Guild | null;
+  public readonly hasThread: boolean;
   public id: Snowflake;
   public interaction: MessageInteraction | null;
   public readonly member: GuildMember | null;
@@ -1010,7 +1011,7 @@ export class Message extends Base {
   public reactions: ReactionManager;
   public stickers: Collection<Snowflake, Sticker>;
   public system: boolean;
-  public thread: ThreadChannel | null;
+  public readonly thread: ThreadChannel | null;
   public tts: boolean;
   public type: MessageType;
   public readonly url: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a bug where #thread is null after a message update because it does not contain the thread data, relying on thread create instead.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
