### PR TITLE
fix(Shard): use provided timeout when respawning

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -96,7 +96,7 @@ class Shard extends EventEmitter {
      * @type {Function}
      * @private
      */
-    this._exitListener = this._handleExit.bind(this, undefined);
+    this._exitListener = null;
   }
 
   /**
@@ -109,6 +109,8 @@ class Shard extends EventEmitter {
   spawn(timeout = 30_000) {
     if (this.process) throw new Error('SHARDING_PROCESS_EXISTS', this.id);
     if (this.worker) throw new Error('SHARDING_WORKER_EXISTS', this.id);
+
+    this._exitListener = this._handleExit.bind(this, undefined, timeout);
 
     if (this.manager.mode === 'process') {
       this.process = childProcess
@@ -136,7 +138,7 @@ class Shard extends EventEmitter {
      */
     this.emit('spawn', child);
 
-    if (timeout === -1 || timeout === Infinity) return child;
+    if (timeout === -1 || timeout === Infinity) return Promise.resolve(child);
     return new Promise((resolve, reject) => {
       const cleanup = () => {
         clearTimeout(spawnTimeoutTimer);
@@ -383,9 +385,11 @@ class Shard extends EventEmitter {
   /**
    * Handles the shard's process/worker exiting.
    * @param {boolean} [respawn=this.manager.respawn] Whether to spawn the shard again
+   * @param {number} [timeout] The amount in milliseconds to wait until the {@link Client}
+   * has become ready (`-1` or `Infinity` for no wait)
    * @private
    */
-  _handleExit(respawn = this.manager.respawn) {
+  _handleExit(respawn = this.manager.respawn, timeout) {
     /**
      * Emitted upon the shard's child process/worker exiting.
      * @event Shard#death
@@ -399,7 +403,7 @@ class Shard extends EventEmitter {
     this._evals.clear();
     this._fetches.clear();
 
-    if (respawn) this.spawn().catch(err => this.emit('error', err));
+    if (respawn) this.spawn(timeout).catch(err => this.emit('error', err));
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1651,7 +1651,7 @@ export class Shard extends EventEmitter {
   private _evals: Map<string, Promise<unknown>>;
   private _exitListener: (...args: any[]) => void;
   private _fetches: Map<string, Promise<unknown>>;
-  private _handleExit(respawn?: boolean): void;
+  private _handleExit(respawn?: boolean, timeout?: number): void;
   private _handleMessage(message: unknown): void;
 
   public args: string[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR resolves #6575 in a semver: patch manner by attaching the provided timeout to the exit listener which then passes this timeout back to the spawn method.
Also resolved a bug where `Shard#spawn` would not return a promise when the timeout was disabled.

A semver: major solution would be to remove timeout parameters and make them properties to be specified when constructing the sharding manger (or at least the shard).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
