### PR TITLE
feat: Add support for API command types in `ApplicationCommandManager`

### DIFF
--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -100,7 +100,7 @@ class ApplicationCommandManager extends CachedManager {
 
   /**
    * Creates an application command.
-   * @param {ApplicationCommandData|RESTPostAPIApplicationCommandsJSONBody} command The command
+   * @param {ApplicationCommandData|APIApplicationCommand} command The command
    * @param {Snowflake} [guildId] The guild's id to create this command in,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Promise<ApplicationCommand>}
@@ -115,14 +115,14 @@ class ApplicationCommandManager extends CachedManager {
    */
   async create(command, guildId) {
     const data = await this.commandPath({ guildId }).post({
-      data: ApplicationCommand.isAPICommandData(command) ? command : this.constructor.transformCommand(command),
+      data: this.constructor.transformCommand(command),
     });
     return this._add(data, !guildId, guildId);
   }
 
   /**
    * Sets all the commands for this application or guild.
-   * @param {ApplicationCommandData[]|RESTPostAPIApplicationCommandsJSONBody[]} commands The commands
+   * @param {ApplicationCommandData[]|APIApplicationCommand[]} commands The commands
    * @param {Snowflake} [guildId] The guild's id to create the commands in,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Promise<Collection<Snowflake, ApplicationCommand>>}
@@ -144,7 +144,7 @@ class ApplicationCommandManager extends CachedManager {
    */
   async set(commands, guildId) {
     const data = await this.commandPath({ guildId }).put({
-      data: commands.map(c => (ApplicationCommand.isAPICommandData(c) ? c : this.constructor.transformCommand(c))),
+      data: commands.map(c => this.constructor.transformCommand(c)),
     });
     return data.reduce(
       (coll, command) => coll.set(command.id, this._add(command, !guildId, guildId)),
@@ -155,7 +155,7 @@ class ApplicationCommandManager extends CachedManager {
   /**
    * Edits an application command.
    * @param {ApplicationCommandResolvable} command The command to edit
-   * @param {ApplicationCommandData|RESTPostAPIApplicationCommandsJSONBody} data The data to update the command with
+   * @param {ApplicationCommandData|APIApplicationCommand} data The data to update the command with
    * @param {Snowflake} [guildId] The guild's id where the command registered,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Promise<ApplicationCommand>}
@@ -172,7 +172,7 @@ class ApplicationCommandManager extends CachedManager {
     if (!id) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
 
     const patched = await this.commandPath({ id, guildId }).patch({
-      data: ApplicationCommand.isAPICommandData(data) ? data : this.constructor.transformCommand(data),
+      data: this.constructor.transformCommand(data),
     });
     return this._add(patched, !guildId, guildId);
   }
@@ -202,7 +202,7 @@ class ApplicationCommandManager extends CachedManager {
 
   /**
    * Transforms an {@link ApplicationCommandData} object into something that can be used with the API.
-   * @param {ApplicationCommandData} command The command to transform
+   * @param {ApplicationCommandData|APIApplicationCommand} command The command to transform
    * @returns {APIApplicationCommand}
    * @private
    */
@@ -212,7 +212,7 @@ class ApplicationCommandManager extends CachedManager {
       description: command.description,
       type: typeof command.type === 'number' ? command.type : ApplicationCommandTypes[command.type],
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
-      default_permission: command.defaultPermission,
+      default_permission: command.defaultPermission ?? command.default_permission,
     };
   }
 }

--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -100,7 +100,7 @@ class ApplicationCommandManager extends CachedManager {
 
   /**
    * Creates an application command.
-   * @param {ApplicationCommandData} command The command
+   * @param {ApplicationCommandData|RESTPostAPIApplicationCommandsJSONBody} command The command
    * @param {Snowflake} [guildId] The guild's id to create this command in,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Promise<ApplicationCommand>}
@@ -115,14 +115,14 @@ class ApplicationCommandManager extends CachedManager {
    */
   async create(command, guildId) {
     const data = await this.commandPath({ guildId }).post({
-      data: this.constructor.transformCommand(command),
+      data: ApplicationCommand.isAPICommandData(command) ? command : this.constructor.transformCommand(command),
     });
     return this._add(data, !guildId, guildId);
   }
 
   /**
    * Sets all the commands for this application or guild.
-   * @param {ApplicationCommandData[]} commands The commands
+   * @param {ApplicationCommandData[]|RESTPostAPIApplicationCommandsJSONBody[]} commands The commands
    * @param {Snowflake} [guildId] The guild's id to create the commands in,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Promise<Collection<Snowflake, ApplicationCommand>>}
@@ -144,7 +144,7 @@ class ApplicationCommandManager extends CachedManager {
    */
   async set(commands, guildId) {
     const data = await this.commandPath({ guildId }).put({
-      data: commands.map(c => this.constructor.transformCommand(c)),
+      data: commands.map(c => (ApplicationCommand.isAPICommandData(c) ? c : this.constructor.transformCommand(c))),
     });
     return data.reduce(
       (coll, command) => coll.set(command.id, this._add(command, !guildId, guildId)),
@@ -155,7 +155,7 @@ class ApplicationCommandManager extends CachedManager {
   /**
    * Edits an application command.
    * @param {ApplicationCommandResolvable} command The command to edit
-   * @param {ApplicationCommandData} data The data to update the command with
+   * @param {ApplicationCommandData|RESTPostAPIApplicationCommandsJSONBody} data The data to update the command with
    * @param {Snowflake} [guildId] The guild's id where the command registered,
    * ignored when using a {@link GuildApplicationCommandManager}
    * @returns {Promise<ApplicationCommand>}
@@ -171,7 +171,9 @@ class ApplicationCommandManager extends CachedManager {
     const id = this.resolveId(command);
     if (!id) throw new TypeError('INVALID_TYPE', 'command', 'ApplicationCommandResolvable');
 
-    const patched = await this.commandPath({ id, guildId }).patch({ data: this.constructor.transformCommand(data) });
+    const patched = await this.commandPath({ id, guildId }).patch({
+      data: ApplicationCommand.isAPICommandData(data) ? data : this.constructor.transformCommand(data),
+    });
     return this._add(patched, !guildId, guildId);
   }
 

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -298,31 +298,6 @@ class ApplicationCommand extends Base {
       options: option.options?.map(o => this.transformOption(o, received)),
     };
   }
-
-  /**
-   * Transforms an {@link ApplicationCommandData} object into something that can be used with the API.
-   * @param {ApplicationCommandData} command The command to transform
-   * @returns {APIApplicationCommand}]
-   * @private
-   */
-  static transformCommand(command) {
-    return {
-      name: command.name,
-      description: command.description,
-      type: typeof command.type === 'number' ? command.type : ApplicationCommandTypes[command.type],
-      options: command.options?.map(o => ApplicationCommand.transformOption(o)),
-      default_permission: command.defaultPermission,
-    };
-  }
-
-  /**
-   * Whether or not the given object is api command data or not.
-   * @param {Object} command The command object to check.
-   * @returns {boolean} True if the object is api command data, false otherwise.
-   */
-  static isAPICommandData(command) {
-    return 'default_permission' in command || 'guild_id' in command;
-  }
 }
 
 module.exports = ApplicationCommand;

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -298,6 +298,31 @@ class ApplicationCommand extends Base {
       options: option.options?.map(o => this.transformOption(o, received)),
     };
   }
+
+  /**
+   * Transforms an {@link ApplicationCommandData} object into something that can be used with the API.
+   * @param {ApplicationCommandData} command The command to transform
+   * @returns {APIApplicationCommand}]
+   * @private
+   */
+  static transformCommand(command) {
+    return {
+      name: command.name,
+      description: command.description,
+      type: typeof command.type === 'number' ? command.type : ApplicationCommandTypes[command.type],
+      options: command.options?.map(o => ApplicationCommand.transformOption(o)),
+      default_permission: command.defaultPermission,
+    };
+  }
+
+  /**
+   * Whether or not the given object is api command data or not.
+   * @param {Object} command The command object to check.
+   * @returns {boolean} True if the object is api command data, false otherwise.
+   */
+  static isAPICommandData(command) {
+    return 'default_permission' in command || 'guild_id' in command;
+  }
 }
 
 module.exports = ApplicationCommand;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -44,6 +44,7 @@ import {
   APIUser,
   GatewayVoiceServerUpdateDispatchData,
   GatewayVoiceStateUpdateDispatchData,
+  RESTPostAPIApplicationCommandsJSONBody,
   Snowflake,
 } from 'discord-api-types/v9';
 import { EventEmitter } from 'events';
@@ -235,6 +236,8 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
     enforceOptionorder?: boolean,
   ): boolean;
   private static transformOption(option: ApplicationCommandOptionData, received?: boolean): unknown;
+  private static transformCommand(command: ApplicationCommandData): RESTPostAPIApplicationCommandsJSONBody;
+  private static isAPICommandData(command: object): command is RESTPostAPIApplicationCommandsJSONBody;
 }
 
 export type ApplicationResolvable = Application | Activity | Snowflake;
@@ -2383,6 +2386,8 @@ export abstract class CachedManager<K, Holds, R> extends DataManager<K, Holds, R
   private _add(data: unknown, cache?: boolean, { id, extras }?: { id: K; extras: unknown[] }): Holds;
 }
 
+export type ApplicationCommandDataResolvable = ApplicationCommandData | RESTPostAPIApplicationCommandsJSONBody;
+
 export class ApplicationCommandManager<
   ApplicationCommandScope = ApplicationCommand<{ guild: GuildResolvable }>,
   PermissionsOptionsExtras = { guild: GuildResolvable },
@@ -2397,13 +2402,16 @@ export class ApplicationCommandManager<
     null
   >;
   private commandPath({ id, guildId }: { id?: Snowflake; guildId?: Snowflake }): unknown;
-  public create(command: ApplicationCommandData): Promise<ApplicationCommandScope>;
-  public create(command: ApplicationCommandData, guildId: Snowflake): Promise<ApplicationCommand>;
+  public create(command: ApplicationCommandDataResolvable): Promise<ApplicationCommandScope>;
+  public create(command: ApplicationCommandDataResolvable, guildId: Snowflake): Promise<ApplicationCommand>;
   public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<ApplicationCommandScope | null>;
-  public edit(command: ApplicationCommandResolvable, data: ApplicationCommandData): Promise<ApplicationCommandScope>;
   public edit(
     command: ApplicationCommandResolvable,
-    data: ApplicationCommandData,
+    data: ApplicationCommandDataResolvable,
+  ): Promise<ApplicationCommandScope>;
+  public edit(
+    command: ApplicationCommandResolvable,
+    data: ApplicationCommandDataResolvable,
     guildId: Snowflake,
   ): Promise<ApplicationCommand>;
   public fetch(
@@ -2415,9 +2423,9 @@ export class ApplicationCommandManager<
     id?: Snowflake,
     options?: FetchApplicationCommandOptions,
   ): Promise<Collection<Snowflake, ApplicationCommandScope>>;
-  public set(commands: ApplicationCommandData[]): Promise<Collection<Snowflake, ApplicationCommandScope>>;
+  public set(commands: ApplicationCommandDataResolvable[]): Promise<Collection<Snowflake, ApplicationCommandScope>>;
   public set(
-    commands: ApplicationCommandData[],
+    commands: ApplicationCommandDataResolvable[],
     guildId: Snowflake,
   ): Promise<Collection<Snowflake, ApplicationCommand>>;
   private static transformCommand(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2493,12 +2493,15 @@ export class ChannelManager extends CachedManager<Snowflake, Channel, ChannelRes
 export class GuildApplicationCommandManager extends ApplicationCommandManager<ApplicationCommand, {}, Guild> {
   public constructor(guild: Guild, iterable?: Iterable<RawApplicationCommandData>);
   public guild: Guild;
-  public create(command: ApplicationCommandData): Promise<ApplicationCommand>;
+  public create(command: ApplicationCommandDataResolvable): Promise<ApplicationCommand>;
   public delete(command: ApplicationCommandResolvable): Promise<ApplicationCommand | null>;
-  public edit(command: ApplicationCommandResolvable, data: ApplicationCommandData): Promise<ApplicationCommand>;
+  public edit(
+    command: ApplicationCommandResolvable,
+    data: ApplicationCommandDataResolvable,
+  ): Promise<ApplicationCommand>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<ApplicationCommand>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, ApplicationCommand>>;
-  public set(commands: ApplicationCommandData[]): Promise<Collection<Snowflake, ApplicationCommand>>;
+  public set(commands: ApplicationCommandDataResolvable[]): Promise<Collection<Snowflake, ApplicationCommand>>;
 }
 
 export class GuildChannelManager extends CachedManager<


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allows api types to be accepted in `ApplicationCommandManager` methods. This means typescript will no longer complain about type mismatches when using something like builders for example.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
