### PR TITLE
chore: update conventional commit URL

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,4 +14,4 @@ To get ready to work on the codebase, please do the following:
 2. Run `npm ci`
 3. Code your heart out!
 4. Run `npm test` to run ESLint and ensure any JSDoc changes are valid
-5. [Submit a pull request](https://github.com/discordjs/discord.js/compare) (Make sure you follow the [conventional commit format](https://github.com/discordjs/discord.js-next/blob/main/.github/COMMIT_CONVENTION.md))
+5. [Submit a pull request](https://github.com/discordjs/discord.js/compare) (Make sure you follow the [conventional commit format](https://github.com/discordjs/discord.js-modules/blob/main/.github/COMMIT_CONVENTION.md))


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
updates the conventional commit url, to use `discord.js-modules` instead of `discord.js-next`


**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
