### PR TITLE
docs(Application): rename Oauth2Application to Application

### DIFF
--- a/src/structures/interfaces/Application.js
+++ b/src/structures/interfaces/Application.js
@@ -115,7 +115,7 @@ class Application extends Base {
 
   /**
    * When concatenated with a string, this automatically returns the application's name instead of the
-   * Oauth2Application object.
+   * Application object.
    * @returns {?string}
    * @example
    * // Logs: Application name: My App


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This change was not included when `OAuth2Application` got renamed to `Application` in v12.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
