### PR TITLE
feat(Guild): add premiumProgressbarEnabled

### DIFF
--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -154,7 +154,6 @@ class GuildManager extends CachedManager {
    * @property {Snowflake|number} [systemChannelId] The system channel's id
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel
    * @property {VerificationLevel} [verificationLevel] The verification level for the guild
-   * @property {boolean} [premiumProgressBarEnabled] Whether the guild's premium progress bar is enabled
    */
 
   /**
@@ -177,7 +176,6 @@ class GuildManager extends CachedManager {
       systemChannelId,
       systemChannelFlags,
       verificationLevel,
-      premiumProgressBarEnabled,
     } = {},
   ) {
     icon = await DataResolver.resolveImage(icon);
@@ -231,7 +229,6 @@ class GuildManager extends CachedManager {
         afk_timeout: afkTimeout,
         system_channel_id: systemChannelId,
         system_channel_flags: systemChannelFlags,
-        premium_progress_bar_enabled: premiumProgressBarEnabled,
       },
     });
 

--- a/src/managers/GuildManager.js
+++ b/src/managers/GuildManager.js
@@ -154,6 +154,7 @@ class GuildManager extends CachedManager {
    * @property {Snowflake|number} [systemChannelId] The system channel's id
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The flags of the system channel
    * @property {VerificationLevel} [verificationLevel] The verification level for the guild
+   * @property {boolean} [premiumProgressBarEnabled] Whether the guild's premium progress bar is enabled
    */
 
   /**
@@ -176,6 +177,7 @@ class GuildManager extends CachedManager {
       systemChannelId,
       systemChannelFlags,
       verificationLevel,
+      premiumProgressBarEnabled,
     } = {},
   ) {
     icon = await DataResolver.resolveImage(icon);
@@ -229,6 +231,7 @@ class GuildManager extends CachedManager {
         afk_timeout: afkTimeout,
         system_channel_id: systemChannelId,
         system_channel_flags: systemChannelFlags,
+        premium_progress_bar_enabled: premiumProgressBarEnabled,
       },
     });
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -875,7 +875,7 @@ class Guild extends AnonymousGuild {
       _data.description = data.description;
     }
     if (data.preferredLocale) _data.preferred_locale = data.preferredLocale;
-    if (data.premiumProgressBarEnabled) _data.premium_progress_bar_enabled = data.premiumProgressBarEnabled;
+    if ('premiumProgressBarEnabled' in data) _data.premium_progress_bar_enabled = data.premiumProgressBarEnabled;
     const newData = await this.client.api.guilds(this.id).patch({ data: _data, reason });
     return this.client.actions.GuildUpdate.handle(newData).updated;
   }

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -167,6 +167,14 @@ class Guild extends AnonymousGuild {
       this.large = Boolean(data.large);
     }
 
+    if ('premium_progress_bar_enabled' in data) {
+      /**
+       * Whether this guild has its premium progress bar enabled (GOAL bar below the guild name on the client)
+       * @type {boolean}
+       */
+      this.premiumProgressBarEnabled = data.premium_progress_bar_enabled;
+    }
+
     /**
      * An array of enabled guild features, here are the possible values:
      * * ANIMATED_ICON
@@ -784,6 +792,7 @@ class Guild extends AnonymousGuild {
    * @property {TextChannelResolvable} [rulesChannel] The rules channel of the guild
    * @property {TextChannelResolvable} [publicUpdatesChannel] The community updates channel of the guild
    * @property {string} [preferredLocale] The preferred locale of the guild
+   * @property {boolean} [premiumProgressBarEnabled] Whether the guild's premium progress bar is enabled
    * @property {string} [description] The discovery description of the guild
    * @property {Features[]} [features] The features of the guild
    */
@@ -866,6 +875,7 @@ class Guild extends AnonymousGuild {
       _data.description = data.description;
     }
     if (data.preferredLocale) _data.preferred_locale = data.preferredLocale;
