### PR TITLE
typings: `Message#createMessageComponentCollector` use `MessageComponentInteractionOptions<T>`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1160,7 +1160,7 @@ type InteractionExtractor<T extends MessageComponentType | MessageComponentTypes
 type MessageCollectorOptionsParams<T extends MessageComponentType | MessageComponentTypes | undefined> =
   | {
       componentType?: T;
-    } & InteractionCollectorOptions<InteractionExtractor<T>>;
+    } & MessageComponentCollectorOptions<InteractionExtractor<T>>;
 
 type AwaitMessageCollectorOptionsParams<T extends MessageComponentType | MessageComponentTypes | undefined> =
   | { componentType?: T } & Pick<
@@ -4024,15 +4024,16 @@ export interface InteractionCollectorOptions<T extends Interaction> extends Coll
   message?: Message | APIMessage;
 }
 
-export interface ButtonInteractionCollectorOptions extends InteractionCollectorOptions<ButtonInteraction> {
+export interface ButtonInteractionCollectorOptions extends MessageComponentCollectorOptions<ButtonInteraction> {
   componentType: 'BUTTON' | MessageComponentTypes.BUTTON;
 }
 
-export interface SelectMenuInteractionCollectorOptions extends InteractionCollectorOptions<SelectMenuInteraction> {
+export interface SelectMenuInteractionCollectorOptions extends MessageComponentCollectorOptions<SelectMenuInteraction> {
   componentType: 'SELECT_MENU' | MessageComponentTypes.SELECT_MENU;
 }
 
-export interface MessageInteractionCollectorOptions extends InteractionCollectorOptions<MessageComponentInteraction> {
+export interface MessageInteractionCollectorOptions
+  extends MessageComponentCollectorOptions<MessageComponentInteraction> {
   componentType: 'ACTION_ROW' | MessageComponentTypes.ACTION_ROW;
 }
 

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -508,8 +508,13 @@ client.on('messageCreate', message => {
   assertType<InteractionCollector<MessageComponentInteraction>>(defaultCollector);
 
   // Verify that additional options don't affect default collector types.
-  const semiDefaultCollector = message.createMessageComponentCollector({ interactionType: 'APPLICATION_COMMAND' });
+  const semiDefaultCollector = message.createMessageComponentCollector({ time: 10000 });
   assertType<InteractionCollector<MessageComponentInteraction>>(semiDefaultCollector);
+
+  // Verify that interaction collector options can't be used.
+
+  // @ts-expect-error
+  const interactionOptions = message.createMessageComponentCollector({ interactionType: 'APPLICATION_COMMAND' });
 
   // Make sure filter parameters are properly inferred.
   message.createMessageComponentCollector({


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Simply uses `MessageComponentCollectorOptions<T>` instead of `InteractionCollectorOptions<T>` for `Message#createMessageComponentCollector`, since the latter type has options
that don't apply to message component collectors.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

