### PR TITLE
fix(GuildBanManager): send reason in the headers instead of json body

### DIFF
--- a/src/managers/GuildBanManager.js
+++ b/src/managers/GuildBanManager.js
@@ -144,10 +144,8 @@ class GuildBanManager extends CachedManager {
       .guilds(this.guild.id)
       .bans(id)
       .put({
-        data: {
-          reason: options.reason,
-          delete_message_days: options.days,
-        },
+        data: { delete_message_days: options.days },
+        reason: options.reason,
       });
     if (user instanceof GuildMember) return user;
     const _user = this.client.users.resolve(id);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `reason` field in the json body was marked as deprecated in:
- discord/discord-api-docs#3421

**Status and versioning classification:**
- Code changes have been tested against the Discord API
<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
