### PR TITLE
types(Constants): remove deleted properties from Package

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2363,7 +2363,6 @@ export const Constants: {
     name: string;
     version: string;
     description: string;
-    author: string;
     license: string;
     main: string;
     types: string;
@@ -2374,7 +2373,6 @@ export const Constants: {
     scripts: Record<string, string>;
     engines: Record<string, string>;
     dependencies: Record<string, string>;
-    peerDependencies: Record<string, string>;
     devDependencies: Record<string, string>;
     [key: string]: unknown;
   };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
These properties are no longer present in the package file.

The `directories` and `contributors` properties are missing, but I'm not sure I should add them since there's `[key: string]: unknown` in the interface. Let me know.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
