### PR TITLE
docs(GuildManager): Correct `GuildCreateOptions` typo

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -134,7 +134,7 @@ class GuildManager extends CachedManager {
    * @property {Snowflake|number} [afkChannelId] The AFK channel's id
    * @property {number} [afkTimeout] The AFK timeout in seconds
    * @property {PartialChannelData[]} [channels=[]] The channels for this guild
-   * @property {DefaultMessageNotifications} [defaultMessageNotifications] The default message notifications
+   * @property {DefaultMessageNotificationLevel|number} [defaultMessageNotifications] The default message notifications
    * for the guild
    * @property {ExplicitContentFilterLevel} [explicitContentFilter] The explicit content filter level for the guild
    * @property {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The property `defaultMessageNotifications` on `GuildCreateOptions` used the `DefaultMessageNotifications` type definition, but it should be using instead the `DefaultMessageNotificationLevel` type definition or a number.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
