### PR TITLE
docs(GuildStickerManager): fix create() example

### DIFF
--- a/src/managers/GuildStickerManager.js
+++ b/src/managers/GuildStickerManager.js
@@ -47,12 +47,12 @@ class GuildStickerManager extends CachedManager {
    * @returns {Promise<Sticker>} The created sticker
    * @example
    * // Create a new sticker from a URL
-   * guild.stickers.create('https://i.imgur.com/w3duR07.png', 'rip')
+   * guild.stickers.create('https://i.imgur.com/w3duR07.png', 'rip', '🪦')
    *   .then(sticker => console.log(`Created new sticker with name ${sticker.name}!`))
    *   .catch(console.error);
    * @example
    * // Create a new sticker from a file on your computer
-   * guild.stickers.create('./memes/banana.png', 'banana')
+   * guild.stickers.create('./memes/banana.png', 'banana', '🍌')
    *   .then(sticker => console.log(`Created new sticker with name ${sticker.name}!`))
    *   .catch(console.error);
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the example on `GuildStickerManager.create()` where there was a missing `tags` parameter not specified.

Thank you `potsu#0002` for pointing this out in #site-discussion.  
https://discord.com/channels/222078108977594368/682245387985092711/902802619460902942

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
