### PR TITLE
refactor: Remove `Util.removeMentions()`

### DIFF
--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { parse } = require('node:path');
-const process = require('node:process');
 const { Collection } = require('@discordjs/collection');
 const fetch = require('node-fetch');
 const { Colors, Endpoints } = require('./Constants');
@@ -9,8 +8,6 @@ const Options = require('./Options');
 const { Error: DiscordError, RangeError, TypeError } = require('../errors');
 const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
 const isObject = d => typeof d === 'object' && d !== null;
-
-let deprecationEmittedForRemoveMentions = false;
 
 /**
  * Contains various general-purpose utility methods.
@@ -522,34 +519,8 @@ class Util extends null {
     const res = parse(path);
     return ext && res.ext.startsWith(ext) ? res.name : res.base.split('?')[0];
   }
-
-  /**
-   * Breaks user, role and everyone/here mentions by adding a zero width space after every @ character
-   * @param {string} str The string to sanitize
-   * @returns {string}
-   * @deprecated Use {@link BaseMessageOptions#allowedMentions} instead.
-   */
-  static removeMentions(str) {
-    if (!deprecationEmittedForRemoveMentions) {
-      process.emitWarning(
-        'The Util.removeMentions method is deprecated. Use MessageOptions#allowedMentions instead.',
-        'DeprecationWarning',
-      );
-
-      deprecationEmittedForRemoveMentions = true;
-    }
-
-    return Util._removeMentions(str);
-  }
-
-  static _removeMentions(str) {
-    return str.replaceAll('@', '@\u200b');
-  }
-
   /**
    * The content to have all mentions replaced by the equivalent text.
-   * <warn>When {@link Util.removeMentions} is removed, this method will no longer sanitize mentions.
-   * Use {@link BaseMessageOptions#allowedMentions} instead to prevent mentions when sending a message.</warn>
    * @param {string} str The string to be converted
    * @param {TextBasedChannels} channel The channel the string was sent in
    * @returns {string}
@@ -560,15 +531,15 @@ class Util extends null {
         const id = input.replace(/<|!|>|@/g, '');
         if (channel.type === 'DM') {
           const user = channel.client.users.cache.get(id);
-          return user ? Util._removeMentions(`@${user.username}`) : input;
+          return user ? `@${user.username}` : input;
         }
 
         const member = channel.guild.members.cache.get(id);
         if (member) {
-          return Util._removeMentions(`@${member.displayName}`);
+          return `@${member.displayName}`;
         } else {
           const user = channel.client.users.cache.get(id);
-          return user ? Util._removeMentions(`@${user.username}`) : input;
+          return user ? `@${user.username}` : input;
         }
       })
       .replace(/<#[0-9]+>/g, input => {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2420,9 +2420,6 @@ export class Util extends null {
   public static archivedThreadSweepFilter<K, V>(lifetime?: number): SweepFilter<K, V>;
   public static basename(path: string, ext?: string): string;
   public static cleanContent(str: string, channel: TextBasedChannel): string;
-  /** @deprecated Use {@link MessageOptions.allowedMentions} to control mentions in a message instead. */
-  public static removeMentions(str: string): string;
-  private static _removeMentions(str: string): string;
   public static cloneObject(obj: unknown): unknown;
   public static discordSort<K, V extends { rawPosition: number; id: Snowflake }>(
     collection: Collection<K, V>,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This method removes the user & role mentioning ability by inserting `\u200b` after the `@`. This essentially sanitises input to prevent mention injections when running `Message#cleanContent`. However, `Message#cleanContent` should only return the content with mentions replaced with names. Otherwise, this ruins the original message. 

`allowedMentions` has been implemented into discord.js for quite some time now and supersedes this "workaround". Therefore, I believe it's time we remove this method. Users should sanitise their own sending of messages via the `allowedMentions` feature if they don't want mentions to occur.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
