### PR TITLE
GuildMemberRoleManager: add role that sets the role icon/emoji

### DIFF
--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -48,6 +48,17 @@ class GuildMemberRoleManager extends DataManager {
   }
 
   /**
+   * The role of the member used to set their role icon
+   * @type {?Role}
+   * @readonly
+   */
+  get icon() {
+    const iconRoles = this.cache.filter(role => role.icon || role.unicodeEmoji);
+    if (!iconRoles.size) return null;
+    return iconRoles.reduce((prev, role) => (!prev || role.comparePositionTo(prev) > 0 ? role : prev));
+  }
+
+  /**
    * The role of the member used to set their color
    * @type {?Role}
    * @readonly

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2751,6 +2751,7 @@ export class GuildStickerManager extends CachedManager<Snowflake, Sticker, Stick
 export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleResolvable> {
   private constructor(member: GuildMember);
   public readonly hoist: Role | null;
+  public readonly icon: Role | null;
   public readonly color: Role | null;
   public readonly highest: Role;
   public readonly premiumSubscriberRole: Role | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adding `icon` property to GuildMemberRoleManager for easy access to the role used to display the role icon for the member. This matches existing properties like hoist, highest and color.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
