### PR TITLE
docs: grammar fixes

### DIFF
--- a/src/structures/GuildTemplate.js
+++ b/src/structures/GuildTemplate.js
@@ -205,7 +205,7 @@ class GuildTemplate extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically returns the templates's code instead of the template object.
+   * When concatenated with a string, this automatically returns the templates' code instead of the template object.
    * @returns {string}
    * @example
    * // Logs: Template: FKvmczH2HyUf

--- a/src/structures/GuildTemplate.js
+++ b/src/structures/GuildTemplate.js
@@ -205,7 +205,7 @@ class GuildTemplate extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically returns the templates' code instead of the template object.
+   * When concatenated with a string, this automatically returns the template's code instead of the template object.
    * @returns {string}
    * @example
    * // Logs: Template: FKvmczH2HyUf

--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -80,7 +80,7 @@ class Team extends Base {
   }
 
   /**
-   * A link to the teams's icon.
+   * A link to the teams' icon.
    * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */

--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -80,7 +80,7 @@ class Team extends Base {
   }
 
   /**
-   * A link to the teams' icon.
+   * A link to the team's icon.
    * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */

--- a/src/structures/TeamMember.js
+++ b/src/structures/TeamMember.js
@@ -50,7 +50,7 @@ class TeamMember extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically returns the team members's mention instead of the
+   * When concatenated with a string, this automatically returns the team members' mention instead of the
    * TeamMember object.
    * @returns {string}
    * @example

--- a/src/structures/TeamMember.js
+++ b/src/structures/TeamMember.js
@@ -50,7 +50,7 @@ class TeamMember extends Base {
   }
 
   /**
-   * When concatenated with a string, this automatically returns the team members' mention instead of the
+   * When concatenated with a string, this automatically returns the team member's mention instead of the
    * TeamMember object.
    * @returns {string}
    * @example

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -840,7 +840,7 @@ exports.APIErrors = {
 exports.DefaultMessageNotificationLevels = createEnum(['ALL_MESSAGES', 'ONLY_MENTIONS']);
 
 /**
- * The value set for a team members' membership state:
+ * The value set for a team member's membership state:
  * * INVITED
  * * ACCEPTED
  * @typedef {string} MembershipState
@@ -1052,7 +1052,7 @@ function createEnum(keys) {
  * The value set for the explicit content filter levels for a guild.
  * @property {InteractionResponseType} InteractionResponseTypes The type of an interaction response.
  * @property {InteractionType} InteractionTypes The type of an {@link Interaction} object.
- * @property {MembershipState} MembershipStates The value set for a team members' membership state.
+ * @property {MembershipState} MembershipStates The value set for a team member's membership state.
  * @property {MessageButtonStyle} MessageButtonStyles The style of a message button.
  * @property {MessageComponentType} MessageComponentTypes The type of a message component.
  * @property {MFALevel} MFALevels The required MFA level for a guild.

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -840,7 +840,7 @@ exports.APIErrors = {
 exports.DefaultMessageNotificationLevels = createEnum(['ALL_MESSAGES', 'ONLY_MENTIONS']);
 
 /**
- * The value set for a team members's membership state:
+ * The value set for a team members' membership state:
  * * INVITED
  * * ACCEPTED
  * @typedef {string} MembershipState
@@ -1052,7 +1052,7 @@ function createEnum(keys) {
  * The value set for the explicit content filter levels for a guild.
  * @property {InteractionResponseType} InteractionResponseTypes The type of an interaction response.
  * @property {InteractionType} InteractionTypes The type of an {@link Interaction} object.
- * @property {MembershipState} MembershipStates The value set for a team members's membership state.
+ * @property {MembershipState} MembershipStates The value set for a team members' membership state.
  * @property {MessageButtonStyle} MessageButtonStyles The style of a message button.
  * @property {MessageComponentType} MessageComponentTypes The type of a message component.
  * @property {MFALevel} MFALevels The required MFA level for a guild.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes grammar regarding plural possessives. 

In some places, it said something like `The value set for a team members's membership state:`. Not only is this incorrect (since it would be `The value set for a team members' membership state:`), but it does make it too consistent with documentation in other places. 

For example, for stickers, nowhere does it say `The value set for a stickers's type:`; instead it says `The value set for a sticker's type:` which uses genitive case, so the same thing should apply with others.

**Status and versioning classification:**

- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
