### PR TITLE
fix(StageInstance): Ensure `discoverableDisabled` is not `undefined`

### DIFF
--- a/src/structures/StageInstance.js
+++ b/src/structures/StageInstance.js
@@ -54,9 +54,9 @@ class StageInstance extends Base {
 
     /**
      * Whether or not stage discovery is disabled
-     * @type {boolean}
+     * @type {?boolean}
      */
-    this.discoverableDisabled = data.discoverable_disabled;
+    this.discoverableDisabled = data.discoverable_disabled ?? null;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1663,7 +1663,7 @@ export class StageInstance extends Base {
   public channelId: Snowflake;
   public topic: string;
   public privacyLevel: PrivacyLevel;
-  public discoverableDisabled: boolean;
+  public discoverableDisabled: boolean | null;
   public readonly channel: StageChannel | null;
   public readonly guild: Guild | null;
   public edit(options: StageInstanceEditOptions): Promise<StageInstance>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`StageInstance#discoverableDisabled` was possibly `undefined`.

This can occur via the following steps:
1. Start a stage channel instance
2. End the stage channel instance
3. Restart the bot to ensure that the instance is not cached
4. Fetch the audit log entry for this stage instance

<details>
<summary>Response</summary>

```JavaScript
GuildAuditLogsEntry {
  targetType: 'STAGE_INSTANCE',
  actionType: 'DELETE',
  action: 'STAGE_INSTANCE_DELETE',
  reason: null,
  executor: User {},
  changes: [
    { key: 'topic', old: 'hi', new: undefined },
    { key: 'privacy_level', old: 2, new: undefined }
  ],
  id: '875086920567377920',
  extra: {
    channel: StageChannel {
      type: 'GUILD_STAGE_VOICE',
      deleted: false,
      guild: [Guild],
      guildId: '534940241002233896',
      parentId: '610956146450235414',
      permissionOverwrites: [PermissionOverwriteManager],
      id: '875085532114321409',
      name: 'hi',
      rawPosition: 0,
      rtcRegion: null,
      bitrate: 64000,
      userLimit: 10000,
      topic: null
    }
  },
  target: StageInstance {
    id: '875085574103511081',
    deleted: false,
    guildId: '534940241002233896',
    channelId: '875085532114321409',
    topic: 'hi',
    privacyLevel: 'GUILD_ONLY',
    discoverableDisabled: undefined
  }
}
```
</details>

This pull request asserts this property to `null` in the case of not knowing anything about this property.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
