### PR TITLE
docs: grammar fix 

### DIFF
--- a/src/managers/GuildStickerManager.js
+++ b/src/managers/GuildStickerManager.js
@@ -65,13 +65,13 @@ class GuildStickerManager extends CachedManager {
 
   /**
    * Data that resolves to give a Sticker object. This can be:
-   * * An Sticker object
+   * * A Sticker object
    * * A Snowflake
    * @typedef {Sticker|Snowflake} StickerResolvable
    */
 
   /**
-   * Resolves an StickerResolvable to a Sticker object.
+   * Resolves a StickerResolvable to a Sticker object.
    * @method resolve
    * @memberof GuildStickerManager
    * @instance
@@ -80,7 +80,7 @@ class GuildStickerManager extends CachedManager {
    */
 
   /**
-   * Resolves an StickerResolvable to an Sticker id string.
+   * Resolves a StickerResolvable to a Sticker id string.
    * @method resolveId
    * @memberof GuildStickerManager
    * @instance


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a grammar mistake in the documentation, which can be found somewhere like [here](https://discord.js.org/#/docs/main/master/typedef/StickerResolvable). "An Sticker" is not correct, and neither is "an StickerResolvable", and should be "A sticker" instead because Sticker is not a vowel. 

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
