### PR TITLE
docs: typo in ClientOptions

### DIFF
--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -35,7 +35,7 @@
  * (e.g. recommended shard count, shard count of the ShardingManager)
  * @property {CacheFactory} [makeCache] Function to create a cache.
  * You can use your own function, or the {@link Options} class to customize the Collection used for the cache.
- * <warn>Overriding the cache used in `GuildManager`, `ChannelManager`, 'GuildChannelManager', `RoleManager`,
+ * <warn>Overriding the cache used in `GuildManager`, `ChannelManager`, `GuildChannelManager`, `RoleManager`,
  * and `PermissionOverwriteManager` is unsupported and **will** break functionality</warn>
  * @property {number} [messageCacheLifetime=0] DEPRECATED: Use `makeCache` with a `LimitedCollection` instead.
  * How long a message should stay in the cache until it is considered sweepable (in seconds, 0 for forever)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Just fixed a small typo introduced in #6282
![image](https://user-images.githubusercontent.com/47282153/128366069-ae0d0e50-92af-4870-84da-f7c46206969e.png)

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.