### PR TITLE
feat: Give removed `MessageReaction`s on `messageReactionRemoveAll` event

### DIFF
--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -13,7 +13,7 @@ class MessageReactionRemoveAll extends Action {
     const message = this.getMessage(data, channel);
     if (!message) return false;
 
-    // Clone removed reactions.
+    // Copy removed reactions, for event.
     const removed = message.reactions.cache.clone();
 
     message.reactions.cache.clear();

--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -13,8 +13,11 @@ class MessageReactionRemoveAll extends Action {
     const message = this.getMessage(data, channel);
     if (!message) return false;
 
+    // Clone removed reactions.
+    const removed = message.reactions.cache.clone();
+
     message.reactions.cache.clear();
-    this.client.emit(Events.MESSAGE_REACTION_REMOVE_ALL, message);
+    this.client.emit(Events.MESSAGE_REACTION_REMOVE_ALL, message, removed);
 
     return { message };
   }

--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -27,7 +27,7 @@ class MessageReactionRemoveAll extends Action {
  * Emitted whenever all reactions are removed from a cached message.
  * @event Client#messageReactionRemoveAll
  * @param {Message} message The message the reactions were removed from
- * @param {Collection} removed The message reactions that were removed.
+ * @param {Collection} reactions The message reactions that were removed.
  */
 
 module.exports = MessageReactionRemoveAll;

--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -27,6 +27,7 @@ class MessageReactionRemoveAll extends Action {
  * Emitted whenever all reactions are removed from a cached message.
  * @event Client#messageReactionRemoveAll
  * @param {Message} message The message the reactions were removed from
+ * @param {Collection} removed The message reactions that were removed.
  */
 
 module.exports = MessageReactionRemoveAll;

--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -27,7 +27,7 @@ class MessageReactionRemoveAll extends Action {
  * Emitted whenever all reactions are removed from a cached message.
  * @event Client#messageReactionRemoveAll
  * @param {Message} message The message the reactions were removed from
- * @param {Collection<string | Snowflake, MessageReaction>} reactions The cached message reactions that were removed.
+ * @param {Collection<string|Snowflake, MessageReaction>} reactions The cached message reactions that were removed.
  */
 
 module.exports = MessageReactionRemoveAll;

--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -27,7 +27,7 @@ class MessageReactionRemoveAll extends Action {
  * Emitted whenever all reactions are removed from a cached message.
  * @event Client#messageReactionRemoveAll
  * @param {Message} message The message the reactions were removed from
- * @param {Collection<Snowflake, MessageReaction>} reactions The cached message reactions that were removed.
+ * @param {Collection<string | Snowflake, MessageReaction>} reactions The cached message reactions that were removed.
  */
 
 module.exports = MessageReactionRemoveAll;

--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -13,7 +13,7 @@ class MessageReactionRemoveAll extends Action {
     const message = this.getMessage(data, channel);
     if (!message) return false;
 
-    // Copy removed reactions, for event.
+    // Copy removed reactions to emit for the event.
     const removed = message.reactions.cache.clone();
 
     message.reactions.cache.clear();

--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -27,7 +27,7 @@ class MessageReactionRemoveAll extends Action {
  * Emitted whenever all reactions are removed from a cached message.
  * @event Client#messageReactionRemoveAll
  * @param {Message} message The message the reactions were removed from
- * @param {Collection} reactions The message reactions that were removed.
+ * @param {Collection} reactions The cached message reactions that were removed.
  */
 
 module.exports = MessageReactionRemoveAll;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3278,7 +3278,7 @@ export interface ClientEvents {
   message: [message: Message];
   messageCreate: [message: Message];
   messageDelete: [message: Message | PartialMessage];
-  messageReactionRemoveAll: [message: Message | PartialMessage, removed: Collection<Snowflake, MessageReaction>];
+  messageReactionRemoveAll: [message: Message | PartialMessage, reactions: Collection<Snowflake, MessageReaction>];
   messageReactionRemoveEmoji: [reaction: MessageReaction | PartialMessageReaction];
   messageDeleteBulk: [messages: Collection<Snowflake, Message | PartialMessage>];
   messageReactionAdd: [reaction: MessageReaction | PartialMessageReaction, user: User | PartialUser];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3278,7 +3278,7 @@ export interface ClientEvents {
   message: [message: Message];
   messageCreate: [message: Message];
   messageDelete: [message: Message | PartialMessage];
-  messageReactionRemoveAll: [message: Message | PartialMessage, reactions: Collection<Snowflake, MessageReaction>];
+  messageReactionRemoveAll: [message: Message | PartialMessage, reactions: Collection<string | Snowflake, MessageReaction>];
   messageReactionRemoveEmoji: [reaction: MessageReaction | PartialMessageReaction];
   messageDeleteBulk: [messages: Collection<Snowflake, Message | PartialMessage>];
   messageReactionAdd: [reaction: MessageReaction | PartialMessageReaction, user: User | PartialUser];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3278,7 +3278,7 @@ export interface ClientEvents {
   message: [message: Message];
   messageCreate: [message: Message];
   messageDelete: [message: Message | PartialMessage];
-  messageReactionRemoveAll: [message: Message | PartialMessage];
+  messageReactionRemoveAll: [message: Message | PartialMessage, removed: Collection<Snowflake, MessageReaction>];
   messageReactionRemoveEmoji: [reaction: MessageReaction | PartialMessageReaction];
   messageDeleteBulk: [messages: Collection<Snowflake, Message | PartialMessage>];
   messageReactionAdd: [reaction: MessageReaction | PartialMessageReaction, user: User | PartialUser];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Closes #6599

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
