### PR TITLE
docs(Options): defaultMakeCacheSettings typo

### DIFF
--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -219,7 +219,7 @@ class Options extends null {
    * * `GuildChannelManager` - Sweep archived threads
    * * `ThreadManager` - Sweep archived threads
    * <info>If you want to keep default behavior and add on top of it you can use this object and add on to it, e.g.
-   * `makeCache: Options.cacheWithLimits({ ...Options.defaultmakeCacheSettings, ReactionManager: 0 })`</info>
+   * `makeCache: Options.cacheWithLimits({ ...Options.defaultMakeCacheSettings, ReactionManager: 0 })`</info>
    * @type {Object<string, LimitedCollectionOptions|number>}
    */
   static get defaultMakeCacheSettings() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
fix defaultMakeCacheSettings to be consistant with the actual name.

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
