### PR TITLE
refactor(GuildMember): prefer && over ternaries

### DIFF
--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -362,7 +362,7 @@ class GuildMember extends Base {
    * console.log(`Hello from ${member}!`);
    */
   toString() {
-    return `<@${this.nickname ? '!' : ''}${this.user.id}>`;
+    return `<@${this.nickname && '!'}${this.user.id}>`;
   }
 
   toJSON() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This change prefers the AND operator (`&&`) over ternaries with nothing in the `else` statement. 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
