### PR TITLE
fix(WebSocketShard): mark shard ready if no guilds intent

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -474,17 +474,23 @@ class WebSocketShard extends EventEmitter {
       this.emit(ShardEvents.ALL_READY);
       return;
     }
+    let time = 15000;
+    if (!new Intents(this.manager.client.options.intents).has(Intents.FLAGS.GUILDS)) {
+      time = 0;
+    }
     // Step 2. Create a 15s timeout that will mark the shard as ready if there are still unavailable guilds
     this.readyTimeout = setTimeout(() => {
-      this.debug(`Shard did not receive any more guild packets in 15 seconds.
-  Unavailable guild count: ${this.expectedGuilds.size}`);
+      this.debug(
+        `Shard ${time === 0 ? 'will' : 'did'} not receive any more guild packets` +
+          `${time === 0 ? '' : ' in 15 seconds'}.\n   Unavailable guild count: ${this.expectedGuilds.size}`,
+      );
 
       this.readyTimeout = null;
 
       this.status = Status.READY;
 
       this.emit(ShardEvents.ALL_READY, this.expectedGuilds);
-    }, 15000).unref();
+    }, time).unref();
   }
 
   /**

--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -474,23 +474,23 @@ class WebSocketShard extends EventEmitter {
       this.emit(ShardEvents.ALL_READY);
       return;
     }
-    let time = 15000;
-    if (!new Intents(this.manager.client.options.intents).has(Intents.FLAGS.GUILDS)) {
-      time = 0;
-    }
+    const hasGuildsIntent = new Intents(this.manager.client.options.intents).has(Intents.FLAGS.GUILDS);
     // Step 2. Create a 15s timeout that will mark the shard as ready if there are still unavailable guilds
-    this.readyTimeout = setTimeout(() => {
-      this.debug(
-        `Shard ${time === 0 ? 'will' : 'did'} not receive any more guild packets` +
-          `${time === 0 ? '' : ' in 15 seconds'}.\n   Unavailable guild count: ${this.expectedGuilds.size}`,
-      );
+    this.readyTimeout = setTimeout(
+      () => {
+        this.debug(
+          `Shard ${hasGuildsIntent ? 'did' : 'will'} not receive any more guild packets` +
+            `${hasGuildsIntent ? ' in 15 seconds' : ''}.\n   Unavailable guild count: ${this.expectedGuilds.size}`,
+        );
 
-      this.readyTimeout = null;
+        this.readyTimeout = null;
 
-      this.status = Status.READY;
+        this.status = Status.READY;
 
-      this.emit(ShardEvents.ALL_READY, this.expectedGuilds);
-    }, time).unref();
+        this.emit(ShardEvents.ALL_READY, this.expectedGuilds);
+      },
+      hasGuildsIntent ? 15000 : 0,
+    ).unref();
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a bug where the client would not emit ready despite being ready, having to wait 15 seconds instead when no guilds intent was specified

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
