### PR TITLE
docs: rename implementation of deferReply

### DIFF
--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -182,7 +182,7 @@ class BaseCommandInteraction extends Interaction {
 
   // These are here only for documentation purposes - they are implemented by InteractionResponses
   /* eslint-disable no-empty-function */
-  defer() {}
+  deferReply() {}
   reply() {}
   fetchReply() {}
   editReply() {}


### PR DESCRIPTION
Fixes missing documentation for `deferReply()`

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
