### PR TITLE
docs: grammar fixes

### DIFF
--- a/src/rest/HTTPError.js
+++ b/src/rest/HTTPError.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Represents a HTTP error from a request.
+ * Represents an HTTP error from a request.
  * @extends Error
  */
 class HTTPError extends Error {

--- a/src/util/DataResolver.js
+++ b/src/util/DataResolver.js
@@ -20,7 +20,7 @@ class DataResolver extends null {
    */
 
   /**
-   * Data that can be resolved to give an template code. This can be:
+   * Data that can be resolved to give a template code. This can be:
    * * A template code
    * * A template URL
    * @typedef {string} GuildTemplateResolvable


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes two grammar mistakes. Since `HTTP` is an acronym, and when saying the first H, it sounds like a vowel, it should be "an HTTP" and not "a HTTP". 

This also fixes "an template code". 

Examples:
A HTTP request ❌
A SAT exam ❌
An HTTP request ✔️
An SAT exam ✔️

**Status and versioning classification:**

- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
