### PR TITLE
refactor(Client): remove message sweeping options

### DIFF
--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -37,11 +37,6 @@
  * You can use your own function, or the {@link Options} class to customize the Collection used for the cache.
  * <warn>Overriding the cache used in `GuildManager`, `ChannelManager`, `GuildChannelManager`, `RoleManager`,
  * and `PermissionOverwriteManager` is unsupported and **will** break functionality</warn>
- * @property {number} [messageCacheLifetime=0] DEPRECATED: Use `makeCache` with a `LimitedCollection` instead.
- * How long a message should stay in the cache until it is considered sweepable (in seconds, 0 for forever)
- * @property {number} [messageSweepInterval=0] DEPRECATED: Use `makeCache` with a `LimitedCollection` instead.
- * How frequently to remove messages from the cache that are older than the message cache lifetime
- * (in seconds, 0 for never)
  * @property {MessageMentionOptions} [allowedMentions] Default value for {@link MessageOptions#allowedMentions}
  * @property {number} [invalidRequestWarningInterval=0] The number of invalid REST requests (those that return
  * 401, 403, or 429) in a 10 minute window between emitted warnings (0 for no warnings). That is, if set to 500,
@@ -112,8 +107,6 @@ class Options extends null {
     return {
       shardCount: 1,
       makeCache: this.cacheWithLimits(this.defaultMakeCacheSettings),
-      messageCacheLifetime: 0,
-      messageSweepInterval: 0,
       invalidRequestWarningInterval: 0,
       partials: [],
       restWsBridgeTimeout: 5_000,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3542,10 +3542,6 @@ export interface ClientOptions {
   shards?: number | number[] | 'auto';
   shardCount?: number;
   makeCache?: CacheFactory;
-  /** @deprecated Use `makeCache` with a `LimitedCollection` for `MessageManager` instead. */
-  messageCacheLifetime?: number;
-  /** @deprecated Use `makeCache` with a `LimitedCollection` for `MessageManager` instead. */
-  messageSweepInterval?: number;
   allowedMentions?: MessageMentionOptions;
   invalidRequestWarningInterval?: number;
   partials?: PartialTypes[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removes the deprecated `messageSweepInterval` and `messageCacheLifetime` client options, and the `sweepMessages` client method that they used.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
