### PR TITLE
docs(VoiceChannel): deprecate editable

### DIFF
--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -21,6 +21,7 @@ class VoiceChannel extends BaseGuildVoiceChannel {
    * Whether the channel is editable by the client user
    * @type {boolean}
    * @readonly
+   * @deprecated Use {@link VoiceChannel#manageable} instead
    */
   get editable() {
     return this.manageable && this.permissionsFor(this.client.user).has(Permissions.FLAGS.CONNECT, false);

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2006,6 +2006,7 @@ export class Formatters extends null {
 }
 
 export class VoiceChannel extends BaseGuildVoiceChannel {
+  /** @deprecated Use manageable instead */
   public readonly editable: boolean;
   public readonly speakable: boolean;
   public type: 'GUILD_VOICE';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
To avoid confusion for library users, it is deprecated as a preliminary step to remove two getters that behave the same. 

related: https://github.com/discordjs/discord.js/pull/6551#discussion_r704167474

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
