### PR TITLE
types(ApplicationCommandOptionData) changed options type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2875,6 +2875,7 @@ export interface ApplicationCommandOptionData {
 
 export interface ApplicationCommandOption extends ApplicationCommandOptionData {
   type: ApplicationCommandOptionType;
+  options?: ApplicationCommandOption[]
 }
 
 export interface ApplicationCommandOptionChoice {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2870,7 +2870,7 @@ export interface ApplicationCommandOptionData {
   description: string;
   required?: boolean;
   choices?: ApplicationCommandOptionChoice[];
-  options?: this[];
+  options?: ApplicationCommandOptionData[];
 }
 
 export interface ApplicationCommandOption extends ApplicationCommandOptionData {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2875,7 +2875,7 @@ export interface ApplicationCommandOptionData {
 
 export interface ApplicationCommandOption extends ApplicationCommandOptionData {
   type: ApplicationCommandOptionType;
-  options?: ApplicationCommandOption[]
+  options?: ApplicationCommandOption[];
 }
 
 export interface ApplicationCommandOptionChoice {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The options type `this[]` as a self reference causes issues when implementing this interface. Changing this to `ApplicationCommandOptionData[]` fixes this issue https://imgur.com/a/0eVBoJU


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
