### PR TITLE
refactor(Interaction): rename defer to deferReply

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -129,8 +129,8 @@ const Messages = {
     "or from a guild's application command manager.",
   GUILD_UNCACHED_ROLE_RESOLVE: 'Cannot resolve roles from an arbitrary guild, provide an id instead',
 
-  INTERACTION_ALREADY_REPLIED: 'This interaction has already been deferred or replied to.',
-  INTERACTION_NOT_REPLIED: 'This interaction has not been deferred or replied to.',
+  INTERACTION_ALREADY_REPLIED: 'The reply to this interaction has already been sent or deferred.',
+  INTERACTION_NOT_REPLIED: 'The reply to this interaction has not been sent or deferred.',
   INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be fetched or deleted.',
   INTERACTION_FETCH_EPHEMERAL: 'Ephemeral responses cannot be fetched.',
 

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -134,7 +134,7 @@ class CommandInteraction extends Interaction {
 
   // These are here only for documentation purposes - they are implemented by InteractionResponses
   /* eslint-disable no-empty-function */
-  defer() {}
+  deferReply() {}
   reply() {}
   fetchReply() {}
   editReply() {}

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -89,7 +89,7 @@ class MessageComponentInteraction extends Interaction {
 
   // These are here only for documentation purposes - they are implemented by InteractionResponses
   /* eslint-disable no-empty-function */
-  defer() {}
+  deferReply() {}
   reply() {}
   fetchReply() {}
   editReply() {}

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -12,7 +12,7 @@ const MessagePayload = require('../MessagePayload');
 class InteractionResponses {
   /**
    * Options for deferring the reply to an {@link Interaction}.
-   * @typedef {Object} InteractionDeferOptions
+   * @typedef {Object} InteractionDeferReplyOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
    * @property {boolean} [fetchReply] Whether to fetch the reply
    */
@@ -38,20 +38,20 @@ class InteractionResponses {
 
   /**
    * Defers the reply to this interaction.
-   * @param {InteractionDeferOptions} [options] Options for deferring the reply to this interaction
+   * @param {InteractionDeferReplyOptions} [options] Options for deferring the reply to this interaction
    * @returns {Promise<Message|APIMessage|void>}
    * @example
    * // Defer the reply to this interaction
-   * interaction.defer()
+   * interaction.deferReply()
    *   .then(console.log)
    *   .catch(console.error)
    * @example
    * // Defer to send an ephemeral reply later
-   * interaction.defer({ ephemeral: true })
+   * interaction.deferReply({ ephemeral: true })
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async defer(options = {}) {
+  async deferReply(options = {}) {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
     if (options.fetchReply && options.ephemeral) throw new Error('INTERACTION_FETCH_EPHEMERAL');
     this.ephemeral = options.ephemeral ?? false;
@@ -228,7 +228,17 @@ class InteractionResponses {
   }
 
   static applyToClass(structure, ignore = []) {
-    const props = ['defer', 'reply', 'fetchReply', 'editReply', 'deleteReply', 'followUp', 'deferUpdate', 'update'];
+    const props = [
+      'deferReply',
+      'reply',
+      'fetchReply',
+      'editReply',
+      'deleteReply',
+      'followUp',
+      'deferUpdate',
+      'update',
+    ];
+
     for (const prop of props) {
       if (ignore.includes(prop)) continue;
       Object.defineProperty(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -505,8 +505,8 @@ export class CommandInteraction extends Interaction {
   public options: CommandInteractionOptionResolver;
   public replied: boolean;
   public webhook: InteractionWebhook;
-  public defer(options: InteractionDeferOptions & { fetchReply: true }): Promise<Message | APIMessage>;
-  public defer(options?: InteractionDeferOptions): Promise<void>;
+  public deferReply(options: InteractionDeferReplyOptions & { fetchReply: true }): Promise<Message | APIMessage>;
+  public deferReply(options?: InteractionDeferReplyOptions): Promise<void>;
   public deleteReply(): Promise<void>;
   public editReply(options: string | MessagePayload | WebhookEditMessageOptions): Promise<Message | APIMessage>;
   public fetchReply(): Promise<Message | APIMessage>;
@@ -1218,8 +1218,8 @@ export class MessageComponentInteraction extends Interaction {
   public message: Message | APIMessage;
   public replied: boolean;
   public webhook: InteractionWebhook;
-  public defer(options: InteractionDeferOptions & { fetchReply: true }): Promise<Message | APIMessage>;
-  public defer(options?: InteractionDeferOptions): Promise<void>;
+  public deferReply(options: InteractionDeferReplyOptions & { fetchReply: true }): Promise<Message | APIMessage>;
+  public deferReply(options?: InteractionDeferReplyOptions): Promise<void>;
   public deferUpdate(options: InteractionDeferUpdateOptions & { fetchReply: true }): Promise<Message | APIMessage>;
   public deferUpdate(options?: InteractionDeferUpdateOptions): Promise<void>;
   public deleteReply(): Promise<void>;
@@ -3794,12 +3794,12 @@ export interface InteractionCollectorOptions<T extends Interaction> extends Coll
   message?: Message | APIMessage;
 }
 
-export interface InteractionDeferOptions {
+export interface InteractionDeferReplyOptions {
   ephemeral?: boolean;
   fetchReply?: boolean;
 }
 
-export type InteractionDeferUpdateOptions = Omit<InteractionDeferOptions, 'ephemeral'>;
+export type InteractionDeferUpdateOptions = Omit<InteractionDeferReplyOptions, 'ephemeral'>;
 
 export interface InteractionReplyOptions extends Omit<WebhookMessageOptions, 'username' | 'avatarURL'> {
   ephemeral?: boolean;


### PR DESCRIPTION
*Just one more PR to defer the v13 release*

**Please describe the changes this PR makes and why it should be merged:**

This renames `.defer()` to `.deferReply()` and with it also `InteractionDeferOptions` for more correctness (you do not defer the interaction itself) and better consistency with `.deferUpdate()` and possible upcoming methods.

I wasn't sure if `.deferred` should be renamed to `.replyDeferred` or something like that, so I kept it at the current name for now.

**Status and versioning classification:**

- I know how to update typings and have done so
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
