### PR TITLE
feat(GuildMemberUpdate): emit on user updates

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -506,6 +506,9 @@ class Client extends BaseClient {
     if (typeof options.failIfNotExists !== 'boolean') {
       throw new TypeError('CLIENT_INVALID_OPTION', 'failIfNotExists', 'a boolean');
     }
+    if (typeof options.emitUserUpdatesPerGuild !== 'boolean') {
+      throw new TypeError('CLIENT_INVALID_OPTION', 'emitUserUpdatesPerGuild', 'a boolean');
+    }
   }
 }
 

--- a/packages/discord.js/src/client/actions/GuildMemberUpdate.js
+++ b/packages/discord.js/src/client/actions/GuildMemberUpdate.js
@@ -29,7 +29,7 @@ class GuildMemberUpdateAction extends Action {
          * @param {GuildMember} newMember The member after the update
          */
         if (shard.status === Status.READY && (!member.equals(old) || !old.user._equals(data.user))) {
-          client.emit(Events.GUILD_MEMBER_UPDATE, old, member);
+          client.emit(Events.GuildMemberUpdate, old, member);
         }
       } else {
         const newMember = guild.members._add(data);

--- a/packages/discord.js/src/client/actions/GuildMemberUpdate.js
+++ b/packages/discord.js/src/client/actions/GuildMemberUpdate.js
@@ -23,11 +23,14 @@ class GuildMemberUpdateAction extends Action {
         const old = member._update(data);
         /**
          * Emitted whenever a guild member changes - i.e. new role, removed role, nickname.
+         * Also emitted when the user's details (e.g. username, avatar) change.
          * @event Client#guildMemberUpdate
          * @param {GuildMember} oldMember The member before the update
          * @param {GuildMember} newMember The member after the update
          */
-        if (shard.status === Status.Ready && !member.equals(old)) client.emit(Events.GuildMemberUpdate, old, member);
+        if (shard.status === Status.READY && (!member.equals(old) || !old.user._equals(data.user))) {
+          client.emit(Events.GUILD_MEMBER_UPDATE, old, member);
+        }
       } else {
         const newMember = guild.members._add(data);
         /**

--- a/packages/discord.js/src/client/actions/PresenceUpdate.js
+++ b/packages/discord.js/src/client/actions/PresenceUpdate.js
@@ -16,8 +16,8 @@ class PresenceUpdateAction extends Action {
     const guild = this.client.guilds.cache.get(data.guild_id);
     if (!guild) return;
 
-    const oldPresence = guild.presences.cache.get(user.id)?._clone() ?? null;
-    let member = guild.members.cache.get(user.id);
+    const oldPresence = guild.presences.cache.get(data.user.id)?._clone() ?? null;
+    let member = guild.members.cache.get(data.user.id);
     if (!member && data.status !== 'offline') {
       member = guild.members._add({
         user,

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -63,7 +63,9 @@ class GuildMember extends Base {
        * The user that this guild member instance represents
        * @type {?User}
        */
-      this.user = this.client.users._add(data.user, true)._clone();
+      this.user = this.client.options.emitUserUpdatesPerGuild
+        ? this.client.users._add(data.user, true)._clone()
+        : this.client.users._add(data.user, true);
     }
 
     if ('nick' in data) this.nickname = data.nick;

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -63,7 +63,7 @@ class GuildMember extends Base {
        * The user that this guild member instance represents
        * @type {?User}
        */
-      this.user = this.client.users._add(data.user, true);
+      this.user = this.client.users._add(data.user, true)._clone();
     }
 
     if ('nick' in data) this.nickname = data.nick;

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -254,7 +254,7 @@ class User extends Base {
       this.username === user.username &&
       this.discriminator === user.discriminator &&
       this.avatar === user.avatar &&
-      this.flags?.bitfield === user.public_flags &&
+      (this.flags?.bitfield ?? 0) === (user.public_flags ?? 0) &&
       ('banner' in user ? this.banner === user.banner : true) &&
       ('accent_color' in user ? this.accentColor === user.accent_color : true)
     );

--- a/packages/discord.js/src/util/Options.js
+++ b/packages/discord.js/src/util/Options.js
@@ -33,6 +33,8 @@ const { DefaultRestOptions } = require('@discordjs/rest');
  * @property {number} [waitGuildTimeout=15_000] Time in milliseconds that Clients with the GUILDS intent should wait for
  * missing guilds to be received before starting the bot. If not specified, the default is 15 seconds.
  * @property {SweeperOptions} [sweepers={}] Options for cache sweeping
+ * @property {boolean} [emitUserUpdatesPerGuild=false] Emits the guildMemberUpdate event on every guild on USER_UPDATE
+ * ws events. Note that this may increase memory usage.
  * @property {WebsocketOptions} [ws] Options for the WebSocket
  * @property {RESTOptions} [rest] Options for the REST manager
  */
@@ -77,6 +79,7 @@ class Options extends null {
       failIfNotExists: true,
       presence: {},
       sweepers: this.defaultSweeperSettings,
+      emitUserUpdatesPerGuild: false,
       ws: {
         large_threshold: 50,
         compress: false,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3565,6 +3565,7 @@ export interface ClientOptions {
   intents: BitFieldResolvable<GatewayIntentsString, number>;
   waitGuildTimeout?: number;
   sweepers?: SweeperOptions;
+  emitUserUpdatesPerGuild?: boolean;
   ws?: WebSocketOptions;
   rest?: Partial<RESTOptions>;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the guildMemberUpdate event in a (hopefully) `semver: minor` way in order to emit it on user updates like Discord intends us to. The `USER_UPDATE` event will still be emitted on both the `GUILD_MEMBER_UPDATE` and the `PRESENCE_UPDATE` gateway events, however we will not fire presenceUpdate events as presences do not exist on users like it was discussed [here](https://discord.com/channels/222078108977594368/682166281826598932/895689920667062323). There is only 1 possible issue with this which is that the events will fire when we don't have a user's flags cached and they have flags in reality. This is due to the fact that Discord does not send the `public_flags` property on startup and thus it doesn't get cached. The only alternative would be not to emit the event when the old flags are not present, however this would become an issue in scenarios where the first userUpdate received on a session is a flags update.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
