### PR TITLE
feat(Interaction): add memberPermissions

### DIFF
--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -73,7 +73,7 @@ class Interaction extends Base {
      * The permissions of the member, if one exists, in the channel this interaction was executed in
      * @type {?Readonly<Permissions>}
      */
-    this.memberPermissions = data.member?.permissions ? new Permissions(data.member.permissions) : null;
+    this.memberPermissions = data.member?.permissions ? new Permissions(data.member.permissions).freeze() : null;
   }
 
   /**

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -70,7 +70,7 @@ class Interaction extends Base {
     this.version = data.version;
 
     /**
-     * This member permissions, if exists, in the channel this interaction was sent in
+     * The permissions of the member, if one exists, in the channel this interaction was executed in
      * @type {?Permissions}
      */
     this.memberPermissions = data.member?.permissions != null ? new Permissions(data.member.permissions) : null;

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -3,6 +3,7 @@
 const Base = require('./Base');
 const { InteractionTypes, MessageComponentTypes } = require('../util/Constants');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
+const Permissions = require('../util/Permissions');
 
 /**
  * Represents an interaction.
@@ -67,6 +68,12 @@ class Interaction extends Base {
      * @type {number}
      */
     this.version = data.version;
+
+    /**
+     * This member permissions, if exists, in the channel this interaction was sent in
+     * @type {?Permissions}
+     */
+     this.memberPermissions = data.member?.permissions ? new Permissions( data.member.permissions ) : null;
   }
 
   /**

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -71,7 +71,7 @@ class Interaction extends Base {
 
     /**
      * The permissions of the member, if one exists, in the channel this interaction was executed in
-     * @type {?Permissions}
+     * @type {?Readonly<Permissions>}
      */
     this.memberPermissions = data.member?.permissions ? new Permissions(data.member.permissions) : null;
   }

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -73,7 +73,7 @@ class Interaction extends Base {
      * This member permissions, if exists, in the channel this interaction was sent in
      * @type {?Permissions}
      */
-     this.memberPermissions = data.member?.permissions ? new Permissions( data.member.permissions ) : null;
+    this.memberPermissions = data.member?.permissions != null ? new Permissions(data.member.permissions) : null;
   }
 
   /**

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -2,8 +2,8 @@
 
 const Base = require('./Base');
 const { InteractionTypes, MessageComponentTypes } = require('../util/Constants');
-const SnowflakeUtil = require('../util/SnowflakeUtil');
 const Permissions = require('../util/Permissions');
+const SnowflakeUtil = require('../util/SnowflakeUtil');
 
 /**
  * Represents an interaction.
@@ -73,7 +73,7 @@ class Interaction extends Base {
      * The permissions of the member, if one exists, in the channel this interaction was executed in
      * @type {?Permissions}
      */
-    this.memberPermissions = data.member?.permissions != null ? new Permissions(data.member.permissions) : null;
+    this.memberPermissions = data.member?.permissions ? new Permissions(data.member.permissions) : null;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1032,6 +1032,7 @@ export class Interaction extends Base {
   public type: InteractionType;
   public user: User;
   public version: number;
+  public memberPermissions: Permissions | null;
   public inGuild(): this is this & {
     guildId: Snowflake;
     member: GuildMember | APIInteractionGuildMember;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1032,7 +1032,7 @@ export class Interaction extends Base {
   public type: InteractionType;
   public user: User;
   public version: number;
-  public memberPermissions: Permissions | null;
+  public memberPermissions: Readonly<Permissions> | null;
   public inGuild(): this is this & {
     guildId: Snowflake;
     member: GuildMember | APIInteractionGuildMember;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Implements `<Interaction>.member.permissions`, if exists, sent with an interaction. `null` if the interaction was sent via DM.

Attempting to fetch an _uncached_ channel without `VIEW_CHANNEL` will result in a `Missing Access` error. However, interactions can still be received and responded to in channels which a bot does not have `VIEW_CHANNEL` for. Unless we use `<Interaction>.member.permissions` [sent with the interaction](https://canary.discord.com/developers/docs/interactions/slash-commands#receiving-an-interaction) , it's impossible to get the permissions of a member in an uncached channel.

Large bots which cannot afford to cache tens of millions of channels, roles, and permissions, could rely on the permissions sent with the interaction.


**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
