### PR TITLE
docs(Guild): Correct `GuildRolePosition` typo

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1199,7 +1199,7 @@ class Guild extends AnonymousGuild {
   /**
    * The data needed for updating a guild role's position
    * @typedef {Object} GuildRolePosition
-   * @property {RoleResolveable} role The role's id
+   * @property {RoleResolvable} role The role's id
    * @property {number} position The position to update
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I found another typo! D:

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
