### PR TITLE
refactor(User): set accentColor and banner to undefined when not yet received

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -60,6 +60,7 @@ const Messages = {
 
   FILE_NOT_FOUND: file => `File could not be found: ${file}`,
 
+  USER_BANNER_NOT_FETCHED: "You must fetch this user's banner before trying to generate its URL!",
   USER_NO_DMCHANNEL: 'No DM Channel exists!',
 
   VOICE_NOT_STAGE_CHANNEL: 'You are only allowed to do this in stage channels.',

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -89,7 +89,7 @@ class User extends Base {
        * @type {?number}
        */
       this.accentColor = data.accent_color;
-    } else if (this.banner !== null) {
+    } else if (this.accentColor !== null) {
       this.accentColor ??= undefined;
     }
 

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -175,7 +175,7 @@ class User extends Base {
    * @readonly
    */
   get hexAccentColor() {
-    if (!this.accentColor && typeof this.accentColor !== 'number') return this.accentColor;
+    if (typeof this.accentColor !== 'number') return this.accentColor;
     return `#${this.accentColor.toString(16).padStart(6, '0')}`;
   }
 

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -74,23 +74,23 @@ class User extends Base {
     if ('banner' in data) {
       /**
        * The user banner's hash
-       * <info>The user must be force fetched for this property to be present</info>
+       * <info>The user must be force fetched for this property to be present or be updated</info>
        * @type {?string}
        */
       this.banner = data.banner;
-    } else {
-      this.banner ??= null;
+    } else if (this.banner !== null) {
+      this.banner ??= undefined;
     }
 
     if ('accent_color' in data) {
       /**
        * The base 10 accent color of the user's banner
-       * <info>The user must be force fetched for this property to be present</info>
+       * <info>The user must be force fetched for this property to be present or be updated</info>
        * @type {?number}
        */
       this.accentColor = data.accent_color;
-    } else {
-      this.accentColor ??= null;
+    } else if (this.banner !== null) {
+      this.accentColor ??= undefined;
     }
 
     if ('system' in data) {
@@ -175,17 +175,19 @@ class User extends Base {
    * @readonly
    */
   get hexAccentColor() {
-    if (!this.accentColor) return null;
+    if (!this.accentColor) return this.accentColor;
     return `#${this.accentColor.toString(16).padStart(6, '0')}`;
   }
 
   /**
    * A link to the user's banner.
-   * <info>The user must be force fetched for this property to be present</info>
+   * <info>This method will throw an error if called before the user is force fetched.
+   * See {@link User#banner} for more info</info>
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   bannerURL({ format, size, dynamic } = {}) {
+    if (typeof this.banner === 'undefined') throw new Error('USER_BANNER_NOT_FETCHED');
     if (!this.banner) return null;
     return this.client.rest.cdn.Banner(this.id, this.banner, format, size, dynamic);
   }

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -175,7 +175,7 @@ class User extends Base {
    * @readonly
    */
   get hexAccentColor() {
-    if (!this.accentColor) return this.accentColor;
+    if (!this.accentColor && typeof this.accentColor !== 'number') return this.accentColor;
     return `#${this.accentColor.toString(16).padStart(6, '0')}`;
   }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2039,9 +2039,9 @@ export class User extends PartialTextBasedChannel(Base) {
   protected constructor(client: Client, data: RawUserData);
   private _equals(user: APIUser): boolean;
 
-  public accentColor: number | null;
+  public accentColor: number | null | undefined;
   public avatar: string | null;
-  public banner: string | null;
+  public banner: string | null | undefined;
   public bot: boolean;
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -2049,7 +2049,7 @@ export class User extends PartialTextBasedChannel(Base) {
   public readonly defaultAvatarURL: string;
   public readonly dmChannel: DMChannel | null;
   public flags: Readonly<UserFlags> | null;
-  public readonly hexAccentColor: HexColorString | null;
+  public readonly hexAccentColor: HexColorString | null | undefined;
   public id: Snowflake;
   public readonly partial: false;
   public system: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the accentColor and banner properties in User to default to undefined when they're not present in the payload since they need to be force-fetched for the client to receive them. I'm doing this because these properties can actually be null after being fetched (meaning they're not present) and that would make it hard to tell those two scenarios apart. To go along with these changes I also made hexAccentColor return accentColor when this is falsy (so either null or undefined, to avoid duplicating code) and made User#bannerURL throw an error when being called before the user is fetched. Despite the new error, this should not be semver major as these properties are not live on stable yet.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
