### PR TITLE
types(ApplicationCommandOptionData): remove required on subcommands

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3209,22 +3209,22 @@ export interface ApplicationCommandChoicesOption extends BaseApplicationCommandO
   choices?: ApplicationCommandOptionChoice[];
 }
 
-export interface ApplicationCommandSubGroupData extends BaseApplicationCommandOptionsData {
+export interface ApplicationCommandSubGroupData extends Omit<BaseApplicationCommandOptionsData, 'required'> {
   type: 'SUB_COMMAND_GROUP' | ApplicationCommandOptionTypes.SUB_COMMAND_GROUP;
   options?: ApplicationCommandSubCommandData[];
 }
 
-export interface ApplicationCommandSubGroup extends BaseApplicationCommandOptionsData {
+export interface ApplicationCommandSubGroup extends Omit<BaseApplicationCommandOptionsData, 'required'> {
   type: 'SUB_COMMAND_GROUP';
   options?: ApplicationCommandSubCommand[];
 }
 
-export interface ApplicationCommandSubCommandData extends BaseApplicationCommandOptionsData {
+export interface ApplicationCommandSubCommandData extends Omit<BaseApplicationCommandOptionsData, 'required'> {
   type: 'SUB_COMMAND' | ApplicationCommandOptionTypes.SUB_COMMAND;
   options?: (ApplicationCommandChoicesData | ApplicationCommandNonOptionsData | ApplicationCommandChannelOptionData)[];
 }
 
-export interface ApplicationCommandSubCommand extends BaseApplicationCommandOptionsData {
+export interface ApplicationCommandSubCommand extends Omit<BaseApplicationCommandOptionsData, 'required'> {
   type: 'SUB_COMMAND';
   options?: (ApplicationCommandChoicesOption | ApplicationCommandNonOptions | ApplicationCommandChannelOption)[];
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR simply removes the required property from SUB_COMMAND and SUB_COMMAND_GROUP type options as passing this results in an API error

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
