### PR TITLE
feat(Invite): support friend invites

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -277,6 +277,7 @@ class Client extends BaseClient {
 
   /**
    * Obtains an invite from Discord.
+   * If a friend invite is passed and {@link ClientOptions#supportFriendInvites} is not `true`, an error will be thrown.
    * @param {InviteResolvable} invite Invite code or URL
    * @returns {Promise<Invite>}
    * @example

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -107,10 +107,13 @@ class Invite extends Base {
     this.targetType = data.target_type ?? null;
 
     /**
-     * The channel the invite is for
-     * @type {Channel}
+     * The channel the invite is for, can only be null if {@link ClientOptions#supportFriendInvites} is `true`
+     * @type {?Channel}
      */
-    this.channel = this.client.channels._add(data.channel, this.guild, { cache: false });
+    this.channel =
+      data.channel || !this.client.options.supportFriendInvites
+        ? this.client.channels._add(data.channel, this.guild, { cache: false })
+        : null;
 
     /**
      * The timestamp the invite was created at

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -67,6 +67,9 @@
  * @property {boolean} [failIfNotExists=true] Default value for {@link ReplyMessageOptions#failIfNotExists}
  * @property {string[]} [userAgentSuffix] An array of additional bot info to be appended to the end of the required
  * [User Agent](https://discord.com/developers/docs/reference#user-agent) header
+ * @property {boolean} [supportFriendInvites=false] Whether to support friend invites (where channel is null),
+ * if false, an error will be thrown when fetching a friend invite.
+ * This option exists for backwards compatibility, and will always be true in a future version.
  * @property {PresenceData} [presence={}] Presence data to use upon login
  * @property {IntentsResolvable} intents Intents to enable for this connection
  * @property {WebsocketOptions} [ws] Options for the WebSocket
@@ -123,6 +126,7 @@ class Options extends null {
       restSweepInterval: 60,
       failIfNotExists: true,
       userAgentSuffix: [],
+      supportFriendInvites: false,
       presence: {},
       ws: {
         large_threshold: 50,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3251,6 +3251,7 @@ export interface ClientOptions {
   retryLimit?: number;
   failIfNotExists?: boolean;
   userAgentSuffix?: string[];
+  supportFriendInvites?: boolean;
   presence?: PresenceData;
   intents: BitFieldResolvable<IntentsString, number>;
   ws?: WebSocketOptions;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1049,7 +1049,7 @@ export class InteractionWebhook extends PartialWebhookMixin() {
 
 export class Invite extends Base {
   public constructor(client: Client, data: RawInviteData);
-  public channel: GuildChannel | PartialGroupDMChannel;
+  public channel: GuildChannel | PartialGroupDMChannel | null;
   public code: string;
   public readonly deletable: boolean;
   public readonly createdAt: Date | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds support for friend invites:
* https://github.com/discord/discord-api-docs/pull/3659

To be non-breaking, this PR adds a `supportFriendInvites` ClientOption: by default, it is `false`, and fetching a friend invite will continue to throw an error. If it is set to `true`, fetching a friend invite will return an Invite with channel as null.

The guide should recommend setting `supportFriendInvites` to true.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
