### PR TITLE
fix(GuildManager): add missing types and converts

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -85,7 +85,7 @@ class GuildManager extends CachedManager {
    * @property {Snowflake|number} [id] The channel's id, used to set its parent,
    * this is a placeholder and will be replaced by the API after consumption
    * @property {Snowflake|number} [parentId] The parent id for this channel
-   * @property {ChannelType} [type] The type of the channel
+   * @property {ChannelType|number} [type] The type of the channel
    * @property {string} name The name of the channel
    * @property {string} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -189,6 +189,7 @@ class GuildManager extends CachedManager {
     }
     for (const channel of channels) {
       if (channel.type) channel.type = ChannelTypes[channel.type.toUpperCase()];
+      if (channel.type) channel.type = typeof channel.type === 'number' ? channel.type : ChannelTypes[channel.type];
       channel.parent_id = channel.parentId;
       delete channel.parentId;
       channel.user_limit = channel.userLimit;

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -12,6 +12,7 @@ const Role = require('../structures/Role');
 const {
   ChannelTypes,
   Events,
+  OverwriteTypes,
   VerificationLevels,
   DefaultMessageNotificationLevels,
   ExplicitContentFilterLevels,
@@ -73,7 +74,7 @@ class GuildManager extends CachedManager {
    * Partial overwrite data.
    * @typedef {Object} PartialOverwriteData
    * @property {Snowflake|number} id The id of the {@link Role} or {@link User} this overwrite belongs to
-   * @property {string} [type] The type of this overwrite
+   * @property {OverwriteType} [type] The type of this overwrite
    * @property {PermissionResolvable} [allow] The permissions to allow
    * @property {PermissionResolvable} [deny] The permissions to deny
    */
@@ -190,8 +191,15 @@ class GuildManager extends CachedManager {
       if (channel.type) channel.type = ChannelTypes[channel.type.toUpperCase()];
       channel.parent_id = channel.parentId;
       delete channel.parentId;
+      channel.user_limit = channel.userLimit;
+      delete channel.userLimit;
+      channel.rate_limit_per_user = channel.rateLimitPerUser;
+      delete channel.rateLimitPerUser;
       if (!channel.permissionOverwrites) continue;
       for (const overwrite of channel.permissionOverwrites) {
+        if (typeof overwrite.type === 'string') {
+          overwrite.type = OverwriteTypes[overwrite.type];
+        }
         if (overwrite.allow) overwrite.allow = Permissions.resolve(overwrite.allow).toString();
         if (overwrite.deny) overwrite.deny = Permissions.resolve(overwrite.deny).toString();
       }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4509,7 +4509,27 @@ export type PresenceResolvable = Presence | UserResolvable | Snowflake;
 export interface PartialChannelData {
   id?: Snowflake | number;
   parentId?: Snowflake | number;
-  type?: ChannelTypes;
+  type?: Exclude<
+    keyof typeof ChannelTypes | ChannelTypes,
+    | 'DM'
+    | 'GROUP_DM'
+    | 'GUILD_NEWS'
+    | 'GUILD_STORE'
+    | 'UNKNOWN'
+    | 'GUILD_NEWS_THREAD'
+    | 'GUILD_PUBLIC_THREAD'
+    | 'GUILD_PRIVATE_THREAD'
+    | 'GUILD_STAGE_VOICE'
+    | ChannelTypes.DM
+    | ChannelTypes.GROUP_DM
+    | ChannelTypes.GUILD_NEWS
+    | ChannelTypes.GUILD_STORE
+    | ChannelTypes.UNKNOWN
+    | ChannelTypes.GUILD_NEWS_THREAD
+    | ChannelTypes.GUILD_PUBLIC_THREAD
+    | ChannelTypes.GUILD_PRIVATE_THREAD
+    | ChannelTypes.GUILD_STAGE_VOICE
+  >;
   name: string;
   topic?: string;
   nsfw?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4508,11 +4508,15 @@ export type PresenceResolvable = Presence | UserResolvable | Snowflake;
 
 export interface PartialChannelData {
   id?: Snowflake | number;
+  parentId?: Snowflake | number;
+  type?: ChannelTypes;
   name: string;
   topic?: string;
-  type?: ChannelTypes;
-  parentId?: Snowflake | number;
+  nsfw?: boolean;
+  bitrate?: number;
+  userLimit?: number;
   permissionOverwrites?: PartialOverwriteData[];
+  rateLimitPerUser?: number;
 }
 
 export type Partialize<


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Updated PartialChannelData at [/typings/index.d.ts#L4509](https://github.com/discordjs/discord.js/blob/839974ca432c70d57e82e9b47334f743e0c20281/typings/index.d.ts#L4509) to match [/src/managers/GuildManager.js#L83](https://github.com/discordjs/discord.js/blob/839974ca432c70d57e82e9b47334f743e0c20281/src/managers/GuildManager.js#L83).
Added missing converts (userLimit, rateLimitPerUser, overwrite.type) to `GuildManager#create`.
Made `PartialOverwriteData.type` to take `OverwriteType` instead of `string`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
