### PR TITLE
typings(MessageEmbed): allow `null` for `setTimestamp`

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -374,7 +374,8 @@ class MessageEmbed {
 
   /**
    * Sets the timestamp of this embed.
-   * @param {Date|number} [timestamp=Date.now()] The timestamp or date
+   * @param {Date|number|null} [timestamp=Date.now()] The timestamp or date.
+   * If `null` then the timestamp will be unset (i.e. when editing an existing {@link MessageEmbed})
    * @returns {MessageEmbed}
    */
   setTimestamp(timestamp = Date.now()) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1297,7 +1297,7 @@ export class MessageEmbed {
   public setFooter(text: string, iconURL?: string): this;
   public setImage(url: string): this;
   public setThumbnail(url: string): this;
-  public setTimestamp(timestamp?: Date | number): this;
+  public setTimestamp(timestamp?: Date | number | null): this;
   public setTitle(title: string): this;
   public setURL(url: string): this;
   public spliceFields(index: number, deleteCount: number, ...fields: EmbedFieldData[] | EmbedFieldData[][]): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This one is for @almostSouji. Can't post a screenshot of prof chat but y'all can find it there.

**Status and versioning classification:**
- Code changes have been tested against the Discord API (by Souji, as far as I can tell), or there are no code changes
- I know how to update typings and have done so, or typings don't need updating