### PR TITLE
types(CommandInteractionOptionResolver): allow narrowing of `getMember()`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -606,12 +606,17 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
   public once(event: 'end', listener: (collected: Collection<K, V>, reason: string) => Awaitable<void>): this;
 }
 
-export class CommandInteraction extends BaseCommandInteraction {
-  public options: CommandInteractionOptionResolver;
+export type GuildCommandInteraction<Cached extends GuildCacheState> = InteractionResponses<Cached> &
+  CommandInteraction<Cached>;
+
+export class CommandInteraction<Cached extends GuildCacheState = GuildCacheState> extends BaseCommandInteraction {
+  public options: CommandInteractionOptionResolver<Cached>;
+  public inCachedGuild(): this is GuildCommandInteraction<'cached'> & this;
+  public inRawGuild(): this is GuildCommandInteraction<'raw'> & this;
   public toString(): string;
 }
 
-export class CommandInteractionOptionResolver {
+export class CommandInteractionOptionResolver<Cached extends GuildCacheState = GuildCacheState> {
   private constructor(client: Client, options: CommandInteractionOption[], resolved: CommandInteractionResolvedData);
   public readonly client: Client;
   public readonly data: readonly CommandInteractionOption[];
@@ -651,8 +656,14 @@ export class CommandInteractionOptionResolver {
   public getNumber(name: string, required?: boolean): number | null;
   public getUser(name: string, required: true): NonNullable<CommandInteractionOption['user']>;
   public getUser(name: string, required?: boolean): NonNullable<CommandInteractionOption['user']> | null;
-  public getMember(name: string, required: true): NonNullable<CommandInteractionOption['member']>;
-  public getMember(name: string, required?: boolean): NonNullable<CommandInteractionOption['member']> | null;
+  public getMember(
+    name: string,
+    required: true,
+  ): CacheTypeReducer<Cached, GuildMember, NonNullable<APIInteractionDataResolvedGuildMember>>;
+  public getMember(
+    name: string,
+    required?: boolean,
+  ): CacheTypeReducer<Cached, GuildMember, NonNullable<APIInteractionDataResolvedGuildMember>> | null;
   public getRole(name: string, required: true): NonNullable<CommandInteractionOption['role']>;
   public getRole(name: string, required?: boolean): NonNullable<CommandInteractionOption['role']> | null;
   public getMentionable(
@@ -1090,6 +1101,7 @@ export interface GuildInteraction<Cached extends GuildCacheState = GuildCacheSta
   member: CacheTypeReducer<Cached, GuildMember, APIInteractionGuildMember>;
   readonly guild: CacheTypeReducer<Cached, Guild, null>;
   channel: CacheTypeReducer<Cached, Exclude<TextBasedChannels, PartialDMChannel | DMChannel> | null>;
+  isCommand(): this is GuildCommandInteraction<Cached> & this;
 }
 
 export class Interaction extends Base {

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -1,4 +1,9 @@
-import { APIGuildMember, APIInteractionGuildMember, APIMessage } from 'discord-api-types/v9';
+import {
+  APIGuildMember,
+  APIInteractionDataResolvedGuildMember,
+  APIInteractionGuildMember,
+  APIMessage,
+} from 'discord-api-types/v9';
 import {
   ApplicationCommand,
   ApplicationCommandChannelOptionData,
@@ -943,8 +948,12 @@ client.on('interactionCreate', async interaction => {
       consumeCachedCommand(interaction);
       assertType<CommandInteraction>(interaction);
       assertType<Promise<APIMessage>>(interaction.reply({ fetchReply: true }));
+      assertType<APIInteractionDataResolvedGuildMember | null>(interaction.options.getMember('test'));
+      assertType<APIInteractionDataResolvedGuildMember>(interaction.options.getMember('test', true));
     } else if (interaction.inCachedGuild()) {
       consumeCachedCommand(interaction);
+      assertType<GuildMember>(interaction.options.getMember('test', true));
+      assertType<GuildMember | null>(interaction.options.getMember('test'));
       assertType<CommandInteraction>(interaction);
       assertType<Promise<Message>>(interaction.reply({ fetchReply: true }));
     } else {
@@ -952,6 +961,8 @@ client.on('interactionCreate', async interaction => {
       consumeCachedCommand(interaction);
       assertType<CommandInteraction>(interaction);
       assertType<Promise<Message | APIMessage>>(interaction.reply({ fetchReply: true }));
+      assertType<APIInteractionDataResolvedGuildMember | GuildMember | null>(interaction.options.getMember('test'));
+      assertType<APIInteractionDataResolvedGuildMember | GuildMember>(interaction.options.getMember('test', true));
     }
 
     assertType<CommandInteraction>(interaction);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

As per @ImRodry's request. Allows `CommandInteractionOptionResolver#getMember` to be narrowed to `GuildMember` if bot is within guild.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating