### PR TITLE
types(MessageEmbed): allow APIEmbed type

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -30,9 +30,9 @@ class MessageEmbed {
    * @property {Partial<MessageEmbedFooter>} [footer] The footer of this embed
    */
 
+  // eslint-disable-next-line valid-jsdoc
   /**
    * @param {MessageEmbed|MessageEmbedOptions|APIEmbed} [data={}] MessageEmbed to clone or raw embed data
-   * @param {boolean} [skipValidation=false] Whether to skip validation of embed fields
    */
   constructor(data = {}, skipValidation = false) {
     this.setup(data, skipValidation);

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -8,13 +8,6 @@ const Util = require('../util/Util');
  */
 class MessageEmbed {
   /**
-   * @name MessageEmbed
-   * @kind constructor
-   * @memberof MessageEmbed
-   * @param {MessageEmbed|MessageEmbedOptions} [data={}] MessageEmbed to clone or raw embed data
-   */
-
-  /**
    * A `Partial` object is a representation of any existing object.
    * This object contains between 0 and all of the original objects parameters.
    * This is true regardless of whether the parameters are optional in the base object.
@@ -37,6 +30,10 @@ class MessageEmbed {
    * @property {Partial<MessageEmbedFooter>} [footer] The footer of this embed
    */
 
+  /**
+   * @param {MessageEmbed|MessageEmbedOptions|APIEmbed} [data={}] MessageEmbed to clone or raw embed data
+   * @param {boolean} [skipValidation=false] Whether to skip validation of embed fields
+   */
   constructor(data = {}, skipValidation = false) {
     this.setup(data, skipValidation);
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -29,6 +29,7 @@ import {
   APIApplicationCommandOption,
   APIApplicationCommandPermission,
   APIAuditLogChange,
+  APIEmbed,
   APIEmoji,
   APIInteractionDataResolvedChannel,
   APIInteractionDataResolvedGuildMember,
@@ -1342,7 +1343,7 @@ export class MessageComponentInteraction extends Interaction {
 }
 
 export class MessageEmbed {
-  public constructor(data?: MessageEmbed | MessageEmbedOptions);
+  public constructor(data?: MessageEmbed | MessageEmbedOptions | APIEmbed);
   public author: MessageEmbedAuthor | null;
   public color: number | null;
   public readonly createdAt: Date | null;
@@ -3283,7 +3284,10 @@ export interface ClientEvents {
   message: [message: Message];
   messageCreate: [message: Message];
   messageDelete: [message: Message | PartialMessage];
-  messageReactionRemoveAll: [message: Message | PartialMessage, reactions: Collection<string | Snowflake, MessageReaction>];
+  messageReactionRemoveAll: [
+    message: Message | PartialMessage,
+    reactions: Collection<string | Snowflake, MessageReaction>,
+  ];
   messageReactionRemoveEmoji: [reaction: MessageReaction | PartialMessageReaction];
   messageDeleteBulk: [messages: Collection<Snowflake, Message | PartialMessage>];
   messageReactionAdd: [reaction: MessageReaction | PartialMessageReaction, user: User | PartialUser];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds support for the APIEmbed type in the MessageEmbed constructor. The code didn't need to be updated as it already supported this type. Fixes #6627

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
