### PR TITLE
Revert #6102 (see #6681)

### DIFF
--- a/src/client/actions/ActionsManager.js
+++ b/src/client/actions/ActionsManager.js
@@ -6,12 +6,49 @@ class ActionsManager {
   constructor(client) {
     this.client = client;
 
-    const files = fs.readdirSync(__dirname);
-
-    for (const file of files) {
-      if (['Action.js', 'ActionsManager.js'].includes(file)) continue;
-      this.register(require(`./${file}`));
-    }
+    this.register(require('./MessageCreate'));
+    this.register(require('./MessageDelete'));
+    this.register(require('./MessageDeleteBulk'));
+    this.register(require('./MessageUpdate'));
+    this.register(require('./MessageReactionAdd'));
+    this.register(require('./MessageReactionRemove'));
+    this.register(require('./MessageReactionRemoveAll'));
+    this.register(require('./MessageReactionRemoveEmoji'));
+    this.register(require('./ChannelCreate'));
+    this.register(require('./ChannelDelete'));
+    this.register(require('./ChannelUpdate'));
+    this.register(require('./GuildDelete'));
+    this.register(require('./GuildUpdate'));
+    this.register(require('./InteractionCreate'));
+    this.register(require('./InviteCreate'));
+    this.register(require('./InviteDelete'));
+    this.register(require('./GuildMemberRemove'));
+    this.register(require('./GuildMemberUpdate'));
+    this.register(require('./GuildBanAdd'));
+    this.register(require('./GuildBanRemove'));
+    this.register(require('./GuildRoleCreate'));
+    this.register(require('./GuildRoleDelete'));
+    this.register(require('./GuildRoleUpdate'));
+    this.register(require('./PresenceUpdate'));
+    this.register(require('./UserUpdate'));
+    this.register(require('./VoiceStateUpdate'));
+    this.register(require('./GuildEmojiCreate'));
+    this.register(require('./GuildEmojiDelete'));
+    this.register(require('./GuildEmojiUpdate'));
+    this.register(require('./GuildEmojisUpdate'));
+    this.register(require('./ThreadCreate'));
+    this.register(require('./ThreadDelete'));
+    this.register(require('./ThreadListSync'));
+    this.register(require('./ThreadMemberUpdate'));
+    this.register(require('./ThreadMembersUpdate'));
+    this.register(require('./GuildRolesPositionUpdate'));
+    this.register(require('./GuildChannelsPositionUpdate'));
+    this.register(require('./GuildIntegrationsUpdate'));
+    this.register(require('./WebhooksUpdate'));
+    this.register(require('./TypingStart'));
+    this.register(require('./StageInstanceCreate'));
+    this.register(require('./StageInstanceUpdate'));
+    this.register(require('./StageInstanceDelete'));
   }
 
   register(Action) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Revert changes made in pull request #6102, which causes bundlers like webpack to break (#6681).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
