### PR TITLE
feat: Allow webhooks to fetch, edit and delete messages in threads

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -257,7 +257,7 @@ class Webhook {
   async fetchMessage(message, cacheOrOptions) {
     const options = { cache: true, threadId: undefined };
 
-    if (this.client.options.allowedWebhookThreadFetching) {
+    if (this.client.options.allowWebhookThreadFetching) {
       options.cache = cacheOrOptions.cache ?? true;
       options.threadId = cacheOrOptions.threadId;
     } else {

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -254,9 +254,7 @@ class Webhook {
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */
   async fetchMessage(message, cacheOrOptions = { cache: true }) {
-    if (typeof cacheOrOptions === 'object') {
-      cacheOrOptions.cache ??= true;
-    } else {
+    if (typeof cacheOrOptions === 'boolean') {
       cacheOrOptions = { cache: cacheOrOptions };
     }
 

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -248,20 +248,16 @@ class Webhook {
   /**
    * Gets a message that was sent by this webhook.
    * @param {Snowflake|'@original'} message The id of the message to fetch
-   * @param {boolean|WebhookFetchMessageOptions} [cacheOrOptions=true|cacheOrOptions={}] If
-   * {@link ClientOptions#allowWebhookThreadFetching} is `true`, this will be {@link WebhookFetchMessageOptions}
-   * to enable fetching messages in threads. Otherwise, this will be the `cache` parameter.
+   * @param {WebhookFetchMessageOptions|boolean} [cacheOrOptions={}] The options to provide to fetch the message.
+   * A boolean may be passed instead to specify whether to cache the message.
    * @returns {Promise<Message|APIMessage>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */
-  async fetchMessage(message, cacheOrOptions) {
-    const options = { cache: true, threadId: undefined };
-
-    if (this.client.options.allowWebhookThreadFetching) {
-      options.cache = cacheOrOptions.cache ?? true;
-      options.threadId = cacheOrOptions.threadId;
+  async fetchMessage(message, cacheOrOptions = { cache: true }) {
+    if (typeof cacheOrOptions === 'object') {
+      cacheOrOptions.cache ??= true;
     } else {
-      options.cache = cacheOrOptions ?? true;
+      cacheOrOptions = { cache: cacheOrOptions };
     }
 
     if (!this.token) throw new Error('WEBHOOK_TOKEN_UNAVAILABLE');
@@ -271,10 +267,10 @@ class Webhook {
       .messages(message)
       .get({
         query: {
-          thread_id: options.threadId,
+          thread_id: cacheOrOptions.threadId,
         },
       });
-    return this.client.channels?.cache.get(data.channel_id)?.messages._add(data, options.cache) ?? data;
+    return this.client.channels?.cache.get(data.channel_id)?.messages._add(data, cacheOrOptions.cache) ?? data;
   }
 
   /**

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -238,7 +238,7 @@ class Webhook {
   }
 
   /**
-   * Options that can be passed to fetch a message.
+   * Options that can be passed into fetchMessage.
    * @typedef {options} WebhookFetchMessageOptions
    * @property {boolean} [cache=true] Whether to cache the message.
    * @property {Snowflake} [threadId] The id of the thread this message belongs to.

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -249,7 +249,7 @@ class Webhook {
    * Gets a message that was sent by this webhook.
    * @param {Snowflake|'@original'} message The id of the message to fetch
    * @param {WebhookFetchMessageOptions|boolean} [cacheOrOptions={}] The options to provide to fetch the message.
-   * A boolean may be passed instead to specify whether to cache the message.
+   * A **deprecated** boolean may be passed instead to specify whether to cache the message.
    * @returns {Promise<Message|APIMessage>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -71,8 +71,8 @@
  * @property {IntentsResolvable} intents Intents to enable for this connection
  * @property {WebsocketOptions} [ws] Options for the WebSocket
  * @property {HTTPOptions} [http] HTTP options
- * @property {boolean} [allowWebhookThreadFetching] This changes {@link Webhook#fetchMessage}'s second parameter to
- * accept {@link WebhookFetchMessageOptions} which allows the fetching of messages in threads.
+ * @property {boolean} [allowWebhookThreadFetching=false] This changes {@link Webhook#fetchMessage}'s second parameter
+ * to accept {@link WebhookFetchMessageOptions} which allows the fetching of messages in threads.
  */
 
 /**

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -144,6 +144,7 @@ class Options extends null {
         invite: 'https://discord.gg',
         template: 'https://discord.new',
       },
+      allowWebhookThreadFetching: false,
     };
   }
 

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -71,6 +71,8 @@
  * @property {IntentsResolvable} intents Intents to enable for this connection
  * @property {WebsocketOptions} [ws] Options for the WebSocket
  * @property {HTTPOptions} [http] HTTP options
+ * @property {boolean} [allowWebhookThreadFetching] This changes {@link Webhook#fetchMessage}'s second parameter to
+ * accept {@link WebhookFetchMessageOptions} which allows the fetching of messages in threads.
  */
 
 /**

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -71,8 +71,6 @@
  * @property {IntentsResolvable} intents Intents to enable for this connection
  * @property {WebsocketOptions} [ws] Options for the WebSocket
  * @property {HTTPOptions} [http] HTTP options
- * @property {boolean} [allowWebhookThreadFetching=false] This changes {@link Webhook#fetchMessage}'s second parameter
- * to accept {@link WebhookFetchMessageOptions} which allows the fetching of messages in threads.
  */
 
 /**
@@ -144,7 +142,6 @@ class Options extends null {
         invite: 'https://discord.gg',
         template: 'https://discord.new',
       },
-      allowWebhookThreadFetching: false,
     };
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2119,7 +2119,11 @@ export class WebhookClient extends WebhookMixin(BaseClient) {
     message: MessageResolvable,
     options: string | MessagePayload | WebhookEditMessageOptions,
   ): Promise<APIMessage>;
-  public fetchMessage(message: Snowflake, cacheOrOptions?: WebhookFetchMessageOptions | boolean): Promise<APIMessage>;
+  public fetchMessage(message: Snowflake, options?: WebhookFetchMessageOptions): Promise<APIMessage>;
+  /* tslint:disable:unified-signatures */
+  /** @deprecated */
+  public fetchMessage(message: Snowflake, cache?: boolean): Promise<APIMessage>;
+  /* tslint:enable:unified-signatures */
   public send(options: string | MessagePayload | WebhookMessageOptions): Promise<APIMessage>;
 }
 
@@ -2830,10 +2834,11 @@ export interface PartialWebhookFields {
     message: MessageResolvable | '@original',
     options: string | MessagePayload | WebhookEditMessageOptions,
   ): Promise<Message | APIMessage>;
-  fetchMessage(
-    message: Snowflake | '@original',
-    cacheOrOptions?: WebhookFetchMessageOptions | boolean,
-  ): Promise<Message | APIMessage>;
+  fetchMessage(message: Snowflake | '@original', options?: WebhookFetchMessageOptions): Promise<Message | APIMessage>;
+  /* tslint:disable:unified-signatures */
+  /** @deprecated */
+  fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | APIMessage>;
+  /* tslint:enable:unified-signatures */
   send(options: string | MessagePayload | WebhookMessageOptions): Promise<Message | APIMessage>;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2119,7 +2119,7 @@ export class WebhookClient extends WebhookMixin(BaseClient) {
     message: MessageResolvable,
     options: string | MessagePayload | WebhookEditMessageOptions,
   ): Promise<APIMessage>;
-  public fetchMessage(message: Snowflake, cache?: boolean): Promise<APIMessage>;
+  public fetchMessage(message: Snowflake, cacheOrOptions?: boolean | WebhookFetchMessageOptions): Promise<APIMessage>;
   public send(options: string | MessagePayload | WebhookMessageOptions): Promise<APIMessage>;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2825,12 +2825,15 @@ export function WebhookMixin<T>(Base?: Constructable<T>): Constructable<T & Webh
 export interface PartialWebhookFields {
   id: Snowflake;
   readonly url: string;
-  deleteMessage(message: MessageResolvable | APIMessage | '@original'): Promise<void>;
+  deleteMessage(message: MessageResolvable | APIMessage | '@original', threadId?: Snowflake): Promise<void>;
   editMessage(
     message: MessageResolvable | '@original',
     options: string | MessagePayload | WebhookEditMessageOptions,
   ): Promise<Message | APIMessage>;
-  fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | APIMessage>;
+  fetchMessage(
+    message: Snowflake | '@original',
+    cacheOrOptions?: boolean | WebhookFetchMessageOptions,
+  ): Promise<Message | APIMessage>;
   send(options: string | MessagePayload | WebhookMessageOptions): Promise<Message | APIMessage>;
 }
 
@@ -3378,6 +3381,7 @@ export interface ClientOptions {
   ws?: WebSocketOptions;
   http?: HTTPOptions;
   rejectOnRateLimit?: string[] | ((data: RateLimitData) => boolean | Promise<boolean>);
+  allowWebhookThreadFetching?: boolean;
 }
 
 export type ClientPresenceStatus = 'online' | 'idle' | 'dnd';
@@ -4779,7 +4783,7 @@ export interface WebhookClientDataURL {
 
 export type WebhookClientOptions = Pick<
   ClientOptions,
-  'allowedMentions' | 'restTimeOffset' | 'restRequestTimeout' | 'retryLimit' | 'http'
+  'allowedMentions' | 'restTimeOffset' | 'restRequestTimeout' | 'retryLimit' | 'http' | 'allowWebhookThreadFetching'
 >;
 
 export interface WebhookEditData {
@@ -4790,8 +4794,13 @@ export interface WebhookEditData {
 
 export type WebhookEditMessageOptions = Pick<
   WebhookMessageOptions,
-  'content' | 'embeds' | 'files' | 'allowedMentions' | 'components' | 'attachments'
+  'content' | 'embeds' | 'files' | 'allowedMentions' | 'components' | 'attachments' | 'threadId'
 >;
+
+export interface WebhookFetchMessageOptions {
+  cache?: boolean;
+  threadId?: Snowflake;
+}
 
 export interface WebhookMessageOptions extends Omit<MessageOptions, 'reply'> {
   username?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2119,7 +2119,7 @@ export class WebhookClient extends WebhookMixin(BaseClient) {
     message: MessageResolvable,
     options: string | MessagePayload | WebhookEditMessageOptions,
   ): Promise<APIMessage>;
-  public fetchMessage(message: Snowflake, cacheOrOptions?: boolean | WebhookFetchMessageOptions): Promise<APIMessage>;
+  public fetchMessage(message: Snowflake, cacheOrOptions?: WebhookFetchMessageOptions | boolean): Promise<APIMessage>;
   public send(options: string | MessagePayload | WebhookMessageOptions): Promise<APIMessage>;
 }
 
@@ -2832,7 +2832,7 @@ export interface PartialWebhookFields {
   ): Promise<Message | APIMessage>;
   fetchMessage(
     message: Snowflake | '@original',
-    cacheOrOptions?: boolean | WebhookFetchMessageOptions,
+    cacheOrOptions?: WebhookFetchMessageOptions | boolean,
   ): Promise<Message | APIMessage>;
   send(options: string | MessagePayload | WebhookMessageOptions): Promise<Message | APIMessage>;
 }
@@ -3381,7 +3381,6 @@ export interface ClientOptions {
   ws?: WebSocketOptions;
   http?: HTTPOptions;
   rejectOnRateLimit?: string[] | ((data: RateLimitData) => boolean | Promise<boolean>);
-  allowWebhookThreadFetching?: boolean;
 }
 
 export type ClientPresenceStatus = 'online' | 'idle' | 'dnd';
@@ -4783,7 +4782,7 @@ export interface WebhookClientDataURL {
 
 export type WebhookClientOptions = Pick<
   ClientOptions,
-  'allowedMentions' | 'restTimeOffset' | 'restRequestTimeout' | 'retryLimit' | 'http' | 'allowWebhookThreadFetching'
+  'allowedMentions' | 'restTimeOffset' | 'restRequestTimeout' | 'retryLimit' | 'http'
 >;
 
 export interface WebhookEditData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This will allow webhooks to fetch, edit and delete messages in threads.

Webhook#fetchMessage() unfortunately didn't already have an object for its second parameter. I would have liked to change it to what I commented [here](https://github.com/discordjs/discord.js/issues/6592#issuecomment-927191151) but to keep it not breaking, I instead added a new client option for webhooks that as a sort of opt-in feature flag that makes the library parse the second parameter as an object, thus allowing access to fetching a message in a thread.

Here's an example:
```JavaScript
const { WebhookClient } = require("discord.js");

const webhook1 = new WebhookClient({
  url: "webhook_url1"
});

const webhook2 = new WebhookClient({
  url: "webhook_url2"
}, {
  allowWebhookThreadFetching: true // With this enabled, I can now fetch messages in threads!
});

webhook1.fetchMessage("message_id1", false).then(console.log); // Success!
// No error or change in code as we did not opt-in to fetching in threads. Parameter is unchanged.

webhook2.fetchMessage("message_id2", {
  cache: false,
  threadId: "thread_id"
}).then(console.log); // Success!
```

This should resolve #6592, additional. I am open to adjustments and feedback!


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
