### PR TITLE
fix: await message component collectors should return component interactions not collectors

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1135,6 +1135,14 @@ type InteractionCollectorReturnType<T extends MessageComponentType | MessageComp
   ? ConditionalInteractionCollectorType<MappedInteractionCollectorOptions[T]>
   : InteractionCollector<MessageComponentInteraction>;
 
+type InteractionReturnType<T extends MessageComponentType | MessageComponentTypes | undefined> = T extends
+  | MessageComponentType
+  | MessageComponentTypes
+  ? MappedInteractionCollectorOptions[T] extends InteractionCollectorOptions<infer Item>
+    ? Item
+    : never
+  : MessageComponentInteraction;
+
 type MessageCollectorOptionsParams<T> =
   | ({ componentType?: T } & InteractionCollectorOptionsResolvable)
   | InteractionCollectorOptions<MessageComponentInteraction>;
@@ -1192,7 +1200,7 @@ export class Message extends Base {
   public reference: MessageReference | null;
   public awaitMessageComponent<T extends MessageComponentType | MessageComponentTypes | undefined = undefined>(
     options?: AwaitMessageCollectorOptionsParams<T>,
-  ): Promise<InteractionCollectorReturnType<T>>;
+  ): Promise<InteractionReturnType<T>>;
   public awaitReactions(options?: AwaitReactionsOptions): Promise<Collection<Snowflake | string, MessageReaction>>;
   public createReactionCollector(options?: ReactionCollectorOptions): ReactionCollector;
   public createMessageComponentCollector<

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -494,21 +494,17 @@ client.on('messageCreate', message => {
 
   // Verify that buttons interactions are inferred.
   const buttonCollector = message.createMessageComponentCollector({ componentType: 'BUTTON' });
-  assertType<Promise<InteractionCollector<ButtonInteraction>>>(
-    message.awaitMessageComponent({ componentType: 'BUTTON' }),
-  );
+  assertType<Promise<ButtonInteraction>>(message.awaitMessageComponent({ componentType: 'BUTTON' }));
   assertType<InteractionCollector<ButtonInteraction>>(buttonCollector);
 
   // Verify that select menus interaction are inferred.
   const selectMenuCollector = message.createMessageComponentCollector({ componentType: 'SELECT_MENU' });
-  assertType<Promise<InteractionCollector<SelectMenuInteraction>>>(
-    message.awaitMessageComponent({ componentType: 'SELECT_MENU' }),
-  );
+  assertType<Promise<SelectMenuInteraction>>(message.awaitMessageComponent({ componentType: 'SELECT_MENU' }));
   assertType<InteractionCollector<SelectMenuInteraction>>(selectMenuCollector);
 
   // Verify that message component interactions are default collected types.
   const defaultCollector = message.createMessageComponentCollector();
-  assertType<Promise<InteractionCollector<MessageComponentInteraction>>>(message.awaitMessageComponent());
+  assertType<Promise<MessageComponentInteraction>>(message.awaitMessageComponent());
   assertType<InteractionCollector<MessageComponentInteraction>>(defaultCollector);
 
   // Verify that additional options don't affect default collector types.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Closes #6561

**Status and versioning classification:**
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
