### PR TITLE
test(webhooktest): replace unused url

### DIFF
--- a/test/webhooktest.js
+++ b/test/webhooktest.js
@@ -14,8 +14,8 @@ const read = util.promisify(fs.readFile);
 const readStream = fs.createReadStream;
 const wait = util.promisify(setTimeout);
 
-const linkA = 'https://lolisafe.moe/iiDMtAXA.png';
-const linkB = 'https://lolisafe.moe/9hSpedPh.png';
+const linkA = 'https://chibisafe.moe/iiDMtAXA.png';
+const linkB = 'https://chibisafe.moe/9hSpedPh.png';
 const fileA = path.join(__dirname, 'blobReach.png');
 
 const embed = () => new MessageEmbed();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I think lolisafe.moe has been replaced by chibisafe.moe

lolisafe.moe is redirect to chibisafe.moe


**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
