### PR TITLE
feat(MessageAttachment): description (alt text) support

### DIFF
--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -51,7 +51,7 @@ class APIRequest {
     if (this.options.files?.length) {
       body = new FormData();
       for (const [index, file] of this.options.files.entries()) {
-        if (file?.file) body.append(`files[${index}]`, file.file, file.name);
+        if (file?.file) body.append(file.key ?? `files[${index}]`, file.file, file.name);
       }
       if (typeof this.options.data !== 'undefined') {
         if (this.options.dontUsePayloadJSON) {

--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -50,8 +50,8 @@ class APIRequest {
     let body;
     if (this.options.files?.length) {
       body = new FormData();
-      for (const file of this.options.files) {
-        if (file?.file) body.append(file.key ?? file.name, file.file, file.name);
+      for (const [index, file] of this.options.files.entries()) {
+        if (file?.file) body.append(`files[${index}]`, file.file, file.name);
       }
       if (typeof this.options.data !== 'undefined') {
         if (this.options.dontUsePayloadJSON) {

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -22,6 +22,16 @@ class MessageAttachment {
   }
 
   /**
+   * Sets the description of this attachment.
+   * @param {string} description The description of the file
+   * @returns {MessageAttachment} This attachment
+   */
+   setDescription(description) {
+    this.description = description;
+    return this;
+  }
+
+  /**
    * Sets the file of this attachment.
    * @param {BufferResolvable|Stream} attachment The file
    * @param {string} [name=null] The name of the file, if any
@@ -120,6 +130,16 @@ class MessageAttachment {
       this.contentType = data.content_type;
     } else {
       this.contentType ??= null;
+    }
+
+    if ('description' in data) {
+      /**
+       * This description (alt text) of this attachment
+       * @type {?string}
+       */
+      this.description = data.description;
+    } else {
+      this.description ??= null;
     }
 
     /**

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -134,7 +134,7 @@ class MessageAttachment {
 
     if ('description' in data) {
       /**
-       * This description (alt text) of this attachment
+       * The description (alt text) of this attachment
        * @type {?string}
        */
       this.description = data.description;

--- a/src/structures/MessageAttachment.js
+++ b/src/structures/MessageAttachment.js
@@ -26,7 +26,7 @@ class MessageAttachment {
    * @param {string} description The description of the file
    * @returns {MessageAttachment} This attachment
    */
-   setDescription(description) {
+  setDescription(description) {
     this.description = description;
     return this;
   }

--- a/src/structures/MessagePayload.js
+++ b/src/structures/MessagePayload.js
@@ -177,7 +177,10 @@ class MessagePayload {
       }
     }
 
-    const attachments = this.options.files?.map((file, index) => ({ id: index.toString(), description: file.description }));
+    const attachments = this.options.files?.map((file, index) => ({
+      id: index.toString(),
+      description: file.description,
+    }));
     if (Array.isArray(this.options.attachments)) {
       this.options.attachments.push(...attachments);
     } else {

--- a/src/structures/MessagePayload.js
+++ b/src/structures/MessagePayload.js
@@ -177,6 +177,13 @@ class MessagePayload {
       }
     }
 
+    const attachments = this.options.files?.map((file, index) => ({ id: index.toString(), description: file.description }));
+    if (Array.isArray(this.options.attachments)) {
+      this.options.attachments.push(...attachments);
+    } else {
+      this.options.attachments = attachments;
+    }
+
     this.data = {
       content,
       tts,

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -129,6 +129,7 @@ class TextBasedChannel {
    *   files: [{
    *     attachment: 'entire/path/to/file.jpg',
    *     name: 'file.jpg'
+   *     description: 'A description of the file'
    *   }]
    * })
    *   .then(console.log)
@@ -147,6 +148,7 @@ class TextBasedChannel {
    *   files: [{
    *     attachment: 'entire/path/to/file.jpg',
    *     name: 'file.jpg'
+   *     description: 'A description of the file'
    *   }]
    * })
    *   .then(console.log)

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -96,6 +96,7 @@ class TextBasedChannel {
    * @typedef {Object} FileOptions
    * @property {BufferResolvable} attachment File to attach
    * @property {string} [name='file.jpg'] Filename of the attachment
+   * @property {string} description The description of the file
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3966,7 +3966,7 @@ export interface FetchThreadsOptions {
 export interface FileOptions {
   attachment: BufferResolvable | Stream;
   name?: string;
-  description?: string
+  description?: string;
 }
 
 export interface GuildApplicationCommandPermissionData {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3966,6 +3966,7 @@ export interface FetchThreadsOptions {
 export interface FileOptions {
   attachment: BufferResolvable | Stream;
   name?: string;
+  description?: string
 }
 
 export interface GuildApplicationCommandPermissionData {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1375,6 +1375,7 @@ export class MessageAttachment {
 
   public attachment: BufferResolvable | Stream;
   public contentType: string | null;
+  public description: string | null;
   public ephemeral: boolean;
   public height: number | null;
   public id: Snowflake;
@@ -1384,6 +1385,7 @@ export class MessageAttachment {
   public readonly spoiler: boolean;
   public url: string;
   public width: number | null;
+  public setDescription(description: string): this;
   public setFile(attachment: BufferResolvable | Stream, name?: string): this;
   public setName(name: string): this;
   public setSpoiler(spoiler?: boolean): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This adds the description property to the MessageAttachment class which is used for alt text added in the client (just added in the latest build but behind an experiment)

- https://github.com/discord/discord-api-docs/pull/3860

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
