### PR TITLE
fix: correctly access guild IDs inside managers

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -210,9 +210,9 @@ class GuildChannelManager extends CachedManager {
       parent_id: typeof r.parent !== 'undefined' ? this.channels.resolveId(r.parent) : undefined,
     }));
 
-    await this.client.api.guilds(this.id).channels.patch({ data: channelPositions });
+    await this.client.api.guilds(this.guild.id).channels.patch({ data: channelPositions });
     return this.client.actions.GuildChannelsPositionUpdate.handle({
-      guild_id: this.id,
+      guild_id: this.guild.id,
       channels: channelPositions,
     }).guild;
   }

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -235,11 +235,11 @@ class RoleManager extends CachedManager {
     }));
 
     // Call the API to update role positions
-    await this.client.api.guilds(this.id).roles.patch({
+    await this.client.api.guilds(this.guild.id).roles.patch({
       data: rolePositions,
     });
     return this.client.actions.GuildRolesPositionUpdate.handle({
-      guild_id: this.id,
+      guild_id: this.guild.id,
       roles: rolePositions,
     }).guild;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a stupid oversight introduced in #6875 where guild IDs were incorrectly accessed through the manager instead of through the guild. My bad!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
