### PR TITLE
docs: Correct wrong interaction links

### DIFF
--- a/src/managers/ApplicationCommandPermissionsManager.js
+++ b/src/managers/ApplicationCommandPermissionsManager.js
@@ -411,6 +411,7 @@ class ApplicationCommandPermissionsManager extends BaseManager {
 
 module.exports = ApplicationCommandPermissionsManager;
 
+/* eslint-disable max-len */
 /**
  * @external APIApplicationCommandPermissions
  * @see {@link https://discord.com/developers/docs/interactions/slash-commands#application-command-permissions-object-application-command-permissions-structure}

--- a/src/managers/ApplicationCommandPermissionsManager.js
+++ b/src/managers/ApplicationCommandPermissionsManager.js
@@ -413,5 +413,5 @@ module.exports = ApplicationCommandPermissionsManager;
 
 /**
  * @external APIApplicationCommandPermissions
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#applicationcommandpermissions}
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#application-command-permissions-object-application-command-permissions-structure}
  */

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -192,10 +192,10 @@ module.exports = ApplicationCommand;
 
 /**
  * @external APIApplicationCommand
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#applicationcommand}
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-structure}
  */
 
 /**
  * @external APIApplicationCommandOption
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoption}
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-structure}
  */

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -190,11 +190,13 @@ class ApplicationCommand extends Base {
 
 module.exports = ApplicationCommand;
 
+/* eslint-disable max-len */
 /**
  * @external APIApplicationCommand
  * @see {@link https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-structure}
  */
 
+/* eslint-disable max-len */
 /**
  * @external APIApplicationCommandOption
  * @see {@link https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-structure}

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -92,8 +92,8 @@ class CommandInteraction extends Interaction {
    * @property {CommandInteractionOption[]} [options] Additional options if this option is a
    * subcommand (group)
    * @property {User} [user] The resolved user
-   * @property {GuildMember|APIInteractionDataResolvedGuildMember} [member] The resolved member
-   * @property {GuildChannel|APIInteractionDataResolvedChannel} [channel] The resolved channel
+   * @property {GuildMember|APIInteractionDataResolvedOption} [member] The resolved member
+   * @property {GuildChannel|APIInteractionDataResolvedOption} [channel] The resolved channel
    * @property {Role|APIRole} [role] The resolved role
    */
 
@@ -153,11 +153,6 @@ module.exports = CommandInteraction;
  */
 
 /**
- * @external APIInteractionDataResolvedChannel
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-object-application-command-interaction-data-resolved-structure}
- */
-
-/**
- * @external APIInteractionDataResolvedGuildMember
+ * @external APIInteractionDataResolvedOption
  * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-object-application-command-interaction-data-resolved-structure}
  */

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -92,8 +92,8 @@ class CommandInteraction extends Interaction {
    * @property {CommandInteractionOption[]} [options] Additional options if this option is a
    * subcommand (group)
    * @property {User} [user] The resolved user
-   * @property {GuildMember|APIGuildMember} [member] The resolved member
-   * @property {GuildChannel|APIChannel} [channel] The resolved channel
+   * @property {GuildMember|APIInteractionDataResolvedGuildMember} [member] The resolved member
+   * @property {GuildChannel|APIInteractionDataResolvedChannel} [channel] The resolved channel
    * @property {Role|APIRole} [role] The resolved role
    */
 
@@ -150,4 +150,14 @@ module.exports = CommandInteraction;
 /**
  * @external APIApplicationCommandOptionResolved
  * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-applicationcommandinteractiondataresolved}
+ */
+
+/**
+ * @external APIInteractionDataResolvedChannel
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-object-application-command-interaction-data-resolved-structure}
+ */
+
+/**
+ * @external APIInteractionDataResolvedGuildMember
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-object-application-command-interaction-data-resolved-structure}
  */

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -154,5 +154,5 @@ module.exports = CommandInteraction;
 
 /**
  * @external APIInteractionDataResolvedOption
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-object-application-command-interaction-data-resolved-structure}
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#sample-application-command-interaction-application-command-interaction-data-resolved-structure}
  */

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -134,7 +134,7 @@ class CommandInteractionOptionResolver {
    * Gets a channel option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?(GuildChannel|APIInteractionDataResolvedChannel)}
+   * @returns {?(GuildChannel|APIInteractionDataResolvedOption)}
    * The value of the option, or null if not set and not required.
    */
   getChannel(name, required = false) {
@@ -190,7 +190,7 @@ class CommandInteractionOptionResolver {
    * Gets a member option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?(GuildMember|APIInteractionDataResolvedGuildMember)}
+   * @returns {?(GuildMember|APIInteractionDataResolvedOption)}
    * The value of the option, or null if not set and not required.
    */
   getMember(name, required = false) {
@@ -213,7 +213,7 @@ class CommandInteractionOptionResolver {
    * Gets a mentionable option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?(User|GuildMember|APIInteractionDataResolvedGuildMember|Role|APIRole)}
+   * @returns {?(User|GuildMember|APIInteractionDataResolvedOption|Role|APIRole)}
    * The value of the option, or null if not set and not required.
    */
   getMentionable(name, required = false) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Some links related to interactions were wrong (you can tell straight away because there was no `-` separating the words!) - I've gone ahead and pointed them to the correct area.

`APIInteractionDataResolvedChannel` & `APIInteractionDataResolvedGuildMember` were missing documentation links, so I've gone ahead and pointed them to https://discord.com/developers/docs/interactions/slash-commands#interaction-object-application-command-interaction-data-resolved-structure instead of the usual structure's object. This is because in this link, it tells you _exactly_ what to expect from the data received rather than looking at the whole object and taking guesses:
> Partial Member objects are missing user, deaf and mute fields
> Partial Channel objects only have id, name, type and permissions fields

I've also changed `CommandInteractionOption`'s properties to use `APIInteractionDataResolvedChannel` and `APIInteractionDataResolvedGuildMember` as these are more specific and correct.

I would also correct `APIApplicationCommandOptionResolved`, but I am not sure what this is supposed to be. I also cannot find any typings of this. It looks like https://discord.com/developers/docs/interactions/slash-commands#interaction-object-application-command-interaction-data-resolved-structure but I'm not comfortable with this as it has no typings for me to verify against - is anybody able to confirm this? Maybe @vladfrangu since I can't find it even in [discordjs/discord-api-types](https://github.com/discordjs/discord-api-types)?

Additionally, whilst I corrected the link of `APIApplicationCommandPermissions`, I cannot find any typings of this either...

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
