### PR TITLE
feat(Threads): add support for invitable in private threads

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -99,6 +99,7 @@ const Messages = {
 
   MESSAGE_THREAD_PARENT: 'The message was not sent in a guild text or news channel',
   MESSAGE_EXISTING_THREAD: 'The message already has a thread',
+  THREAD_INVITABLE_TYPE: type => `Invitable cannot be edited on ${type}`,
 
   WEBHOOK_MESSAGE: 'The message was not sent by a webhook.',
   WEBHOOK_TOKEN_UNAVAILABLE: 'This action requires a webhook token, but none is available.',

--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -78,6 +78,8 @@ class ThreadManager extends CachedManager {
    * @property {ThreadChannelTypes|number} [type] The type of thread to create. Defaults to `GUILD_PUBLIC_THREAD` if
    * created in a {@link TextChannel} <warn>When creating threads in a {@link NewsChannel} this is ignored and is always
    * `GUILD_NEWS_THREAD`</warn>
+   * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
+   * <info>Can only be set when type will be `GUILD_PRIVATE_THREAD` (12)</info>
    */
 
   /**
@@ -106,7 +108,7 @@ class ThreadManager extends CachedManager {
    *   .then(threadChannel => console.log(threadChannel))
    *   .catch(console.error);
    */
-  async create({ name, autoArchiveDuration, startMessage, type, reason } = {}) {
+  async create({ name, autoArchiveDuration, startMessage, type, invitable, reason } = {}) {
     let path = this.client.api.channels(this.channel.id);
     if (type && typeof type !== 'string' && typeof type !== 'number') {
       throw new TypeError('INVALID_TYPE', 'type', 'ThreadChannelType or Number');
@@ -134,6 +136,7 @@ class ThreadManager extends CachedManager {
         name,
         auto_archive_duration: autoArchiveDuration,
         type: resolvedType,
+        invitable: resolvedType === ChannelTypes.GUILD_PRIVATE_THREAD ? invitable : undefined,
       },
       reason,
     });

--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -79,7 +79,7 @@ class ThreadManager extends CachedManager {
    * created in a {@link TextChannel} <warn>When creating threads in a {@link NewsChannel} this is ignored and is always
    * `GUILD_NEWS_THREAD`</warn>
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
-   * <info>Can only be set when type will be `GUILD_PRIVATE_THREAD` (12)</info>
+   * <info>Can only be set when type will be `GUILD_PRIVATE_THREAD`</info>
    */
 
   /**

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -2,6 +2,7 @@
 
 const Channel = require('./Channel');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
+const { RangeError } = require('../errors');
 const MessageManager = require('../managers/MessageManager');
 const ThreadMemberManager = require('../managers/ThreadMemberManager');
 const Permissions = require('../util/Permissions');
@@ -78,6 +79,13 @@ class ThreadChannel extends Channel {
       this.locked = data.thread_metadata.locked ?? false;
 
       /**
+       * Whether members without `MANAGE_THREADS` can invite other members without `MANAGE_THREADS`
+       * <info>Always `null` in public threads</info>
+       * @type {?boolean}
+       */
+      this.invitable = this.type === 'GUILD_PRIVATE_THREAD' ? data.thread_metadata.invitable ?? false : null;
+
+      /**
        * Whether the thread is archived
        * @type {?boolean}
        */
@@ -108,6 +116,9 @@ class ThreadChannel extends Channel {
       }
       if (!this.archiveTimestamp) {
         this.archiveTimestamp = null;
+      }
+      if (!this.invitable) {
+        this.invitable = null;
       }
     }
 
@@ -262,6 +273,8 @@ class ThreadChannel extends Channel {
    * should automatically archive in case of no recent activity
    * @property {number} [rateLimitPerUser] The ratelimit per user for the thread in seconds
    * @property {boolean} [locked] Whether the thread is locked
+   * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to a thread
+   * <info>Can only be edited on `GUILD_PRIVATE_THREAD`</info>
    */
 
   /**
@@ -292,6 +305,7 @@ class ThreadChannel extends Channel {
         auto_archive_duration: autoArchiveDuration,
         rate_limit_per_user: data.rateLimitPerUser,
         locked: data.locked,
+        invitable: this.type === 'GUILD_PRIVATE_THREAD' ? data.invitable : undefined,
       },
       reason,
     });
@@ -330,6 +344,18 @@ class ThreadChannel extends Channel {
    */
   setAutoArchiveDuration(autoArchiveDuration, reason) {
     return this.edit({ autoArchiveDuration }, reason);
+  }
+
+  /**
+   * Sets whether members without the `MANAGE_THREADS` permission can invite other members without the
+   * `MANAGE_THREADS` permission to this thread.
+   * @param {boolean} [invitable=true] Whether non-moderators can invite non-moderators to this thread
+   * @param {string} [reason] Reason for changing invite
+   * @returns {Promise<ThreadChannel>}
+   */
+  setInvitable(invitable = true, reason) {
+    if (this.type !== 'GUILD_PRIVATE_THREAD') return Promise.reject(new RangeError('THREAD_INVITABLE_TYPE', this.type));
+    return this.edit({ invitable }, reason);
   }
 
   /**

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -117,9 +117,7 @@ class ThreadChannel extends Channel {
       if (!this.archiveTimestamp) {
         this.archiveTimestamp = null;
       }
-      if (!this.invitable) {
-        this.invitable = null;
-      }
+      this.invitable ??= null;
     }
 
     if ('owner_id' in data) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -306,7 +306,7 @@ export class BaseGuildTextChannel extends TextBasedChannel(GuildChannel) {
   public defaultAutoArchiveDuration?: ThreadAutoArchiveDuration;
   public messages: MessageManager;
   public nsfw: boolean;
-  public threads: ThreadManager<AllowedThreadTypeForTextChannel>;
+  public threads: ThreadManager<AllowedThreadTypeForTextChannel | AllowedThreadTypeForNewsChannel>;
   public topic: string | null;
   public createInvite(options?: CreateInviteOptions): Promise<Invite>;
   public createWebhook(name: string, options?: ChannelWebhookCreateOptions): Promise<Webhook>;
@@ -1405,6 +1405,7 @@ export class MessageSelectMenu extends BaseMessageComponent {
 }
 
 export class NewsChannel extends BaseGuildTextChannel {
+  public threads: ThreadManager<AllowedThreadTypeForNewsChannel>;
   public type: 'GUILD_NEWS';
   public addFollower(channel: GuildChannelResolvable, reason?: string): Promise<NewsChannel>;
 }
@@ -1775,6 +1776,7 @@ export class TeamMember extends Base {
 
 export class TextChannel extends BaseGuildTextChannel {
   public rateLimitPerUser: number;
+  public threads: ThreadManager<AllowedThreadTypeForTextChannel>;
   public type: 'GUILD_TEXT';
   public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<TextChannel>;
 }
@@ -1789,6 +1791,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
   public guild: Guild;
   public guildId: Snowflake;
   public readonly guildMembers: Collection<Snowflake, GuildMember>;
+  public invitable: boolean | null;
   public readonly joinable: boolean;
   public readonly joined: boolean;
   public locked: boolean | null;
@@ -1817,6 +1820,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
     autoArchiveDuration: ThreadAutoArchiveDuration,
     reason?: string,
   ): Promise<ThreadChannel>;
+  public setInvitable(invitable?: boolean, reason?: string): Promise<ThreadChannel>;
   public setLocked(locked?: boolean, reason?: string): Promise<ThreadChannel>;
   public setName(name: string, reason?: string): Promise<ThreadChannel>;
   public setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<ThreadChannel>;
@@ -4571,6 +4575,7 @@ export type ThreadChannelTypes = 'GUILD_NEWS_THREAD' | 'GUILD_PUBLIC_THREAD' | '
 export interface ThreadCreateOptions<AllowedThreadType> extends StartThreadOptions {
   startMessage?: MessageResolvable;
   type?: AllowedThreadType;
+  invitable?: AllowedThreadType extends 'GUILD_PRIVATE_THREAD' | 12 ? boolean : undefined;
 }
 
 export interface ThreadEditData {
@@ -4579,6 +4584,7 @@ export interface ThreadEditData {
   autoArchiveDuration?: ThreadAutoArchiveDuration;
   rateLimitPerUser?: number;
   locked?: boolean;
+  invitable?: boolean;
 }
 
 export type ThreadMemberFlagsString = '';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4575,7 +4575,7 @@ export type ThreadChannelTypes = 'GUILD_NEWS_THREAD' | 'GUILD_PUBLIC_THREAD' | '
 export interface ThreadCreateOptions<AllowedThreadType> extends StartThreadOptions {
   startMessage?: MessageResolvable;
   type?: AllowedThreadType;
-  invitable?: AllowedThreadType extends 'GUILD_PRIVATE_THREAD' | 12 ? boolean : undefined;
+  invitable?: AllowedThreadType extends 'GUILD_PRIVATE_THREAD' | 12 ? boolean : never;
 }
 
 export interface ThreadEditData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes: #6379 

Fixes a bug in typings that didn't pass the allowable thread types properly for news channels since this relies on it.

⚠️ The `invitable` field in the thread creation endpoint does not seem to be respected at the moment, it is supported here, but the API does not utilize it, always setting true.
- https://github.com/discord/discord-api-docs/issues/3700

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
