### PR TITLE
typings(Options): createDefaultOptions => createDefault

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -450,7 +450,7 @@ export class ClientUser extends User {
 export class Options extends null {
   private constructor();
   public static defaultMakeCacheSettings: CacheWithLimitsOptions;
-  public static createDefaultOptions(): ClientOptions;
+  public static createDefault(): ClientOptions;
   public static cacheWithLimits(settings?: CacheWithLimitsOptions): CacheFactory;
   public static cacheEverything(): CacheFactory;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a method name mismatch in the typings.
Preferred to edit the typing instead of the actual method name since `Options.createDefaultOptions` seems a little bit repetitive.

Closes #6375 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
