### PR TITLE
types(MessageButtonOptions): Clean up and export some button option type definitions

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3908,17 +3908,17 @@ export interface BaseButtonOptions extends BaseMessageComponentOptions {
   label?: string;
 }
 
-export type MessageButtonOptions = BaseButtonOptions &
-  (
-    | {
-        style: Exclude<MessageButtonStyleResolvable, 'LINK' | MessageButtonStyles.LINK>;
-        customId: string;
-      }
-    | {
-        style: 'LINK' | MessageButtonStyles.LINK;
-        url: string;
-      }
-  );
+export interface LinkButtonOptions extends BaseButtonOptions {
+  style: 'LINK' | MessageButtonStyles.LINK;
+  url: string;
+}
+
+export interface NonLinkButtonOptions extends BaseButtonOptions {
+  style: Exclude<MessageButtonStyleResolvable, 'LINK' | MessageButtonStyles.LINK>;
+  customId: string;
+}
+
+export type MessageButtonOptions = NonLinkButtonOptions | LinkButtonOptions;
 
 export type MessageButtonStyle = keyof typeof MessageButtonStyles;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3913,12 +3913,12 @@ export interface LinkButtonOptions extends BaseButtonOptions {
   url: string;
 }
 
-export interface NonLinkButtonOptions extends BaseButtonOptions {
+export interface InteractionButtonOptions extends BaseButtonOptions {
   style: Exclude<MessageButtonStyleResolvable, 'LINK' | MessageButtonStyles.LINK>;
   customId: string;
 }
 
-export type MessageButtonOptions = NonLinkButtonOptions | LinkButtonOptions;
+export type MessageButtonOptions = InteractionButtonOptions | LinkButtonOptions;
 
 export type MessageButtonStyle = keyof typeof MessageButtonStyles;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This is an addendum to #6212, it simply exports the different button option variants, and cleans up definitions.

**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
