### PR TITLE
types(ImageURLOptions): allow 'gif' format

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3786,6 +3786,7 @@ export interface HTTPOptions {
 
 export interface ImageURLOptions extends StaticImageURLOptions {
   dynamic?: boolean;
+  format?: DynamicImageFormat;
 }
 
 export interface IntegrationAccount {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3784,10 +3784,10 @@ export interface HTTPOptions {
   headers?: Record<string, string>;
 }
 
-export interface ImageURLOptions extends StaticImageURLOptions {
+export type ImageURLOptions = StaticImageURLOptions & {
   dynamic?: boolean;
   format?: DynamicImageFormat;
-}
+};
 
 export interface IntegrationAccount {
   id: string | Snowflake;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3784,10 +3784,10 @@ export interface HTTPOptions {
   headers?: Record<string, string>;
 }
 
-export type ImageURLOptions = StaticImageURLOptions & {
+export interface ImageURLOptions extends Omit<StaticImageURLOptions, 'format'> {
   dynamic?: boolean;
   format?: DynamicImageFormat;
-};
+}
 
 export interface IntegrationAccount {
   id: string | Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`<User>.avatarURL({ format: 'gif' });` throws the following:
Type '"gif"' is not assignable to type 'AllowedImageFormat | undefined'.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
