### PR TITLE
types(TextBasedChannel): text channel interaction collectors should have `message` option

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1240,6 +1240,11 @@ export type MessageCollectorOptionsParams<T extends MessageComponentType | Messa
       componentType?: T;
     } & MessageComponentCollectorOptions<InteractionExtractor<T>>;
 
+export type MessageChannelCollectorOptionsParams<T extends MessageComponentType | MessageComponentTypes | undefined> =
+  | {
+      componentType?: T;
+    } & MessageChannelComponentCollectorOptions<InteractionExtractor<T>>;
+
 export type AwaitMessageCollectorOptionsParams<T extends MessageComponentType | MessageComponentTypes | undefined> =
   | { componentType?: T } & Pick<
       InteractionCollectorOptions<InteractionExtractor<T>>,
@@ -2923,7 +2928,7 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     filterOld?: boolean,
   ): Promise<Collection<Snowflake, Message>>;
   createMessageComponentCollector<T extends MessageComponentType | MessageComponentTypes | undefined = undefined>(
-    options?: MessageCollectorOptionsParams<T>,
+    options?: MessageChannelCollectorOptionsParams<T>,
   ): InteractionCollectorReturnType<T>;
   createMessageCollector(options?: MessageCollectorOptions): MessageCollector;
   sendTyping(): Promise<void>;
@@ -4397,6 +4402,11 @@ export type MessageComponent = BaseMessageComponent | MessageActionRow | Message
 export type MessageComponentCollectorOptions<T extends MessageComponentInteraction> = Omit<
   InteractionCollectorOptions<T>,
   'channel' | 'message' | 'guild' | 'interactionType'
+>;
+
+export type MessageChannelComponentCollectorOptions<T extends MessageComponentInteraction> = Omit<
+  InteractionCollectorOptions<T>,
+  'channel' | 'guild' | 'interactionType'
 >;
 
 export type MessageComponentOptions =


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a type error where `TextChannel#createMessageComponentCollector` didn't allow you to have a `message` option to filter by.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating