### PR TITLE
chore(Typings): fix WebhookEditMessageOptions not having attachments

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -102,8 +102,8 @@ class Webhook {
    * @property {string} [content] See {@link BaseMessageOptions#content}
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
+   * @property {MessageAttachment[]} [attachments] Attachments to send with the message
    * @property {MessageActionRow[]|MessageActionRowOptions[]} [components]
-   * @property {MessageAttachment[]} [attachments]
    * Action rows containing interactive components for the message (buttons, select menus)
    */
 

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -103,6 +103,7 @@ class Webhook {
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
    * @property {MessageActionRow[]|MessageActionRowOptions[]} [components]
+   * @property {MessageAttachment[]} [attachments]
    * Action rows containing interactive components for the message (buttons, select menus)
    */
 

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -66,6 +66,7 @@ class TextBasedChannel {
    * @property {MessageActionRow[]|MessageActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    * @property {StickerResolvable[]} [stickers=[]] Stickers to send in the message
+   * @property {MessageAttachment[]} [attachments] Attachments to send in the message
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4181,6 +4181,7 @@ export interface MessageOptions {
   files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
   reply?: ReplyOptions;
   stickers?: StickerResolvable[];
+  attachments?: MessageAttachment[];
 }
 
 export type MessageReactionResolvable =
@@ -4625,7 +4626,7 @@ export interface WebhookEditData {
 
 export type WebhookEditMessageOptions = Pick<
   WebhookMessageOptions,
-  'content' | 'embeds' | 'files' | 'allowedMentions' | 'components'
+  'content' | 'embeds' | 'files' | 'allowedMentions' | 'components' | 'attachments'
 >;
 
 export interface WebhookMessageOptions extends Omit<MessageOptions, 'reply'> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes some issues in the Typings (basically like my previous PR #6162)

`attachments` wasn't typed in `MessageOptions`, so I added that and update the Pick when defining `WebhookEditMessageOptions` to add attachments to the typings and to ensure this doesn't bug

**Status and versioning classification:**

Code changes have been tested against the Discord API, or there are no code changes
I know how to update typings and have done so, or typings don't need updating
