### PR TITLE
fix(User): `bannerURL()` should not throw when not present

### DIFF
--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -180,8 +180,8 @@ class User extends Base {
   }
 
   /**
-   * A link to the user's banner.
    * See {@link User#banner} for more info
+   * A link to the user's banner.
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -180,8 +180,7 @@ class User extends Base {
   }
 
   /**
-   * See {@link User#banner} for more info
-   * A link to the user's banner.
+   * A link to the user's banner. See {@link User#banner} for more info
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -2,7 +2,6 @@
 
 const Base = require('./Base');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
-const { Error } = require('../errors');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
 const UserFlags = require('../util/UserFlags');
 

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -181,7 +181,7 @@ class User extends Base {
 
   /**
    * A link to the user's banner.
-   * See {@link User#banner} for more info</info>
+   * See {@link User#banner} for more info
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -181,14 +181,12 @@ class User extends Base {
 
   /**
    * A link to the user's banner.
-   * <info>This method will throw an error if called before the user is force fetched.
    * See {@link User#banner} for more info</info>
    * @param {ImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   bannerURL({ format, size, dynamic } = {}) {
-    if (typeof this.banner === 'undefined') throw new Error('USER_BANNER_NOT_FETCHED');
-    if (!this.banner) return null;
+    if (!this.banner) return this.banner;
     return this.client.rest.cdn.Banner(this.id, this.banner, format, size, dynamic);
   }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2391,7 +2391,7 @@ export class User extends PartialTextBasedChannel(Base) {
   public readonly tag: string;
   public username: string;
   public avatarURL(options?: ImageURLOptions): string | null;
-  public bannerURL(options?: ImageURLOptions): string | null;
+  public bannerURL(options?: ImageURLOptions): string | null | undefined;
   public createDM(force?: boolean): Promise<DMChannel>;
   public deleteDM(): Promise<DMChannel>;
   public displayAvatarURL(options?: ImageURLOptions): string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Makes `User#bannerURL` not throw even if the user hasn't been forced fetched, it will just return `undefined`. (breaking change)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
