### PR TITLE
docs(GuildChannelCreateOptions): fix #type type

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -94,8 +94,7 @@ class GuildChannelManager extends CachedManager {
   /**
    * Options used to create a new channel in a guild.
    * @typedef {Object} GuildChannelCreateOptions
-   * @property {string|number} [type='GUILD_TEXT'] The type of the new channel, either `GUILD_TEXT`, `GUILD_VOICE`,
-   * `GUILD_CATEGORY`, `GUILD_NEWS`, `GUILD_STORE`, or `GUILD_STAGE_VOICE`
+   * @property {ChannelType|number} [type='GUILD_TEXT'] The type of the new channel.
    * @property {string} [topic] The topic for the new channel
    * @property {boolean} [nsfw] Whether the new channel is nsfw
    * @property {number} [bitrate] Bitrate of the new channel in bits (only voice)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The type of the type property in this typedef was set to `string|number` which is misleading since this is actually supposed to be a ChannelType, so this PR fixes that.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
