### PR TITLE
feat(ApplicationCommand): add #equals

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -157,7 +157,7 @@ class ApplicationCommand extends Base {
   }
 
   /**
-   * Whether this copmmand equals another command. It compares all properties, so for most operations
+   * Whether this command equals another command. It compares all properties, so for most operations
    * it is advisable to just compare `command.id === command2.id` as it is much faster and is often
    * what most users need.
    * @param {ApplicationCommand|ApplicationCommandData|APIApplicationCommand} command The command to compare with

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -219,7 +219,7 @@ class ApplicationCommand extends Base {
       option.name !== existing.name ||
       optionType !== existing.type ||
       option.description !== existing.description ||
-      (option.required ?? (optionType === 'SUB_COMMAND' || optionType === 'SUB_COMMAND_GROUP' ? undefined : false)) !==
+      (option.required ?? (['SUB_COMMAND', 'SUB_COMMAND_GROUP'].includes(optionType) ? undefined : false)) !==
         existing.required ||
       option.choices?.length !== existing.choices?.length ||
       option.options?.length !== existing.options?.length

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -219,9 +219,8 @@ class ApplicationCommand extends Base {
       option.name !== existing.name ||
       optionType !== existing.type ||
       option.description !== existing.description ||
-      (option.required ??
-        (optionType === 'SUB_COMMAND' || optionType === 'SUB_COMMAND_GROUP' ? undefined : false) !==
-          existing.required) ||
+      (option.required ?? (optionType === 'SUB_COMMAND' || optionType === 'SUB_COMMAND_GROUP' ? undefined : false)) !==
+        existing.required ||
       option.choices?.length !== existing.choices?.length ||
       option.options?.length !== existing.options?.length
     ) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -219,7 +219,7 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
   public type: ApplicationCommandType;
   public delete(): Promise<ApplicationCommand<PermissionsFetchType>>;
   public edit(data: ApplicationCommandData): Promise<ApplicationCommand<PermissionsFetchType>>;
-  public isEqual(command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData): boolean;
+  public equals(command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData): boolean;
   private static transformOption(option: ApplicationCommandOptionData, received?: boolean): unknown;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -219,6 +219,7 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
   public type: ApplicationCommandType;
   public delete(): Promise<ApplicationCommand<PermissionsFetchType>>;
   public edit(data: ApplicationCommandData): Promise<ApplicationCommand<PermissionsFetchType>>;
+  public isEqual(command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData): boolean;
   private static transformOption(option: ApplicationCommandOptionData, received?: boolean): unknown;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -220,6 +220,14 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
   public delete(): Promise<ApplicationCommand<PermissionsFetchType>>;
   public edit(data: ApplicationCommandData): Promise<ApplicationCommand<PermissionsFetchType>>;
   public equals(command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData): boolean;
+  public static optionsEqual(
+    existing: ApplicationCommandOption[],
+    options: ApplicationCommandOption[] | ApplicationCommandOptionData[] | APIApplicationCommandOption[],
+  ): boolean;
+  private static _optionEquals(
+    existing: ApplicationCommandOption,
+    options: ApplicationCommandOption | ApplicationCommandOptionData | APIApplicationCommandOption,
+  ): boolean;
   private static transformOption(option: ApplicationCommandOptionData, received?: boolean): unknown;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -219,14 +219,19 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
   public type: ApplicationCommandType;
   public delete(): Promise<ApplicationCommand<PermissionsFetchType>>;
   public edit(data: ApplicationCommandData): Promise<ApplicationCommand<PermissionsFetchType>>;
-  public equals(command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData): boolean;
+  public equals(
+    command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData,
+    enforceOptionorder?: boolean,
+  ): boolean;
   public static optionsEqual(
     existing: ApplicationCommandOption[],
     options: ApplicationCommandOption[] | ApplicationCommandOptionData[] | APIApplicationCommandOption[],
+    enforceOptionorder?: boolean,
   ): boolean;
   private static _optionEquals(
     existing: ApplicationCommandOption,
     options: ApplicationCommandOption | ApplicationCommandOptionData | APIApplicationCommandOption,
+    enforceOptionorder?: boolean,
   ): boolean;
   private static transformOption(option: ApplicationCommandOptionData, received?: boolean): unknown;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds `ApplicationCommand#equals` since checking the equivalence of application commands is a non-trivial task. Especially when handling the instantiated class and raw data.

Oh, and also because @IanMitchell asked for it

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
