### PR TITLE
docs: undocument private constructors

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -14,10 +14,6 @@ let Worker = null;
  * @extends EventEmitter
  */
 class Shard extends EventEmitter {
-  /**
-   * @param {ShardingManager} manager Manager that is creating this shard
-   * @param {number} id The shard's id
-   */
   constructor(manager, id) {
     super();
 

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -9,10 +9,6 @@ const Util = require('../util/Util');
  * Utilises IPC to send and receive data to/from the master process and other shards.
  */
 class ShardClientUtil {
-  /**
-   * @param {Client} client Client of the current shard
-   * @param {ShardingManagerMode} mode Mode the shard was spawned with
-   */
   constructor(client, mode) {
     /**
      * Client for the shard

--- a/src/structures/BaseGuildTextChannel.js
+++ b/src/structures/BaseGuildTextChannel.js
@@ -14,11 +14,6 @@ const DataResolver = require('../util/DataResolver');
  * @implements {TextBasedChannel}
  */
 class BaseGuildTextChannel extends GuildChannel {
-  /**
-   * @param {Guild} guild The guild the text channel is part of
-   * @param {APIChannel} data The data for the text channel
-   * @param {Client} [client] A safety parameter for the client that instantiated this
-   */
   constructor(guild, data, client) {
     super(guild, data, client, false);
 

--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -72,3 +72,9 @@ class ClientPresence extends Presence {
 }
 
 module.exports = ClientPresence;
+
+/* eslint-disable max-len */
+/**
+ * @external APIPresence
+ * @see {@link https://discord.com/developers/docs/rich-presence/how-to#updating-presence-update-presence-payload-fields}
+ */

--- a/src/structures/ClientPresence.js
+++ b/src/structures/ClientPresence.js
@@ -9,10 +9,6 @@ const { ActivityTypes, Opcodes } = require('../util/Constants');
  * @extends {Presence}
  */
 class ClientPresence extends Presence {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIPresence} [data={}] The data for the client presence
-   */
   constructor(client, data = {}) {
     super(client, Object.assign(data, { status: data.status ?? 'online', user: { id: null } }));
   }

--- a/src/structures/DMChannel.js
+++ b/src/structures/DMChannel.js
@@ -10,10 +10,6 @@ const MessageManager = require('../managers/MessageManager');
  * @implements {TextBasedChannel}
  */
 class DMChannel extends Channel {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIChannel} data The data for the DM channel
-   */
   constructor(client, data) {
     super(client, data);
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -132,11 +132,6 @@ class Guild extends AnonymousGuild {
     return this.client.ws.shards.get(this.shardId);
   }
 
-  /**
-   * Sets up the guild.
-   * @param {*} data The raw data of the guild
-   * @private
-   */
   _patch(data) {
     super._patch(data);
     this.id = data.id;

--- a/src/structures/GuildBan.js
+++ b/src/structures/GuildBan.js
@@ -55,8 +55,3 @@ class GuildBan extends Base {
 }
 
 module.exports = GuildBan;
-
-/**
- * @external APIBanData
- * @see {@link https://discord.com/developers/docs/resources/guild#create-guild-ban-json-params}
- */

--- a/src/structures/GuildBan.js
+++ b/src/structures/GuildBan.js
@@ -7,11 +7,6 @@ const Base = require('./Base');
  * @extends {Base}
  */
 class GuildBan extends Base {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIBanData} data The data for the ban
-   * @param {Guild} guild The guild in which the ban is
-   */
   constructor(client, data, guild) {
     super(client);
 

--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -20,12 +20,6 @@ const Util = require('../util/Util');
  * @abstract
  */
 class GuildChannel extends Channel {
-  /**
-   * @param {Guild} guild The guild the guild channel is part of
-   * @param {APIChannel} data The data for the guild channel
-   * @param {Client} [client] A safety parameter for the client that instantiated this
-   * @param {boolean} [immediatePatch=true] Control variable for patching
-   */
   constructor(guild, data, client, immediatePatch = true) {
     super(guild?.client ?? client, data, false);
 

--- a/src/structures/GuildEmoji.js
+++ b/src/structures/GuildEmoji.js
@@ -10,11 +10,6 @@ const Permissions = require('../util/Permissions');
  * @extends {BaseGuildEmoji}
  */
 class GuildEmoji extends BaseGuildEmoji {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIEmoji} data The data for the guild emoji
-   * @param {Guild} guild The guild the guild emoji is part of
-   */
   constructor(client, data, guild) {
     super(client, data, guild);
 

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -13,11 +13,6 @@ const Permissions = require('../util/Permissions');
  * @extends {Base}
  */
 class GuildMember extends Base {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIGuildMember} data The data for the guild member
-   * @param {Guild} guild The guild the member is part of
-   */
   constructor(client, data, guild) {
     super(client);
 

--- a/src/structures/GuildPreview.js
+++ b/src/structures/GuildPreview.js
@@ -18,11 +18,6 @@ class GuildPreview extends Base {
     this._patch(data);
   }
 
-  /**
-   * Builds the guild with the provided data.
-   * @param {*} data The raw data of the guild
-   * @private
-   */
   _patch(data) {
     /**
      * The id of this guild

--- a/src/structures/GuildTemplate.js
+++ b/src/structures/GuildTemplate.js
@@ -14,12 +14,6 @@ class GuildTemplate extends Base {
     this._patch(data);
   }
 
-  /**
-   * Builds or updates the template with the provided data.
-   * @param {APIGuildTemplate} data The raw data for the template
-   * @returns {GuildTemplate}
-   * @private
-   */
   _patch(data) {
     /**
      * The unique code of this template
@@ -219,9 +213,3 @@ class GuildTemplate extends Base {
 GuildTemplate.GUILD_TEMPLATES_PATTERN = /discord(?:app)?\.(?:com\/template|new)\/([\w-]{2,255})/gi;
 
 module.exports = GuildTemplate;
-
-/* eslint-disable max-len */
-/**
- * @external APIGuildTemplate
- * @see {@link https://discord.com/developers/docs/resources/guild-template#guild-template-object-guild-template-structure}
- */

--- a/src/structures/GuildTemplate.js
+++ b/src/structures/GuildTemplate.js
@@ -9,10 +9,6 @@ const DataResolver = require('../util/DataResolver');
  * @extends {Base}
  */
 class GuildTemplate extends Base {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIGuildTemplate} data The raw data for the template
-   */
   constructor(client, data) {
     super(client);
     this._patch(data);

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -24,10 +24,6 @@ const Util = require('../util/Util');
  * @extends {Base}
  */
 class Message extends Base {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIMessage} data The data for the message
-   */
   constructor(client, data) {
     super(client);
 

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -9,11 +9,6 @@ const Util = require('../util/Util');
  * Represents a reaction to a message.
  */
 class MessageReaction {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIReaction} data The data for the message reaction
-   * @param {Message} message The message the reaction refers to
-   */
   constructor(client, data, message) {
     /**
      * The client that instantiated this message reaction

--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -130,8 +130,3 @@ class MessageReaction {
 }
 
 module.exports = MessageReaction;
-
-/**
- * @external APIReaction
- * @see {@link https://discord.com/developers/docs/resources/channel#reaction-object}
- */

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -370,9 +370,3 @@ class RichPresenceAssets {
 exports.Presence = Presence;
 exports.Activity = Activity;
 exports.RichPresenceAssets = RichPresenceAssets;
-
-/* eslint-disable max-len */
-/**
- * @external APIPresence
- * @see {@link https://discord.com/developers/docs/rich-presence/how-to#updating-presence-update-presence-payload-fields}
- */

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -35,10 +35,6 @@ const Util = require('../util/Util');
  * @extends {Base}
  */
 class Presence extends Base {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIPresence} [data={}] The data for the presence
-   */
   constructor(client, data = {}) {
     super(client);
 

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -11,11 +11,6 @@ const Util = require('../util/Util');
  * @extends {Base}
  */
 class Role extends Base {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIRole} data The data for the role
-   * @param {Guild} guild The guild the role is part of
-   */
   constructor(client, data, guild) {
     super(client);
 

--- a/src/structures/Sticker.js
+++ b/src/structures/Sticker.js
@@ -9,10 +9,6 @@ const SnowflakeUtil = require('../util/SnowflakeUtil');
  * @extends {Base}
  */
 class Sticker extends Base {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APISticker | APIStickerItem} sticker The data for the sticker
-   */
   constructor(client, sticker) {
     super(client);
 

--- a/src/structures/Sticker.js
+++ b/src/structures/Sticker.js
@@ -234,8 +234,3 @@ module.exports = Sticker;
  * @external APISticker
  * @see {@link https://discord.com/developers/docs/resources/sticker#sticker-object}
  */
-
-/**
- * @external APIStickerItem
- * @see {@link https://discord.com/developers/docs/resources/sticker#sticker-item-object}
- */

--- a/src/structures/StickerPack.js
+++ b/src/structures/StickerPack.js
@@ -10,10 +10,6 @@ const SnowflakeUtil = require('../util/SnowflakeUtil');
  * @extends {Base}
  */
 class StickerPack extends Base {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIStickerPack} pack The data for the sticker pack
-   */
   constructor(client, pack) {
     super(client);
     /**

--- a/src/structures/StickerPack.js
+++ b/src/structures/StickerPack.js
@@ -93,8 +93,3 @@ class StickerPack extends Base {
 }
 
 module.exports = StickerPack;
-
-/**
- * @external APIStickerPack
- * @see {@link https://discord.com/developers/docs/resources/sticker#sticker-pack-object}
- */

--- a/src/structures/StoreChannel.js
+++ b/src/structures/StoreChannel.js
@@ -7,11 +7,6 @@ const GuildChannel = require('./GuildChannel');
  * @extends {GuildChannel}
  */
 class StoreChannel extends GuildChannel {
-  /**
-   * @param {Guild} guild The guild the store channel is part of
-   * @param {APIChannel} data The data for the store channel
-   * @param {Client} [client] A safety parameter for the client that instantiated this
-   */
   constructor(guild, data, client) {
     super(guild, data, client);
 

--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -13,12 +13,6 @@ const Permissions = require('../util/Permissions');
  * @implements {TextBasedChannel}
  */
 class ThreadChannel extends Channel {
-  /**
-   * @param {Guild} guild The guild the thread channel is part of
-   * @param {APIChannel} data The data for the thread channel
-   * @param {Client} [client] A safety parameter for the client that instantiated this
-   * @param {boolean} [fromInteraction=false] Whether the data was from an interaction (partial)
-   */
   constructor(guild, data, client, fromInteraction = false) {
     super(guild?.client ?? client, data, false);
 

--- a/src/structures/ThreadMember.js
+++ b/src/structures/ThreadMember.js
@@ -8,10 +8,6 @@ const ThreadMemberFlags = require('../util/ThreadMemberFlags');
  * @extends {Base}
  */
 class ThreadMember extends Base {
-  /**
-   * @param {ThreadChannel} thread The thread that this member is associated with
-   * @param {APIThreadMember} data The data for the thread member
-   */
   constructor(thread, data) {
     super(thread.client);
 

--- a/src/structures/ThreadMember.js
+++ b/src/structures/ThreadMember.js
@@ -90,8 +90,3 @@ class ThreadMember extends Base {
 }
 
 module.exports = ThreadMember;
-
-/**
- * @external APIThreadMember
- * @see {@link https://discord.com/developers/docs/resources/channel#thread-member-object}
- */

--- a/src/structures/Typing.js
+++ b/src/structures/Typing.js
@@ -7,11 +7,6 @@ const Base = require('./Base');
  * @extends {Base}
  */
 class Typing extends Base {
-  /**
-   * @param {TextBasedChannels} channel The channel this typing came from
-   * @param {User} user The user that started typing
-   * @param {APITypingStart} data The raw data received
-   */
   constructor(channel, user, data) {
     super(channel.client);
 

--- a/src/structures/Typing.js
+++ b/src/structures/Typing.js
@@ -70,8 +70,3 @@ class Typing extends Base {
 }
 
 module.exports = Typing;
-
-/**
- * @external APITypingStart
- * @see {@link https://discord.com/developers/docs/topics/gateway#typing-start-typing-start-event-fields}
- */

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -12,10 +12,6 @@ const UserFlags = require('../util/UserFlags');
  * @extends {Base}
  */
 class User extends Base {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {APIUser} data The data for the user
-   */
   constructor(client, data) {
     super(client);
 

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -225,8 +225,3 @@ class VoiceState extends Base {
 }
 
 module.exports = VoiceState;
-
-/**
- * @external APIVoiceState
- * @see {@link https://discord.com/developers/docs/resources/voice#voice-state-object}
- */

--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -7,10 +7,6 @@ const { Error, TypeError } = require('../errors');
  * Represents the voice state for a Guild Member.
  */
 class VoiceState extends Base {
-  /**
-   * @param {Guild} guild The guild the voice state is part of
-   * @param {APIVoiceState} data The data for the voice state
-   */
   constructor(guild, data) {
     super(guild.client);
     /**

--- a/src/structures/Widget.js
+++ b/src/structures/Widget.js
@@ -8,10 +8,6 @@ const WidgetMember = require('./WidgetMember');
  * Represents a Widget.
  */
 class Widget extends Base {
-  /**
-   * @param {Client} client The instantiating client
-   * @param {Object} data The raw data
-   */
   constructor(client, data) {
     super(client);
     this._patch(data);

--- a/src/structures/Widget.js
+++ b/src/structures/Widget.js
@@ -21,11 +21,6 @@ class Widget extends Base {
    * @property {number} position Position of the channel
    */
 
-  /**
-   * Builds the widget with the provided data.
-   * @param {*} data The raw data of the widget
-   * @private
-   */
   _patch(data) {
     /**
      * The id of the guild.

--- a/src/structures/WidgetMember.js
+++ b/src/structures/WidgetMember.js
@@ -12,10 +12,6 @@ class WidgetMember extends Base {
    * @property {string} name The name of the activity
    */
 
-  /**
-   * @param {Client} client The instantiating client
-   * @param {Object} data The raw data
-   */
   constructor(client, data) {
     super(client);
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -137,7 +137,7 @@ import {
 //#region Classes
 
 export class Activity {
-  public constructor(presence: Presence, data?: RawActivityData);
+  private constructor(presence: Presence, data?: RawActivityData);
   public applicationId: Snowflake | null;
   public assets: RichPresenceAssets | null;
   public buttons: string[];
@@ -171,7 +171,7 @@ export class ActivityFlags extends BitField<ActivityFlagsString> {
 }
 
 export abstract class AnonymousGuild extends BaseGuild {
-  public constructor(client: Client, data: RawAnonymousGuildData, immediatePatch?: boolean);
+  protected constructor(client: Client, data: RawAnonymousGuildData, immediatePatch?: boolean);
   public banner: string | null;
   public description: string | null;
   public nsfwLevel: NSFWLevel;
@@ -183,7 +183,7 @@ export abstract class AnonymousGuild extends BaseGuild {
 }
 
 export abstract class Application extends Base {
-  public constructor(client: Client, data: RawApplicationData);
+  protected constructor(client: Client, data: RawApplicationData);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
   public description: string | null;
@@ -198,7 +198,7 @@ export abstract class Application extends Base {
 }
 
 export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
-  public constructor(client: Client, data: RawApplicationCommandData, guild?: Guild, guildId?: Snowflake);
+  private constructor(client: Client, data: RawApplicationCommandData, guild?: Guild, guildId?: Snowflake);
   public applicationId: Snowflake;
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -247,7 +247,7 @@ export class ApplicationFlags extends BitField<ApplicationFlagsString> {
   public static resolve(bit?: BitFieldResolvable<ApplicationFlagsString, number>): number;
 }
 
-export class Base {
+export abstract class Base {
   public constructor(client: Client);
   public readonly client: Client;
   public toJSON(...props: Record<string, boolean | string>[]): unknown;
@@ -292,7 +292,7 @@ export abstract class BaseCommandInteraction extends Interaction {
 }
 
 export abstract class BaseGuild extends Base {
-  public constructor(client: Client, data: RawBaseGuildData);
+  protected constructor(client: Client, data: RawBaseGuildData);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
   public features: GuildFeatures[];
@@ -308,7 +308,7 @@ export abstract class BaseGuild extends Base {
 }
 
 export class BaseGuildEmoji extends Emoji {
-  public constructor(client: Client, data: RawGuildEmojiData, guild: Guild | GuildPreview);
+  protected constructor(client: Client, data: RawGuildEmojiData, guild: Guild | GuildPreview);
   public available: boolean | null;
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -319,7 +319,7 @@ export class BaseGuildEmoji extends Emoji {
 }
 
 export class BaseGuildTextChannel extends TextBasedChannel(GuildChannel) {
-  public constructor(guild: Guild, data?: RawGuildChannelData, client?: Client, immediatePatch?: boolean);
+  protected constructor(guild: Guild, data?: RawGuildChannelData, client?: Client, immediatePatch?: boolean);
   public defaultAutoArchiveDuration?: ThreadAutoArchiveDuration;
   public messages: MessageManager;
   public nsfw: boolean;
@@ -340,7 +340,7 @@ export class BaseGuildTextChannel extends TextBasedChannel(GuildChannel) {
 }
 
 export class BaseGuildVoiceChannel extends GuildChannel {
-  public constructor(guild: Guild, data?: RawGuildChannelData);
+  protected constructor(guild: Guild, data?: RawGuildChannelData);
   public readonly members: Collection<Snowflake, GuildMember>;
   public readonly full: boolean;
   public readonly joinable: boolean;
@@ -353,7 +353,7 @@ export class BaseGuildVoiceChannel extends GuildChannel {
 }
 
 export class BaseMessageComponent {
-  public constructor(data?: BaseMessageComponent | BaseMessageComponentOptions);
+  protected constructor(data?: BaseMessageComponent | BaseMessageComponentOptions);
   public type: MessageComponentType | null;
   private static create(
     data: MessageComponentOptions,
@@ -383,7 +383,7 @@ export class BitField<S extends string, N extends number | bigint = number> {
 }
 
 export class ButtonInteraction extends MessageComponentInteraction {
-  public constructor(client: Client, data: RawMessageButtonInteractionData);
+  private constructor(client: Client, data: RawMessageButtonInteractionData);
   public componentType: 'BUTTON';
 }
 
@@ -394,7 +394,7 @@ export class CategoryChannel extends GuildChannel {
 
 export type CategoryChannelResolvable = Snowflake | CategoryChannel;
 
-export class Channel extends Base {
+export abstract class Channel extends Base {
   public constructor(client: Client, data?: RawChannelData, immediatePatch?: boolean);
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -474,7 +474,7 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
 }
 
 export class ClientApplication extends Application {
-  public constructor(client: Client, data: RawClientApplicationData);
+  private constructor(client: Client, data: RawClientApplicationData);
   public botPublic: boolean | null;
   public botRequireCodeGrant: boolean | null;
   public commands: ApplicationCommandManager;
@@ -487,7 +487,7 @@ export class ClientApplication extends Application {
 }
 
 export class ClientPresence extends Presence {
-  public constructor(client: Client, data: RawPresenceData);
+  private constructor(client: Client, data: RawPresenceData);
   private _parse(data: PresenceData): RawPresenceData;
 
   public set(presence: PresenceData): ClientPresence;
@@ -516,7 +516,7 @@ export class Options extends null {
 }
 
 export class ClientVoiceManager {
-  public constructor(client: Client);
+  private constructor(client: Client);
   public readonly client: Client;
   public adapters: Map<Snowflake, InternalDiscordGatewayAdapterLibraryMethods>;
 }
@@ -524,7 +524,7 @@ export class ClientVoiceManager {
 export { Collection } from '@discordjs/collection';
 
 export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmitter {
-  public constructor(client: Client, options?: CollectorOptions<[V, ...F]>);
+  protected constructor(client: Client, options?: CollectorOptions<[V, ...F]>);
   private _timeout: NodeJS.Timeout | null;
   private _idletimeout: NodeJS.Timeout | null;
 
@@ -559,7 +559,7 @@ export class CommandInteraction extends BaseCommandInteraction {
 }
 
 export class CommandInteractionOptionResolver {
-  public constructor(client: Client, options: CommandInteractionOption[], resolved: CommandInteractionResolvedData);
+  private constructor(client: Client, options: CommandInteractionOption[], resolved: CommandInteractionResolvedData);
   public readonly client: Client;
   public readonly data: readonly CommandInteractionOption[];
   public readonly resolved: Readonly<CommandInteractionResolvedData>;
@@ -633,7 +633,7 @@ export class DataResolver extends null {
 }
 
 export class DiscordAPIError extends Error {
-  public constructor(error: unknown, status: number, request: unknown);
+  private constructor(error: unknown, status: number, request: unknown);
   private static flattenErrors(obj: unknown, key: string): string[];
 
   public code: number;
@@ -644,7 +644,7 @@ export class DiscordAPIError extends Error {
 }
 
 export class DMChannel extends TextBasedChannel(Channel, ['bulkDelete']) {
-  public constructor(client: Client, data?: RawDMChannelData);
+  private constructor(client: Client, data?: RawDMChannelData);
   public messages: MessageManager;
   public recipient: User;
   public type: 'DM';
@@ -652,7 +652,7 @@ export class DMChannel extends TextBasedChannel(Channel, ['bulkDelete']) {
 }
 
 export class Emoji extends Base {
-  public constructor(client: Client, emoji: RawEmojiData);
+  protected constructor(client: Client, emoji: RawEmojiData);
   public animated: boolean | null;
   public readonly createdAt: Date | null;
   public readonly createdTimestamp: number | null;
@@ -666,7 +666,7 @@ export class Emoji extends Base {
 }
 
 export class Guild extends AnonymousGuild {
-  public constructor(client: Client, data: RawGuildData);
+  private constructor(client: Client, data: RawGuildData);
   private _sortedRoles(): Collection<Snowflake, Role>;
   private _sortedChannels(channel: Channel): Collection<Snowflake, GuildChannel>;
 
@@ -768,7 +768,7 @@ export class Guild extends AnonymousGuild {
 }
 
 export class GuildAuditLogs {
-  public constructor(guild: Guild, data: RawGuildAuditLogData);
+  private constructor(guild: Guild, data: RawGuildAuditLogData);
   private webhooks: Collection<Snowflake, Webhook>;
   private integrations: Collection<Snowflake | string, Integration>;
 
@@ -784,7 +784,7 @@ export class GuildAuditLogs {
 }
 
 export class GuildAuditLogsEntry {
-  public constructor(logs: GuildAuditLogs, guild: Guild, data: RawGuildAuditLogEntryData);
+  private constructor(logs: GuildAuditLogs, guild: Guild, data: RawGuildAuditLogEntryData);
   public action: GuildAuditLogsAction;
   public actionType: GuildAuditLogsActionType;
   public changes: AuditLogChange[] | null;
@@ -814,7 +814,7 @@ export class GuildAuditLogsEntry {
 }
 
 export class GuildBan extends Base {
-  public constructor(client: Client, data: RawGuildBanData, guild: Guild);
+  private constructor(client: Client, data: RawGuildBanData, guild: Guild);
   public guild: Guild;
   public user: User;
   public readonly partial: boolean;
@@ -822,7 +822,7 @@ export class GuildBan extends Base {
   public fetch(force?: boolean): Promise<GuildBan>;
 }
 
-export class GuildChannel extends Channel {
+export abstract class GuildChannel extends Channel {
   public constructor(guild: Guild, data?: RawGuildChannelData, client?: Client, immediatePatch?: boolean);
   private memberPermissions(member: GuildMember): Readonly<Permissions>;
   private rolePermissions(role: Role): Readonly<Permissions>;
@@ -856,7 +856,7 @@ export class GuildChannel extends Channel {
 }
 
 export class GuildEmoji extends BaseGuildEmoji {
-  public constructor(client: Client, data: RawGuildEmojiData, guild: Guild);
+  private constructor(client: Client, data: RawGuildEmojiData, guild: Guild);
   private _roles: Snowflake[];
 
   public readonly deletable: boolean;
@@ -872,7 +872,7 @@ export class GuildEmoji extends BaseGuildEmoji {
 }
 
 export class GuildMember extends PartialTextBasedChannel(Base) {
-  public constructor(client: Client, data: RawGuildMemberData, guild: Guild);
+  private constructor(client: Client, data: RawGuildMemberData, guild: Guild);
   public avatar: string | null;
   public readonly bannable: boolean;
   public deleted: boolean;
@@ -911,7 +911,7 @@ export class GuildMember extends PartialTextBasedChannel(Base) {
 }
 
 export class GuildPreview extends Base {
-  public constructor(client: Client, data: RawGuildPreviewData);
+  private constructor(client: Client, data: RawGuildPreviewData);
   public approximateMemberCount: number;
   public approximatePresenceCount: number;
   public readonly createdAt: Date;
@@ -933,7 +933,7 @@ export class GuildPreview extends Base {
 }
 
 export class GuildTemplate extends Base {
-  public constructor(client: Client, data: RawGuildTemplateData);
+  private constructor(client: Client, data: RawGuildTemplateData);
   public readonly createdTimestamp: number;
   public readonly updatedTimestamp: number;
   public readonly url: string;
@@ -957,13 +957,13 @@ export class GuildTemplate extends Base {
 }
 
 export class GuildPreviewEmoji extends BaseGuildEmoji {
-  public constructor(client: Client, data: RawGuildEmojiData, guild: GuildPreview);
+  private constructor(client: Client, data: RawGuildEmojiData, guild: GuildPreview);
   public guild: GuildPreview;
   public roles: Snowflake[];
 }
 
 export class HTTPError extends Error {
-  public constructor(message: string, name: string, code: number, request: unknown);
+  private constructor(message: string, name: string, code: number, request: unknown);
   public code: number;
   public method: string;
   public name: string;
@@ -974,12 +974,12 @@ export class HTTPError extends Error {
 // tslint:disable-next-line:no-empty-interface - Merge RateLimitData into RateLimitError to not have to type it again
 export interface RateLimitError extends RateLimitData {}
 export class RateLimitError extends Error {
-  public constructor(data: RateLimitData);
+  private constructor(data: RateLimitData);
   public name: 'RateLimitError';
 }
 
 export class Integration extends Base {
-  public constructor(client: Client, data: RawIntegrationData, guild: Guild);
+  private constructor(client: Client, data: RawIntegrationData, guild: Guild);
   public account: IntegrationAccount;
   public application: IntegrationApplication | null;
   public enabled: boolean;
@@ -1001,7 +1001,7 @@ export class Integration extends Base {
 }
 
 export class IntegrationApplication extends Application {
-  public constructor(client: Client, data: RawIntegrationApplicationData);
+  private constructor(client: Client, data: RawIntegrationApplicationData);
   public bot: User | null;
   public termsOfServiceURL: string | null;
   public privacyPolicyURL: string | null;
@@ -1018,7 +1018,7 @@ export class Intents extends BitField<IntentsString> {
 }
 
 export class Interaction extends Base {
-  public constructor(client: Client, data: RawInteractionData);
+  protected constructor(client: Client, data: RawInteractionData);
   public applicationId: Snowflake;
   public readonly channel: TextBasedChannels | null;
   public channelId: Snowflake | null;
@@ -1079,7 +1079,7 @@ export class InteractionWebhook extends PartialWebhookMixin() {
 }
 
 export class Invite extends Base {
-  public constructor(client: Client, data: RawInviteData);
+  private constructor(client: Client, data: RawInviteData);
   public channel: GuildChannel | PartialGroupDMChannel;
   public code: string;
   public readonly deletable: boolean;
@@ -1107,7 +1107,7 @@ export class Invite extends Base {
 }
 
 export class InviteStageInstance extends Base {
-  public constructor(client: Client, data: RawInviteStageInstance, channelId: Snowflake, guildId: Snowflake);
+  private constructor(client: Client, data: RawInviteStageInstance, channelId: Snowflake, guildId: Snowflake);
   public channelId: Snowflake;
   public guildId: Snowflake;
   public members: Collection<Snowflake, GuildMember>;
@@ -1119,7 +1119,7 @@ export class InviteStageInstance extends Base {
 }
 
 export class InviteGuild extends AnonymousGuild {
-  public constructor(client: Client, data: RawInviteGuildData);
+  private constructor(client: Client, data: RawInviteGuildData);
   public welcomeScreen: WelcomeScreen | null;
 }
 
@@ -1185,7 +1185,7 @@ type AwaitMessageCollectorOptionsParams<T extends MessageComponentType | Message
     >;
 
 export class Message extends Base {
-  public constructor(client: Client, data: RawMessageData);
+  private constructor(client: Client, data: RawMessageData);
   private _patch(data: RawPartialMessageData, partial: true): void;
   private _patch(data: RawMessageData, partial?: boolean): void;
   private _update(data: RawPartialMessageData, partial: true): Message;
@@ -1330,7 +1330,7 @@ export class MessageCollector extends Collector<Snowflake, Message> {
 }
 
 export class MessageComponentInteraction extends Interaction {
-  public constructor(client: Client, data: RawMessageComponentInteractionData);
+  protected constructor(client: Client, data: RawMessageComponentInteractionData);
   public readonly channel: TextBasedChannels | null;
   public readonly component: MessageActionRowComponent | Exclude<APIMessageComponent, APIActionRowComponent> | null;
   public componentType: Exclude<MessageComponentType, 'ACTION_ROW'>;
@@ -1401,7 +1401,7 @@ export class MessageFlags extends BitField<MessageFlagsString> {
 }
 
 export class MessageMentions {
-  public constructor(
+  private constructor(
     message: Message,
     users: APIUser[] | Collection<Snowflake, User>,
     roles: Snowflake[] | Collection<Snowflake, Role>,
@@ -1457,7 +1457,7 @@ export class MessagePayload {
 }
 
 export class MessageReaction {
-  public constructor(client: Client, data: RawMessageReactionData, message: Message);
+  private constructor(client: Client, data: RawMessageReactionData, message: Message);
   private _emoji: GuildEmoji | ReactionEmoji;
 
   public readonly client: Client;
@@ -1503,20 +1503,20 @@ export class NewsChannel extends BaseGuildTextChannel {
 }
 
 export class OAuth2Guild extends BaseGuild {
-  public constructor(client: Client, data: RawOAuth2GuildData);
+  private constructor(client: Client, data: RawOAuth2GuildData);
   public owner: boolean;
   public permissions: Readonly<Permissions>;
 }
 
 export class PartialGroupDMChannel extends Channel {
-  public constructor(client: Client, data: RawPartialGroupDMChannelData);
+  private constructor(client: Client, data: RawPartialGroupDMChannelData);
   public name: string;
   public icon: string | null;
   public iconURL(options?: StaticImageURLOptions): string | null;
 }
 
 export class PermissionOverwrites extends Base {
-  public constructor(client: Client, data: RawPermissionOverwriteData, channel: GuildChannel);
+  private constructor(client: Client, data: RawPermissionOverwriteData, channel: GuildChannel);
   public allow: Readonly<Permissions>;
   public readonly channel: GuildChannel;
   public deny: Readonly<Permissions>;
@@ -1547,7 +1547,7 @@ export class Permissions extends BitField<PermissionString, bigint> {
 }
 
 export class Presence extends Base {
-  public constructor(client: Client, data?: RawPresenceData);
+  protected constructor(client: Client, data?: RawPresenceData);
   public activities: Activity[];
   public clientStatus: ClientPresenceStatusData | null;
   public guild: Guild | null;
@@ -1589,13 +1589,13 @@ export class ReactionCollector extends Collector<Snowflake | string, MessageReac
 }
 
 export class ReactionEmoji extends Emoji {
-  public constructor(reaction: MessageReaction, emoji: RawReactionEmojiData);
+  private constructor(reaction: MessageReaction, emoji: RawReactionEmojiData);
   public reaction: MessageReaction;
   public toJSON(): unknown;
 }
 
 export class RichPresenceAssets {
-  public constructor(activity: Activity, assets: RawRichPresenceAssets);
+  private constructor(activity: Activity, assets: RawRichPresenceAssets);
   public largeImage: Snowflake | null;
   public largeText: string | null;
   public smallImage: Snowflake | null;
@@ -1605,7 +1605,7 @@ export class RichPresenceAssets {
 }
 
 export class Role extends Base {
-  public constructor(client: Client, data: RawRoleData, guild: Guild);
+  private constructor(client: Client, data: RawRoleData, guild: Guild);
   public color: number;
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
@@ -1647,7 +1647,7 @@ export class SelectMenuInteraction extends MessageComponentInteraction {
 }
 
 export class Shard extends EventEmitter {
-  public constructor(manager: ShardingManager, id: number);
+  private constructor(manager: ShardingManager, id: number);
   private _evals: Map<string, Promise<unknown>>;
   private _exitListener: (...args: any[]) => void;
   private _fetches: Map<string, Promise<unknown>>;
@@ -1684,7 +1684,7 @@ export class Shard extends EventEmitter {
 }
 
 export class ShardClientUtil {
-  public constructor(client: Client, mode: ShardingManagerMode);
+  private constructor(client: Client, mode: ShardingManagerMode);
   private _handleMessage(message: unknown): void;
   private _respond(type: string, message: unknown): void;
 
@@ -1767,7 +1767,7 @@ export class StageChannel extends BaseGuildVoiceChannel {
 }
 
 export class StageInstance extends Base {
-  public constructor(client: Client, data: RawStageInstanceData, channel: StageChannel);
+  private constructor(client: Client, data: RawStageInstanceData, channel: StageChannel);
   public id: Snowflake;
   public deleted: boolean;
   public guildId: Snowflake;
@@ -1785,7 +1785,7 @@ export class StageInstance extends Base {
 }
 
 export class Sticker extends Base {
-  public constructor(client: Client, data: RawStickerData);
+  private constructor(client: Client, data: RawStickerData);
   public readonly createdTimestamp: number;
   public readonly createdAt: Date;
   public available: boolean | null;
@@ -1811,7 +1811,7 @@ export class Sticker extends Base {
 }
 
 export class StickerPack extends Base {
-  public constructor(client: Client, data: RawStickerPackData);
+  private constructor(client: Client, data: RawStickerPackData);
   public readonly createdTimestamp: number;
   public readonly createdAt: Date;
   public bannerId: Snowflake;
@@ -1826,7 +1826,7 @@ export class StickerPack extends Base {
 }
 
 export class StoreChannel extends GuildChannel {
-  public constructor(guild: Guild, data?: RawGuildChannelData, client?: Client);
+  private constructor(guild: Guild, data?: RawGuildChannelData, client?: Client);
   public createInvite(options?: CreateInviteOptions): Promise<Invite>;
   public fetchInvites(cache?: boolean): Promise<Collection<string, Invite>>;
   public nsfw: boolean;
@@ -1839,7 +1839,7 @@ export class SystemChannelFlags extends BitField<SystemChannelFlagsString> {
 }
 
 export class Team extends Base {
-  public constructor(client: Client, data: RawTeamData);
+  private constructor(client: Client, data: RawTeamData);
   public id: Snowflake;
   public name: string;
   public icon: string | null;
@@ -1856,7 +1856,7 @@ export class Team extends Base {
 }
 
 export class TeamMember extends Base {
-  public constructor(team: Team, data: RawTeamMemberData);
+  private constructor(team: Team, data: RawTeamMemberData);
   public team: Team;
   public readonly id: Snowflake;
   public permissions: string[];
@@ -1874,7 +1874,7 @@ export class TextChannel extends BaseGuildTextChannel {
 }
 
 export class ThreadChannel extends TextBasedChannel(Channel) {
-  public constructor(guild: Guild, data?: RawThreadChannelData, client?: Client, fromInteraction?: boolean);
+  private constructor(guild: Guild, data?: RawThreadChannelData, client?: Client, fromInteraction?: boolean);
   public archived: boolean | null;
   public readonly archivedAt: Date | null;
   public archiveTimestamp: number | null;
@@ -1920,7 +1920,7 @@ export class ThreadChannel extends TextBasedChannel(Channel) {
 }
 
 export class ThreadMember extends Base {
-  public constructor(thread: ThreadChannel, data?: RawThreadMemberData);
+  private constructor(thread: ThreadChannel, data?: RawThreadMemberData);
   public flags: ThreadMemberFlags;
   public readonly guildMember: GuildMember | null;
   public id: Snowflake;
@@ -1938,7 +1938,7 @@ export class ThreadMemberFlags extends BitField<ThreadMemberFlagsString> {
 }
 
 export class Typing extends Base {
-  public constructor(channel: TextBasedChannels, user: PartialUser, data?: RawTypingData);
+  private constructor(channel: TextBasedChannels, user: PartialUser, data?: RawTypingData);
   public channel: TextBasedChannels;
   public user: PartialUser;
   public startedTimestamp: number;
@@ -1952,7 +1952,7 @@ export class Typing extends Base {
 }
 
 export class User extends PartialTextBasedChannel(Base) {
-  public constructor(client: Client, data: RawUserData);
+  protected constructor(client: Client, data: RawUserData);
   public accentColor: number | null;
   public avatar: string | null;
   public banner: string | null;
@@ -2060,7 +2060,7 @@ export class VoiceChannel extends BaseGuildVoiceChannel {
 }
 
 export class VoiceRegion {
-  public constructor(data: RawVoiceRegionData);
+  private constructor(data: RawVoiceRegionData);
   public custom: boolean;
   public deprecated: boolean;
   public id: string;
@@ -2071,7 +2071,7 @@ export class VoiceRegion {
 }
 
 export class VoiceState extends Base {
-  public constructor(guild: Guild, data: RawVoiceStateData);
+  private constructor(guild: Guild, data: RawVoiceStateData);
   public readonly channel: VoiceChannel | StageChannel | null;
   public channelId: Snowflake | null;
   public readonly deaf: boolean | null;
@@ -2098,7 +2098,7 @@ export class VoiceState extends Base {
 }
 
 export class Webhook extends WebhookMixin() {
-  public constructor(client: Client, data?: RawWebhookData);
+  private constructor(client: Client, data?: RawWebhookData);
   public avatar: string;
   public avatarURL(options?: StaticImageURLOptions): string | null;
   public channelId: Snowflake;
@@ -2126,7 +2126,7 @@ export class WebhookClient extends WebhookMixin(BaseClient) {
 }
 
 export class WebSocketManager extends EventEmitter {
-  public constructor(client: Client);
+  private constructor(client: Client);
   private totalShards: number | string;
   private shardQueue: Set<WebSocketShard>;
   private packetQueue: unknown[];
@@ -2154,7 +2154,7 @@ export class WebSocketManager extends EventEmitter {
 }
 
 export class WebSocketShard extends EventEmitter {
-  public constructor(manager: WebSocketManager, id: number);
+  private constructor(manager: WebSocketManager, id: number);
   private sequence: number;
   private closeSequence: number;
   private sessionId: string | null;
@@ -2207,7 +2207,7 @@ export class WebSocketShard extends EventEmitter {
 }
 
 export class Widget extends Base {
-  public constructor(client: Client, data: RawWidgetData);
+  private constructor(client: Client, data: RawWidgetData);
   private _patch(data: RawWidgetData): void;
   public fetch(): Promise<Widget>;
   public id: Snowflake;
@@ -2218,7 +2218,7 @@ export class Widget extends Base {
 }
 
 export class WidgetMember extends Base {
-  public constructor(client: Client, data: RawWidgetMemberData);
+  private constructor(client: Client, data: RawWidgetMemberData);
   public id: string;
   public username: string;
   public discriminator: string;
@@ -2235,7 +2235,7 @@ export class WidgetMember extends Base {
 }
 
 export class WelcomeChannel extends Base {
-  constructor(guild: Guild, data: RawWelcomeChannelData);
+  private constructor(guild: Guild, data: RawWelcomeChannelData);
   private _emoji: Omit<APIEmoji, 'animated'>;
   public channelId: Snowflake;
   public guild: Guild | InviteGuild;
@@ -2245,7 +2245,7 @@ export class WelcomeChannel extends Base {
 }
 
 export class WelcomeScreen extends Base {
-  constructor(guild: Guild, data: RawWelcomeScreenData);
+  private constructor(guild: Guild, data: RawWelcomeScreenData);
   public readonly enabled: boolean;
   public guild: Guild | InviteGuild;
   public description: string | null;
@@ -2393,12 +2393,12 @@ export const version: string;
 //#region Managers
 
 export abstract class BaseManager {
-  public constructor(client: Client);
+  protected constructor(client: Client);
   public readonly client: Client;
 }
 
 export abstract class DataManager<K, Holds, R> extends BaseManager {
-  public constructor(client: Client, holds: Constructable<Holds>);
+  protected constructor(client: Client, holds: Constructable<Holds>);
   public readonly holds: Constructable<Holds>;
   public readonly cache: Collection<K, Holds>;
   public resolve(resolvable: Holds): Holds;
@@ -2409,7 +2409,7 @@ export abstract class DataManager<K, Holds, R> extends BaseManager {
 }
 
 export abstract class CachedManager<K, Holds, R> extends DataManager<K, Holds, R> {
-  public constructor(client: Client, holds: Constructable<Holds>);
+  protected constructor(client: Client, holds: Constructable<Holds>);
   private _add(data: unknown, cache?: boolean, { id, extras }?: { id: K; extras: unknown[] }): Holds;
 }
 
@@ -2420,7 +2420,7 @@ export class ApplicationCommandManager<
   PermissionsOptionsExtras = { guild: GuildResolvable },
   PermissionsGuildType = null,
 > extends CachedManager<Snowflake, ApplicationCommandScope, ApplicationCommandResolvable> {
-  public constructor(client: Client, iterable?: Iterable<unknown>);
+  protected constructor(client: Client, iterable?: Iterable<unknown>);
   public permissions: ApplicationCommandPermissionsManager<
     { command?: ApplicationCommandResolvable } & PermissionsOptionsExtras,
     { command: ApplicationCommandResolvable } & PermissionsOptionsExtras,
@@ -2467,7 +2467,7 @@ export class ApplicationCommandPermissionsManager<
   GuildType,
   CommandIdType,
 > extends BaseManager {
-  public constructor(manager: ApplicationCommandManager | GuildApplicationCommandManager | ApplicationCommand);
+  private constructor(manager: ApplicationCommandManager | GuildApplicationCommandManager | ApplicationCommand);
   private manager: ApplicationCommandManager | GuildApplicationCommandManager | ApplicationCommand;
 
   public client: Client;
@@ -2508,17 +2508,17 @@ export class ApplicationCommandPermissionsManager<
 }
 
 export class BaseGuildEmojiManager extends CachedManager<Snowflake, GuildEmoji, EmojiResolvable> {
-  public constructor(client: Client, iterable?: Iterable<RawGuildEmojiData>);
+  protected constructor(client: Client, iterable?: Iterable<RawGuildEmojiData>);
   public resolveIdentifier(emoji: EmojiIdentifierResolvable): string | null;
 }
 
 export class ChannelManager extends CachedManager<Snowflake, Channel, ChannelResolvable> {
-  public constructor(client: Client, iterable: Iterable<RawChannelData>);
+  private constructor(client: Client, iterable: Iterable<RawChannelData>);
   public fetch(id: Snowflake, options?: FetchChannelOptions): Promise<Channel | null>;
 }
 
 export class GuildApplicationCommandManager extends ApplicationCommandManager<ApplicationCommand, {}, Guild> {
-  public constructor(guild: Guild, iterable?: Iterable<RawApplicationCommandData>);
+  private constructor(guild: Guild, iterable?: Iterable<RawApplicationCommandData>);
   public guild: Guild;
   public create(command: ApplicationCommandDataResolvable): Promise<ApplicationCommand>;
   public delete(command: ApplicationCommandResolvable): Promise<ApplicationCommand | null>;
@@ -2536,7 +2536,7 @@ export class GuildChannelManager extends CachedManager<
   GuildChannel | ThreadChannel,
   GuildChannelResolvable
 > {
-  public constructor(guild: Guild, iterable?: Iterable<RawGuildChannelData>);
+  private constructor(guild: Guild, iterable?: Iterable<RawGuildChannelData>);
   public readonly channelCountWithoutThreads: number;
   public guild: Guild;
   public create(name: string, options: GuildChannelCreateOptions & { type: 'GUILD_VOICE' }): Promise<VoiceChannel>;
@@ -2569,7 +2569,7 @@ export class GuildChannelManager extends CachedManager<
 }
 
 export class GuildEmojiManager extends BaseGuildEmojiManager {
-  public constructor(guild: Guild, iterable?: Iterable<RawGuildEmojiData>);
+  private constructor(guild: Guild, iterable?: Iterable<RawGuildEmojiData>);
   public guild: Guild;
   public create(
     attachment: BufferResolvable | Base64Resolvable,
@@ -2581,7 +2581,7 @@ export class GuildEmojiManager extends BaseGuildEmojiManager {
 }
 
 export class GuildEmojiRoleManager extends DataManager<Snowflake, Role, RoleResolvable> {
-  public constructor(emoji: GuildEmoji);
+  private constructor(emoji: GuildEmoji);
   public emoji: GuildEmoji;
   public guild: Guild;
   public add(
@@ -2594,14 +2594,14 @@ export class GuildEmojiRoleManager extends DataManager<Snowflake, Role, RoleReso
 }
 
 export class GuildManager extends CachedManager<Snowflake, Guild, GuildResolvable> {
-  public constructor(client: Client, iterable?: Iterable<RawGuildData>);
+  private constructor(client: Client, iterable?: Iterable<RawGuildData>);
   public create(name: string, options?: GuildCreateOptions): Promise<Guild>;
   public fetch(options: Snowflake | FetchGuildOptions): Promise<Guild>;
   public fetch(options?: FetchGuildsOptions): Promise<Collection<Snowflake, OAuth2Guild>>;
 }
 
 export class GuildMemberManager extends CachedManager<Snowflake, GuildMember, GuildMemberResolvable> {
-  public constructor(guild: Guild, iterable?: Iterable<RawGuildMemberData>);
+  private constructor(guild: Guild, iterable?: Iterable<RawGuildMemberData>);
   public guild: Guild;
   public add(
     user: UserResolvable,
@@ -2623,7 +2623,7 @@ export class GuildMemberManager extends CachedManager<Snowflake, GuildMember, Gu
 }
 
 export class GuildBanManager extends CachedManager<Snowflake, GuildBan, GuildBanResolvable> {
-  public constructor(guild: Guild, iterable?: Iterable<RawGuildBanData>);
+  private constructor(guild: Guild, iterable?: Iterable<RawGuildBanData>);
   public guild: Guild;
   public create(user: UserResolvable, options?: BanOptions): Promise<GuildMember | User | Snowflake>;
   public fetch(options: UserResolvable | FetchBanOptions): Promise<GuildBan>;
@@ -2632,7 +2632,7 @@ export class GuildBanManager extends CachedManager<Snowflake, GuildBan, GuildBan
 }
 
 export class GuildInviteManager extends DataManager<string, Invite, InviteResolvable> {
-  public constructor(guild: Guild, iterable?: Iterable<RawInviteData>);
+  private constructor(guild: Guild, iterable?: Iterable<RawInviteData>);
   public guild: Guild;
   public create(channel: GuildChannelResolvable, options?: CreateInviteOptions): Promise<Invite>;
   public fetch(options: InviteResolvable | FetchInviteOptions): Promise<Invite>;
@@ -2641,7 +2641,7 @@ export class GuildInviteManager extends DataManager<string, Invite, InviteResolv
 }
 
 export class GuildStickerManager extends CachedManager<Snowflake, Sticker, StickerResolvable> {
-  public constructor(guild: Guild, iterable?: Iterable<RawStickerData>);
+  private constructor(guild: Guild, iterable?: Iterable<RawStickerData>);
   public guild: Guild;
   public create(
     file: BufferResolvable | Stream | FileOptions | MessageAttachment,
@@ -2656,7 +2656,7 @@ export class GuildStickerManager extends CachedManager<Snowflake, Sticker, Stick
 }
 
 export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleResolvable> {
-  public constructor(member: GuildMember);
+  private constructor(member: GuildMember);
   public readonly hoist: Role | null;
   public readonly color: Role | null;
   public readonly highest: Role;
@@ -2677,7 +2677,7 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
 }
 
 export class MessageManager extends CachedManager<Snowflake, Message, MessageResolvable> {
-  public constructor(channel: TextBasedChannels, iterable?: Iterable<RawMessageData>);
+  private constructor(channel: TextBasedChannels, iterable?: Iterable<RawMessageData>);
   public channel: TextBasedChannels;
   public cache: Collection<Snowflake, Message>;
   public crosspost(message: MessageResolvable): Promise<Message>;
@@ -2699,7 +2699,7 @@ export class PermissionOverwriteManager extends CachedManager<
   PermissionOverwrites,
   PermissionOverwriteResolvable
 > {
-  public constructor(client: Client, iterable?: Iterable<RawPermissionOverwriteData>);
+  private constructor(client: Client, iterable?: Iterable<RawPermissionOverwriteData>);
   public set(
     overwrites: readonly OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>,
     reason?: string,
@@ -2724,24 +2724,24 @@ export class PermissionOverwriteManager extends CachedManager<
 }
 
 export class PresenceManager extends CachedManager<Snowflake, Presence, PresenceResolvable> {
-  public constructor(client: Client, iterable?: Iterable<RawPresenceData>);
+  private constructor(client: Client, iterable?: Iterable<RawPresenceData>);
 }
 
 export class ReactionManager extends CachedManager<Snowflake | string, MessageReaction, MessageReactionResolvable> {
-  public constructor(message: Message, iterable?: Iterable<RawMessageReactionData>);
+  private constructor(message: Message, iterable?: Iterable<RawMessageReactionData>);
   public message: Message;
   public removeAll(): Promise<Message>;
 }
 
 export class ReactionUserManager extends CachedManager<Snowflake, User, UserResolvable> {
-  public constructor(reaction: MessageReaction, iterable?: Iterable<RawUserData>);
+  private constructor(reaction: MessageReaction, iterable?: Iterable<RawUserData>);
   public reaction: MessageReaction;
   public fetch(options?: FetchReactionUsersOptions): Promise<Collection<Snowflake, User>>;
   public remove(user?: UserResolvable): Promise<MessageReaction>;
 }
 
 export class RoleManager extends CachedManager<Snowflake, Role, RoleResolvable> {
-  public constructor(guild: Guild, iterable?: Iterable<RawRoleData>);
+  private constructor(guild: Guild, iterable?: Iterable<RawRoleData>);
   public readonly everyone: Role;
   public readonly highest: Role;
   public guild: Guild;
@@ -2754,7 +2754,7 @@ export class RoleManager extends CachedManager<Snowflake, Role, RoleResolvable> 
 }
 
 export class StageInstanceManager extends CachedManager<Snowflake, StageInstance, StageInstanceResolvable> {
-  public constructor(guild: Guild, iterable?: Iterable<RawStageInstanceData>);
+  private constructor(guild: Guild, iterable?: Iterable<RawStageInstanceData>);
   public guild: Guild;
   public create(channel: StageChannelResolvable, options: StageInstanceCreateOptions): Promise<StageInstance>;
   public fetch(channel: StageChannelResolvable, options?: BaseFetchOptions): Promise<StageInstance>;
@@ -2763,7 +2763,7 @@ export class StageInstanceManager extends CachedManager<Snowflake, StageInstance
 }
 
 export class ThreadManager<AllowedThreadType> extends CachedManager<Snowflake, ThreadChannel, ThreadChannelResolvable> {
-  public constructor(channel: TextChannel | NewsChannel, iterable?: Iterable<RawThreadChannelData>);
+  private constructor(channel: TextChannel | NewsChannel, iterable?: Iterable<RawThreadChannelData>);
   public channel: TextChannel | NewsChannel;
   public create(options: ThreadCreateOptions<AllowedThreadType>): Promise<ThreadChannel>;
   public fetch(options: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<ThreadChannel | null>;
@@ -2773,7 +2773,7 @@ export class ThreadManager<AllowedThreadType> extends CachedManager<Snowflake, T
 }
 
 export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, ThreadMemberResolvable> {
-  public constructor(thread: ThreadChannel, iterable?: Iterable<RawThreadMemberData>);
+  private constructor(thread: ThreadChannel, iterable?: Iterable<RawThreadMemberData>);
   public thread: ThreadChannel;
   public add(member: UserResolvable | '@me', reason?: string): Promise<Snowflake>;
   public fetch(cache?: boolean): Promise<Collection<Snowflake, ThreadMember>>;
@@ -2781,12 +2781,12 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
 }
 
 export class UserManager extends CachedManager<Snowflake, User, UserResolvable> {
-  public constructor(client: Client, iterable?: Iterable<RawUserData>);
+  private constructor(client: Client, iterable?: Iterable<RawUserData>);
   public fetch(user: UserResolvable, options?: BaseFetchOptions): Promise<User>;
 }
 
 export class VoiceStateManager extends CachedManager<Snowflake, VoiceState, typeof VoiceState> {
-  public constructor(guild: Guild, iterable?: Iterable<RawVoiceStateData>);
+  private constructor(guild: Guild, iterable?: Iterable<RawVoiceStateData>);
   public guild: Guild;
 }
 
@@ -2798,7 +2798,7 @@ export class VoiceStateManager extends CachedManager<Snowflake, VoiceState, type
 // to the classes that use these methods without having to manually add them
 // to each of those classes
 
-export type Constructable<T> = new (...args: any[]) => T;
+export type Constructable<T> = abstract new (...args: any[]) => T;
 export function PartialTextBasedChannel<T>(Base?: Constructable<T>): Constructable<T & PartialTextBasedChannelFields>;
 export function TextBasedChannel<T, I extends keyof TextBasedChannelFields = never>(
   Base?: Constructable<T>,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1509,7 +1509,7 @@ export class OAuth2Guild extends BaseGuild {
 }
 
 export class PartialGroupDMChannel extends Channel {
-  public constructor(client: Client, data: RawPartialGroupDMChannelData);
+  private constructor(client: Client, data: RawPartialGroupDMChannelData);
   public name: string | null;
   public icon: string | null;
   public recipients: PartialRecipient[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes documentation for private constructors.
Those being documented confused library consumers into thinking that they are supposed / intended to instantiate those classes themselves.

Some constructors were intended to be documented due to `Structures.extend` use-cases, but this feature has, since then, been removed.

Changed classes:
- `Shard`
- `ShardClientUtil`
- `BaseGuildTextChannel`
- `ClientPresence`
- `DMChannel`
- `GuildBan`
- `GuildChannel`
- `GuildEmoji`
- `GuildTemplate`
- `Message`
- `MessageReaction`
- `Presence`
- `Role`
- `Sticker`
- `StickerPack`
- `StoreChannel`
- `ThreadChannel`
- `ThreadMember`
- `Typing`
- `User`
- `VoiceState`
- `Widget`
- `WidgetMember`

This PR also modifies the types to no longer allow instantiation where unintended, this includes few more classes than listed above.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

