### PR TITLE
docs(InteractionResponses): move embed var position in example

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -74,13 +74,13 @@ class InteractionResponses {
    * @returns {Promise<Message|APIMessage|void>}
    * @example
    * // Reply to the interaction and fetch the response
-   * const embed = new MessageEmbed().setDescription('Pong!');
-   *
    * interaction.reply({ content: 'Pong!', fetchReply: true })
    *   .then((message) => console.log(`Reply sent with content ${message.content}`))
    *   .catch(console.error);
    * @example
    * // Create an ephemeral reply with an embed
+   * const embed = new MessageEmbed().setDescription('Pong!');
+   *
    * interaction.reply({ embeds: [embed], ephemeral: true })
    *   .then(() => console.log('Reply sent.'))
    *   .catch(console.error);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR moves the position of the embed variable declaration to the other example (hard to explain).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
