### PR TITLE
fix(WidgetMember): Default to `null` and not `undefined`

### DIFF
--- a/src/structures/WidgetMember.js
+++ b/src/structures/WidgetMember.js
@@ -53,37 +53,37 @@ class WidgetMember extends Base {
      * IIf the member is server deafened
      * @type {?boolean}
      */
-    this.deaf = data.deaf;
+    this.deaf = data.deaf ?? null;
 
     /**
      * If the member is server muted
      * @type {?boolean}
      */
-    this.mute = data.mute;
+    this.mute = data.mute ?? null;
 
     /**
      * If the member is self deafened
      * @type {?boolean}
      */
-    this.selfDeaf = data.self_deaf;
+    this.selfDeaf = data.self_deaf ?? null;
 
     /**
      * If the member is self muted
      * @type {?boolean}
      */
-    this.selfMute = data.self_mute;
+    this.selfMute = data.self_mute ?? null;
 
     /**
      * If the member is suppressed
      * @type {?boolean}
      */
-    this.suppress = data.suppress;
+    this.suppress = data.suppress ?? null;
 
     /**
      * The id of the voice channel the member is in, if any
      * @type {?Snowflake}
      */
-    this.channelId = data.channel_id;
+    this.channelId = data.channel_id ?? null;
 
     /**
      * The avatar URL of the member.
@@ -95,7 +95,7 @@ class WidgetMember extends Base {
      * The activity of the member.
      * @type {?WidgetActivity}
      */
-    this.activity = data.activity;
+    this.activity = data.activity ?? null;
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -130,7 +130,7 @@ import {
   RawWelcomeChannelData,
   RawWelcomeScreenData,
   RawWidgetData,
-  RawWidgetMemberData
+  RawWidgetMemberData,
 } from './rawDataTypes';
 
 //#region Classes
@@ -2107,16 +2107,16 @@ export class WidgetMember extends Base {
   public id: string;
   public username: string;
   public discriminator: string;
-  public avatar?: string;
+  public avatar: string | null;
   public status: PresenceStatus;
-  public deaf?: boolean;
-  public mute?: boolean;
-  public selfDeaf?: boolean;
-  public selfMute?: boolean;
-  public suppress?: boolean;
-  public channelId?: Snowflake;
+  public deaf: boolean | null;
+  public mute: boolean | null;
+  public selfDeaf: boolean | null;
+  public selfMute: boolean | null;
+  public suppress: boolean | null;
+  public channelId: Snowflake | null;
   public avatarURL: string;
-  public activity?: WidgetActivity;
+  public activity: WidgetActivity | null;
 }
 
 export class WelcomeChannel extends Base {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The [`WidgetMember`](https://discord.js.org/#/docs/main/main/class/WidgetMember) class had a bunch of properties that would default to `undefined` if said member was not in voice or did not have an activity. The documentation already assumed them to be nullable, but the typings didn't! Side note: `WidgetMember#avatar` typings were wrong as they return `null` if not found.

I've defaulted them now to `null`. The JSDocs are already nullable, so no change there. The typings have been updated from them being optional properties to nullable.

I believe the linter modified the typings file, so that went in here as well.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
