### PR TITLE
feat: add support for autocomplete interactions

### DIFF
--- a/src/structures/AutocompleteInteraction.js
+++ b/src/structures/AutocompleteInteraction.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const CommandInteractionOptionResolver = require('./CommandInteractionOptionResolver');
+const Interaction = require('./Interaction');
+
+/**
+ * Represents a autocomplete interaction.
+ * @extends {Interaction}
+ */
+class AutocompleteInteraction extends Interaction {
+  constructor(client, data) {
+    super(client, data);
+
+    /**
+     * The options passed to the command.
+     * @type {CommandInteractionOptionResolver}
+     */
+    this.options = new CommandInteractionOptionResolver(
+      this.client,
+      data.data.options?.map(option => this.transformOption(option, data.data.resolved)) ?? [],
+      this.transformResolved(data.data.resolved ?? {}),
+    );
+  }
+}
+
+module.exports = AutocompleteInteraction;

--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -162,6 +162,7 @@ class BaseCommandInteraction extends Interaction {
 
     if ('value' in option) result.value = option.value;
     if ('options' in option) result.options = option.options.map(opt => this.transformOption(opt, resolved));
+    if ('focused' in option) result.focused = option.focused;
 
     if (resolved) {
       const user = resolved.users?.[option.value];

--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -239,6 +239,18 @@ class CommandInteractionOptionResolver {
     const option = this._getTypedOption(name, '_MESSAGE', ['message'], required);
     return option?.message ?? null;
   }
+
+  /**
+   * Gets a focused option.
+   * @param {name} name The name of the option.
+   * @param {boolean} [required=false] Whether to throw an error if the option is not found.
+   * @returns {?(string)}
+   * The value of the option, or null if not set and not required.
+   */
+  getFocused(name, required = false) {
+    const option = this._getTypedOption(name, 'STRING', ['value'], required);
+    return option?.value ?? null;
+  }
 }
 
 module.exports = CommandInteractionOptionResolver;

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -130,6 +130,17 @@ class Interaction extends Base {
   }
 
   /**
+   * Indicates whether this interaction is a {@link AutocompleteInteraction}
+   * @returns {boolean}
+   */
+  isAutocomplete() {
+    return (
+      InteractionTypes[this.type] === InteractionTypes.APPLICATION_COMMAND_AUTOCOMPLETE &&
+      typeof this.targetId === 'undefined'
+    );
+  }
+
+  /**
    * Indicates whether this interaction is a {@link MessageComponentInteraction}.
    * @returns {boolean}
    */

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -218,6 +218,35 @@ class InteractionResponses {
     return options.fetchReply ? this.fetchReply() : undefined;
   }
 
+  /**
+   * Sends results for the autocomplete of this interaction.
+   * @param {InteractionResultOptions} options The options for the autocomplete
+   * @returns {Promise<void>}
+   * @example
+   * // respond to autocomplete interaction
+   * interaction.autocomplete({
+   *  options: [
+   *   {
+   *    name: 'Option 1',
+   *    value: 'option1',
+   *   },
+   *  ],
+   * })
+   *  .then(console.log)
+   * .catch(console.error);
+   */
+  async result(options) {
+    if (this.replied) throw new Error('INTERACTION_ALREADY_REPLIED');
+
+    await this.client.api.interactions(this.id, this.token).callback.post({
+      data: {
+        type: InteractionResponseTypes.APPLICATION_COMMAND_AUTOCOMPLETE_RESULT,
+        data: options,
+      },
+    });
+    this.replied = true;
+  }
+
   static applyToClass(structure, ignore = []) {
     const props = [
       'deferReply',

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -954,7 +954,13 @@ exports.ApplicationCommandPermissionTypes = createEnum([null, 'ROLE', 'USER']);
  * @typedef {string} InteractionType
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-interaction-type}
  */
-exports.InteractionTypes = createEnum([null, 'PING', 'APPLICATION_COMMAND', 'MESSAGE_COMPONENT']);
+exports.InteractionTypes = createEnum([
+  null,
+  'PING',
+  'APPLICATION_COMMAND',
+  'MESSAGE_COMPONENT',
+  'APPLICATION_COMMAND_AUTOCOMPLETE',
+]);
 
 /**
  * The type of an interaction response:
@@ -975,6 +981,7 @@ exports.InteractionResponseTypes = createEnum([
   'DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE',
   'DEFERRED_MESSAGE_UPDATE',
   'UPDATE_MESSAGE',
+  'APPLICATION_COMMAND_AUTOCOMPLETE_RESULT',
 ]);
 /* eslint-enable max-len */
 

--- a/typings/enums.d.ts
+++ b/typings/enums.d.ts
@@ -66,12 +66,14 @@ export const enum InteractionResponseTypes {
   DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5,
   DEFERRED_MESSAGE_UPDATE = 6,
   UPDATE_MESSAGE = 7,
+  APPLICATION_COMMAND_AUTOCOMPLETE_RESULT = 8,
 }
 
 export const enum InteractionTypes {
   PING = 1,
   APPLICATION_COMMAND = 2,
   MESSAGE_COMPONENT = 3,
+  APPLICATION_COMMAND_AUTOCOMPLETE = 4,
 }
 
 export const enum InviteTargetType {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -557,6 +557,11 @@ export class CommandInteraction extends BaseCommandInteraction {
   public options: CommandInteractionOptionResolver;
 }
 
+export class AutocompleteInteraction extends Interaction {
+  public options: CommandInteractionOptionResolver;
+  public result: (name: string, required: boolean) => Promise<string | null>;
+}
+
 export class CommandInteractionOptionResolver {
   public constructor(client: Client, options: CommandInteractionOption[], resolved: CommandInteractionResolvedData);
   public readonly client: Client;
@@ -611,6 +616,7 @@ export class CommandInteractionOptionResolver {
   ): NonNullable<CommandInteractionOption['member' | 'role' | 'user']> | null;
   public getMessage(name: string, required: true): NonNullable<CommandInteractionOption['message']>;
   public getMessage(name: string, required?: boolean): NonNullable<CommandInteractionOption['message']> | null;
+  public getFocused(name: string, require?: boolean): string | null;
 }
 
 export class ContextMenuInteraction extends BaseCommandInteraction {
@@ -1025,6 +1031,7 @@ export class Interaction extends Base {
   public inGuild(): this is this & { guildId: Snowflake; member: GuildMember | APIInteractionGuildMember };
   public isButton(): this is ButtonInteraction;
   public isCommand(): this is CommandInteraction;
+  public isAutocomplete(): this is AutocompleteInteraction;
   public isContextMenu(): this is ContextMenuInteraction;
   public isMessageComponent(): this is MessageComponentInteraction;
   public isSelectMenu(): this is SelectMenuInteraction;
@@ -3432,6 +3439,8 @@ export interface CommandInteractionOption {
   name: string;
   type: ApplicationCommandOptionType;
   value?: string | number | boolean;
+  autocomplete?: boolean;
+  focused?: boolean;
   options?: CommandInteractionOption[];
   user?: User;
   member?: GuildMember | APIInteractionDataResolvedGuildMember;
@@ -4071,6 +4080,10 @@ export type InteractionType = keyof typeof InteractionTypes;
 
 export interface InteractionUpdateOptions extends MessageEditOptions {
   fetchReply?: boolean;
+}
+
+export interface InteractionResultOptions {
+  options: CommandInteractionOption[];
 }
 
 export type IntentsString =


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- [Document Application Commands Autocompletion](https://github.com/discord/discord-api-docs/pull/3849)
 

**Status and versioning classification:**
- Code changes have been tested against the Discord API
- I know how to update typings and have done so
- This PR changes the library's interface (methods or parameters added)
