### PR TITLE
refactor: node-fetch & @discordjs/formdata -> undici

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ discord.js is a powerful [Node.js](https://nodejs.org) module that allows you to
 
 ## Installation
 
-**Node.js 16.6.0 or newer is required.**
+**Node.js 16.7.0 or newer is required.**  
 
 ```sh-session
 npm install discord.js

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -52,11 +52,9 @@
     "@discordjs/builders": "^0.11.0",
     "@discordjs/collection": "^0.4.0",
     "@sapphire/async-queue": "^1.1.9",
-    "@types/node-fetch": "^2.5.12",
     "@types/ws": "^8.2.2",
     "discord-api-types": "^0.26.0",
-    "form-data": "^4.0.0",
-    "node-fetch": "^2.6.1",
+    "undici": "^4.12.1",
     "ws": "^8.4.0"
   },
   "devDependencies": {
@@ -77,6 +75,6 @@
     "typescript": "^4.5.4"
   },
   "engines": {
-    "node": ">=16.6.0"
+    "node": ">=16.7.0"
   }
 }

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { Buffer } = require('node:buffer');
 const { setTimeout } = require('node:timers');
+const { types } = require('node:util');
 const { Collection } = require('@discordjs/collection');
 const CachedManager = require('./CachedManager');
 const { Error, TypeError, RangeError } = require('../errors');
@@ -115,7 +115,11 @@ class GuildMemberManager extends CachedManager {
     }
     const data = await this.client.api.guilds(this.guild.id).members(userId).put({ data: resolvedOptions });
     // Data is an empty buffer if the member is already part of the guild.
-    return data instanceof Buffer ? (options.fetchWhenExisting === false ? null : this.fetch(userId)) : this._add(data);
+    return types.isArrayBuffer(data)
+      ? options.fetchWhenExisting === false
+        ? null
+        : this.fetch(userId)
+      : this._add(data);
   }
 
   /**

--- a/packages/discord.js/src/rest/APIRequest.js
+++ b/packages/discord.js/src/rest/APIRequest.js
@@ -2,8 +2,7 @@
 
 const https = require('node:https');
 const { setTimeout } = require('node:timers');
-const FormData = require('form-data');
-const fetch = require('node-fetch');
+const { fetch, FormData } = require('undici');
 const { UserAgent } = require('../util/Constants');
 
 let agent = null;
@@ -61,7 +60,6 @@ class APIRequest {
           body.append('payload_json', JSON.stringify(this.options.data));
         }
       }
-      headers = Object.assign(headers, body.getHeaders());
       // eslint-disable-next-line eqeqeq
     } else if (this.options.data != null) {
       body = JSON.stringify(this.options.data);

--- a/packages/discord.js/src/rest/APIRequest.js
+++ b/packages/discord.js/src/rest/APIRequest.js
@@ -8,14 +8,6 @@ const { UserAgent } = require('../util/Constants');
 
 let agent = null;
 
-function toBlob(value) {
-  if (Buffer.isBuffer(value)) {
-    return new Blob([value]);
-  } else {
-    return value;
-  }
-}
-
 class APIRequest {
   constructor(rest, method, path, options) {
     this.rest = rest;

--- a/packages/discord.js/src/rest/APIRequest.js
+++ b/packages/discord.js/src/rest/APIRequest.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { Blob } = require('node:buffer');
 const https = require('node:https');
 const { setTimeout } = require('node:timers');
 const { fetch, FormData } = require('undici');

--- a/packages/discord.js/src/rest/APIRequest.js
+++ b/packages/discord.js/src/rest/APIRequest.js
@@ -1,11 +1,20 @@
 'use strict';
 
+const { Blob } = require('node:buffer');
 const https = require('node:https');
 const { setTimeout } = require('node:timers');
 const { fetch, FormData } = require('undici');
 const { UserAgent } = require('../util/Constants');
 
 let agent = null;
+
+function toBlob(value) {
+  if (Buffer.isBuffer(value)) {
+    return new Blob([value]);
+  } else {
+    return value;
+  }
+}
 
 class APIRequest {
   constructor(rest, method, path, options) {
@@ -51,7 +60,7 @@ class APIRequest {
     if (this.options.files?.length) {
       body = new FormData();
       for (const [index, file] of this.options.files.entries()) {
-        if (file?.file) body.append(file.key ?? `files[${index}]`, file.file, file.name);
+        if (file?.file) body.append(file.key ?? file.name ?? `files[${index}]`, file.file, file.name);
       }
       if (typeof this.options.data !== 'undefined') {
         if (this.options.dontUsePayloadJSON) {

--- a/packages/discord.js/src/rest/APIRequest.js
+++ b/packages/discord.js/src/rest/APIRequest.js
@@ -51,7 +51,7 @@ class APIRequest {
     if (this.options.files?.length) {
       body = new FormData();
       for (const [index, file] of this.options.files.entries()) {
-        if (file?.file) body.append(file.key ?? file.name ?? `files[${index}]`, file.file, file.name);
+        if (file?.file) body.append(file.key ?? `files[${index}]`, file.file, file.name);
       }
       if (typeof this.options.data !== 'undefined') {
         if (this.options.dontUsePayloadJSON) {

--- a/packages/discord.js/src/rest/APIRequest.js
+++ b/packages/discord.js/src/rest/APIRequest.js
@@ -8,6 +8,14 @@ const { UserAgent } = require('../util/Constants');
 
 let agent = null;
 
+function toBlob(value) {
+  if (Buffer.isBuffer(value)) {
+    return new Blob([value]);
+  } else {
+    return value;
+  }
+}
+
 class APIRequest {
   constructor(rest, method, path, options) {
     this.rest = rest;

--- a/packages/discord.js/src/rest/RequestHandler.js
+++ b/packages/discord.js/src/rest/RequestHandler.js
@@ -12,7 +12,7 @@ const {
 
 function parseResponse(res) {
   if (res.headers.get('content-type').startsWith('application/json')) return res.json();
-  return res.buffer();
+  return res.arrayBuffer();
 }
 
 function getAPIOffset(serverDate) {

--- a/packages/discord.js/src/rest/RequestHandler.js
+++ b/packages/discord.js/src/rest/RequestHandler.js
@@ -12,7 +12,7 @@ const {
 
 function parseResponse(res) {
   if (res.headers.get('content-type').startsWith('application/json')) return res.json();
-  return res.arrayBuffer().then(buffer => Buffer.from(buffer));
+  return res.arrayBuffer();
 }
 
 async function consumeBody(res) {

--- a/packages/discord.js/src/rest/RequestHandler.js
+++ b/packages/discord.js/src/rest/RequestHandler.js
@@ -12,7 +12,7 @@ const {
 
 function parseResponse(res) {
   if (res.headers.get('content-type').startsWith('application/json')) return res.json();
-  return res.arrayBuffer();
+  return res.arrayBuffer().then(buffer => Buffer.from(buffer));
 }
 
 function getAPIOffset(serverDate) {

--- a/packages/discord.js/src/rest/RequestHandler.js
+++ b/packages/discord.js/src/rest/RequestHandler.js
@@ -12,7 +12,7 @@ const {
 
 function parseResponse(res) {
   if (res.headers.get('content-type').startsWith('application/json')) return res.json();
-  return res.arrayBuffer();
+  return res.arrayBuffer().then(buffer => Buffer.from(buffer));
 }
 
 async function consumeBody(res) {

--- a/packages/discord.js/src/rest/RequestHandler.js
+++ b/packages/discord.js/src/rest/RequestHandler.js
@@ -12,7 +12,7 @@ const {
 
 function parseResponse(res) {
   if (res.headers.get('content-type').startsWith('application/json')) return res.json();
-  return res.arrayBuffer().then(buffer => Buffer.from(buffer));
+  return res.arrayBuffer();
 }
 
 function getAPIOffset(serverDate) {

--- a/packages/discord.js/src/structures/MessageAttachment.js
+++ b/packages/discord.js/src/structures/MessageAttachment.js
@@ -7,7 +7,7 @@ const Util = require('../util/Util');
  */
 class MessageAttachment {
   /**
-   * @param {BufferResolvable|Stream} attachment The file
+   * @param {BufferResolvable|Stream|Blob} attachment The file
    * @param {string} [name=null] The name of the file, if any
    * @param {APIAttachment} [data] Extra data
    */
@@ -33,7 +33,7 @@ class MessageAttachment {
 
   /**
    * Sets the file of this attachment.
-   * @param {BufferResolvable|Stream} attachment The file
+   * @param {BufferResolvable|Stream|Blob} attachment The file
    * @param {string} [name=null] The name of the file, if any
    * @returns {MessageAttachment} This attachment
    */

--- a/packages/discord.js/src/structures/MessageAttachment.js
+++ b/packages/discord.js/src/structures/MessageAttachment.js
@@ -7,7 +7,7 @@ const Util = require('../util/Util');
  */
 class MessageAttachment {
   /**
-   * @param {BufferResolvable|Stream|Blob} attachment The file
+   * @param {BufferResolvable|Stream|Blob|File} attachment The file
    * @param {string} [name=null] The name of the file, if any
    * @param {APIAttachment} [data] Extra data
    */
@@ -17,7 +17,7 @@ class MessageAttachment {
      * The name of this attachment
      * @type {?string}
      */
-    this.name = name;
+    this.name = attachment.name ?? name;
     if (data) this._patch(data);
   }
 

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -219,7 +219,7 @@ class MessagePayload {
 
   /**
    * Resolves a single file into an object sendable to the API.
-   * @param {BufferResolvable|Stream|FileOptions|MessageAttachment|Blob} fileLike Something that could be resolved
+   * @param {BufferResolvable|Stream|FileOptions|MessageAttachment|Blob|File} fileLike Something that could be resolved
    * to a file
    * @returns {Promise<MessageFile>}
    */
@@ -234,6 +234,10 @@ class MessagePayload {
 
       if (thing.path) {
         return Util.basename(thing.path);
+      }
+
+      if (thing.name) {
+        return thing.name;
       }
 
       return 'file.jpg';

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Buffer } = require('node:buffer');
+const { Buffer, Blob } = require('node:buffer');
 const BaseMessageComponent = require('./BaseMessageComponent');
 const MessageEmbed = require('./MessageEmbed');
 const { RangeError } = require('../errors');
@@ -219,7 +219,8 @@ class MessagePayload {
 
   /**
    * Resolves a single file into an object sendable to the API.
-   * @param {BufferResolvable|Stream|FileOptions|MessageAttachment} fileLike Something that could be resolved to a file
+   * @param {BufferResolvable|Stream|FileOptions|MessageAttachment|Blob} fileLike Something that could be resolved
+   * to a file
    * @returns {Promise<MessageFile>}
    */
   static async resolveFile(fileLike) {
@@ -239,7 +240,10 @@ class MessagePayload {
     };
 
     const ownAttachment =
-      typeof fileLike === 'string' || fileLike instanceof Buffer || typeof fileLike.pipe === 'function';
+      typeof fileLike === 'string' ||
+      fileLike instanceof Buffer ||
+      typeof fileLike.pipe === 'function' ||
+      fileLike instanceof Blob;
     if (ownAttachment) {
       attachment = fileLike;
       name = findName(attachment);

--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -4,7 +4,7 @@ const { Buffer } = require('node:buffer');
 const fs = require('node:fs');
 const path = require('node:path');
 const stream = require('node:stream');
-const fetch = require('node-fetch');
+const { fetch } = require('undici');
 const { Error: DiscordError, TypeError } = require('../errors');
 const Invite = require('../structures/Invite');
 

--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -3,7 +3,7 @@
 const { Buffer, Blob } = require('node:buffer');
 const fs = require('node:fs');
 const path = require('node:path');
-const stream = require('node:stream');
+const { blob } = require('node:stream/consumers');
 const { fetch } = require('undici');
 const { Error: DiscordError, TypeError } = require('../errors');
 const Invite = require('../structures/Invite');
@@ -115,8 +115,8 @@ class DataResolver extends null {
   static async resolveFile(resource) {
     if (resource instanceof Blob) return resource;
     if (Buffer.isBuffer(resource)) return new Blob([resource]);
-    if (resource !== null && resource !== undefined && resource[Symbol.asyncIterator]) {
-      return stream.consumers.blob(resource);
+    if (resource?.[Symbol.asyncIterator]) {
+      return blob(resource);
     }
     if (typeof resource === 'string') {
       if (/^https?:\/\//.test(resource)) {

--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -115,12 +115,8 @@ class DataResolver extends null {
   static async resolveFile(resource) {
     if (resource instanceof Blob) return resource;
     if (Buffer.isBuffer(resource)) return new Blob([resource]);
-    if (resource instanceof stream.Readable) {
-      const chunks = [];
-      for await (const chunk of resource) {
-        chunks.push(chunk);
-      }
-      return new Blob(chunks);
+    if (resource !== null && resource !== undefined && resource[Symbol.asyncIterator]) {
+      return stream.consumers.blob(resource);
     }
     if (typeof resource === 'string') {
       if (/^https?:\/\//.test(resource)) {

--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -87,7 +87,7 @@ class DataResolver extends null {
     if (data instanceof Blob) {
       const text = await data.text();
       const buffer = Buffer.from(text);
-      return `data:image/jpg;base64,${buffer.toString('base64')}`;
+      return `data:${data.type || 'image/jpg'};base64,${buffer.toString('base64')}`;
     }
     return data;
   }

--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -58,7 +58,7 @@ class DataResolver extends null {
 
   /**
    * Resolves a Base64Resolvable, a string, Blob, or a BufferResolvable to a Base 64 image.
-   * @param {BufferResolvable|Base64Resolvable|Blob} image The image to be resolved
+   * @param {BufferResolvable|Base64Resolvable|Blob|File} image The image to be resolved
    * @returns {Promise<?string>}
    */
   static async resolveImage(image) {
@@ -78,12 +78,13 @@ class DataResolver extends null {
    */
 
   /**
-   * Resolves a Base64Resolvable to a Base 64 image.
-   * @param {Base64Resolvable|Blob} data The base 64 resolvable you want to resolve
+   * Resolves a Base64Resolvable or Blob to a Base 64 image.
+   * @param {Base64Resolvable|Blob|File} data The base 64 resolvable you want to resolve
    * @returns {Promise<string>}
    */
   static async resolveBase64(data) {
     if (Buffer.isBuffer(data)) return `data:image/jpg;base64,${data.toString('base64')}`;
+    // File is an instance of Blob
     if (data instanceof Blob) {
       const text = await data.text();
       const buffer = Buffer.from(text);
@@ -108,7 +109,7 @@ class DataResolver extends null {
 
   /**
    * Resolves a BufferResolvable, Blob, or Stream to a Blob.
-   * @param {BufferResolvable|Stream|Blob} resource The buffer or stream resolvable to resolve
+   * @param {BufferResolvable|Stream|Blob|File} resource The buffer or stream resolvable to resolve
    * @returns {Promise<Blob>}
    */
   static async resolveFile(resource) {

--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -102,7 +102,7 @@ class DataResolver extends null {
    */
 
   /**
-   * Resolves a BufferResolvable to a Buffer or a Stream.
+   * Resolves a BufferResolvable or Stream to a Blob.
    * @param {BufferResolvable|Stream} resource The buffer or stream resolvable to resolve
    * @returns {Promise<Blob>}
    */

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -3,7 +3,7 @@
 const { parse } = require('node:path');
 const process = require('node:process');
 const { Collection } = require('@discordjs/collection');
-const fetch = require('node-fetch');
+const { fetch } = require('undici');
 const { Colors, Endpoints } = require('./Constants');
 const Options = require('./Options');
 const { Error: DiscordError, RangeError, TypeError } = require('../errors');

--- a/packages/discord.js/test/sendtest.js
+++ b/packages/discord.js/test/sendtest.js
@@ -11,7 +11,10 @@ const { Client, Intents, MessageAttachment, MessageEmbed } = require('../src');
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 
-const buffer = l => fetch(l).then(res => res.arrayBuffer());
+const buffer = l =>
+  fetch(l)
+    .then(res => res.arrayBuffer())
+    .then(buff => Buffer.from(buff));
 const read = util.promisify(fs.readFile);
 const readStream = fs.createReadStream;
 

--- a/packages/discord.js/test/sendtest.js
+++ b/packages/discord.js/test/sendtest.js
@@ -5,13 +5,13 @@ const path = require('node:path');
 const process = require('node:process');
 const { setTimeout: sleep } = require('node:timers/promises');
 const util = require('node:util');
-const fetch = require('node-fetch');
+const { fetch } = require('undici');
 const { owner, token } = require('./auth.js');
 const { Client, Intents, MessageAttachment, MessageEmbed } = require('../src');
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 
-const buffer = l => fetch(l).then(res => res.buffer());
+const buffer = l => fetch(l).then(res => res.arrayBuffer());
 const read = util.promisify(fs.readFile);
 const readStream = fs.createReadStream;
 

--- a/packages/discord.js/test/webhooktest.js
+++ b/packages/discord.js/test/webhooktest.js
@@ -10,7 +10,10 @@ const { Client, Intents, MessageAttachment, MessageEmbed, WebhookClient } = requ
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 
-const buffer = l => fetch(l).then(res => res.arrayBuffer());
+const buffer = l =>
+  fetch(l)
+    .then(res => res.arrayBuffer())
+    .then(buff => Buffer.from(buff));
 const read = util.promisify(fs.readFile);
 const readStream = fs.createReadStream;
 

--- a/packages/discord.js/test/webhooktest.js
+++ b/packages/discord.js/test/webhooktest.js
@@ -4,13 +4,13 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { setTimeout: sleep } = require('node:timers/promises');
 const util = require('node:util');
-const fetch = require('node-fetch');
+const { fetch } = require('undici');
 const { owner, token, webhookChannel, webhookToken } = require('./auth.js');
 const { Client, Intents, MessageAttachment, MessageEmbed, WebhookClient } = require('../src');
 
 const client = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES] });
 
-const buffer = l => fetch(l).then(res => res.buffer());
+const buffer = l => fetch(l).then(res => res.arrayBuffer());
 const read = util.promisify(fs.readFile);
 const readStream = fs.createReadStream;
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -49,6 +49,7 @@ import {
   RESTPostAPIApplicationCommandsJSONBody,
   Snowflake,
 } from 'discord-api-types/v9';
+import { Blob } from 'node:buffer';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { AgentOptions } from 'node:https';
@@ -826,7 +827,7 @@ export class DataResolver extends null {
   private constructor();
   public static resolveBase64(data: Base64Resolvable): string;
   public static resolveCode(data: string, regx: RegExp): string;
-  public static resolveFile(resource: BufferResolvable | Stream): Promise<Buffer | Stream>;
+  public static resolveFile(resource: BufferResolvable | Stream): Promise<Blob>;
   public static resolveFileAsBuffer(resource: BufferResolvable | Stream): Promise<Buffer>;
   public static resolveImage(resource: BufferResolvable | Base64Resolvable): Promise<string | null>;
   public static resolveInviteCode(data: InviteResolvable): string;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -53,8 +53,8 @@ import { Blob } from 'node:buffer';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { AgentOptions } from 'node:https';
-import { Response } from 'node-fetch';
 import { Stream } from 'node:stream';
+import { Response } from 'undici';
 import { MessagePort, Worker } from 'node:worker_threads';
 import * as WebSocket from 'ws';
 import {
@@ -1571,9 +1571,9 @@ export class MessageActionRow extends BaseMessageComponent {
 }
 
 export class MessageAttachment {
-  public constructor(attachment: BufferResolvable | Stream, name?: string, data?: RawMessageAttachmentData);
+  public constructor(attachment: BufferResolvable | Stream | Blob, name?: string, data?: RawMessageAttachmentData);
 
-  public attachment: BufferResolvable | Stream;
+  public attachment: BufferResolvable | Stream | Blob;
   public contentType: string | null;
   public description: string | null;
   public ephemeral: boolean;
@@ -1586,7 +1586,7 @@ export class MessageAttachment {
   public url: string;
   public width: number | null;
   public setDescription(description: string): this;
-  public setFile(attachment: BufferResolvable | Stream, name?: string): this;
+  public setFile(attachment: BufferResolvable | Stream | Blob, name?: string): this;
   public setName(name: string): this;
   public setSpoiler(spoiler?: boolean): this;
   public toJSON(): unknown;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -54,7 +54,7 @@ import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { AgentOptions } from 'node:https';
 import { Stream } from 'node:stream';
-import { Response } from 'undici';
+import { File, Response } from 'undici';
 import { MessagePort, Worker } from 'node:worker_threads';
 import * as WebSocket from 'ws';
 import {
@@ -825,11 +825,11 @@ export class ContextMenuInteraction<Cached extends CacheType = CacheType> extend
 
 export class DataResolver extends null {
   private constructor();
-  public static resolveBase64(data: Base64Resolvable): Promise<string>;
+  public static resolveBase64(data: Base64Resolvable | Blob | File): Promise<string>;
   public static resolveCode(data: string, regx: RegExp): string;
-  public static resolveFile(resource: BufferResolvable | Stream | Blob): Promise<Blob>;
+  public static resolveFile(resource: BufferResolvable | Stream | Blob | File): Promise<Blob>;
   public static resolveFileAsBuffer(resource: BufferResolvable | Stream): Promise<Buffer>;
-  public static resolveImage(resource: BufferResolvable | Base64Resolvable | Blob): Promise<string | null>;
+  public static resolveImage(resource: BufferResolvable | Base64Resolvable | Blob | File): Promise<string | null>;
   public static resolveInviteCode(data: InviteResolvable): string;
   public static resolveGuildTemplateCode(data: GuildTemplateResolvable): string;
 }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -825,11 +825,11 @@ export class ContextMenuInteraction<Cached extends CacheType = CacheType> extend
 
 export class DataResolver extends null {
   private constructor();
-  public static resolveBase64(data: Base64Resolvable): string;
+  public static resolveBase64(data: Base64Resolvable): Promise<string>;
   public static resolveCode(data: string, regx: RegExp): string;
-  public static resolveFile(resource: BufferResolvable | Stream): Promise<Blob>;
+  public static resolveFile(resource: BufferResolvable | Stream | Blob): Promise<Blob>;
   public static resolveFileAsBuffer(resource: BufferResolvable | Stream): Promise<Buffer>;
-  public static resolveImage(resource: BufferResolvable | Base64Resolvable): Promise<string | null>;
+  public static resolveImage(resource: BufferResolvable | Base64Resolvable | Blob): Promise<string | null>;
   public static resolveInviteCode(data: InviteResolvable): string;
   public static resolveGuildTemplateCode(data: GuildTemplateResolvable): string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,7 +1623,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node-fetch@^2.5.10", "@types/node-fetch@^2.5.12":
+"@types/node-fetch@^2.5.10":
   version "2.5.12"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz#8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66"
   integrity sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==
@@ -5899,7 +5899,7 @@ node-fetch@2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
-node-fetch@^2.6.1, node-fetch@^2.6.5:
+node-fetch@^2.6.5:
   version "2.6.6"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.6.tgz#1751a7c01834e8e1697758732e9efb6eeadfaf89"
   integrity sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==
@@ -7794,6 +7794,11 @@ underscore@~1.13.1:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.2.tgz#276cea1e8b9722a8dbed0100a407dda572125881"
   integrity sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
+
+undici@^4.12.1:
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-4.12.1.tgz#3a7b5fb12f835a96a65397dd94578464b08d1c27"
+  integrity sha512-MSfap7YiQJqTPP12C11PFRs9raZuVicDbwsZHTjB0a8+SsCqt7KdUis54f373yf7ZFhJzAkGJLaKm0202OIxHg==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removed the dependencies of `node-fetch` and `@discordjs/formdata` in favor of `undici`.

Undici contains spec-compliant `fetch` and `FormData` implementations, is maintained by
NodeJS contributors, and is just basically all around better. [Repo](https://github.com/nodejs/undici)

Complete list of changes:
- Removed `@discordjs/form-data` package and its 4 dependencies.
- Removed `node-fetch` (still installed as a dev package)
- [MessageAttachment](https://discord.js.org/#/docs/main/stable/class/MessageAttachment) and [MessageAttachment.setFile](https://discord.js.org/#/docs/main/stable/class/MessageAttachment?scrollTo=setFile) now accept a `Blob` parameter. 
- Likewise, [DataResolver.resolveFile](https://discord.js.org/#/docs/main/stable/class/DataResolver?scrollTo=s-resolveFile) also accepts a Blob. It also returns a `Blob` now, whereas it used to return a `Buffer` or `ReadableStream`.
- [DataResolver.resolveBase64](https://discord.js.org/#/docs/main/stable/class/DataResolver?scrollTo=s-resolveBase64) now returns `Promise<string>`.
- [DataResolver.resolveFileAsBuffer](https://discord.js.org/#/docs/main/stable/class/DataResolver?scrollTo=s-resolveFileAsBuffer) is no longer used anywhere in the code, so like previously unused utility functions, will likely get removed in v14 (if this pr lands).
- The library now requires Node >=16.7.0 (bumped from Node >=16.6.0)

edit: I've been personally using this on my bot (roughly 21,000 members) that has made thousands of http requests and there has been no issue. This PR is likely ready for production use if anyone reading this wants to try it out. ;)

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- Code changes have been tested against the Discord API, or there are no code changes
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
