### PR TITLE
chore(IssueForms): remove default titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,7 +60,7 @@ body:
       label: Node.js version
       description: |
         Which version of Node.js are you using? Run `node --version` in your project directory and paste the output.
-        If your issue is directly related to TypeScript, please include the version of TypeScript you are using as well. (`npm list typescript`)
+        If you are using TypeScript, please include its version (`npm list typescript`) as well. 
       placeholder: Node.js version 16.6+ is required for version 13.0.0+
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,7 +60,7 @@ body:
       label: Node.js version
       description: |
         Which version of Node.js are you using? Run `node --version` in your project directory and paste the output.
-        If your issue is directly related to Typescript, please include the version of Typescript you are using as well. (`npm list typescript`)
+        If your issue is directly related to TypeScript, please include the version of TypeScript you are using as well. (`npm list typescript`)
       placeholder: Node.js version 16.6+ is required for version 13.0.0+
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug report
 description: Report incorrect or unexpected behavior of discord.js
-title: 'Bug: <title>'
 labels: [bug, need repro]
 body:
   - type: markdown
@@ -27,7 +26,7 @@ body:
   - type: textarea
     id: codesample
     attributes:
-      label: Codesample
+      label: Code sample
       description: Include a reproducible, minimal code sample. This will be automatically formatted into code, so no need for backticks.
       render: typescript
       placeholder: |
@@ -59,7 +58,9 @@ body:
     id: node-version
     attributes:
       label: Node.js version
-      description: Which version of Node.js are you using? Run `node --version` in your project directory and paste the output.
+      description: |
+        Which version of Node.js are you using? Run `node --version` in your project directory and paste the output.
+        If your issue is directly related to Typescript, please include the version of Typescript you are using as well. (`npm list typescript`)
       placeholder: Node.js version 16.6+ is required for version 13.0.0+
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: Feature request
 description: Request a new feature (documented features of the official Discord developer API only!)
-title: 'Feature request: <title>'
 labels: [feature request]
 body:
   - type: markdown


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR brings 2 changes to issue forms:
- Removed the default titles from both. This is so that users don't accidentally submit an issue without a proper title, so GitHub will alert them if they try to. The type of issue (bug/request) can already be inferred through the labels
- Changed the Node.js version field in the bug report form to mention that you can also provide your typescript version there, if your issue is strictly related to TS, as discussed [on the discord server](https://canary.discord.com/channels/222078108977594368/884983786545238047/888774406128689222)
And also fixes a small typo in "Codesample"

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
