### PR TITLE
typings: require component type in raw object formats

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4011,7 +4011,9 @@ export type MembershipState = keyof typeof MembershipStates;
 
 export type MessageActionRowComponent = MessageButton | MessageSelectMenu;
 
-export type MessageActionRowComponentOptions = MessageButtonOptions | MessageSelectMenuOptions;
+export type MessageActionRowComponentOptions =
+  | (Required<BaseMessageComponentOptions> & MessageButtonOptions)
+  | (Required<BaseMessageComponentOptions> & MessageSelectMenuOptions);
 
 export type MessageActionRowComponentResolvable = MessageActionRowComponent | MessageActionRowComponentOptions;
 
@@ -4077,7 +4079,7 @@ export interface MessageEditOptions {
   files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
   flags?: BitFieldResolvable<MessageFlagsString, number>;
   allowedMentions?: MessageMentionOptions;
-  components?: (MessageActionRow | MessageActionRowOptions)[];
+  components?: (MessageActionRow | (Required<BaseMessageComponentOptions> & MessageActionRowOptions))[];
 }
 
 export interface MessageEmbedAuthor {
@@ -4176,7 +4178,7 @@ export interface MessageOptions {
   nonce?: string | number;
   content?: string | null;
   embeds?: (MessageEmbed | MessageEmbedOptions)[];
-  components?: (MessageActionRow | MessageActionRowOptions)[];
+  components?: (MessageActionRow | (Required<BaseMessageComponentOptions> & MessageActionRowOptions))[];
   allowedMentions?: MessageMentionOptions;
   files?: (FileOptions | BufferResolvable | Stream | MessageAttachment)[];
   reply?: ReplyOptions;


### PR DESCRIPTION
Opening this one up for discussion as to pros and cons - this change enforces the `type` property when using JSON object format for components, rather than builders.

This works and enforces the param, but does mean that objects typed as the base typedefs:
 - `MessageActionRowOptions`
 - `MessageButtonOptions`
 - `MessageSelectMenuOptions`

are not compatible with `MessageOptions` anymore, and instead must be typed as:
 - `Required<BaseMessageComponentOptions> & MessageActionRowOptions` for action rows
 - `MessageActionRowComponentOptions` for buttons and selects.

Open to feedback on ways to address that without change the fact that the type is not required in the base typedefs, such as creating separately named types e.g. \
`type RawMessageActionRowData = Required<BaseMessageComponentOptions> & MessageActionRowOptions`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

