### PR TITLE
types(MessageComponentInteraction): fix componentType

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1251,7 +1251,7 @@ export class MessageComponentInteraction extends Interaction {
   public constructor(client: Client, data: RawMessageComponentInteractionData);
   public readonly channel: TextBasedChannels | null;
   public readonly component: MessageActionRowComponent | Exclude<APIMessageComponent, APIActionRowComponent> | null;
-  public componentType: MessageComponentType;
+  public componentType: Exclude<MessageComponentType, 'ACTION_ROW'>;
   public customId: string;
   public deferred: boolean;
   public ephemeral: boolean | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the type for the componentType property in a MessageComponentInteraction by excluding ACTION_ROW from the list of component types

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
