### PR TITLE
docs(ApplicationCommandType): add DAPI link

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -893,6 +893,7 @@ exports.OverwriteTypes = createEnum(['role', 'member']);
  * * USER
  * * MESSAGE
  * @typedef {string} ApplicationCommandType
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types}
  */
 exports.ApplicationCommandTypes = createEnum([null, 'CHAT_INPUT', 'USER', 'MESSAGE']);
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Following the tradition from #6299 this PR adds a link to Discord's API documentation regarding ApplicationCommandTypes

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
