### PR TITLE
types: make MessageTarget extend on TextBasedChannels

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4101,10 +4101,7 @@ export interface MessageSelectOptionData {
 export type MessageTarget =
   | Interaction
   | InteractionWebhook
-  | TextChannel
-  | NewsChannel
-  | ThreadChannel
-  | DMChannel
+  | TextBasedChannels
   | User
   | GuildMember
   | Webhook


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

@kyranet and I found the bug when updating `@skyra/editable-commands` when our custom function that accepted an argument of `MessageTarget` was suddenly no longer accepting `message.channel`. Turns out it was because of a mistake @kyranet made lulz

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
