### PR TITLE
chore(exports): allow imports of specific paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "typings"
   ],
   "exports": {
-    "require": "./src/index.js",
-    "import": "./src/index.mjs"
+    "./*": "./*",
+    ".": {
+      "require": "./src/index.js",
+      "import": "./src/index.mjs"
+    }
   },
   "scripts": {
     "test": "npm run lint && npm run docs:test && npm run lint:typings",


### PR DESCRIPTION
This allows to import from specific paths.

**Why?**
In my case:
Jest does not currently support `exports`. So when ESM is enabled, and discord.js is imported, Jest resolves its CJS version (`main`). This commit will  allow to import from `discord.js/src/index.mjs` into the source code to avoid problems with Jest.

In other cases it would allow to import a specific path which is rather interesting.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
