### PR TITLE
types(Webhook): More accurate type for `sourceChannel`

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -98,7 +98,7 @@ class Webhook {
     if ('source_channel' in data) {
       /**
        * The source channel of the webhook
-       * @type {?(Channel|APIChannel)}
+       * @type {?(NewsChannel|APIChannel)}
        */
       this.sourceChannel = this.client.channels?.resolve(data.source_channel?.id) ?? data.source_channel;
     } else {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2135,7 +2135,7 @@ export class Webhook extends WebhookMixin() {
   public name: string;
   public owner: User | APIUser | null;
   public sourceGuild: Guild | APIPartialGuild | null;
-  public sourceChannel: Channel | APIPartialChannel | null;
+  public sourceChannel: NewsChannel | APIPartialChannel | null;
   public token: string | null;
   public type: WebhookType;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The [`source_channel`](https://discord.com/developers/docs/resources/webhook#webhook-object-webhook-structure) is:
> the channel that this webhook is following (returned for Channel Follower Webhooks)

This is only ever going to be a `NewsChannel`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
