### PR TITLE
refactor(GuildChannel): use filter method for #members

### DIFF
--- a/src/structures/BaseGuildVoiceChannel.js
+++ b/src/structures/BaseGuildVoiceChannel.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { Collection } = require('@discordjs/collection');
 const GuildChannel = require('./GuildChannel');
 const Permissions = require('../util/Permissions');
 

--- a/src/structures/BaseGuildVoiceChannel.js
+++ b/src/structures/BaseGuildVoiceChannel.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Collection } = require('@discordjs/collection');
 const GuildChannel = require('./GuildChannel');
 const Permissions = require('../util/Permissions');
 
@@ -36,7 +37,13 @@ class BaseGuildVoiceChannel extends GuildChannel {
    * @readonly
    */
   get members() {
-    return this.guild.voiceStates.cache.filter(s => s.channelId === this.id && s.member);
+    const coll = new Collection();
+    for (const state of this.guild.voiceStates.cache.values()) {
+      if (state.channelId === this.id && state.member) {
+        coll.set(state.id, state.member);
+      }
+    }
+    return coll;
   }
 
   /**

--- a/src/structures/BaseGuildVoiceChannel.js
+++ b/src/structures/BaseGuildVoiceChannel.js
@@ -37,13 +37,7 @@ class BaseGuildVoiceChannel extends GuildChannel {
    * @readonly
    */
   get members() {
-    const coll = new Collection();
-    for (const state of this.guild.voiceStates.cache.values()) {
-      if (state.channelId === this.id && state.member) {
-        coll.set(state.id, state.member);
-      }
-    }
-    return coll;
+    return this.guild.voiceStates.cache.filter(s => s.channelId === this.id && s.member);
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -258,13 +258,7 @@ class GuildChannel extends Channel {
    * @readonly
    */
   get members() {
-    const members = new Collection();
-    for (const member of this.guild.members.cache.values()) {
-      if (this.permissionsFor(member).has(Permissions.FLAGS.VIEW_CHANNEL, false)) {
-        members.set(member.id, member);
-      }
-    }
-    return members;
+    return this.guild.members.cache.filter(m => this.permissionsFor(m).has(Permissions.FLAGS.VIEW_CHANNEL));
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -257,7 +257,7 @@ class GuildChannel extends Channel {
    * @readonly
    */
   get members() {
-    return this.guild.members.cache.filter(m => this.permissionsFor(m).has(Permissions.FLAGS.VIEW_CHANNEL));
+    return this.guild.members.cache.filter(m => this.permissionsFor(m).has(Permissions.FLAGS.VIEW_CHANNEL, false));
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { Collection } = require('@discordjs/collection');
 const Channel = require('./Channel');
 const PermissionOverwrites = require('./PermissionOverwrites');
 const { Error } = require('../errors');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR modifies `GuildChannel` to use `Collection#filter` for its `members` getter. `BaseGuildVoiceChannel#members` remains unchanged for optimization purposes (one iteration with a for-of loop instead of two using .filter and .map).

Also removes the administrator permission ignore from `GuildChannel#members`, not sure why this was set? If someone has got Administrator permission, even if they don't have View Channel, they are still supposed to see that channel so they should be included in their members.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
