### PR TITLE
refactor: added `TextBasedChannels` type

### DIFF
--- a/src/client/websocket/handlers/CHANNEL_PINS_UPDATE.js
+++ b/src/client/websocket/handlers/CHANNEL_PINS_UPDATE.js
@@ -14,7 +14,7 @@ module.exports = (client, { d: data }) => {
      * Emitted whenever the pins of a channel are updated. Due to the nature of the WebSocket event,
      * not much information can be provided easily here - you need to manually check the pins yourself.
      * @event Client#channelPinsUpdate
-     * @param {DMChannel|TextChannel|NewsChannel} channel The channel that the pins update occurred in
+     * @param {TextBasedChannels} channel The channel that the pins update occurred in
      * @param {Date} time The time of the pins update
      */
     client.emit(Events.CHANNEL_PINS_UPDATE, channel, time);

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -16,7 +16,7 @@ class MessageManager extends CachedManager {
 
     /**
      * The channel that the messages belong to
-     * @type {TextBasedChannel}
+     * @type {TextBasedChannels}
      */
     this.channel = channel;
   }

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -110,8 +110,7 @@ class Channel extends Base {
   }
 
   /**
-   * Indicates whether this channel is text-based
-   * ({@link TextChannel}, {@link DMChannel}, {@link NewsChannel} or {@link ThreadChannel}).
+   * Indicates whether this channel is {@link TextBasedChannels text-based}.
    * @returns {boolean}
    */
   isText() {

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -17,7 +17,7 @@ class CommandInteraction extends Interaction {
 
     /**
      * The channel this interaction was sent in
-     * @type {?(TextChannel|NewsChannel|DMChannel)}
+     * @type {?TextBasedChannels}
      * @name CommandInteraction#channel
      * @readonly
      */

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -89,7 +89,7 @@ class Interaction extends Base {
 
   /**
    * The channel this interaction was sent in
-   * @type {?Channel}
+   * @type {?TextBasedChannels}
    * @readonly
    */
   get channel() {

--- a/src/structures/InteractionCollector.js
+++ b/src/structures/InteractionCollector.js
@@ -7,7 +7,7 @@ const { InteractionTypes, MessageComponentTypes } = require('../util/Constants')
 
 /**
  * @typedef {CollectorOptions} InteractionCollectorOptions
- * @property {TextChannel|DMChannel|NewsChannel} [channel] The channel to listen to interactions from
+ * @property {TextBasedChannels} [channel] The channel to listen to interactions from
  * @property {MessageComponentType} [componentType] The type of component to listen for
  * @property {Guild} [guild] The guild to listen to interactions from
  * @property {InteractionType} [interactionType] The type of interaction to listen for
@@ -39,7 +39,7 @@ class InteractionCollector extends Collector {
 
     /**
      * The channel from which to collect interactions, if provided
-     * @type {?(TextChannel|DMChannel|NewsChannel)}
+     * @type {?TextBasedChannels}
      */
     this.channel = this.message?.channel ?? options.channel ?? null;
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -27,14 +27,14 @@ class Message extends Base {
   /**
    * @param {Client} client The instantiating client
    * @param {APIMessage} data The data for the message
-   * @param {TextChannel|DMChannel|NewsChannel|ThreadChannel} channel The channel the message was sent in
+   * @param {TextBasedChannels} channel The channel the message was sent in
    */
   constructor(client, data, channel) {
     super(client);
 
     /**
      * The channel that the message was sent in
-     * @type {TextChannel|DMChannel|NewsChannel|ThreadChannel}
+     * @type {TextBasedChannels}
      */
     this.channel = channel;
 

--- a/src/structures/MessageCollector.js
+++ b/src/structures/MessageCollector.js
@@ -16,7 +16,7 @@ const { Events } = require('../util/Constants');
  */
 class MessageCollector extends Collector {
   /**
-   * @param {TextChannel|DMChannel} channel The channel
+   * @param {TextBasedChannels} channel The channel
    * @param {MessageCollectorOptions} options The options to be applied to this collector
    * @emits MessageCollector#message
    */
@@ -25,7 +25,7 @@ class MessageCollector extends Collector {
 
     /**
      * The channel
-     * @type {TextBasedChannel}
+     * @type {TextBasedChannels}
      */
     this.channel = channel;
 

--- a/src/structures/Typing.js
+++ b/src/structures/Typing.js
@@ -8,7 +8,7 @@ const Base = require('./Base');
  */
 class Typing extends Base {
   /**
-   * @param {TextChannel|DMChannel|NewsChannel|ThreadChannel} channel The channel this typing came from
+   * @param {TextBasedChannels} channel The channel this typing came from
    * @param {User} user The user that started typing
    * @param {APITypingStart} data The raw data received
    */
@@ -17,7 +17,7 @@ class Typing extends Base {
 
     /**
      * The channel the status is from
-     * @type {TextChannel|DMChannel|NewsChannel|ThreadChannel}
+     * @type {TextBasedChannels}
      */
     this.channel = channel;
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -458,12 +458,11 @@ exports.ChannelTypes = createEnum([
 
 /**
  * The channels that are text-based.
- * * PartialDMChannel
  * * DMChannel
  * * TextChannel
  * * NewsChannel
  * * ThreadChannel
- * @typedef {PartialDMChannel|DMChannel|TextChannel|NewsChannel|ThreadChannel} TextBasedChannels
+ * @typedef {DMChannel|TextChannel|NewsChannel|ThreadChannel} TextBasedChannels
  */
 
 /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -457,6 +457,16 @@ exports.ChannelTypes = createEnum([
 ]);
 
 /**
+ * The channels that are text-based.
+ * * PartialDMChannel
+ * * DMChannel
+ * * TextChannel
+ * * NewsChannel
+ * * ThreadChannel
+ * @typedef {PartialDMChannel|DMChannel|TextChannel|NewsChannel|ThreadChannel} TextBasedChannels
+ */
+
+/**
  * The types of channels that are text-based. The available types are:
  * * DM
  * * GUILD_TEXT

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -330,7 +330,7 @@ export class Channel extends Base {
   public type: keyof typeof ChannelTypes;
   public delete(): Promise<Channel>;
   public fetch(force?: boolean): Promise<Channel>;
-  public isText(): this is TextChannel | DMChannel | NewsChannel | ThreadChannel;
+  public isText(): this is TextBasedChannels;
   public isThread(): this is ThreadChannel;
   public toString(): ChannelMention;
 }
@@ -472,7 +472,7 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
 export class CommandInteraction extends Interaction {
   public constructor(client: Client, data: RawCommandInteractionData);
   public readonly command: ApplicationCommand | ApplicationCommand<{ guild: GuildResolvable }> | null;
-  public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | ThreadChannel | null;
+  public readonly channel: TextBasedChannels | null;
   public channelId: Snowflake;
   public commandId: Snowflake;
   public commandName: string;
@@ -939,7 +939,7 @@ export class Intents extends BitField<IntentsString> {
 export class Interaction extends Base {
   public constructor(client: Client, data: RawInteractionData);
   public applicationId: Snowflake;
-  public readonly channel: Channel | PartialDMChannel | null;
+  public readonly channel: TextBasedChannels | null;
   public channelId: Snowflake | null;
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -964,7 +964,7 @@ export class InteractionCollector<T extends Interaction> extends Collector<Snowf
   private _handleChannelDeletion(channel: GuildChannel): void;
   private _handleGuildDeletion(guild: Guild): void;
 
-  public channel: TextChannel | NewsChannel | DMChannel | null;
+  public channel: TextBasedChannels | null;
   public componentType: MessageComponentType | null;
   public readonly endReason: string | null;
   public guild: Guild | null;
@@ -1048,11 +1048,7 @@ export class LimitedCollection<K, V> extends Collection<K, V> {
 }
 
 export class Message extends Base {
-  public constructor(
-    client: Client,
-    data: RawMessageData,
-    channel: TextChannel | DMChannel | NewsChannel | ThreadChannel,
-  );
+  public constructor(client: Client, data: RawMessageData, channel: TextBasedChannels);
   private _patch(data: RawPartialMessageData, partial: true): Message;
   private _patch(data: RawMessageData, partial?: boolean): Message;
   private _update(data: RawPartialMessageData, partial: true): Message;
@@ -1062,7 +1058,7 @@ export class Message extends Base {
   public applicationId: Snowflake | null;
   public attachments: Collection<Snowflake, MessageAttachment>;
   public author: User;
-  public channel: TextChannel | DMChannel | NewsChannel | ThreadChannel;
+  public channel: TextBasedChannels;
   public readonly cleanContent: string;
   public components: MessageActionRow[];
   public content: string;
@@ -1175,11 +1171,11 @@ export class MessageButton extends BaseMessageComponent {
 }
 
 export class MessageCollector extends Collector<Snowflake, Message> {
-  public constructor(channel: TextChannel | DMChannel | ThreadChannel, options?: MessageCollectorOptions);
+  public constructor(channel: TextBasedChannels, options?: MessageCollectorOptions);
   private _handleChannelDeletion(channel: GuildChannel): void;
   private _handleGuildDeletion(guild: Guild): void;
 
-  public channel: TextChannel | DMChannel | ThreadChannel;
+  public channel: TextBasedChannels;
   public readonly endReason: string | null;
   public options: MessageCollectorOptions;
   public received: number;
@@ -1190,7 +1186,7 @@ export class MessageCollector extends Collector<Snowflake, Message> {
 
 export class MessageComponentInteraction extends Interaction {
   public constructor(client: Client, data: RawMessageComponentInteractionData);
-  public readonly channel: TextChannel | DMChannel | NewsChannel | PartialDMChannel | ThreadChannel | null;
+  public readonly channel: TextBasedChannels | null;
   public readonly component: MessageActionRowComponent | Exclude<APIMessageComponent, APIActionRowComponent> | null;
   public componentType: MessageComponentType;
   public customId: string;
@@ -1813,12 +1809,8 @@ export class ThreadMemberFlags extends BitField<ThreadMemberFlagsString> {
 }
 
 export class Typing extends Base {
-  public constructor(
-    channel: TextChannel | PartialDMChannel | NewsChannel | ThreadChannel,
-    user: PartialUser,
-    data?: RawTypingData,
-  );
-  public channel: TextChannel | PartialDMChannel | NewsChannel | ThreadChannel;
+  public constructor(channel: TextBasedChannels, user: PartialUser, data?: RawTypingData);
+  public channel: TextBasedChannels;
   public user: PartialUser;
   public startedTimestamp: number;
   public readonly startedAt: Date;
@@ -2499,8 +2491,8 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
 }
 
 export class MessageManager extends CachedManager<Snowflake, Message, MessageResolvable> {
-  public constructor(channel: TextChannel | DMChannel | ThreadChannel, iterable?: Iterable<RawMessageData>);
-  public channel: TextBasedChannelFields;
+  public constructor(channel: TextBasedChannels, iterable?: Iterable<RawMessageData>);
+  public channel: TextBasedChannels;
   public cache: Collection<Snowflake, Message>;
   public crosspost(message: MessageResolvable): Promise<Message>;
   public delete(message: MessageResolvable): Promise<void>;
@@ -3039,7 +3031,7 @@ export interface ClientEvents {
   applicationCommandUpdate: [oldCommand: ApplicationCommand | null, newCommand: ApplicationCommand];
   channelCreate: [channel: GuildChannel];
   channelDelete: [channel: DMChannel | GuildChannel];
-  channelPinsUpdate: [channel: TextChannel | NewsChannel | DMChannel | PartialDMChannel, date: Date];
+  channelPinsUpdate: [channel: TextBasedChannels, date: Date];
   channelUpdate: [oldChannel: DMChannel | GuildChannel, newChannel: DMChannel | GuildChannel];
   debug: [message: string];
   warn: [message: string];
@@ -3788,7 +3780,7 @@ export interface IntegrationAccount {
 }
 
 export interface InteractionCollectorOptions<T extends Interaction> extends CollectorOptions<[T]> {
-  channel?: TextChannel | DMChannel | NewsChannel | ThreadChannel;
+  channel?: TextBasedChannels;
   componentType?: MessageComponentType | MessageComponentTypes;
   guild?: Guild;
   interactionType?: InteractionType | InteractionTypes;
@@ -4421,13 +4413,9 @@ export interface LimitedCollectionOptions<K, V> {
   sweepInterval?: number;
 }
 
-export type TextBasedChannelTypes =
-  | 'DM'
-  | 'GUILD_TEXT'
-  | 'GUILD_NEWS'
-  | 'GUILD_NEWS_THREAD'
-  | 'GUILD_PUBLIC_THREAD'
-  | 'GUILD_PRIVATE_THREAD';
+export type TextBasedChannels = PartialDMChannel | DMChannel | TextChannel | NewsChannel | ThreadChannel;
+
+export type TextBasedChannelTypes = TextBasedChannels['type'];
 
 export type TextChannelResolvable = Snowflake | TextChannel;
 

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -49,6 +49,7 @@ import {
   StageChannel,
   StoreChannel,
   TextBasedChannelFields,
+  TextBasedChannels,
   TextChannel,
   ThreadChannel,
   Typing,
@@ -662,7 +663,7 @@ declare const typing: Typing;
 assertType<PartialUser>(typing.user);
 if (typing.user.partial) assertType<null>(typing.user.username);
 
-assertType<TextChannel | PartialDMChannel | NewsChannel | ThreadChannel>(typing.channel);
+assertType<TextBasedChannels>(typing.channel);
 if (typing.channel.partial) assertType<undefined>(typing.channel.lastMessageId);
 
 assertType<GuildMember | null>(typing.member);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

At the moment, if Discord adds a new channel type, we have to update the types in many places, this creates issues as far as the type consistency go, such as `MessageCollector` not accepting `NewsChannel` as a valid channel type.

I also considered #6262 as an alternative fix for this, however, a generic type doesn't have many of the benefits from an union, such as being able to exclude certain types (`channel.guild ? <channel is TextChannel | NewsChannel | ThreadChannel> : <channel is DMChannel | PartialDMChannel>`).

I also made a typedef in the JavaScript side so the documentation for it is readily available in the documentation website, and refactored the TS type for `TextBasedChannelTypes` to read the new type's `type` field, so any change we do to `TextBasedChannels` will reflect on it.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
