### PR TITLE
types(ApplicationCommand): applicationCommandData type over raw type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "discord.js",
       "version": "13.0.0-dev",
       "license": "Apache-2.0",
       "dependencies": {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -190,7 +190,7 @@ export abstract class Application extends Base {
 }
 
 export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
-  public constructor(client: Client, data: RawApplicationCommandData, guild?: Guild, guildId?: Snowflake);
+  public constructor(client: Client, data: ApplicationCommandData, guild?: Guild, guildId?: Snowflake);
   public applicationId: Snowflake;
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR Changes the typings for the data variable inside ApplicationCommand. As of now, it requires RawApplicationCommandData, which is the incorrect type. This fixes that by reverting to the ApplicationCommandData type.


**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

- I know how to update typings and have done so, or typings don't need updating