### PR TITLE
fix(Webhook): Resolve source guild only if cached

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -90,7 +90,7 @@ class Webhook {
        * The source guild of the webhook
        * @type {?(Guild|APIGuild)}
        */
-      this.sourceGuild = this.client.guilds?._add(data.source_guild, false) ?? data.source_guild;
+      this.sourceGuild = this.client.guilds?.resolve(data.source_guild.id) ?? data.source_guild;
     } else {
       this.sourceGuild ??= null;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This resolves #6773 (tl;dr: checking the `.sourceGuild` property of a channel follower webhook that the bot is not in (or has cached) yields a weird `Guild` structure with improperly-set & `undefined` properties).

I went with the `.resolve()` approach here as trying to move `features` out of the `BaseGuild` and no longer having it abstract would mean that another abstract intermediary guild structure would have to be created just for `features`, which is a bit much. In addition, if we were to create a `SourceGuild` structure, it would be somewhat of a copy of the existing `BaseGuild`, which I don't think is desired.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
