### PR TITLE
docs(PermissionOverwriteManager): Correct `@returns` of delete

### DIFF
--- a/src/managers/PermissionOverwriteManager.js
+++ b/src/managers/PermissionOverwriteManager.js
@@ -150,7 +150,7 @@ class PermissionOverwriteManager extends CachedManager {
    * Deletes permission overwrites for a user or role in this channel.
    * @param {UserResolvable|RoleResolvable} userOrRole The user or role to delete
    * @param {string} [reason] The reason for deleting the overwrite
-   * @returns {GuildChannel}
+   * @returns {Promise<GuildChannel>}
    */
   async delete(userOrRole, reason) {
     const userOrRoleId = this.channel.guild.roles.resolveId(userOrRole) ?? this.client.users.resolveId(userOrRole);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `@returns` description was missing the fact that it is a `Promise`.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
