### PR TITLE
types(Shard): eval returns a promise resolving with T instead of T[]

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1746,7 +1746,7 @@ export class Shard extends EventEmitter {
   public ready: boolean;
   public worker: Worker | null;
   public eval(script: string): Promise<unknown>;
-  public eval<T>(fn: (client: Client) => T): Promise<T[]>;
+  public eval<T>(fn: (client: Client) => T): Promise<T>;
   public fetchClientValue(prop: string): Promise<unknown>;
   public kill(): void;
   public respawn(options?: { delay?: number; timeout?: number }): Promise<ChildProcess>;

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -76,6 +76,7 @@ import {
   Typing,
   User,
   VoiceChannel,
+  Shard,
 } from '.';
 import type { ApplicationCommandOptionTypes } from './enums';
 
@@ -1050,3 +1051,7 @@ client.on('interactionCreate', async interaction => {
     assertType<string | null>(interaction.options.getSubcommandGroup(false));
   }
 });
+
+declare const shard: Shard;
+
+assertType<Promise<number | null>>(shard.eval(c => c.readyTimestamp));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR resolves #6853 by correcting the return type of `Shard#eval` to be `Promise<T>` instead of `Promise<T[]>`.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
