### PR TITLE
fix: correct the error checking bounds

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -469,7 +469,7 @@ class Util extends null {
       color = (color[0] << 16) + (color[1] << 8) + color[2];
     }
 
-    if (color < 0 || color > 0xffffff) throw new RangeError('COLOR_RANGE');
+    if (color < 0 || color >= 0xffffff) throw new RangeError('COLOR_RANGE');
     else if (Number.isNaN(color)) throw new TypeError('COLOR_CONVERT');
 
     return color;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Prevents 0xffffff from being classified as an invalid value. Probably just an old typo


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
