### PR TITLE
fix(CommandInteractionOption): don't set undefined props

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -239,7 +239,12 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
     options: ApplicationCommandOption | ApplicationCommandOptionData | APIApplicationCommandOption,
     enforceOptionorder?: boolean,
   ): boolean;
-  private static transformOption(option: ApplicationCommandOptionData, received?: boolean): unknown;
+  private static transformOption(option: APIApplicationCommandOption, received: true): ApplicationCommandOption;
+  private static transformOption(option: ApplicationCommandOptionData, received?: false): APIApplicationCommandOption;
+  private static transformOption(
+    option: ApplicationCommandOptionData | APIApplicationCommandOption,
+    received?: boolean,
+  ): APIApplicationCommandOption | ApplicationCommandOption;
   private static transformCommand(command: ApplicationCommandData): RESTPostAPIApplicationCommandsJSONBody;
   private static isAPICommandData(command: object): command is RESTPostAPIApplicationCommandsJSONBody;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes certain props in ApplicationCommand#options being set to undefined where they weren't documented/typed as such. This means that no property should now be set to undefined and will only be present if the user has passed it when creating the command.
Also changed the typings for the ApplicationCommand#transformOption method to include overloads and API types.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
