### PR TITLE
fix(ChannelUpdate): restore accidentally removed line

### DIFF
--- a/src/client/actions/ChannelUpdate.js
+++ b/src/client/actions/ChannelUpdate.js
@@ -15,6 +15,7 @@ class ChannelUpdateAction extends Action {
       if (ChannelTypes[channel.type] !== data.type) {
         const newChannel = Channel.create(this.client, data, channel.guild);
         for (const [id, message] of channel.messages.cache) newChannel.messages.cache.set(id, message);
+        channel = newChannel;
         this.client.channels.cache.set(channel.id, channel);
       }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

#6114 accidentally removed a line which caused a converted TextChannel to not be updated.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
