### PR TITLE
fix(xxxable): follow more properly with discord behavior

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -497,11 +497,7 @@ class GuildChannel extends Channel {
    * @readonly
    */
   get deletable() {
-    return (
-      this.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_CHANNELS, false) &&
-      this.guild.rulesChannelId !== this.id &&
-      this.guild.publicUpdatesChannelId !== this.id
-    );
+    return this.manageable && this.guild.rulesChannelId !== this.id && this.guild.publicUpdatesChannelId !== this.id;
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -548,7 +548,11 @@ class Message extends Base {
    * @readonly
    */
   get editable() {
-    return this.author.id === this.client.user.id;
+    return (
+      this.author.id === this.client.user.id &&
+      (!this.guild ||
+        (this.channel.viewable && this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.SEND_MESSAGES)))
+    );
   }
 
   /**
@@ -557,10 +561,18 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
-    return Boolean(
-      !this.deleted &&
-        (this.author.id === this.client.user.id ||
-          this.channel.permissionsFor?.(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES)),
+    if (this.deleted) {
+      return false;
+    }
+    if (!this.guild) {
+      return this.author.id === this.client.user.id;
+    }
+    if (!this.channel.viewable) {
+      return false;
+    }
+    return (
+      this.author.id === this.client.user.id ||
+      this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)
     );
   }
 
@@ -570,9 +582,11 @@ class Message extends Base {
    * @readonly
    */
   get pinnable() {
-    return Boolean(
+    return (
       !this.system &&
-        (!this.guild || this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false)),
+      (!this.guild ||
+        (this.channel.viewable &&
+          this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
     );
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -550,6 +550,7 @@ class Message extends Base {
   get editable() {
     return (
       this.author.id === this.client.user.id &&
+      !this.deleted &&
       (!this.guild ||
         (this.channel.viewable && this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.SEND_MESSAGES)))
     );
@@ -584,6 +585,7 @@ class Message extends Base {
   get pinnable() {
     return (
       !this.system &&
+      !this.deleted &&
       (!this.guild ||
         (this.channel.viewable &&
           this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
@@ -616,7 +618,8 @@ class Message extends Base {
       this.channel.viewable &&
       this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.SEND_MESSAGES) &&
       (this.author.id === this.client.user.id ||
-        this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES))
+        this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES)) &&
+      !this.deleted
     );
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -615,7 +615,7 @@ class Message extends Base {
   get crosspostable() {
     const bitfield =
       Permissions.FLAGS.SEND_MESSAGES |
-      (this.author.id === this.client.user.id ? 0 : Permissions.FLAGS.MANAGE_MESSAGES);
+      (this.author.id === this.client.user.id ? Permissions.defaultBit : Permissions.FLAGS.MANAGE_MESSAGES);
     return Boolean(
       this.channel?.type === 'GUILD_NEWS' &&
         !this.flags.has(MessageFlags.FLAGS.CROSSPOSTED) &&

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -553,7 +553,7 @@ class Message extends Base {
         !this.deleted &&
         (!this.guild ||
           (this.channel?.viewable &&
-            this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.SEND_MESSAGES))),
+            this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.SEND_MESSAGES))),
     );
   }
 
@@ -569,9 +569,9 @@ class Message extends Base {
     if (!this.guild) {
       return this.author.id === this.client.user.id;
     }
-    return (
+    return Boolean(
       this.author.id === this.client.user.id ||
-      this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)
+        this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false),
     );
   }
 
@@ -585,8 +585,8 @@ class Message extends Base {
       !this.system &&
         !this.deleted &&
         (!this.guild ||
-          (this.channel.viewable &&
-            this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false))),
+          (this.channel?.viewable &&
+            this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false))),
     );
   }
 
@@ -609,15 +609,16 @@ class Message extends Base {
    * @readonly
    */
   get crosspostable() {
-    return (
+    const bitfield =
+      Permissions.FLAGS.SEND_MESSAGES |
+      (this.author.id === this.client.user.id ? 0 : Permissions.FLAGS.MANAGE_MESSAGES);
+    return Boolean(
       this.channel?.type === 'GUILD_NEWS' &&
-      !this.flags.has(MessageFlags.FLAGS.CROSSPOSTED) &&
-      this.type === 'DEFAULT' &&
-      this.channel.viewable &&
-      this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.SEND_MESSAGES) &&
-      (this.author.id === this.client.user.id ||
-        this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES)) &&
-      !this.deleted
+        !this.flags.has(MessageFlags.FLAGS.CROSSPOSTED) &&
+        this.type === 'DEFAULT' &&
+        this.channel.viewable &&
+        this.channel.permissionsFor(this.client.user)?.has(bitfield) &&
+        !this.deleted,
     );
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -548,11 +548,12 @@ class Message extends Base {
    * @readonly
    */
   get editable() {
-    return (
+    return Boolean(
       this.author.id === this.client.user.id &&
-      !this.deleted &&
-      (!this.guild ||
-        (this.channel.viewable && this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.SEND_MESSAGES)))
+        !this.deleted &&
+        (!this.guild ||
+          (this.channel?.viewable &&
+            this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.SEND_MESSAGES))),
     );
   }
 
@@ -562,14 +563,11 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
-    if (this.deleted) {
+    if (this.deleted || !this.channel?.viewable) {
       return false;
     }
     if (!this.guild) {
       return this.author.id === this.client.user.id;
-    }
-    if (!this.channel.viewable) {
-      return false;
     }
     return (
       this.author.id === this.client.user.id ||
@@ -583,12 +581,12 @@ class Message extends Base {
    * @readonly
    */
   get pinnable() {
-    return (
+    return Boolean(
       !this.system &&
-      !this.deleted &&
-      (!this.guild ||
-        (this.channel.viewable &&
-          this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)))
+        !this.deleted &&
+        (!this.guild ||
+          (this.channel.viewable &&
+            this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false))),
     );
   }
 
@@ -612,7 +610,7 @@ class Message extends Base {
    */
   get crosspostable() {
     return (
-      this.channel.type === 'GUILD_NEWS' &&
+      this.channel?.type === 'GUILD_NEWS' &&
       !this.flags.has(MessageFlags.FLAGS.CROSSPOSTED) &&
       this.type === 'DEFAULT' &&
       this.channel.viewable &&

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -563,11 +563,15 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
-    if (this.deleted || !this.channel?.viewable) {
+    if (this.deleted) {
       return false;
     }
     if (!this.guild) {
       return this.author.id === this.client.user.id;
+    }
+    // DMChannel does not have viewable property, so check viewable after proved that message is on a guild.
+    if (!this.channel?.viewable) {
+      return false;
     }
     return Boolean(
       this.author.id === this.client.user.id ||

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -553,7 +553,7 @@ class Message extends Base {
         !this.deleted &&
         (!this.guild ||
           (this.channel?.viewable &&
-            this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.SEND_MESSAGES))),
+            this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.SEND_MESSAGES, false))),
     );
   }
 
@@ -617,7 +617,7 @@ class Message extends Base {
         !this.flags.has(MessageFlags.FLAGS.CROSSPOSTED) &&
         this.type === 'DEFAULT' &&
         this.channel.viewable &&
-        this.channel.permissionsFor(this.client.user)?.has(bitfield) &&
+        this.channel.permissionsFor(this.client.user)?.has(bitfield, false) &&
         !this.deleted,
     );
   }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -548,13 +548,7 @@ class Message extends Base {
    * @readonly
    */
   get editable() {
-    return Boolean(
-      this.author.id === this.client.user.id &&
-        !this.deleted &&
-        (!this.guild ||
-          (this.channel?.viewable &&
-            this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.SEND_MESSAGES, false))),
-    );
+    return Boolean(this.author.id === this.client.user.id && !this.deleted && (!this.guild || this.channel?.viewable));
   }
 
   /**

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -9,21 +9,12 @@ const Permissions = require('../util/Permissions');
  */
 class VoiceChannel extends BaseGuildVoiceChannel {
   /**
-   * Whether the channel is deletable by the client user
-   * @type {boolean}
-   * @readonly
-   */
-  get deletable() {
-    return super.deletable && this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false);
-  }
-
-  /**
    * Whether the channel is editable by the client user
    * @type {boolean}
    * @readonly
    */
   get editable() {
-    return this.manageable && this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false);
+    return this.manageable;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In rare cases, the result returned by the current XXXable property may not return the exact result, but it will return the correct result.
However, it seems difficult to maintain this, so consider removing this property. 

- Cannot delete channels that are not viewable/connectable(have CONNECT permission).
- ~~Cannot edit messages on channels that cannot send messages.~~
  - Cannot edit messages on channels that cannot view messages.
- Cannot pin messages on channels that cannot view messages.
- Cannot delete messages on channels that cannot view messages.
- ~~Messages that are not system messages can be pinned.~~
  - #6585 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
