### PR TITLE
docs(InteractionCollector): Add info block about being prone to always running

### DIFF
--- a/src/structures/InteractionCollector.js
+++ b/src/structures/InteractionCollector.js
@@ -22,6 +22,8 @@ const { InteractionTypes, MessageComponentTypes } = require('../util/Constants')
  * Will automatically stop if the message ({@link Client#event:messageDelete messageDelete}),
  * channel ({@link Client#event:channelDelete channelDelete}), or
  * guild ({@link Client#event:guildDelete guildDelete}) is deleted.
+ * <info>Interaction collectors that do not specify `time` or `idle` may be prone to always running.
+ * Ensure your interaction collectors end via either of these options or manual cancellation.</info>
  * @extends {Collector}
  */
 class InteractionCollector extends Collector {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Added an agreed-upon information block about ensuring interaction collectors do end and not run indefinitely.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
