### PR TITLE
types(Vanity): Make `uses` non-nullable

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -617,7 +617,7 @@ class Guild extends AnonymousGuild {
    * An object containing information about a guild's vanity invite.
    * @typedef {Object} Vanity
    * @property {?string} code Vanity invite code
-   * @property {?number} uses How many times this invite has been used
+   * @property {number} uses How many times this invite has been used
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4804,7 +4804,7 @@ export type UserResolvable = User | Snowflake | Message | GuildMember | ThreadMe
 
 export interface Vanity {
   code: string | null;
-  uses: number | null;
+  uses: number;
 }
 
 export type VerificationLevel = keyof typeof VerificationLevels;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Guild#fetchVanityData() seems to always return a number for `uses`, even in the event that:

- A guild has no vanity URL access
- A guild has vanity URL access but has not set it
- A guild has a vanity URL with no uses

In the above cases, Discord returns 0 for `uses`, so this can never be `null`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
