### PR TITLE
fix(Guild): guild.available is never set on new joins

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -137,7 +137,7 @@ class Guild extends AnonymousGuild {
     this.id = data.id;
     if ('name' in data) this.name = data.name;
     if ('icon' in data) this.icon = data.icon;
-    if ('unavailable' in data) this.available = !data.unavailable;
+    this.available = 'unavailable' in data ? !data.unavailable : this.available ?? true;
 
     if ('discovery_splash' in data) {
       /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes a bug that was introduced in https://github.com/discordjs/discord.js/pull/6694 where, if the `data` passed to the constructor of a Guild doesn't explicitly have the `unavailable` field, then the corresponding `available` field of the cached Guild will never be set, resulting in `this.available` returning `undefined` (false-y) despite the guild being available.

This scenario specifically happens when inviting a bot to a new guild since the `unavailable` field is missing, whereas the `GUILD_CREATE` event the client receives on startup has the field and is processed correctly.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
