### PR TITLE
chore(README): more explanation in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ npm install discord.js
 - [@discordjs/voice](https://github.com/discordjs/voice) for interacting with the Discord Voice API
 
 ## Example usage
+
 Install all required dependencies:
 ```sh
 npm install discord.js @discordjs/rest discord-api-types
+yarn add discord.js @discordjs/rest discord-api-types
+pnpm add discord.js @discordjs/rest discord-api-types
 ```
 
 Register a slash command against the Discord API:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ npm install discord.js
 ## Example usage
 
 Install all required dependencies:
-```sh
+```sh-session
 npm install discord.js @discordjs/rest discord-api-types
 yarn add discord.js @discordjs/rest discord-api-types
 pnpm add discord.js @discordjs/rest discord-api-types

--- a/README.md
+++ b/README.md
@@ -40,8 +40,12 @@ npm install discord.js
 - [@discordjs/voice](https://github.com/discordjs/voice) for interacting with the Discord Voice API
 
 ## Example usage
+Install all required dependencies:
+```sh
+npm install discord.js @discordjs/rest discord-api-types
+```
 
-First, we need to register a slash command against the Discord API:
+Register a slash command against the Discord API:
 ```js
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');


### PR DESCRIPTION
**Why this change should be merged:**
Because some people keep installing `discord-api-types` using `discord-api-types/v9` which is not available.
Probably because they just install by copy and paste the module name. So this is just to make it clearer.


**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
