### PR TITLE
fix(BaseGuildTextChannel): call patch

### DIFF
--- a/src/structures/BaseGuildTextChannel.js
+++ b/src/structures/BaseGuildTextChannel.js
@@ -39,6 +39,8 @@ class BaseGuildTextChannel extends GuildChannel {
      * @type {boolean}
      */
     this.nsfw = Boolean(data.nsfw);
+
+    this._patch(data);
   }
 
   _patch(data) {


### PR DESCRIPTION
Fixes a bug introduced in #6262 which meant TextChannel and NewsChannel weren't calling `_patch()` on creation.
