### PR TITLE
fix(MessageMentions): check guild exists before adding roles

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -304,7 +304,7 @@ class Message extends Base {
     }
 
     if (data.referenced_message) {
-      this.channel?.messages._add(data.referenced_message);
+      this.channel?.messages._add({ guild_id: data.message_reference?.guild_id, ...data.referenced_message });
     }
 
     /**

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -59,19 +59,18 @@ class MessageMentions {
       this.users = new Collection();
     }
 
-    if (roles) {
-      if (roles instanceof Collection) {
-        /**
-         * Any roles that were mentioned
-         * <info>Order as received from the API, not as they appear in the message content</info>
-         * @type {Collection<Snowflake, Role>}
-         */
-        this.roles = new Collection(roles);
-      } else {
-        this.roles = new Collection();
-        const guild = message.guild;
+    if (roles instanceof Collection) {
+      /**
+       * Any roles that were mentioned
+       * <info>Order as received from the API, not as they appear in the message content</info>
+       * @type {Collection<Snowflake, Role>}
+       */
+      this.roles = new Collection(roles);
+    } else if (roles) {
+      this.roles = new Collection();
+      const guild = message.guild;
+      if (guild) {
         for (const mention of roles) {
-          if (!guild) break;
           const role = guild.roles.cache.get(mention);
           if (role) this.roles.set(role.id, role);
         }

--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -71,6 +71,7 @@ class MessageMentions {
         this.roles = new Collection();
         const guild = message.guild;
         for (const mention of roles) {
+          if (!guild) break;
           const role = guild.roles.cache.get(mention);
           if (role) this.roles.set(role.id, role);
         }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a hard crash when resolving mentioned roles in previously uncached messages being replied to.
Also passes the guild id that is received with said message reference so that it is more likely the mentions will be resolved.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
