### PR TITLE
docs: fetchReply info + example

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -69,18 +69,19 @@ class InteractionResponses {
 
   /**
    * Creates a reply to this interaction.
+   * <info>By default `void`, provide the `fetchReply` option to fetch the bot's response.</info>
    * @param {string|MessagePayload|InteractionReplyOptions} options The options for the reply
    * @returns {Promise<Message|APIMessage|void>}
    * @example
-   * // Reply to the interaction with an embed
+   * // Reply to the interaction and fetch the response
    * const embed = new MessageEmbed().setDescription('Pong!');
    *
-   * interaction.reply({ embeds: [embed] })
-   *   .then(() => console.log('Reply sent.'))
+   * interaction.reply({ content: 'Pong!', fetchReply: true })
+   *   .then((message) => console.log(`Reply sent with content ${message.content}`))
    *   .catch(console.error);
    * @example
-   * // Create an ephemeral reply
-   * interaction.reply({ content: 'Pong!', ephemeral: true })
+   * // Create an ephemeral reply with an embed
+   * interaction.reply({ embeds: [embed], ephemeral: true })
    *   .then(() => console.log('Reply sent.'))
    *   .catch(console.error);
    */

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -69,7 +69,7 @@ class InteractionResponses {
 
   /**
    * Creates a reply to this interaction.
-   * <info>By default `void`, provide the `fetchReply` option to fetch the bot's response.</info>
+   * <info>Use the `fetchReply` option to get the bot's reply message.</info>
    * @param {string|MessagePayload|InteractionReplyOptions} options The options for the reply
    * @returns {Promise<Message|APIMessage|void>}
    * @example


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Users often get confused when trying to get a message from `CommandInteraction#reply`, as per default the returned Promise resolved with a void value. 

This PR clarifies this with an infobox as well as example code. To not overload the first example, the embed usage moved into the second example, together with the `ephemeral` option, providing an alternative non-empty message to `content`. 

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
