### PR TITLE
docs(ApplicationCommandData): fix type property

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -111,7 +111,7 @@ class ApplicationCommand extends Base {
    * @typedef {Object} ApplicationCommandData
    * @property {string} name The name of the command
    * @property {string} description The description of the command
-   * @property {ApplicationCommandTypes} [type] The type of the command
+   * @property {ApplicationCommandType} [type] The type of the command
    * @property {ApplicationCommandOptionData[]} [options] Options for the command
    * @property {boolean} [defaultPermission] Whether the command is enabled by default when the app is added to a guild
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the type property of ApplicationCommandData to use ApplicationCommandType

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.