### PR TITLE
docs(Message): fix return type for `reply`

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -749,7 +749,7 @@ class Message extends Base {
   /**
    * Send an inline reply to this message.
    * @param {string|MessagePayload|ReplyMessageOptions} options The options to provide
-   * @returns {Promise<Message|Message[]>}
+   * @returns {Promise<Message>}
    * @example
    * // Reply to a message
    * message.reply('This is a reply!')


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the return type of `Message#reply` from `Promise<Message | Message[]>` to `Promise<Message>`.

Due to #5918 `Message#reply` can no longer return an array of messages, which is also reflected in [the TypeScript typings][1].


**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

[1]: https://github.com/discordjs/discord.js/blob/fe9500538e76423e49e16a1e1756eb04b5f40531/typings/index.d.ts#L1252