### PR TITLE
fix(threadMembersUpdate): fixed typo

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3298,7 +3298,7 @@ export interface ClientEvents {
   threadMemberUpdate: [oldMember: ThreadMember, newMember: ThreadMember];
   threadMembersUpdate: [
     oldMembers: Collection<Snowflake, ThreadMember>,
-    mewMembers: Collection<Snowflake, ThreadMember>,
+    newMembers: Collection<Snowflake, ThreadMember>,
   ];
   threadUpdate: [oldThread: ThreadChannel, newThread: ThreadChannel];
   typingStart: [typing: Typing];


### PR DESCRIPTION
Changed 'mewMembers' to 'newMembers'

**Please describe the changes this PR makes and why it should be merged:**

It fixed a typo and changed 'mewMembers' to 'newMembers'

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
