### PR TITLE
types(Presence): fix ActivityOptions#type and Activity#id types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -148,7 +148,7 @@ export class Activity {
   public details: string | null;
   public emoji: Emoji | null;
   public flags: Readonly<ActivityFlags>;
-  public id: Snowflake;
+  public id: string;
   public name: string;
   public party: {
     id: string | null;
@@ -2853,7 +2853,7 @@ export type ActivitiesOptions = Omit<ActivityOptions, 'shardId'>;
 export interface ActivityOptions {
   name?: string;
   url?: string;
-  type?: ActivityType | number;
+  type?: Exclude<ActivityType, 'CUSTOM'> | Exclude<ActivityTypes, ActivityTypes.CUSTOM>;
   shardId?: number | readonly number[];
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the types for ActivityOptions#type by removing the ability to set CUSTOM types as this interface is only used when setting values for the client presence, as well as the type of Activity#id which was incorrectly marked as Snowflake (these are never snowflakes, instead they are strings of numbers and letters like `73ce6c5d7bcf522f`, `spotify:1` or `custom`). The docs didn't need to be changed as these were already correctly set.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
