### PR TITLE
feat(CategoryChannel): add createChannel shortcut method

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -93,18 +93,8 @@ class GuildChannelManager extends CachedManager {
 
   /**
    * Options used to create a new channel in a guild.
-   * @typedef {Object} GuildChannelCreateOptions
-   * @property {ChannelType|number} [type='GUILD_TEXT'] The type of the new channel.
-   * @property {string} [topic] The topic for the new channel
-   * @property {boolean} [nsfw] Whether the new channel is nsfw
-   * @property {number} [bitrate] Bitrate of the new channel in bits (only voice)
-   * @property {number} [userLimit] Maximum amount of users allowed in the new channel (only voice)
+   * @typedef {CategoryCreateChannelOptions} GuildChannelCreateOptions
    * @property {CategoryChannelResolvable} [parent] Parent of the new channel
-   * @property {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [permissionOverwrites]
-   * Permission overwrites of the new channel
-   * @property {number} [position] Position of the new channel
-   * @property {number} [rateLimitPerUser] The ratelimit per user for the new channel
-   * @property {string} [reason] Reason for creating the new channel
    */
 
   /**

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -26,6 +26,35 @@ class CategoryChannel extends GuildChannel {
    * @param {SetParentOptions} [options={}] The options for setting the parent
    * @returns {Promise<GuildChannel>}
    */
+
+  /**
+   * Options for creating a channel using {@link CategoryChannel#createChannel}.
+   * @typedef {Object} CategoryCreateChannelOptions
+   * @property {ChannelType|number} [type='GUILD_TEXT'] The type of the new channel.
+   * @property {string} [topic] The topic for the new channel
+   * @property {boolean} [nsfw] Whether the new channel is nsfw
+   * @property {number} [bitrate] Bitrate of the new channel in bits (only voice)
+   * @property {number} [userLimit] Maximum amount of users allowed in the new channel (only voice)
+   * @property {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [permissionOverwrites]
+   * Permission overwrites of the new channel
+   * @property {number} [position] Position of the new channel
+   * @property {number} [rateLimitPerUser] The ratelimit per user for the new channel
+   * @property {string} [reason] Reason for creating the new channel
+   */
+
+  /**
+   * Creates a new channel on this category.
+   * <info>You cannot create a channel of type `GUILD_CATEGORY` inside a CategoryChannel.</info>
+   * @param {string} name The name of the new channel
+   * @param {CategoryCreateChannelOptions} options Options for creating the new channel
+   * @returns {Promise<GuildChannel>}
+   */
+  createChannel(name, options = {}) {
+    return this.guild.channels.create(name, {
+      parent: this.id,
+      ...options,
+    });
+  }
 }
 
 module.exports = CategoryChannel;

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -49,7 +49,7 @@ class CategoryChannel extends GuildChannel {
    * @param {CategoryCreateChannelOptions} options Options for creating the new channel
    * @returns {Promise<GuildChannel>}
    */
-  createChannel(name, options = {}) {
+  createChannel(name, options) {
     return this.guild.channels.create(name, {
       ...options,
       parent: this.id,

--- a/src/structures/CategoryChannel.js
+++ b/src/structures/CategoryChannel.js
@@ -51,8 +51,8 @@ class CategoryChannel extends GuildChannel {
    */
   createChannel(name, options = {}) {
     return this.guild.channels.create(name, {
-      parent: this.id,
       ...options,
+      parent: this.id,
     });
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -387,6 +387,30 @@ export class ButtonInteraction extends MessageComponentInteraction {
 export class CategoryChannel extends GuildChannel {
   public readonly children: Collection<Snowflake, GuildChannel>;
   public type: 'GUILD_CATEGORY';
+  public createChannel(
+    name: string,
+    options: CategoryCreateChannelOptions & { type: 'GUILD_VOICE' },
+  ): Promise<VoiceChannel>;
+  public createChannel(
+    name: string,
+    options?: CategoryCreateChannelOptions & { type?: 'GUILD_TEXT' },
+  ): Promise<TextChannel>;
+  public createChannel(
+    name: string,
+    options: CategoryCreateChannelOptions & { type: 'GUILD_NEWS' },
+  ): Promise<NewsChannel>;
+  public createChannel(
+    name: string,
+    options: CategoryCreateChannelOptions & { type: 'GUILD_STORE' },
+  ): Promise<StoreChannel>;
+  public createChannel(
+    name: string,
+    options: CategoryCreateChannelOptions & { type: 'GUILD_STAGE_VOICE' },
+  ): Promise<StageChannel>;
+  public createChannel(
+    name: string,
+    options: CategoryCreateChannelOptions,
+  ): Promise<TextChannel | VoiceChannel | NewsChannel | StoreChannel | StageChannel>;
 }
 
 export type CategoryChannelResolvable = Snowflake | CategoryChannel;
@@ -3199,6 +3223,34 @@ export type CacheWithLimitsOptions = {
     : never;
 };
 
+export interface CategoryCreateChannelOptions {
+  permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
+  topic?: string;
+  type?: Exclude<
+    keyof typeof ChannelTypes | ChannelTypes,
+    | 'DM'
+    | 'GROUP_DM'
+    | 'UNKNOWN'
+    | 'GUILD_PUBLIC_THREAD'
+    | 'GUILD_NEWS_THREAD'
+    | 'GUILD_PRIVATE_THREAD'
+    | 'GUILD_CATEGORY'
+    | ChannelTypes.DM
+    | ChannelTypes.GROUP_DM
+    | ChannelTypes.UNKNOWN
+    | ChannelTypes.GUILD_PUBLIC_THREAD
+    | ChannelTypes.GUILD_NEWS_THREAD
+    | ChannelTypes.GUILD_PRIVATE_THREAD
+    | ChannelTypes.GUILD_CATEGORY
+  >;
+  nsfw?: boolean;
+  bitrate?: number;
+  userLimit?: number;
+  rateLimitPerUser?: number;
+  position?: number;
+  reason?: string;
+}
+
 export interface ChannelCreationOverwrites {
   allow?: PermissionResolvable;
   deny?: PermissionResolvable;
@@ -3824,29 +3876,23 @@ export interface GuildChannelOverwriteOptions {
 
 export type GuildChannelResolvable = Snowflake | GuildChannel | ThreadChannel;
 
-export interface GuildChannelCreateOptions {
-  permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
-  topic?: string;
+export interface GuildChannelCreateOptions extends Omit<CategoryCreateChannelOptions, 'type'> {
+  parent?: CategoryChannelResolvable;
   type?: Exclude<
     keyof typeof ChannelTypes | ChannelTypes,
     | 'DM'
     | 'GROUP_DM'
     | 'UNKNOWN'
     | 'GUILD_PUBLIC_THREAD'
+    | 'GUILD_NEWS_THREAD'
     | 'GUILD_PRIVATE_THREAD'
     | ChannelTypes.DM
     | ChannelTypes.GROUP_DM
     | ChannelTypes.UNKNOWN
     | ChannelTypes.GUILD_PUBLIC_THREAD
+    | ChannelTypes.GUILD_NEWS_THREAD
     | ChannelTypes.GUILD_PRIVATE_THREAD
   >;
-  nsfw?: boolean;
-  parent?: CategoryChannelResolvable;
-  bitrate?: number;
-  userLimit?: number;
-  rateLimitPerUser?: number;
-  position?: number;
-  reason?: string;
 }
 
 export interface GuildChannelCloneOptions extends GuildChannelCreateOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a method to CategoryChannel called createChannel that creates a channel inside that category. It also fixes a bug in the options interface to disallow GUILD_NEWS_THREAD types on both the GuildChannelCreateOptions and the CategoryCreateChannelOptions interfaces

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
