### PR TITLE
docs(EmojiResolvable): update description of typedef to remove ambiguity

### DIFF
--- a/src/managers/BaseGuildEmojiManager.js
+++ b/src/managers/BaseGuildEmojiManager.js
@@ -22,7 +22,7 @@ class BaseGuildEmojiManager extends CachedManager {
 
   /**
    * Data that can be resolved into a GuildEmoji object. This can be:
-   * * A custom emoji identifier
+   * * A Snowflake
    * * A GuildEmoji object
    * * A ReactionEmoji object
    * @typedef {Snowflake|GuildEmoji|ReactionEmoji} EmojiResolvable


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Updates the description to make it clear that it's not referring to the [`identifier`](https://discord.js.org/#/docs/main/stable/class/Emoji?scrollTo=identifier) attribute.

**Status and versioning classification:**
- This PR **only** includes non-code changes
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
