### PR TITLE
feat(ApplicationCommand): add support for min and max values

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -261,7 +261,9 @@ class ApplicationCommand extends Base {
         existing.required ||
       option.choices?.length !== existing.choices?.length ||
       option.options?.length !== existing.options?.length ||
-      (option.channelTypes ?? option.channel_types)?.length !== existing.channelTypes?.length
+      (option.channelTypes ?? option.channel_types)?.length !== existing.channelTypes?.length ||
+      (option.minValue ?? option.min_value) !== existing.minValue ||
+      (option.maxValue ?? option.maxValue) !== existing.maxValue
     ) {
       return false;
     }
@@ -330,6 +332,8 @@ class ApplicationCommand extends Base {
   static transformOption(option, received) {
     const stringType = typeof option.type === 'string' ? option.type : ApplicationCommandOptionTypes[option.type];
     const channelTypesKey = received ? 'channelTypes' : 'channel_types';
+    const minValueKey = received ? 'minValue' : 'min_value';
+    const maxValueKey = received ? 'maxValue' : 'max_value';
     return {
       type: typeof option.type === 'number' && !received ? option.type : ApplicationCommandOptionTypes[option.type],
       name: option.name,
@@ -344,6 +348,8 @@ class ApplicationCommand extends Base {
         : option.channelTypes?.map(type => (typeof type === 'string' ? ChannelTypes[type] : type)) ??
           // When transforming to API data, accept API data
           option.channel_types,
+      [minValueKey]: option.minValue ?? option.min_value,
+      [maxValueKey]: option.maxValue ?? option.max_value,
     };
   }
 }

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -136,6 +136,10 @@ class ApplicationCommand extends Base {
 
   /**
    * An option for an application command or subcommand.
+   * <info>In addition to the listed properties, when used as a parameter,
+   * API style `snake_case` properties can be used for compatibility with generators like `@discordjs/builders`.</info>
+   * <warn>Note that providing a value for the `camelCase` counterpart for any `snake_case` property
+   * will discard the provided `snake_case` property.</warn>
    * @typedef {Object} ApplicationCommandOptionData
    * @property {ApplicationCommandOptionType|number} type The type of the option
    * @property {string} name The name of the option
@@ -146,18 +150,8 @@ class ApplicationCommand extends Base {
    * @property {ApplicationCommandOptionData[]} [options] Additional options if this option is a subcommand (group)
    * @property {ChannelType[]|number[]} [channelTypes] When the option type is channel,
    * the allowed types of channels that can be selected
-   * @property {number[]} [channel_types] When the option type is channel,
-   * the API data for allowed types of channels that can be selected
-   * <warn>This is provided for compatibility with something like `@discordjs/builders`
-   * and will be discarded when `channelTypes` is present</warn>
    * @property {number} [minValue] The minimum value for an `INTEGER` or `NUMBER` option
-   * @property {number} [min_value] API data for the minimum value for an `INTEGER` or `NUMBER` option
-   * <warn>This is provided for compatibility with something like `@discordjs/builders`
-   * and will be discarded when `minValue` is present</warn>
    * @property {number} [maxValue] The maximum value for an `INTEGER` or `NUMBER` option
-   * @property {number} [max_value] API data for the maximum value for an `INTEGER` or `NUMBER` option
-   * <warn>This is provided for compatibility with something like `@discordjs/builders`
-   * and will be discarded when `maxValue` is present</warn>
    */
 
   /**

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -150,6 +150,14 @@ class ApplicationCommand extends Base {
    * the API data for allowed types of channels that can be selected
    * <warn>This is provided for compatibility with something like `@discordjs/builders`
    * and will be discarded when `channelTypes` is present</warn>
+   * @property {number} [minValue] The minimum value for an `INTEGER` or `NUMBER` option
+   * @property {number} [min_value] API data for the minimum value for an `INTEGER` or `NUMBER` option
+   * <warn>This is provided for compatibility with something like `@discordjs/builders`
+   * and will be discarded when `minValue` is present</warn>
+   * @property {number} [maxValue] The maximum value for an `INTEGER` or `NUMBER` option
+   * @property {number} [max_value] API data for the maximum value for an `INTEGER` or `NUMBER` option
+   * <warn>This is provided for compatibility with something like `@discordjs/builders`
+   * and will be discarded when `maxValue` is present</warn>
    */
 
   /**
@@ -313,6 +321,8 @@ class ApplicationCommand extends Base {
    * @property {ApplicationCommandOption[]} [options] Additional options if this option is a subcommand (group)
    * @property {ChannelType[]} [channelTypes] When the option type is channel,
    * the allowed types of channels that can be selected
+   * @property {number} [minValue] The minimum value for an `INTEGER` or `NUMBER` option
+   * @property {number} [maxValue] The maximum value for an `INTEGER` or `NUMBER` option
    */
 
   /**

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -263,7 +263,7 @@ class ApplicationCommand extends Base {
       option.options?.length !== existing.options?.length ||
       (option.channelTypes ?? option.channel_types)?.length !== existing.channelTypes?.length ||
       (option.minValue ?? option.min_value) !== existing.minValue ||
-      (option.maxValue ?? option.maxValue) !== existing.maxValue
+      (option.maxValue ?? option.max_value) !== existing.maxValue
     ) {
       return false;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3289,10 +3289,13 @@ export type CommandOptionDataTypeResolvable = ApplicationCommandOptionType | App
 export type CommandOptionChannelResolvableType = ApplicationCommandOptionTypes.CHANNEL | 'CHANNEL';
 
 export type CommandOptionChoiceResolvableType =
-  | ApplicationCommandOptionTypes.NUMBER
-  | 'NUMBER'
   | ApplicationCommandOptionTypes.STRING
   | 'STRING'
+  | CommandOptionNumericResolvableType;
+
+export type CommandOptionNumericResolvableType =
+  | ApplicationCommandOptionTypes.NUMBER
+  | 'NUMBER'
   | ApplicationCommandOptionTypes.INTEGER
   | 'INTEGER';
 
@@ -3354,6 +3357,20 @@ export interface ApplicationCommandChoicesOption extends BaseApplicationCommandO
   choices?: ApplicationCommandOptionChoice[];
 }
 
+export interface ApplicationCommandNumericOptionData extends ApplicationCommandChoicesData {
+  type: CommandOptionNumericResolvableType;
+  minValue: number;
+  min_value: number;
+  maxValue: number;
+  max_value: number;
+}
+
+export interface ApplicationCommandNumericOption extends ApplicationCommandChoicesOption {
+  type: Exclude<CommandOptionNumericResolvableType, ApplicationCommandOptionTypes>;
+  minValue: number;
+  maxValue: number;
+}
+
 export interface ApplicationCommandSubGroupData extends Omit<BaseApplicationCommandOptionsData, 'required'> {
   type: 'SUB_COMMAND_GROUP' | ApplicationCommandOptionTypes.SUB_COMMAND_GROUP;
   options?: ApplicationCommandSubCommandData[];
@@ -3387,6 +3404,7 @@ export type ApplicationCommandOptionData =
   | ApplicationCommandNonOptionsData
   | ApplicationCommandChannelOptionData
   | ApplicationCommandChoicesData
+  | ApplicationCommandNumericOptionData
   | ApplicationCommandSubCommandData;
 
 export type ApplicationCommandOption =
@@ -3394,6 +3412,7 @@ export type ApplicationCommandOption =
   | ApplicationCommandNonOptions
   | ApplicationCommandChannelOption
   | ApplicationCommandChoicesOption
+  | ApplicationCommandNumericOption
   | ApplicationCommandSubCommand;
 
 export interface ApplicationCommandOptionChoice {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3359,16 +3359,16 @@ export interface ApplicationCommandChoicesOption extends BaseApplicationCommandO
 
 export interface ApplicationCommandNumericOptionData extends ApplicationCommandChoicesData {
   type: CommandOptionNumericResolvableType;
-  minValue: number;
-  min_value: number;
-  maxValue: number;
-  max_value: number;
+  minValue?: number;
+  min_value?: number;
+  maxValue?: number;
+  max_value?: number;
 }
 
 export interface ApplicationCommandNumericOption extends ApplicationCommandChoicesOption {
   type: Exclude<CommandOptionNumericResolvableType, ApplicationCommandOptionTypes>;
-  minValue: number;
-  maxValue: number;
+  minValue?: number;
+  maxValue?: number;
 }
 
 export interface ApplicationCommandSubGroupData extends Omit<BaseApplicationCommandOptionsData, 'required'> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds support for number and int types max and min values

- https://github.com/discord/discord-api-docs/pull/3967

Typings are not yet updated due to a potential issue with choices and min / max that I will be noting upstream

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
