### PR TITLE
fix(Managers): fix typo in unsupported warning

### DIFF
--- a/src/managers/ChannelManager.js
+++ b/src/managers/ChannelManager.js
@@ -21,7 +21,7 @@ class ChannelManager extends CachedManager {
       cacheWarningEmitted = true;
       process.emitWarning(
         `Overriding the cache handling for ${this.constructor.name} is unsupported and breaks functionality.`,
-        'UnuspportedCacheOverwriteWarning',
+        'UnsupportedCacheOverwriteWarning',
       );
     }
   }

--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -26,7 +26,7 @@ class GuildChannelManager extends CachedManager {
       cacheWarningEmitted = true;
       process.emitWarning(
         `Overriding the cache handling for ${this.constructor.name} is unsupported and breaks functionality.`,
-        'UnuspportedCacheOverwriteWarning',
+        'UnsupportedCacheOverwriteWarning',
       );
     }
 

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -34,7 +34,7 @@ class GuildManager extends CachedManager {
       cacheWarningEmitted = true;
       process.emitWarning(
         `Overriding the cache handling for ${this.constructor.name} is unsupported and breaks functionality.`,
-        'UnuspportedCacheOverwriteWarning',
+        'UnsupportedCacheOverwriteWarning',
       );
     }
   }

--- a/src/managers/PermissionOverwriteManager.js
+++ b/src/managers/PermissionOverwriteManager.js
@@ -20,7 +20,7 @@ class PermissionOverwriteManager extends CachedManager {
       cacheWarningEmitted = true;
       process.emitWarning(
         `Overriding the cache handling for ${this.constructor.name} is unsupported and breaks functionality.`,
-        'UnuspportedCacheOverwriteWarning',
+        'UnsupportedCacheOverwriteWarning',
       );
     }
 

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -20,7 +20,7 @@ class RoleManager extends CachedManager {
       cacheWarningEmitted = true;
       process.emitWarning(
         `Overriding the cache handling for ${this.constructor.name} is unsupported and breaks functionality.`,
-        'UnuspportedCacheOverwriteWarning',
+        'UnsupportedCacheOverwriteWarning',
       );
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a typo in the warning for `UnsupportedCacheOverwriteWarning`.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.