### PR TITLE
types(ApplicationCommandData): Stronger typings for `ApplicationCommandData` variants.

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2881,13 +2881,29 @@ export interface ApplicationAsset {
   type: 'BIG' | 'SMALL';
 }
 
-export interface ApplicationCommandData {
+export interface BaseApplicationCommandData {
   name: string;
-  description?: string;
-  type?: ApplicationCommandType | ApplicationCommandTypes;
-  options?: ApplicationCommandOptionData[];
   defaultPermission?: boolean;
 }
+
+export interface UserApplicationCommandData extends BaseApplicationCommandData {
+  type: 'USER' | ApplicationCommandTypes.USER;
+}
+
+export interface MessageApplicationCommandData extends BaseApplicationCommandData {
+  type: 'MESSAGE' | ApplicationCommandTypes.MESSAGE;
+}
+
+export interface ChatInputApplicationCommandData extends BaseApplicationCommandData {
+  description: string;
+  type: 'CHAT_INPUT' | ApplicationCommandTypes.CHAT_INPUT;
+  options?: ApplicationCommandOptionData[];
+}
+
+export type ApplicationCommandData =
+  | UserApplicationCommandData
+  | MessageApplicationCommandData
+  | ChatInputApplicationCommandData;
 
 export interface ApplicationCommandOptionData {
   type: ApplicationCommandOptionType | ApplicationCommandOptionTypes;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This introduces compile-time constraints for the changes recently added to `ApplicationCommandData`:
- `description` is required when type is set to `'CHAT_INPUT'`
- `options` is only available to commands of `'CHAT_INPUT'` types as per the discord docs

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

