### PR TITLE
refactor(VoiceState): Change kick to disconnect

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -236,8 +236,8 @@ class GuildMember extends Base {
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles or role ids to apply
    * @property {boolean} [mute] Whether or not the member should be muted
    * @property {boolean} [deaf] Whether or not the member should be deafened
-   * @property {GuildVoiceChannelResolvable|null} [channel] Channel to move member to (if they are connected to voice),
-   * or `null` if you want to disconnect them from voice
+   * @property {GuildVoiceChannelResolvable|null} [channel] Channel to move the member to
+   * (if they are connected to voice), or `null` if you want to disconnect them from voice
    */
 
   /**

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -139,11 +139,11 @@ class VoiceState extends Base {
   }
 
   /**
-   * Kicks the member from the channel.
-   * @param {string} [reason] Reason for kicking member from the channel
+   * Disconnects the member from the channel.
+   * @param {string} [reason] Reason for disconnecting the member from the channel
    * @returns {Promise<GuildMember>}
    */
-  kick(reason) {
+  disconnect(reason) {
     return this.setChannel(null, reason);
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1884,7 +1884,7 @@ export class VoiceState extends Base {
 
   public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;
   public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
-  public kick(reason?: string): Promise<GuildMember>;
+  public disconnect(reason?: string): Promise<GuildMember>;
   public setChannel(channel: VoiceChannelResolvable | null, reason?: string): Promise<GuildMember>;
   public setRequestToSpeak(request: boolean): Promise<void>;
   public setSuppressed(suppressed: boolean): Promise<void>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This changes `VoiceState#kick()` to `VoiceState#disconnect()`.

Changing it to use disconnect reflects well on descriptions elsewhere such as `VoiceState#setChannel()` and `GuildMemberEditData` and the [Discord documentation](https://discord.com/developers/docs/resources/guild#modify-guild-member). Even in the Discord client when you right click someone, the option is "disconnect". I feel like this is a consistent change that should be made.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
