### PR TITLE
fix(BaseClient): Remove selfbot ability

### DIFF
--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -24,7 +24,7 @@ class BaseClient extends EventEmitter {
      * @type {RESTManager}
      * @private
      */
-    this.rest = new RESTManager(this, "Bot");
+    this.rest = new RESTManager(this, 'Bot');
   }
 
   /**

--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -24,7 +24,7 @@ class BaseClient extends EventEmitter {
      * @type {RESTManager}
      * @private
      */
-    this.rest = new RESTManager(this, 'Bot');
+    this.rest = new RESTManager(this);
   }
 
   /**

--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -24,7 +24,7 @@ class BaseClient extends EventEmitter {
      * @type {RESTManager}
      * @private
      */
-    this.rest = new RESTManager(this, options._tokenType);
+    this.rest = new RESTManager(this, "Bot");
   }
 
   /**

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -35,7 +35,7 @@ class Client extends BaseClient {
    * @param {ClientOptions} options Options for the client
    */
   constructor(options) {
-    super(Object.assign({ _tokenType: 'Bot' }, options));
+    super(options);
 
     const data = require('worker_threads').workerData ?? process.env;
     const defaults = Options.createDefault();

--- a/src/rest/RESTManager.js
+++ b/src/rest/RESTManager.js
@@ -8,10 +8,9 @@ const { Error } = require('../errors');
 const { Endpoints } = require('../util/Constants');
 
 class RESTManager {
-  constructor(client, tokenPrefix = 'Bot') {
+  constructor(client) {
     this.client = client;
     this.handlers = new Collection();
-    this.tokenPrefix = tokenPrefix;
     this.versioned = true;
     this.globalLimit = client.options.restGlobalRateLimit > 0 ? client.options.restGlobalRateLimit : Infinity;
     this.globalRemaining = this.globalLimit;
@@ -30,7 +29,7 @@ class RESTManager {
 
   getAuth() {
     const token = this.client.token ?? this.client.accessToken;
-    if (token) return `${this.tokenPrefix} ${token}`;
+    if (token) return `Bot ${token}`;
     throw new Error('TOKEN_MISSING');
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removing this will prevent people from raiding easier. Yes they can do fork, but I don't think a well known library like this should support it.

How can you make a self bot?
`new Client({_tokenType:""})`

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
