### PR TITLE
refactor(Options): separate default settings for make cache

### DIFF
--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -102,21 +102,7 @@ class Options extends null {
   static createDefault() {
     return {
       shardCount: 1,
-      makeCache: this.cacheWithLimits({
-        MessageManager: 200,
-        ChannelManager: {
-          sweepInterval: 3600,
-          sweepFilter: require('./Util').archivedThreadSweepFilter(),
-        },
-        GuildChannelManager: {
-          sweepInterval: 3600,
-          sweepFilter: require('./Util').archivedThreadSweepFilter(),
-        },
-        ThreadManager: {
-          sweepInterval: 3600,
-          sweepFilter: require('./Util').archivedThreadSweepFilter(),
-        },
-      }),
+      makeCache: this.cacheWithLimits(this.defaultMakeCacheSettings),
       messageCacheLifetime: 0,
       messageSweepInterval: 0,
       invalidRequestWarningInterval: 0,
@@ -173,6 +159,9 @@ class Options extends null {
    * @example
    * // Sweep messages every 5 minutes, removing messages that have not been edited or created in the last 30 minutes
    * Options.cacheWithLimits({
+   *   // Keep default thread sweeping behavior
+   *   ...Options.defaultMakeCacheSettings,
+   *   // Override MessageManager
    *   MessageManager: {
    *     sweepInterval: 300,
    *     sweepFilter: LimitedCollection.filterByLifetime({
@@ -220,6 +209,35 @@ class Options extends null {
   static cacheEverything() {
     const { Collection } = require('@discordjs/collection');
     return () => new Collection();
+  }
+
+  /**
+   * The default settings passed to {@link Options.cacheWithLimits}.
+   * The caches that this changes are:
+   * * `MessageManager` - Limit to 200 messages
+   * * `ChannelManager` - Sweep archived threads
+   * * `GuildChannelManager` - Sweep archived threads
+   * * `ThreadManager` - Sweep archived threads
+   * <info>If you want to keep default behavior and add on top of it you can use this object and add on to it, e.g.
+   * `makeCache: Options.cacheWithLimits({ ...Options.defaultmakeCacheSettings, ReactionManager: 0 })`</info>
+   * @type {Object<string, LimitedCollectionOptions|number>}
+   */
+  static get defaultMakeCacheSettings() {
+    return {
+      MessageManager: 200,
+      ChannelManager: {
+        sweepInterval: 3600,
+        sweepFilter: require('./Util').archivedThreadSweepFilter(),
+      },
+      GuildChannelManager: {
+        sweepInterval: 3600,
+        sweepFilter: require('./Util').archivedThreadSweepFilter(),
+      },
+      ThreadManager: {
+        sweepInterval: 3600,
+        sweepFilter: require('./Util').archivedThreadSweepFilter(),
+      },
+    };
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -449,6 +449,7 @@ export class ClientUser extends User {
 
 export class Options extends null {
   private constructor();
+  public static defaultMakeCacheSettings: CacheWithLimitsOptions;
   public static createDefaultOptions(): ClientOptions;
   public static cacheWithLimits(settings?: CacheWithLimitsOptions): CacheFactory;
   public static cacheEverything(): CacheFactory;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Separates out the default options being passed to Options.cacheWithLimits.
This allows devs to change only a single one of the default overrides or add on top without having to redo the rest.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
