### PR TITLE
feat(GuildManager): allow setting with_counts to false

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -246,6 +246,7 @@ class GuildManager extends CachedManager {
    * Options used to fetch a single guild.
    * @typedef {BaseFetchOptions} FetchGuildOptions
    * @property {GuildResolvable} guild The guild to fetch
+   * @property {boolean} [withCounts=true] Whether the approximate member and presence counts should be returned
    */
 
   /**
@@ -270,7 +271,7 @@ class GuildManager extends CachedManager {
         if (existing) return existing;
       }
 
-      const data = await this.client.api.guilds(id).get({ query: { with_counts: true } });
+      const data = await this.client.api.guilds(id).get({ query: { with_counts: options.withCounts ?? true } });
       return this._add(data, options.cache);
     }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -130,7 +130,7 @@ import {
   RawWelcomeChannelData,
   RawWelcomeScreenData,
   RawWidgetData,
-  RawWidgetMemberData
+  RawWidgetMemberData,
 } from './rawDataTypes';
 
 //#region Classes
@@ -3524,6 +3524,7 @@ export interface FetchedThreads {
 
 export interface FetchGuildOptions extends BaseFetchOptions {
   guild: GuildResolvable;
+  withCounts?: boolean;
 }
 
 export interface FetchGuildsOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This allows setting the `with_counts` query parameter when fetching a guild. I'm not sure when you would want to disable it, but the option exists so it counts towards the API coverage

**Status and versioning classification:**

- I know how to update typings and have done so
- This PR changes the library's interface (methods or parameters added)