### PR TITLE
fix(*RoleManager): Create set of role ids correctly

### DIFF
--- a/src/managers/GuildEmojiRoleManager.js
+++ b/src/managers/GuildEmojiRoleManager.js
@@ -51,7 +51,7 @@ class GuildEmojiRoleManager extends DataManager {
       resolvedRoles.push(resolvedRole);
     }
 
-    const newRoles = [...new Set(resolvedRoles.concat(...this.cache.values()))];
+    const newRoles = [...new Set(resolvedRoles.concat(...this.cache.map(role => role.id)))];
     return this.set(newRoles);
   }
 

--- a/src/managers/GuildEmojiRoleManager.js
+++ b/src/managers/GuildEmojiRoleManager.js
@@ -51,7 +51,7 @@ class GuildEmojiRoleManager extends DataManager {
       resolvedRoles.push(resolvedRole);
     }
 
-    const newRoles = [...new Set(resolvedRoles.concat(...this.cache.map(role => role.id)))];
+    const newRoles = [...new Set(resolvedRoles.concat(...this.cache.keys()))];
     return this.set(newRoles);
   }
 

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -102,7 +102,7 @@ class GuildMemberRoleManager extends DataManager {
         resolvedRoles.push(resolvedRole);
       }
 
-      const newRoles = [...new Set(resolvedRoles.concat(...this.cache.values()))];
+      const newRoles = [...new Set(resolvedRoles.concat(...this.cache.map(role => role.id)))];
       return this.set(newRoles, reason);
     } else {
       roleOrRoles = this.guild.roles.resolveId(roleOrRoles);

--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -102,7 +102,7 @@ class GuildMemberRoleManager extends DataManager {
         resolvedRoles.push(resolvedRole);
       }
 
-      const newRoles = [...new Set(resolvedRoles.concat(...this.cache.map(role => role.id)))];
+      const newRoles = [...new Set(resolvedRoles.concat(...this.cache.keys()))];
       return this.set(newRoles, reason);
     } else {
       roleOrRoles = this.guild.roles.resolveId(roleOrRoles);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `Set` in these two managers were being created improperly as it compared ids with `Role`s, which wouldn't work. This pull request resolves this (and resolves #6673).


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
