### PR TITLE
typings(ApplicationCommandData): make `type` field optional

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2940,10 +2940,17 @@ export interface ChatInputApplicationCommandData extends BaseApplicationCommandD
   options?: ApplicationCommandOptionData[];
 }
 
+export interface OptionalChatInputApplicationCommandData extends Omit<ChatInputApplicationCommandData, 'type'> {
+  description: string;
+  type?: 'CHAT_INPUT' | ApplicationCommandTypes.CHAT_INPUT;
+  options?: ApplicationCommandOptionData[];
+}
+
 export type ApplicationCommandData =
   | UserApplicationCommandData
   | MessageApplicationCommandData
-  | ChatInputApplicationCommandData;
+  | ChatInputApplicationCommandData
+  | OptionalChatInputApplicationCommandData;
 
 export interface ApplicationCommandChoicesData extends BaseApplicationCommandOptionsData {
   type: CommandOptionChoiceResolvableType;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2941,9 +2941,7 @@ export interface ChatInputApplicationCommandData extends BaseApplicationCommandD
 }
 
 export interface OptionalChatInputApplicationCommandData extends Omit<ChatInputApplicationCommandData, 'type'> {
-  description: string;
   type?: 'CHAT_INPUT' | ApplicationCommandTypes.CHAT_INPUT;
-  options?: ApplicationCommandOptionData[];
 }
 
 export type ApplicationCommandData =

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2936,19 +2936,14 @@ export interface MessageApplicationCommandData extends BaseApplicationCommandDat
 
 export interface ChatInputApplicationCommandData extends BaseApplicationCommandData {
   description: string;
-  type: 'CHAT_INPUT' | ApplicationCommandTypes.CHAT_INPUT;
-  options?: ApplicationCommandOptionData[];
-}
-
-export interface OptionalChatInputApplicationCommandData extends Omit<ChatInputApplicationCommandData, 'type'> {
   type?: 'CHAT_INPUT' | ApplicationCommandTypes.CHAT_INPUT;
+  options?: ApplicationCommandOptionData[];
 }
 
 export type ApplicationCommandData =
   | UserApplicationCommandData
   | MessageApplicationCommandData
-  | ChatInputApplicationCommandData
-  | OptionalChatInputApplicationCommandData;
+  | ChatInputApplicationCommandData;
 
 export interface ApplicationCommandChoicesData extends BaseApplicationCommandOptionsData {
   type: CommandOptionChoiceResolvableType;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

It has come to my attention that the discord API doesn't require the `type` field, and when not provided it defaults to `CHAT_INPUT`. This PR makes the `type` field optional, and assumes if not provided, that the `ApplicationCommandData` typings correspond to a slash command.

This also alleviates a breaking type change for typescript users going from v13 to v13.1, when using `ApplicationCommandData`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating