### PR TITLE
feat(ApplicationCommand): add version property

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -77,6 +77,12 @@ class ApplicationCommand extends Base {
      * @type {boolean}
      */
     this.defaultPermission = data.default_permission;
+
+    /**
+     * Autoincrementing version identifier updated during substantial record changes
+     * @type {Snowflake}
+     */
+    this.version = data.version;
   }
 
   /**

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -185,7 +185,7 @@ class ApplicationCommand extends Base {
       // TODO: remove ?? 0 on each when nullable
       (command.options?.length ?? 0) !== (this.options?.length ?? 0) ||
       (command.defaultPermission ?? command.default_permission ?? true) !== this.defaultPermission ||
-      command.version !== this.version
+      ('version' in command && command.version !== this.version)
     ) {
       return false;
     }

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -180,12 +180,12 @@ class ApplicationCommand extends Base {
     if (
       command.name !== this.name ||
       ('description' in command && command.description !== this.description) ||
+      ('version' in command && command.version !== this.version) ||
       (commandType && commandType !== this.type) ||
       // Future proof for options being nullable
       // TODO: remove ?? 0 on each when nullable
       (command.options?.length ?? 0) !== (this.options?.length ?? 0) ||
-      (command.defaultPermission ?? command.default_permission ?? true) !== this.defaultPermission ||
-      ('version' in command && command.version !== this.version)
+      (command.defaultPermission ?? command.default_permission ?? true) !== this.defaultPermission
     ) {
       return false;
     }

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -184,7 +184,8 @@ class ApplicationCommand extends Base {
       // Future proof for options being nullable
       // TODO: remove ?? 0 on each when nullable
       (command.options?.length ?? 0) !== (this.options?.length ?? 0) ||
-      (command.defaultPermission ?? command.default_permission ?? true) !== this.defaultPermission
+      (command.defaultPermission ?? command.default_permission ?? true) !== this.defaultPermission ||
+      command.version !== this.version
     ) {
       return false;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -218,6 +218,7 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
     Snowflake
   >;
   public type: ApplicationCommandType;
+  public version: Snowflake;
   public delete(): Promise<ApplicationCommand<PermissionsFetchType>>;
   public edit(data: ApplicationCommandData): Promise<ApplicationCommand<PermissionsFetchType>>;
   public equals(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds the new `version` field of `ApplicationCommand`:
- discord/discord-api-docs#3524


**Status and versioning classification:**
- I know how to update typings and have done so
- This PR changes the library's interface
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
