### PR TITLE
fix(PermissionOverwrites): throw better error if resolving option fails

### DIFF
--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -118,14 +118,14 @@ class PermissionOverwrites extends Base {
 
     for (const [perm, value] of Object.entries(options)) {
       if (value === true) {
-        allow.add(Permissions.FLAGS[perm]);
-        deny.remove(Permissions.FLAGS[perm]);
+        allow.add(perm);
+        deny.remove(perm);
       } else if (value === false) {
-        allow.remove(Permissions.FLAGS[perm]);
-        deny.add(Permissions.FLAGS[perm]);
+        allow.remove(perm);
+        deny.add(perm);
       } else if (value === null) {
-        allow.remove(Permissions.FLAGS[perm]);
-        deny.remove(Permissions.FLAGS[perm]);
+        allow.remove(perm);
+        deny.remove(perm);
       }
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a bug that causes invalid permission flags to be reported back as `undefined`
e.g.

```js
channel.permissionOverwrites.edit(role, {
    FOO_BAR: true,
});
```

Would throw this error: `RangeError [BITFIELD_INVALID]: Invalid bitfield flag or number: undefined.`

With this PR it will throw: `RangeError [BITFIELD_INVALID]: Invalid bitfield flag or number: FOO_BAR.`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
