### PR TITLE
typings: Message#_patch typings return type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1093,8 +1093,8 @@ export class LimitedCollection<K, V> extends Collection<K, V> {
 
 export class Message extends Base {
   public constructor(client: Client, data: RawMessageData);
-  private _patch(data: RawPartialMessageData, partial: true): Message;
-  private _patch(data: RawMessageData, partial?: boolean): Message;
+  private _patch(data: RawPartialMessageData, partial: true): void;
+  private _patch(data: RawMessageData, partial?: boolean): void;
   private _update(data: RawPartialMessageData, partial: true): Message;
   private _update(data: RawMessageData, partial?: boolean): Message;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In PR #6071 the Message#_patch method was changed to return type Message because the old patch method did that. But looking at the _patch method it doesn't return anything.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating