### PR TITLE
docs(CommandInteractionResolvedData): fix key type

### DIFF
--- a/src/structures/BaseCommandInteraction.js
+++ b/src/structures/BaseCommandInteraction.js
@@ -78,11 +78,11 @@ class BaseCommandInteraction extends Interaction {
   /**
    * Represents the resolved data of a received command interaction.
    * @typedef {Object} CommandInteractionResolvedData
-   * @property {Collection<string, User>} [users] The resolved users
-   * @property {Collection<string, GuildMember|APIGuildMember>} [members] The resolved guild members
-   * @property {Collection<string, Role|APIRole>} [roles] The resolved roles
-   * @property {Collection<string, Channel|APIChannel>} [channels] The resolved channels
-   * @property {Collection<string, Message|APIMessage>} [messages] The resolved messages
+   * @property {Collection<Snowflake, User>} [users] The resolved users
+   * @property {Collection<Snowflake, GuildMember|APIGuildMember>} [members] The resolved guild members
+   * @property {Collection<Snowflake, Role|APIRole>} [roles] The resolved roles
+   * @property {Collection<Snowflake, Channel|APIChannel>} [channels] The resolved channels
+   * @property {Collection<Snowflake, Message|APIMessage>} [messages] The resolved messages
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3510,11 +3510,11 @@ export interface CommandInteractionOption {
 }
 
 export interface CommandInteractionResolvedData {
-  users?: Collection<string, User>;
-  members?: Collection<string, GuildMember | APIInteractionDataResolvedGuildMember>;
-  roles?: Collection<string, Role | APIRole>;
-  channels?: Collection<string, Channel | APIInteractionDataResolvedChannel>;
-  messages?: Collection<string, Message | APIMessage>;
+  users?: Collection<Snowflake, User>;
+  members?: Collection<Snowflake, GuildMember | APIInteractionDataResolvedGuildMember>;
+  roles?: Collection<Snowflake, Role | APIRole>;
+  channels?: Collection<Snowflake, Channel | APIInteractionDataResolvedChannel>;
+  messages?: Collection<Snowflake, Message | APIMessage>;
 }
 
 export interface ConstantsClientApplicationAssetTypes {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the type of the key value in the CommandInteractionResolvedData collections in both the docs and the typings

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
