### PR TITLE
feat(Channel): add isVoice()

### DIFF
--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -9,7 +9,7 @@ let StoreChannel;
 let TextChannel;
 let ThreadChannel;
 let VoiceChannel;
-const { ChannelTypes, ThreadChannelTypes } = require('../util/Constants');
+const { ChannelTypes, ThreadChannelTypes, VoiceBasedChannelTypes } = require('../util/Constants');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
 
 /**
@@ -115,6 +115,15 @@ class Channel extends Base {
    */
   isText() {
     return 'messages' in this;
+  }
+
+  /**
+   * Indicates whether this channel is voice-based
+   * ({@link VoiceChannel} or {@link StageChannel}).
+   * @returns {boolean}
+   */
+  isVoice() {
+    return VoiceBasedChannelTypes.includes(this.type);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -354,6 +354,7 @@ export class Channel extends Base {
   public delete(): Promise<Channel>;
   public fetch(force?: boolean): Promise<Channel>;
   public isText(): this is TextBasedChannels;
+  public isVoice(): this is VoiceChannel | StageChannel;
   public isThread(): this is ThreadChannel;
   public toString(): ChannelMention;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds `isVoice()` type guard to Channel. We already have `isText()` and `isThread()`, so it's logical to have one for voice-based channels as well.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)