### PR TITLE
docs: Refactor a few `@returns` descriptions

### DIFF
--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -152,7 +152,7 @@ class GuildEmoji extends BaseGuildEmoji {
   /**
    * Whether this emoji is the same as another one.
    * @param {GuildEmoji|APIEmoji} other The emoji to compare it to
-   * @returns {boolean} Whether the emoji is equal to the given emoji or not
+   * @returns {boolean}
    */
   equals(other) {
     if (other instanceof GuildEmoji) {

--- a/src/structures/Sticker.js
+++ b/src/structures/Sticker.js
@@ -204,7 +204,7 @@ class Sticker extends Base {
   /**
    * Whether this sticker is the same as another one.
    * @param {Sticker|APISticker} other The sticker to compare it to
-   * @returns {boolean} Whether the sticker is equal to the given sticker or not
+   * @returns {boolean}
    */
   equals(other) {
     if (other instanceof Sticker) {

--- a/src/structures/TextChannel.js
+++ b/src/structures/TextChannel.js
@@ -162,7 +162,7 @@ class TextChannel extends GuildChannel {
    * Creates a webhook for the channel.
    * @param {string} name The name of the webhook
    * @param {ChannelWebhookCreateOptions} [options] Options for creating the webhook
-   * @returns {Promise<Webhook>} webhook The created webhook
+   * @returns {Promise<Webhook>} Returns the created Webhook
    * @example
    * // Create a webhook for the current channel
    * channel.createWebhook('Snek', {

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -284,7 +284,7 @@ class TextBasedChannel {
    * @param {Collection<Snowflake, Message>|MessageResolvable[]|number} messages
    * Messages or number of messages to delete
    * @param {boolean} [filterOld=false] Filter messages to remove those which are older than two weeks automatically
-   * @returns {Promise<Collection<Snowflake, Message>>} Deleted messages
+   * @returns {Promise<Collection<Snowflake, Message>>} Returns the deleted messages
    * @example
    * // Bulk delete messages
    * channel.bulkDelete(5)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pull request tweaks some `@returns` descriptions that I have judged... strange.

When I was looking through the documentation for a [`GuildEmoji`](https://discord.js.org/#/docs/main/master/class/GuildEmoji), I noticed the `GuildEmoji#equals()` method had a `@returns` description on it. I also noticed the description is quite literally the same as the initial description. So like, why is it there? This is the same for [`Sticker#equals()`](https://discord.js.org/#/docs/main/master/class/Sticker?scrollTo=equals), but there does not appear to be a `@returns` description for other `equal()` methods around discord.js such as [`User#equals()`](https://discord.js.org/#/docs/main/master/class/User?scrollTo=equals) or [`Role#equals()`](https://discord.js.org/#/docs/main/master/class/Role?scrollTo=equals). I went ahead and removed the two instances that had `@returns` descriptions for also the sake of being consistent.

[`TextChannel#createWebhook()`](https://discord.js.org/#/docs/main/master/class/TextChannel?scrollTo=createWebhook) had a `@returns` description of "webhook The created webhook". Obviously the first word shouldn't be there, but I altered this nonetheless to "Returns the created Webhook" to provide a better feedback description.

I also saw [`TextChannel#bulkDelete()`](https://discord.js.org/#/docs/main/master/class/TextChannel?scrollTo=bulkDelete) just say "Deleted messages", so I thought it would be better to provide a better feedback description here also.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
