### PR TITLE
chore(GuildMemberRoleManager): Remove unnecessary `!prev` check

### DIFF
--- a/src/managers/GuildMemberRoleManager.js
+++ b/src/managers/GuildMemberRoleManager.js
@@ -44,7 +44,7 @@ class GuildMemberRoleManager extends DataManager {
   get hoist() {
     const hoistedRoles = this.cache.filter(role => role.hoist);
     if (!hoistedRoles.size) return null;
-    return hoistedRoles.reduce((prev, role) => role.comparePositionTo(prev) > 0 ? role : prev);
+    return hoistedRoles.reduce((prev, role) => (role.comparePositionTo(prev) > 0 ? role : prev));
   }
 
   /**
@@ -55,7 +55,7 @@ class GuildMemberRoleManager extends DataManager {
   get color() {
     const coloredRoles = this.cache.filter(role => role.color);
     if (!coloredRoles.size) return null;
-    return coloredRoles.reduce((prev, role) => role.comparePositionTo(prev) > 0 ? role : prev);
+    return coloredRoles.reduce((prev, role) => (role.comparePositionTo(prev) > 0 ? role : prev));
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Because `Collection#reduce` follows the spec just like `Array#map` does, the initial element isn't set to a nullish value, but to the first entry (and later iterates at the second entry).

Therefore, the `!prev` check is unnecessary.

_Originally posted by @kyranet in https://github.com/discordjs/discord.js/pull/6768#discussion_r723986884_

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
