### PR TITLE
fix(Constants): fix CDN endpoint typings

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -55,10 +55,10 @@ exports.Endpoints = {
         if (dynamic) format = hash.startsWith('a_') ? 'gif' : format;
         return makeImageUrl(`${root}/icons/${guildId}/${hash}`, { format, size });
       },
-      AppIcon: (clientId, hash, { format = 'webp', size } = {}) =>
-        makeImageUrl(`${root}/app-icons/${clientId}/${hash}`, { size, format }),
-      AppAsset: (clientId, hash, { format = 'webp', size } = {}) =>
-        makeImageUrl(`${root}/app-assets/${clientId}/${hash}`, { size, format }),
+      AppIcon: (appId, hash, { format = 'webp', size } = {}) =>
+        makeImageUrl(`${root}/app-icons/${appId}/${hash}`, { size, format }),
+      AppAsset: (appId, hash, { format = 'webp', size } = {}) =>
+        makeImageUrl(`${root}/app-assets/${appId}/${hash}`, { size, format }),
       StickerPackBanner: (bannerId, format = 'webp', size) =>
         makeImageUrl(`${root}/app-assets/710982414301790216/store/${bannerId}`, { size, format }),
       GDMIcon: (channelId, hash, format = 'webp', size) =>

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2140,33 +2140,42 @@ export const Constants: {
     botGateway: string;
     invite: (root: string, code: string) => string;
     CDN: (root: string) => {
-      Asset: (name: string) => string;
-      DefaultAvatar: (id: Snowflake | number) => string;
       Emoji: (emojiId: Snowflake, format: DynamicImageFormat) => string;
-      Avatar: (userId: Snowflake, hash: string, format: DynamicImageFormat, size: AllowedImageSize) => string;
-      Banner: (guildId: Snowflake | number, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
-      Icon: (userId: Snowflake | number, hash: string, format: DynamicImageFormat, size: AllowedImageSize) => string;
-      AppIcon: (userId: Snowflake | number, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
-      AppAsset: (
-        userId: Snowflake | number,
+      Asset: (name: string) => string;
+      DefaultAvatar: (discriminator: number) => string;
+      Avatar: (
+        userId: Snowflake,
         hash: string,
-        format: AllowedImageFormat,
+        format: DynamicImageFormat,
         size: AllowedImageSize,
+        dynamic: boolean,
+      ) => string;
+      Banner: (guildId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
+      Icon: (
+        guildId: Snowflake,
+        hash: string,
+        format: DynamicImageFormat,
+        size: AllowedImageSize,
+        dynamic: boolean,
+      ) => string;
+      AppIcon: (
+        appId: Snowflake,
+        hash: string,
+        { format, size }: { format: AllowedImageFormat; size: AllowedImageSize },
+      ) => string;
+      AppAsset: (
+        appId: Snowflake,
+        hash: string,
+        { format, size }: { format: AllowedImageFormat; size: AllowedImageSize },
       ) => string;
       StickerPackBanner: (bannerId: Snowflake, format: AllowedImageFormat, size: AllowedImageSize) => string;
-      GDMIcon: (userId: Snowflake | number, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
-      Splash: (guildId: Snowflake | number, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
-      DiscoverySplash: (
-        guildId: Snowflake | number,
-        hash: string,
-        format: AllowedImageFormat,
-        size: AllowedImageSize,
-      ) => string;
+      GDMIcon: (channelId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
+      Splash: (guildId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
+      DiscoverySplash: (guildId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
       TeamIcon: (
-        teamId: Snowflake | number,
+        teamId: Snowflake,
         hash: string,
-        format: AllowedImageFormat,
-        size: AllowedImageSize,
+        { format, size }: { format: AllowedImageFormat; size: AllowedImageSize },
       ) => string;
       Sticker: (stickerId: Snowflake, stickerFormat: StickerFormatType) => string;
     };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
CDN typings had a surprising number of issues so this fixes them:
- DefaultAvatar takes "discriminator" (number), not id
- a few used `userId` when they were not for users
- added `dynamic` option to Avatar and Icon (pulled from the banner prs)
- a bunch of id args were typed as `Snowflake | number` for some reason, changed those to just `Snowflake`
- some methods actually take format and size in an object (for some reason) but they were typed as separate args

also changes `clientId` to `appId` to reflect Discord now using "application id" in non-OAuth2 contexts

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.