### PR TITLE
fix(Message): pinnable returning false in non-DEFAULT messages

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -570,10 +570,9 @@ class Message extends Base {
    * @readonly
    */
   get pinnable() {
-    return (
-      ['DEFAULT', 'REPLY', 'APPLICATION_COMMAND', 'THREAD_STARTER_MESSAGE'].includes(this.type) &&
-      (!this.guild || this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)) &&
-      !this.system
+    return Boolean(
+      !this.system &&
+        (!this.guild || this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false))
     );
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -573,6 +573,7 @@ class Message extends Base {
     return (
       ['DEFAULT', 'REPLY', 'APPLICATION_COMMAND', 'THREAD_STARTER_MESSAGE'].includes(this.type) &&
       (!this.guild || this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false))
+      !this.system
     );
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -571,7 +571,7 @@ class Message extends Base {
    */
   get pinnable() {
     return (
-      this.type === 'DEFAULT' &&
+      ['DEFAULT', 'REPLY', 'APPLICATION_COMMAND', 'THREAD_STARTER_MESSAGE'].includes(this.type) &&
       (!this.guild || this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false))
     );
   }

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -572,7 +572,7 @@ class Message extends Base {
   get pinnable() {
     return Boolean(
       !this.system &&
-        (!this.guild || this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false))
+        (!this.guild || this.channel.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false)),
     );
   }
 

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -572,7 +572,7 @@ class Message extends Base {
   get pinnable() {
     return (
       ['DEFAULT', 'REPLY', 'APPLICATION_COMMAND', 'THREAD_STARTER_MESSAGE'].includes(this.type) &&
-      (!this.guild || this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false))
+      (!this.guild || this.channel.permissionsFor(this.client.user).has(Permissions.FLAGS.MANAGE_MESSAGES, false)) &&
       !this.system
     );
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a bug with Message#pinnable where it would return false if the type of message was not DEFAULT in some types that can be pinned. This PR fixes that so that it will now work on non system messages.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
