### PR TITLE
refactor(MessageCreate): remove message event

### DIFF
--- a/packages/discord.js/src/client/actions/MessageCreate.js
+++ b/packages/discord.js/src/client/actions/MessageCreate.js
@@ -4,8 +4,6 @@ const process = require('node:process');
 const Action = require('./Action');
 const { Events } = require('../../util/Constants');
 
-let deprecationEmitted = false;
-
 class MessageCreateAction extends Action {
   handle(data) {
     const client = this.client;
@@ -24,17 +22,6 @@ class MessageCreateAction extends Action {
        * @param {Message} message The created message
        */
       client.emit(Events.MESSAGE_CREATE, message);
-
-      /**
-       * Emitted whenever a message is created.
-       * @event Client#message
-       * @param {Message} message The created message
-       * @deprecated Use {@link Client#event:messageCreate} instead
-       */
-      if (client.emit('message', message) && !deprecationEmitted) {
-        deprecationEmitted = true;
-        process.emitWarning('The message event is deprecated. Use messageCreate instead', 'DeprecationWarning');
-      }
 
       return { message };
     }

--- a/packages/discord.js/src/client/actions/MessageCreate.js
+++ b/packages/discord.js/src/client/actions/MessageCreate.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const process = require('node:process');
 const Action = require('./Action');
 const { Events } = require('../../util/Constants');
 

--- a/packages/discord.js/test/tester2000.js
+++ b/packages/discord.js/test/tester2000.js
@@ -48,7 +48,7 @@ const commands = {
   ping: message => message.channel.send('pong'),
 };
 
-client.on('message', message => {
+client.on('messageCreate', message => {
   if (!message.content.startsWith(prefix) || message.author.bot) return;
 
   message.content = message.content.replace(prefix, '').trim().split(' ');

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3899,8 +3899,6 @@ export interface ClientEvents extends BaseClientEvents {
   guildUpdate: [oldGuild: Guild, newGuild: Guild];
   inviteCreate: [invite: Invite];
   inviteDelete: [invite: Invite];
-  /** @deprecated Use messageCreate instead */
-  message: [message: Message];
   messageCreate: [message: Message];
   messageDelete: [message: Message | PartialMessage];
   messageReactionRemoveAll: [


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

First(?) semver major PR ready for v14 -- removes the deprecated client `message` event.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
