### PR TITLE
types(ApplicationCommandOptionData): Export enums

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -128,30 +128,7 @@ import {
   RawWidgetMemberData,
 } from './rawDataTypes';
 
-export {
-  ActivityTypes,
-  ApplicationCommandOptionTypes,
-  ApplicationCommandPermissionTypes,
-  ApplicationCommandTypes,
-  ChannelTypes,
-  DefaultMessageNotificationLevels,
-  ExplicitContentFilterLevels,
-  InteractionResponseTypes,
-  InteractionTypes,
-  InviteTargetType,
-  MembershipStates,
-  MessageButtonStyles,
-  MessageComponentTypes,
-  MFALevels,
-  NSFWLevels,
-  OverwriteTypes,
-  PremiumTiers,
-  PrivacyLevels,
-  StickerFormatTypes,
-  StickerTypes,
-  VerificationLevels,
-  WebhookTypes,
-} from './enums';
+export * from './enums';
 
 //#region Classes
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -128,6 +128,31 @@ import {
   RawWidgetMemberData,
 } from './rawDataTypes';
 
+export {
+  ActivityTypes,
+  ApplicationCommandOptionTypes,
+  ApplicationCommandPermissionTypes,
+  ApplicationCommandTypes,
+  ChannelTypes,
+  DefaultMessageNotificationLevels,
+  ExplicitContentFilterLevels,
+  InteractionResponseTypes,
+  InteractionTypes,
+  InviteTargetType,
+  MembershipStates,
+  MessageButtonStyles,
+  MessageComponentTypes,
+  MFALevels,
+  NSFWLevels,
+  OverwriteTypes,
+  PremiumTiers,
+  PrivacyLevels,
+  StickerFormatTypes,
+  StickerTypes,
+  VerificationLevels,
+  WebhookTypes,
+} from './enums';
+
 //#region Classes
 
 export class Activity {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

A lot of our typings use a `*Types` enum for different type definitions, with the recent changes in #6291 and #6212 this has become more prevalent. We decide type properties based on the `type` field. The issue is that a consumer of the library cannot properly type narrow our types because our types are using unexposed enums.

For example:
```typescript
  if (command.type === 'CHAT_INPUT') {
   // Command is Chat input command type.
  } else {
   // Command is a context menu command type.
  }
```

However this ^ doesn't actually work as expected. If you want to type narrow based on `CHAT_INPUT` you have to include:

` && command.type === ApplicationCommandTypes.CHAT_INPUT`
 in the if clause.

This will compile, and produce expected results, however, `ApplicationCommandTypes` isn't exported, you'll get a runtime error for trying to use something that isn't exported:

```
Cannot find module 'discord.js/typings/enums' (...)
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
