### PR TITLE
fix(Message): make #channel and #guild getters

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -28,7 +28,7 @@ class MessageManager extends CachedManager {
    */
 
   _add(data, cache) {
-    return super._add(data, cache, { extras: [this.channel] });
+    return super._add(data, cache);
   }
 
   /**

--- a/src/managers/ReactionManager.js
+++ b/src/managers/ReactionManager.js
@@ -58,7 +58,7 @@ class ReactionManager extends CachedManager {
    * @returns {Promise<Message>}
    */
   async removeAll() {
-    await this.client.api.channels(this.message.channel.id).messages(this.message.id).reactions.delete();
+    await this.client.api.channels(this.message.channelId).messages(this.message.id).reactions.delete();
     return this.message;
   }
 }

--- a/src/managers/ReactionUserManager.js
+++ b/src/managers/ReactionUserManager.js
@@ -40,7 +40,7 @@ class ReactionUserManager extends CachedManager {
    */
   async fetch({ limit = 100, after } = {}) {
     const message = this.reaction.message;
-    const data = await this.client.api.channels[message.channel.id].messages[message.id].reactions[
+    const data = await this.client.api.channels[message.channelId].messages[message.id].reactions[
       this.reaction.emoji.identifier
     ].get({ query: { limit, after } });
     const users = new Collection();
@@ -61,7 +61,7 @@ class ReactionUserManager extends CachedManager {
     const userId = this.client.users.resolveId(user);
     if (!userId) throw new Error('REACTION_RESOLVE_USER');
     const message = this.reaction.message;
-    await this.client.api.channels[message.channel.id].messages[message.id].reactions[this.reaction.emoji.identifier][
+    await this.client.api.channels[message.channelId].messages[message.id].reactions[this.reaction.emoji.identifier][
       userId === this.client.user.id ? '@me' : userId
     ].delete();
     return this.reaction;

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -27,16 +27,21 @@ class Message extends Base {
   /**
    * @param {Client} client The instantiating client
    * @param {APIMessage} data The data for the message
-   * @param {TextBasedChannels} channel The channel the message was sent in
    */
-  constructor(client, data, channel) {
+  constructor(client, data) {
     super(client);
 
     /**
-     * The channel that the message was sent in
-     * @type {TextBasedChannels}
+     * The id of the channel the message was sent in
+     * @type {Snowflake}
      */
-    this.channel = channel;
+    this.channelId = data.channel_id;
+
+    /**
+     * The id of the guild the message was sent in, if any
+     * @type {?Snowflake}
+     */
+    this.guildId = data.guild_id ?? null;
 
     /**
      * Whether this message has been deleted
@@ -334,6 +339,15 @@ class Message extends Base {
   }
 
   /**
+   * The channel that the message was sent in
+   * @type {TextChannel|DMChannel|NewsChannel|ThreadChannel}
+   * @readonly
+   */
+  get channel() {
+    return this.client.channels.resolve(this.channelId);
+  }
+
+  /**
    * Whether or not this message is a partial
    * @type {boolean}
    * @readonly
@@ -376,7 +390,7 @@ class Message extends Base {
    * @readonly
    */
   get guild() {
-    return this.channel.guild ?? null;
+    return this.client.guilds.resolve(this.guildId);
   }
 
   /**
@@ -405,7 +419,7 @@ class Message extends Base {
    * @readonly
    */
   get url() {
-    return `https://discord.com/channels/${this.guild ? this.guild.id : '@me'}/${this.channel.id}/${this.id}`;
+    return `https://discord.com/channels/${this.guildId ?? '@me'}/${this.channelId}/${this.id}`;
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -304,7 +304,7 @@ class Message extends Base {
     }
 
     if (data.referenced_message) {
-      this.channel.messages._add(data.referenced_message);
+      this.channel?.messages._add(data.referenced_message);
     }
 
     /**
@@ -410,7 +410,7 @@ class Message extends Base {
    * @readonly
    */
   get thread() {
-    return this.channel.threads.resolve(this.id);
+    return this.channel?.threads.resolve(this.id) ?? null;
   }
 
   /**

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -70,7 +70,7 @@ class MessageCollector extends Collector {
      * @event MessageCollector#collect
      * @param {Message} message The message that was collected
      */
-    if (message.channel.id !== this.channel.id) return null;
+    if (message.channelId !== this.channel.id) return null;
     this.received++;
     return message.id;
   }
@@ -86,7 +86,7 @@ class MessageCollector extends Collector {
      * @event MessageCollector#dispose
      * @param {Message} message The message that was disposed of
      */
-    return message.channel.id === this.channel.id ? message.id : null;
+    return message.channelId === this.channel.id ? message.id : null;
   }
 
   /**

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -70,7 +70,7 @@ class MessageMentions {
       } else {
         this.roles = new Collection();
         for (const mention of roles) {
-          const role = message.channel.guild.roles.cache.get(mention);
+          const role = message.guild.roles.cache.get(mention);
           if (role) this.roles.set(role.id, role);
         }
       }

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -69,8 +69,9 @@ class MessageMentions {
         this.roles = new Collection(roles);
       } else {
         this.roles = new Collection();
+        const guild = message.guild;
         for (const mention of roles) {
-          const role = message.guild.roles.cache.get(mention);
+          const role = guild.roles.cache.get(mention);
           if (role) this.roles.set(role.id, role);
         }
       }

--- a/src/structures/MessagePayload.js
+++ b/src/structures/MessagePayload.js
@@ -167,9 +167,8 @@ class MessagePayload {
 
     let message_reference;
     if (typeof this.options.reply === 'object') {
-      const message_id = this.isMessage
-        ? this.target.channel.messages.resolveId(this.options.reply.messageReference)
-        : this.target.messages.resolveId(this.options.reply.messageReference);
+      const reference = this.options.reply.messageReference;
+      const message_id = this.isMessage ? reference.id ?? reference : this.target.messages.resolveId(reference);
       if (message_id) {
         message_reference = {
           message_id,

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -63,7 +63,7 @@ class MessageReaction {
    */
   async remove() {
     await this.client.api
-      .channels(this.message.channel.id)
+      .channels(this.message.channelId)
       .messages(this.message.id)
       .reactions(this._emoji.identifier)
       .delete();

--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -176,7 +176,7 @@ class ReactionCollector extends Collector {
    * @returns {void}
    */
   _handleChannelDeletion(channel) {
-    if (channel.id === this.message.channel.id) {
+    if (channel.id === this.message.channelId) {
       this.stop('channelDelete');
     }
   }

--- a/test/random.js
+++ b/test/random.js
@@ -234,12 +234,12 @@ client.on('messageCreate', msg => {
 });
 
 client.on('messageReactionAdd', (reaction, user) => {
-  if (reaction.message.channel.id !== '222086648706498562') return;
+  if (reaction.message.channelId !== '222086648706498562') return;
   reaction.message.channel.send(`${user.username} added reaction ${reaction.emoji}, count is now ${reaction.count}`);
 });
 
 client.on('messageReactionRemove', (reaction, user) => {
-  if (reaction.message.channel.id !== '222086648706498562') return;
+  if (reaction.message.channelId !== '222086648706498562') return;
   reaction.message.channel.send(`${user.username} removed reaction ${reaction.emoji}, count is now ${reaction.count}`);
 });
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1048,7 +1048,7 @@ export class LimitedCollection<K, V> extends Collection<K, V> {
 }
 
 export class Message extends Base {
-  public constructor(client: Client, data: RawMessageData, channel: TextBasedChannels);
+  public constructor(client: Client, data: RawMessageData);
   private _patch(data: RawPartialMessageData, partial: true): Message;
   private _patch(data: RawMessageData, partial?: boolean): Message;
   private _update(data: RawPartialMessageData, partial: true): Message;
@@ -1058,7 +1058,8 @@ export class Message extends Base {
   public applicationId: Snowflake | null;
   public attachments: Collection<Snowflake, MessageAttachment>;
   public author: User;
-  public channel: TextBasedChannels;
+  public readonly channel: TextBasedChannels;
+  public channelId: Snowflake;
   public readonly cleanContent: string;
   public components: MessageActionRow[];
   public content: string;
@@ -1072,6 +1073,7 @@ export class Message extends Base {
   public editedTimestamp: number | null;
   public embeds: MessageEmbed[];
   public groupActivityApplication: ClientApplication | null;
+  public guildId: Snowflake | null;
   public readonly guild: Guild | null;
   public readonly hasThread: boolean;
   public id: Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

While the direct issue outlined in #6168 has been fixed in #6263, the same issue (`Message#channel` returning a text channel) still persists for old messages sent in this same channel before it was converted. As outlined in the issue the least intrusive way to fix this I could think of is making `Message#channel` a getter to retrieve the channel from cache on demand. I use the Client cache (versus the guild cache) to be robust against DMs, if that has any caveats I did not think of, please let me know

- Make `Message#channel` a getter
- Change`Message#guild` getter (relied on `Message#channel` before)
- remove the extra channel from the Message constructor and `MessageManager#_add` call
- use ids within Message structure when possible
- use `Message#channelId` whenever possible in other structures
- shortcut `Message#channel#guild` to `Message#guild`

| :warning: technically this has the caveat of evicting the channel from cache and trying to do operations with the message that rely on its channel. to fix this a plethora of operations on the Message class would need to be changed to use optional chaining or even throw if the channel is not available. however for now we decided to handle it like this: <br><br> DO NOT UNCACHE CHANNELS IF YOU NEED THEM TO DO THINGS |
| --- |

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
