### PR TITLE
feat(UserManager): allow #fetch to take UserResolvable

### DIFF
--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -61,13 +61,13 @@ class UserManager extends CachedManager {
    * @returns {Promise<User>}
    */
   async fetch(user, { cache = true, force = false } = {}) {
-    user = this.resolveId(user);
+    const id = this.resolveId(user);
     if (!force) {
-      const existing = this.cache.get(user);
+      const existing = this.cache.get(id);
       if (existing && !existing.partial) return existing;
     }
 
-    const data = await this.client.api.users(user).get();
+    const data = await this.client.api.users(id).get();
     return this._add(data, cache);
   }
 }

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -56,17 +56,18 @@ class UserManager extends CachedManager {
 
   /**
    * Obtains a user from Discord, or the user cache if it's already available.
-   * @param {Snowflake} id The user's id
+   * @param {UserResolvable} user The user to fetch
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<User>}
    */
-  async fetch(id, { cache = true, force = false } = {}) {
+  async fetch(user, { cache = true, force = false } = {}) {
+    user = this.resolveId(user);
     if (!force) {
-      const existing = this.cache.get(id);
+      const existing = this.cache.get(user);
       if (existing && !existing.partial) return existing;
     }
 
-    const data = await this.client.api.users(id).get();
+    const data = await this.client.api.users(user).get();
     return this._add(data, cache);
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2750,7 +2750,7 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
 
 export class UserManager extends CachedManager<Snowflake, User, UserResolvable> {
   public constructor(client: Client, iterable?: Iterable<RawUserData>);
-  public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<User>;
+  public fetch(user: UserResolvable, options?: BaseFetchOptions): Promise<User>;
 }
 
 export class VoiceStateManager extends CachedManager<Snowflake, VoiceState, typeof VoiceState> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Allow [`UserManager#fetch`](https://discord.js.org/#/docs/main/stable/class/UserManager?scrollTo=fetch) to take a [`UserResolvable`](https://discord.js.org/#/docs/main/stable/typedef/UserResolvable)

**Status and versioning classification:**
- I know how to update typings and have done so
- Code changes have been tested against the Discord API
- ~~This PR includes breaking changes ⚠️~~
<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
