### PR TITLE
docs: Fix JSDoc for `ClientUser#edit`

### DIFF
--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -43,7 +43,7 @@ class ClientUser extends User {
 
   /**
    * Data used to edit the logged in client
-   * @typdef {Object} ClientUserEditData
+   * @typedef {Object} ClientUserEditData
    * @property {string} [username] The new username
    * @property {BufferResolvable|Base64Resolvable} [avatar] The new avatar
    */

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -51,6 +51,7 @@ class ClientUser extends User {
   /**
    * Edits the logged in client.
    * @param {ClientUserEditData} data The new data
+   * @returns {Promise<ClientUser>}
    */
   async edit(data) {
     const newData = await this.client.api.users('@me').patch({ data });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
A typo in the JSDoc made the type definition for the `.edit` method not appear in the documentation. Also, the `@returns` type now exists for it!

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
