### PR TITLE
fix(Util): remove truthy check before isNaN check

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -470,7 +470,7 @@ class Util extends null {
     }
 
     if (color < 0 || color > 0xffffff) throw new RangeError('COLOR_RANGE');
-    else if (color && isNaN(color)) throw new TypeError('COLOR_CONVERT');
+    else if (isNaN(color)) throw new TypeError('COLOR_CONVERT');
 
     return color;
   }

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -470,7 +470,7 @@ class Util extends null {
     }
 
     if (color < 0 || color > 0xffffff) throw new RangeError('COLOR_RANGE');
-    else if (isNaN(color)) throw new TypeError('COLOR_CONVERT');
+    else if (Number.isNaN(color)) throw new TypeError('COLOR_CONVERT');
 
     return color;
   }


### PR DESCRIPTION
[If an invalid string is passed into resolveColor, it never actually throws a `COLOR_CONVERT` error and will return NaN](https://user-images.githubusercontent.com/19440022/128658616-6420ae74-1021-4405-b2d0-3f8b5ca2c9ee.png). Why is this? Well because of this line:
https://github.com/discordjs/discord.js/blob/cd393fd4214e111f1cf6de779cfcc07315e80fbd/src/util/Util.js#L473

Because [NaN isn't a truthy value](https://cdn.discordapp.com/attachments/768856355255484469/874136189278519346/node_IBCxEagdZz.png), we don't get past that first condition to be able to check whether the color is NaN. This PR fixes that.


**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
