### PR TITLE
refactor(InteractionCreate): remove interaction event

### DIFF
--- a/packages/discord.js/src/client/actions/InteractionCreate.js
+++ b/packages/discord.js/src/client/actions/InteractionCreate.js
@@ -10,8 +10,6 @@ const SelectMenuInteraction = require('../../structures/SelectMenuInteraction');
 const UserContextMenuCommandInteraction = require('../../structures/UserContextMenuCommandInteraction');
 const { Events, InteractionTypes, MessageComponentTypes, ApplicationCommandTypes } = require('../../util/Constants');
 
-let deprecationEmitted = false;
-
 class InteractionCreateAction extends Action {
   handle(data) {
     const client = this.client;
@@ -72,17 +70,6 @@ class InteractionCreateAction extends Action {
      * @param {Interaction} interaction The interaction which was created
      */
     client.emit(Events.INTERACTION_CREATE, interaction);
-
-    /**
-     * Emitted when an interaction is created.
-     * @event Client#interaction
-     * @param {Interaction} interaction The interaction which was created
-     * @deprecated Use {@link Client#event:interactionCreate} instead
-     */
-    if (client.emit('interaction', interaction) && !deprecationEmitted) {
-      deprecationEmitted = true;
-      process.emitWarning('The interaction event is deprecated. Use interactionCreate instead', 'DeprecationWarning');
-    }
   }
 }
 

--- a/packages/discord.js/src/client/actions/InteractionCreate.js
+++ b/packages/discord.js/src/client/actions/InteractionCreate.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const process = require('node:process');
 const Action = require('./Action');
 const AutocompleteInteraction = require('../../structures/AutocompleteInteraction');
 const ButtonInteraction = require('../../structures/ButtonInteraction');

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3931,8 +3931,6 @@ export interface ClientEvents extends BaseClientEvents {
   userUpdate: [oldUser: User | PartialUser, newUser: User];
   voiceStateUpdate: [oldState: VoiceState, newState: VoiceState];
   webhookUpdate: [channel: TextChannel | NewsChannel];
-  /** @deprecated Use interactionCreate instead */
-  interaction: [interaction: Interaction];
   interactionCreate: [interaction: Interaction];
   shardDisconnect: [closeEvent: CloseEvent, shardId: number];
   shardError: [error: Error, shardId: number];

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -661,7 +661,7 @@ client.on('messageCreate', async message => {
   });
 });
 
-client.on('interaction', async interaction => {
+client.on('interactionCreate', async interaction => {
   expectType<Snowflake | null>(interaction.guildId);
   expectType<Snowflake | null>(interaction.channelId);
   expectType<GuildMember | APIInteractionGuildMember | null>(interaction.member);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Akin to #6324, removes the deprecated client `interaction` event.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
