### PR TITLE
docs: fix wrong type being displayed in docs

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -11,7 +11,7 @@ const MessagePayload = require('../MessagePayload');
  */
 class InteractionResponses {
   /**
-   * Options for deferring the reply to a {@link MessageComponentInteraction}.
+   * Options for deferring the reply to a {@link Interaction}.
    * @typedef {Object} InteractionDeferReplyOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
    * @property {boolean} [fetchReply] Whether to fetch the reply

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -11,14 +11,14 @@ const MessagePayload = require('../MessagePayload');
  */
 class InteractionResponses {
   /**
-   * Options for deferring the reply to an {@link Interaction}.
+   * Options for deferring the reply to a {@link MessageComponentInteraction}.
    * @typedef {Object} InteractionDeferReplyOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
    * @property {boolean} [fetchReply] Whether to fetch the reply
    */
 
   /**
-   * Options for deferring and updating the reply to a {@link ButtonInteraction}.
+   * Options for deferring and updating the reply to a {@link MessageComponentInteraction}.
    * @typedef {Object} InteractionDeferUpdateOptions
    * @property {boolean} [fetchReply] Whether to fetch the reply
    */

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -11,7 +11,7 @@ const MessagePayload = require('../MessagePayload');
  */
 class InteractionResponses {
   /**
-   * Options for deferring the reply to a {@link Interaction}.
+   * Options for deferring the reply to an {@link Interaction}.
    * @typedef {Object} InteractionDeferReplyOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
    * @property {boolean} [fetchReply] Whether to fetch the reply

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -31,7 +31,7 @@ class InteractionResponses {
    */
 
   /**
-   * Options for updating the message received from a {@link ButtonInteraction}.
+   * Options for updating the message received from a {@link MessageComponentInteraction}.
    * @typedef {MessageEditOptions} InteractionUpdateOptions
    * @property {boolean} [fetchReply] Whether to fetch the reply
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Interaction should be MessageComponentInteraction instead of ButtonInteraction


**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
