### PR TITLE
docs: add missing semicolon to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const rest = new REST({ version: '9' }).setToken('token');
     } catch (error) {
       console.error(error);
     }
-})()
+})();
 ```
 
 Afterwards we can create a quite simple example bot:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The new example of the README was missing a semicolon, added it for consistency with the styling since the guide has that semicolon and it's used everywhere else at the end of functions


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->