### PR TITLE
 docs: change example in readme to slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ client.on('ready', () => {
 });
 
 client.on('interactionCreate', async interaction => {
-	if (!interaction.isCommand()) return;
+  if (!interaction.isCommand()) return;
 
-	if (interaction.commandName === 'ping') {
-		await interaction.reply('Pong!');
-	}
+  if (interaction.commandName === 'ping') {
+    await interaction.reply('Pong!');
+  }
 });
 
 client.login('token');

--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ client.on('ready', () => {
   console.log(`Logged in as ${client.user.tag}!`);
 });
 
-client.on('messageCreate', message => {
-  if (message.content === 'ping') {
-    message.channel.send('pong');
-  }
+client.on('interactionCreate', async interaction => {
+	if (!interaction.isCommand()) return;
+
+	if (interaction.commandName === 'ping') {
+		await interaction.reply('Pong!');
+	}
 });
 
 client.login('token');

--- a/README.md
+++ b/README.md
@@ -53,18 +53,20 @@ const commands = [{
 
 const rest = new REST({ version: '9' }).setToken('token');
 
-try {
-  console.log('Started refreshing application (/) commands');
-
-  await rest.put(
-    Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID),
-    { body: commands },
-  );
-
-  console.log('Sucessfully reloaded application (/) commands.');
-} catch (error) {
-  console.error(error);
-}
+(async () => {
+	  try {
+	    console.log('Started refreshing application (/) commands');
+	  
+	    await rest.put(
+	      Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID),
+	      { body: commands },
+	    );
+	  
+	    console.log('Sucessfully reloaded application (/) commands.');
+	  } catch (error) {
+	    console.error(error);
+	  }
+})()
 ```
 Afterwards, run this to turn on your bot
 ```js

--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ npm install discord.js
 
 ## Example usage
 
+Execute this code first to deploy your command
+```js
+const { REST } = require('@discordjs/rest');
+const { Routes } = require('discord-api-types/v9');
+
+const commands = [{
+  name: 'ping',
+  description: 'Replies with Pong!'
+}]; 
+
+const rest = new REST({ version: '9' }).setToken('token');
+
+try {
+  console.log('Started refreshing application (/) commands');
+
+  await rest.put(
+    Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID),
+    { body: commands },
+  );
+
+  console.log('Sucessfully reloaded application (/) commands.');
+} catch (error) {
+  console.error(error);
+}
+```
+Afterwards, run this to turn on your bot
 ```js
 const { Client, Intents } = require('discord.js');
 const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });

--- a/README.md
+++ b/README.md
@@ -54,18 +54,18 @@ const commands = [{
 const rest = new REST({ version: '9' }).setToken('token');
 
 (async () => {
-	  try {
-	    console.log('Started refreshing application (/) commands');
-	  
-	    await rest.put(
-	      Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID),
-	      { body: commands },
-	    );
-	  
-	    console.log('Sucessfully reloaded application (/) commands.');
-	  } catch (error) {
-	    console.error(error);
-	  }
+    try {
+      console.log('Started refreshing application (/) commands');
+    
+      await rest.put(
+        Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID),
+        { body: commands },
+      );
+    
+      console.log('Sucessfully reloaded application (/) commands.');
+    } catch (error) {
+      console.error(error);
+    }
 })()
 ```
 Afterwards, run this to turn on your bot

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install discord.js
 
 ## Example usage
 
-Execute this code first to deploy your command
+First, we need to register a slash command against the Discord API:
 ```js
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
@@ -68,7 +68,8 @@ const rest = new REST({ version: '9' }).setToken('token');
     }
 })()
 ```
-Afterwards, run this to turn on your bot
+
+Afterwards we can create a quite simple example bot:
 ```js
 const { Client, Intents } = require('discord.js');
 const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since we are using application commands instead of message based commands for all examples, the readme should do it too for consistency


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
