### PR TITLE
types: More accurate types instead of `GuildChannelResolvable`

### DIFF
--- a/src/managers/GuildInviteManager.js
+++ b/src/managers/GuildInviteManager.js
@@ -67,7 +67,8 @@ class GuildInviteManager extends CachedManager {
   /**
    * Options used to fetch all invites from a guild.
    * @typedef {Object} FetchInvitesOptions
-   * @property {GuildChannelResolvable} [channelId] The channel to fetch all invites from
+   * @property {TextChannel|VoiceChannel|NewsChannel|StoreChannel|StageChannel|Snowflake} [channelId]
+   * The channel to fetch all invites from
    * @property {boolean} [cache=true] Whether or not to cache the fetched invites
    */
 
@@ -153,7 +154,8 @@ class GuildInviteManager extends CachedManager {
 
   /**
    * Create an invite to the guild from the provided channel.
-   * @param {GuildChannelResolvable} channel The options for creating the invite from a channel.
+   * @param {TextChannel|VoiceChannel|NewsChannel|StoreChannel|StageChannel|Snowflake} channel
+   * The options for creating the invite from a channel.
    * @param {CreateInviteOptions} [options={}] The options for creating the invite from a channel.
    * @returns {Promise<Invite>}
    * @example

--- a/src/managers/GuildInviteManager.js
+++ b/src/managers/GuildInviteManager.js
@@ -39,6 +39,18 @@ class GuildInviteManager extends CachedManager {
    */
 
   /**
+   * Data that can be resolved to a channel that an invite can be created on. This can be:
+   * * TextChannel
+   * * VoiceChannel
+   * * NewsChannel
+   * * StoreChannel
+   * * StageChannel
+   * * Snowflake
+   * @typedef {TextChannel|VoiceChannel|NewsChannel|StoreChannel|StageChannel|Snowflake}
+   * GuildInvitableChannelResolvable
+   */
+
+  /**
    * Resolves an InviteResolvable to an Invite object.
    * @method resolve
    * @memberof GuildInviteManager
@@ -67,7 +79,7 @@ class GuildInviteManager extends CachedManager {
   /**
    * Options used to fetch all invites from a guild.
    * @typedef {Object} FetchInvitesOptions
-   * @property {TextChannel|VoiceChannel|NewsChannel|StoreChannel|StageChannel|Snowflake} [channelId]
+   * @property {GuildInvitableChannelResolvable} [channelId]
    * The channel to fetch all invites from
    * @property {boolean} [cache=true] Whether or not to cache the fetched invites
    */
@@ -154,8 +166,7 @@ class GuildInviteManager extends CachedManager {
 
   /**
    * Create an invite to the guild from the provided channel.
-   * @param {TextChannel|VoiceChannel|NewsChannel|StoreChannel|StageChannel|Snowflake} channel
-   * The options for creating the invite from a channel.
+   * @param {GuildInvitableChannelResolvable} channel The options for creating the invite from a channel.
    * @param {CreateInviteOptions} [options={}] The options for creating the invite from a channel.
    * @returns {Promise<Invite>}
    * @example

--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -10,7 +10,7 @@ const { Error } = require('../errors');
 class NewsChannel extends BaseGuildTextChannel {
   /**
    * Adds the target to this channel's followers.
-   * @param {GuildChannelResolvable} channel The channel where the webhook should be created
+   * @param {TextChannelResolvable} channel The channel where the webhook should be created
    * @param {string} [reason] Reason for creating the webhook
    * @returns {Promise<NewsChannel>}
    * @example

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2639,10 +2639,7 @@ export class GuildBanManager extends CachedManager<Snowflake, GuildBan, GuildBan
 export class GuildInviteManager extends DataManager<string, Invite, InviteResolvable> {
   public constructor(guild: Guild, iterable?: Iterable<RawInviteData>);
   public guild: Guild;
-  public create(
-    channel: TextChannel | VoiceChannel | NewsChannel | StoreChannel | StageChannel | Snowflake,
-    options?: CreateInviteOptions,
-  ): Promise<Invite>;
+  public create(channel: GuildInvitableChannelResolvable, options?: CreateInviteOptions): Promise<Invite>;
   public fetch(options: InviteResolvable | FetchInviteOptions): Promise<Invite>;
   public fetch(options?: FetchInvitesOptions): Promise<Collection<string, Invite>>;
   public delete(invite: InviteResolvable, reason?: string): Promise<Invite>;
@@ -3786,7 +3783,7 @@ interface FetchInviteOptions extends BaseFetchOptions {
 }
 
 interface FetchInvitesOptions {
-  channelId?: TextChannel | VoiceChannel | NewsChannel | StoreChannel | StageChannel | Snowflake;
+  channelId?: GuildInvitableChannelResolvable;
   cache?: boolean;
 }
 
@@ -4177,6 +4174,14 @@ export interface InviteGenerationOptions {
   disableGuildSelect?: boolean;
   scopes: InviteScope[];
 }
+
+type GuildInvitableChannelResolvable =
+  | TextChannel
+  | VoiceChannel
+  | NewsChannel
+  | StoreChannel
+  | StageChannel
+  | Snowflake;
 
 export interface CreateInviteOptions {
   temporary?: boolean;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1499,7 +1499,7 @@ export class MessageSelectMenu extends BaseMessageComponent {
 export class NewsChannel extends BaseGuildTextChannel {
   public threads: ThreadManager<AllowedThreadTypeForNewsChannel>;
   public type: 'GUILD_NEWS';
-  public addFollower(channel: GuildChannelResolvable, reason?: string): Promise<NewsChannel>;
+  public addFollower(channel: TextChannelResolvable, reason?: string): Promise<NewsChannel>;
 }
 
 export class OAuth2Guild extends BaseGuild {
@@ -2639,7 +2639,10 @@ export class GuildBanManager extends CachedManager<Snowflake, GuildBan, GuildBan
 export class GuildInviteManager extends DataManager<string, Invite, InviteResolvable> {
   public constructor(guild: Guild, iterable?: Iterable<RawInviteData>);
   public guild: Guild;
-  public create(channel: GuildChannelResolvable, options?: CreateInviteOptions): Promise<Invite>;
+  public create(
+    channel: TextChannel | VoiceChannel | NewsChannel | StoreChannel | StageChannel | Snowflake,
+    options?: CreateInviteOptions,
+  ): Promise<Invite>;
   public fetch(options: InviteResolvable | FetchInviteOptions): Promise<Invite>;
   public fetch(options?: FetchInvitesOptions): Promise<Collection<string, Invite>>;
   public delete(invite: InviteResolvable, reason?: string): Promise<Invite>;
@@ -3783,7 +3786,7 @@ interface FetchInviteOptions extends BaseFetchOptions {
 }
 
 interface FetchInvitesOptions {
-  channelId?: GuildChannelResolvable;
+  channelId?: TextChannel | VoiceChannel | NewsChannel | StoreChannel | StageChannel | Snowflake;
   cache?: boolean;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Discord rejects fetching invites from category channels and thread channel
- Discord rejects creating an invite on category channels and thread channel
- Discord rejects NewsChannel#addFollower() from anything that isn't a text channel

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
