### PR TITLE
refactor(VoiceState): use manager edit method to remove error

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -64,7 +64,6 @@ const Messages = {
 
   VOICE_NOT_STAGE_CHANNEL: 'You are only allowed to do this in stage channels.',
 
-  VOICE_STATE_UNCACHED_MEMBER: 'The member of this voice state is uncached.',
   VOICE_STATE_NOT_OWN:
     'You cannot self-deafen/mute/request to speak on VoiceStates that do not belong to the ClientUser.',
   VOICE_STATE_INVALID_TYPE: name => `${name} must be a boolean.`,

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -125,7 +125,7 @@ class VoiceState extends Base {
    * @returns {Promise<GuildMember>}
    */
   setMute(mute = true, reason) {
-    return this.member?.edit({ mute }, reason) ?? Promise.reject(new Error('VOICE_STATE_UNCACHED_MEMBER'));
+    return this.guild.members.edit(this.id, { mute }, reason);
   }
 
   /**
@@ -135,7 +135,7 @@ class VoiceState extends Base {
    * @returns {Promise<GuildMember>}
    */
   setDeaf(deaf = true, reason) {
-    return this.member?.edit({ deaf }, reason) ?? Promise.reject(new Error('VOICE_STATE_UNCACHED_MEMBER'));
+    return this.guild.members.edit(this.id, { deaf }, reason);
   }
 
   /**
@@ -155,7 +155,7 @@ class VoiceState extends Base {
    * @returns {Promise<GuildMember>}
    */
   setChannel(channel, reason) {
-    return this.member?.edit({ channel }, reason) ?? Promise.reject(new Error('VOICE_STATE_UNCACHED_MEMBER'));
+    return this.guild.members.edit(this.id, { channel }, reason);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR removes an error that was thrown when trying to edit an uncached GuildMember through the VoiceState (using VoiceState#setMute, VoiceState#setDeaf, or VoiceState#setChannel) and uses the GuildMemberManager#edit method instead which doesn't require the member to be cached

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
