### PR TITLE
refactor(RequestHandler): Do not return await

### DIFF
--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -47,7 +47,7 @@ class RequestHandler {
   async push(request) {
     await this.queue.wait();
     try {
-      return await this.execute(request);
+      return this.execute(request);
     } finally {
       this.queue.shift();
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- There's no reason `return`'ing `await ...` because function ([RequestHandler#push](https://github.com/discordjs/discord.js/blob/main/src/rest/RequestHandler.js#L50)) itself returns a `Promise`.
- [`no-return-await`](https://github.com/discordjs/discord.js/blob/main/.eslintrc.json#L79) is also enabled.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
