### PR TITLE
ci(PublishDev): change version number to be sequential

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Publish
         run: |
-          npm version --git-tag-version=false $(jq --raw-output '.version' package.json).$(git rev-parse --short HEAD).$(date +%s)
+          npm version --git-tag-version=false $(jq --raw-output '.version' package.json).t$(date +%s).$(git rev-parse --short HEAD)
           npm publish --tag dev || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the version number format of dev builds to be alphabetically sortable by putting the timestamp first, followed by the commit SHA.

This should address issues with `yarn outdated` caused by version numbers that aren't compliant with semver (yarnpkg/yarn#3560).

This also corrects the version number to be compliant with semver.

A `t` is prepended to the timestamp of the version to ensure it sorts higher than any prior versions' commit hashes. This can be removed after the next publish to NPM.

*Old commit format:*
`13.0.0-dev.2675b08.1627646567`
*New commit format:*
`13.0.0-dev.t1627646567.2675b08`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
