### PR TITLE
fix(Message): handle fetched messages

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -41,7 +41,7 @@ class Message extends Base {
      * The id of the guild the message was sent in, if any
      * @type {?Snowflake}
      */
-    this.guildId = data.guild_id ?? null;
+    this.guildId = data.guild_id ?? this.channel?.guild?.id ?? null;
 
     /**
      * Whether this message has been deleted
@@ -390,7 +390,7 @@ class Message extends Base {
    * @readonly
    */
   get guild() {
-    return this.client.guilds.resolve(this.guildId);
+    return this.client.guilds.resolve(this.guildId) ?? this.channel?.guild ?? null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

PR #6271 has introduced a regression, because fetched messages do not include a `guild_id` property in the rest response. This causes `Message#guild` to become `null` for fetched messages, even if they were fetched from a guild channel.

- try to assign the guild id from the channel, if available
- adapt the `Message#guild` getter to also return the guild from the `Message#channel` getter, if necessary and available

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
