### PR TITLE
refactor: move member adding to manager

### DIFF
--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -94,11 +94,11 @@ class GuildMemberManager extends CachedManager {
       if (cachedUser) return cachedUser;
     }
     const resolvedOptions = {
+      access_token: options.accessToken,
       nick: options.nick,
       mute: options.mute,
       deaf: options.deaf,
     };
-    resolvedOptions.access_token = options.accessToken;
     if (options.roles) {
       if (!Array.isArray(options.roles) && !(options.roles instanceof Collection)) {
         throw new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true);
@@ -113,11 +113,7 @@ class GuildMemberManager extends CachedManager {
     }
     const data = await this.client.api.guilds(this.guild.id).members(userId).put({ data: resolvedOptions });
     // Data is an empty buffer if the member is already part of the guild.
-    let newUser = data instanceof Buffer ? null : this._add(data);
-    if (!newUser && options.fetchWhenExisting !== false) {
-      newUser = this.fetch(userId);
-    }
-    return newUser;
+    return data instanceof Buffer ? (options.fetchWhenExisting === false ? null : this.fetch(userId)) : this._add(data);
   }
 
   /**

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -93,7 +93,12 @@ class GuildMemberManager extends CachedManager {
       const cachedUser = this.cache.get(userId);
       if (cachedUser) return cachedUser;
     }
-    options.access_token = options.accessToken;
+    const resolvedOptions = {
+      nick: options.nick,
+      mute: options.mute,
+      deaf: options.deaf,
+    };
+    resolvedOptions.access_token = options.accessToken;
     if (options.roles) {
       if (!Array.isArray(options.roles) && !(options.roles instanceof Collection)) {
         throw new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true);
@@ -104,12 +109,12 @@ class GuildMemberManager extends CachedManager {
         if (!resolvedRole) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role);
         resolvedRoles.push(resolvedRole);
       }
-      options.roles = resolvedRoles;
+      resolvedOptions.roles = resolvedRoles;
     }
-    const data = await this.client.api.guilds(this.guild.id).members(userId).put({ data: options });
+    const data = await this.client.api.guilds(this.guild.id).members(userId).put({ data: resolvedOptions });
     // Data is an empty buffer if the member is already part of the guild.
     let newUser = data instanceof Buffer ? null : this._add(data);
-    if (!newUser && (options.fetchWhenExisting ?? true)) {
+    if (!newUser && options.fetchWhenExisting !== false) {
       newUser = this.fetch(userId);
     }
     return newUser;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -7,7 +7,7 @@ const GuildTemplate = require('./GuildTemplate');
 const Integration = require('./Integration');
 const Webhook = require('./Webhook');
 const WelcomeScreen = require('./WelcomeScreen');
-const { Error, TypeError } = require('../errors');
+const { Error } = require('../errors');
 const GuildApplicationCommandManager = require('../managers/GuildApplicationCommandManager');
 const GuildBanManager = require('../managers/GuildBanManager');
 const GuildChannelManager = require('../managers/GuildChannelManager');
@@ -728,46 +728,6 @@ class Guild extends AnonymousGuild {
         },
       })
       .then(data => GuildAuditLogs.build(this, data));
-  }
-
-  /**
-   * Options used to add a user to a guild using OAuth2.
-   * @typedef {Object} AddGuildMemberOptions
-   * @property {string} accessToken An OAuth2 access token for the user with the `guilds.join` scope granted to the
-   * bot's application
-   * @property {string} [nick] The nickname to give to the member (requires `MANAGE_NICKNAMES`)
-   * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles to add to the member
-   * (requires `MANAGE_ROLES`)
-   * @property {boolean} [mute] Whether the member should be muted (requires `MUTE_MEMBERS`)
-   * @property {boolean} [deaf] Whether the member should be deafened (requires `DEAFEN_MEMBERS`)
-   */
-
-  /**
-   * Adds a user to the guild using OAuth2. Requires the `CREATE_INSTANT_INVITE` permission.
-   * @param {UserResolvable} user The user to add to the guild
-   * @param {AddGuildMemberOptions} options Options for adding the user to the guild
-   * @returns {Promise<GuildMember>}
-   */
-  async addMember(user, options) {
-    user = this.client.users.resolveId(user);
-    if (!user) throw new TypeError('INVALID_TYPE', 'user', 'UserResolvable');
-    if (this.members.cache.has(user)) return this.members.cache.get(user);
-    options.access_token = options.accessToken;
-    if (options.roles) {
-      if (!Array.isArray(options.roles) && !(options.roles instanceof Collection)) {
-        throw new TypeError('INVALID_TYPE', 'options.roles', 'Array or Collection of Roles or Snowflakes', true);
-      }
-      const resolvedRoles = [];
-      for (const role of options.roles.values()) {
-        const resolvedRole = this.roles.resolveId(role);
-        if (!role) throw new TypeError('INVALID_ELEMENT', 'Array or Collection', 'options.roles', role);
-        resolvedRoles.push(resolvedRole);
-      }
-      options.roles = resolvedRoles;
-    }
-    const data = await this.client.api.guilds(this.id).members(user).put({ data: options });
-    // Data is an empty buffer if the member is already part of the guild.
-    return data instanceof Buffer ? this.members.fetch(user) : this.members._add(data);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2332,8 +2332,11 @@ export class GuildManager extends CachedManager<Snowflake, Guild, GuildResolvabl
 export class GuildMemberManager extends CachedManager<Snowflake, GuildMember, GuildMemberResolvable> {
   public constructor(guild: Guild, iterable?: Iterable<unknown>);
   public guild: Guild;
-  public add(user: UserResolvable, options: AddGuildMemberOptions & { fetchWhenExisting: true }): Promise<GuildMember>;
-  public add(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember | null>;
+  public add(
+    user: UserResolvable,
+    options: AddGuildMemberOptions & { fetchWhenExisting: false },
+  ): Promise<GuildMember | null>;
+  public add(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
   public ban(user: UserResolvable, options?: BanOptions): Promise<GuildMember | User | Snowflake>;
   public edit(user: UserResolvable, data: GuildMemberEditData, reason?: string): Promise<void>;
   public fetch(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2332,7 +2332,8 @@ export class GuildManager extends CachedManager<Snowflake, Guild, GuildResolvabl
 export class GuildMemberManager extends CachedManager<Snowflake, GuildMember, GuildMemberResolvable> {
   public constructor(guild: Guild, iterable?: Iterable<unknown>);
   public guild: Guild;
-  public add(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
+  public add(user: UserResolvable, options: AddGuildMemberOptions & { fetchWhenExisting: true }): Promise<GuildMember>;
+  public add(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember | null>;
   public ban(user: UserResolvable, options?: BanOptions): Promise<GuildMember | User | Snowflake>;
   public edit(user: UserResolvable, data: GuildMemberEditData, reason?: string): Promise<void>;
   public fetch(
@@ -2602,6 +2603,7 @@ export interface AddGuildMemberOptions {
   mute?: boolean;
   deaf?: boolean;
   force?: boolean;
+  fetchWhenExisting?: boolean;
 }
 
 export type AllowedImageFormat = 'webp' | 'png' | 'jpg' | 'jpeg' | 'gif';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -575,7 +575,6 @@ export class Guild extends AnonymousGuild {
   public readonly widgetChannel: TextChannel | null;
   public widgetChannelId: Snowflake | null;
   public widgetEnabled: boolean | null;
-  public addMember(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
   public createTemplate(name: string, description?: string): Promise<GuildTemplate>;
   public delete(): Promise<Guild>;
   public discoverySplashURL(options?: StaticImageURLOptions): string | null;
@@ -2333,6 +2332,7 @@ export class GuildManager extends CachedManager<Snowflake, Guild, GuildResolvabl
 export class GuildMemberManager extends CachedManager<Snowflake, GuildMember, GuildMemberResolvable> {
   public constructor(guild: Guild, iterable?: Iterable<unknown>);
   public guild: Guild;
+  public add(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
   public ban(user: UserResolvable, options?: BanOptions): Promise<GuildMember | User | Snowflake>;
   public edit(user: UserResolvable, data: GuildMemberEditData, reason?: string): Promise<void>;
   public fetch(
@@ -2601,6 +2601,7 @@ export interface AddGuildMemberOptions {
   roles?: Collection<Snowflake, Role> | RoleResolvable[];
   mute?: boolean;
   deaf?: boolean;
+  force?: boolean;
 }
 
 export type AllowedImageFormat = 'webp' | 'png' | 'jpg' | 'jpeg' | 'gif';

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -19,6 +19,7 @@ import {
   GuildEmoji,
   GuildEmojiManager,
   GuildMember,
+  GuildMemberManager,
   GuildResolvable,
   Intents,
   Interaction,

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -399,7 +399,7 @@ client.on('ready', async () => {
 });
 
 // This is to check that stuff is the right type
-declare const assertIsMember: (m: Promise<GuildMember>) => void;
+declare const assertIsMember: (m: Promise<GuildMember> | GuildMember) => void;
 
 client.on('guildCreate', g => {
   const channel = g.channels.cache.random();
@@ -421,6 +421,8 @@ client.on('guildCreate', g => {
   // @ts-expect-error
   assertIsMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken', fetchWhenExisting: false }));
 
+  assertIsMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken' }));
+
   assertIsMember(
     g.members.add(testUserId, {
       accessToken: 'totallyRealAccessToken',
@@ -428,6 +430,7 @@ client.on('guildCreate', g => {
       deaf: false,
       roles: [g.roles.cache.first()!],
       force: true,
+      fetchWhenExisting: true,
     }),
   );
 });

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -418,8 +418,9 @@ client.on('guildCreate', g => {
   // @ts-expect-error invalid role resolvable
   assertIsPromiseMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken', roles: [g.roles.cache] }));
 
-  // @ts-expect-error non fetched returns Promise<null>
-  assertIsPromiseMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken', fetchWhenExisting: false }));
+  assertType<Promise<GuildMember | null>>(
+    g.members.add(testUserId, { accessToken: 'totallyRealAccessToken', fetchWhenExisting: false }),
+  );
 
   assertIsPromiseMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken' }));
 

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -399,7 +399,7 @@ client.on('ready', async () => {
 });
 
 // This is to check that stuff is the right type
-declare const assertIsMember: (m: Promise<GuildMember> | GuildMember) => void;
+declare const assertIsPromiseMember: (m: Promise<GuildMember>) => void;
 
 client.on('guildCreate', g => {
   const channel = g.channels.cache.random();
@@ -409,21 +409,21 @@ client.on('guildCreate', g => {
     console.log(`New channel name: ${updatedChannel.name}`);
   });
 
-  // @ts-expect-error
-  assertIsMember(g.members.add(testUserId));
+  // @ts-expect-error no options
+  assertIsPromiseMember(g.members.add(testUserId));
 
-  // @ts-expect-error
-  assertIsMember(g.members.add(testUserId, {}));
+  // @ts-expect-error no access token
+  assertIsPromiseMember(g.members.add(testUserId, {}));
 
-  // @ts-expect-error
-  assertIsMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken', roles: [g.roles.cache] }));
+  // @ts-expect-error invalid role resolvable
+  assertIsPromiseMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken', roles: [g.roles.cache] }));
 
-  // @ts-expect-error
-  assertIsMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken', fetchWhenExisting: false }));
+  // @ts-expect-error non fetched returns Promise<null>
+  assertIsPromiseMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken', fetchWhenExisting: false }));
 
-  assertIsMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken' }));
+  assertIsPromiseMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken' }));
 
-  assertIsMember(
+  assertIsPromiseMember(
     g.members.add(testUserId, {
       accessToken: 'totallyRealAccessToken',
       mute: true,

--- a/typings/index.ts
+++ b/typings/index.ts
@@ -19,7 +19,6 @@ import {
   GuildEmoji,
   GuildEmojiManager,
   GuildMember,
-  GuildMemberManager,
   GuildResolvable,
   Intents,
   Interaction,
@@ -399,6 +398,9 @@ client.on('ready', async () => {
   });
 });
 
+// This is to check that stuff is the right type
+declare const assertIsMember: (m: Promise<GuildMember>) => void;
+
 client.on('guildCreate', g => {
   const channel = g.channels.cache.random();
   if (!channel) return;
@@ -406,6 +408,28 @@ client.on('guildCreate', g => {
   channel.setName('foo').then(updatedChannel => {
     console.log(`New channel name: ${updatedChannel.name}`);
   });
+
+  // @ts-expect-error
+  assertIsMember(g.members.add(testUserId));
+
+  // @ts-expect-error
+  assertIsMember(g.members.add(testUserId, {}));
+
+  // @ts-expect-error
+  assertIsMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken', roles: [g.roles.cache] }));
+
+  // @ts-expect-error
+  assertIsMember(g.members.add(testUserId, { accessToken: 'totallyRealAccessToken', fetchWhenExisting: false }));
+
+  assertIsMember(
+    g.members.add(testUserId, {
+      accessToken: 'totallyRealAccessToken',
+      mute: true,
+      deaf: false,
+      roles: [g.roles.cache.first()!],
+      force: true,
+    }),
+  );
 });
 
 client.on('messageReactionRemoveAll', async message => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The long awaited move is here.
Also comes with a bug fix to the method (throws properly when a role is invalid), along with no more param mutation.
Further adds a force param for those of you that don't get member events (if a member has left while the bot is running, they still are cached 😢 )

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
