### PR TITLE
typings: Allow message component interaction collectors to infer collected interaction types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1171,7 +1171,9 @@ export class Message extends Base {
   public createMessageComponentCollector<
     T extends MessageComponentType | MessageComponentTypes = MessageComponentTypes.ACTION_ROW,
   >(
-    options?: { componentType?: T } & InteractionCollectorOptionsResolvable,
+    options?:
+      | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
+      | InteractionCollectorOptions<MessageComponentInteraction>,
   ): ConditionalType<MappedInteractionCollectorOptions[T]>;
   public delete(): Promise<Message>;
   public edit(content: string | MessageEditOptions | MessagePayload): Promise<Message>;
@@ -2714,7 +2716,9 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
   createMessageComponentCollector<
     T extends MessageComponentType | MessageComponentTypes = MessageComponentTypes.ACTION_ROW,
   >(
-    options?: { componentType?: T } & InteractionCollectorOptionsResolvable,
+    options?:
+      | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
+      | InteractionCollectorOptions<MessageComponentInteraction>,
   ): ConditionalType<MappedInteractionCollectorOptions[T]>;
   sendTyping(): Promise<void>;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1091,7 +1091,7 @@ export class LimitedCollection<K, V> extends Collection<K, V> {
   public static filterByLifetime<K, V>(options?: LifetimeFilterOptions<K, V>): SweepFilter<K, V>;
 }
 
-type ConditionalInteractionCollector<T extends InteractionCollectorOptionsResolvable> =
+type ConditionalInteractionCollector<T extends InteractionCollectorOptionsResolvable | undefined> =
   T extends MessageInteractionCollectorOptions
     ? InteractionCollector<MessageComponentInteraction>
     : T extends ButtonInteractionCollectorOptions
@@ -1150,9 +1150,9 @@ export class Message extends Base {
   ): Promise<T>;
   public awaitReactions(options?: AwaitReactionsOptions): Promise<Collection<Snowflake | string, MessageReaction>>;
   public createReactionCollector(options?: ReactionCollectorOptions): ReactionCollector;
-  public createMessageComponentCollector<T extends InteractionCollectorOptionsResolvable>(
-    options?: T,
-  ): ConditionalInteractionCollector<T>;
+  public createMessageComponentCollector<
+    T extends InteractionCollectorOptionsResolvable = MessageInteractionCollectorOptions,
+  >(options?: T): ConditionalInteractionCollector<T>;
   public delete(): Promise<Message>;
   public edit(content: string | MessageEditOptions | MessagePayload): Promise<Message>;
   public equals(message: Message, rawData: unknown): boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1116,6 +1116,10 @@ type ConditionalType<T extends InteractionCollectorOptionsResolvable | undefined
 // This maps each componentType key to each variant.
 type MappedInteractionCollectorOptions = CollectorOptionsTypeResolver<InteractionCollectorOptionsResolvable>;
 
+type MessageCollectorOptionsParams<T> =
+  | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
+  | InteractionCollectorOptions<MessageComponentInteraction>;
+
 export class Message extends Base {
   public constructor(client: Client, data: RawMessageData);
   private _patch(data: RawPartialMessageData, partial: true): void;
@@ -1170,11 +1174,7 @@ export class Message extends Base {
   public createReactionCollector(options?: ReactionCollectorOptions): ReactionCollector;
   public createMessageComponentCollector<
     T extends MessageComponentType | MessageComponentTypes = MessageComponentTypes.ACTION_ROW,
-  >(
-    options?:
-      | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
-      | InteractionCollectorOptions<MessageComponentInteraction>,
-  ): ConditionalType<MappedInteractionCollectorOptions[T]>;
+  >(options?: MessageCollectorOptionsParams<T>): ConditionalType<MappedInteractionCollectorOptions[T]>;
   public delete(): Promise<Message>;
   public edit(content: string | MessageEditOptions | MessagePayload): Promise<Message>;
   public equals(message: Message, rawData: unknown): boolean;
@@ -2716,9 +2716,7 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
   createMessageComponentCollector<
     T extends MessageComponentType | MessageComponentTypes = MessageComponentTypes.ACTION_ROW,
   >(
-    options?:
-      | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
-      | InteractionCollectorOptions<MessageComponentInteraction>,
+    options?: MessageCollectorOptionsParams<T>,
   ): ConditionalType<MappedInteractionCollectorOptions[T]>;
   sendTyping(): Promise<void>;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1108,7 +1108,7 @@ type CollectorOptionsTypeResolver<U extends InteractionCollectorOptionsResolvabl
 
 // This basically says "Given a `InteractionCollectorOptionsResolvable` variant", I'll give the corresponding
 // `InteractionCollector<T>` variant back.
-type ConditionalType<T extends InteractionCollectorOptionsResolvable | undefined> =
+type ConditionalInteractionCollectorType<T extends InteractionCollectorOptionsResolvable | undefined> =
   T extends InteractionCollectorOptions<infer Item>
     ? InteractionCollector<Item>
     : InteractionCollector<MessageComponentInteraction>;
@@ -1120,7 +1120,7 @@ type MappedInteractionCollectorOptions = CollectorOptionsTypeResolver<Interactio
 type InteractionCollectorReturnType<T extends MessageComponentType | MessageComponentTypes | undefined> = T extends
   | MessageComponentType
   | MessageComponentTypes
-  ? ConditionalType<MappedInteractionCollectorOptions[T]>
+  ? ConditionalInteractionCollectorType<MappedInteractionCollectorOptions[T]>
   : InteractionCollector<MessageComponentInteraction>;
 
 type MessageCollectorOptionsParams<T> =

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1127,6 +1127,10 @@ type MessageCollectorOptionsParams<T> =
   | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
   | InteractionCollectorOptions<MessageComponentInteraction>;
 
+type AwaitMessageCollectorOptionsParams<T> =
+  | ({ componentType?: T } & AwaitInteractionCollectorOptionsResolvable)
+  | MessageComponentCollectorOptions<MessageComponentInteraction>;
+
 export class Message extends Base {
   public constructor(client: Client, data: RawMessageData);
   private _patch(data: RawPartialMessageData, partial: true): void;
@@ -1174,9 +1178,9 @@ export class Message extends Base {
   public webhookId: Snowflake | null;
   public flags: Readonly<MessageFlags>;
   public reference: MessageReference | null;
-  public awaitMessageComponent<T extends MessageComponentInteraction = MessageComponentInteraction>(
-    options?: AwaitMessageComponentOptions<T>,
-  ): Promise<T>;
+  public awaitMessageComponent<T extends MessageComponentType | MessageComponentTypes | undefined = undefined>(
+    options?: AwaitMessageCollectorOptionsParams<T>,
+  ): Promise<InteractionCollectorReturnType<T>>;
   public awaitReactions(options?: AwaitReactionsOptions): Promise<Collection<Snowflake | string, MessageReaction>>;
   public createReactionCollector(options?: ReactionCollectorOptions): ReactionCollector;
   public createMessageComponentCollector<
@@ -2712,9 +2716,9 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
   readonly lastMessage: Message | null;
   lastPinTimestamp: number | null;
   readonly lastPinAt: Date | null;
-  awaitMessageComponent<T extends MessageComponentInteraction = MessageComponentInteraction>(
-    options?: AwaitMessageComponentOptions<T>,
-  ): Promise<T>;
+  awaitMessageComponent<T extends MessageComponentType | MessageComponentTypes | undefined = undefined>(
+    options?: AwaitMessageCollectorOptionsParams<T>,
+  ): Promise<InteractionCollectorReturnType<T>>;
   awaitMessages(options?: AwaitMessagesOptions): Promise<Collection<Snowflake, Message>>;
   bulkDelete(
     messages: Collection<Snowflake, Message> | readonly MessageResolvable[] | number,
@@ -3968,6 +3972,25 @@ export interface SelectMenuInteractionCollectorOptions extends InteractionCollec
 export interface MessageInteractionCollectorOptions extends InteractionCollectorOptions<MessageComponentInteraction> {
   componentType: 'ACTION_ROW' | MessageComponentTypes.ACTION_ROW;
 }
+
+export interface AwaitButtonInteractionCollectorOptions extends MessageComponentCollectorOptions<ButtonInteraction> {
+  componentType: 'BUTTON' | MessageComponentTypes.BUTTON;
+}
+
+export interface AwaitSelectMenuInteractionCollectorOptions
+  extends MessageComponentCollectorOptions<SelectMenuInteraction> {
+  componentType: 'SELECT_MENU' | MessageComponentTypes.SELECT_MENU;
+}
+
+export interface AwaitMessageInteractionCollectorOptions
+  extends MessageComponentCollectorOptions<MessageComponentInteraction> {
+  componentType: 'ACTION_ROW' | MessageComponentTypes.ACTION_ROW;
+}
+
+export type AwaitInteractionCollectorOptionsResolvable =
+  | AwaitButtonInteractionCollectorOptions
+  | AwaitSelectMenuInteractionCollectorOptions
+  | AwaitMessageInteractionCollectorOptions;
 
 export type InteractionCollectorOptionsResolvable =
   | MessageInteractionCollectorOptions

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1151,7 +1151,7 @@ export class Message extends Base {
   public awaitReactions(options?: AwaitReactionsOptions): Promise<Collection<Snowflake | string, MessageReaction>>;
   public createReactionCollector(options?: ReactionCollectorOptions): ReactionCollector;
   public createMessageComponentCollector<T extends InteractionCollectorOptionsResolvable>(
-    options: T,
+    options?: T,
   ): ConditionalInteractionCollector<T>;
   public delete(): Promise<Message>;
   public edit(content: string | MessageEditOptions | MessagePayload): Promise<Message>;
@@ -2692,7 +2692,7 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     filterOld?: boolean,
   ): Promise<Collection<Snowflake, Message>>;
   createMessageComponentCollector<T extends InteractionCollectorOptionsResolvable>(
-    options: T,
+    options?: T,
   ): ConditionalInteractionCollector<T>;
   sendTyping(): Promise<void>;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1143,6 +1143,12 @@ export class Message extends Base {
   ): Promise<T>;
   public awaitReactions(options?: AwaitReactionsOptions): Promise<Collection<Snowflake | string, MessageReaction>>;
   public createReactionCollector(options?: ReactionCollectorOptions): ReactionCollector;
+  createMessageComponentCollector<T extends MessageComponentInteraction = ButtonInteraction>(
+    options: ButtonInteractionCollectorOptions,
+  ): InteractionCollector<T>;
+  createMessageComponentCollector<T extends MessageComponentInteraction = SelectMenuInteraction>(
+    options: SelectMenuInteractionCollectorOptions,
+  ): InteractionCollector<T>;
   public createMessageComponentCollector<T extends MessageComponentInteraction = MessageComponentInteraction>(
     options?: InteractionCollectorOptions<T>,
   ): InteractionCollector<T>;
@@ -2687,6 +2693,14 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
   createMessageComponentCollector<T extends MessageComponentInteraction = MessageComponentInteraction>(
     options?: InteractionCollectorOptions<T>,
   ): InteractionCollector<T>;
+
+  createMessageComponentCollector<T extends MessageComponentInteraction = ButtonInteraction>(
+    options: ButtonInteractionCollectorOptions,
+  ): InteractionCollector<T>;
+  createMessageComponentCollector<T extends MessageComponentInteraction = SelectMenuInteraction>(
+    options: SelectMenuInteractionCollectorOptions,
+  ): InteractionCollector<T>;
+
   createMessageCollector(options?: MessageCollectorOptions): MessageCollector;
   sendTyping(): Promise<void>;
 }
@@ -3911,7 +3925,7 @@ export interface IntegrationAccount {
   name: string;
 }
 
-export interface InteractionCollectorOptions<T extends Interaction> extends CollectorOptions<[T]> {
+export interface InteractionCollectorOptions<T extends Interaction> extends CollectorOptions<T[]> {
   channel?: TextBasedChannels;
   componentType?: MessageComponentType | MessageComponentTypes;
   guild?: Guild;
@@ -3920,6 +3934,14 @@ export interface InteractionCollectorOptions<T extends Interaction> extends Coll
   maxComponents?: number;
   maxUsers?: number;
   message?: Message | APIMessage;
+}
+
+export interface ButtonInteractionCollectorOptions extends CollectorOptions<ButtonInteraction[]> {
+  componentType: 'BUTTON' | MessageComponentTypes.BUTTON;
+}
+
+export interface SelectMenuInteractionCollectorOptions extends CollectorOptions<SelectMenuInteraction[]> {
+  componentType: 'SELECT_MENU' | MessageComponentTypes.SELECT_MENU;
 }
 
 export interface InteractionDeferReplyOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1143,10 +1143,10 @@ export class Message extends Base {
   ): Promise<T>;
   public awaitReactions(options?: AwaitReactionsOptions): Promise<Collection<Snowflake | string, MessageReaction>>;
   public createReactionCollector(options?: ReactionCollectorOptions): ReactionCollector;
-  createMessageComponentCollector<T extends MessageComponentInteraction = ButtonInteraction>(
+  public createMessageComponentCollector<T extends MessageComponentInteraction = ButtonInteraction>(
     options: ButtonInteractionCollectorOptions,
   ): InteractionCollector<T>;
-  createMessageComponentCollector<T extends MessageComponentInteraction = SelectMenuInteraction>(
+  public createMessageComponentCollector<T extends MessageComponentInteraction = SelectMenuInteraction>(
     options: SelectMenuInteractionCollectorOptions,
   ): InteractionCollector<T>;
   public createMessageComponentCollector<T extends MessageComponentInteraction = MessageComponentInteraction>(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1127,17 +1127,8 @@ type MessageCollectorOptionsParams<T> =
   | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
   | InteractionCollectorOptions<MessageComponentInteraction>;
 
-type AwaitMessageOmissions =
-  | 'channel'
-  | 'interactionType'
-  | 'guild'
-  | 'interactionType'
-  | 'max'
-  | 'maxComponents'
-  | 'maxUsers';
-
 type AwaitMessageCollectorOptionsParams<T> =
-  | ({ componentType?: T } & Omit<InteractionCollectorOptionsResolvable, AwaitMessageOmissions>)
+  | ({ componentType?: T } & Pick<InteractionCollectorOptionsResolvable, keyof AwaitMessageComponentOptions<any>>)
   | AwaitMessageComponentOptions<MessageComponentInteraction>;
 
 export class Message extends Base {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1116,6 +1116,12 @@ type ConditionalType<T extends InteractionCollectorOptionsResolvable | undefined
 // This maps each componentType key to each variant.
 type MappedInteractionCollectorOptions = CollectorOptionsTypeResolver<InteractionCollectorOptionsResolvable>;
 
+type InteractionCollectorReturnType<T extends MessageComponentType | MessageComponentTypes | undefined> = T extends
+  | MessageComponentType
+  | MessageComponentTypes
+  ? ConditionalType<MappedInteractionCollectorOptions[T]>
+  : InteractionCollector<MessageComponentInteraction>;
+
 type MessageCollectorOptionsParams<T> =
   | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
   | InteractionCollectorOptions<MessageComponentInteraction>;
@@ -1172,9 +1178,9 @@ export class Message extends Base {
   ): Promise<T>;
   public awaitReactions(options?: AwaitReactionsOptions): Promise<Collection<Snowflake | string, MessageReaction>>;
   public createReactionCollector(options?: ReactionCollectorOptions): ReactionCollector;
-  public createMessageComponentCollector<
-    T extends MessageComponentType | MessageComponentTypes = MessageComponentTypes.ACTION_ROW,
-  >(options?: MessageCollectorOptionsParams<T>): ConditionalType<MappedInteractionCollectorOptions[T]>;
+  public createMessageComponentCollector<T extends MessageComponentType | MessageComponentTypes>(
+    options?: MessageCollectorOptionsParams<T>,
+  ): InteractionCollectorReturnType<T>;
   public delete(): Promise<Message>;
   public edit(content: string | MessageEditOptions | MessagePayload): Promise<Message>;
   public equals(message: Message, rawData: unknown): boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1091,7 +1091,7 @@ export class LimitedCollection<K, V> extends Collection<K, V> {
   public static filterByLifetime<K, V>(options?: LifetimeFilterOptions<K, V>): SweepFilter<K, V>;
 }
 
-type ConditionalInteractionCollector<T extends InteractionCollectorOptionsResolvable | undefined> =
+type ConditionalInteractionCollector<T extends InteractionCollectorOptionsResolvable> =
   T extends MessageInteractionCollectorOptions
     ? InteractionCollector<MessageComponentInteraction>
     : T extends ButtonInteractionCollectorOptions
@@ -2691,7 +2691,7 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     messages: Collection<Snowflake, Message> | readonly MessageResolvable[] | number,
     filterOld?: boolean,
   ): Promise<Collection<Snowflake, Message>>;
-  createMessageComponentCollector<T extends InteractionCollectorOptionsResolvable>(
+  createMessageComponentCollector<T extends InteractionCollectorOptionsResolvable = MessageInteractionCollectorOptions>(
     options?: T,
   ): ConditionalInteractionCollector<T>;
   sendTyping(): Promise<void>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1116,6 +1116,7 @@ type ConditionalType<T extends InteractionCollectorOptionsResolvable | undefined
 // This maps each componentType key to each variant.
 type MappedInteractionCollectorOptions = CollectorOptionsTypeResolver<InteractionCollectorOptionsResolvable>;
 
+// Converts mapped types to complimentary collector types.
 type InteractionCollectorReturnType<T extends MessageComponentType | MessageComponentTypes | undefined> = T extends
   | MessageComponentType
   | MessageComponentTypes
@@ -2719,11 +2720,9 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     messages: Collection<Snowflake, Message> | readonly MessageResolvable[] | number,
     filterOld?: boolean,
   ): Promise<Collection<Snowflake, Message>>;
-  createMessageComponentCollector<
-    T extends MessageComponentType | MessageComponentTypes = MessageComponentTypes.ACTION_ROW,
-  >(
+  createMessageComponentCollector<T extends MessageComponentType | MessageComponentTypes>(
     options?: MessageCollectorOptionsParams<T>,
-  ): ConditionalType<MappedInteractionCollectorOptions[T]>;
+  ): InteractionCollectorReturnType<T>;
   sendTyping(): Promise<void>;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1127,9 +1127,18 @@ type MessageCollectorOptionsParams<T> =
   | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
   | InteractionCollectorOptions<MessageComponentInteraction>;
 
+type AwaitOmissions =
+  | 'channel'
+  | 'interactionType'
+  | 'guild'
+  | 'interactionType'
+  | 'max'
+  | 'maxComponents'
+  | 'maxUsers';
+
 type AwaitMessageCollectorOptionsParams<T> =
-  | ({ componentType?: T } & AwaitInteractionCollectorOptionsResolvable)
-  | MessageComponentCollectorOptions<MessageComponentInteraction>;
+  | ({ componentType?: T } & Omit<InteractionCollectorOptionsResolvable, AwaitOmissions>)
+  | AwaitMessageComponentOptions<MessageComponentInteraction>;
 
 export class Message extends Base {
   public constructor(client: Client, data: RawMessageData);
@@ -3972,25 +3981,6 @@ export interface SelectMenuInteractionCollectorOptions extends InteractionCollec
 export interface MessageInteractionCollectorOptions extends InteractionCollectorOptions<MessageComponentInteraction> {
   componentType: 'ACTION_ROW' | MessageComponentTypes.ACTION_ROW;
 }
-
-export interface AwaitButtonInteractionCollectorOptions extends MessageComponentCollectorOptions<ButtonInteraction> {
-  componentType: 'BUTTON' | MessageComponentTypes.BUTTON;
-}
-
-export interface AwaitSelectMenuInteractionCollectorOptions
-  extends MessageComponentCollectorOptions<SelectMenuInteraction> {
-  componentType: 'SELECT_MENU' | MessageComponentTypes.SELECT_MENU;
-}
-
-export interface AwaitMessageInteractionCollectorOptions
-  extends MessageComponentCollectorOptions<MessageComponentInteraction> {
-  componentType: 'ACTION_ROW' | MessageComponentTypes.ACTION_ROW;
-}
-
-export type AwaitInteractionCollectorOptionsResolvable =
-  | AwaitButtonInteractionCollectorOptions
-  | AwaitSelectMenuInteractionCollectorOptions
-  | AwaitMessageInteractionCollectorOptions;
 
 export type InteractionCollectorOptionsResolvable =
   | MessageInteractionCollectorOptions

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1179,9 +1179,9 @@ export class Message extends Base {
   ): Promise<T>;
   public awaitReactions(options?: AwaitReactionsOptions): Promise<Collection<Snowflake | string, MessageReaction>>;
   public createReactionCollector(options?: ReactionCollectorOptions): ReactionCollector;
-  public createMessageComponentCollector<T extends MessageComponentType | MessageComponentTypes>(
-    options?: MessageCollectorOptionsParams<T>,
-  ): InteractionCollectorReturnType<T>;
+  public createMessageComponentCollector<
+    T extends MessageComponentType | MessageComponentTypes | undefined = undefined,
+  >(options?: MessageCollectorOptionsParams<T>): InteractionCollectorReturnType<T>;
   public delete(): Promise<Message>;
   public edit(content: string | MessageEditOptions | MessagePayload): Promise<Message>;
   public equals(message: Message, rawData: unknown): boolean;
@@ -2720,7 +2720,7 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     messages: Collection<Snowflake, Message> | readonly MessageResolvable[] | number,
     filterOld?: boolean,
   ): Promise<Collection<Snowflake, Message>>;
-  createMessageComponentCollector<T extends MessageComponentType | MessageComponentTypes>(
+  createMessageComponentCollector<T extends MessageComponentType | MessageComponentTypes | undefined = undefined>(
     options?: MessageCollectorOptionsParams<T>,
   ): InteractionCollectorReturnType<T>;
   sendTyping(): Promise<void>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1143,12 +1143,12 @@ export class Message extends Base {
   ): Promise<T>;
   public awaitReactions(options?: AwaitReactionsOptions): Promise<Collection<Snowflake | string, MessageReaction>>;
   public createReactionCollector(options?: ReactionCollectorOptions): ReactionCollector;
-  public createMessageComponentCollector<T extends MessageComponentInteraction = ButtonInteraction>(
+  public createMessageComponentCollector(
     options: ButtonInteractionCollectorOptions,
-  ): InteractionCollector<T>;
-  public createMessageComponentCollector<T extends MessageComponentInteraction = SelectMenuInteraction>(
+  ): InteractionCollector<ButtonInteraction>;
+  public createMessageComponentCollector(
     options: SelectMenuInteractionCollectorOptions,
-  ): InteractionCollector<T>;
+  ): InteractionCollector<SelectMenuInteraction>;
   public createMessageComponentCollector<T extends MessageComponentInteraction = MessageComponentInteraction>(
     options?: InteractionCollectorOptions<T>,
   ): InteractionCollector<T>;
@@ -2690,17 +2690,13 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     messages: Collection<Snowflake, Message> | readonly MessageResolvable[] | number,
     filterOld?: boolean,
   ): Promise<Collection<Snowflake, Message>>;
+  createMessageComponentCollector(options: ButtonInteractionCollectorOptions): InteractionCollector<ButtonInteraction>;
+  createMessageComponentCollector<T extends MessageComponentInteraction = SelectMenuInteraction>(
+    options: SelectMenuInteractionCollectorOptions,
+  ): InteractionCollector<SelectMenuInteraction>;
   createMessageComponentCollector<T extends MessageComponentInteraction = MessageComponentInteraction>(
     options?: InteractionCollectorOptions<T>,
   ): InteractionCollector<T>;
-
-  createMessageComponentCollector<T extends MessageComponentInteraction = ButtonInteraction>(
-    options: ButtonInteractionCollectorOptions,
-  ): InteractionCollector<T>;
-  createMessageComponentCollector<T extends MessageComponentInteraction = SelectMenuInteraction>(
-    options: SelectMenuInteractionCollectorOptions,
-  ): InteractionCollector<T>;
-
   createMessageCollector(options?: MessageCollectorOptions): MessageCollector;
   sendTyping(): Promise<void>;
 }
@@ -3936,11 +3932,11 @@ export interface InteractionCollectorOptions<T extends Interaction> extends Coll
   message?: Message | APIMessage;
 }
 
-export interface ButtonInteractionCollectorOptions extends CollectorOptions<ButtonInteraction[]> {
+export interface ButtonInteractionCollectorOptions extends InteractionCollectorOptions<ButtonInteraction> {
   componentType: 'BUTTON' | MessageComponentTypes.BUTTON;
 }
 
-export interface SelectMenuInteractionCollectorOptions extends CollectorOptions<SelectMenuInteraction[]> {
+export interface SelectMenuInteractionCollectorOptions extends InteractionCollectorOptions<SelectMenuInteraction> {
   componentType: 'SELECT_MENU' | MessageComponentTypes.SELECT_MENU;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2691,7 +2691,7 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     filterOld?: boolean,
   ): Promise<Collection<Snowflake, Message>>;
   createMessageComponentCollector(options: ButtonInteractionCollectorOptions): InteractionCollector<ButtonInteraction>;
-  createMessageComponentCollector<T extends MessageComponentInteraction = SelectMenuInteraction>(
+  createMessageComponentCollector(
     options: SelectMenuInteractionCollectorOptions,
   ): InteractionCollector<SelectMenuInteraction>;
   createMessageComponentCollector<T extends MessageComponentInteraction = MessageComponentInteraction>(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1127,7 +1127,7 @@ type MessageCollectorOptionsParams<T> =
   | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
   | InteractionCollectorOptions<MessageComponentInteraction>;
 
-type AwaitOmissions =
+type AwaitMessageOmissions =
   | 'channel'
   | 'interactionType'
   | 'guild'
@@ -1137,7 +1137,7 @@ type AwaitOmissions =
   | 'maxUsers';
 
 type AwaitMessageCollectorOptionsParams<T> =
-  | ({ componentType?: T } & Omit<InteractionCollectorOptionsResolvable, AwaitOmissions>)
+  | ({ componentType?: T } & Omit<InteractionCollectorOptionsResolvable, AwaitMessageOmissions>)
   | AwaitMessageComponentOptions<MessageComponentInteraction>;
 
 export class Message extends Base {

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -8,6 +8,7 @@ import {
   ApplicationCommandResolvable,
   ApplicationCommandSubCommandData,
   ApplicationCommandSubGroupData,
+  ButtonInteraction,
   CacheFactory,
   Caches,
   CategoryChannel,
@@ -31,12 +32,14 @@ import {
   GuildResolvable,
   Intents,
   Interaction,
+  InteractionCollector,
   LimitedCollection,
   Message,
   MessageActionRow,
   MessageAttachment,
   MessageButton,
   MessageCollector,
+  MessageComponentInteraction,
   MessageEmbed,
   MessageManager,
   MessageReaction,
@@ -49,6 +52,7 @@ import {
   ReactionCollector,
   Role,
   RoleManager,
+  SelectMenuInteraction,
   Serialized,
   ShardClientUtil,
   ShardingManager,
@@ -469,7 +473,8 @@ client.on('messageReactionRemoveAll', async message => {
 // This is to check that stuff is the right type
 declare const assertIsMessage: (m: Promise<Message>) => void;
 
-client.on('messageCreate', ({ channel }) => {
+client.on('messageCreate', message => {
+  const { channel } = message;
   assertIsMessage(channel.send('string'));
   assertIsMessage(channel.send({}));
   assertIsMessage(channel.send({ embeds: [] }));
@@ -484,6 +489,24 @@ client.on('messageCreate', ({ channel }) => {
   channel.send();
   // @ts-expect-error
   channel.send({ another: 'property' });
+
+  // Check collector creations.
+
+  // Verify that buttons interactions are inferred.
+  const buttonCollector = message.createMessageComponentCollector({ componentType: 'BUTTON' });
+  assertType<InteractionCollector<ButtonInteraction>>(buttonCollector);
+
+  // Verify that select menus interaction are inferred.
+  const selectMenuCollector = message.createMessageComponentCollector({ componentType: 'SELECT_MENU' });
+  assertType<InteractionCollector<SelectMenuInteraction>>(selectMenuCollector);
+
+  // Verify that message component interactions are default collected types.
+  const defaultCollector = message.createMessageComponentCollector();
+  assertType<InteractionCollector<MessageComponentInteraction>>(defaultCollector);
+
+  // Verify that additional options don't affect default collector types.
+  const semiDefaultCollector = message.createMessageComponentCollector({ interactionType: 'APPLICATION_COMMAND' });
+  assertType<InteractionCollector<MessageComponentInteraction>>(semiDefaultCollector);
 });
 
 client.on('interaction', async interaction => {

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -494,14 +494,21 @@ client.on('messageCreate', message => {
 
   // Verify that buttons interactions are inferred.
   const buttonCollector = message.createMessageComponentCollector({ componentType: 'BUTTON' });
+  assertType<Promise<InteractionCollector<ButtonInteraction>>>(
+    message.awaitMessageComponent({ componentType: 'BUTTON' }),
+  );
   assertType<InteractionCollector<ButtonInteraction>>(buttonCollector);
 
   // Verify that select menus interaction are inferred.
   const selectMenuCollector = message.createMessageComponentCollector({ componentType: 'SELECT_MENU' });
+  assertType<Promise<InteractionCollector<SelectMenuInteraction>>>(
+    message.awaitMessageComponent({ componentType: 'SELECT_MENU' }),
+  );
   assertType<InteractionCollector<SelectMenuInteraction>>(selectMenuCollector);
 
   // Verify that message component interactions are default collected types.
   const defaultCollector = message.createMessageComponentCollector();
+  assertType<Promise<InteractionCollector<MessageComponentInteraction>>>(message.awaitMessageComponent());
   assertType<InteractionCollector<MessageComponentInteraction>>(defaultCollector);
 
   // Verify that additional options don't affect default collector types.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

As it stands now if you use this code:

```ts
const collector = message.createMessageComponentCollector({ componentType: 'SELECT_MENU' });

collector.on('collect', interaction => {
  // Interaction is type of `MessageComponentInteraction`
});
```

You'll end up with a `MessageComponentInteraction` in the `collect` handler.

Currently there are two trivial ways to narrow this type.

1) Type Guard it:
```ts
collector.on('collect', interaction => {
  if (!interaction.isSelectMenu()) {
    return;
  }
  // Interaction is type of `SelectMenuInteraction`
});
```

2) Use the generic parameter:
```ts
.createMessageComponentCollector<SelectMenuInteraction>(...);
```

However, even though these methods are straightforward, these types really shouldn't have to be narrowed at all for collectors, where `componentType` is specified.

We already stated the `componentType` in the `options`, which means we have proven which component types we should receive.  In addition the d.js collector will *always* return a `ButtonInteraction` if `componentType` is `'BUTTON'` and a `SelectMenuInteraction` if `componentType` is a `'SELECT_MENU'`. If all else fails then we know at the very least it's a `MessageComponentInteraction`.  The function should infer these parameters and give the correct `InteractionCollector<T>` as a return value.

This PR addresses this by inferring interaction collector types via the options given, this allows our first example to properly deduce that, in fact, `SelectMenuInteraction` is being collected rather than `MessageComponentInteraction`:

```ts
const collector = message.createMessageComponentCollector({ componentType: 'SELECT_MENU' });

collector.on('collect', interaction => {
  // Interaction is type of `SelectMenuInteraction`, 
  // function properly inferred types from given parameters.
});
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating