### PR TITLE
feat(CommandInteractionOptionResolver): make `subcommand` and `group` public, and add raw `hoistedOptions`

### DIFF
--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -18,16 +18,14 @@ class CommandInteractionOptionResolver {
     /**
      * The name of the subcommand group.
      * @type {?string}
-     * @private
      */
-    this._group = null;
+    this.group = null;
 
     /**
      * The name of the subcommand.
      * @type {?string}
-     * @private
      */
-    this._subcommand = null;
+    this.subcommand = null;
 
     /**
      * The bottom-level options for the interaction.
@@ -39,12 +37,12 @@ class CommandInteractionOptionResolver {
 
     // Hoist subcommand group if present
     if (this._hoistedOptions[0]?.type === 'SUB_COMMAND_GROUP') {
-      this._group = this._hoistedOptions[0].name;
+      this.group = this._hoistedOptions[0].name;
       this._hoistedOptions = this._hoistedOptions[0].options ?? [];
     }
     // Hoist subcommand if present
     if (this._hoistedOptions[0]?.type === 'SUB_COMMAND') {
-      this._subcommand = this._hoistedOptions[0].name;
+      this.subcommand = this._hoistedOptions[0].name;
       this._hoistedOptions = this._hoistedOptions[0].options ?? [];
     }
 
@@ -55,6 +53,14 @@ class CommandInteractionOptionResolver {
      * @readonly
      */
     Object.defineProperty(this, 'data', { value: Object.freeze([...options]) });
+
+    /**
+     * The hoisted interaction options array, so without any subcommand(groups).
+     * @name CommandInteractionOptionResolver#hoistedOptions
+     * @type {ReadonlyArray<CommandInteractionOption>}
+     * @readonly
+     */
+    Object.defineProperty(this, 'hoistedOptions', { value: Object.freeze([...this._hoistedOptions]) });
 
     /**
      * The interaction resolved data
@@ -108,10 +114,10 @@ class CommandInteractionOptionResolver {
    * @returns {?string} The name of the selected subcommand, or null if not set and not required.
    */
   getSubcommand(required = true) {
-    if (required && !this._subcommand) {
+    if (required && !this.subcommand) {
       throw new TypeError('COMMAND_INTERACTION_OPTION_NO_SUB_COMMAND');
     }
-    return this._subcommand;
+    return this.subcommand;
   }
 
   /**
@@ -120,10 +126,10 @@ class CommandInteractionOptionResolver {
    * @returns {?string} The name of the selected subcommand group, or null if not set and not required.
    */
   getSubcommandGroup(required = true) {
-    if (required && !this._group) {
+    if (required && !this.group) {
       throw new TypeError('COMMAND_INTERACTION_OPTION_NO_SUB_COMMAND_GROUP');
     }
-    return this._group;
+    return this.group;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -545,10 +545,11 @@ export class CommandInteractionOptionResolver {
   public constructor(client: Client, options: CommandInteractionOption[]);
   public readonly client: Client;
   public readonly data: readonly CommandInteractionOption[];
+  public readonly hoistedOptions: readonly CommandInteractionOption[];
   public readonly resolved: Readonly<CommandInteractionResolvedData>;
-  private _group: string | null;
+  public group: string | null;
+  public subcommand: string | null;
   private _hoistedOptions: CommandInteractionOption[];
-  private _subcommand: string | null;
   private _getTypedOption(
     name: string,
     type: ApplicationCommandOptionType,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

While in the process of engineering my bot application, I found the `CommandInteractionOptionResolver`'s way of managing subcommand(group)s rather unnecessary.

As `_group` and `_subcommand` were already processed, there was no need to implement two separate methods fetching it (`getSubcommandGroup` and `getSubcommand`), except for consistency and the `required` parameter. I ended up using the `_group` property instead, and I'm proposing that it should be public because of that.

Besides that, `_hoistedOptions` is also rather useful to navigate yourself but wasn't public either. I implemented a change similar to the `data` property (which is the same, just not hoisted).

People can now navigate the options with `group`, `subcommand` and `hoistedOptions` to manage the interaction arguments themselves (like I would do, personally, with my own implementation).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
