### PR TITLE
fix: `PartialGuildMember#id` is not null

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4709,15 +4709,12 @@ export interface PartialDMChannel extends Partialize<DMChannel, null, null, 'las
   lastMessageId: undefined;
 }
 
-export type PartialGuildMember = Partialize<GuildMember, 'joinedAt' | 'joinedTimestamp'>;
+export interface PartialGuildMember extends Partialize<GuildMember, 'joinedAt' | 'joinedTimestamp'> {}
 
-export type PartialMessage = Partialize<
-  Message,
-  'type' | 'system' | 'pinned' | 'tts',
-  'content' | 'cleanContent' | 'author'
->;
+export interface PartialMessage
+  extends Partialize<Message, 'type' | 'system' | 'pinned' | 'tts', 'content' | 'cleanContent' | 'author'> {}
 
-export type PartialMessageReaction = Partialize<MessageReaction, 'count'>;
+export interface PartialMessageReaction extends Partialize<MessageReaction, 'count'> {}
 
 export interface PartialOverwriteData {
   id: Snowflake | number;
@@ -4732,7 +4729,7 @@ export interface PartialRoleData extends RoleData {
 
 export type PartialTypes = 'USER' | 'CHANNEL' | 'GUILD_MEMBER' | 'MESSAGE' | 'REACTION';
 
-export type PartialUser = Partialize<User, 'username' | 'tag' | 'discriminator'>;
+export interface PartialUser extends Partialize<User, 'username' | 'tag' | 'discriminator'> {}
 
 export type PresenceStatusData = ClientPresenceStatus | 'invisible';
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes #6839, This seems to fix a regression introduced in #6066

The [docs](https://discord.com/developers/docs/topics/gateway#guild-member-remove-guild-member-remove-event-fields) say a user object is always provided in these events. So it shouldn't be nullable. 

I also converted some empty interfaces into types.

**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating