### PR TITLE
feat(InteractionReponses): allow fetching of ephemeral messages

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -131,8 +131,7 @@ const Messages = {
 
   INTERACTION_ALREADY_REPLIED: 'The reply to this interaction has already been sent or deferred.',
   INTERACTION_NOT_REPLIED: 'The reply to this interaction has not been sent or deferred.',
-  INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be fetched or deleted.',
-  INTERACTION_FETCH_EPHEMERAL: 'Ephemeral responses cannot be fetched.',
+  INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be deleted.',
 
   COMMAND_INTERACTION_OPTION_NOT_FOUND: name => `Required option "${name}" not found.`,
   COMMAND_INTERACTION_OPTION_TYPE: (name, type, expected) =>

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -53,7 +53,6 @@ class InteractionResponses {
    */
   async deferReply(options = {}) {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
-    if (options.fetchReply && options.ephemeral) throw new Error('INTERACTION_FETCH_EPHEMERAL');
     this.ephemeral = options.ephemeral ?? false;
     await this.client.api.interactions(this.id, this.token).callback.post({
       data: {
@@ -87,7 +86,6 @@ class InteractionResponses {
    */
   async reply(options) {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
-    if (options.fetchReply && options.ephemeral) throw new Error('INTERACTION_FETCH_EPHEMERAL');
     this.ephemeral = options.ephemeral ?? false;
 
     let messagePayload;
@@ -119,7 +117,6 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   fetchReply() {
-    if (this.ephemeral) throw new Error('INTERACTION_EPHEMERAL_REPLIED');
     return this.webhook.fetchMessage('@original');
   }
 
@@ -177,9 +174,6 @@ class InteractionResponses {
    */
   async deferUpdate(options = {}) {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
-    if (options.fetchReply && new MessageFlags(this.message.flags).has(MessageFlags.FLAGS.EPHEMERAL)) {
-      throw new Error('INTERACTION_FETCH_EPHEMERAL');
-    }
     await this.client.api.interactions(this.id, this.token).callback.post({
       data: {
         type: InteractionResponseTypes.DEFERRED_MESSAGE_UPDATE,
@@ -205,9 +199,6 @@ class InteractionResponses {
    */
   async update(options) {
     if (this.deferred || this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
-    if (options.fetchReply && new MessageFlags(this.message.flags).has(MessageFlags.FLAGS.EPHEMERAL)) {
-      throw new Error('INTERACTION_FETCH_EPHEMERAL');
-    }
 
     let messagePayload;
     if (options instanceof MessagePayload) messagePayload = options;


### PR DESCRIPTION
It appears a recent API change now allows fetching of ephemeral messages - this removes the internal checks which were in place to prevent API errors.

Attempting to delete an ephemeral still responds with `Unknown Message`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
