### PR TITLE
types(GuildBanManager): remove can return null

### DIFF
--- a/src/managers/GuildBanManager.js
+++ b/src/managers/GuildBanManager.js
@@ -161,7 +161,7 @@ class GuildBanManager extends CachedManager {
    * Unbans a user from the guild.
    * @param {UserResolvable} user The user to unban
    * @param {string} [reason] Reason for unbanning user
-   * @returns {Promise<User>}
+   * @returns {Promise<?User>}
    * @example
    * // Unban a user by id (or with a user/guild member object)
    * guild.bans.remove('84484653687267328')

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2661,7 +2661,7 @@ export class GuildBanManager extends CachedManager<Snowflake, GuildBan, GuildBan
   public create(user: UserResolvable, options?: BanOptions): Promise<GuildMember | User | Snowflake>;
   public fetch(options: UserResolvable | FetchBanOptions): Promise<GuildBan>;
   public fetch(options?: FetchBansOptions): Promise<Collection<Snowflake, GuildBan>>;
-  public remove(user: UserResolvable, reason?: string): Promise<User>;
+  public remove(user: UserResolvable, reason?: string): Promise<User | null>;
 }
 
 export class GuildInviteManager extends DataManager<string, Invite, InviteResolvable> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the types and docs for GuildBanManager#remove which can return null

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
