### PR TITLE
docs: remove unparsed examples

### DIFF
--- a/src/client/WebhookClient.js
+++ b/src/client/WebhookClient.js
@@ -21,10 +21,6 @@ class WebhookClient extends BaseClient {
   /**
    * @param {WebhookClientData} data The data of the webhook
    * @param {ClientOptions} [options] Options for the client
-   * @example
-   * // Create a new webhook and send a message
-   * const hook = new Discord.WebhookClient({ id: '1234', token: 'abcdef' });
-   * hook.send('This will send a message').catch(console.error);
    */
   constructor(data, options) {
     super(options);

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1284,13 +1284,6 @@ class Guild extends AnonymousGuild {
    * and stage channels.
    * @type {Function}
    * @readonly
-   * @example
-   * const { joinVoiceChannel } = require('@discordjs/voice');
-   * const voiceConnection = joinVoiceChannel({
-   *  channelId: channel.id,
-   *  guildId: channel.guild.id,
-   *  adapterCreator: channel.guild.voiceAdapterCreator,
-   * });
    */
   get voiceAdapterCreator() {
     return methods => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This removes two examples that the docgen doesn't parse because they are not on methods.

**Status and versioning classification:**

- There are no code changes
- Typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.