### PR TITLE
fix(Guild): `preferredLocale` to always be a string

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -337,7 +337,7 @@ class Guild extends AnonymousGuild {
 
     /**
      * The preferred locale of the guild, defaults to `en-US`
-     * @type {?string}
+     * @type {string}
      * @see {@link https://discord.com/developers/docs/dispatch/field-values#predefined-field-values-accepted-locales}
      */
     this.preferredLocale = data.preferred_locale;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -667,7 +667,7 @@ export class Guild extends AnonymousGuild {
   public members: GuildMemberManager;
   public mfaLevel: MFALevel;
   public ownerId: Snowflake;
-  public preferredLocale?: string;
+  public preferredLocale: string;
   public premiumSubscriptionCount: number | null;
   public premiumTier: PremiumTier;
   public presences: PresenceManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#6299 modified this to be nullable, but upon looking through Discord's documentation (and all prior versions) with testing on non-community guilds, it seems it is documented to always return a string and testing has verified this. Thus, this property will be modified to be only a string!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
