### PR TITLE
docs(Constants): fix StickerTypes typedef

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -829,7 +829,7 @@ exports.WebhookTypes = createEnum([null, 'Incoming', 'Channel Follower']);
  * The value set for a sticker's type:
  * * STANDARD
  * * GUILD
- * @typedef {string} StickerFormatType
+ * @typedef {string} StickerType
  */
 exports.StickerTypes = createEnum([null, 'STANDARD', 'GUILD']);
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the name of the typedef for Constants.StickerTypes.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
