### PR TITLE
ci: release dev version only if required

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -21,7 +21,7 @@ jobs:
       - name: pre-release
         id: pre-release
         run: |
-          if [[ $(npm view discordx@dev version | grep -e "$(jq --raw-output '.version' package.json).*.$(git rev-parse --short HEAD | cut -b1-3)") ]]; \
+          if [[ $(npm view discord.js@dev version | grep -e "$(jq --raw-output '.version' package.json).*.$(git rev-parse --short HEAD | cut -b1-3)") ]]; \
           then echo '::set-output name=release::false'; \
           else echo '::set-output name=release::true'; fi
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

### Reposting #6872 with update.

![image](https://user-images.githubusercontent.com/43092101/138610509-56fa946a-f369-4642-92ba-977f02c12375.png)

Stop workflow from releasing dev version if there are no changes on repo.

### **Reason for reopen**

- could not update code on last pull request.
- Question asked by @ImRodry 

![image](https://user-images.githubusercontent.com/43092101/138610068-2243cd04-462b-43e0-b628-4d9b0b7a7eb1.png)

**Status and versioning classification:**
 - This PR only includes non-code changes, like changes to documentation, README, etc.
 
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
