### PR TITLE
docs(Formatters): fix typo of TimestampStyles

### DIFF
--- a/src/util/Formatters.js
+++ b/src/util/Formatters.js
@@ -161,7 +161,7 @@ Formatters.strikethrough = strikethrough;
  * @method time
  * @memberof Formatters
  * @param {number|Date} [date] The date to format.
- * @param {TimestampStyles} [style] The style to use.
+ * @param {TimestampStylesString} [style] The style to use.
  * @returns {string}
  */
 Formatters.time = time;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
same as #6499 except it targets main as crawl said here 
https://github.com/discordjs/discord.js/pull/6499#issuecomment-904958771

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed) -->
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