+    if (data.premiumProgressBarEnabled) _data.premium_progress_bar_enabled = data.premiumProgressBarEnabled;
     const newData = await this.client.api.guilds(this.id).patch({ data: _data, reason });
     return this.client.actions.GuildUpdate.handle(newData).updated;
   }
@@ -1164,6 +1174,16 @@ class Guild extends AnonymousGuild {
    */
   setPreferredLocale(preferredLocale, reason) {
     return this.edit({ preferredLocale }, reason);
+  }
+
+  /**
+   * Edits the enabled state of the guild's premium progress bar
+   * @param {boolean} [enabled=true] The new enabled state of the guild's premium progress bar
+   * @param {string} [reason] Reason for changing the state of the guild's premium progress bar
+   * @returns {Promise<Guild>}
+   */
+  setPremiumProgressBarEnabled(enabled = true, reason) {
+    return this.edit({ premiumProgressBarEnabled: enabled }, reason);
   }
 
   /**

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -169,7 +169,7 @@ class Guild extends AnonymousGuild {
 
     if ('premium_progress_bar_enabled' in data) {
       /**
-       * Whether this guild has its premium progress bar enabled (GOAL bar below the guild name on the client)
+       * Whether this guild has its premium (boost) progress bar enabled
        * @type {boolean}
        */
       this.premiumProgressBarEnabled = data.premium_progress_bar_enabled;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4111,7 +4111,6 @@ export interface GuildCreateOptions {
   systemChannelFlags?: SystemChannelFlagsResolvable;
   systemChannelId?: Snowflake | number;
   verificationLevel?: VerificationLevel | number;
-  premiumProgressBarEnabled?: boolean;
 }
 
 export interface GuildWidgetSettings {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -756,6 +756,7 @@ export class Guild extends AnonymousGuild {
   public ownerId: Snowflake;
   public preferredLocale: string;
   public premiumSubscriptionCount: number | null;
+  public premiumProgressBarEnabled: boolean;
   public premiumTier: PremiumTier;
   public presences: PresenceManager;
   public readonly publicUpdatesChannel: TextChannel | null;
@@ -821,6 +822,7 @@ export class Guild extends AnonymousGuild {
   public setSystemChannel(systemChannel: TextChannelResolvable | null, reason?: string): Promise<Guild>;
   public setSystemChannelFlags(systemChannelFlags: SystemChannelFlagsResolvable, reason?: string): Promise<Guild>;
   public setVerificationLevel(verificationLevel: VerificationLevel | number, reason?: string): Promise<Guild>;
+  public setPremiumProgressBarEnabled(enabled?: boolean, reason?: string): Promise<Guild>;
   public setWidgetSettings(settings: GuildWidgetSettingsData, reason?: string): Promise<Guild>;
   public toJSON(): unknown;
 }
@@ -4109,6 +4111,7 @@ export interface GuildCreateOptions {
   systemChannelFlags?: SystemChannelFlagsResolvable;
   systemChannelId?: Snowflake | number;
   verificationLevel?: VerificationLevel | number;
+  premiumProgressBarEnabled?: boolean;
 }
 
 export interface GuildWidgetSettings {
@@ -4133,6 +4136,7 @@ export interface GuildEditData {
   rulesChannel?: TextChannelResolvable;
   publicUpdatesChannel?: TextChannelResolvable;
   preferredLocale?: string;
+  premiumProgressBarEnabled?: boolean;
   description?: string | null;
   features?: GuildFeatures[];
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- https://github.com/discord/discord-api-docs/pull/4001

This PR adds Discord's new feature: premium_progress_bar_enabled, which is only available on certain Guilds at the moment. Here's what it looks like:
![image](https://user-images.githubusercontent.com/38259440/138782965-2535dd3f-d6c0-4eb2-b928-44f7a14b8e82.png)
And in the settings:
![image](https://user-images.githubusercontent.com/38259440/138782978-472625f1-515e-4cc0-b6c0-bc0a7c9b4b3d.png)
Upstream PR:
- None yet!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
