### PR TITLE
types(Util): fix cleanContent parameter type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1855,7 +1855,7 @@ export class Util extends null {
   public static archivedThreadSweepFilter<K, V>(lifetime?: number): SweepFilter<K, V>;
   public static basename(path: string, ext?: string): string;
   public static binaryToId(num: string): Snowflake;
-  public static cleanContent(str: string, channel: Channel): string;
+  public static cleanContent(str: string, channel: TextBasedChannels): string;
   public static removeMentions(str: string): string;
   public static cloneObject(obj: unknown): unknown;
   public static delayFor(ms: number): Promise<void>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes this TypeScript error that was introduced cause of https://github.com/discordjs/discord.js/pull/6286
![image](https://user-images.githubusercontent.com/18150845/128560111-c38e84c1-fa31-4400-8dc6-51dc82d9e8b5.png)


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
