### PR TITLE
fix(ApplicationCommandManager): update guild command cache on c/u/d

### DIFF
--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -117,7 +117,7 @@ class ApplicationCommandManager extends CachedManager {
     const data = await this.commandPath({ guildId }).post({
       data: this.constructor.transformCommand(command),
     });
-    return this._add(data, !guildId, guildId);
+    return this._add(data, true, guildId);
   }
 
   /**
@@ -146,10 +146,7 @@ class ApplicationCommandManager extends CachedManager {
     const data = await this.commandPath({ guildId }).put({
       data: commands.map(c => this.constructor.transformCommand(c)),
     });
-    return data.reduce(
-      (coll, command) => coll.set(command.id, this._add(command, !guildId, guildId)),
-      new Collection(),
-    );
+    return data.reduce((coll, command) => coll.set(command.id, this._add(command, true, guildId)), new Collection());
   }
 
   /**
@@ -174,7 +171,7 @@ class ApplicationCommandManager extends CachedManager {
     const patched = await this.commandPath({ id, guildId }).patch({
       data: this.constructor.transformCommand(data),
     });
-    return this._add(patched, !guildId, guildId);
+    return this._add(patched, true, guildId);
   }
 
   /**
@@ -196,7 +193,7 @@ class ApplicationCommandManager extends CachedManager {
     await this.commandPath({ id, guildId }).delete();
 
     const cached = this.cache.get(id);
-    if (!guildId) this.cache.delete(id);
+    this.cache.delete(id);
     return cached ?? null;
   }
 


### PR DESCRIPTION
### Please describe the changes this PR makes and why it should be merged:
Currently, the cache is not updated when guild commands are created, updated, or deleted; this PR fixes that.

[discussion](https://canary.discord.com/channels/222078108977594368/682166281826598932/890029573008425011) (about a month ago)


### Status and versioning classification:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
