### PR TITLE
fix(AllowedImageSizes): add new image sizes

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -16,7 +16,7 @@ exports.WSCodes = {
 
 const AllowedImageFormats = ['webp', 'png', 'jpg', 'jpeg', 'gif'];
 
-const AllowedImageSizes = [...Array.from({ length: 9 }, (e, i) => 2 ** (i + 4)), 300, 600].sort((a, b) => a - b);
+const AllowedImageSizes = [16, 32, 64, 128, 256, 300, 512, 600, 1024, 2048, 4096];
 
 function makeImageUrl(root, { format = 'webp', size } = {}) {
   if (!['undefined', 'number'].includes(typeof size)) throw new TypeError('INVALID_TYPE', 'size', 'number');

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -16,7 +16,7 @@ exports.WSCodes = {
 
 const AllowedImageFormats = ['webp', 'png', 'jpg', 'jpeg', 'gif'];
 
-const AllowedImageSizes = Array.from({ length: 9 }, (e, i) => 2 ** (i + 4));
+const AllowedImageSizes = [...Array.from({ length: 9 }, (e, i) => 2 ** (i + 4)), 300, 600].sort((a, b) => a - b);
 
 function makeImageUrl(root, { format = 'webp', size } = {}) {
   if (!['undefined', 'number'].includes(typeof size)) throw new TypeError('INVALID_TYPE', 'size', 'number');
@@ -35,7 +35,7 @@ function makeImageUrl(root, { format = 'webp', size } = {}) {
  * Options for static Image URLs.
  * @typedef {Object} StaticImageURLOptions
  * @property {string} [format='webp'] One of `webp`, `png`, `jpg`, `jpeg`.
- * @property {number} [size] One of `16`, `32`, `64`, `128`, `256`, `512`, `1024`, `2048`, `4096`
+ * @property {number} [size] One of `16`, `32`, `64`, `128`, `256`, `300`, `512`, `600`, `1024`, `2048`, `4096`
  */
 
 // https://discord.com/developers/docs/reference#image-formatting-cdn-endpoints

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2892,7 +2892,7 @@ export interface AddGuildMemberOptions {
 
 export type AllowedImageFormat = 'webp' | 'png' | 'jpg' | 'jpeg';
 
-export type AllowedImageSize = 16 | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 | 4096;
+export type AllowedImageSize = 16 | 32 | 64 | 128 | 256 | 300 | 512 | 600 | 1024 | 2048 | 4096;
 
 export type AllowedPartial = User | Channel | GuildMember | Message | MessageReaction;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The user banner update added two new image sizes — 300 and 600. These new sizes work for all images, including guild icons, user avatars, and user banners.


**Status and versioning classification:**
- Code changes have been tested against the Discord API
- I know how to update typings and have done so

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
