### PR TITLE
fix(Sticker): Rename method correctly to _add

### DIFF
--- a/src/structures/Sticker.js
+++ b/src/structures/Sticker.js
@@ -78,7 +78,7 @@ class Sticker extends Base {
      * The user that uploaded the guild sticker
      * @type {?User}
      */
-    this.user = sticker.user ? this.client.users.add(sticker.user) : null;
+    this.user = sticker.user ? this.client.users._add(sticker.user) : null;
 
     /**
      * The standard sticker's sort order within its pack


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #6420 - an instance where `._add()` was missed.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
