### PR TITLE
chore: remove jsdoc.json

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,3 +1,0 @@
-{
-  "plugins": ["node_modules/jsdoc-strip-async-await"]
-}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes jsdoc.json, this file existed for @discordjs/docgen but it's not used anymore, the plugin has also been uninstalled so this file has become useless.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
