### PR TITLE
refactor: replace dependency with initial implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@discordjs/form-data": "^3.0.1",
         "@sapphire/async-queue": "^1.1.4",
         "@types/ws": "^7.4.7",
-        "abort-controller": "^3.0.0",
         "discord-api-types": "^0.22.0",
         "node-fetch": "^2.6.1",
         "ws": "^7.5.1"
@@ -40,7 +39,7 @@
         "typescript": "^4.3.5"
       },
       "engines": {
-        "node": ">=14.6.0",
+        "node": ">=16.6.0",
         "npm": ">=7.0.0"
       }
     },
@@ -2217,17 +2216,6 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
-    },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -5088,14 +5076,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -13317,14 +13297,6 @@
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -15543,11 +15515,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "execa": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "@discordjs/form-data": "^3.0.1",
     "@sapphire/async-queue": "^1.1.4",
     "@types/ws": "^7.4.7",
-    "abort-controller": "^3.0.0",
     "discord-api-types": "^0.22.0",
     "node-fetch": "^2.6.1",
     "ws": "^7.5.1"

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -2,7 +2,6 @@
 
 const https = require('https');
 const FormData = require('@discordjs/form-data');
-const AbortController = require('abort-controller');
 const fetch = require('node-fetch');
 const { UserAgent } = require('../util/Constants');
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR removes the [abort-controller](https://npmjs.com/package/abort-controller) package from the dependencies as a favor of the initial Node.js implementation of the [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) API which was graduated [here](https://github.com/nodejs/node/pull/35949).

The lib should use the initial implementation of the APIs if possible.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
