### PR TITLE
typings(MessageReference): correctly add undefined type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4289,8 +4289,8 @@ export type MessageReactionResolvable =
 
 export interface MessageReference {
   channelId: Snowflake;
-  guildId: Snowflake;
-  messageId: Snowflake | null;
+  guildId: Snowflake | undefined;
+  messageId: Snowflake | undefined;
 }
 
 export type MessageResolvable = Message | Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the types for MessageReference as guildId can be undefined and messageId can be undefined, not null.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
