### PR TITLE
docs: fix links to Discord API interaction docs

### DIFF
--- a/src/managers/ApplicationCommandPermissionsManager.js
+++ b/src/managers/ApplicationCommandPermissionsManager.js
@@ -411,7 +411,8 @@ class ApplicationCommandPermissionsManager extends BaseManager {
 
 module.exports = ApplicationCommandPermissionsManager;
 
+/* eslint-disable max-len */
 /**
  * @external APIApplicationCommandPermissions
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#applicationcommandpermissions}
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure}
  */

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -190,12 +190,13 @@ class ApplicationCommand extends Base {
 
 module.exports = ApplicationCommand;
 
+/* eslint-disable max-len */
 /**
  * @external APIApplicationCommand
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#applicationcommand}
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure}
  */
 
 /**
  * @external APIApplicationCommandOption
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoption}
+ * @see {@link hhttps://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure}
  */

--- a/src/structures/CommandInteraction.js
+++ b/src/structures/CommandInteraction.js
@@ -149,5 +149,5 @@ module.exports = CommandInteraction;
 /* eslint-disable max-len */
 /**
  * @external APIApplicationCommandOptionResolved
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-applicationcommandinteractiondataresolved}
+ * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure}
  */

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -900,7 +900,7 @@ exports.OverwriteTypes = createEnum(['role', 'member']);
  * * MENTIONABLE
  * * NUMBER
  * @typedef {string} ApplicationCommandOptionType
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-type}
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type}
  */
 exports.ApplicationCommandOptionTypes = createEnum([
   null,
@@ -921,7 +921,7 @@ exports.ApplicationCommandOptionTypes = createEnum([
  * * ROLE
  * * USER
  * @typedef {string} ApplicationCommandPermissionType
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#application-command-permissions-object-application-command-permission-type}
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type}
  */
 exports.ApplicationCommandPermissionTypes = createEnum([null, 'ROLE', 'USER']);
 
@@ -931,7 +931,7 @@ exports.ApplicationCommandPermissionTypes = createEnum([null, 'ROLE', 'USER']);
  * * APPLICATION_COMMAND
  * * MESSAGE_COMPONENT
  * @typedef {string} InteractionType
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-object-interaction-request-type}
+ * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-request-type}
  */
 exports.InteractionTypes = createEnum([null, 'PING', 'APPLICATION_COMMAND', 'MESSAGE_COMPONENT']);
 
@@ -943,7 +943,7 @@ exports.InteractionTypes = createEnum([null, 'PING', 'APPLICATION_COMMAND', 'MES
  * * DEFERRED_MESSAGE_UPDATE
  * * UPDATE_MESSAGE
  * @typedef {string} InteractionResponseType
- * @see {@link https://discord.com/developers/docs/interactions/slash-commands#interaction-response-object-interaction-callback-type}
+ * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type}
  */
 exports.InteractionResponseTypes = createEnum([
   null,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes some of the links to the Discord documentation for interactions. Some of these docs were moved around as part of [this PR](https://github.com/discord/discord-api-docs/pull/3614).

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
