### PR TITLE
fix: assert channel types in message actions

### DIFF
--- a/src/client/actions/MessageCreate.js
+++ b/src/client/actions/MessageCreate.js
@@ -10,6 +10,8 @@ class MessageCreateAction extends Action {
     const client = this.client;
     const channel = this.getChannel(data);
     if (channel) {
+      if (!channel.isText()) return {};
+
       const existing = channel.messages.cache.get(data.id);
       if (existing) return { message: existing };
       const message = channel.messages._add(data);

--- a/src/client/actions/MessageDelete.js
+++ b/src/client/actions/MessageDelete.js
@@ -9,6 +9,8 @@ class MessageDeleteAction extends Action {
     const channel = this.getChannel(data);
     let message;
     if (channel) {
+      if (!channel.isText()) return {};
+
       message = this.getMessage(data, channel);
       if (message) {
         channel.messages.cache.delete(message.id);

--- a/src/client/actions/MessageDeleteBulk.js
+++ b/src/client/actions/MessageDeleteBulk.js
@@ -10,6 +10,8 @@ class MessageDeleteBulkAction extends Action {
     const channel = client.channels.cache.get(data.channel_id);
 
     if (channel) {
+      if (!channel.isText()) return {};
+
       const ids = data.ids;
       const messages = new Collection();
       for (const id of ids) {

--- a/src/client/actions/MessageReactionAdd.js
+++ b/src/client/actions/MessageReactionAdd.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Action = require('./Action');
-const { Events, VoiceBasedChannelTypes } = require('../../util/Constants');
+const { Events } = require('../../util/Constants');
 const { PartialTypes } = require('../../util/Constants');
 
 /*
@@ -23,7 +23,7 @@ class MessageReactionAdd extends Action {
 
     // Verify channel
     const channel = this.getChannel(data);
-    if (!channel || VoiceBasedChannelTypes.includes(channel.type)) return false;
+    if (!channel || !channel.isText()) return false;
 
     // Verify message
     const message = this.getMessage(data, channel);

--- a/src/client/actions/MessageReactionRemove.js
+++ b/src/client/actions/MessageReactionRemove.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Action = require('./Action');
-const { Events, VoiceBasedChannelTypes } = require('../../util/Constants');
+const { Events } = require('../../util/Constants');
 
 /*
 { user_id: 'id',
@@ -20,7 +20,7 @@ class MessageReactionRemove extends Action {
 
     // Verify channel
     const channel = this.getChannel(data);
-    if (!channel || VoiceBasedChannelTypes.includes(channel.type)) return false;
+    if (!channel || !channel.isText()) return false;
 
     // Verify message
     const message = this.getMessage(data, channel);

--- a/src/client/actions/MessageReactionRemoveAll.js
+++ b/src/client/actions/MessageReactionRemoveAll.js
@@ -1,13 +1,13 @@
 'use strict';
 
 const Action = require('./Action');
-const { Events, VoiceBasedChannelTypes } = require('../../util/Constants');
+const { Events } = require('../../util/Constants');
 
 class MessageReactionRemoveAll extends Action {
   handle(data) {
     // Verify channel
     const channel = this.getChannel(data);
-    if (!channel || VoiceBasedChannelTypes.includes(channel.type)) return false;
+    if (!channel || !channel.isText()) return false;
 
     // Verify message
     const message = this.getMessage(data, channel);

--- a/src/client/actions/MessageReactionRemoveEmoji.js
+++ b/src/client/actions/MessageReactionRemoveEmoji.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const Action = require('./Action');
-const { Events, VoiceBasedChannelTypes } = require('../../util/Constants');
+const { Events } = require('../../util/Constants');
 
 class MessageReactionRemoveEmoji extends Action {
   handle(data) {
     const channel = this.getChannel(data);
-    if (!channel || VoiceBasedChannelTypes.includes(channel.type)) return false;
+    if (!channel || !channel.isText()) return false;
 
     const message = this.getMessage(data, channel);
     if (!message) return false;

--- a/src/client/actions/MessageUpdate.js
+++ b/src/client/actions/MessageUpdate.js
@@ -6,6 +6,8 @@ class MessageUpdateAction extends Action {
   handle(data) {
     const channel = this.getChannel(data);
     if (channel) {
+      if (!channel.isText()) return {};
+
       const { id, channel_id, guild_id, author, timestamp, type } = data;
       const message = this.getMessage({ id, channel_id, guild_id, author, timestamp, type }, channel);
       if (message) {

--- a/src/client/actions/TypingStart.js
+++ b/src/client/actions/TypingStart.js
@@ -2,14 +2,14 @@
 
 const Action = require('./Action');
 const Typing = require('../../structures/Typing');
-const { Events, TextBasedChannelTypes } = require('../../util/Constants');
+const { Events } = require('../../util/Constants');
 
 class TypingStart extends Action {
   handle(data) {
     const channel = this.getChannel(data);
     if (!channel) return;
 
-    if (!TextBasedChannelTypes.includes(channel.type)) {
+    if (!channel.isText()) {
       this.client.emit(Events.WARN, `Discord sent a typing packet to a ${channel.type} channel ${channel.id}`);
       return;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR ensures that message related actions take place in a channel that is supported to avoid throwing an unhandled exceptions. (Read: text in voice, also future-proofing)

Changed actions:
- MessageCreate
- MessageDelete
- MessageReactionAdd
- MessageReactionRemove
- MessageReactionRemoveAll
- MessageReactionRemoveEmoji
- MessageUpdate
- TypingStart

The reaction actions previously were ensuring that the action was not taking place in a voice channel (as per type) and the typing start action in a text channel (as per type).

I went with `Channel#isText` since it seems to be the less error-prone method to check whether messages can be accessed in said channel, since it's just `return 'messages' in this`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

