### PR TITLE
docs(GuildMemberUpdateAction): event doesn't get emitted on user update

### DIFF
--- a/src/client/actions/GuildMemberUpdate.js
+++ b/src/client/actions/GuildMemberUpdate.js
@@ -22,7 +22,6 @@ class GuildMemberUpdateAction extends Action {
         const old = member._update(data);
         /**
          * Emitted whenever a guild member changes - i.e. new role, removed role, nickname.
-         * Also emitted when the user's details (e.g. username) change.
          * @event Client#guildMemberUpdate
          * @param {GuildMember} oldMember The member before the update
          * @param {GuildMember} newMember The member after the update


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR simply removes a line in the Client#guildMemberUpdate event that said the event would fire for updates in the user object, which is not true and cannot be fixed in a semver minor way, as it would require the userUpdate event to not be emitted with this event. See the the [discussion on Discord](https://canary.discord.com/channels/222078108977594368/682166281826598932/894293511522897960) for more info on this

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
