### PR TITLE
chore: add other maintainers to GH Sponsors config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,11 +1,2 @@
-# These are supported funding model platforms
-
-# github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-# patreon: # Replace with a single Patreon username
-# open_collective: # Replace with a single Open Collective username
-# ko_fi: # Replace with a single Ko-fi username
-# tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-# custom: # Replace with a single custom sponsorship URL
-
-github: amishshah
+github: [amishshah, iCrawl, vladfrangu, kyranet]
 patreon: discordjs


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds the core maintainers with GitHub Sponsors enabled to the funding doc to help point folks in the right direction if they wanna sponsor those that keep this lib going.

Space, ily, but you don't have Sponsors enabled (which is in a way great 'cause the config only allows four usernames)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
