### PR TITLE
fix(GuildChannel): Fix manageable method for voice-channels

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -514,7 +514,7 @@ class GuildChannel extends Channel {
     const permissions = this.permissionsFor(this.client.user);
     if (!permissions) return false;
     const bitfield = VoiceBasedChannelTypes.includes(this.type)
-      ? Permissions.FLAGS.VIEW_CHANNEL | Permissions.FLAGS.MANAGE_CHANNELS | Permissions.FLAGS.CONNECT
+      ? Permissions.FLAGS.MANAGE_CHANNELS | Permissions.FLAGS.CONNECT
       : Permissions.FLAGS.VIEW_CHANNEL | Permissions.FLAGS.MANAGE_CHANNELS;
     return permissions.has(bitfield, false);
   }

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -514,10 +514,11 @@ class GuildChannel extends Channel {
     if (!this.viewable) {
       return false;
     }
-    if (VoiceBasedChannelTypes.includes(this.type)) {
-      if (!this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false)) {
-        return false;
-      }
+    if (
+      VoiceBasedChannelTypes.includes(this.type) &&
+      !this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false)
+    ) {
+      return false;
     }
     return this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false);
   }

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -511,16 +511,13 @@ class GuildChannel extends Channel {
    */
   get manageable() {
     if (this.client.user.id === this.guild.ownerId) return true;
-    if (!this.viewable) {
+    if (!this.viewable) return false;
+    const permissions = this.permissionsFor(this.client.user);
+    if (!permissions) return false;
+    if (VoiceBasedChannelTypes.includes(this.type) && !permissions.has(Permissions.FLAGS.CONNECT, false)) {
       return false;
     }
-    if (
-      VoiceBasedChannelTypes.includes(this.type) &&
-      !this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false)
-    ) {
-      return false;
-    }
-    return this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false);
+    return permissions.has(Permissions.FLAGS.MANAGE_CHANNELS, false);
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -511,13 +511,12 @@ class GuildChannel extends Channel {
    */
   get manageable() {
     if (this.client.user.id === this.guild.ownerId) return true;
-    if (!this.viewable) return false;
     const permissions = this.permissionsFor(this.client.user);
     if (!permissions) return false;
-    if (VoiceBasedChannelTypes.includes(this.type) && !permissions.has(Permissions.FLAGS.CONNECT, false)) {
-      return false;
-    }
-    return permissions.has(Permissions.FLAGS.MANAGE_CHANNELS, false);
+    const bitfield = VoiceBasedChannelTypes.includes(this.type)
+      ? Permissions.FLAGS.VIEW_CHANNEL | Permissions.FLAGS.MANAGE_CHANNELS | Permissions.FLAGS.CONNECT
+      : Permissions.FLAGS.VIEW_CHANNEL | Permissions.FLAGS.MANAGE_CHANNELS;
+    return permissions.has(bitfield, false);
   }
 
   /**

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -511,12 +511,13 @@ class GuildChannel extends Channel {
    */
   get manageable() {
     if (this.client.user.id === this.guild.ownerId) return true;
+    if (!this.viewable) {
+      return false;
+    }
     if (VoiceBasedChannelTypes.includes(this.type)) {
       if (!this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false)) {
         return false;
       }
-    } else if (!this.viewable) {
-      return false;
     }
     return this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false);
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #6446

`<GuildChannel>.manageable` is not efficient with voice channels because `<GuildChannel>.viewable` is not checked on voice channels.

```js
if (VoiceBasedChannelTypes.includes(this.type)) { 
   // connect permission check
 } else if (!this.viewable) { 
   return false;
 }
```

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
