### PR TITLE
refactor(Interaction): rename `deferred` to `deferredReply`

### DIFF
--- a/src/managers/GuildStickerManager.js
+++ b/src/managers/GuildStickerManager.js
@@ -65,13 +65,13 @@ class GuildStickerManager extends CachedManager {
 
   /**
    * Data that resolves to give a Sticker object. This can be:
-   * * An Sticker object
+   * * A Sticker object
    * * A Snowflake
    * @typedef {Sticker|Snowflake} StickerResolvable
    */
 
   /**
-   * Resolves an StickerResolvable to a Sticker object.
+   * Resolves a StickerResolvable to a Sticker object.
    * @method resolve
    * @memberof GuildStickerManager
    * @instance
@@ -80,7 +80,7 @@ class GuildStickerManager extends CachedManager {
    */
 
   /**
-   * Resolves an StickerResolvable to an Sticker id string.
+   * Resolves a StickerResolvable to a Sticker id string.
    * @method resolveId
    * @memberof GuildStickerManager
    * @instance

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -44,7 +44,7 @@ class CommandInteraction extends Interaction {
      * Whether the reply to this interaction has been deferred
      * @type {boolean}
      */
-    this.deferred = false;
+    this.deferredReply = false;
 
     /**
      * The options passed to the command.

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -36,7 +36,7 @@ class MessageComponentInteraction extends Interaction {
      * Whether the reply to this interaction has been deferred
      * @type {boolean}
      */
-    this.deferred = false;
+    this.deferredReply = false;
 
     /**
      * Whether the reply to this interaction is ephemeral

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -52,7 +52,7 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   async deferReply(options = {}) {
-    if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
+    if (this.deferredReply || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
     if (options.fetchReply && options.ephemeral) throw new Error('INTERACTION_FETCH_EPHEMERAL');
     this.ephemeral = options.ephemeral ?? false;
     await this.client.api.interactions(this.id, this.token).callback.post({
@@ -63,7 +63,7 @@ class InteractionResponses {
         },
       },
     });
-    this.deferred = true;
+    this.deferredReply = true;
 
     return options.fetchReply ? this.fetchReply() : undefined;
   }
@@ -86,7 +86,7 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   async reply(options) {
-    if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
+    if (this.deferredReply || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
     if (options.fetchReply && options.ephemeral) throw new Error('INTERACTION_FETCH_EPHEMERAL');
     this.ephemeral = options.ephemeral ?? false;
 
@@ -135,7 +135,7 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   async editReply(options) {
-    if (!this.deferred && !this.replied) throw new Error('INTERACTION_NOT_REPLIED');
+    if (!this.deferredReply && !this.replied) throw new Error('INTERACTION_NOT_REPLIED');
     const message = await this.webhook.editMessage('@original', options);
     this.replied = true;
     return message;
@@ -176,7 +176,7 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   async deferUpdate(options = {}) {
-    if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
+    if (this.deferredReply || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
     if (options.fetchReply && new MessageFlags(this.message.flags).has(MessageFlags.FLAGS.EPHEMERAL)) {
       throw new Error('INTERACTION_FETCH_EPHEMERAL');
     }
@@ -185,7 +185,7 @@ class InteractionResponses {
         type: InteractionResponseTypes.DEFERRED_MESSAGE_UPDATE,
       },
     });
-    this.deferred = true;
+    this.deferredReply = true;
 
     return options.fetchReply ? this.fetchReply() : undefined;
   }
@@ -204,7 +204,7 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   async update(options) {
-    if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
+    if (this.deferredReply || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
     if (options.fetchReply && new MessageFlags(this.message.flags).has(MessageFlags.FLAGS.EPHEMERAL)) {
       throw new Error('INTERACTION_FETCH_EPHEMERAL');
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -500,7 +500,7 @@ export class CommandInteraction extends Interaction {
   public channelId: Snowflake;
   public commandId: Snowflake;
   public commandName: string;
-  public deferred: boolean;
+  public deferredReply: boolean;
   public ephemeral: boolean | null;
   public options: CommandInteractionOptionResolver;
   public replied: boolean;
@@ -1213,7 +1213,7 @@ export class MessageComponentInteraction extends Interaction {
   public readonly component: MessageActionRowComponent | Exclude<APIMessageComponent, APIActionRowComponent> | null;
   public componentType: MessageComponentType;
   public customId: string;
-  public deferred: boolean;
+  public deferredReply: boolean;
   public ephemeral: boolean | null;
   public message: Message | APIMessage;
   public replied: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR renames `.deferred` to `.deferredReply` in order to be consistent with the recent change from `.defer()` to `.deferReply()` in PR #6306. 

I wasn't too sure whether to do deferredReply or replyDeferred, but the only reason I went with deferredReply instead is that it sounds more consistent with `deferReply()`. If replyDeferred is decided instead I can change it to that. I guess you can see which is better by looking below and deciding based upon that.

```js
if (interaction.deferredReply) { // do stuff }
```
OR
```js
if (interaction.replyDeferred) { // do stuff }
```

**Update**: Just realized this applies for `deferUpdate` too. What about having both a `deferredReply` and `deferredUpdate`? Would that work?

**Status and versioning classification:**

- [x] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] I know how to update typings and have done so