### PR TITLE
fix(GuildEmoji): Cache restricted roles and author data

### DIFF
--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -30,7 +30,7 @@ class GuildEmoji extends BaseGuildEmoji {
      * @type {Snowflake[]}
      * @private
      */
-    Object.defineProperty(this, '_roles', { value: [], writable: true });
+    Object.defineProperty(this, '_roles', { value: data.roles, writable: true });
   }
 
   /**

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -30,7 +30,9 @@ class GuildEmoji extends BaseGuildEmoji {
      * @type {Snowflake[]}
      * @private
      */
-    Object.defineProperty(this, '_roles', { value: data.roles, writable: true });
+    Object.defineProperty(this, '_roles', { value: [], writable: true });
+
+    this._patch(data);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Guild emojis that were restricted to roles were not being stored in discord.js over the gateway - an empty array would always be set. As such, methods like `GuildEmojiRoleManager.add()` would completely wipe all other roles from the emoji (since it calls `.set()` from the cache which is empty), and then only add what you specified, which is bad behaviour and not intended.

I believe I managed to fix this by setting the default value to the provided array. I have tested this and it works as expected.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
