### PR TITLE
docs(MessagePayload): change the typo of "wether" to "whether"

### DIFF
--- a/src/structures/MessagePayload.js
+++ b/src/structures/MessagePayload.js
@@ -81,7 +81,7 @@ class MessagePayload {
   }
 
   /**
-   * Wether or not the target is a {@link MessageManager}
+   * Whether or not the target is a {@link MessageManager}
    * @type {boolean}
    * @readonly
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

There is a typo - the missing "h". Changes `wether` to `whether`.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
