### PR TITLE
fix(Action): getChannel interaction DM

### DIFF
--- a/src/client/actions/Action.js
+++ b/src/client/actions/Action.js
@@ -39,7 +39,7 @@ class GenericAction {
         {
           id,
           guild_id: data.guild_id,
-          recipients: [data.author ?? { id: data.user_id }],
+          recipients: [data.author ?? data.user ?? { id: data.user_id }],
         },
         this.client.channels,
         id,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since #5906 interaction channels get resolved by Action#getChannel, however this method does not account for the User being in data.user for interactions instead of data.author. Since the interaction data does not include a 'user_id' field a partial user with the id of `undefined` gets added to the cache if the interaction is triggered from a DM channel.
I am not too familiar with discord.js internals, so I hope this change does not break something elsewhere (tested it for a few days on a fork and my bot ran fine with it)


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
