### PR TITLE
types: fix missing channel type in subcommand options

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3111,12 +3111,12 @@ export interface ApplicationCommandSubGroup extends BaseApplicationCommandOption
 
 export interface ApplicationCommandSubCommandData extends BaseApplicationCommandOptionsData {
   type: 'SUB_COMMAND' | ApplicationCommandOptionTypes.SUB_COMMAND;
-  options?: (ApplicationCommandChoicesData | ApplicationCommandNonOptionsData)[];
+  options?: (ApplicationCommandChoicesData | ApplicationCommandNonOptionsData | ApplicationCommandChannelOptionData)[];
 }
 
 export interface ApplicationCommandSubCommand extends BaseApplicationCommandOptionsData {
   type: 'SUB_COMMAND';
-  options?: (ApplicationCommandChoicesOption | ApplicationCommandNonOptions)[];
+  options?: (ApplicationCommandChoicesOption | ApplicationCommandNonOptions | ApplicationCommandChannelOption)[];
 }
 
 export interface ApplicationCommandNonOptionsData extends BaseApplicationCommandOptionsData {

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -1,6 +1,8 @@
 import { APIInteractionGuildMember } from 'discord-api-types';
 import {
   ApplicationCommand,
+  ApplicationCommandChannelOption,
+  ApplicationCommandChannelOptionData,
   ApplicationCommandChoicesData,
   ApplicationCommandData,
   ApplicationCommandManager,
@@ -752,9 +754,10 @@ declare const applicationSubCommandData: ApplicationCommandSubCommandData;
   assertType<'SUB_COMMAND' | ApplicationCommandOptionTypes.SUB_COMMAND>(applicationSubCommandData.type);
 
   // Check that only subcommands can have no subcommand or subcommand group sub-options.
-  assertType<(ApplicationCommandChoicesData | ApplicationCommandNonOptionsData)[] | undefined>(
-    applicationSubCommandData.options,
-  );
+  assertType<
+    | (ApplicationCommandChoicesData | ApplicationCommandNonOptionsData | ApplicationCommandChannelOptionData)[]
+    | undefined
+  >(applicationSubCommandData.options);
 }
 
 declare const guildApplicationCommandManager: GuildApplicationCommandManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Forgot a thing 🤦 

Closes #6702 

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
