### PR TITLE
types(Constants): add `ApplicationCommandTypes` to `Constants`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2241,6 +2241,7 @@ export const Constants: {
   PrivacyLevels: typeof PrivacyLevels;
   WebhookTypes: typeof WebhookTypes;
   PremiumTiers: typeof PremiumTiers;
+  ApplicationCommandTypes: typeof ApplicationCommandTypes;
 };
 
 export const version: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Simply exposes `ApplicationCommandTypes` in the exported `Constants`

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
-->
