### PR TITLE
docs: grammatical fix

### DIFF
--- a/src/structures/InteractionCollector.js
+++ b/src/structures/InteractionCollector.js
@@ -128,7 +128,7 @@ class InteractionCollector extends Collector {
    */
   collect(interaction) {
     /**
-     * Emitted whenever a interaction is collected.
+     * Emitted whenever an interaction is collected.
      * @event InteractionCollector#collect
      * @param {Interaction} interaction The interaction that was collected
      */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR introduces a grammatical fix. `a interaction` is incorrect, and in turn has been fixed to `an interaction`.

**Status and versioning classification:**
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.

