### PR TITLE
fix(Invite): #guild never resolving into a Guild

### DIFF
--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -26,7 +26,7 @@ class Invite extends Base {
      */
     this.guild = null;
     if (data.guild) {
-      this.guild = this.client.guilds.resolve(data.guild) ?? new InviteGuild(this.client, data.guild);
+      this.guild = this.client.guilds.resolve(data.guild.id) ?? new InviteGuild(this.client, data.guild);
     }
 
     /**

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -20,14 +20,13 @@ class Invite extends Base {
 
   _patch(data) {
     const InviteGuild = require('./InviteGuild');
-    const Guild = require('./Guild');
     /**
      * The guild the invite is for including welcome screen data if present
      * @type {?(Guild|InviteGuild)}
      */
     this.guild = null;
     if (data.guild) {
-      this.guild = data.guild instanceof Guild ? data.guild : new InviteGuild(this.client, data.guild);
+      this.guild = this.client.guilds.resolve(data.guild) ?? new InviteGuild(this.client, data.guild);
     }
 
     /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixed a bug with Invite#guild where it was documented as possibly being InviteGuild or Guild but it could never be the latter since `data.guild` can never be an instanceof Guild, since that's the raw data received from Discord. This shouldn't be breaking as the docs and types already had this behavior predicted, it was just poorly implemented

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
