### PR TITLE
feature(UserFlags): add BOT_HTTP_INTERACTIONS

### DIFF
--- a/src/util/UserFlags.js
+++ b/src/util/UserFlags.js
@@ -52,6 +52,7 @@ UserFlags.FLAGS = {
   VERIFIED_BOT: 1 << 16,
   EARLY_VERIFIED_BOT_DEVELOPER: 1 << 17,
   DISCORD_CERTIFIED_MODERATOR: 1 << 18,
+  BOT_HTTP_INTERACTIONS: 1 << 19,
 };
 
 module.exports = UserFlags;

--- a/src/util/UserFlags.js
+++ b/src/util/UserFlags.js
@@ -35,6 +35,7 @@ class UserFlags extends BitField {}
  * * `VERIFIED_BOT`
  * * `EARLY_VERIFIED_BOT_DEVELOPER`
  * * `DISCORD_CERTIFIED_MODERATOR`
+ * * `BOT_HTTP_INTERACTIONS`
  * @type {Object}
  * @see {@link https://discord.com/developers/docs/resources/user#user-object-user-flags}
  */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4796,7 +4796,8 @@ export type UserFlagsString =
   | 'BUGHUNTER_LEVEL_2'
   | 'VERIFIED_BOT'
   | 'EARLY_VERIFIED_BOT_DEVELOPER'
-  | 'DISCORD_CERTIFIED_MODERATOR';
+  | 'DISCORD_CERTIFIED_MODERATOR'
+  | 'BOT_HTTP_INTERACTIONS';
 
 export type UserMention = `<@${Snowflake}>`;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds the `BOT_HTTP_INTERACTIONS` user flag, which removes the offline status indicator for bots that only use interactions over HTTP in the client.
- https://github.com/Discord-Datamining/Discord-Datamining/commit/816e51e609e7baf0f34b2bf23d5dc4c00479a9b1#commitcomment-57376404
- https://github.com/discord/discord-api-docs/pull/3903


**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
