### PR TITLE
fix(User): don't generate the banner URL when not cached

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -324,7 +324,7 @@ class User extends Base {
     );
     json.avatarURL = this.avatarURL();
     json.displayAvatarURL = this.displayAvatarURL();
-    json.bannerURL = this.bannerURL();
+    json.bannerURL = this.banner ? this.bannerURL() : this.banner;
     return json;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a bug with User#toJSON that would throw an error when the banner wasn't cached. This was changed to make the property undefined instead to allow users to generate the JSON object without this error being thrown as this was quite confusing for some users.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
