### PR TITLE
feat(Message): prevent fetching an interaction webhook.

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -103,6 +103,7 @@ const Messages = {
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
   WEBHOOK_TOKEN_UNAVAILABLE: 'This action requires a webhook token, but none is available.',
   WEBHOOK_URL_INVALID: 'The provided webhook URL is not valid.',
+  WEBHOOK_APPLICATION: 'This message webhook belongs to an application and cannot be fetched.',
   MESSAGE_REFERENCE_MISSING: 'The message does not reference another message',
 
   EMOJI_TYPE: 'Emoji must be a string or GuildEmoji/ReactionEmoji',

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -788,6 +788,7 @@ class Message extends Base {
    */
   fetchWebhook() {
     if (!this.webhookId) return Promise.reject(new Error('WEBHOOK_MESSAGE'));
+    if (this.webhookId === this.applicationId) return Promise.reject(new Error('WEBHOOK_APPLICATION'));
     return this.client.fetchWebhook(this.webhookId);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
After some testings, it seems that we can't use `.fetchWebhook()` on a message that was sent by an application (interaction). The way so check this is by comparing the applicationId in the message and the webhookId. If they match, this means that the message comes from an interaction and the webhook behind it cannot be fetched from the api.

The api returns `DiscordAPIError: Unknown Webhook`


Correct me if i'm wrong but i think that it's not possible to send webhooks from an applicationId except through interactions.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
