### PR TITLE
types(Interaction): improve type guard for inGuild()

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1025,7 +1025,7 @@ export class Interaction extends Base {
   public inGuild(): this is this & {
     guildId: Snowflake;
     member: GuildMember | APIInteractionGuildMember;
-    channel: GuildTextBasedChannels | null;
+    readonly channel: GuildTextBasedChannels | null;
   };
   public isButton(): this is ButtonInteraction;
   public isCommand(): this is CommandInteraction;
@@ -3973,6 +3973,8 @@ export interface GuildPruneMembersOptions {
   roles?: RoleResolvable[];
 }
 
+export type GuildTextBasedChannels = TextChannel | NewsChannel | ThreadChannel;
+
 export interface GuildWidgetSettingsData {
   enabled: boolean;
   channel: GuildChannelResolvable | null;
@@ -4687,7 +4689,6 @@ export interface LimitedCollectionOptions<K, V> {
 }
 
 export type TextBasedChannels = PartialDMChannel | DMChannel | TextChannel | NewsChannel | ThreadChannel;
-export type GuildTextBasedChannels = TextChannel | NewsChannel | ThreadChannel;
 
 export type TextBasedChannelTypes = TextBasedChannels['type'];
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1025,7 +1025,7 @@ export class Interaction extends Base {
   public inGuild(): this is this & {
     guildId: Snowflake;
     member: GuildMember | APIInteractionGuildMember;
-    readonly channel: GuildTextBasedChannels | null;
+    readonly channel: Exclude<TextBasedChannels, PartialDMChannel | DMChannel> | null;
   };
   public isButton(): this is ButtonInteraction;
   public isCommand(): this is CommandInteraction;
@@ -3972,8 +3972,6 @@ export interface GuildPruneMembersOptions {
   reason?: string;
   roles?: RoleResolvable[];
 }
-
-export type GuildTextBasedChannels = TextChannel | NewsChannel | ThreadChannel;
 
 export interface GuildWidgetSettingsData {
   enabled: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1022,7 +1022,11 @@ export class Interaction extends Base {
   public type: InteractionType;
   public user: User;
   public version: number;
-  public inGuild(): this is this & { guildId: Snowflake; member: GuildMember | APIInteractionGuildMember };
+  public inGuild(): this is this & {
+    guildId: Snowflake;
+    member: GuildMember | APIInteractionGuildMember;
+    channel: GuildTextBasedChannels | null;
+  };
   public isButton(): this is ButtonInteraction;
   public isCommand(): this is CommandInteraction;
   public isContextMenu(): this is ContextMenuInteraction;
@@ -4683,6 +4687,7 @@ export interface LimitedCollectionOptions<K, V> {
 }
 
 export type TextBasedChannels = PartialDMChannel | DMChannel | TextChannel | NewsChannel | ThreadChannel;
+export type GuildTextBasedChannels = TextChannel | NewsChannel | ThreadChannel;
 
 export type TextBasedChannelTypes = TextBasedChannels['type'];
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR improves the type control of the inGuild() function. Before, the type of the "channel" property was not modified, so if the interaction was sent in a guild the "channel" property could be of type DMChannel (in reality this is not possible)


**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
