### PR TITLE
fix(Caching): sweep archived threads in all channel caches

### DIFF
--- a/src/managers/ChannelManager.js
+++ b/src/managers/ChannelManager.js
@@ -13,7 +13,11 @@ let cacheWarningEmitted = false;
 class ChannelManager extends CachedManager {
   constructor(client, iterable) {
     super(client, Channel, iterable);
-    if (!cacheWarningEmitted && this._cache.constructor.name !== 'Collection') {
+    const defaultCaching =
+      this._cache.constructor.name === 'Collection' ||
+      ((this._cache.maxSize === undefined || this._cache.maxSize === Infinity) &&
+        (this._cache.sweepFilter === undefined || this._cache.sweepFilter.isDefault));
+    if (!cacheWarningEmitted && !defaultCaching) {
       cacheWarningEmitted = true;
       process.emitWarning(
         `Overriding the cache handling for ${this.constructor.name} is unsupported and breaks functionality.`,

--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -18,7 +18,11 @@ let cacheWarningEmitted = false;
 class GuildChannelManager extends CachedManager {
   constructor(guild, iterable) {
     super(guild.client, GuildChannel, iterable);
-    if (!cacheWarningEmitted && this._cache.constructor.name !== 'Collection') {
+    const defaultCaching =
+      this._cache.constructor.name === 'Collection' ||
+      ((this._cache.maxSize === undefined || this._cache.maxSize === Infinity) &&
+        (this._cache.sweepFilter === undefined || this._cache.sweepFilter.isDefault));
+    if (!cacheWarningEmitted && !defaultCaching) {
       cacheWarningEmitted = true;
       process.emitWarning(
         `Overriding the cache handling for ${this.constructor.name} is unsupported and breaks functionality.`,

--- a/src/util/LimitedCollection.js
+++ b/src/util/LimitedCollection.js
@@ -15,7 +15,7 @@ const { TypeError } = require('../errors/DJSError.js');
 /**
  * Options for defining the behavior of a LimitedCollection
  * @typedef {Object} LimitedCollectionOptions
- * @property {?number} [maxSize=0] The maximum size of the Collection
+ * @property {?number} [maxSize=Infinity] The maximum size of the Collection
  * @property {?Function} [keepOverLimit=null] A function, which is passed the value and key of an entry, ran to decide
  * to keep an entry past the maximum size
  * @property {?SweepFilter} [sweepFilter=null] A function ran every `sweepInterval` to determine how to sweep

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -104,12 +104,17 @@ class Options extends null {
       shardCount: 1,
       makeCache: this.cacheWithLimits({
         MessageManager: 200,
+        ChannelManager: {
+          sweepInterval: 3600,
+          sweepFilter: require('./Util').archivedThreadSweepFilter(),
+        },
+        GuildChannelManager: {
+          sweepInterval: 3600,
+          sweepFilter: require('./Util').archivedThreadSweepFilter(),
+        },
         ThreadManager: {
           sweepInterval: 3600,
-          sweepFilter: require('./LimitedCollection').filterByLifetime({
-            getComparisonTimestamp: e => e.archiveTimestamp,
-            excludeFromSweep: e => !e.archived,
-          }),
+          sweepFilter: require('./Util').archivedThreadSweepFilter(),
         },
       }),
       messageCacheLifetime: 0,
@@ -154,6 +159,7 @@ class Options extends null {
    * @returns {CacheFactory}
    * @example
    * // Store up to 200 messages per channel and discard archived threads if they were archived more than 4 hours ago.
+   * // Note archived threads will remain in the guild and client caches with these settings
    * Options.cacheWithLimits({
    *    MessageManager: 200,
    *    ThreadManager: {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -635,6 +635,21 @@ class Util extends null {
       setTimeout(resolve, ms);
     });
   }
+
+  /**
+   * Creates a sweep filter that sweeps archived threads
+   * @param {number} [lifetime=14400] How long a thread has to be archived to be valid for sweeping
+   * @returns {SweepFilter}
+   */
+  static archivedThreadSweepFilter(lifetime = 14400) {
+    const filter = require('./LimitedCollection').filterByLifetime({
+      lifetime,
+      getComparisonTimestamp: e => e.archiveTimestamp,
+      excludeFromSweep: e => !e.archived,
+    });
+    filter.isDefault = true;
+    return filter;
+  }
 }
 
 module.exports = Util;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1852,6 +1852,7 @@ export class UserFlags extends BitField<UserFlagsString> {
 
 export class Util extends null {
   private constructor();
+  public static archivedThreadSweepFilter<K, V>(lifetime?: number): SweepFilter<K, V>;
   public static basename(path: string, ext?: string): string;
   public static binaryToId(num: string): Snowflake;
   public static cleanContent(str: string, channel: Channel): string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a bug in the current sweeping of caches where ThreadChannels would remain in the client and guild channel caches, only being removed from the thread channel caches.

Allows a bit more control over how thread channels are swept from these caches without triggering the process warning for overriding the channel caches.

Also fixes a minor documentation error in LimitedCollection.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
