### PR TITLE
docs(ApplicationCommandPermissionsManager): fix example set method

### DIFF
--- a/src/managers/ApplicationCommandPermissionsManager.js
+++ b/src/managers/ApplicationCommandPermissionsManager.js
@@ -133,12 +133,13 @@ class ApplicationCommandPermissionsManager extends BaseManager {
    * @returns {Promise<ApplicationCommandPermissions[]|Collection<Snowflake, ApplicationCommandPermissions[]>>}
    * @example
    * // Set the permissions for one command
-   * client.application.commands.permissions.set({ guild: '123456789012345678', command: '123456789012345678', permissions: [
-   *   {
-   *     id: '876543210987654321',
-   *     type: 'USER',
-   *     permission: false,
-   *   },
+   * client.application.commands.permissions.set({ guild: '892455839386304532', command: '123456789012345678',
+   *  permissions: [
+   *    {
+   *      id: '876543210987654321',
+   *      type: 'USER',
+   *      permission: false,
+   *    },
    * ]})
    *   .then(console.log)
    *   .catch(console.error);

--- a/src/managers/ApplicationCommandPermissionsManager.js
+++ b/src/managers/ApplicationCommandPermissionsManager.js
@@ -133,7 +133,7 @@ class ApplicationCommandPermissionsManager extends BaseManager {
    * @returns {Promise<ApplicationCommandPermissions[]|Collection<Snowflake, ApplicationCommandPermissions[]>>}
    * @example
    * // Set the permissions for one command
-   * client.application.commands.permissions.set({ command: '123456789012345678', permissions: [
+   * client.application.commands.permissions.set({ guild: '123456789012345678', command: '123456789012345678', permissions: [
    *   {
    *     id: '876543210987654321',
    *     type: 'USER',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`ApplicationCommandPermissionsManager.set` needs guild as an argument, the examples have been updated to reflect this

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
