### PR TITLE
docs(Shard): Point to correct events

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -311,7 +311,7 @@ class Shard extends EventEmitter {
       if (message._ready) {
         this.ready = true;
         /**
-         * Emitted upon the shard's {@link Client#ready} event.
+         * Emitted upon the shard's {@link Client#event:shardReady} event.
          * @event Shard#ready
          */
         this.emit('ready');
@@ -322,7 +322,7 @@ class Shard extends EventEmitter {
       if (message._disconnect) {
         this.ready = false;
         /**
-         * Emitted upon the shard's {@link Client#disconnect} event.
+         * Emitted upon the shard's {@link Client#event:shardDisconnect} event.
          * @event Shard#disconnect
          */
         this.emit('disconnect');
@@ -333,7 +333,7 @@ class Shard extends EventEmitter {
       if (message._reconnecting) {
         this.ready = false;
         /**
-         * Emitted upon the shard's {@link Client#reconnecting} event.
+         * Emitted upon the shard's {@link Client#event:shardReconnecting} event.
          * @event Shard#reconnecting
          */
         this.emit('reconnecting');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The events in the `@link`s didn't actually exist, but now they do!

One cannot do `{@link Client#shardReady}` as this would redirect to the method which doesn't exist. Prefixing `event:` to this will redirect to the correct area (the event). This will require https://github.com/discordjs/website/pull/104 to be merged as this is new parsing.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
