### PR TITLE
typings(CommandInteractionOptionResolver): add missing parameter

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -542,7 +542,7 @@ export class CommandInteraction extends BaseCommandInteraction {
 }
 
 export class CommandInteractionOptionResolver {
-  public constructor(client: Client, options: CommandInteractionOption[]);
+  public constructor(client: Client, options: CommandInteractionOption[], resolved: CommandInteractionResolvedData);
   public readonly client: Client;
   public readonly data: readonly CommandInteractionOption[];
   public readonly resolved: Readonly<CommandInteractionResolvedData>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the missing parameter called `resolved` in `CommandInteractionOptionResolver` that was introduced in #6384 but not added in the typings.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
