### PR TITLE
fix(VoiceState): Patch streaming value

### DIFF
--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -83,7 +83,7 @@ class VoiceState extends Base {
       this.sessionId ??= null;
     }
 
-    if ('self_streaming' in data) {
+    if ('self_stream' in data) {
       /**
        * Whether this member is streaming using "Screen Share"
        * @type {boolean}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes a regression from #6694: Discord sends `self_stream`, not `self_streaming`. This resulted in this property always being `null`.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
