### PR TITLE
types: make embed author and footer props `name` and `text` required

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4393,14 +4393,14 @@ export interface MessageEditOptions {
 }
 
 export interface MessageEmbedAuthor {
-  name?: string;
+  name: string;
   url?: string;
   iconURL?: string;
   proxyIconURL?: string;
 }
 
 export interface MessageEmbedFooter {
-  text?: string;
+  text: string;
   iconURL?: string;
   proxyIconURL?: string;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Aligns types to: [docs](https://discord.com/developers/docs/resources/channel#embed-object-embed-author-structure)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating