### PR TITLE
docs(Message): Specify `Snowflake` in return type of `awaitReactions()`

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -468,7 +468,7 @@ class Message extends Base {
    * Similar to createReactionCollector but in promise form.
    * Resolves with a collection of reactions that pass the specified filter.
    * @param {AwaitReactionsOptions} [options={}] Optional options to pass to the internal collector
-   * @returns {Promise<Collection<string, MessageReaction>>}
+   * @returns {Promise<Collection<string | Snowflake, MessageReaction>>}
    * @example
    * // Create a reaction collector
    * const filter = (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someId'


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Documenting that Message#awaitReactions() may possess a `Snowflake` in the key type of the `Collection` (explicitly for custom emojis).

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
