### PR TITLE
feat: default values for setX boolean methods

### DIFF
--- a/src/structures/BaseGuildTextChannel.js
+++ b/src/structures/BaseGuildTextChannel.js
@@ -99,11 +99,11 @@ class BaseGuildTextChannel extends GuildChannel {
 
   /**
    * Sets whether this channel is flagged as NSFW.
-   * @param {boolean} nsfw Whether the channel should be considered NSFW
+   * @param {boolean} [nsfw=true] Whether the channel should be considered NSFW
    * @param {string} [reason] Reason for changing the channel's NSFW flag
    * @returns {Promise<TextChannel>}
    */
-  setNSFW(nsfw, reason) {
+  setNSFW(nsfw = true, reason) {
     return this.edit({ nsfw }, reason);
   }
 

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -168,11 +168,11 @@ class ClientUser extends User {
 
   /**
    * Sets/removes the AFK flag for the client user.
-   * @param {boolean} afk Whether or not the user is AFK
+   * @param {boolean} [afk=true] Whether or not the user is AFK
    * @param {number|number[]} [shardId] Shard Id(s) to have the AFK flag set on
    * @returns {ClientPresence}
    */
-  setAFK(afk, shardId) {
+  setAFK(afk = true, shardId) {
     return this.setPresence({ afk, shardId });
   }
 }

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -244,7 +244,7 @@ class Role extends Base {
 
   /**
    * Sets whether or not the role should be hoisted.
-   * @param {boolean} hoist Whether or not to hoist the role
+   * @param {boolean} [hoist=true] Whether or not to hoist the role
    * @param {string} [reason] Reason for setting whether or not the role should be hoisted
    * @returns {Promise<Role>}
    * @example
@@ -253,7 +253,7 @@ class Role extends Base {
    *   .then(updated => console.log(`Role hoisted: ${updated.hoist}`))
    *   .catch(console.error);
    */
-  setHoist(hoist, reason) {
+  setHoist(hoist = true, reason) {
     return this.edit({ hoist }, reason);
   }
 
@@ -279,7 +279,7 @@ class Role extends Base {
 
   /**
    * Sets whether this role is mentionable.
-   * @param {boolean} mentionable Whether this role should be mentionable
+   * @param {boolean} [mentionable=true] Whether this role should be mentionable
    * @param {string} [reason] Reason for setting whether or not this role should be mentionable
    * @returns {Promise<Role>}
    * @example
@@ -288,7 +288,7 @@ class Role extends Base {
    *   .then(updated => console.log(`Role updated ${updated.name}`))
    *   .catch(console.error);
    */
-  setMentionable(mentionable, reason) {
+  setMentionable(mentionable = true, reason) {
     return this.edit({ mentionable }, reason);
   }
 

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -120,21 +120,21 @@ class VoiceState extends Base {
 
   /**
    * Mutes/unmutes the member of this voice state.
-   * @param {boolean} mute Whether or not the member should be muted
+   * @param {boolean} [mute=true] Whether or not the member should be muted
    * @param {string} [reason] Reason for muting or unmuting
    * @returns {Promise<GuildMember>}
    */
-  setMute(mute, reason) {
+  setMute(mute = true, reason) {
     return this.member?.edit({ mute }, reason) ?? Promise.reject(new Error('VOICE_STATE_UNCACHED_MEMBER'));
   }
 
   /**
    * Deafens/undeafens the member of this voice state.
-   * @param {boolean} deaf Whether or not the member should be deafened
+   * @param {boolean} [deaf=true] Whether or not the member should be deafened
    * @param {string} [reason] Reason for deafening or undeafening
    * @returns {Promise<GuildMember>}
    */
-  setDeaf(deaf, reason) {
+  setDeaf(deaf = true, reason) {
     return this.member?.edit({ deaf }, reason) ?? Promise.reject(new Error('VOICE_STATE_UNCACHED_MEMBER'));
   }
 
@@ -161,7 +161,7 @@ class VoiceState extends Base {
   /**
    * Toggles the request to speak in the channel.
    * Only applicable for stage channels and for the client's own voice state.
-   * @param {boolean} request Whether or not the client is requesting to become a speaker.
+   * @param {boolean} [request=true] Whether or not the client is requesting to become a speaker.
    * @example
    * // Making the client request to speak in a stage channel (raise its hand)
    * guild.me.voice.setRequestToSpeak(true);
@@ -170,7 +170,7 @@ class VoiceState extends Base {
    * guild.me.voice.setRequestToSpeak(false);
    * @returns {Promise<void>}
    */
-  async setRequestToSpeak(request) {
+  async setRequestToSpeak(request = true) {
     if (this.channel?.type !== 'GUILD_STAGE_VOICE') throw new Error('VOICE_NOT_STAGE_CHANNEL');
 
     if (this.client.user.id !== this.id) throw new Error('VOICE_STATE_NOT_OWN');
@@ -185,7 +185,7 @@ class VoiceState extends Base {
 
   /**
    * Suppress/unsuppress the user. Only applicable for stage channels.
-   * @param {boolean} suppressed - Whether or not the user should be suppressed.
+   * @param {boolean} [suppressed=true] Whether or not the user should be suppressed.
    * @example
    * // Making the client a speaker
    * guild.me.voice.setSuppressed(false);
@@ -200,7 +200,7 @@ class VoiceState extends Base {
    * voiceState.setSuppressed(true);
    * @returns {Promise<void>}
    */
-  async setSuppressed(suppressed) {
+  async setSuppressed(suppressed = true) {
     if (typeof suppressed !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'suppressed');
 
     if (this.channel?.type !== 'GUILD_STAGE_VOICE') throw new Error('VOICE_NOT_STAGE_CHANNEL');

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -330,7 +330,7 @@ export class BaseGuildTextChannel extends TextBasedChannel(GuildChannel) {
     defaultAutoArchiveDuration: ThreadAutoArchiveDuration,
     reason?: string,
   ): Promise<this>;
-  public setNSFW(nsfw: boolean, reason?: string): Promise<this>;
+  public setNSFW(nsfw?: boolean, reason?: string): Promise<this>;
   public setTopic(topic: string | null, reason?: string): Promise<this>;
   public setType(type: Pick<typeof ChannelTypes, 'GUILD_TEXT'>, reason?: string): Promise<TextChannel>;
   public setType(type: Pick<typeof ChannelTypes, 'GUILD_NEWS'>, reason?: string): Promise<NewsChannel>;
@@ -498,7 +498,7 @@ export class ClientUser extends User {
   public edit(data: ClientUserEditData): Promise<this>;
   public setActivity(options?: ActivityOptions): ClientPresence;
   public setActivity(name: string, options?: ActivityOptions): ClientPresence;
-  public setAFK(afk: boolean, shardId?: number | number[]): ClientPresence;
+  public setAFK(afk?: boolean, shardId?: number | number[]): ClientPresence;
   public setAvatar(avatar: BufferResolvable | Base64Resolvable): Promise<this>;
   public setPresence(data: PresenceData): ClientPresence;
   public setStatus(status: PresenceStatusData, shardId?: number | number[]): ClientPresence;
@@ -1613,8 +1613,8 @@ export class Role extends Base {
   public equals(role: Role): boolean;
   public permissionsIn(channel: GuildChannel | Snowflake): Readonly<Permissions>;
   public setColor(color: ColorResolvable, reason?: string): Promise<Role>;
-  public setHoist(hoist: boolean, reason?: string): Promise<Role>;
-  public setMentionable(mentionable: boolean, reason?: string): Promise<Role>;
+  public setHoist(hoist?: boolean, reason?: string): Promise<Role>;
+  public setMentionable(mentionable?: boolean, reason?: string): Promise<Role>;
   public setName(name: string, reason?: string): Promise<Role>;
   public setPermissions(permissions: PermissionResolvable, reason?: string): Promise<Role>;
   public setPosition(position: number, options?: SetRolePositionOptions): Promise<Role>;
@@ -2072,12 +2072,12 @@ export class VoiceState extends Base {
   public suppress: boolean;
   public requestToSpeakTimestamp: number | null;
 
-  public setDeaf(deaf: boolean, reason?: string): Promise<GuildMember>;
-  public setMute(mute: boolean, reason?: string): Promise<GuildMember>;
+  public setDeaf(deaf?: boolean, reason?: string): Promise<GuildMember>;
+  public setMute(mute?: boolean, reason?: string): Promise<GuildMember>;
   public disconnect(reason?: string): Promise<GuildMember>;
   public setChannel(channel: VoiceChannelResolvable | null, reason?: string): Promise<GuildMember>;
-  public setRequestToSpeak(request: boolean): Promise<void>;
-  public setSuppressed(suppressed: boolean): Promise<void>;
+  public setRequestToSpeak(request?: boolean): Promise<void>;
+  public setSuppressed(suppressed?: boolean): Promise<void>;
 }
 
 export class Webhook extends WebhookMixin() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a default value of true for all setX methods across the library that accept a boolean. This follows the direction the library has recently been going in with #6279 and #6509.
This affects the following methods:
- BaseGuildTextChannel#setNSFW
- ClientUser#setAFK
- Role#setHoist
- Role#setMentionable
- VoiceState#setDeaf
- VoiceState#setMute
- VoiceState#setRequestToSpeak
- VoiceState#setSuppressed

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
