### PR TITLE
chore(readme): remove erlpack from optional packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ pnpm add discord.js
 ### Optional packages
 
 - [zlib-sync](https://www.npmjs.com/package/zlib-sync) for WebSocket data compression and inflation (`npm install zlib-sync`)
-- [erlpack](https://github.com/discord/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install discord/erlpack`)
 - [bufferutil](https://www.npmjs.com/package/bufferutil) for a much faster WebSocket connection (`npm install bufferutil`)
 - [utf-8-validate](https://www.npmjs.com/package/utf-8-validate) in combination with `bufferutil` for much faster WebSocket processing (`npm install utf-8-validate`)
 - [@discordjs/voice](https://github.com/discordjs/voice) for interacting with the Discord Voice API


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR removes [erlpack](https://github.com/discord/erlpack) from the optional packages section of the README. 

Erlpack is __not__ compatible with Node.js v16.6.0 (which discord.js requires) so it can't be used, and shouldn't be listed.

These changes should be reverted if/when https://github.com/discord/erlpack/pull/41 is merged.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
