### PR TITLE
typings(CommandInteractionOptionResolver): Document & type thread channels

### DIFF
--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -143,7 +143,7 @@ class BaseCommandInteraction extends Interaction {
    * subcommand (group)
    * @property {User} [user] The resolved user
    * @property {GuildMember|APIGuildMember} [member] The resolved member
-   * @property {GuildChannel|APIChannel} [channel] The resolved channel
+   * @property {GuildChannel|ThreadChannel|APIChannel} [channel] The resolved channel
    * @property {Role|APIRole} [role] The resolved role
    */
 

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -141,7 +141,7 @@ class CommandInteractionOptionResolver {
    * Gets a channel option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?(GuildChannel|ThreadChannel|APIGuildChannel)}
+   * @returns {?(GuildChannel|ThreadChannel|APIChannel)}
    * The value of the option, or null if not set and not required.
    */
   getChannel(name, required = false) {

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -141,7 +141,7 @@ class CommandInteractionOptionResolver {
    * Gets a channel option.
    * @param {string} name The name of the option.
    * @param {boolean} [required=false] Whether to throw an error if the option is not found.
-   * @returns {?(GuildChannel|APIGuildChannel)}
+   * @returns {?(GuildChannel|ThreadChannel|APIGuildChannel)}
    * The value of the option, or null if not set and not required.
    */
   getChannel(name, required = false) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3355,7 +3355,7 @@ export interface CommandInteractionOption {
   options?: CommandInteractionOption[];
   user?: User;
   member?: GuildMember | APIInteractionDataResolvedGuildMember;
-  channel?: GuildChannel | APIInteractionDataResolvedChannel;
+  channel?: GuildChannel | ThreadChannel | APIInteractionDataResolvedChannel;
   role?: Role | APIRole;
   message?: Message | APIMessage;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Threads are a possible channel type via `CommandInteractionOptionResolver#getChannel()`. This wasn't in the typings & documentation, but they are now! discord.js already parses them, so no behavioural change is needed.

Also, I changed `APIGuildChannel` to `APIChannel`, as the former didn't have a link & would be the same link as the `APIChannel`. Let me know if it's desired to be the former way (with a link)!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
