### PR TITLE
typings: make `channelId` non-nullable on `MessageComponentInteraction`

### DIFF
--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -39,7 +39,8 @@ class Interaction extends Base {
     this.applicationId = data.application_id;
 
     /**
-     * The id of the channel this interaction was sent in
+     * The id of the channel this interaction was sent in,
+     * non-null if {@link MessageComponentInteraction}
      * @type {?Snowflake}
      */
     this.channelId = data.channel_id ?? null;

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -39,8 +39,7 @@ class Interaction extends Base {
     this.applicationId = data.application_id;
 
     /**
-     * The id of the channel this interaction was sent in,
-     * non-null if {@link MessageComponentInteraction}
+     * The id of the channel this interaction was sent in
      * @type {?Snowflake}
      */
     this.channelId = data.channel_id ?? null;

--- a/src/structures/MessageComponentInteraction.js
+++ b/src/structures/MessageComponentInteraction.js
@@ -15,6 +15,12 @@ class MessageComponentInteraction extends Interaction {
     super(client, data);
 
     /**
+     * The id of the channel this interaction was sent in
+     * @type {Snowflake}
+     * @name MessageComponentInteraction#channelId
+     */
+
+    /**
      * The message to which the component was attached
      * @type {Message|APIMessage}
      */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1318,7 +1318,6 @@ export class MessageComponentInteraction extends Interaction {
   public readonly component: MessageActionRowComponent | Exclude<APIMessageComponent, APIActionRowComponent> | null;
   public componentType: Exclude<MessageComponentType, 'ACTION_ROW'>;
   public customId: string;
-  public guildId: Snowflake;
   public channelId: Snowflake;
   public deferred: boolean;
   public ephemeral: boolean | null;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1320,7 +1320,6 @@ export class MessageComponentInteraction extends Interaction {
   public customId: string;
   public guildId: Snowflake;
   public channelId: Snowflake;
-  public member: GuildMember | APIInteractionGuildMember;
   public deferred: boolean;
   public ephemeral: boolean | null;
   public message: Message | APIMessage;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1318,6 +1318,9 @@ export class MessageComponentInteraction extends Interaction {
   public readonly component: MessageActionRowComponent | Exclude<APIMessageComponent, APIActionRowComponent> | null;
   public componentType: Exclude<MessageComponentType, 'ACTION_ROW'>;
   public customId: string;
+  public guildId: Snowflake;
+  public channelId: Snowflake;
+  public member: GuildMember | APIInteractionGuildMember;
   public deferred: boolean;
   public ephemeral: boolean | null;
   public message: Message | APIMessage;

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -587,7 +587,6 @@ client.on('interaction', async interaction => {
   if (interaction.isMessageComponent()) {
     assertType<Snowflake>(interaction.channelId);
     assertType<Snowflake>(interaction.guildId);
-    assertType<GuildMember | APIInteractionGuildMember>(interaction.member);
   }
 });
 

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -1,3 +1,4 @@
+import { APIInteractionGuildMember } from 'discord-api-types';
 import {
   ApplicationCommand,
   ApplicationCommandChoicesData,
@@ -560,6 +561,10 @@ client.on('messageCreate', message => {
 });
 
 client.on('interaction', async interaction => {
+  assertType<Snowflake | null>(interaction.guildId);
+  assertType<Snowflake | null>(interaction.channelId);
+  assertType<GuildMember | APIInteractionGuildMember | null>(interaction.member);
+
   if (!interaction.isCommand()) return;
 
   void new MessageActionRow();
@@ -578,6 +583,12 @@ client.on('interaction', async interaction => {
 
   // @ts-expect-error
   await interaction.reply({ content: 'Hi!', components: [button] });
+
+  if (interaction.isMessageComponent()) {
+    assertType<Snowflake>(interaction.channelId);
+    assertType<Snowflake>(interaction.guildId);
+    assertType<GuildMember | APIInteractionGuildMember>(interaction.member);
+  }
 });
 
 client.login('absolutely-valid-token');

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -586,7 +586,6 @@ client.on('interaction', async interaction => {
 
   if (interaction.isMessageComponent()) {
     assertType<Snowflake>(interaction.channelId);
-    assertType<Snowflake>(interaction.guildId);
   }
 });
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes #6591, references: https://discord.com/developers/docs/interactions/receiving-and-responding#interactions

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
