### PR TITLE
fix(Sticker): use renamed method

### DIFF
--- a/src/structures/Sticker.js
+++ b/src/structures/Sticker.js
@@ -78,7 +78,7 @@ class Sticker extends Base {
      * The user that uploaded the guild sticker
      * @type {?User}
      */
-    this.user = sticker.user ? this.client.users.add(sticker.user) : null;
+    this.user = sticker.user ? this.client.users._add(sticker.user) : null;
 
     /**
      * The standard sticker's sort order within its pack


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `CachedManager#add()` method was renamed to `CachedManager#_add()` to be treated as an internal method, which should be used here.

Fixes #6420

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes.
- I know how to update typings and have done so, or typings don't need updating.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
