### PR TITLE
types(ChannelTypes): remove unknown from CHANNEL options

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3080,8 +3080,8 @@ export type ApplicationCommandData =
 
 export interface ApplicationCommandChannelOptionData extends BaseApplicationCommandOptionsData {
   type: CommandOptionChannelResolvableType;
-  channelTypes?: (keyof typeof ChannelTypes | ChannelTypes)[];
-  channel_types?: ChannelTypes[];
+  channelTypes?: Exclude<keyof typeof ChannelTypes | ChannelTypes, 'UNKNOWN' | ChannelTypes.UNKNOWN>[];
+  channel_types?: Exclude<ChannelTypes, ChannelTypes.UNKNOWN>[];
 }
 
 export interface ApplicationCommandChannelOption extends BaseApplicationCommandOptionsData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR simply removes the ability to put UNKNOWN in the channelTypes array in a CHANNEL option on a chat input application command.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
