### PR TITLE
docs(WelcomeChannel): Correct guild return type

### DIFF
--- a/src/structures/WelcomeChannel.js
+++ b/src/structures/WelcomeChannel.js
@@ -13,7 +13,7 @@ class WelcomeChannel extends Base {
 
     /**
      * The guild for this welcome channel
-     * @type {Guild|WelcomeGuild}
+     * @type {Guild|InviteGuild}
      */
     this.guild = guild;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`WelcomeChannel#guild`'s return type should be either a `Guild` or an `InviteGuild`. `WelcomeGuild` was incorrectly documented here!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
