### PR TITLE
docs(Constants): Document missing autocomplete interaction constants

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -987,6 +987,7 @@ exports.InteractionTypes = createEnum([
  * * DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE
  * * DEFERRED_MESSAGE_UPDATE
  * * UPDATE_MESSAGE
+ * * APPLICATION_COMMAND_AUTOCOMPLETE_RESULT
  * @typedef {string} InteractionResponseType
  * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object-interaction-callback-type}
  */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Documents `APPLICATION_COMMAND_AUTOCOMPLETE` as an interaction type
- Documents `APPLICATION_COMMAND_AUTOCOMPLETE_RESULT` as an interaction response type

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
