### PR TITLE
docs(Client): mark _finalize as private

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -366,6 +366,7 @@ class Client extends BaseClient {
    * @param {Function} options.cleanup The function called to GC
    * @param {string} [options.message] The message to send after a successful GC
    * @param {string} [options.name] The name of the item being GCed
+   * @private
    */
   _finalize({ cleanup, message, name }) {
     try {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Client#_finalize is currently showing up in the docs due it being not marked as private


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
