### PR TITLE
types: message component cached props narrowing 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "discord.js",
       "version": "13.3.0-dev",
       "license": "Apache-2.0",
       "dependencies": {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -303,11 +303,16 @@ export abstract class BaseCommandInteraction extends Interaction {
   private transformResolved(resolved: APIApplicationCommandInteractionData['resolved']): CommandInteractionResolvedData;
 }
 
-export type InteractionResponsesResolvable = BaseCommandInteraction | MessageComponentInteraction;
+export interface InteractionResponsesResolvable {
+  inGuild(): this is InteractionResponses<'present'> & this;
+  inCachedGuild(): this is InteractionResponses<'cached'> & this;
+  inRawGuild(): this is InteractionResponses<'raw'> & this;
+}
 
-type CacheHelper<T extends Interaction, Cached extends GuildCacheState> = T extends InteractionResponsesResolvable
-  ? InteractionResponses<Cached> & T
-  : GuildInteraction<Cached> & T;
+export type CacheHelper<
+  T extends Interaction,
+  Cached extends GuildCacheState,
+> = T extends InteractionResponsesResolvable ? InteractionResponses<Cached> & T : GuildInteraction<Cached> & T;
 
 export type GuildCached<T extends Interaction> = CacheHelper<T, 'cached'>;
 export type GuildRaw<T extends Interaction> = CacheHelper<T, 'raw'>;

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -858,12 +858,22 @@ declare const booleanValue: boolean;
 if (interaction.inGuild()) assertType<Snowflake>(interaction.guildId);
 
 client.on('interactionCreate', async interaction => {
+  const consumeCachedCommand = (_i: GuildCached<CommandInteraction>) => {};
+  const consumeCachedInteraction = (_i: GuildCached<Interaction>) => {};
+
   if (interaction.inCachedGuild()) {
     assertType<GuildMember>(interaction.member);
+    // @ts-expect-error
+    consumeCachedCommand(interaction);
+    consumeCachedInteraction(interaction);
   } else if (interaction.inRawGuild()) {
     assertType<APIInteractionGuildMember>(interaction.member);
+    // @ts-expect-error
+    consumeCachedInteraction(interaction);
   } else {
     assertType<APIGuildMember | GuildMember | null>(interaction.member);
+    // @ts-expect-error
+    consumeCachedInteraction(interaction);
   }
 
   if (interaction.isContextMenu()) {
@@ -871,6 +881,7 @@ client.on('interactionCreate', async interaction => {
     if (interaction.inCachedGuild()) {
       assertType<ContextMenuInteraction>(interaction);
       assertType<Guild>(interaction.guild);
+      consumeCachedCommand(interaction);
     } else if (interaction.inRawGuild()) {
       assertType<ContextMenuInteraction>(interaction);
       assertType<null>(interaction.guild);
@@ -885,12 +896,15 @@ client.on('interactionCreate', async interaction => {
     if (interaction.inCachedGuild()) {
       assertType<ButtonInteraction>(interaction);
       assertType<Guild>(interaction.guild);
+      assertType<Promise<Message>>(interaction.reply({ fetchReply: true }));
     } else if (interaction.inRawGuild()) {
       assertType<ButtonInteraction>(interaction);
       assertType<null>(interaction.guild);
+      assertType<Promise<APIMessage>>(interaction.reply({ fetchReply: true }));
     } else if (interaction.inGuild()) {
       assertType<ButtonInteraction>(interaction);
       assertType<Guild | null>(interaction.guild);
+      assertType<Promise<APIMessage | Message>>(interaction.reply({ fetchReply: true }));
     }
   }
 
@@ -899,12 +913,15 @@ client.on('interactionCreate', async interaction => {
     if (interaction.inCachedGuild()) {
       assertType<MessageComponentInteraction>(interaction);
       assertType<Guild>(interaction.guild);
+      assertType<Promise<Message>>(interaction.reply({ fetchReply: true }));
     } else if (interaction.inRawGuild()) {
       assertType<MessageComponentInteraction>(interaction);
       assertType<null>(interaction.guild);
+      assertType<Promise<APIMessage>>(interaction.reply({ fetchReply: true }));
     } else if (interaction.inGuild()) {
       assertType<MessageComponentInteraction>(interaction);
       assertType<Guild | null>(interaction.guild);
+      assertType<Promise<APIMessage | Message>>(interaction.reply({ fetchReply: true }));
     }
   }
 
@@ -921,17 +938,23 @@ client.on('interactionCreate', async interaction => {
     } else if (interaction.inGuild()) {
       assertType<SelectMenuInteraction>(interaction);
       assertType<Guild | null>(interaction.guild);
+      assertType<Promise<Message | APIMessage>>(interaction.reply({ fetchReply: true }));
     }
   }
 
   if (interaction.isCommand()) {
     if (interaction.inRawGuild()) {
+      // @ts-expect-error
+      consumeCachedCommand(interaction);
       assertType<CommandInteraction>(interaction);
       assertType<Promise<APIMessage>>(interaction.reply({ fetchReply: true }));
     } else if (interaction.inCachedGuild()) {
+      consumeCachedCommand(interaction);
       assertType<CommandInteraction>(interaction);
       assertType<Promise<Message>>(interaction.reply({ fetchReply: true }));
     } else {
+      // @ts-expect-error
+      consumeCachedCommand(interaction);
       assertType<CommandInteraction>(interaction);
       assertType<Promise<Message | APIMessage>>(interaction.reply({ fetchReply: true }));
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Just like #6668, but now narrows message component interactions.

In addition utility types have been added to easily represent cache states on interactions:
For example: 

`GuildCached<T>`

`GuildCached<Interaction>` - Interaction sent in a cached guild.
`GuildCached<CommandInteraction>` - Command sent in cached guild.

Same idea for `GuildRaw<T>` and `GuildPresent<T>`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
