### PR TITLE
fix: allow null to be passed in order to reset icon/avatar

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -146,7 +146,7 @@ class GuildManager extends CachedManager {
    * @property {DefaultMessageNotificationLevel|number} [defaultMessageNotifications] The default message notifications
    * for the guild
    * @property {ExplicitContentFilterLevel} [explicitContentFilter] The explicit content filter level for the guild
-   * @property {BufferResolvable|Base64Resolvable} [icon=null] The icon for the guild
+   * @property {?(BufferResolvable|Base64Resolvable)} [icon=null] The icon for the guild
    * @property {PartialRoleData[]} [roles=[]] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.
    * @property {Snowflake|number} [systemChannelId] The system channel's id

--- a/src/structures/BaseGuildTextChannel.js
+++ b/src/structures/BaseGuildTextChannel.js
@@ -136,7 +136,7 @@ class BaseGuildTextChannel extends GuildChannel {
   /**
    * Options used to create a {@link Webhook} for {@link TextChannel} and {@link NewsChannel}.
    * @typedef {Object} ChannelWebhookCreateOptions
-   * @property {BufferResolvable|Base64Resolvable} [avatar] Avatar for the webhook
+   * @property {?(BufferResolvable|Base64Resolvable)} [avatar] Avatar for the webhook
    * @property {string} [reason] Reason for creating the webhook
    */
 

--- a/src/structures/ClientUser.js
+++ b/src/structures/ClientUser.js
@@ -45,7 +45,7 @@ class ClientUser extends User {
    * Data used to edit the logged in client
    * @typedef {Object} ClientUserEditData
    * @property {string} [username] The new username
-   * @property {BufferResolvable|Base64Resolvable} [avatar] The new avatar
+   * @property {?(BufferResolvable|Base64Resolvable)} [avatar] The new avatar
    */
 
   /**
@@ -54,6 +54,7 @@ class ClientUser extends User {
    * @returns {Promise<ClientUser>}
    */
   async edit(data) {
+    if (typeof data.avatar !== 'undefined') data.avatar = await DataResolver.resolveImage(data.avatar);
     const newData = await this.client.api.users('@me').patch({ data });
     this.client.token = newData.token;
     const { updated } = this.client.actions.UserUpdate.handle(newData);
@@ -78,7 +79,7 @@ class ClientUser extends User {
 
   /**
    * Sets the avatar of the logged in client.
-   * @param {BufferResolvable|Base64Resolvable} avatar The new avatar
+   * @param {?(BufferResolvable|Base64Resolvable)} avatar The new avatar
    * @returns {Promise<ClientUser>}
    * @example
    * // Set avatar
@@ -86,8 +87,8 @@ class ClientUser extends User {
    *   .then(user => console.log(`New avatar set!`))
    *   .catch(console.error);
    */
-  async setAvatar(avatar) {
-    return this.edit({ avatar: await DataResolver.resolveImage(avatar) });
+  setAvatar(avatar) {
+    return this.edit({ avatar });
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -750,9 +750,9 @@ class Guild extends AnonymousGuild {
    * @property {number} [afkTimeout] The AFK timeout of the guild
    * @property {?(BufferResolvable|Base64Resolvable)} [icon] The icon of the guild
    * @property {GuildMemberResolvable} [owner] The owner of the guild
-   * @property {Base64Resolvable} [splash] The invite splash image of the guild
-   * @property {Base64Resolvable} [discoverySplash] The discovery splash image of the guild
-   * @property {Base64Resolvable} [banner] The banner of the guild
+   * @property {?(BufferResolvable|Base64Resolvable)} [splash] The invite splash image of the guild
+   * @property {?(BufferResolvable|Base64Resolvable)} [discoverySplash] The discovery splash image of the guild
+   * @property {?(BufferResolvable|Base64Resolvable)} [banner] The banner of the guild
    * @property {DefaultMessageNotificationLevel|number} [defaultMessageNotifications] The default message notification
    * level of the guild
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The system channel flags of the guild
@@ -808,9 +808,11 @@ class Guild extends AnonymousGuild {
     if (data.afkTimeout) _data.afk_timeout = Number(data.afkTimeout);
     if (typeof data.icon !== 'undefined') _data.icon = await DataResolver.resolveImage(data.icon);
     if (data.owner) _data.owner_id = this.client.users.resolveId(data.owner);
-    if (data.splash) _data.splash = data.splash;
-    if (data.discoverySplash) _data.discovery_splash = data.discoverySplash;
-    if (data.banner) _data.banner = data.banner;
+    if (typeof data.splash !== 'undefined') _data.splash = await DataResolver.resolveImage(data.splash);
+    if (typeof data.discoverySplash !== 'undefined') {
+      _data.discovery_splash = await DataResolver.resolveImage(data.discoverySplash);
+    }
+    if (typeof data.banner !== 'undefined') _data.banner = await DataResolver.resolveImage(data.banner);
     if (typeof data.explicitContentFilter !== 'undefined') {
       _data.explicit_content_filter =
         typeof data.explicitContentFilter === 'number'
@@ -1052,7 +1054,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Sets a new guild invite splash image.
-   * @param {Base64Resolvable|BufferResolvable} splash The new invite splash image of the guild
+   * @param {?(Base64Resolvable|BufferResolvable)} splash The new invite splash image of the guild
    * @param {string} [reason] Reason for changing the guild's invite splash image
    * @returns {Promise<Guild>}
    * @example
@@ -1061,13 +1063,13 @@ class Guild extends AnonymousGuild {
    *  .then(updated => console.log('Updated the guild splash'))
    *  .catch(console.error);
    */
-  async setSplash(splash, reason) {
-    return this.edit({ splash: await DataResolver.resolveImage(splash) }, reason);
+  setSplash(splash, reason) {
+    return this.edit({ splash }, reason);
   }
 
   /**
    * Sets a new guild discovery splash image.
-   * @param {Base64Resolvable|BufferResolvable} discoverySplash The new discovery splash image of the guild
+   * @param {?(Base64Resolvable|BufferResolvable)} discoverySplash The new discovery splash image of the guild
    * @param {string} [reason] Reason for changing the guild's discovery splash image
    * @returns {Promise<Guild>}
    * @example
@@ -1076,13 +1078,13 @@ class Guild extends AnonymousGuild {
    *   .then(updated => console.log('Updated the guild discovery splash'))
    *   .catch(console.error);
    */
-  async setDiscoverySplash(discoverySplash, reason) {
-    return this.edit({ discoverySplash: await DataResolver.resolveImage(discoverySplash) }, reason);
+  setDiscoverySplash(discoverySplash, reason) {
+    return this.edit({ discoverySplash }, reason);
   }
 
   /**
    * Sets a new guild banner.
-   * @param {Base64Resolvable|BufferResolvable} banner The new banner of the guild
+   * @param {?(Base64Resolvable|BufferResolvable)} banner The new banner of the guild
    * @param {string} [reason] Reason for changing the guild's banner
    * @returns {Promise<Guild>}
    * @example
@@ -1090,8 +1092,8 @@ class Guild extends AnonymousGuild {
    *  .then(updated => console.log('Updated the guild banner'))
    *  .catch(console.error);
    */
-  async setBanner(banner, reason) {
-    return this.edit({ banner: await DataResolver.resolveImage(banner) }, reason);
+  setBanner(banner, reason) {
+    return this.edit({ banner }, reason);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -748,7 +748,7 @@ class Guild extends AnonymousGuild {
    * @property {VoiceChannelResolvable} [afkChannel] The AFK channel of the guild
    * @property {TextChannelResolvable} [systemChannel] The system channel of the guild
    * @property {number} [afkTimeout] The AFK timeout of the guild
-   * @property {Base64Resolvable} [icon] The icon of the guild
+   * @property {?(BufferResolvable|Base64Resolvable)} [icon] The icon of the guild
    * @property {GuildMemberResolvable} [owner] The owner of the guild
    * @property {Base64Resolvable} [splash] The invite splash image of the guild
    * @property {Base64Resolvable} [discoverySplash] The discovery splash image of the guild
@@ -806,7 +806,7 @@ class Guild extends AnonymousGuild {
       _data.system_channel_id = this.client.channels.resolveId(data.systemChannel);
     }
     if (data.afkTimeout) _data.afk_timeout = Number(data.afkTimeout);
-    if (typeof data.icon !== 'undefined') _data.icon = data.icon;
+    if (typeof data.icon !== 'undefined') _data.icon = await DataResolver.resolveImage(data.icon);
     if (data.owner) _data.owner_id = this.client.users.resolveId(data.owner);
     if (data.splash) _data.splash = data.splash;
     if (data.discoverySplash) _data.discovery_splash = data.discoverySplash;

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1022,7 +1022,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Sets a new guild icon.
-   * @param {Base64Resolvable|BufferResolvable} icon The new icon of the guild
+   * @param {?(Base64Resolvable|BufferResolvable)} icon The new icon of the guild
    * @param {string} [reason] Reason for changing the guild's icon
    * @returns {Promise<Guild>}
    * @example
@@ -1031,8 +1031,8 @@ class Guild extends AnonymousGuild {
    *  .then(updated => console.log('Updated the guild icon'))
    *  .catch(console.error);
    */
-  async setIcon(icon, reason) {
-    return this.edit({ icon: await DataResolver.resolveImage(icon) }, reason);
+  setIcon(icon, reason) {
+    return this.edit({ icon }, reason);
   }
 
   /**

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -209,7 +209,7 @@ class Webhook {
    * Options used to edit a {@link Webhook}.
    * @typedef {Object} WebhookEditData
    * @property {string} [name=this.name] The new name for the webhook
-   * @property {BufferResolvable} [avatar] The new avatar for the webhook
+   * @property {?(BufferResolvable)} [avatar] The new avatar for the webhook
    * @property {GuildTextChannelResolvable} [channel] The new channel for the webhook
    */
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -500,7 +500,7 @@ export class ClientUser extends User {
   public setActivity(options?: ActivityOptions): ClientPresence;
   public setActivity(name: string, options?: ActivityOptions): ClientPresence;
   public setAFK(afk?: boolean, shardId?: number | number[]): ClientPresence;
-  public setAvatar(avatar: BufferResolvable | Base64Resolvable): Promise<this>;
+  public setAvatar(avatar: BufferResolvable | Base64Resolvable | null): Promise<this>;
   public setPresence(data: PresenceData): ClientPresence;
   public setStatus(status: PresenceStatusData, shardId?: number | number[]): ClientPresence;
   public setUsername(username: string): Promise<this>;
@@ -3246,7 +3246,7 @@ export type GuildTextChannelResolvable = TextChannel | NewsChannel | Snowflake;
 export type ChannelResolvable = Channel | Snowflake;
 
 export interface ChannelWebhookCreateOptions {
-  avatar?: BufferResolvable | Base64Resolvable;
+  avatar?: BufferResolvable | Base64Resolvable | null;
   reason?: string;
 }
 
@@ -3368,7 +3368,7 @@ export interface ClientPresenceStatusData {
 
 export interface ClientUserEditData {
   username?: string;
-  avatar?: BufferResolvable | Base64Resolvable;
+  avatar?: BufferResolvable | Base64Resolvable | null;
 }
 
 export interface CloseEvent {
@@ -3893,7 +3893,7 @@ export interface GuildEditData {
   systemChannel?: TextChannelResolvable;
   systemChannelFlags?: SystemChannelFlagsResolvable;
   afkTimeout?: number;
-  icon?: Base64Resolvable;
+  icon?: BufferResolvable | Base64Resolvable | null;
   owner?: GuildMemberResolvable;
   splash?: Base64Resolvable;
   discoverySplash?: Base64Resolvable;
@@ -4761,7 +4761,7 @@ export type WebhookClientOptions = Pick<
 
 export interface WebhookEditData {
   name?: string;
-  avatar?: BufferResolvable;
+  avatar?: BufferResolvable | null;
   channel?: GuildTextChannelResolvable;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -737,13 +737,16 @@ export class Guild extends AnonymousGuild {
   public leave(): Promise<Guild>;
   public setAFKChannel(afkChannel: VoiceChannelResolvable | null, reason?: string): Promise<Guild>;
   public setAFKTimeout(afkTimeout: number, reason?: string): Promise<Guild>;
-  public setBanner(banner: Base64Resolvable | null, reason?: string): Promise<Guild>;
+  public setBanner(banner: BufferResolvable | Base64Resolvable | null, reason?: string): Promise<Guild>;
   public setChannelPositions(channelPositions: readonly ChannelPosition[]): Promise<Guild>;
   public setDefaultMessageNotifications(
     defaultMessageNotifications: DefaultMessageNotificationLevel | number,
     reason?: string,
   ): Promise<Guild>;
-  public setDiscoverySplash(discoverySplash: Base64Resolvable | null, reason?: string): Promise<Guild>;
+  public setDiscoverySplash(
+    discoverySplash: BufferResolvable | Base64Resolvable | null,
+    reason?: string,
+  ): Promise<Guild>;
   public setExplicitContentFilter(
     explicitContentFilter: ExplicitContentFilterLevel | number,
     reason?: string,
@@ -755,7 +758,7 @@ export class Guild extends AnonymousGuild {
   public setPublicUpdatesChannel(publicUpdatesChannel: TextChannelResolvable | null, reason?: string): Promise<Guild>;
   public setRolePositions(rolePositions: readonly RolePosition[]): Promise<Guild>;
   public setRulesChannel(rulesChannel: TextChannelResolvable | null, reason?: string): Promise<Guild>;
-  public setSplash(splash: Base64Resolvable | null, reason?: string): Promise<Guild>;
+  public setSplash(splash: BufferResolvable | Base64Resolvable | null, reason?: string): Promise<Guild>;
   public setSystemChannel(systemChannel: TextChannelResolvable | null, reason?: string): Promise<Guild>;
   public setSystemChannelFlags(systemChannelFlags: SystemChannelFlagsResolvable, reason?: string): Promise<Guild>;
   public setVerificationLevel(verificationLevel: VerificationLevel | number, reason?: string): Promise<Guild>;
@@ -3895,9 +3898,9 @@ export interface GuildEditData {
   afkTimeout?: number;
   icon?: BufferResolvable | Base64Resolvable | null;
   owner?: GuildMemberResolvable;
-  splash?: Base64Resolvable;
-  discoverySplash?: Base64Resolvable;
-  banner?: Base64Resolvable;
+  splash?: BufferResolvable | Base64Resolvable | null;
+  discoverySplash?: BufferResolvable | Base64Resolvable | null;
+  banner?: BufferResolvable | Base64Resolvable | null;
   rulesChannel?: TextChannelResolvable;
   publicUpdatesChannel?: TextChannelResolvable;
   preferredLocale?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -748,7 +748,7 @@ export class Guild extends AnonymousGuild {
     explicitContentFilter: ExplicitContentFilterLevel | number,
     reason?: string,
   ): Promise<Guild>;
-  public setIcon(icon: Base64Resolvable | null, reason?: string): Promise<Guild>;
+  public setIcon(icon: BufferResolvable | Base64Resolvable | null, reason?: string): Promise<Guild>;
   public setName(name: string, reason?: string): Promise<Guild>;
   public setOwner(owner: GuildMemberResolvable, reason?: string): Promise<Guild>;
   public setPreferredLocale(preferredLocale: string, reason?: string): Promise<Guild>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR updates documentation and typings to allow `null` as a valid value for icon/avatar of a `Guild`, `ClientUser`, and `Webhook`.

It also fixes a bug in `ClientUser#edit` and `Guild#edit` where the `icon` option wasn't being resolved, making it impossible to set a new icon using a path to the local file.

⚠️ From the docs for [`Modify Guild Docs`](https://discord.com/developers/docs/resources/guild#modify-guild), it seems that `splash`, `discovery_splash`, and `banner` can also be set to `null`. My test guild doesn't have those features, so I didn't add changes related to them  here. It would be great if someone can confirm it.

**Status and versioning classification:**
- Code changes have been tested against the Discord API
- I know how to update typings and have done so
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
