### PR TITLE
types(MessageOptions): add missing typings

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4300,6 +4300,8 @@ export interface MessageOptions {
   reply?: ReplyOptions;
   stickers?: StickerResolvable[];
   attachments?: MessageAttachment[];
+  ephemeral?: boolean;
+  flags?: BitFieldResolvable<string, number | bigint>;
 }
 
 export type MessageReactionResolvable =


### PR DESCRIPTION
typings added for ephemeral and flags options

Signed-off-by: Oliver Henrichs <Oliver Henrichs>


When using MessageOptions in MessagePayload's constructor, the typings hide the fact that[ ephemeral-bool is available](https://github.com/discordjs/discord.js/blob/main/src/structures/MessagePayload.js#L150) and used.
Therefore typescript-programmers currently cannot create ephemeral MessagePayloads.

Regarding the other fix to flags I am unsure about the typings. This was my best guess after browsing the library for a while.
I thought it's better to try fix all the issues with typings for this interface.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
- I know how to update typings and have done so, or typings don't need updating
