### PR TITLE
docs(Guild): Add GuildTextChannelResolvable type definition

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -897,6 +897,14 @@ class Guild extends AnonymousGuild {
    * @property {string} [description] The description for the welcome screen
    * @property {WelcomeChannelData[]} [welcomeChannels] The welcome channel data for the welcome screen
    */
+  
+  /**
+   * Data that can be resolved to a GuildTextChannel object. This can be:
+   * * A TextChannel
+   * * A NewsChannel
+   * * A Snowflake
+   * @typedef {TextChannel|NewsChannel|Snowflake} GuildTextChannelResolvable
+   */
 
   /**
    * Updates the guild's welcome screen

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -897,7 +897,7 @@ class Guild extends AnonymousGuild {
    * @property {string} [description] The description for the welcome screen
    * @property {WelcomeChannelData[]} [welcomeChannels] The welcome channel data for the welcome screen
    */
-  
+
   /**
    * Data that can be resolved to a GuildTextChannel object. This can be:
    * * A TextChannel


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The type definition for the `GuildTextChannelResolvable` in the documentation was missing, so I've gone ahead and added it in!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
