### PR TITLE
docs(GuildManager): increase fetch limit to 200

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -253,7 +253,7 @@ class GuildManager extends CachedManager {
    * @typedef {Object} FetchGuildsOptions
    * @property {Snowflake} [before] Get guilds before this guild id
    * @property {Snowflake} [after] Get guilds after this guild id
-   * @property {number} [limit=100] Maximum number of guilds to request (1-100)
+   * @property {number} [limit=200] Maximum number of guilds to request (1-200)
    */
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Now that users can join 200 guilds with nitro, bots got a higher limit as well: https://discord.com/developers/docs/resources/user#get-current-user-guilds-query-string-params

**Status and versioning classification:**

- There are no code changes
- Typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.