### PR TITLE
refactor: Strengthen channel typings in appropriate places

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -86,7 +86,7 @@ class GuildChannelManager extends CachedManager {
    * @property {boolean} [nsfw] Whether the new channel is nsfw
    * @property {number} [bitrate] Bitrate of the new channel in bits (only voice)
    * @property {number} [userLimit] Maximum amount of users allowed in the new channel (only voice)
-   * @property {ChannelResolvable} [parent] Parent of the new channel
+   * @property {CategoryChannelResolvable} [parent] Parent of the new channel
    * @property {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [permissionOverwrites]
    * Permission overwrites of the new channel
    * @property {number} [position] Position of the new channel

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -22,7 +22,7 @@ class CategoryChannel extends GuildChannel {
    * @method setParent
    * @memberof CategoryChannel
    * @instance
-   * @param {?(GuildChannel|Snowflake)} channel The channel to set as parent
+   * @param {?CategoryChannelResolvable} channel The channel to set as parent
    * @param {SetParentOptions} [options={}] The options for setting the parent
    * @returns {Promise<GuildChannel>}
    */

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -776,8 +776,8 @@ class Guild extends AnonymousGuild {
    * @property {string} [name] The name of the guild
    * @property {VerificationLevel|number} [verificationLevel] The verification level of the guild
    * @property {ExplicitContentFilterLevel|number} [explicitContentFilter] The level of the explicit content filter
-   * @property {ChannelResolvable} [afkChannel] The AFK channel of the guild
-   * @property {ChannelResolvable} [systemChannel] The system channel of the guild
+   * @property {VoiceChannelResolvable} [afkChannel] The AFK channel of the guild
+   * @property {TextChannelResolvable} [systemChannel] The system channel of the guild
    * @property {number} [afkTimeout] The AFK timeout of the guild
    * @property {Base64Resolvable} [icon] The icon of the guild
    * @property {GuildMemberResolvable} [owner] The owner of the guild
@@ -787,11 +787,25 @@ class Guild extends AnonymousGuild {
    * @property {DefaultMessageNotificationLevel|number} [defaultMessageNotifications] The default message notification
    * level of the guild
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The system channel flags of the guild
-   * @property {ChannelResolvable} [rulesChannel] The rules channel of the guild
-   * @property {ChannelResolvable} [publicUpdatesChannel] The community updates channel of the guild
+   * @property {TextChannelResolvable} [rulesChannel] The rules channel of the guild
+   * @property {TextChannelResolvable} [publicUpdatesChannel] The community updates channel of the guild
    * @property {string} [preferredLocale] The preferred locale of the guild
    * @property {string} [description] The discovery description of the guild
    * @property {Features[]} [features] The features of the guild
+   */
+
+  /**
+   * Data that can be resolved to a Text Channel object. This can be:
+   * * A TextChannel
+   * * A Snowflake
+   * @typedef {TextChannel|Snowflake} TextChannelResolvable
+   */
+
+  /**
+   * Data that can be resolved to a Voice Channel object. This can be:
+   * * A VoiceChannel
+   * * A Snowflake
+   * @typedef {VoiceChannel|Snowflake} VoiceChannelResolvable
    */
 
   /**
@@ -884,6 +898,14 @@ class Guild extends AnonymousGuild {
    * * A NewsChannel
    * * A Snowflake
    * @typedef {TextChannel|NewsChannel|Snowflake} GuildTextChannelResolvable
+   */
+
+  /**
+   * Data that can be resolved to a GuildVoiceChannel object. This can be:
+   * * A VoiceChannel
+   * * A StageChannel
+   * * A Snowflake
+   * @typedef {VoiceChannel|StageChannel|Snowflake} GuildVoiceChannelResolvable
    */
 
   /**
@@ -988,7 +1010,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Edits the AFK channel of the guild.
-   * @param {ChannelResolvable} afkChannel The new AFK channel
+   * @param {VoiceChannelResolvable} afkChannel The new AFK channel
    * @param {string} [reason] Reason for changing the guild's AFK channel
    * @returns {Promise<Guild>}
    * @example
@@ -1003,7 +1025,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Edits the system channel of the guild.
-   * @param {ChannelResolvable} systemChannel The new system channel
+   * @param {TextChannelResolvable} systemChannel The new system channel
    * @param {string} [reason] Reason for changing the guild's system channel
    * @returns {Promise<Guild>}
    * @example
@@ -1107,7 +1129,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Edits the rules channel of the guild.
-   * @param {ChannelResolvable} rulesChannel The new rules channel
+   * @param {TextChannelResolvable} rulesChannel The new rules channel
    * @param {string} [reason] Reason for changing the guild's rules channel
    * @returns {Promise<Guild>}
    * @example
@@ -1122,7 +1144,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Edits the community updates channel of the guild.
-   * @param {ChannelResolvable} publicUpdatesChannel The new community updates channel
+   * @param {TextChannelResolvable} publicUpdatesChannel The new community updates channel
    * @param {string} [reason] Reason for changing the guild's community updates channel
    * @returns {Promise<Guild>}
    * @example
@@ -1160,7 +1182,7 @@ class Guild extends AnonymousGuild {
   /**
    * The data needed for updating a channel's position.
    * @typedef {Object} ChannelPosition
-   * @property {ChannelResolvable} channel Channel to update
+   * @property {GuildChannel|Snowflake} channel Channel to update
    * @property {number} [position] New position for the channel
    * @property {CategoryChannelResolvable} [parent] Parent channel for this channel
    * @property {boolean} [lockPermissions] If the overwrites should be locked to the parents overwrites

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -384,7 +384,7 @@ class GuildChannel extends Channel {
 
   /**
    * Sets the parent of this channel.
-   * @param {?CategoryChannelResolvable} channel The category channel to set as parent
+   * @param {?CategoryChannelResolvable} channel The category channel to set as the parent
    * @param {SetParentOptions} [options={}] The options for setting the parent
    * @returns {Promise<GuildChannel>}
    * @example

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -397,7 +397,7 @@ class GuildChannel extends Channel {
     return this.edit(
       {
         // eslint-disable-next-line no-prototype-builtins
-        parentId: channel?.id ?? channel ?? null,
+        parent: channel ?? null,
         lockPermissions,
       },
       reason,

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -277,7 +277,7 @@ class GuildChannel extends Channel {
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the voice channel
-   * @property {?Snowflake} [parentId] The parent's id of the channel
+   * @property {?CategoryChannelResolvable} [parent] The parent of the channel
    * @property {boolean} [lockPermissions]
    * Lock the permissions of the channel to what the parent's permissions are
    * @property {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [permissionOverwrites]
@@ -300,6 +300,8 @@ class GuildChannel extends Channel {
    *   .catch(console.error);
    */
   async edit(data, reason) {
+    if (data.parent) data.parent = this.client.channels.resolveId(data.parent);
+
     if (typeof data.position !== 'undefined') {
       await Util.setPosition(
         this,
@@ -323,8 +325,8 @@ class GuildChannel extends Channel {
     }
 
     if (data.lockPermissions) {
-      if (data.parentId) {
-        const newParent = this.guild.channels.resolve(data.parentId);
+      if (data.parent) {
+        const newParent = this.guild.channels.resolve(data.parent);
         if (newParent?.type === 'GUILD_CATEGORY') {
           permission_overwrites = newParent.permissionOverwrites.cache.map(o =>
             PermissionOverwrites.resolve(o, this.guild),
@@ -346,7 +348,7 @@ class GuildChannel extends Channel {
         bitrate: data.bitrate ?? this.bitrate,
         user_limit: data.userLimit ?? this.userLimit,
         rtc_region: data.rtcRegion ?? this.rtcRegion,
-        parent_id: data.parentId,
+        parent_id: data.parent,
         lock_permissions: data.lockPermissions,
         rate_limit_per_user: data.rateLimitPerUser,
         default_auto_archive_duration: data.defaultAutoArchiveDuration,
@@ -382,7 +384,7 @@ class GuildChannel extends Channel {
 
   /**
    * Sets the parent of this channel.
-   * @param {?(CategoryChannel|Snowflake)} channel The category channel to set as parent
+   * @param {?CategoryChannelResolvable} channel The category channel to set as parent
    * @param {SetParentOptions} [options={}] The options for setting the parent
    * @returns {Promise<GuildChannel>}
    * @example

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -236,7 +236,8 @@ class GuildMember extends Base {
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles or role ids to apply
    * @property {boolean} [mute] Whether or not the member should be muted
    * @property {boolean} [deaf] Whether or not the member should be deafened
-   * @property {GuildVoiceChannelResolvable|null} [channel] Channel to move member to (if they are connected to voice), or `null`
+   * @property {GuildVoiceChannelResolvable|null} [channel] Channel to move member to (if they are connected to voice),
+   * or `null`
    * if you want to kick them from voice
    */
 

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -237,8 +237,7 @@ class GuildMember extends Base {
    * @property {boolean} [mute] Whether or not the member should be muted
    * @property {boolean} [deaf] Whether or not the member should be deafened
    * @property {GuildVoiceChannelResolvable|null} [channel] Channel to move member to (if they are connected to voice),
-   * or `null`
-   * if you want to kick them from voice
+   * or `null` if you want to disconnect them from voice
    */
 
   /**

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -236,7 +236,7 @@ class GuildMember extends Base {
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles or role ids to apply
    * @property {boolean} [mute] Whether or not the member should be muted
    * @property {boolean} [deaf] Whether or not the member should be deafened
-   * @property {ChannelResolvable|null} [channel] Channel to move member to (if they are connected to voice), or `null`
+   * @property {GuildVoiceChannelResolvable|null} [channel] Channel to move member to (if they are connected to voice), or `null`
    * if you want to kick them from voice
    */
 

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -203,7 +203,7 @@ class Role extends Base {
   /**
    * Returns `channel.permissionsFor(role)`. Returns permissions for a role in a guild channel,
    * taking into account permission overwrites.
-   * @param {ChannelResolvable} channel The guild channel to use as context
+   * @param {GuildChannel|Snowflake} channel The guild channel to use as context
    * @returns {Readonly<Permissions>}
    */
   permissionsIn(channel) {

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -149,8 +149,8 @@ class VoiceState extends Base {
 
   /**
    * Moves the member to a different channel, or disconnects them from the one they're in.
-   * @param {VoiceChannelResolvable|null} channel Channel to move the member to, or `null` if you want to disconnect them
-   * from voice.
+   * @param {VoiceChannelResolvable|null} channel Channel to move the member to, or `null` if you want to disconnect
+   * them from voice.
    * @param {string} [reason] Reason for moving member to another channel or disconnecting
    * @returns {Promise<GuildMember>}
    */

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -149,7 +149,7 @@ class VoiceState extends Base {
 
   /**
    * Moves the member to a different channel, or disconnects them from the one they're in.
-   * @param {ChannelResolvable|null} channel Channel to move the member to, or `null` if you want to disconnect them
+   * @param {VoiceChannelResolvable|null} channel Channel to move the member to, or `null` if you want to disconnect them
    * from voice.
    * @param {string} [reason] Reason for moving member to another channel or disconnecting
    * @returns {Promise<GuildMember>}

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Channel = require('./Channel');
 const MessagePayload = require('./MessagePayload');
 const { Error } = require('../errors');
 const { WebhookTypes } = require('../util/Constants');
@@ -214,7 +213,7 @@ class Webhook {
    * @typedef {Object} WebhookEditData
    * @property {string} [name=this.name] The new name for the webhook
    * @property {BufferResolvable} [avatar] The new avatar for the webhook
-   * @property {ChannelResolvable} [channel] The new channel for the webhook
+   * @property {GuildTextChannelResolvable} [channel] The new channel for the webhook
    */
 
   /**
@@ -227,7 +226,7 @@ class Webhook {
     if (avatar && !(typeof avatar === 'string' && avatar.startsWith('data:'))) {
       avatar = await DataResolver.resolveImage(avatar);
     }
-    if (channel) channel = channel instanceof Channel ? channel.id : channel;
+    if (channel) channel = channel?.id ?? channel;
     const data = await this.client.api.webhooks(this.id, channel ? undefined : this.token).patch({
       data: { name, avatar, channel_id: channel },
       reason,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1415,7 +1415,7 @@ export class Role extends Base {
   public delete(reason?: string): Promise<Role>;
   public edit(data: RoleData, reason?: string): Promise<Role>;
   public equals(role: Role): boolean;
-  public permissionsIn(channel: GuildChannel|Snowflake): Readonly<Permissions>;
+  public permissionsIn(channel: GuildChannel | Snowflake): Readonly<Permissions>;
   public setColor(color: ColorResolvable, reason?: string): Promise<Role>;
   public setHoist(hoist: boolean, reason?: string): Promise<Role>;
   public setMentionable(mentionable: boolean, reason?: string): Promise<Role>;
@@ -1670,8 +1670,6 @@ export class TextChannel extends TextBasedChannel(GuildChannel) {
   public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
 }
 
-export type TextChannelResolvable = Snowflake | TextChannel;
-
 export class ThreadChannel extends TextBasedChannel(Channel) {
   public constructor(guild: Guild, data?: object, client?: Client, fromInteraction?: boolean);
   public archived: boolean | null;
@@ -1845,8 +1843,6 @@ export class VoiceChannel extends BaseGuildVoiceChannel {
   public setBitrate(bitrate: number, reason?: string): Promise<VoiceChannel>;
   public setUserLimit(userLimit: number, reason?: string): Promise<VoiceChannel>;
 }
-
-export type VoiceChannelResolvable = Snowflake | VoiceChannel;
 
 export class VoiceRegion {
   public constructor(data: unknown);
@@ -2921,7 +2917,6 @@ export interface ChannelPosition {
 }
 
 export type GuildTextChannelResolvable = TextChannel | NewsChannel | Snowflake;
-export type GuildVoiceChannelResolvable = VoiceChannel | StageChannel | Snowflake;
 export type ChannelResolvable = Channel | Snowflake;
 
 export interface ChannelWebhookCreateOptions {
@@ -3645,6 +3640,8 @@ export interface GuildSearchMembersOptions {
 
 export type GuildTemplateResolvable = string;
 
+export type GuildVoiceChannelResolvable = VoiceChannel | StageChannel | Snowflake;
+
 export type HexColorString = `#${string}`;
 
 export interface HTTPAttachmentData {
@@ -4289,6 +4286,8 @@ export type TextBasedChannelTypes =
   | 'GUILD_PUBLIC_THREAD'
   | 'GUILD_PRIVATE_THREAD';
 
+export type TextChannelResolvable = Snowflake | TextChannel;
+
 export type ThreadAutoArchiveDuration = 60 | 1440 | 4320 | 10080;
 
 export type ThreadChannelResolvable = ThreadChannel | Snowflake;
@@ -4342,6 +4341,8 @@ export interface Vanity {
 export type VerificationLevel = keyof typeof VerificationLevels;
 
 export type VoiceBasedChannelTypes = 'GUILD_VOICE' | 'GUILD_STAGE_VOICE';
+
+export type VoiceChannelResolvable = Snowflake | VoiceChannel;
 
 export type WebhookClientData = WebhookClientDataIdWithToken | WebhookClientDataURL;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -705,7 +705,7 @@ export class GuildChannel extends Channel {
   public permissionsFor(memberOrRole: GuildMember | Role): Readonly<Permissions>;
   public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
   public setName(name: string, reason?: string): Promise<this>;
-  public setParent(channel: CategoryChannel | Snowflake | null, options?: SetParentOptions): Promise<this>;
+  public setParent(channel: CategoryChannelResolvable | null, options?: SetParentOptions): Promise<this>;
   public setPosition(position: number, options?: SetChannelPositionOptions): Promise<this>;
   public setTopic(topic: string | null, reason?: string): Promise<this>;
   public isText(): this is TextChannel | NewsChannel;
@@ -2892,7 +2892,7 @@ export interface ChannelData {
   nsfw?: boolean;
   bitrate?: number;
   userLimit?: number;
-  parentId?: Snowflake | null;
+  parent?: CategoryChannelResolvable | null;
   rateLimitPerUser?: number;
   lockPermissions?: boolean;
   permissionOverwrites?: readonly OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
@@ -3506,7 +3506,7 @@ export interface GuildChannelCreateOptions {
     | ChannelTypes.GUILD_PRIVATE_THREAD
   >;
   nsfw?: boolean;
-  parent?: ChannelResolvable;
+  parent?: CategoryChannelResolvable;
   bitrate?: number;
   userLimit?: number;
   rateLimitPerUser?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -593,7 +593,7 @@ export class Guild extends AnonymousGuild {
   public fetchWidget(): Promise<Widget>;
   public fetchWidgetSettings(): Promise<GuildWidgetSettings>;
   public leave(): Promise<Guild>;
-  public setAFKChannel(afkChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
+  public setAFKChannel(afkChannel: VoiceChannelResolvable | null, reason?: string): Promise<Guild>;
   public setAFKTimeout(afkTimeout: number, reason?: string): Promise<Guild>;
   public setBanner(banner: Base64Resolvable | null, reason?: string): Promise<Guild>;
   public setChannelPositions(channelPositions: readonly ChannelPosition[]): Promise<Guild>;
@@ -610,11 +610,11 @@ export class Guild extends AnonymousGuild {
   public setName(name: string, reason?: string): Promise<Guild>;
   public setOwner(owner: GuildMemberResolvable, reason?: string): Promise<Guild>;
   public setPreferredLocale(preferredLocale: string, reason?: string): Promise<Guild>;
-  public setPublicUpdatesChannel(publicUpdatesChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
+  public setPublicUpdatesChannel(publicUpdatesChannel: TextChannelResolvable | null, reason?: string): Promise<Guild>;
   public setRolePositions(rolePositions: readonly RolePosition[]): Promise<Guild>;
-  public setRulesChannel(rulesChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
+  public setRulesChannel(rulesChannel: TextChannelResolvable | null, reason?: string): Promise<Guild>;
   public setSplash(splash: Base64Resolvable | null, reason?: string): Promise<Guild>;
-  public setSystemChannel(systemChannel: ChannelResolvable | null, reason?: string): Promise<Guild>;
+  public setSystemChannel(systemChannel: TextChannelResolvable | null, reason?: string): Promise<Guild>;
   public setSystemChannelFlags(systemChannelFlags: SystemChannelFlagsResolvable, reason?: string): Promise<Guild>;
   public setVerificationLevel(verificationLevel: VerificationLevel | number, reason?: string): Promise<Guild>;
   public setWidgetSettings(settings: GuildWidgetSettingsData, reason?: string): Promise<Guild>;
@@ -1415,7 +1415,7 @@ export class Role extends Base {
   public delete(reason?: string): Promise<Role>;
   public edit(data: RoleData, reason?: string): Promise<Role>;
   public equals(role: Role): boolean;
-  public permissionsIn(channel: ChannelResolvable): Readonly<Permissions>;
+  public permissionsIn(channel: GuildChannel|Snowflake): Readonly<Permissions>;
   public setColor(color: ColorResolvable, reason?: string): Promise<Role>;
   public setHoist(hoist: boolean, reason?: string): Promise<Role>;
   public setMentionable(mentionable: boolean, reason?: string): Promise<Role>;
@@ -1670,6 +1670,8 @@ export class TextChannel extends TextBasedChannel(GuildChannel) {
   public fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
 }
 
+export type TextChannelResolvable = Snowflake | TextChannel;
+
 export class ThreadChannel extends TextBasedChannel(Channel) {
   public constructor(guild: Guild, data?: object, client?: Client, fromInteraction?: boolean);
   public archived: boolean | null;
@@ -1844,6 +1846,8 @@ export class VoiceChannel extends BaseGuildVoiceChannel {
   public setUserLimit(userLimit: number, reason?: string): Promise<VoiceChannel>;
 }
 
+export type VoiceChannelResolvable = Snowflake | VoiceChannel;
+
 export class VoiceRegion {
   public constructor(data: unknown);
   public custom: boolean;
@@ -1877,7 +1881,7 @@ export class VoiceState extends Base {
   public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;
   public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
   public kick(reason?: string): Promise<GuildMember>;
-  public setChannel(channel: ChannelResolvable | null, reason?: string): Promise<GuildMember>;
+  public setChannel(channel: VoiceChannelResolvable | null, reason?: string): Promise<GuildMember>;
   public setRequestToSpeak(request: boolean): Promise<void>;
   public setSuppressed(suppressed: boolean): Promise<void>;
 }
@@ -2910,13 +2914,14 @@ export interface ChannelLogsQueryOptions {
 export type ChannelMention = `<#${Snowflake}>`;
 
 export interface ChannelPosition {
-  channel: ChannelResolvable;
+  channel: GuildChannel | Snowflake;
   lockPermissions?: boolean;
   parent?: CategoryChannelResolvable | null;
   position?: number;
 }
 
 export type GuildTextChannelResolvable = TextChannel | NewsChannel | Snowflake;
+export type GuildVoiceChannelResolvable = VoiceChannel | StageChannel | Snowflake;
 export type ChannelResolvable = Channel | Snowflake;
 
 export interface ChannelWebhookCreateOptions {
@@ -3546,8 +3551,8 @@ export interface GuildEditData {
   verificationLevel?: VerificationLevel | number;
   explicitContentFilter?: ExplicitContentFilterLevel | number;
   defaultMessageNotifications?: DefaultMessageNotificationLevel | number;
-  afkChannel?: ChannelResolvable;
-  systemChannel?: ChannelResolvable;
+  afkChannel?: VoiceChannelResolvable;
+  systemChannel?: TextChannelResolvable;
   systemChannelFlags?: SystemChannelFlagsResolvable;
   afkTimeout?: number;
   icon?: Base64Resolvable;
@@ -3555,8 +3560,8 @@ export interface GuildEditData {
   splash?: Base64Resolvable;
   discoverySplash?: Base64Resolvable;
   banner?: Base64Resolvable;
-  rulesChannel?: ChannelResolvable;
-  publicUpdatesChannel?: ChannelResolvable;
+  rulesChannel?: TextChannelResolvable;
+  publicUpdatesChannel?: TextChannelResolvable;
   preferredLocale?: string;
   description?: string | null;
   features?: GuildFeatures[];
@@ -3612,7 +3617,7 @@ export interface GuildMemberEditData {
   roles?: Collection<Snowflake, Role> | readonly RoleResolvable[];
   mute?: boolean;
   deaf?: boolean;
-  channel?: ChannelResolvable | null;
+  channel?: GuildVoiceChannelResolvable | null;
 }
 
 export type GuildMemberResolvable = GuildMember | UserResolvable;
@@ -4357,7 +4362,7 @@ export type WebhookClientOptions = Pick<
 export interface WebhookEditData {
   name?: string;
   avatar?: BufferResolvable;
-  channel?: ChannelResolvable;
+  channel?: GuildTextChannelResolvable;
 }
 
 export type WebhookEditMessageOptions = Pick<


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Per #5521, methods and typings that were solely for category channels (and ids) were instead allowing any channel to go through instead of just `CategoryChannelResolvable`. This pull request should address this and resolve #5521.

Additionally, this pull request changes the type definition for `ChannelData`. Before, it only could take the parent id (`Snowflake`) of a potential category channel, but now, it is possible to take a `CategoryChannelResolvable` instead. This means a rename is in order, so I've changed `parentId` here to just `parent`. This also makes it a breaking change, but this also matches nicely now with the `GuildChannelCreateOptions` type definition!


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
