### PR TITLE
feat: set methods for MessageActionRow and MessageSelectMenu

### DIFF
--- a/src/structures/MessageActionRow.js
+++ b/src/structures/MessageActionRow.js
@@ -60,6 +60,16 @@ class MessageActionRow extends BaseMessageComponent {
   }
 
   /**
+   * Sets the components of the action row.
+   * @param {...MessageActionRowComponentResolvable[]} components The components to set
+   * @returns {MessageActionRow}
+   */
+  setComponents(...components) {
+    this.spliceComponents(0, this.components.length, components);
+    return this;
+  }
+
+  /**
    * Removes, replaces, and inserts components in the action row.
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of components to remove

--- a/src/structures/MessageSelectMenu.js
+++ b/src/structures/MessageSelectMenu.js
@@ -146,6 +146,16 @@ class MessageSelectMenu extends BaseMessageComponent {
   }
 
   /**
+   * Sets the options of the select menu.
+   * @param {...MessageSelectOptionData|MessageSelectOptionData[]} options The options to set
+   * @returns {MessageSelectMenu}
+   */
+  setOptions(...options) {
+    this.spliceOptions(0, this.options.length, options);
+    return this;
+  }
+
+  /**
    * Removes, replaces, and inserts options in the select menu.
    * @param {number} index The index to start at
    * @param {number} deleteCount The number of options to remove

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1182,6 +1182,9 @@ export class MessageActionRow extends BaseMessageComponent {
   public addComponents(
     ...components: MessageActionRowComponentResolvable[] | MessageActionRowComponentResolvable[][]
   ): this;
+  public setComponents(
+    ...components: MessageActionRowComponentResolvable[] | MessageActionRowComponentResolvable[][]
+  ): this;
   public spliceComponents(
     index: number,
     deleteCount: number,
@@ -1391,6 +1394,7 @@ export class MessageSelectMenu extends BaseMessageComponent {
   public placeholder: string | null;
   public type: 'SELECT_MENU';
   public addOptions(...options: MessageSelectOptionData[] | MessageSelectOptionData[][]): this;
+  public setOptions(...options: MessageSelectOptionData[] | MessageSelectOptionData[][]): this;
   public setCustomId(customId: string): this;
   public setDisabled(disabled?: boolean): this;
   public setMaxValues(maxValues: number): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Following the [PR](https://github.com/discordjs/discord.js/pull/6186) that added the setFields method for MessageEmbeds, this PR adds two new methods: setOptions for MessageSelectMenu and setComponents for MessageActionRow.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
