### PR TITLE
fix(UserUpdateAction): rely on client.user when ids match

### DIFF
--- a/src/client/actions/UserUpdate.js
+++ b/src/client/actions/UserUpdate.js
@@ -7,7 +7,7 @@ class UserUpdateAction extends Action {
   handle(data) {
     const client = this.client;
 
-    const newUser = client.users.cache.get(data.id);
+    const newUser = data.id === client.user.id ? client.user : client.users.cache.get(data.id);
     const oldUser = newUser._update(data);
 
     if (!oldUser.equals(newUser)) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When the `UserManager` cache is disabled, updating the client user will result in a crash. The user update action gets the old state of the user via the `UserManager` cache, even if it's the client user. However, when it's disabled, nothing is being returned and so `newUser._update` throws a type error.

This fix makes the code get `client.user` if `client.user.id` and `data.id` are equal.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
