### PR TITLE
feat(CommandInteractionResolvedData): access to "raw" resolved data

### DIFF
--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -80,7 +80,7 @@ class BaseCommandInteraction extends Interaction {
    * @typedef {Object} CommandInteractionResolvedData
    * @property {Collection<string, User>} [users] The resolved users
    * @property {Collection<string, GuildMember|APIGuildMember>} [members] The resolved guild members
-   * @property {Collection<string, Role|APIRole>} [roles] The resolved messages
+   * @property {Collection<string, Role|APIRole>} [roles] The resolved roles
    * @property {Collection<string, Channel|APIChannel>} [channels] The resolved channels
    * @property {Collection<string, Message|APIMessage>} [messages] The resolved messages
    */

--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -79,10 +79,10 @@ class BaseCommandInteraction extends Interaction {
    * Represents the resolved data of a received command interaction.
    * @typedef {Object} CommandInteractionResolvedData
    * @property {Collection<string, User>} users The resolved users
-   * @property {Collection<string, GuildMember|APIGuildMember} members The resolved guild members
-   * @property {Collection<string, Role|APIRole} roles The resolved messages
-   * @property {Collection<string, Channel|APIChannel} channels The resolved channels
-   * @property {Collection<string, Message|APIMessage} messages The resolved messages
+   * @property {Collection<string, GuildMember|APIGuildMember>} members The resolved guild members
+   * @property {Collection<string, Role|APIRole>} roles The resolved messages
+   * @property {Collection<string, Channel|APIChannel>} channels The resolved channels
+   * @property {Collection<string, Message|APIMessage>} messages The resolved messages
    */
 
   /**

--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -96,9 +96,9 @@ class BaseCommandInteraction extends Interaction {
 
     if (members) {
       result.members = new Collection();
-      for (const member of Object.values(members)) {
-        const user = users[member.id];
-        result.members.set(member.id, this.guild?.members._add({ user, ...member }) ?? member);
+      for (const [id, member] of Object.entries(members)) {
+        const user = users[id];
+        result.members.set(id, this.guild?.members._add({ user, ...member }) ?? member);
       }
     }
 

--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Collection } = require('@discordjs/collection');
 const Interaction = require('./Interaction');
 const InteractionWebhook = require('./InteractionWebhook');
 const InteractionResponses = require('./interfaces/InteractionResponses');
@@ -72,6 +73,64 @@ class BaseCommandInteraction extends Interaction {
   get command() {
     const id = this.commandId;
     return this.guild?.commands.cache.get(id) ?? this.client.application.commands.cache.get(id) ?? null;
+  }
+
+  /**
+   * Represents the resolved data of a received command interaction.
+   * @typedef {Object} CommandInteractionResolvedData
+   * @property {Collection<string, User>} users The resolved users
+   * @property {Collection<string, GuildMember|APIGuildMember} members The resolved guild members
+   * @property {Collection<string, Role|APIRole} roles The resolved messages
+   * @property {Collection<string, Channel|APIChannel} channels The resolved channels
+   * @property {Collection<string, Message|APIMessage} messages The resolved messages
+   */
+
+  /**
+   * Transforms the resolved received from the API.
+   * @param {APIInteractionDataResolved} resolved The received resolved objects
+   * @returns {CommandInteractionResolvedData}
+   * @private
+   */
+  transformResolved({ members, users, channels, roles, messages }) {
+    const result = {};
+
+    if (members) {
+      result.members = new Collection();
+      for (const member of Object.values(members)) {
+        const user = users[member.id];
+        result.members.set(member.id, this.guild?.members._add({ user, ...member }) ?? member);
+      }
+    }
+
+    if (users) {
+      result.users = new Collection();
+      for (const user of Object.values(users)) {
+        result.users.set(user.id, this.client.users._add(user));
+      }
+    }
+
+    if (roles) {
+      result.roles = new Collection();
+      for (const role of Object.values(roles)) {
+        result.roles.set(role.id, this.guild?.roles._add(role) ?? role);
+      }
+    }
+
+    if (channels) {
+      result.channels = new Collection();
+      for (const channel of Object.values(channels)) {
+        result.channels.set(channel.id, this.client.channels._add(channel, this.guild) ?? channel);
+      }
+    }
+
+    if (messages) {
+      result.messages = new Collection();
+      for (const message of Object.values(messages)) {
+        result.messages.set(message.id, this.channel?.messages?._add(message) ?? message);
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -78,11 +78,11 @@ class BaseCommandInteraction extends Interaction {
   /**
    * Represents the resolved data of a received command interaction.
    * @typedef {Object} CommandInteractionResolvedData
-   * @property {Collection<string, User>} users The resolved users
-   * @property {Collection<string, GuildMember|APIGuildMember>} members The resolved guild members
-   * @property {Collection<string, Role|APIRole>} roles The resolved messages
-   * @property {Collection<string, Channel|APIChannel>} channels The resolved channels
-   * @property {Collection<string, Message|APIMessage>} messages The resolved messages
+   * @property {Collection<string, User>} [users] The resolved users
+   * @property {Collection<string, GuildMember|APIGuildMember>} [members] The resolved guild members
+   * @property {Collection<string, Role|APIRole>} [roles] The resolved messages
+   * @property {Collection<string, Channel|APIChannel>} [channels] The resolved channels
+   * @property {Collection<string, Message|APIMessage>} [messages] The resolved messages
    */
 
   /**

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -18,7 +18,7 @@ class CommandInteraction extends BaseCommandInteraction {
     this.options = new CommandInteractionOptionResolver(
       this.client,
       data.data.options?.map(option => this.transformOption(option, data.data.resolved)) ?? [],
-      this.transformResolved(data.data.resolved),
+      this.transformResolved(data.data.resolved ?? {}),
     );
   }
 }

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -18,6 +18,7 @@ class CommandInteraction extends BaseCommandInteraction {
     this.options = new CommandInteractionOptionResolver(
       this.client,
       data.data.options?.map(option => this.transformOption(option, data.data.resolved)) ?? [],
+      this.transformResolved(data.data.resolved),
     );
   }
 }

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -6,7 +6,7 @@ const { TypeError } = require('../errors');
  * A resolver for command interaction options.
  */
 class CommandInteractionOptionResolver {
-  constructor(client, options) {
+  constructor(client, options, resolved) {
     /**
      * The client that instantiated this.
      * @name CommandInteractionOptionResolver#client
@@ -55,6 +55,13 @@ class CommandInteractionOptionResolver {
      * @readonly
      */
     Object.defineProperty(this, 'data', { value: Object.freeze([...options]) });
+
+    /**
+     * The interaction resolved data
+     * @name CommandInteractionOptionResolver#resolved
+     * @type {Readonly<CommandInteractionResolvedData>}
+     */
+    Object.defineProperty(this, 'resolved', { value: Object.freeze(resolved) });
   }
 
   /**

--- a/src/structures/ContextMenuInteraction.js
+++ b/src/structures/ContextMenuInteraction.js
@@ -15,7 +15,11 @@ class ContextMenuInteraction extends BaseCommandInteraction {
      * The target of the interaction, parsed into options
      * @type {CommandInteractionOptionResolver}
      */
-    this.options = new CommandInteractionOptionResolver(this.client, this.resolveContextMenuOptions(data.data));
+    this.options = new CommandInteractionOptionResolver(
+      this.client,
+      this.resolveContextMenuOptions(data.data),
+      this.transformResolved(data.data.resolved),
+    );
 
     /**
      * The id of the target of the interaction

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3261,7 +3261,7 @@ export interface CommandInteractionResolvedData {
   users?: Collection<string, User>;
   members?: Collection<string, GuildMember | APIInteractionDataResolvedGuildMember>;
   roles?: Collection<string, Role | APIRole>;
-  channels?: Collection<string, GuildChannel | APIInteractionDataResolvedChannel>;
+  channels?: Collection<string, Channel | APIInteractionDataResolvedChannel>;
   messages?: Collection<string, Message | APIMessage>;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -265,6 +265,7 @@ export abstract class BaseCommandInteraction extends Interaction {
     option: APIApplicationCommandOption,
     resolved: APIApplicationCommandInteractionData['resolved'],
   ): CommandInteractionOption;
+  private transformResolved(resolved: APIApplicationCommandInteractionData['resolved']): CommandInteractionResolvedData;
 }
 
 export abstract class BaseGuild extends Base {
@@ -529,6 +530,7 @@ export class CommandInteractionOptionResolver {
   public constructor(client: Client, options: CommandInteractionOption[]);
   public readonly client: Client;
   public readonly data: readonly CommandInteractionOption[];
+  public readonly resolved: Readonly<CommandInteractionResolvedData>;
   private _group: string | null;
   private _hoistedOptions: CommandInteractionOption[];
   private _subcommand: string | null;
@@ -3253,6 +3255,14 @@ export interface CommandInteractionOption {
   channel?: GuildChannel | APIInteractionDataResolvedChannel;
   role?: Role | APIRole;
   message?: Message | APIMessage;
+}
+
+export interface CommandInteractionResolvedData {
+  users?: Collection<string, User>;
+  members?: Collection<string, GuildMember | APIInteractionDataResolvedGuildMember>;
+  roles?: Collection<string, Role | APIRole>;
+  channels?: Collection<string, GuildChannel | APIInteractionDataResolvedChannel>;
+  messages?: Collection<string, Message | APIMessage>;
 }
 
 export interface ConstantsClientApplicationAssetTypes {


### PR DESCRIPTION
In the absence of a good way to expose individual resolved data as "mentions", this exposed the complete, parsed `interaction.data.resolved` object as a number of Collections, similar to how MessageMentions are provided.

Aim is to do this in a non-breaking way for 13.1.0, hence using the "resolved" property name, leaving "mentions" available if we want to do a better filtering of it somewhere else down the track.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:


- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
