### PR TITLE
feat(Client): add global sweepers

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -555,7 +555,7 @@ class Client extends BaseClient {
     if (typeof options.messageSweepInterval !== 'number' || isNaN(options.messageSweepInterval)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'messageSweepInterval', 'a number');
     }
-    if (typeof options.sweepers !== 'object') {
+    if (typeof options.sweepers !== 'object' || options.sweepers === null) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'sweepers', 'an object');
     }
     if (typeof options.invalidRequestWarningInterval !== 'number' || isNaN(options.invalidRequestWarningInterval)) {

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -183,7 +183,7 @@ class Client extends BaseClient {
 
     if (this.options.messageSweepInterval > 0) {
       process.emitWarning(
-        'The message sweeping client options are deprecated, use the makeCache option with LimitedCollection instead.',
+        'The message sweeping client options are deprecated, use the global sweepers instead.',
         'DeprecationWarning',
       );
       this.sweepMessageInterval = setInterval(
@@ -409,9 +409,7 @@ class Client extends BaseClient {
       return -1;
     }
 
-    const messages = this.sweepers.sweepMessages(
-      Sweepers.filterByLifetime({ lifetime, getComparisonTimestamp: m => m.editedTimestamp ?? m.createdTimestamp })(),
-    );
+    const messages = this.sweepers.sweepMessages(Sweepers.outdatedMessageSweepFilter(lifetime)());
     this.emit(Events.DEBUG, `Swept ${messages} messages older than ${lifetime} seconds`);
     return messages;
   }

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -188,6 +188,7 @@ exports.Events = {
   ERROR: 'error',
   WARN: 'warn',
   DEBUG: 'debug',
+  CACHE_SWEEP: 'cacheSweep',
   SHARD_DISCONNECT: 'shardDisconnect',
   SHARD_ERROR: 'shardError',
   SHARD_RECONNECTING: 'shardReconnecting',
@@ -429,6 +430,41 @@ exports.MessageTypes = [
   'THREAD_STARTER_MESSAGE',
   'GUILD_INVITE_REMINDER',
   'CONTEXT_MENU_COMMAND',
+];
+
+/**
+ * The name of an item to be swept in Sweepers
+ * * `applicationCommands` - both global and guild commands
+ * * `bans`
+ * * `emojis`
+ * * `invites` - accepts the `lifetime` property, using it will sweep based on expires timestamp
+ * * `guildMembers`
+ * * `messages` - accepts the `lifetime` property, using it will sweep based on edited or created timestamp
+ * * `presences`
+ * * `reactions`
+ * * `stageInstances`
+ * * `stickers`
+ * * `threadMembers`
+ * * `threads` - accepts the `lifetime` property, using it will sweep archived threads based on archived timestamp
+ * * `users`
+ * * `voiceStates`
+ * @typedef {string} SweeperKey
+ */
+exports.SweeperKeys = [
+  'applicationCommands',
+  'bans',
+  'emojis',
+  'invites',
+  'guildMembers',
+  'messages',
+  'presences',
+  'reactions',
+  'stageInstances',
+  'stickers',
+  'threadMembers',
+  'threads',
+  'users',
+  'voiceStates',
 ];
 
 /**

--- a/src/util/LimitedCollection.js
+++ b/src/util/LimitedCollection.js
@@ -19,8 +19,12 @@ const { TypeError } = require('../errors/DJSError.js');
  * @property {?number} [maxSize=Infinity] The maximum size of the Collection
  * @property {?Function} [keepOverLimit=null] A function, which is passed the value and key of an entry, ran to decide
  * to keep an entry past the maximum size
- * @property {?SweepFilter} [sweepFilter=null] A function ran every `sweepInterval` to determine how to sweep
- * @property {?number} [sweepInterval=0] How frequently, in seconds, to sweep the collection.
+ * @property {?SweepFilter} [sweepFilter=null] DEPRECATED: There is no direct alternative to this,
+ * however most of its purpose is fulfilled by {@link Client#sweepers}
+ * A function ran every `sweepInterval` to determine how to sweep
+ * @property {?number} [sweepInterval=0] DEPRECATED: There is no direct alternative to this,
+ * however most of its purpose is fulfilled by {@link Client#sweepers}
+ * How frequently, in seconds, to sweep the collection.
  */
 
 /**
@@ -65,12 +69,14 @@ class LimitedCollection extends Collection {
 
     /**
      * A function called every sweep interval that returns a function passed to `sweep`.
+     * @deprecated in favor of {@link Client#sweepers}
      * @type {?SweepFilter}
      */
     this.sweepFilter = sweepFilter;
 
     /**
      * The id of the interval being used to sweep.
+     * @deprecated in favor of {@link Client#sweepers}
      * @type {?Timeout}
      */
     this.interval =

--- a/src/util/LimitedCollection.js
+++ b/src/util/LimitedCollection.js
@@ -101,7 +101,7 @@ class LimitedCollection extends Collection {
   /**
    * Create a sweepFilter function that uses a lifetime to determine sweepability.
    * @param {LifetimeFilterOptions} [options={}] The options used to generate the filter function
-   * @deprecated Use `Sweepers.filterByLifetime` instead
+   * @deprecated Use {@link Sweepers.filterByLifetime} instead
    * @returns {SweepFilter}
    */
   static filterByLifetime({

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -37,9 +37,9 @@
  * You can use your own function, or the {@link Options} class to customize the Collection used for the cache.
  * <warn>Overriding the cache used in `GuildManager`, `ChannelManager`, `GuildChannelManager`, `RoleManager`,
  * and `PermissionOverwriteManager` is unsupported and **will** break functionality</warn>
- * @property {number} [messageCacheLifetime=0] DEPRECATED: Use `makeCache` with a `LimitedCollection` instead.
+ * @property {number} [messageCacheLifetime=0] DEPRECATED: Pass `lifetime` to `sweepers.messages` instead.
  * How long a message should stay in the cache until it is considered sweepable (in seconds, 0 for forever)
- * @property {number} [messageSweepInterval=0] DEPRECATED: Use `makeCache` with a `LimitedCollection` instead.
+ * @property {number} [messageSweepInterval=0] DEPRECATED: Pass `interval` to `sweepers.messages` instead.
  * How frequently to remove messages from the cache that are older than the message cache lifetime
  * (in seconds, 0 for never)
  * @property {MessageMentionOptions} [allowedMentions] Default value for {@link MessageOptions#allowedMentions}

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -269,4 +269,19 @@ class Options extends null {
   }
 }
 
+/**
+ * The default settings passed to {@link Options.sweepers} (for v14).
+ * The sweepers that this changes are:
+ * * `threads` - Sweep archived threads every hour, removing those archived more than 4 hours ago
+ * <info>If you want to keep default behavior and add on top of it you can use this object and add on to it, e.g.
+ * `sweepers: { ...Options.defaultSweeperSettings, messages: { interval: 300, lifetime: 600 } })`</info>
+ * @type {SweeperOptions}
+ */
+Options.defaultSweeperSettings = {
+  threads: {
+    interval: 3600,
+    lifetime: 14400,
+  },
+};
+
 module.exports = Options;

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -70,8 +70,25 @@
  * [User Agent](https://discord.com/developers/docs/reference#user-agent) header
  * @property {PresenceData} [presence={}] Presence data to use upon login
  * @property {IntentsResolvable} intents Intents to enable for this connection
+ * @property {SweeperOptions} [sweepers={}] Options for cache sweeping
  * @property {WebsocketOptions} [ws] Options for the WebSocket
  * @property {HTTPOptions} [http] HTTP options
+ */
+
+/**
+ * Options for {@link Sweepers} defining the behavior of cache sweeping
+ * @typedef {Object<SweeperKey, SweepOptions>} SweeperOptions
+ */
+
+/**
+ * Options for sweeping a single type of item from cache
+ * @typedef {Object} SweepOptions
+ * @property {number} interval The interval (in seconds) at which to perform sweeping of the item
+ * @property {number} [lifetime] How long an item should stay in cache until it is considered sweepable.
+ * <warn>This property is only valid for the `invites`, `messages`, and `threads` keys. The `filter` property
+ * is mutually exclusive to this property and takes priority</warn>
+ * @property {GlobalSweepFilter} filter The function used to determine the function passed to the sweep method
+ * <info>This property is optional when the key is `invites`, `messages`, or `threads` and `lifetime` is set</info>
  */
 
 /**
@@ -125,6 +142,7 @@ class Options extends null {
       failIfNotExists: true,
       userAgentSuffix: [],
       presence: {},
+      sweepers: {},
       ws: {
         large_threshold: 50,
         compress: false,

--- a/src/util/Sweepers.js
+++ b/src/util/Sweepers.js
@@ -364,10 +364,11 @@ class Sweepers {
     let items = 0;
 
     for (const guild of this.client.guilds.cache.values()) {
-      if (guild[key].cache.size === 0) continue;
+      const cache = guild[key].cache;
+      if (cache.size === 0) continue;
       guilds++;
 
-      items += guild[key].cache.sweep(filter);
+      items += cache.sweep(filter);
     }
 
     if (emit) {

--- a/src/util/Sweepers.js
+++ b/src/util/Sweepers.js
@@ -135,8 +135,9 @@ class Sweepers {
     let messages = 0;
 
     for (const channel of this.client.channels.cache.values()) {
-      if (!channel.messages || channel.messages.cache.size === 0) continue;
+      if (!channel.isText()) continue;
       channels++;
+      if (channel.messages.cache.size === 0) continue;
 
       messages += channel.messages.cache.sweep(filter);
     }
@@ -167,12 +168,13 @@ class Sweepers {
     let reactions = 0;
 
     for (const channel of this.client.channels.cache.values()) {
-      if (!channel.messages || channel.messages.cache.size === 0) continue;
+      if (!channel.isText()) continue;
       channels++;
+      if (channel.messages.cache.size === 0) continue;
 
       for (const message of channel.messages.cache.values()) {
-        if (message.reactions.cache.size === 0) continue;
         messages++;
+        if (message.reactions.cache.size === 0) continue;
 
         reactions += message.reactions.cache.sweep(filter);
       }
@@ -207,8 +209,9 @@ class Sweepers {
     let threads = 0;
     let members = 0;
     for (const channel of this.client.channels.cache.values()) {
-      if (!ThreadChannelTypes.includes(channel.type) || channel.members.cache.size === 0) continue;
+      if (!ThreadChannelTypes.includes(channel.type)) continue;
       threads++;
+      if (channel.members.cache.size === 0) continue;
       members += channel.members.cache.sweep(filter);
     }
     this.client.emit(Events.CACHE_SWEEP, `Swept ${members} thread members in ${threads} threads.`);
@@ -390,8 +393,8 @@ class Sweepers {
 
     for (const guild of this.client.guilds.cache.values()) {
       const { cache } = guild[key];
-      if (cache.size === 0) continue;
       guilds++;
+      if (cache.size === 0) continue;
 
       items += cache.sweep(filter);
     }

--- a/src/util/Sweepers.js
+++ b/src/util/Sweepers.js
@@ -1,0 +1,423 @@
+'use strict';
+
+const { Events, ThreadChannelTypes, SweeperKeys } = require('./Constants');
+const { TypeError } = require('../errors/DJSError.js');
+
+/**
+ * @typedef {Function} GlobalSweepFilter
+ * @returns {Function|null} Return `null` to skip sweeping, otherwise a function passed to `sweep()`,
+ * See {@link [Collection#sweep](https://discord.js.org/#/docs/collection/main/class/Collection?scrollTo=sweep)}
+ * for the definition of this function.
+ */
+
+/**
+ * A container for all cache sweeping intervals and their associated sweep methods.
+ */
+class Sweepers {
+  constructor(client, options) {
+    /**
+     * The client that instantiated this
+     * @type {Client}
+     * @readonly
+     */
+    Object.defineProperty(this, 'client', { value: client });
+
+    /**
+     * The options the sweepers were instantiated with
+     * @type {SweeperOptions}
+     */
+    this.options = options;
+
+    /**
+     * The interval timeout that is used to sweep the indicated items, or null if not being swept
+     * @name Sweepers#*Interval
+     * @type {?Timeout}
+     */
+
+    for (const key of SweeperKeys) {
+      this[`${key.slice(0, -1)}Interval]`] = null;
+      if (key in options) {
+        this._validateProperties(key);
+
+        const clonedOptions = { ...this.options[key] };
+
+        // Handle cases that have a "lifetime"
+        if (!('filter' in clonedOptions)) {
+          switch (key) {
+            case 'invites':
+              clonedOptions.filter = this.constructor.filterByLifetime({
+                lifetime: clonedOptions.lifetime,
+                getComparisonTimestamp: i => i.expiresTimestamp,
+              });
+              break;
+            case 'messages':
+              clonedOptions.filter = this.constructor.filterByLifetime({
+                lifetime: clonedOptions.lifetime,
+                getComparisonTimestamp: m => m.editedTimestamp ?? m.createdTimestamp,
+              });
+              break;
+            case 'threads':
+              clonedOptions.filter = this.constructor.filterByLifetime({
+                lifetime: clonedOptions.lifetime,
+                getComparisonTimestamp: t => t.archivedTimestamp,
+                excludeFromSweep: t => !t.archived,
+              });
+          }
+        }
+
+        this._initInterval(`${key.slice(0, -1)}Interval`, `sweep${key[0].toUpperCase()}${key.slice(1)}`, clonedOptions);
+      }
+    }
+  }
+
+  /**
+   * Sweeps all guild and global application commands and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which commands will be removed from the caches.
+   * @returns {number} Amount of commands that were removed from the caches
+   */
+  sweepApplicationCommands(filter) {
+    const { guilds, items: guildCommands } = this._sweepGuildDirectProp('commands', filter, { emit: false });
+
+    const globalCommands = this.client.application?.commands.cache.sweep(filter) ?? 0;
+
+    this.client.emit(
+      Events.CACHE_SWEEP,
+      `Swept ${globalCommands} global application commands and ${guildCommands} guild commands in ${guilds} guilds.`,
+    );
+    return guildCommands + globalCommands;
+  }
+
+  /**
+   * Sweeps all guild bans and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which bans will be removed from the caches.
+   * @returns {number} Amount of bans that were removed from the caches
+   */
+  sweepBans(filter) {
+    return this._sweepGuildDirectProp('bans', filter).items;
+  }
+
+  /**
+   * Sweeps all guild emojis and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which emojis will be removed from the caches.
+   * @returns {number} Amount of emojis that were removed from the caches
+   */
+  sweepEmojis(filter) {
+    return this._sweepGuildDirectProp('emojis', filter).items;
+  }
+
+  /**
+   * Sweeps all guild invites and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which invites will be removed from the caches.
+   * @returns {number} Amount of invites that were removed from the caches
+   */
+  sweepInvites(filter) {
+    return this._sweepGuildDirectProp('invites', filter).items;
+  }
+
+  /**
+   * Sweeps all guild members and removes the ones which are indicated by the filter.
+   * <info>It is highly recommended to keep the client guild member cached</info>
+   * @param {Function} filter The function used to determine which guild members will be removed from the caches.
+   * @returns {number} Amount of guild members that were removed from the caches
+   */
+  sweepGuildMembers(filter) {
+    return this._sweepGuildDirectProp('members', filter, { outputName: 'guild members' }).items;
+  }
+
+  /**
+   * Sweeps all text-based channels' messages and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which messages will be removed from the caches.
+   * @returns {number} Amount of messages that were removed from the caches
+   * @example
+   * // Remove all messages older than 1800 seconds from the messages cache
+   * const amount = sweepers.sweepMessages(
+   *   Sweepers.filterByLifetime({
+   *     lifetime: 1800,
+   *     getComparisonTimestamp: m => m.editedTimestamp ?? m.createdTimestamp,
+   *   })(),
+   * );
+   * console.log(`Successfully removed ${amount} messages from the cache.`);
+   */
+  sweepMessages(filter) {
+    if (typeof filter !== 'function') {
+      throw new TypeError('INVALID_TYPE', 'filter', 'function');
+    }
+    let channels = 0;
+    let messages = 0;
+
+    for (const channel of this.client.channels.cache.values()) {
+      if (!channel.messsages || channel.messages.cache.size === 0) continue;
+      channels++;
+
+      messages += channel.messages.cache.sweep(filter);
+    }
+    this.client.emit(Events.CACHE_SWEEP, `Swept ${messages} messages in ${channels} text-based channels.`);
+    return messages;
+  }
+
+  /**
+   * Sweeps all presences and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which presences will be removed from the caches.
+   * @returns {number} Amount of presences that were removed from the caches
+   */
+  sweepPresences(filter) {
+    return this._sweepGuildDirectProp('presences', filter).items;
+  }
+
+  /**
+   * Sweeps all message reactions and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which reactions will be removed from the caches.
+   * @returns {number} Amount of reactions that were removed from the caches
+   */
+  sweepReactions(filter) {
+    if (typeof filter !== 'function') {
+      throw new TypeError('INVALID_TYPE', 'filter', 'function');
+    }
+    let channels = 0;
+    let messages = 0;
+    let reactions = 0;
+
+    for (const channel of this.client.channels.cache.values()) {
+      if (!channel.messsages || channel.messages.cache.size === 0) continue;
+      channels++;
+
+      for (const message of channel.messages.cache.values()) {
+        if (message.reactions.cache.size === 0) continue;
+        messages++;
+
+        reactions += message.reactions.cache.sweep(filter);
+      }
+    }
+    this.client.emit(
+      Events.CACHE_SWEEP,
+      `Swept ${reactions} reactions on ${messages} messages in ${channels} text-based channels.`,
+    );
+    return reactions;
+  }
+
+  /**
+   * Sweeps all guild stage instances and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which stage instances will be removed from the caches.
+   * @returns {number} Amount of stage instances that were removed from the caches
+   */
+  sweepStageInstances(filter) {
+    return this._sweepGuildDirectProp('stageInstances', filter, { outputName: 'stage instances' }).items;
+  }
+
+  /**
+   * Sweeps all thread members and removes the ones which are indicated by the filter.
+   * <info>It is highly recommended to keep the client thread member cached</info>
+   * @param {Function} filter The function used to determine which thread members will be removed from the caches.
+   * @returns {number} Amount of thread members that were removed from the caches
+   */
+  sweepThreadMembers(filter) {
+    if (typeof filter !== 'function') {
+      throw new TypeError('INVALID_TYPE', 'filter', 'function');
+    }
+
+    let threads = 0;
+    let members = 0;
+    for (const channel of this.client.channels.cache.values()) {
+      if (!ThreadChannelTypes.includes(channel.type) || channel.members.cache.size === 0) continue;
+      threads++;
+      members += channel.members.cache.sweep(filter);
+    }
+    this.client.emit(Events.CACHE_SWEEP, `Swept ${members} thread members in ${threads} threads.`);
+    return members;
+  }
+
+  /**
+   * Sweeps all threads and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which threads will be removed from the caches.
+   * @returns {number} filter Amount of threads that were removed from the caches
+   * @example
+   * // Remove all threads archived greater than 1 day ago from all the channel caches
+   * const amount = sweepers.sweepThreads(
+   *   Sweepers.filterByLifetime({
+   *     getComparisonTimestamp: t => t.archivedTimestamp,
+   *     excludeFromSweep: t => !t.archived,
+   *   })(),
+   * );
+   * console.log(`Successfully removed ${amount} threads from the cache.`);
+   */
+  sweepThreads(filter) {
+    if (typeof filter !== 'function') {
+      throw new TypeError('INVALID_TYPE', 'filter', 'function');
+    }
+
+    let threads = 0;
+    for (const [key, val] of this.client.channels.cache.entries()) {
+      if (!ThreadChannelTypes.includes(val.type)) continue;
+      if (filter(val, key, this.client.channels.cache)) {
+        threads++;
+        this.client.channels._remove(key);
+      }
+    }
+    this.client.emit(Events.CACHE_SWEEP, `Swept ${threads} threads.`);
+    return threads;
+  }
+
+  /**
+   * Sweeps all users and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which users will be removed from the caches.
+   * @returns {number} Amount of users that were removed from the caches
+   */
+  sweepUsers(filter) {
+    if (typeof filter !== 'function') {
+      throw new TypeError('INVALID_TYPE', 'filter', 'function');
+    }
+
+    const users = this.client.users.cache.sweep(filter);
+
+    this.client.emit(Events.CACHE_SWEEP, `Swept ${users} users.`);
+
+    return users;
+  }
+
+  /**
+   * Sweeps all guild voice states and removes the ones which are indicated by the filter.
+   * @param {Function} filter The function used to determine which voice states will be removed from the caches.
+   * @returns {number} Amount of voice states that were removed from the caches
+   */
+  sweepVoiceStates(filter) {
+    return this._sweepGuildDirectProp('voiceStates', filter, { outputName: 'voice states' }).items;
+  }
+
+  /**
+   * Cancels all sweeping intervals
+   * @returns {void}
+   */
+  destroy() {
+    const propKeys = SweeperKeys.map(k => `${k.slice(0, -1)}Interval`);
+    for (const key of propKeys) {
+      if (this[key]) clearInterval(this[key]);
+    }
+  }
+
+  /**
+   * Options for generating a filter function based on lifetime
+   * @typedef {Object} LifetimeFilterOptions
+   * @property {number} [lifetime=14400] How long, in seconds, an entry should stay in the collection
+   * before it is considered sweepable.
+   * @property {Function} [getComparisonTimestamp=e => e?.createdTimestamp] A function that takes an entry, key,
+   * and the collection and returns a timestamp to compare against in order to determine the lifetime of the entry.
+   * @property {Function} [excludeFromSweep=() => false] A function that takes an entry, key, and the collection
+   * and returns a boolean, `true` when the entry should not be checked for sweepability.
+   */
+
+  /**
+   * Create a sweepFilter function that uses a lifetime to determine sweepability.
+   * @param {LifetimeFilterOptions} [options={}] The options used to generate the filter function
+   * @returns {GlobalSweepFilter}
+   */
+  static filterByLifetime({
+    lifetime = 14400,
+    getComparisonTimestamp = e => e?.createdTimestamp,
+    excludeFromSweep = () => false,
+  } = {}) {
+    if (typeof lifetime !== 'number') {
+      throw new TypeError('INVALID_TYPE', 'lifetime', 'number');
+    }
+    if (typeof getComparisonTimestamp !== 'function') {
+      throw new TypeError('INVALID_TYPE', 'getComparisonTimestamp', 'function');
+    }
+    if (typeof excludeFromSweep !== 'function') {
+      throw new TypeError('INVALID_TYPE', 'excludeFromSweep', 'function');
+    }
+    return () => {
+      if (lifetime <= 0) return null;
+      const lifetimeMs = lifetime * 1_000;
+      const now = Date.now();
+      return (entry, key, coll) => {
+        if (excludeFromSweep(entry, key, coll)) {
+          return false;
+        }
+        const comparisonTimestamp = getComparisonTimestamp(entry, key, coll);
+        if (!comparisonTimestamp || typeof comparisonTimestamp !== 'number') return false;
+        return now - comparisonTimestamp > lifetimeMs;
+      };
+    };
+  }
+
+  /**
+   * Configuration options for emitting the cache sweep client event
+   * @typedef {Object} SweepEventOptions
+   * @property {boolean} [emit=true] Whether to emit the client event in this method
+   * @property {string} [outputName] A name to output in the client event if it should differ from the key
+   * @private
+   */
+
+  /**
+   * Sweep a direct sub property of all guilds
+   * @param {string} key The name of the property
+   * @param {Function} filter Filter function passed to sweep
+   * @param {SweepEventOptions} [eventOptions] Options for the Client event emitted here
+   * @returns {Object} Object containing the number of guilds swept and the number of items swept
+   * @private
+   */
+  _sweepGuildDirectProp(key, filter, { emit = true, outputName }) {
+    if (typeof filter !== 'function') {
+      throw new TypeError('INVALID_TYPE', 'filter', 'function');
+    }
+
+    let guilds = 0;
+    let items = 0;
+
+    for (const guild of this.client.guilds.cache.values()) {
+      if (guild[key].cache.size === 0) continue;
+      guilds++;
+
+      items += guild[key].cache.sweep(filter);
+    }
+
+    if (emit) {
+      this.client.emit(Events.CACHE_SWEEP, `Swept ${items} ${outputName ?? key} in ${guilds} guilds.`);
+    }
+
+    return { guilds, items };
+  }
+
+  /**
+   * Validates a set of properties
+   * @param {string} key Key of the options object to check
+   * @private
+   */
+  _validateProperties(key) {
+    const props = this.options[key];
+    if (typeof props !== 'object') {
+      throw new TypeError('INVALID_TYPE', `sweepers.${key}`, 'object', true);
+    }
+    if (typeof props.interval !== 'number') {
+      throw new TypeError('INVALID_TYPE', `sweepers.${key}.interval`, 'number');
+    }
+    if (
+      ['invites', 'messages', 'threads'].includes(key) &&
+      !('filter' in props) &&
+      typeof props.lifetime !== 'number'
+    ) {
+      throw new TypeError('INVALID_TYPE', `sweepers.${key}.lifetime`, 'number');
+    } else if (typeof props.filter !== 'function') {
+      throw new TypeError('INVALID_TYPE', `sweepers.${key}.filter`, 'function');
+    }
+  }
+
+  /**
+   * Initialize an interval for sweeping
+   * @param {string} intervalKey The name of the property that stores the interval for this sweeper
+   * @param {string} sweepKey The name of the function that sweeps the desired caches
+   * @param {Object} opts Validated options for a sweep
+   * @private
+   */
+  _initInterval(intervalKey, sweepKey, opts) {
+    if (opts.interval > 0 && opts.interval !== Infinity) {
+      this[intervalKey] = setInterval(() => {
+        const sweepFn = opts.filter();
+        if (sweepFn === null) return;
+        if (typeof sweepFn !== 'function') throw new TypeError('SWEEP_FILTER_RETURN');
+        this[sweepKey](sweepFn);
+      }, opts.interval * 1_000).unref();
+    }
+  }
+}
+
+module.exports = Sweepers;

--- a/src/util/Sweepers.js
+++ b/src/util/Sweepers.js
@@ -29,13 +29,13 @@ class Sweepers {
     this.options = options;
 
     /**
-     * The interval timeout that is used to sweep the indicated items, or null if not being swept
-     * @name Sweepers#*Interval
-     * @type {?Timeout}
+     * A record of interval timeout that is used to sweep the indicated items, or null if not being swept
+     * @type {Object<SweeperKey, ?Timeout>}
      */
+    this.intervals = {};
 
     for (const key of SweeperKeys) {
-      this[`${key.slice(0, -1)}Interval]`] = null;
+      this.intervals[key] = null;
       if (key in options) {
         this._validateProperties(key);
 
@@ -65,7 +65,7 @@ class Sweepers {
           }
         }
 
-        this._initInterval(`${key.slice(0, -1)}Interval`, `sweep${key[0].toUpperCase()}${key.slice(1)}`, clonedOptions);
+        this._initInterval(key, `sweep${key[0].toUpperCase()}${key.slice(1)}`, clonedOptions);
       }
     }
   }
@@ -288,9 +288,8 @@ class Sweepers {
    * @returns {void}
    */
   destroy() {
-    const propKeys = SweeperKeys.map(k => `${k.slice(0, -1)}Interval`);
-    for (const key of propKeys) {
-      if (this[key]) clearInterval(this[key]);
+    for (const key of Object.keys(this.intervals)) {
+      if (this.intervals[key]) clearInterval(this.intervals[key]);
     }
   }
 
@@ -411,7 +410,7 @@ class Sweepers {
    */
   _initInterval(intervalKey, sweepKey, opts) {
     if (opts.interval > 0 && opts.interval !== Infinity) {
-      this[intervalKey] = setInterval(() => {
+      this.intervals[intervalKey] = setInterval(() => {
         const sweepFn = opts.filter();
         if (sweepFn === null) return;
         if (typeof sweepFn !== 'function') throw new TypeError('SWEEP_FILTER_RETURN');

--- a/src/util/Sweepers.js
+++ b/src/util/Sweepers.js
@@ -59,7 +59,7 @@ class Sweepers {
             case 'threads':
               clonedOptions.filter = this.constructor.filterByLifetime({
                 lifetime: clonedOptions.lifetime,
-                getComparisonTimestamp: t => t.archivedTimestamp,
+                getComparisonTimestamp: t => t.archiveTimestamp,
                 excludeFromSweep: t => !t.archived,
               });
           }
@@ -146,7 +146,7 @@ class Sweepers {
     let messages = 0;
 
     for (const channel of this.client.channels.cache.values()) {
-      if (!channel.messsages || channel.messages.cache.size === 0) continue;
+      if (!channel.messages || channel.messages.cache.size === 0) continue;
       channels++;
 
       messages += channel.messages.cache.sweep(filter);
@@ -178,7 +178,7 @@ class Sweepers {
     let reactions = 0;
 
     for (const channel of this.client.channels.cache.values()) {
-      if (!channel.messsages || channel.messages.cache.size === 0) continue;
+      if (!channel.messages || channel.messages.cache.size === 0) continue;
       channels++;
 
       for (const message of channel.messages.cache.values()) {
@@ -390,13 +390,13 @@ class Sweepers {
     if (typeof props.interval !== 'number') {
       throw new TypeError('INVALID_TYPE', `sweepers.${key}.interval`, 'number');
     }
-    if (
-      ['invites', 'messages', 'threads'].includes(key) &&
-      !('filter' in props) &&
-      typeof props.lifetime !== 'number'
-    ) {
-      throw new TypeError('INVALID_TYPE', `sweepers.${key}.lifetime`, 'number');
-    } else if (typeof props.filter !== 'function') {
+    if (['invites', 'messages', 'threads'].includes(key) && !('filter' in props)) {
+      if (typeof props.lifetime !== 'number') {
+        throw new TypeError('INVALID_TYPE', `sweepers.${key}.lifetime`, 'number');
+      }
+      return;
+    }
+    if (typeof props.filter !== 'function') {
       throw new TypeError('INVALID_TYPE', `sweepers.${key}.filter`, 'function');
     }
   }

--- a/src/util/Sweepers.js
+++ b/src/util/Sweepers.js
@@ -277,7 +277,7 @@ class Sweepers {
    * @returns {void}
    */
   destroy() {
-    for (const key of Object.keys(this.intervals)) {
+    for (const key of SweeperKeys) {
       if (this.intervals[key]) clearInterval(this.intervals[key]);
     }
   }

--- a/src/util/Sweepers.js
+++ b/src/util/Sweepers.js
@@ -364,7 +364,7 @@ class Sweepers {
     let items = 0;
 
     for (const guild of this.client.guilds.cache.values()) {
-      const cache = guild[key].cache;
+      const { cache } = guild[key];
       if (cache.size === 0) continue;
       guilds++;
 

--- a/src/util/Sweepers.js
+++ b/src/util/Sweepers.js
@@ -136,9 +136,8 @@ class Sweepers {
 
     for (const channel of this.client.channels.cache.values()) {
       if (!channel.isText()) continue;
-      channels++;
-      if (channel.messages.cache.size === 0) continue;
 
+      channels++;
       messages += channel.messages.cache.sweep(filter);
     }
     this.client.emit(Events.CACHE_SWEEP, `Swept ${messages} messages in ${channels} text-based channels.`);
@@ -170,12 +169,9 @@ class Sweepers {
     for (const channel of this.client.channels.cache.values()) {
       if (!channel.isText()) continue;
       channels++;
-      if (channel.messages.cache.size === 0) continue;
 
       for (const message of channel.messages.cache.values()) {
         messages++;
-        if (message.reactions.cache.size === 0) continue;
-
         reactions += message.reactions.cache.sweep(filter);
       }
     }
@@ -211,7 +207,6 @@ class Sweepers {
     for (const channel of this.client.channels.cache.values()) {
       if (!ThreadChannelTypes.includes(channel.type)) continue;
       threads++;
-      if (channel.members.cache.size === 0) continue;
       members += channel.members.cache.sweep(filter);
     }
     this.client.emit(Events.CACHE_SWEEP, `Swept ${members} thread members in ${threads} threads.`);
@@ -393,9 +388,8 @@ class Sweepers {
 
     for (const guild of this.client.guilds.cache.values()) {
       const { cache } = guild[key];
-      guilds++;
-      if (cache.size === 0) continue;
 
+      guilds++;
       items += cache.sweep(filter);
     }
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -590,14 +590,11 @@ class Util extends null {
   /**
    * Creates a sweep filter that sweeps archived threads
    * @param {number} [lifetime=14400] How long a thread has to be archived to be valid for sweeping
+   * @deprecated When not using with `makeCache` use `Sweepers.archivedThreadSweepFilter` instead
    * @returns {SweepFilter}
    */
   static archivedThreadSweepFilter(lifetime = 14400) {
-    const filter = require('./LimitedCollection').filterByLifetime({
-      lifetime,
-      getComparisonTimestamp: e => e.archiveTimestamp,
-      excludeFromSweep: e => !e.archived,
-    });
+    const filter = require('./Sweepers').archivedThreadSweepFilter(lifetime);
     filter.isDefault = true;
     return filter;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -540,6 +540,7 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
   public generateInvite(options?: InviteGenerationOptions): string;
   public login(token?: string): Promise<string>;
   public isReady(): this is Client<true>;
+  /** @deprecated Use {@link Sweepers#sweepMessages} instead */
   public sweepMessages(lifetime?: number): number;
   public toJSON(): unknown;
 
@@ -3856,9 +3857,9 @@ export interface ClientOptions {
   shards?: number | number[] | 'auto';
   shardCount?: number;
   makeCache?: CacheFactory;
-  /** @deprecated Use `makeCache` with a `LimitedCollection` for `MessageManager` instead. */
+  /** @deprecated Pass the value of this property as `lifetime` to `sweepers.messages` instead. */
   messageCacheLifetime?: number;
-  /** @deprecated Use `makeCache` with a `LimitedCollection` for `MessageManager` instead. */
+  /** @deprecated Pass the value of this property as `interval` to `sweepers.messages` instead. */
   messageSweepInterval?: number;
   allowedMentions?: MessageMentionOptions;
   invalidRequestWarningInterval?: number;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2090,21 +2090,8 @@ export class StoreChannel extends GuildChannel {
 export class Sweepers {
   public constructor(client: Client, options: SweeperOptions);
   public readonly client: Client;
+  public intervals: Record<SweeperKey, NodeJS.Timeout | null>;
   public options: SweeperOptions;
-  public applicationCommandInterval: NodeJS.Timeout | null;
-  public banInterval: NodeJS.Timeout | null;
-  public emojiInterval: NodeJS.Timeout | null;
-  public inviteInterval: NodeJS.Timeout | null;
-  public guildMemberInterval: NodeJS.Timeout | null;
-  public messageInterval: NodeJS.Timeout | null;
-  public presenceInterval: NodeJS.Timeout | null;
-  public reactionInterval: NodeJS.Timeout | null;
-  public stageInstnaceInterval: NodeJS.Timeout | null;
-  public stickerInterval: NodeJS.Timeout | null;
-  public threadMemberInterval: NodeJS.Timeout | null;
-  public threadInterval: NodeJS.Timeout | null;
-  public userInterval: NodeJS.Timeout | null;
-  public voiceStateInterval: NodeJS.Timeout | null;
 
   public sweepApplicationCommands(
     filter: CollectionSweepFilter<

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -605,6 +605,7 @@ export class ClientUser extends User {
 export class Options extends null {
   private constructor();
   public static defaultMakeCacheSettings: CacheWithLimitsOptions;
+  public static defaultSweeperSettings: SweeperOptions;
   public static createDefault(): ClientOptions;
   public static cacheWithLimits(settings?: CacheWithLimitsOptions): CacheFactory;
   public static cacheEverything(): CacheFactory;
@@ -2137,7 +2138,16 @@ export class Sweepers {
     filter: CollectionSweepFilter<SweeperDefinitions['voiceStates'][0], SweeperDefinitions['voiceStates'][1]>,
   ): number;
 
-  public static filterByLifetime<K, V>(options?: LifetimeFilterOptions<K, V>): SweepFilter<K, V>;
+  public static archivedThreadSweepFilter(
+    lifetime?: number,
+  ): GlobalSweepFilter<SweeperDefinitions['threads'][0], SweeperDefinitions['threads'][1]>;
+  public static expiredInviteSweepFilter(
+    lifetime?: number,
+  ): GlobalSweepFilter<SweeperDefinitions['invites'][0], SweeperDefinitions['invites'][1]>;
+  public static filterByLifetime<K, V>(options?: LifetimeFilterOptions<K, V>): GlobalSweepFilter<K, V>;
+  public static outdatedMessageSweepFilter(
+    lifetime?: number,
+  ): GlobalSweepFilter<SweeperDefinitions['messages'][0], SweeperDefinitions['messages'][1]>;
 }
 
 export class SystemChannelFlags extends BitField<SystemChannelFlagsString> {
@@ -2308,6 +2318,7 @@ export class UserFlags extends BitField<UserFlagsString> {
 
 export class Util extends null {
   private constructor();
+  /** @deprecated When not using with `makeCache` use `Sweepers.archivedThreadSweepFilter` instead */
   public static archivedThreadSweepFilter<K, V>(lifetime?: number): SweepFilter<K, V>;
   public static basename(path: string, ext?: string): string;
   public static cleanContent(str: string, channel: TextBasedChannels): string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

<div align="center">

| ⚠️ This is tested, but not all combinations of sweepers have been validated. |
| - |

</div>

- This aims to tackle point 2 in  #6539: Global Sweepers. This does not completely satisfy what was outlined there however, it still relies on `LimitedCollection` to provide max size functionality. After doing the work to get to this point, that seemed out of scope, and can easily be tackled in another PR. This does mean that you are still storing extra properties on LimitedCollection for now, however hopefully not tracking a timeout.

In order to keep this semver: minor, default options have unfortunately <strong>not</strong> been switched to use the sweepers in this PR.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
