### PR TITLE
docs(MessageButton): fix info tag

### DIFF
--- a/src/structures/MessageButton.js
+++ b/src/structures/MessageButton.js
@@ -119,7 +119,7 @@ class MessageButton extends BaseMessageComponent {
 
   /**
    * Sets the URL of this button.
-   * <note>MessageButton#style must be LINK when setting a URL</note>
+   * <info>MessageButton#style must be LINK when setting a URL</info>
    * @param {string} url The URL of this button
    * @returns {MessageButton}
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
note tags don't exist on the website so this PR fixes the one in MessageButton#setURL to be an info tag instead

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
