### PR TITLE
fix(CachedManager): return updated data when cache is false

### DIFF
--- a/src/managers/CachedManager.js
+++ b/src/managers/CachedManager.js
@@ -46,8 +46,13 @@ class CachedManager extends DataManager {
   _add(data, cache = true, { id, extras = [] } = {}) {
     const existing = this.cache.get(id ?? data.id);
     if (existing) {
-      if (cache) return existing._patch(data);
-      return existing._clone()._patch(data);
+      if (cache) {
+        existing._patch(data);
+        return existing;
+      }
+      const clone = existing._clone();
+      clone._patch(data);
+      return clone;
     }
 
     const entry = this.holds ? new this.holds(this.client, data, ...extras) : data;

--- a/src/managers/CachedManager.js
+++ b/src/managers/CachedManager.js
@@ -45,8 +45,10 @@ class CachedManager extends DataManager {
 
   _add(data, cache = true, { id, extras = [] } = {}) {
     const existing = this.cache.get(id ?? data.id);
-    if (cache) existing?._patch(data);
-    if (existing) return existing;
+    if (existing) {
+      if (cache) return existing._patch(data);
+      return existing._clone()._patch(data);
+    }
 
     const entry = this.holds ? new this.holds(this.client, data, ...extras) : data;
     if (cache) this.cache.set(id ?? entry.id, entry);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

fixes: #6667

Under the circumstances where a structure is present in the cache, `<Manager>_add()` returns stale data if `cache` is set to false instead of returning the updated data without caching it.


**Status and versioning classification:**
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
