### PR TITLE
feat(MessageAttachment): allow files to be marked as spoilers

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -178,7 +178,7 @@ class MessageManager extends CachedManager {
 
   /**
    * Adds a reaction to a message, even if it's not cached.
-   * @param {MessageResolvable} message The messag to react to
+   * @param {MessageResolvable} message The message to react to
    * @param {EmojiIdentifierResolvable} emoji The emoji to react with
    * @returns {Promise<void>}
    */

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -50,8 +50,13 @@ class MessageAttachment {
    */
   setSpoiler(spoiler = true) {
     if (spoiler === this.spoiler) return this;
-
-    this.name = spoiler ? `SPOILER_${this.name}` : this.name.slice('SPOILER_'.length);
+    
+    if (!spoiler) {
+      while (this.spoiler) {
+        this.name.slice('SPOILER_'.length);
+      }
+    }
+    this.name = `SPOILER_${this.name}`;
     return this;
   }
 

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -51,8 +51,7 @@ class MessageAttachment {
   setSpoiler(spoiler = true) {
     if (spoiler === true && this.spoiler === false) {
       this.name = `SPOILER_${this.name}`;
-    }
-    if (spoiler === false && this.spoiler === true) {
+    } else if (spoiler === false && this.spoiler === true) {
       this.name = this.name.replace('SPOILER_', '');
     }
     return this;

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -49,10 +49,12 @@ class MessageAttachment {
    * @returns {MessageAttachment} This attachment
    */
   setSpoiler(spoiler = true) {
-    if (spoiler === true && this.spoiler === false) {
-      this.name = `SPOILER_${this.name}`;
-    } else if (spoiler === false && this.spoiler === true) {
-      this.name = this.name.replace('SPOILER_', '');
+    if (spoiler !== this.spoiler) {
+      if (spoiler) {
+        this.name = `SPOILER_${this.name}`;
+      } else {
+        this.name = this.name.replace(/^SPOILER_/, '');
+      }
     }
     return this;
   }

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -43,6 +43,21 @@ class MessageAttachment {
     return this;
   }
 
+  /**
+   * Sets whether this attachment is a spoiler
+   * @param {boolean} [spoiler=true] Whether the attachment should be marked as a spoiler
+   * @returns {MessageAttachment} This attachment
+   */
+  setSpoiler(spoiler = true) {
+    if (spoiler === true && this.spoiler === false) {
+      this.name = `SPOILER_${this.name}`;
+    }
+    if (spoiler === false && this.spoiler === true) {
+      this.name = this.name.replace('SPOILER_', '');
+    }
+    return this;
+  }
+
   _patch(data) {
     /**
      * The attachment's id
@@ -93,7 +108,7 @@ class MessageAttachment {
    * @readonly
    */
   get spoiler() {
-    return Util.basename(this.url).startsWith('SPOILER_');
+    return Util.basename(this.url ?? this.name).startsWith('SPOILER_');
   }
 
   toJSON() {

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -50,11 +50,12 @@ class MessageAttachment {
    */
   setSpoiler(spoiler = true) {
     if (spoiler === this.spoiler) return this;
-    
+
     if (!spoiler) {
       while (this.spoiler) {
         this.name.slice('SPOILER_'.length);
       }
+      return this;
     }
     this.name = `SPOILER_${this.name}`;
     return this;

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -49,13 +49,9 @@ class MessageAttachment {
    * @returns {MessageAttachment} This attachment
    */
   setSpoiler(spoiler = true) {
-    if (spoiler !== this.spoiler) {
-      if (spoiler) {
-        this.name = `SPOILER_${this.name}`;
-      } else {
-        this.name = this.name.replace(/^SPOILER_/, '');
-      }
-    }
+    if (spoiler === this.spoiler) return this;
+
+    this.name = spoiler ? `SPOILER_${this.name}` : this.name.slice('SPOILER_'.length);
     return this;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1205,6 +1205,7 @@ export class MessageAttachment {
   public width: number | null;
   public setFile(attachment: BufferResolvable | Stream, name?: string): this;
   public setName(name: string): this;
+  public setSpoiler(spoiler?: boolean): this;
   public toJSON(): unknown;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This allows users to mark media as spoilers before sending them to Discord's API. The motivation behind this is for convenience, as in, users not needing to place the `SPOILER_` string.

You'll see a validation if the given argument is false, as it's possible to have the spoiler string inside the *string itself*, hence removing the title users would expect. 

I have adapted this PR from `#6473` but I didn't make it an equivalent setter as the function is more easy to use.

Resolves #6473

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
