### PR TITLE
refactor(Message): accept a single object instead of 3 arguments

### DIFF
--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -71,16 +71,12 @@ class ThreadManager extends CachedManager {
 
   /**
    * Options for creating a thread. <warn>Only one of `startMessage` or `type` can be defined.</warn>
-   * @typedef {Object} ThreadCreateOptions
-   * @property {string} name The name of the new thread
-   * @property {ThreadAutoArchiveDuration} autoArchiveDuration The amount of time (in minutes) after which the thread
-   * should automatically archive in case of no recent activity
+   * @typedef {StartThreadOptions} ThreadCreateOptions
    * @property {MessageResolvable} [startMessage] The message to start a thread from. <warn>If this is defined then type
    * of thread gets automatically defined and cannot be changed. The provided `type` field will be ignored</warn>
    * @property {ThreadChannelTypes|number} [type] The type of thread to create. Defaults to `GUILD_PUBLIC_THREAD` if
    * created in a {@link TextChannel} <warn>When creating threads in a {@link NewsChannel} this is ignored and is always
    * `GUILD_NEWS_THREAD`</warn>
-   * @property {string} [reason] Reason for creating the thread
    */
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -742,7 +742,7 @@ class Message extends Base {
    * @param {StartThreadOptions} [options] Options for starting a thread on this message
    * @returns {Promise<ThreadChannel>}
    */
-  startThread({ name, autoArchiveDuration, reason } = {}) {
+  startThread(options = {}) {
     if (!['GUILD_TEXT', 'GUILD_NEWS'].includes(this.channel.type)) {
       return Promise.reject(new Error('MESSAGE_THREAD_PARENT'));
     }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -747,7 +747,7 @@ class Message extends Base {
       return Promise.reject(new Error('MESSAGE_THREAD_PARENT'));
     }
     if (this.hasThread) return Promise.reject(new Error('MESSAGE_EXISTING_THREAD'));
-    return this.channel.threads.create({ name, autoArchiveDuration, startMessage: this, reason });
+    return this.channel.threads.create({ ...options, startMessage: this });
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -728,14 +728,21 @@ class Message extends Base {
   }
 
   /**
+   * Options for starting a thread on a message.
+   * @typedef {Object} StartThreadOptions
+   * @property {string} name The name of the new thread
+   * @property {ThreadAutoArchiveDuration} autoArchiveDuration The amount of time (in minutes) after which the thread
+   * should automatically archive in case of no recent activity
+   * @property {string} [reason] Reason for creating the thread
+   */
+
+  /**
    * Create a new public thread from this message
    * @see ThreadManager#create
-   * @param {string} name The name of the new Thread
-   * @param {ThreadAutoArchiveDuration} autoArchiveDuration How long before the thread is automatically archived
-   * @param {string} [reason] Reason for creating the thread
+   * @param {StartThreadOptions} [options] Options for starting a thread on this message
    * @returns {Promise<ThreadChannel>}
    */
-  startThread(name, autoArchiveDuration, reason) {
+  startThread({ name, autoArchiveDuration, reason } = {}) {
     if (!['GUILD_TEXT', 'GUILD_NEWS'].includes(this.channel.type)) {
       return Promise.reject(new Error('MESSAGE_THREAD_PARENT'));
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1034,11 +1034,7 @@ export class Message extends Base {
   public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
   public removeAttachments(): Promise<Message>;
   public reply(options: string | MessagePayload | ReplyMessageOptions): Promise<Message>;
-  public startThread(
-    name: string,
-    autoArchiveDuration: ThreadAutoArchiveDuration,
-    reason?: string,
-  ): Promise<ThreadChannel>;
+  public startThread(options: StartThreadOptions): Promise<ThreadChannel>;
   public suppressEmbeds(suppress?: boolean): Promise<Message>;
   public toJSON(): unknown;
   public toString(): string;
@@ -4271,6 +4267,12 @@ export interface StaticImageURLOptions {
 
 export type StageInstanceResolvable = StageInstance | Snowflake;
 
+export interface StartThreadOptions {
+  name: string;
+  autoArchiveDuration: ThreadAutoArchiveDuration;
+  reason?: string;
+}
+
 export type Status = number;
 
 export type StickerFormatType = keyof typeof StickerFormatTypes;
@@ -4316,12 +4318,9 @@ export type ThreadChannelResolvable = ThreadChannel | Snowflake;
 
 export type ThreadChannelTypes = 'GUILD_NEWS_THREAD' | 'GUILD_PUBLIC_THREAD' | 'GUILD_PRIVATE_THREAD';
 
-export interface ThreadCreateOptions<AllowedThreadType> {
-  name: string;
-  autoArchiveDuration: ThreadAutoArchiveDuration;
+export interface ThreadCreateOptions<AllowedThreadType> extends StartThreadOptions {
   startMessage?: MessageResolvable;
   type?: AllowedThreadType;
-  reason?: string;
 }
 
 export interface ThreadEditData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This changes the Message#startThread parameters to be consistent with ThreadManager#create to also prevent the need for any breaking changes in the future if extra parameters need to be added.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
