### PR TITLE
feat(GuildChannel): Add `publiclyViewable` getter

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -157,6 +157,15 @@ class GuildChannel extends Channel {
   }
 
   /**
+   * Checks if the channel is viewable by the public.
+   * @returns {boolean} true if public, false otherwise.
+   */
+  get publiclyViewable() {
+    const { everyone } = this.guild.roles;
+    return this.permissionsFor(everyone)?.has(['VIEW_CHANNEL']) ?? false;
+  }
+
+  /**
    * Gets the overall set of permissions for a member or role in this channel, taking into account channel overwrites.
    * @param {GuildMemberResolvable|RoleResolvable} memberOrRole The member or role to obtain the overall permissions for
    * @returns {?Readonly<Permissions>}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -808,6 +808,7 @@ export class GuildChannel extends Channel {
   public permissionOverwrites: PermissionOverwriteManager;
   public readonly permissionsLocked: boolean | null;
   public readonly position: number;
+  public readonly publiclyViewable: boolean;
   public rawPosition: number;
   public type: Exclude<keyof typeof ChannelTypes, 'DM' | 'GROUP_DM' | 'UNKNOWN'>;
   public readonly viewable: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds a getter which indicates if the channel can be viewed by the public or not.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)