### PR TITLE
docs: Remove dangling reference

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -196,8 +196,3 @@ class GuildChannelManager extends CachedManager {
 }
 
 module.exports = GuildChannelManager;
-
-/**
- * @external APIActiveThreadsList
- * @see {@link https://discord.com/developers/docs/resources/guild#list-active-threads-response-body}
- */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`APIActiveThreadsList` isn't being used anywhere. Might as well remove it.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
