### PR TITLE
fix(User): compare flags in #equals

### DIFF
--- a/src/client/actions/GuildMemberUpdate.js
+++ b/src/client/actions/GuildMemberUpdate.js
@@ -10,7 +10,7 @@ class GuildMemberUpdateAction extends Action {
       const user = client.users.cache.get(data.user.id);
       if (!user) {
         client.users._add(data.user);
-      } else if (!user.equals(data.user)) {
+      } else if (!user._equals(data.user)) {
         client.actions.UserUpdate.handle(data.user);
       }
     }

--- a/src/client/actions/PresenceUpdate.js
+++ b/src/client/actions/PresenceUpdate.js
@@ -10,7 +10,7 @@ class PresenceUpdateAction extends Action {
     if (!user) return;
 
     if (data.user?.username) {
-      if (!user.equals(data.user)) this.client.actions.UserUpdate.handle(data.user);
+      if (!user._equals(data.user)) this.client.actions.UserUpdate.handle(data.user);
     }
 
     const guild = this.client.guilds.cache.get(data.guild_id);

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -247,16 +247,35 @@ class User extends Base {
    * @returns {boolean}
    */
   equals(user) {
-    let equal =
+    return (
       user &&
       this.id === user.id &&
       this.username === user.username &&
       this.discriminator === user.discriminator &&
       this.avatar === user.avatar &&
+      this.flags?.bitfield === user.flags?.bitfield &&
       this.banner === user.banner &&
-      this.accentColor === user.accentColor;
+      this.accentColor === user.accentColor
+    );
+  }
 
-    return equal;
+  /**
+   * Compares the user with an API user object
+   * @param {APIUser} user The API user object to compare
+   * @returns {boolean}
+   * @private
+   */
+  _equals(user) {
+    return (
+      user &&
+      this.id === user.id &&
+      this.username === user.username &&
+      this.discriminator === user.discriminator &&
+      this.avatar === user.avatar &&
+      this.flags?.bitfield === user.public_flags &&
+      ('banner' in user ? this.banner === user.banner : true) &&
+      ('accent_color' in user ? this.accentColor === user.accent_color : true)
+    );
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1981,6 +1981,8 @@ export class Typing extends Base {
 
 export class User extends PartialTextBasedChannel(Base) {
   protected constructor(client: Client, data: RawUserData);
+  private _equals(user: APIUser): boolean;
+
   public accentColor: number | null;
   public avatar: string | null;
   public banner: string | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR compares the users' flags in User#equals. I had to create a new _equals method to be used in actions as these compare a user object with an API user, which does not have the same properties as a Discord.js User and thus would always return false when used this way. This wasn't necessarily needed as the user update action compares 2 User objects, but it's better than having broken code. Alternatively we can drop the checks on the GuildMemberUpdate and PresenceUpdate actions and this function won't be needed, let me know what you prefer

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
