### PR TITLE
types(Integration): Add `IntegrationType` values

### DIFF
--- a/src/structures/Integration.js
+++ b/src/structures/Integration.js
@@ -11,6 +11,14 @@ const IntegrationApplication = require('./IntegrationApplication');
  */
 
 /**
+ * The type of an {@link Integration}. This can be:
+ * * `twitch`
+ * * `youtube`
+ * * `discord`
+ * @typedef {string} IntegrationType
+ */
+
+/**
  *  Represents a guild integration.
  */
 class Integration extends Base {
@@ -36,8 +44,8 @@ class Integration extends Base {
     this.name = data.name;
 
     /**
-     * The integration type (twitch, youtube or discord)
-     * @type {string}
+     * The integration type
+     * @type {IntegrationType}
      */
     this.type = data.type;
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1053,7 +1053,7 @@ export class Integration extends Base {
   public readonly roles: Collection<Snowflake, Role>;
   public syncedAt: number | undefined;
   public syncing: boolean | undefined;
-  public type: string;
+  public type: IntegrationType;
   public user: User | null;
   public subscriberCount: number | null;
   public revoked: boolean | null;
@@ -4208,6 +4208,8 @@ export interface IntegrationAccount {
   id: string | Snowflake;
   name: string;
 }
+
+export type IntegrationType = 'twitch' | 'youtube' | 'discord';
 
 export interface InteractionCollectorOptions<T extends Interaction> extends CollectorOptions<[T]> {
   channel?: TextBasedChannels;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently, an integration's type can only be one of three possible values (and has been this way for years).

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
