### PR TITLE
docs(MessagePayload): Correct return type of `resolveFile()`

### DIFF
--- a/src/structures/MessagePayload.js
+++ b/src/structures/MessagePayload.js
@@ -209,7 +209,7 @@ class MessagePayload {
   /**
    * Resolves a single file into an object sendable to the API.
    * @param {BufferResolvable|Stream|FileOptions|MessageAttachment} fileLike Something that could be resolved to a file
-   * @returns {MessageFile}
+   * @returns {Promise<MessageFile>}
    */
   static async resolveFile(fileLike) {
     let attachment;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #6604 by correcting the `@returns` documentation.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
