### PR TITLE
feat(ThreadChannel): add fetchStarterMessage

### DIFF
--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -254,6 +254,17 @@ class ThreadChannel extends Channel {
   }
 
   /**
+   * Fetches the message that started this thread, if any.
+   * <info>This in only available when the thread started from a message in the parent channel.
+   * If you just need the id of that message, use {@link ThreadChannel#id this channel's id} instead.</info>
+   * @param {BaseFetchOptions} [options] Additional options for this fetch
+   * @returns {Promise<?Message>}
+   */
+  fetchStarterMessage(options) {
+    return this.channel.messages.fetch(this.id, options);
+  }
+
+  /**
    * The options used to edit a thread channel
    * @typedef {Object} ThreadEditData
    * @property {string} [name] The new name for the thread

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -255,10 +255,10 @@ class ThreadChannel extends Channel {
 
   /**
    * Fetches the message that started this thread, if any.
-   * <info>This in only available when the thread started from a message in the parent channel.
-   * If you just need the id of that message, use {@link ThreadChannel#id this channel's id} instead.</info>
+   * <info>This only works when the thread started from a message in the parent channel, otherwise the promise will
+   * reject. If you just need the id of that message, use {@link ThreadChannel#id this channel's id} instead.</info>
    * @param {BaseFetchOptions} [options] Additional options for this fetch
-   * @returns {Promise<?Message>}
+   * @returns {Promise<Message>}
    */
   fetchStarterMessage(options) {
     return this.channel.messages.fetch(this.id, options);

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -256,7 +256,7 @@ class ThreadChannel extends Channel {
   /**
    * Fetches the message that started this thread, if any.
    * <info>This only works when the thread started from a message in the parent channel, otherwise the promise will
-   * reject. If you just need the id of that message, use {@link ThreadChannel#id this channel's id} instead.</info>
+   * reject. If you just need the id of that message, use {@link ThreadChannel#id} instead.</info>
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<Message>}
    */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1812,7 +1812,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
   public permissionsFor(memberOrRole: GuildMember | Role): Readonly<Permissions>;
   public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
   public fetchOwner(options?: FetchOwnerOptions): Promise<ThreadMember | null>;
-  public fetchStarterMessage(options?: BaseFetchOptions): Promise<Message | null>;
+  public fetchStarterMessage(options?: BaseFetchOptions): Promise<Message>;
   public setArchived(archived?: boolean, reason?: string): Promise<ThreadChannel>;
   public setAutoArchiveDuration(
     autoArchiveDuration: ThreadAutoArchiveDuration,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1812,6 +1812,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
   public permissionsFor(memberOrRole: GuildMember | Role): Readonly<Permissions>;
   public permissionsFor(memberOrRole: GuildMemberResolvable | RoleResolvable): Readonly<Permissions> | null;
   public fetchOwner(options?: FetchOwnerOptions): Promise<ThreadMember | null>;
+  public fetchStarterMessage(options?: BaseFetchOptions): Promise<Message | null>;
   public setArchived(archived?: boolean, reason?: string): Promise<ThreadChannel>;
   public setAutoArchiveDuration(
     autoArchiveDuration: ThreadAutoArchiveDuration,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a method to ThreadChannels called fetchStarterMessage that fetches the message that started the thread when this exists. I didn't find any better way to tell if a thread channel was started by a message or not so this just fetches the message with the same ID as the channel from the parent channel.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
