### PR TITLE
fix(ContextMenuInteractin): store message as raw value

### DIFF
--- a/src/structures/ContextMenuInteraction.js
+++ b/src/structures/ContextMenuInteraction.js
@@ -50,7 +50,7 @@ class ContextMenuInteraction extends BaseCommandInteraction {
         name: 'message',
         type: '_MESSAGE',
         value: target_id,
-        message: this.channel?.messages._add(resolved.messages[target_id]),
+        message: this.channel?.messages._add(resolved.messages[target_id]) ?? resolved.messages[target_id],
       });
     }
 


### PR DESCRIPTION
Fixes a bug in context menus where the raw message wasn't being used, resulting in the option returning undefined.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating