### PR TITLE
docs: general cleanup and improvements

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -610,3 +610,8 @@ module.exports = Client;
  * @event Client#debug
  * @param {string} info The debug information
  */
+
+/**
+ * @external Collection
+ * @see {@link https://discord.js.org/#/docs/collection/master/class/Collection}
+ */

--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -175,7 +175,7 @@ class WebSocketManager extends EventEmitter {
          * Emitted when a shard turns ready.
          * @event Client#shardReady
          * @param {number} id The shard id that turned ready
-         * @param {?Set<string>} unavailableGuilds Set of unavailable guild ids, if any
+         * @param {?Set<Snowflake>} unavailableGuilds Set of unavailable guild ids, if any
          */
         this.client.emit(Events.SHARD_READY, shard.id, unavailableGuilds);
 

--- a/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
+++ b/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
@@ -12,15 +12,21 @@ module.exports = (client, { d: data }) => {
   if (data.presences) {
     for (const presence of data.presences) guild.presences._add(Object.assign(presence, { guild }));
   }
+
+  /**
+   * Represents the properties of a guild members chunk
+   * @typedef {Object} GuildMembersChunk
+   * @property {number} index Index of the received chunk
+   * @property {number} count Number of chunks the client should receive
+   * @property {?string} nonce Nonce for this chunk
+   */
+
   /**
    * Emitted whenever a chunk of guild members is received (all members come from the same guild).
    * @event Client#guildMembersChunk
    * @param {Collection<Snowflake, GuildMember>} members The members in the chunk
    * @param {Guild} guild The guild related to the member chunk
-   * @param {Object} chunk Properties of the received chunk
-   * @param {number} chunk.index Index of the received chunk
-   * @param {number} chunk.count Number of chunks the client should receive
-   * @param {?string} chunk.nonce Nonce for this chunk
+   * @param {GuildMembersChunk} chunk Properties of the received chunk
    */
   client.emit(Events.GUILD_MEMBERS_CHUNK, members, guild, {
     count: data.chunk_count,

--- a/src/managers/ApplicationCommandPermissionsManager.js
+++ b/src/managers/ApplicationCommandPermissionsManager.js
@@ -124,7 +124,7 @@ class ApplicationCommandPermissionsManager extends BaseManager {
    * @typedef {BaseApplicationCommandPermissionsOptions} SetApplicationCommandPermissionsOptions
    * @param {ApplicationCommandPermissionData[]} [permissions] The new permissions for the command
    * @param {GuildApplicationCommandPermissionData[]} [fullPermissions] The new permissions for all commands
-   * in a guild <warn>When this parameter is set, permissions and command are ignored</warn>
+   * in a guild <warn>When this parameter is set, `permissions` and `command` are ignored</warn>
    */
 
   /**

--- a/src/managers/GuildBanManager.js
+++ b/src/managers/GuildBanManager.js
@@ -135,7 +135,7 @@ class GuildBanManager extends CachedManager {
    * @example
    * // Ban a user by id (or with a user/guild member object)
    * guild.bans.create('84484653687267328')
-   *   .then(user => console.log(`Banned ${user.user?.tag ?? user.tag ?? user} from ${guild.name}`))
+   *   .then(banInfo => console.log(`Banned ${banInfo.user?.tag ?? banInfo.tag ?? banInfo}`))
    *   .catch(console.error);
    */
   async create(user, options = { days: 0 }) {

--- a/src/managers/GuildBanManager.js
+++ b/src/managers/GuildBanManager.js
@@ -62,7 +62,7 @@ class GuildBanManager extends CachedManager {
   /**
    * Fetches ban(s) from Discord.
    * @param {UserResolvable|FetchBanOptions|FetchBansOptions} [options] Options for fetching guild ban(s)
-   * @returns {Promise<GuildBan>|Promise<Collection<Snowflake, GuildBan>>}
+   * @returns {Promise<(GuildBan|Collection<Snowflake, GuildBan>)>}
    * @example
    * // Fetch all bans from a guild
    * guild.bans.fetch()
@@ -135,7 +135,7 @@ class GuildBanManager extends CachedManager {
    * @example
    * // Ban a user by id (or with a user/guild member object)
    * guild.bans.create('84484653687267328')
-   *   .then(user => console.log(`Banned ${user.username ?? user.id ?? user} from ${guild.name}`))
+   *   .then(user => console.log(`Banned ${user.user?.tag ?? user.tag ?? user} from ${guild.name}`))
    *   .catch(console.error);
    */
   async create(user, options = { days: 0 }) {

--- a/src/managers/GuildBanManager.js
+++ b/src/managers/GuildBanManager.js
@@ -62,7 +62,7 @@ class GuildBanManager extends CachedManager {
   /**
    * Fetches ban(s) from Discord.
    * @param {UserResolvable|FetchBanOptions|FetchBansOptions} [options] Options for fetching guild ban(s)
-   * @returns {Promise<(GuildBan|Collection<Snowflake, GuildBan>)>}
+   * @returns {Promise<GuildBan|Collection<Snowflake, GuildBan>>}
    * @example
    * // Fetch all bans from a guild
    * guild.bans.fetch()

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -59,7 +59,7 @@ class GuildManager extends CachedManager {
   /**
    * Partial data for a Role.
    * @typedef {Object} PartialRoleData
-   * @property {Snowflake|number} [id] The role's id, used to set channel overrides,
+   * @property {Snowflake} [id] The role's id, used to set channel overrides,
    * this is a placeholder and will be replaced by the API after consumption
    * @property {string} [name] The name of the role
    * @property {ColorResolvable} [color] The color of the role, either a hex string or a base 10 number
@@ -72,7 +72,7 @@ class GuildManager extends CachedManager {
   /**
    * Partial overwrite data.
    * @typedef {Object} PartialOverwriteData
-   * @property {Snowflake|number} id The {@link Role} or {@link User} id for this overwrite
+   * @property {Snowflake} id The id of the {@link Role} or {@link User} this overwrite belongs to
    * @property {string} [type] The type of this overwrite
    * @property {PermissionResolvable} [allow] The permissions to allow
    * @property {PermissionResolvable} [deny] The permissions to deny
@@ -81,9 +81,9 @@ class GuildManager extends CachedManager {
   /**
    * Partial data for a Channel.
    * @typedef {Object} PartialChannelData
-   * @property {Snowflake|number} [id] The channel's id, used to set its parent,
+   * @property {Snowflake} [id] The channel's id, used to set its parent,
    * this is a placeholder and will be replaced by the API after consumption
-   * @property {Snowflake|number} [parentId] The parent id for this channel
+   * @property {Snowflake} [parentId] The parent id for this channel
    * @property {ChannelType} [type] The type of the channel
    * @property {string} name The name of the channel
    * @property {string} [topic] The topic of the text channel
@@ -140,7 +140,7 @@ class GuildManager extends CachedManager {
   /**
    * Options used to create a guild.
    * @typedef {Object} GuildCreateOptions
-   * @property {Snowflake|number} [afkChannelId] The AFK channel's id
+   * @property {Snowflake} [afkChannelId] The AFK channel's id
    * @property {number} [afkTimeout] The AFK timeout in seconds
    * @property {PartialChannelData[]} [channels=[]] The channels for this guild
    * @property {DefaultMessageNotificationLevel|number} [defaultMessageNotifications] The default message notifications
@@ -149,7 +149,7 @@ class GuildManager extends CachedManager {
    * @property {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild
    * @property {PartialRoleData[]} [roles=[]] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.
-   * @property {Snowflake|number} [systemChannelId] The system channel's id
+   * @property {Snowflake} [systemChannelId] The system channel's id
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel
    * @property {VerificationLevel} [verificationLevel] The verification level for the guild
    */

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -59,7 +59,7 @@ class GuildManager extends CachedManager {
   /**
    * Partial data for a Role.
    * @typedef {Object} PartialRoleData
-   * @property {Snowflake} [id] The role's id, used to set channel overrides,
+   * @property {Snowflake|number} [id] The role's id, used to set channel overrides,
    * this is a placeholder and will be replaced by the API after consumption
    * @property {string} [name] The name of the role
    * @property {ColorResolvable} [color] The color of the role, either a hex string or a base 10 number
@@ -72,7 +72,7 @@ class GuildManager extends CachedManager {
   /**
    * Partial overwrite data.
    * @typedef {Object} PartialOverwriteData
-   * @property {Snowflake} id The id of the {@link Role} or {@link User} this overwrite belongs to
+   * @property {Snowflake|number} id The id of the {@link Role} or {@link User} this overwrite belongs to
    * @property {string} [type] The type of this overwrite
    * @property {PermissionResolvable} [allow] The permissions to allow
    * @property {PermissionResolvable} [deny] The permissions to deny
@@ -81,9 +81,9 @@ class GuildManager extends CachedManager {
   /**
    * Partial data for a Channel.
    * @typedef {Object} PartialChannelData
-   * @property {Snowflake} [id] The channel's id, used to set its parent,
+   * @property {Snowflake|number} [id] The channel's id, used to set its parent,
    * this is a placeholder and will be replaced by the API after consumption
-   * @property {Snowflake} [parentId] The parent id for this channel
+   * @property {Snowflake|number} [parentId] The parent id for this channel
    * @property {ChannelType} [type] The type of the channel
    * @property {string} name The name of the channel
    * @property {string} [topic] The topic of the text channel
@@ -140,7 +140,7 @@ class GuildManager extends CachedManager {
   /**
    * Options used to create a guild.
    * @typedef {Object} GuildCreateOptions
-   * @property {Snowflake} [afkChannelId] The AFK channel's id
+   * @property {Snowflake|number} [afkChannelId] The AFK channel's id
    * @property {number} [afkTimeout] The AFK timeout in seconds
    * @property {PartialChannelData[]} [channels=[]] The channels for this guild
    * @property {DefaultMessageNotificationLevel|number} [defaultMessageNotifications] The default message notifications
@@ -149,7 +149,7 @@ class GuildManager extends CachedManager {
    * @property {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild
    * @property {PartialRoleData[]} [roles=[]] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.
-   * @property {Snowflake} [systemChannelId] The system channel's id
+   * @property {Snowflake|number} [systemChannelId] The system channel's id
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel
    * @property {VerificationLevel} [verificationLevel] The verification level for the guild
    */

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -316,7 +316,7 @@ class GuildMemberManager extends CachedManager {
    * @example
    * // Kick a user by id (or with a user/guild member object)
    * guild.members.kick('84484653687267328')
-   *   .then(user => console.log(`Kicked ${user.user?.tag ?? user.tag ?? user} from ${guild.name}`))
+   *   .then(banInfo => console.log(`Kicked ${banInfo.user?.tag ?? banInfo.tag ?? banInfo}`))
    *   .catch(console.error);
    */
   async kick(user, reason) {
@@ -339,7 +339,7 @@ class GuildMemberManager extends CachedManager {
    * @example
    * // Ban a user by id (or with a user/guild member object)
    * guild.members.ban('84484653687267328')
-   *   .then(user => console.log(`Banned ${user.user?.tag ?? user.tag ?? user} from ${guild.name}`))
+   *   .then(kickInfo => console.log(`Banned ${kickInfo.user?.tag ?? kickInfo.tag ?? kickInfo}`))
    *   .catch(console.error);
    */
   ban(user, options = { days: 0 }) {

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -139,7 +139,7 @@ class GuildMemberManager extends CachedManager {
    * @param {UserResolvable|FetchMemberOptions|FetchMembersOptions} [options] If a UserResolvable, the user to fetch.
    * If undefined, fetches all members.
    * If a query, it limits the results to users with similar usernames.
-   * @returns {Promise<(GuildMember|Collection<Snowflake, GuildMember>)>}
+   * @returns {Promise<GuildMember|Collection<Snowflake, GuildMember>>}
    * @example
    * // Fetch all members from a guild
    * guild.members.fetch()

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -139,7 +139,7 @@ class GuildMemberManager extends CachedManager {
    * @param {UserResolvable|FetchMemberOptions|FetchMembersOptions} [options] If a UserResolvable, the user to fetch.
    * If undefined, fetches all members.
    * If a query, it limits the results to users with similar usernames.
-   * @returns {Promise<GuildMember>|Promise<Collection<Snowflake, GuildMember>>}
+   * @returns {Promise<(GuildMember|Collection<Snowflake, GuildMember>)>}
    * @example
    * // Fetch all members from a guild
    * guild.members.fetch()
@@ -248,6 +248,8 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * Options used for pruning guild members.
+   * <info>It's recommended to set {@link GuildPruneMembersOptions#count options.count}
+   * to `false` for large guilds.</info>
    * @typedef {Object} GuildPruneMembersOptions
    * @property {number} [days=7] Number of days of inactivity required to kick
    * @property {boolean} [dry=false] Get the number of users that will be kicked, without actually kicking them
@@ -258,7 +260,6 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * Prunes members from the guild based on how long they have been inactive.
-   * <info>It's recommended to set `options.count` to `false` for large guilds.</info>
    * @param {GuildPruneMembersOptions} [options] Options for pruning
    * @returns {Promise<number|null>} The number of members that were/will be kicked
    * @example
@@ -315,7 +316,7 @@ class GuildMemberManager extends CachedManager {
    * @example
    * // Kick a user by id (or with a user/guild member object)
    * guild.members.kick('84484653687267328')
-   *   .then(user => console.log(`Kicked ${user.username ?? user.id ?? user} from ${guild.name}`))
+   *   .then(user => console.log(`Kicked ${user.user?.tag ?? user.tag ?? user} from ${guild.name}`))
    *   .catch(console.error);
    */
   async kick(user, reason) {
@@ -338,7 +339,7 @@ class GuildMemberManager extends CachedManager {
    * @example
    * // Ban a user by id (or with a user/guild member object)
    * guild.members.ban('84484653687267328')
-   *   .then(user => console.log(`Banned ${user.username ?? user.id ?? user} from ${guild.name}`))
+   *   .then(user => console.log(`Banned ${user.user?.tag ?? user.tag ?? user} from ${guild.name}`))
    *   .catch(console.error);
    */
   ban(user, options = { days: 0 }) {
@@ -346,11 +347,10 @@ class GuildMemberManager extends CachedManager {
   }
 
   /**
-   * Unbans a user from the guild.
+   * Unbans a user from the guild. Internally calls the {@link GuildBanManager#remove} method.
    * @param {UserResolvable} user The user to unban
    * @param {string} [reason] Reason for unbanning user
-   * @returns {Promise<User>}
-   * Internally calls the GuildBanManager#remove method.
+   * @returns {Promise<User>} The user that was unbanned
    * @example
    * // Unban a user by id (or with a user/guild member object)
    * guild.members.unban('84484653687267328')

--- a/src/managers/GuildStickerManager.js
+++ b/src/managers/GuildStickerManager.js
@@ -32,13 +32,18 @@ class GuildStickerManager extends CachedManager {
   }
 
   /**
+   * Options for creating a guild sticker.
+   * @typedef {Object} GuildStickerCreateOptions
+   * @param {?string} [description] The description for the sticker
+   * @param {string} [reason] Reason for creating the sticker
+   */
+
+  /**
    * Creates a new custom sticker in the guild.
    * @param {BufferResolvable|Stream|FileOptions|MessageAttachment} file The file for the sticker
    * @param {string} name The name for the sticker
    * @param {string} tags The Discord name of a unicode emoji representing the sticker's expression
-   * @param {Object} [options] Options
-   * @param {?string} [options.description] The description for the sticker
-   * @param {string} [options.reason] Reason for creating the sticker
+   * @param {GuildStickerCreateOptions} [options] Options
    * @returns {Promise<Sticker>} The created sticker
    * @example
    * // Create a new sticker from a url

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -47,7 +47,7 @@ class MessageManager extends CachedManager {
    * Those need to be fetched separately in such a case.</info>
    * @param {Snowflake|ChannelLogsQueryOptions} [message] The id of the message to fetch, or query parameters.
    * @param {BaseFetchOptions} [options] Additional options for this fetch
-   * @returns {Promise<(Message|Collection<Snowflake, Message>)>}
+   * @returns {Promise<Message|Collection<Snowflake, Message>>}
    * @example
    * // Get message
    * channel.messages.fetch('99539446449315840')

--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -47,7 +47,7 @@ class MessageManager extends CachedManager {
    * Those need to be fetched separately in such a case.</info>
    * @param {Snowflake|ChannelLogsQueryOptions} [message] The id of the message to fetch, or query parameters.
    * @param {BaseFetchOptions} [options] Additional options for this fetch
-   * @returns {Promise<Message>|Promise<Collection<Snowflake, Message>>}
+   * @returns {Promise<(Message|Collection<Snowflake, Message>)>}
    * @example
    * // Get message
    * channel.messages.fetch('99539446449315840')
@@ -165,7 +165,7 @@ class MessageManager extends CachedManager {
   }
 
   /**
-   * Unins a message from the channel's pinned messages, even if it's not cached.
+   * Unpins a message from the channel's pinned messages, even if it's not cached.
    * @param {MessageResolvable} message The message to unpin
    * @returns {Promise<void>}
    */

--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -144,7 +144,7 @@ class ThreadManager extends CachedManager {
    * @param {ThreadChannelResolvable|FetchThreadsOptions} [options] The options to fetch threads. If it is a
    * ThreadChannelResolvable then the specified thread will be fetched. Fetches all active threads if `undefined`
    * @param {BaseFetchOptions} [cacheOptions] Additional options for this fetch. <warn>The `force` field gets ignored
-   * if `options` is not a ThreadChannelResolvable</warn>
+   * if `options` is not a {@link ThreadChannelResolvable}</warn>
    * @returns {Promise<?(ThreadChannel|FetchedThreads)>}
    * @example
    * // Fetch a thread by its id

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -100,7 +100,7 @@ class ShardClientUtil {
    * Fetches a client property value of each shard, or a given shard.
    * @param {string} prop Name of the client property to get, using periods for nesting
    * @param {number} [shard] Shard to fetch property from, all if undefined
-   * @returns {Promise<*>|Promise<Array<*>>}
+   * @returns {Promise<(*|Array<*>)>}
    * @example
    * client.shard.fetchClientValues('guilds.cache.size')
    *   .then(results => console.log(`${results.reduce((prev, val) => prev + val, 0)} total guilds`))
@@ -130,7 +130,7 @@ class ShardClientUtil {
    * Evaluates a script or function on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {Function} script JavaScript to run on each shard
    * @param {BroadcastEvalOptions} [options={}] The options for the broadcast
-   * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
+   * @returns {Promise<(*|Array<*>)>} Results of the script execution
    * @example
    * client.shard.broadcastEval(client => client.guilds.cache.size)
    *   .then(results => console.log(`${results.reduce((prev, val) => prev + val, 0)} total guilds`))

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -100,7 +100,7 @@ class ShardClientUtil {
    * Fetches a client property value of each shard, or a given shard.
    * @param {string} prop Name of the client property to get, using periods for nesting
    * @param {number} [shard] Shard to fetch property from, all if undefined
-   * @returns {Promise<(*|Array<*>)>}
+   * @returns {Promise<*|Array<*>>}
    * @example
    * client.shard.fetchClientValues('guilds.cache.size')
    *   .then(results => console.log(`${results.reduce((prev, val) => prev + val, 0)} total guilds`))

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -130,7 +130,7 @@ class ShardClientUtil {
    * Evaluates a script or function on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {Function} script JavaScript to run on each shard
    * @param {BroadcastEvalOptions} [options={}] The options for the broadcast
-   * @returns {Promise<(*|Array<*>)>} Results of the script execution
+   * @returns {Promise<*|Array<*>>} Results of the script execution
    * @example
    * client.shard.broadcastEval(client => client.guilds.cache.size)
    *   .then(results => console.log(`${results.reduce((prev, val) => prev + val, 0)} total guilds`))

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -243,7 +243,7 @@ class ShardingManager extends EventEmitter {
    * Evaluates a script on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {Function} script JavaScript to run on each shard
    * @param {BroadcastEvalOptions} [options={}] The options for the broadcast
-   * @returns {Promise<(*|Array<*>)>} Results of the script execution
+   * @returns {Promise<*|Array<*>>} Results of the script execution
    */
   broadcastEval(script, options = {}) {
     if (typeof script !== 'function') return Promise.reject(new TypeError('SHARDING_INVALID_EVAL_BROADCAST'));
@@ -254,7 +254,7 @@ class ShardingManager extends EventEmitter {
    * Fetches a client property value of each shard, or a given shard.
    * @param {string} prop Name of the client property to get, using periods for nesting
    * @param {number} [shard] Shard to fetch property from, all if undefined
-   * @returns {Promise<(*|Array<*>)>}
+   * @returns {Promise<*|Array<*>>}
    * @example
    * manager.fetchClientValues('guilds.cache.size')
    *   .then(results => console.log(`${results.reduce((prev, val) => prev + val, 0)} total guilds`))
@@ -269,7 +269,7 @@ class ShardingManager extends EventEmitter {
    * @param {string} method Method name to run on each shard
    * @param {Array<*>} args Arguments to pass through to the method call
    * @param {number} [shard] Shard to run on, all if undefined
-   * @returns {Promise<(*|Array<*>)>} Results of the method execution
+   * @returns {Promise<*|Array<*>>} Results of the method execution
    * @private
    */
   _performOnShards(method, args, shard) {

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -19,9 +19,9 @@ const Util = require('../util/Util');
  */
 class ShardingManager extends EventEmitter {
   /**
-   * The mode to spawn shards with for a {@link ShardingManager}. Can be either one of
+   * The mode to spawn shards with for a {@link ShardingManager}. Can be either one of:
    * * 'process' to use child processes
-   * * 'worker' to use [Worker threads](https://nodejs.org/api/worker_threads.html).
+   * * 'worker' to use [Worker threads](https://nodejs.org/api/worker_threads.html)
    * @typedef {string} ShardingManagerMode
    */
 

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -19,8 +19,9 @@ const Util = require('../util/Util');
  */
 class ShardingManager extends EventEmitter {
   /**
-   * The mode to spawn shards with for a {@link ShardingManager}. Either "process" to use child processes, or
-   * "worker" to use [Worker threads](https://nodejs.org/api/worker_threads.html).
+   * The mode to spawn shards with for a {@link ShardingManager}. Can be either one of
+   * * 'process' to use child processes
+   * * 'worker' to use [Worker threads](https://nodejs.org/api/worker_threads.html).
    * @typedef {string} ShardingManagerMode
    */
 
@@ -242,7 +243,7 @@ class ShardingManager extends EventEmitter {
    * Evaluates a script on all shards, or a given shard, in the context of the {@link Client}s.
    * @param {Function} script JavaScript to run on each shard
    * @param {BroadcastEvalOptions} [options={}] The options for the broadcast
-   * @returns {Promise<*>|Promise<Array<*>>} Results of the script execution
+   * @returns {Promise<(*|Array<*>)>} Results of the script execution
    */
   broadcastEval(script, options = {}) {
     if (typeof script !== 'function') return Promise.reject(new TypeError('SHARDING_INVALID_EVAL_BROADCAST'));
@@ -253,7 +254,7 @@ class ShardingManager extends EventEmitter {
    * Fetches a client property value of each shard, or a given shard.
    * @param {string} prop Name of the client property to get, using periods for nesting
    * @param {number} [shard] Shard to fetch property from, all if undefined
-   * @returns {Promise<*>|Promise<Array<*>>}
+   * @returns {Promise<(*|Array<*>)>}
    * @example
    * manager.fetchClientValues('guilds.cache.size')
    *   .then(results => console.log(`${results.reduce((prev, val) => prev + val, 0)} total guilds`))
@@ -268,7 +269,7 @@ class ShardingManager extends EventEmitter {
    * @param {string} method Method name to run on each shard
    * @param {Array<*>} args Arguments to pass through to the method call
    * @param {number} [shard] Shard to run on, all if undefined
-   * @returns {Promise<*>|Promise<Array<*>>} Results of the method execution
+   * @returns {Promise<(*|Array<*>)>} Results of the method execution
    * @private
    */
   _performOnShards(method, args, shard) {

--- a/src/structures/BaseMessageComponent.js
+++ b/src/structures/BaseMessageComponent.js
@@ -23,11 +23,12 @@ class BaseMessageComponent {
    */
 
   /**
-   * Components that can be sent in a message. This can be:
+   * Components that can be sent in a message. These can be:
    * * MessageActionRow
    * * MessageButton
    * * MessageSelectMenu
    * @typedef {MessageActionRow|MessageButton|MessageSelectMenu} MessageComponent
+   * @see {@link https://discord.com/developers/docs/interactions/message-components#component-object-component-types}
    */
 
   /**

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -42,10 +42,15 @@ class ClientUser extends User {
   }
 
   /**
+   * Data used to edit the logged in client
+   * @typdef {Object} ClientUserEditData
+   * @property {string} [username] The new username
+   * @property {BufferResolvable|Base64Resolvable} [avatar] The new avatar
+   */
+
+  /**
    * Edits the logged in client.
-   * @param {APIModifyClientData} data The new data
-   * @param {string} [data.username] The new username
-   * @param {BufferResolvable|Base64Resolvable} [data.avatar] The new avatar
+   * @param {ClientUserEditData} data The new data
    */
   async edit(data) {
     const newData = await this.client.api.users('@me').patch({ data });
@@ -172,8 +177,3 @@ class ClientUser extends User {
 }
 
 module.exports = ClientUser;
-
-/**
- * @external APIModifyClientData
- * @see {@link https://discord.com/developers/docs/resources/user#modify-current-user-json-params}
- */

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -37,7 +37,7 @@ const Util = require('../util/Util');
 /**
  * Represents a guild (or a server) on Discord.
  * <info>It's recommended to see if a guild is available before performing operations or reading data from it. You can
- * check this with `guild.available`.</info>
+ * check this with {@link Guild#available}.</info>
  * @extends {AnonymousGuild}
  */
 class Guild extends AnonymousGuild {
@@ -172,21 +172,21 @@ class Guild extends AnonymousGuild {
      * * FEATURABLE
      * * INVITE_SPLASH
      * * MEMBER_VERIFICATION_GATE_ENABLED
-     * * MONETIZATION_ENABLED
-     * * MORE_STICKERS
      * * NEWS
      * * PARTNERED
      * * PREVIEW_ENABLED
-     * * PRIVATE_THREADS
-     * * RELAY_ENABLED
-     * * SEVEN_DAY_THREAD_ARCHIVE
-     * * THREE_DAY_THREAD_ARCHIVE
-     * * TICKETED_EVENTS_ENABLED
      * * VANITY_URL
      * * VERIFIED
      * * VIP_REGIONS
      * * WELCOME_SCREEN_ENABLED
+     * * TICKETED_EVENTS_ENABLED
+     * * MONETIZATION_ENABLED
+     * * MORE_STICKERS
+     * * THREE_DAY_THREAD_ARCHIVE
+     * * SEVEN_DAY_THREAD_ARCHIVE
+     * * PRIVATE_THREADS
      * @typedef {string} Features
+     * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-guild-features}
      */
 
     /**
@@ -337,7 +337,8 @@ class Guild extends AnonymousGuild {
 
     /**
      * The preferred locale of the guild, defaults to `en-US`
-     * @type {string}
+     * @type {?string}
+     * @see {@link https://discord.com/developers/docs/dispatch/field-values#predefined-field-values-accepted-locales}
      */
     this.preferredLocale = data.preferred_locale;
 

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -11,7 +11,7 @@ const SnowflakeUtil = require('../util/SnowflakeUtil');
 const Util = require('../util/Util');
 
 /**
- * The target type of an entry, e.g. `GUILD`. Here are the available types:
+ * The target type of an entry. Here are the available types:
  * * GUILD
  * * CHANNEL
  * * USER
@@ -97,6 +97,7 @@ const Targets = {
  * * THREAD_UPDATE: 111
  * * THREAD_DELETE: 112
  * @typedef {?(number|string)} AuditLogAction
+ * @see {@link https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-audit-log-events}
  */
 
 /**

--- a/src/structures/GuildBan.js
+++ b/src/structures/GuildBan.js
@@ -41,7 +41,7 @@ class GuildBan extends Base {
   }
 
   /**
-   * Whether this GuildBan is a partial. If the reason is not provided the value is null
+   * Whether this GuildBan is partial. If the reason is not provided the value is null
    * @type {boolean}
    * @readonly
    */

--- a/src/structures/GuildBan.js
+++ b/src/structures/GuildBan.js
@@ -41,8 +41,7 @@ class GuildBan extends Base {
   }
 
   /**
-   * Whether this GuildBan is a partial
-   * If the reason is not provided the value is null
+   * Whether this GuildBan is a partial. If the reason is not provided the value is null
    * @type {boolean}
    * @readonly
    */

--- a/src/structures/InteractionCollector.js
+++ b/src/structures/InteractionCollector.js
@@ -19,8 +19,8 @@ const { InteractionTypes, MessageComponentTypes } = require('../util/Constants')
 
 /**
  * Collects interactions.
- * Will automatically stop if the message (`'messageDelete'`),
- * channel (`'channelDelete'`), or guild (`'guildDelete'`) are deleted.
+ * Will automatically stop if the message ({@link Client#messageDelete messageDelete}),
+ * channel ({@link Client#channelDelete channelDelete}), or guild ({@link Client#guildDelete guildDelete}) are deleted.
  * @extends {Collector}
  */
 class InteractionCollector extends Collector {
@@ -69,7 +69,7 @@ class InteractionCollector extends Collector {
 
     /**
      * The users which have interacted to this collector
-     * @type {Collection}
+     * @type {Collection<Snowflake, User>}
      */
     this.users = new Collection();
 

--- a/src/structures/InteractionCollector.js
+++ b/src/structures/InteractionCollector.js
@@ -20,7 +20,7 @@ const { InteractionTypes, MessageComponentTypes } = require('../util/Constants')
 /**
  * Collects interactions.
  * Will automatically stop if the message ({@link Client#messageDelete messageDelete}),
- * channel ({@link Client#channelDelete channelDelete}), or guild ({@link Client#guildDelete guildDelete}) are deleted.
+ * channel ({@link Client#channelDelete channelDelete}), or guild ({@link Client#guildDelete guildDelete}) is deleted.
  * @extends {Collector}
  */
 class InteractionCollector extends Collector {

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -97,6 +97,7 @@ class Invite extends Base {
      * * 1: STREAM
      * * 2: EMBEDDED_APPLICATION
      * @typedef {number} TargetType
+     * @see {@link https://discord.com/developers/docs/resources/invite#invite-object-invite-target-types}
      */
 
     /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -284,9 +284,9 @@ class Message extends Base {
     /**
      * Reference data sent in a message that contains ids identifying the referenced message
      * @typedef {Object} MessageReference
-     * @property {string} channelId The channel's id the message was referenced
-     * @property {?string} guildId The guild's id the message was referenced
-     * @property {?string} messageId The message's id that was referenced
+     * @property {Snowflake} channelId The channel's id the message was referenced
+     * @property {?Snowflake} guildId The guild's id the message was referenced
+     * @property {?Snowflake} messageId The message's id that was referenced
      */
 
     if ('message_reference' in data || !partial) {

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -44,13 +44,14 @@ class MessageEmbed {
   setup(data, skipValidation) {
     /**
      * The type of this embed, either:
-     * * `rich` - a rich embed
+     * * `rich` - a generic embed rendered from embed attributes
      * * `image` - an image embed
      * * `video` - a video embed
-     * * `gifv` - a gifv embed
+     * * `gifv` - a animated gif image embed rendered as a video embed
      * * `article` - an article embed
      * * `link` - a link embed
      * @type {string}
+     * @see {@link https://discord.com/developers/docs/resources/channel#embed-object-embed-types}
      * @deprecated
      */
     this.type = data.type ?? 'rich';
@@ -430,7 +431,7 @@ class MessageEmbed {
   }
 
   /**
-   * Normalizes field input and resolves strings.
+   * Normalizes field input and verifies strings.
    * @param {string} name The name of the field
    * @param {string} value The value of the field
    * @param {boolean} [inline=false] Set the field to display inline

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -47,7 +47,7 @@ class MessageEmbed {
      * * `rich` - a generic embed rendered from embed attributes
      * * `image` - an image embed
      * * `video` - a video embed
-     * * `gifv` - a animated gif image embed rendered as a video embed
+     * * `gifv` - an animated gif image embed rendered as a video embed
      * * `article` - an article embed
      * * `link` - a link embed
      * @type {string}

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -96,9 +96,9 @@ class MessageMentions {
     /**
      * Crossposted channel data.
      * @typedef {Object} CrosspostedChannel
-     * @property {string} channelId The mentioned channel's id
-     * @property {string} guildId The id of the guild that has the channel
-     * @property {string} type The channel's type
+     * @property {Snowflake} channelId The mentioned channel's id
+     * @property {Snowflake} guildId The id of the guild that has the channel
+     * @property {ChannelType} type The channel's type
      * @property {string} name The channel's name
      */
 

--- a/src/structures/MessagePayload.js
+++ b/src/structures/MessagePayload.js
@@ -49,7 +49,7 @@ class MessagePayload {
   }
 
   /**
-   * Whether or not the target is a webhook
+   * Whether or not the target is a {@link Webhook} or a {@link WebhookClient}
    * @type {boolean}
    * @readonly
    */
@@ -60,7 +60,7 @@ class MessagePayload {
   }
 
   /**
-   * Whether or not the target is a user
+   * Whether or not the target is a {@link User}
    * @type {boolean}
    * @readonly
    */
@@ -71,7 +71,7 @@ class MessagePayload {
   }
 
   /**
-   * Whether or not the target is a message
+   * Whether or not the target is a {@link Message}
    * @type {boolean}
    * @readonly
    */
@@ -81,7 +81,7 @@ class MessagePayload {
   }
 
   /**
-   * Wether or not the target is a message manager
+   * Wether or not the target is a {@link MessageManager}
    * @type {boolean}
    * @readonly
    */
@@ -91,7 +91,7 @@ class MessagePayload {
   }
 
   /**
-   * Whether or not the target is an interaction
+   * Whether or not the target is an {@link Interaction} or an {@link InteractionWebhook}
    * @type {boolean}
    * @readonly
    */
@@ -242,7 +242,7 @@ class MessagePayload {
   }
 
   /**
-   * Creates a `MessagePayload` from user-level arguments.
+   * Creates a {@link MessagePayload} from user-level arguments.
    * @param {MessageTarget} target Target to send to
    * @param {string|MessageOptions|WebhookMessageOptions} options Options or content to use
    * @param {MessageOptions|WebhookMessageOptions} [extra={}] - Extra options to add onto specified options

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -71,7 +71,7 @@ class MessageReaction {
   }
 
   /**
-   * The emoji of this reaction, either an GuildEmoji object for known custom emojis, or a ReactionEmoji
+   * The emoji of this reaction. Either a {@link GuildEmoji} object for known custom emojis, or a {@link ReactionEmoji}
    * object which has fewer properties. Whatever the prototype of the emoji, it will still have
    * `name`, `id`, `identifier` and `toString()`
    * @type {GuildEmoji|ReactionEmoji}

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -135,14 +135,16 @@ class PermissionOverwrites extends Base {
   /**
    * The raw data for a permission overwrite
    * @typedef {Object} RawOverwriteData
-   * @property {Snowflake} id The id of the overwrite
+   * @property {Snowflake} id The id of the {@link Role} or {@link User} this overwrite belongs to
    * @property {string} allow The permissions to allow
    * @property {string} deny The permissions to deny
    * @property {number} type The type of this OverwriteData
    */
 
   /**
-   * Data that can be resolved into {@link RawOverwriteData}
+   * Data that can be resolved into {@link RawOverwriteData}. This can be
+   * * PermissionOverwrites
+   * * OverwriteData
    * @typedef {PermissionOverwrites|OverwriteData} OverwriteResolvable
    */
 

--- a/src/structures/PermissionOverwrites.js
+++ b/src/structures/PermissionOverwrites.js
@@ -142,7 +142,7 @@ class PermissionOverwrites extends Base {
    */
 
   /**
-   * Data that can be resolved into {@link RawOverwriteData}. This can be
+   * Data that can be resolved into {@link RawOverwriteData}. This can be:
    * * PermissionOverwrites
    * * OverwriteData
    * @typedef {PermissionOverwrites|OverwriteData} OverwriteResolvable

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -187,10 +187,15 @@ class Activity {
     this.applicationId = data.application_id ?? null;
 
     /**
-     * Timestamps for the activity
-     * @type {?Object}
+     * Represents timestamps of an activity
+     * @typedef {Object} ActivityTimestamps
      * @property {?Date} start When the activity started
      * @property {?Date} end When the activity will end
+     */
+
+    /**
+     * Timestamps for the activity
+     * @type {?ActivityTimestamps}
      */
     this.timestamps = data.timestamps
       ? {
@@ -212,10 +217,15 @@ class Activity {
     this.platform = data.platform ?? null;
 
     /**
-     * Party of the activity
-     * @type {?Object}
+     * Represents a party of an activity
+     * @typedef {Object} ActivityParty
      * @property {?string} id The party's id
      * @property {number[]} size Size of the party as `[current, max]`
+     */
+
+    /**
+     * Party of the activity
+     * @type {?ActivityParty}
      */
     this.party = data.party ?? null;
 
@@ -330,7 +340,7 @@ class RichPresenceAssets {
   /**
    * Gets the URL of the small image asset
    * @param {StaticImageURLOptions} [options] Options for the image url
-   * @returns {?string} The small image URL
+   * @returns {?string}
    */
   smallImageURL({ format, size } = {}) {
     return (
@@ -345,7 +355,7 @@ class RichPresenceAssets {
   /**
    * Gets the URL of the large image asset
    * @param {StaticImageURLOptions} [options] Options for the image url
-   * @returns {?string} The large image URL
+   * @returns {?string}
    */
   largeImageURL({ format, size } = {}) {
     if (!this.largeImage) return null;

--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -82,7 +82,7 @@ class Team extends Base {
   /**
    * A link to the teams's icon.
    * @param {StaticImageURLOptions} [options={}] Options for the Image URL
-   * @returns {?string} URL to the icon
+   * @returns {?string}
    */
   iconURL({ format, size } = {}) {
     if (!this.icon) return null;

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -237,7 +237,8 @@ class ThreadChannel extends Channel {
   }
 
   /**
-   * Fetches the owner of this thread
+   * Fetches the owner of this thread. If the thread member object isn't needed,
+   * use {@link ThreadChannel#ownerId} instead.
    * @param {FetchOwnerOptions} [options] The options for fetching the member
    * @returns {Promise<?ThreadMember>}
    */

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -58,7 +58,7 @@ class VoiceState extends Base {
      */
     this.sessionId = data.session_id ?? null;
     /**
-     * Whether this member is streaming using "Go Live"
+     * Whether this member is streaming using "Screen Share"
      * @type {boolean}
      */
     this.streaming = data.self_stream ?? false;

--- a/src/structures/interfaces/Application.js
+++ b/src/structures/interfaces/Application.js
@@ -63,7 +63,7 @@ class Application extends Base {
   /**
    * A link to the application's icon.
    * @param {StaticImageURLOptions} [options={}] Options for the Image URL
-   * @returns {?string} URL to the icon
+   * @returns {?string}
    */
   iconURL({ format, size } = {}) {
     if (!this.icon) return null;
@@ -73,7 +73,7 @@ class Application extends Base {
   /**
    * A link to this application's cover image.
    * @param {StaticImageURLOptions} [options={}] Options for the Image URL
-   * @returns {?string} URL to the cover image
+   * @returns {?string}
    */
   coverURL({ format, size } = {}) {
     if (!this.cover) return null;

--- a/src/util/ApplicationFlags.js
+++ b/src/util/ApplicationFlags.js
@@ -23,9 +23,6 @@ class ApplicationFlags extends BitField {}
 
 /**
  * Numeric application flags. All available properties:
- * * `MANAGED_EMOJI`
- * * `GROUP_DM_CREATE`
- * * `RPC_HAS_CONNECTED`
  * * `GATEWAY_PRESENCE`
  * * `GATEWAY_PRESENCE_LIMITED`
  * * `GATEWAY_GUILD_MEMBERS`
@@ -33,11 +30,9 @@ class ApplicationFlags extends BitField {}
  * * `VERIFICATION_PENDING_GUILD_LIMIT`
  * * `EMBEDDED`
  * @type {Object}
+ * @see {@link https://discord.com/developers/docs/resources/application#application-object-application-flags}
  */
 ApplicationFlags.FLAGS = {
-  MANAGED_EMOJI: 1 << 2,
-  GROUP_DM_CREATE: 1 << 4,
-  RPC_HAS_CONNECTED: 1 << 11,
   GATEWAY_PRESENCE: 1 << 12,
   GATEWAY_PRESENCE_LIMITED: 1 << 13,
   GATEWAY_GUILD_MEMBERS: 1 << 14,

--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -48,10 +48,11 @@ class BitField {
   /**
    * Gets all given bits that are missing from the bitfield.
    * @param {BitFieldResolvable} bits Bit(s) to check for
+   * @param {...*} hasParams Additional parameters for the has method, if any
    * @returns {string[]}
    */
-  missing(bits) {
-    return new this.constructor(bits).remove(this).toArray();
+  missing(bits, ...hasParams) {
+    return new this.constructor(bits).remove(this).toArray(...hasParams);
   }
 
   /**
@@ -95,20 +96,22 @@ class BitField {
   /**
    * Gets an object mapping field names to a {@link boolean} indicating whether the
    * bit is available.
+   * @param {...*} hasParams Additional parameters for the has method, if any
    * @returns {Object}
    */
-  serialize() {
+  serialize(...hasParams) {
     const serialized = {};
-    for (const [flag, bit] of Object.entries(this.constructor.FLAGS)) serialized[flag] = this.has(bit);
+    for (const [flag, bit] of Object.entries(this.constructor.FLAGS)) serialized[flag] = this.has(bit, ...hasParams);
     return serialized;
   }
 
   /**
    * Gets an {@link Array} of bitfield names based on the bits available.
+   * @param {...*} hasParams Additional parameters for the has method, if any
    * @returns {string[]}
    */
-  toArray() {
-    return Object.keys(this.constructor.FLAGS).filter(bit => this.has(bit));
+  toArray(...hasParams) {
+    return Object.keys(this.constructor.FLAGS).filter(bit => this.has(bit, ...hasParams));
   }
 
   toJSON() {

--- a/src/util/BitField.js
+++ b/src/util/BitField.js
@@ -48,16 +48,15 @@ class BitField {
   /**
    * Gets all given bits that are missing from the bitfield.
    * @param {BitFieldResolvable} bits Bit(s) to check for
-   * @param {...*} hasParams Additional parameters for the has method, if any
    * @returns {string[]}
    */
-  missing(bits, ...hasParams) {
-    return new this.constructor(bits).remove(this).toArray(...hasParams);
+  missing(bits) {
+    return new this.constructor(bits).remove(this).toArray();
   }
 
   /**
    * Freezes these bits, making them immutable.
-   * @returns {Readonly<BitField>} These bits
+   * @returns {Readonly<BitField>}
    */
   freeze() {
     return Object.freeze(this);
@@ -96,22 +95,20 @@ class BitField {
   /**
    * Gets an object mapping field names to a {@link boolean} indicating whether the
    * bit is available.
-   * @param {...*} hasParams Additional parameters for the has method, if any
    * @returns {Object}
    */
-  serialize(...hasParams) {
+  serialize() {
     const serialized = {};
-    for (const [flag, bit] of Object.entries(this.constructor.FLAGS)) serialized[flag] = this.has(bit, ...hasParams);
+    for (const [flag, bit] of Object.entries(this.constructor.FLAGS)) serialized[flag] = this.has(bit);
     return serialized;
   }
 
   /**
    * Gets an {@link Array} of bitfield names based on the bits available.
-   * @param {...*} hasParams Additional parameters for the has method, if any
    * @returns {string[]}
    */
-  toArray(...hasParams) {
-    return Object.keys(this.constructor.FLAGS).filter(bit => this.has(bit, ...hasParams));
+  toArray() {
+    return Object.keys(this.constructor.FLAGS).filter(bit => this.has(bit));
   }
 
   toJSON() {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -416,7 +416,7 @@ exports.SystemMessageTypes = exports.MessageTypes.filter(
 
 /**
  * <info>Bots cannot set a `CUSTOM` activity type, it is only for custom statuses received from users</info>
- * The type of an activity of a users presence. Here are the available types:
+ * The type of an activity of a user's presence. Here are the available types:
  * * PLAYING
  * * STREAMING
  * * LISTENING

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -34,15 +34,15 @@ function makeImageUrl(root, { format = 'webp', size } = {}) {
 /**
  * Options for static Image URLs.
  * @typedef {Object} StaticImageURLOptions
- * @property {string} [format] One of `webp`, `png`, `jpg`, `jpeg`, `gif`. If no format is provided,
- * defaults to `webp`
+ * @property {string} [format='webp'] One of `webp`, `png`, `jpg`, `jpeg`.
  * @property {number} [size] One of `16`, `32`, `64`, `128`, `256`, `512`, `1024`, `2048`, `4096`
  */
 
+// https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints
 exports.Endpoints = {
   CDN(root) {
     return {
-      Emoji: (emojiId, format = 'png') => `${root}/emojis/${emojiId}.${format}`,
+      Emoji: (emojiId, format = 'webp') => `${root}/emojis/${emojiId}.${format}`,
       Asset: name => `${root}/assets/${name}`,
       DefaultAvatar: discriminator => `${root}/embed/avatars/${discriminator}.png`,
       Avatar: (userId, hash, format = 'webp', size, dynamic = false) => {
@@ -262,6 +262,7 @@ exports.PartialTypes = keyMirror(['USER', 'CHANNEL', 'GUILD_MEMBER', 'MESSAGE', 
  * * STAGE_INSTANCE_DELETE
  * * GUILD_STICKERS_UPDATE
  * @typedef {string} WSEventType
+ * @see {@link https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-events}
  */
 exports.WSEvents = keyMirror([
   'READY',
@@ -332,6 +333,7 @@ exports.WSEvents = keyMirror([
  * * `gdm.join`: allows joining the user to a group dm
  * * `webhook.incoming`: generates a webhook to a channel
  * @typedef {string} InviteScope
+ * @see {@link https://discord.com/developers/docs/topics/oauth2#shared-resources-oauth2-scopes}
  */
 exports.InviteScopes = [
   'applications.builds.read',
@@ -356,7 +358,7 @@ exports.InviteScopes = [
  * * CALL
  * * CHANNEL_NAME_CHANGE
  * * CHANNEL_ICON_CHANGE
- * * PINS_ADD
+ * * CHANNEL_PINNED_MESSAGE
  * * GUILD_MEMBER_JOIN
  * * USER_PREMIUM_GUILD_SUBSCRIPTION
  * * USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1
@@ -373,6 +375,7 @@ exports.InviteScopes = [
  * * THREAD_STARTER_MESSAGE
  * * GUILD_INVITE_REMINDER
  * @typedef {string} MessageType
+ * @see {@link https://discord.com/developers/docs/resources/channel#message-object-message-types}
  */
 exports.MessageTypes = [
   'DEFAULT',
@@ -381,7 +384,7 @@ exports.MessageTypes = [
   'CALL',
   'CHANNEL_NAME_CHANGE',
   'CHANNEL_ICON_CHANGE',
-  'PINS_ADD',
+  'CHANNEL_PINNED_MESSAGE',
   'GUILD_MEMBER_JOIN',
   'USER_PREMIUM_GUILD_SUBSCRIPTION',
   'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1',
@@ -413,7 +416,7 @@ exports.SystemMessageTypes = exports.MessageTypes.filter(
 
 /**
  * <info>Bots cannot set a `CUSTOM` activity type, it is only for custom statuses received from users</info>
- * The type of an activity of a users presence, e.g. `PLAYING`. Here are the available types:
+ * The type of an activity of a users presence. Here are the available types:
  * * PLAYING
  * * STREAMING
  * * LISTENING
@@ -421,6 +424,7 @@ exports.SystemMessageTypes = exports.MessageTypes.filter(
  * * CUSTOM
  * * COMPETING
  * @typedef {string} ActivityType
+ * @see {@link https://discord.com/developers/docs/game-sdk/activities#data-models-activitytype-enum}
  */
 exports.ActivityTypes = createEnum(['PLAYING', 'STREAMING', 'LISTENING', 'WATCHING', 'CUSTOM', 'COMPETING']);
 
@@ -439,6 +443,7 @@ exports.ActivityTypes = createEnum(['PLAYING', 'STREAMING', 'LISTENING', 'WATCHI
  * * `GUILD_STAGE_VOICE` - a guild stage voice channel
  * * `UNKNOWN` - a generic channel of unknown type, could be Channel or GuildChannel
  * @typedef {string} ChannelType
+ * @see {@link https://discord.com/developers/docs/resources/channel#channel-object-channel-types}
  */
 exports.ChannelTypes = createEnum([
   'GUILD_TEXT',
@@ -545,6 +550,7 @@ exports.Colors = {
  * * MEMBERS_WITHOUT_ROLES
  * * ALL_MEMBERS
  * @typedef {string} ExplicitContentFilterLevel
+ * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-explicit-content-filter-level}
  */
 exports.ExplicitContentFilterLevels = createEnum(['DISABLED', 'MEMBERS_WITHOUT_ROLES', 'ALL_MEMBERS']);
 
@@ -556,6 +562,7 @@ exports.ExplicitContentFilterLevels = createEnum(['DISABLED', 'MEMBERS_WITHOUT_R
  * * HIGH
  * * VERY_HIGH
  * @typedef {string} VerificationLevel
+ * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-verification-level}
  */
 exports.VerificationLevels = createEnum(['NONE', 'LOW', 'MEDIUM', 'HIGH', 'VERY_HIGH']);
 
@@ -685,6 +692,7 @@ exports.VerificationLevels = createEnum(['NONE', 'LOW', 'MEDIUM', 'HIGH', 'VERY_
  * * MAXIMUM_ACTIVE_THREADS
  * * MAXIMUM_ACTIVE_ANNOUCEMENT_THREAD
  * @typedef {string} APIError
+ * @see {@link https://discord.com/developers/docs/topics/opcodes-and-status-codes#json-json-error-codes}
  */
 exports.APIErrors = {
   UNKNOWN_ACCOUNT: 10001,
@@ -827,6 +835,7 @@ exports.APIErrors = {
  * * ALL_MESSAGES
  * * ONLY_MENTIONS
  * @typedef {string} DefaultMessageNotificationLevel
+ * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-default-message-notification-level}
  */
 exports.DefaultMessageNotificationLevels = createEnum(['ALL_MESSAGES', 'ONLY_MENTIONS']);
 
@@ -835,6 +844,7 @@ exports.DefaultMessageNotificationLevels = createEnum(['ALL_MESSAGES', 'ONLY_MEN
  * * INVITED
  * * ACCEPTED
  * @typedef {string} MembershipState
+ * @see {@link https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum}
  */
 exports.MembershipStates = createEnum([null, 'INVITED', 'ACCEPTED']);
 
@@ -842,15 +852,18 @@ exports.MembershipStates = createEnum([null, 'INVITED', 'ACCEPTED']);
  * The value set for a webhook's type:
  * * Incoming
  * * Channel Follower
+ * * Application
  * @typedef {string} WebhookType
+ * @see {@link https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-types}
  */
-exports.WebhookTypes = createEnum([null, 'Incoming', 'Channel Follower']);
+exports.WebhookTypes = createEnum([null, 'Incoming', 'Channel Follower', 'Application']);
 
 /**
  * The value set for a sticker's type:
  * * STANDARD
  * * GUILD
  * @typedef {string} StickerType
+ * @see {@link https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-types}
  */
 exports.StickerTypes = createEnum([null, 'STANDARD', 'GUILD']);
 
@@ -860,6 +873,7 @@ exports.StickerTypes = createEnum([null, 'STANDARD', 'GUILD']);
  * * APNG
  * * LOTTIE
  * @typedef {string} StickerFormatType
+ * @see {@link https://discord.com/developers/docs/resources/sticker#sticker-object-sticker-format-types}
  */
 exports.StickerFormatTypes = createEnum([null, 'PNG', 'APNG', 'LOTTIE']);
 
@@ -868,9 +882,11 @@ exports.StickerFormatTypes = createEnum([null, 'PNG', 'APNG', 'LOTTIE']);
  * * role
  * * member
  * @typedef {string} OverwriteType
+ * @see {@link https://discord.com/developers/docs/resources/channel#overwrite-object-overwrite-structure}
  */
 exports.OverwriteTypes = createEnum(['role', 'member']);
 
+/* eslint-disable max-len */
 /**
  * The type of an {@link ApplicationCommandOption} object:
  * * SUB_COMMAND
@@ -884,6 +900,7 @@ exports.OverwriteTypes = createEnum(['role', 'member']);
  * * MENTIONABLE
  * * NUMBER
  * @typedef {string} ApplicationCommandOptionType
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-type}
  */
 exports.ApplicationCommandOptionTypes = createEnum([
   null,
@@ -904,6 +921,7 @@ exports.ApplicationCommandOptionTypes = createEnum([
  * * ROLE
  * * USER
  * @typedef {string} ApplicationCommandPermissionType
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#application-command-permissions-object-application-command-permission-type}
  */
 exports.ApplicationCommandPermissionTypes = createEnum([null, 'ROLE', 'USER']);
 
@@ -913,6 +931,7 @@ exports.ApplicationCommandPermissionTypes = createEnum([null, 'ROLE', 'USER']);
  * * APPLICATION_COMMAND
  * * MESSAGE_COMPONENT
  * @typedef {string} InteractionType
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-object-interaction-request-type}
  */
 exports.InteractionTypes = createEnum([null, 'PING', 'APPLICATION_COMMAND', 'MESSAGE_COMPONENT']);
 
@@ -924,6 +943,7 @@ exports.InteractionTypes = createEnum([null, 'PING', 'APPLICATION_COMMAND', 'MES
  * * DEFERRED_MESSAGE_UPDATE
  * * UPDATE_MESSAGE
  * @typedef {string} InteractionResponseType
+ * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-response-object-interaction-callback-type}
  */
 exports.InteractionResponseTypes = createEnum([
   null,
@@ -935,6 +955,7 @@ exports.InteractionResponseTypes = createEnum([
   'DEFERRED_MESSAGE_UPDATE',
   'UPDATE_MESSAGE',
 ]);
+/* eslint-enable max-len */
 
 /**
  * The type of a message component
@@ -942,6 +963,7 @@ exports.InteractionResponseTypes = createEnum([
  * * BUTTON
  * * SELECT_MENU
  * @typedef {string} MessageComponentType
+ * @see {@link https://discord.com/developers/docs/interactions/message-components#component-object-component-types}
  */
 exports.MessageComponentTypes = createEnum([null, 'ACTION_ROW', 'BUTTON', 'SELECT_MENU']);
 
@@ -953,6 +975,7 @@ exports.MessageComponentTypes = createEnum([null, 'ACTION_ROW', 'BUTTON', 'SELEC
  * * DANGER
  * * LINK
  * @typedef {string} MessageButtonStyle
+ * @see {@link https://discord.com/developers/docs/interactions/message-components#button-object-button-styles}
  */
 exports.MessageButtonStyles = createEnum([null, 'PRIMARY', 'SECONDARY', 'SUCCESS', 'DANGER', 'LINK']);
 
@@ -961,6 +984,7 @@ exports.MessageButtonStyles = createEnum([null, 'PRIMARY', 'SECONDARY', 'SUCCESS
  * * NONE
  * * ELEVATED
  * @typedef {string} MFALevel
+ * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-mfa-level}
  */
 exports.MFALevels = createEnum(['NONE', 'ELEVATED']);
 
@@ -971,6 +995,7 @@ exports.MFALevels = createEnum(['NONE', 'ELEVATED']);
  * * SAFE
  * * AGE_RESTRICTED
  * @typedef {string} NSFWLevel
+ * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-guild-nsfw-level}
  */
 exports.NSFWLevels = createEnum(['DEFAULT', 'EXPLICIT', 'SAFE', 'AGE_RESTRICTED']);
 
@@ -979,6 +1004,7 @@ exports.NSFWLevels = createEnum(['DEFAULT', 'EXPLICIT', 'SAFE', 'AGE_RESTRICTED'
  * * PUBLIC
  * * GUILD_ONLY
  * @typedef {string} PrivacyLevel
+ * @see {@link https://discord.com/developers/docs/resources/stage-instance#stage-instance-object-privacy-level}
  */
 exports.PrivacyLevels = createEnum([null, 'PUBLIC', 'GUILD_ONLY']);
 
@@ -989,6 +1015,7 @@ exports.PrivacyLevels = createEnum([null, 'PUBLIC', 'GUILD_ONLY']);
  * * TIER_2
  * * TIER_3
  * @typedef {string} PremiumTier
+ * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-premium-tier}
  */
 exports.PremiumTiers = createEnum(['NONE', 'TIER_1', 'TIER_2', 'TIER_3']);
 

--- a/src/util/LimitedCollection.js
+++ b/src/util/LimitedCollection.js
@@ -102,7 +102,7 @@ class LimitedCollection extends Collection {
    * @typedef {Object} LifetimeFilterOptions
    * @property {number} [lifetime=14400] How long, in seconds, an entry should stay in the collection
    * before it is considered sweepable.
-   * @property {Function} [getComparisonTimestamp='e => e?.createdTimestamp'] A function that takes an entry, key,
+   * @property {Function} [getComparisonTimestamp=e => e?.createdTimestamp] A function that takes an entry, key,
    * and the collection and returns a timestamp to compare against in order to determine the lifetime of the entry.
    * @property {Function} [excludeFromSweep=() => false] A function that takes an entry, key, and the collection
    * and returns a boolean, `true` when the entry should not be checked for sweepability.

--- a/src/util/LimitedCollection.js
+++ b/src/util/LimitedCollection.js
@@ -104,7 +104,7 @@ class LimitedCollection extends Collection {
    * before it is considered sweepable.
    * @property {Function} [getComparisonTimestamp='e => e?.createdTimestamp'] A function that takes an entry, key,
    * and the collection and returns a timestamp to compare against in order to determine the lifetime of the entry.
-   * @property {Function} [excludeFromSweep='() => false'] A function that takes an entry, key, and the collection
+   * @property {Function} [excludeFromSweep=() => false] A function that takes an entry, key, and the collection
    * and returns a boolean, `true` when the entry should not be checked for sweepability.
    */
 

--- a/src/util/LimitedCollection.js
+++ b/src/util/LimitedCollection.js
@@ -100,11 +100,11 @@ class LimitedCollection extends Collection {
   /**
    * Options for generating a filter function based on lifetime
    * @typedef {Object} LifetimeFilterOptions
-   * @property {number} [lifetime=14400] How long an entry should stay in the collection before it is considered
-   * sweepable.
-   * @property {Function} [getComparisonTimestamp=`e => e.createdTimestamp`] A function that takes an entry, key,
+   * @property {number} [lifetime=14400] How long, in seconds, an entry should stay in the collection
+   * before it is considered sweepable.
+   * @property {Function} [getComparisonTimestamp='e => e?.createdTimestamp'] A function that takes an entry, key,
    * and the collection and returns a timestamp to compare against in order to determine the lifetime of the entry.
-   * @property {Function} [excludeFromSweep=`() => false`] A function that takes an entry, key, and the collection
+   * @property {Function} [excludeFromSweep='() => false'] A function that takes an entry, key, and the collection
    * and returns a boolean, `true` when the entry should not be checked for sweepability.
    */
 

--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -57,10 +57,10 @@ class Permissions extends BitField {
 
 /**
  * Numeric permission flags. All available properties:
- * * `ADMINISTRATOR` (implicitly has *all* permissions, and bypasses all channel overwrites)
  * * `CREATE_INSTANT_INVITE` (create invitations to the guild)
  * * `KICK_MEMBERS`
  * * `BAN_MEMBERS`
+ * * `ADMINISTRATOR` (implicitly has *all* permissions, and bypasses all channel overwrites)
  * * `MANAGE_CHANNELS` (edit and reorder channels)
  * * `MANAGE_GUILD` (edit the guild information, region, etc.)
  * * `ADD_REACTIONS` (add new reactions to messages)
@@ -95,7 +95,7 @@ class Permissions extends BitField {
  * * `USE_PRIVATE_THREADS`
  * * `USE_EXTERNAL_STICKERS` (use stickers from different guilds)
  * @type {Object<string, bigint>}
- * @see {@link https://discord.com/developers/docs/topics/permissions}
+ * @see {@link https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags}
  */
 Permissions.FLAGS = {
   CREATE_INSTANT_INVITE: 1n << 0n,

--- a/src/util/SnowflakeUtil.js
+++ b/src/util/SnowflakeUtil.js
@@ -11,10 +11,11 @@ let INCREMENT = 0;
  */
 class SnowflakeUtil extends null {
   /**
-   * A Twitter snowflake, except the epoch is 2015-01-01T00:00:00.000Z
-   * ```
-   * If we have a snowflake '266241948824764416' we can represent it as binary:
+   * A {@link https://developer.twitter.com/en/docs/twitter-ids Twitter snowflake},
+   * except the epoch is 2015-01-01T00:00:00.000Z.
    *
+   * If we have a snowflake '266241948824764416' we can represent it as binary:
+   * ```
    * 64                                          22     17     12          0
    *  000000111011000111100001101001000101000000  00001  00000  000000000000
    *       number of ms since Discord epoch       worker  pid    increment
@@ -56,7 +57,7 @@ class SnowflakeUtil extends null {
   /**
    * Deconstructs a Discord snowflake.
    * @param {Snowflake} snowflake Snowflake to deconstruct
-   * @returns {DeconstructedSnowflake} Deconstructed snowflake
+   * @returns {DeconstructedSnowflake}
    */
   static deconstruct(snowflake) {
     const BINARY = Util.idToBinary(snowflake).toString(2).padStart(64, '0');

--- a/src/util/SystemChannelFlags.js
+++ b/src/util/SystemChannelFlags.js
@@ -38,6 +38,7 @@ class SystemChannelFlags extends BitField {}
  * * `SUPPRESS_PREMIUM_SUBSCRIPTIONS` (Suppress server boost notifications)
  * * `SUPPRESS_GUILD_REMINDER_NOTIFICATIONS` (Suppress server setup tips)
  * @type {Object}
+ * @see {@link https://discord.com/developers/docs/resources/guild#guild-object-system-channel-flags}
  */
 SystemChannelFlags.FLAGS = {
   SUPPRESS_JOIN_NOTIFICATIONS: 1 << 0,

--- a/typings/enums.d.ts
+++ b/typings/enums.d.ts
@@ -143,4 +143,5 @@ export enum VerificationLevels {
 export enum WebhookTypes {
   Incoming = 1,
   'Channel Follower' = 2,
+  Application = 3,
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2704,6 +2704,8 @@ export interface AddGuildMemberOptions {
 
 export type AllowedImageFormat = 'webp' | 'png' | 'jpg' | 'jpeg';
 
+export type AllowedImageSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096;
+
 export type AllowedPartial = User | Channel | GuildMember | Message | MessageReaction;
 
 export type AllowedThreadTypeForNewsChannel = 'GUILD_NEWS_THREAD' | 10;
@@ -3778,8 +3780,6 @@ export interface HTTPOptions {
   template?: string;
   headers?: Record<string, string>;
 }
-
-export type AllowedImageSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096;
 
 export interface ImageURLOptions extends StaticImageURLOptions {
   dynamic?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -646,7 +646,7 @@ export class Guild extends AnonymousGuild {
   public members: GuildMemberManager;
   public mfaLevel: MFALevel;
   public ownerId: Snowflake;
-  public preferredLocale: string;
+  public preferredLocale?: string;
   public premiumSubscriptionCount: number | null;
   public premiumTier: PremiumTier;
   public presences: PresenceManager;
@@ -2140,22 +2140,32 @@ export const Constants: {
     CDN: (root: string) => {
       Asset: (name: string) => string;
       DefaultAvatar: (id: Snowflake | number) => string;
-      Emoji: (emojiId: Snowflake, format: 'png' | 'gif') => string;
-      Avatar: (
+      Emoji: (emojiId: Snowflake, format: DynamicImageFormat) => string;
+      Avatar: (userId: Snowflake, hash: string, format: DynamicImageFormat, size: AllowedImageSize) => string;
+      Banner: (guildId: Snowflake | number, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
+      Icon: (userId: Snowflake | number, hash: string, format: DynamicImageFormat, size: AllowedImageSize) => string;
+      AppIcon: (userId: Snowflake | number, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
+      AppAsset: (
         userId: Snowflake | number,
         hash: string,
-        format: 'default' | AllowedImageFormat,
-        size: number,
+        format: AllowedImageFormat,
+        size: AllowedImageSize,
       ) => string;
-      Banner: (guildId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
-      Icon: (userId: Snowflake | number, hash: string, format: 'default' | AllowedImageFormat, size: number) => string;
-      AppIcon: (userId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
-      AppAsset: (userId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
-      StickerPackBanner: (bannerId: Snowflake, format: AllowedImageFormat, size: number) => string;
-      GDMIcon: (userId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
-      Splash: (guildId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
-      DiscoverySplash: (guildId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
-      TeamIcon: (teamId: Snowflake | number, hash: string, format: AllowedImageFormat, size: number) => string;
+      StickerPackBanner: (bannerId: Snowflake, format: AllowedImageFormat, size: AllowedImageSize) => string;
+      GDMIcon: (userId: Snowflake | number, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
+      Splash: (guildId: Snowflake | number, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
+      DiscoverySplash: (
+        guildId: Snowflake | number,
+        hash: string,
+        format: AllowedImageFormat,
+        size: AllowedImageSize,
+      ) => string;
+      TeamIcon: (
+        teamId: Snowflake | number,
+        hash: string,
+        format: AllowedImageFormat,
+        size: AllowedImageSize,
+      ) => string;
       Sticker: (stickerId: Snowflake, stickerFormat: StickerFormatType) => string;
     };
   };
@@ -2692,7 +2702,7 @@ export interface AddGuildMemberOptions {
   fetchWhenExisting?: boolean;
 }
 
-export type AllowedImageFormat = 'webp' | 'png' | 'jpg' | 'jpeg' | 'gif';
+export type AllowedImageFormat = 'webp' | 'png' | 'jpg' | 'jpeg';
 
 export type AllowedPartial = User | Channel | GuildMember | Message | MessageReaction;
 
@@ -2884,9 +2894,6 @@ export type ApplicationCommandPermissionType = keyof typeof ApplicationCommandPe
 export type ApplicationCommandResolvable = ApplicationCommand | Snowflake;
 
 export type ApplicationFlagsString =
-  | 'MANAGED_EMOJI'
-  | 'GROUP_DM_CREATE'
-  | 'RPC_HAS_CONNECTED'
   | 'GATEWAY_PRESENCE'
   | 'GATEWAY_PRESENCE_LIMITED'
   | 'GATEWAY_GUILD_MEMBERS'
@@ -3383,6 +3390,8 @@ export interface DeconstructedSnowflake {
 
 export type DefaultMessageNotificationLevel = keyof typeof DefaultMessageNotificationLevels;
 
+export type DynamicImageFormat = AllowedImageFormat | 'gif';
+
 export interface EditGuildTemplateOptions {
   name?: string;
   description?: string;
@@ -3698,20 +3707,19 @@ export type GuildFeatures =
   | 'FEATURABLE'
   | 'INVITE_SPLASH'
   | 'MEMBER_VERIFICATION_GATE_ENABLED'
-  | 'MONETIZATION_ENABLED'
-  | 'MORE_STICKERS'
   | 'NEWS'
   | 'PARTNERED'
   | 'PREVIEW_ENABLED'
-  | 'PRIVATE_THREADS'
-  | 'RELAY_ENABLED'
-  | 'SEVEN_DAY_THREAD_ARCHIVE'
-  | 'THREE_DAY_THREAD_ARCHIVE'
-  | 'TICKETED_EVENTS_ENABLED'
   | 'VANITY_URL'
   | 'VERIFIED'
   | 'VIP_REGIONS'
-  | 'WELCOME_SCREEN_ENABLED';
+  | 'WELCOME_SCREEN_ENABLED'
+  | 'TICKETED_EVENTS_ENABLED'
+  | 'MONETIZATION_ENABLED'
+  | 'MORE_STICKERS'
+  | 'THREE_DAY_THREAD_ARCHIVE'
+  | 'SEVEN_DAY_THREAD_ARCHIVE'
+  | 'PRIVATE_THREADS';
 
 export interface GuildMemberEditData {
   nick?: string | null;
@@ -3771,7 +3779,7 @@ export interface HTTPOptions {
   headers?: Record<string, string>;
 }
 
-export type ImageSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096;
+export type AllowedImageSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096;
 
 export interface ImageURLOptions extends StaticImageURLOptions {
   dynamic?: boolean;
@@ -4113,7 +4121,7 @@ export type MessageType =
   | 'CALL'
   | 'CHANNEL_NAME_CHANGE'
   | 'CHANNEL_ICON_CHANGE'
-  | 'PINS_ADD'
+  | 'CHANNEL_PINNED_MESSAGE'
   | 'GUILD_MEMBER_JOIN'
   | 'USER_PREMIUM_GUILD_SUBSCRIPTION'
   | 'USER_PREMIUM_GUILD_SUBSCRIPTION_TIER_1'
@@ -4369,7 +4377,7 @@ export interface SplitOptions {
 
 export interface StaticImageURLOptions {
   format?: AllowedImageFormat;
-  size?: ImageSize;
+  size?: AllowedImageSize;
 }
 
 export type StageInstanceResolvable = StageInstance | Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I went through every page on the docs and added/fixed some things. Although the title says docs this does include very small changes to the typings and code which I will be detailing below and you're welcome to give your opinion on them if you believe they should be reverted.

⚠️ This PR contains the following breaking changes:
- Removed the `RELAY_ENABLED` guild feature as it was not found on the docs
- Marked `Guild#preferredLocale` as nullable since a Guild may not have community enabled
- Removed the `MANAGED_EMOJI`, `GROUP_DM_CREATE` and `RPC_HAS_CONNECTED` Application flags as they could not be found on the docs
- Changed the default format for the Emoji CDN endpoint to 'webp' to match the other endpoints and the docs
- Renamed the PINS_ADD message type to CHANNEL_PINNED_MESSAGE to match the Discord API docs

Along with those, here are the other changes:
- Added the `Application` Webhook type
- Added back the Collection `@external` link
- Fixed some wrong `string` types where they should be `Snowflake`
- Removed nested properties (e.g. options.x) and added them to separate typedefs
- Added monospace markdown to references to properties within typedefs
- Added mentioned class links in multiple descriptions
- Fixed a weird code example in the guild ban and kick methods
- Changed all "Promise\<T>|Promise\<T2>" types to "Promise<T|T2>"
- Removed redundant `@returns` descriptions
- Fixed typos
- Added links to Discord documentation in most enums whenever I was able to find them
- Moved a sentence in the Snowflake typedef out of the code block to prevent formatting issues (not sure if this will cause other issues, please let me know if it does)
- Created the DynamicImageFormat type and assigned it to the CDN endpoints that support dynamic images (including DynamicImageFormat which supported fewer types before)
- Renamed the `ImageSize` type to `AllowedImageSize` for consistency and assigned it to all CDN endpoint sizes (change previously suggested in #5696 but might as well do it now).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
