### PR TITLE
feat(PartialGroupDMChannel): Add recipients & fix name

### DIFF
--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -22,6 +22,13 @@ class PartialGroupDMChannel extends Channel {
      * @type {?string}
      */
     this.icon = data.icon;
+
+    /**
+     * The recipients of this Group DM Channel.
+     * <info>This is an array of usernames</info>
+     * @type {string[]}
+     */
+    this.recipients = data.recipients;
   }
 
   /**

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -24,9 +24,14 @@ class PartialGroupDMChannel extends Channel {
     this.icon = data.icon;
 
     /**
+     * Recipient data received in a {@link PartialGroupDMChannel}.
+     * @typedef {Object} PartialRecipient
+     * @property {string} username The username of the recipient
+     */
+
+    /**
      * The recipients of this Group DM Channel.
-     * <info>This is an array of usernames</info>
-     * @type {string[]}
+     * @type {PartialRecipient[]}
      */
     this.recipients = data.recipients;
   }

--- a/src/structures/PartialGroupDMChannel.js
+++ b/src/structures/PartialGroupDMChannel.js
@@ -13,7 +13,7 @@ class PartialGroupDMChannel extends Channel {
 
     /**
      * The name of this Group DM Channel
-     * @type {string}
+     * @type {?string}
      */
     this.name = data.name;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1512,7 +1512,7 @@ export class PartialGroupDMChannel extends Channel {
   public constructor(client: Client, data: RawPartialGroupDMChannelData);
   public name: string | null;
   public icon: string | null;
-  public recipients: string[];
+  public recipients: PartialRecipient[];
   public iconURL(options?: StaticImageURLOptions): string | null;
 }
 
@@ -4542,6 +4542,10 @@ export type PermissionString =
 export type RecursiveArray<T> = ReadonlyArray<T | RecursiveArray<T>>;
 
 export type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray<T>>;
+
+export interface PartialRecipient {
+  username: string;
+}
 
 export type PremiumTier = keyof typeof PremiumTiers;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1510,7 +1510,7 @@ export class OAuth2Guild extends BaseGuild {
 
 export class PartialGroupDMChannel extends Channel {
   public constructor(client: Client, data: RawPartialGroupDMChannelData);
-  public name: string;
+  public name: string | null;
   public icon: string | null;
   public iconURL(options?: StaticImageURLOptions): string | null;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1512,6 +1512,7 @@ export class PartialGroupDMChannel extends Channel {
   public constructor(client: Client, data: RawPartialGroupDMChannelData);
   public name: string | null;
   public icon: string | null;
+  public recipients: string[];
   public iconURL(options?: StaticImageURLOptions): string | null;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Added recipients (array of objects consisting of only usernames)
- Name is `null` when a group direct message channel does not yet have a name (initially created)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
