### PR TITLE
fix(Util): allow empty strings in splitMessage

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -70,7 +70,7 @@ class Util extends null {
    * @returns {string[]}
    */
   static splitMessage(text, { maxLength = 2000, char = '\n', prepend = '', append = '' } = {}) {
-    text = Util.verifyString(text, RangeError, 'MESSAGE_CONTENT_TYPE', false);
+    text = Util.verifyString(text, RangeError, 'MESSAGE_CONTENT_TYPE');
     if (text.length <= maxLength) return [text];
     let splitText = [text];
     if (Array.isArray(char)) {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -70,7 +70,7 @@ class Util extends null {
    * @returns {string[]}
    */
   static splitMessage(text, { maxLength = 2000, char = '\n', prepend = '', append = '' } = {}) {
-    text = Util.verifyString(text, RangeError, 'MESSAGE_CONTENT_TYPE');
+    text = Util.verifyString(text);
     if (text.length <= maxLength) return [text];
     let splitText = [text];
     if (Array.isArray(char)) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Allow empty strings to be used in Util#splitMessage as there is not reason not to.

close #6436 

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
- Code changes have been tested against the Discord API, or there are no code changes
