### PR TITLE
docs(Invite): `MANAGE_CHANNELS` instead of `MANAGE_CHANNEL`

### DIFF
--- a/src/client/actions/InviteCreate.js
+++ b/src/client/actions/InviteCreate.js
@@ -16,7 +16,7 @@ class InviteCreateAction extends Action {
     /**
      * Emitted when an invite is created.
      * <info> This event only triggers if the client has `MANAGE_GUILD` permissions for the guild,
-     * or `MANAGE_CHANNEL` permissions for the channel.</info>
+     * or `MANAGE_CHANNELS` permissions for the channel.</info>
      * @event Client#inviteCreate
      * @param {Invite} invite The invite that was created
      */

--- a/src/client/actions/InviteDelete.js
+++ b/src/client/actions/InviteDelete.js
@@ -18,7 +18,7 @@ class InviteDeleteAction extends Action {
     /**
      * Emitted when an invite is deleted.
      * <info> This event only triggers if the client has `MANAGE_GUILD` permissions for the guild,
-     * or `MANAGE_CHANNEL` permissions for the channel.</info>
+     * or `MANAGE_CHANNELS` permissions for the channel.</info>
      * @event Client#inviteDelete
      * @param {Invite} invite The invite that was deleted
      */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a doc typo. Should be MANAGE_CHANNEL**S**

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
