### PR TITLE
fix(TextBasedChannel): return the cached message instead of clone it

### DIFF
--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -171,7 +171,7 @@ class TextBasedChannel {
     const { data, files } = await messagePayload.resolveFiles();
     const d = await this.client.api.channels[this.id].messages.post({ data, files });
 
-    return this.messages.cache.get(d.id) || this.messages._add(d);
+    return this.messages.cache.get(d.id) ?? this.messages._add(d);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This probably will also fix #6348 and #6763 about the `.deleted` flags that does never get updated. Their code example wasn't using `setTimeout` and makes it looks like a race condition. But actually I also encounter about this problem and found that the returned object from `textChannel.send` is cloned from the original object, while the cache only stored the original message object. The `.deleted` flag on cached message will get updated, but the cloned message will never get updated because the object property is copied by using `Object.assign` from the `._clone` method.

The code sample about this fix:
```js
let message = await textChannel.send({content: "lalala"}); // Send message
await message.delete(); // Delete it

console.log("Message deleted 1:", message.deleted);

setTimeout(function() {
    console.log("Message deleted 2:", message.deleted);
}, 2000);
```

Result:
```js
// Before the fix
Message deleted 1: false
Message deleted 2: false // This still false, but the cache already updated to true

// After this fix
Message deleted 1: true // Some time this return false for me, but mostly it return true
Message deleted 2: true
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating