### PR TITLE
refactor: Deprecate application command events

### DIFF
--- a/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
@@ -14,7 +14,7 @@ module.exports = (client, { d: data }) => {
    * Emitted when a guild application command is created.
    * @event Client#applicationCommandCreate
    * @param {ApplicationCommand} command The command which was created
-   * @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information.
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
    */
 
   if (client.emit(Events.APPLICATION_COMMAND_CREATE, command) && !deprecationEmitted) {

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
@@ -12,7 +12,7 @@ module.exports = (client, { d: data }) => {
    * Emitted when a guild application command is created.
    * @event Client#applicationCommandCreate
    * @param {ApplicationCommand} command The command which was created
-   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue} for more information.
    */
   client.emit(Events.APPLICATION_COMMAND_CREATE, command);
 };

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
@@ -2,6 +2,8 @@
 
 const { Events } = require('../../../util/Constants');
 
+let deprecationEmitted = false;
+
 module.exports = (client, { d: data }) => {
   const commandManager = data.guild_id ? client.guilds.cache.get(data.guild_id)?.commands : client.application.commands;
   if (!commandManager) return;
@@ -12,6 +14,16 @@ module.exports = (client, { d: data }) => {
    * Emitted when a guild application command is created.
    * @event Client#applicationCommandCreate
    * @param {ApplicationCommand} command The command which was created
+   * @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information.
    */
-  client.emit(Events.APPLICATION_COMMAND_CREATE, command);
+
+  if (client.emit(Events.APPLICATION_COMMAND_CREATE, command) && !deprecationEmitted) {
+    deprecationEmitted = true;
+
+    process.emitWarning(
+      /* eslint-disable-next-line max-len */
+      'The applicationCommandCreate event is deprecated. See https://github.com/discord/discord-api-docs/issues/3690 for more information.',
+      'DeprecationWarning',
+    );
+  }
 };

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_CREATE.js
@@ -2,8 +2,6 @@
 
 const { Events } = require('../../../util/Constants');
 
-let deprecationEmitted = false;
-
 module.exports = (client, { d: data }) => {
   const commandManager = data.guild_id ? client.guilds.cache.get(data.guild_id)?.commands : client.application.commands;
   if (!commandManager) return;
@@ -16,14 +14,5 @@ module.exports = (client, { d: data }) => {
    * @param {ApplicationCommand} command The command which was created
    * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
    */
-
-  if (client.emit(Events.APPLICATION_COMMAND_CREATE, command) && !deprecationEmitted) {
-    deprecationEmitted = true;
-
-    process.emitWarning(
-      /* eslint-disable-next-line max-len */
-      'The applicationCommandCreate event is deprecated. See https://github.com/discord/discord-api-docs/issues/3690 for more information.',
-      'DeprecationWarning',
-    );
-  }
+  client.emit(Events.APPLICATION_COMMAND_CREATE, command);
 };

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
@@ -16,7 +16,7 @@ module.exports = (client, { d: data }) => {
    * Emitted when a guild application command is deleted.
    * @event Client#applicationCommandDelete
    * @param {ApplicationCommand} command The command which was deleted
-   * @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information.
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
    */
 
   if (client.emit(Events.APPLICATION_COMMAND_DELETE, command) && !deprecationEmitted) {

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
@@ -14,7 +14,7 @@ module.exports = (client, { d: data }) => {
    * Emitted when a guild application command is deleted.
    * @event Client#applicationCommandDelete
    * @param {ApplicationCommand} command The command which was deleted
-   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue} for more information.
    */
   client.emit(Events.APPLICATION_COMMAND_DELETE, command);
 };

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
@@ -2,8 +2,6 @@
 
 const { Events } = require('../../../util/Constants');
 
-let deprecationEmitted = false;
-
 module.exports = (client, { d: data }) => {
   const commandManager = data.guild_id ? client.guilds.cache.get(data.guild_id)?.commands : client.application.commands;
   if (!commandManager) return;
@@ -18,14 +16,5 @@ module.exports = (client, { d: data }) => {
    * @param {ApplicationCommand} command The command which was deleted
    * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
    */
-
-  if (client.emit(Events.APPLICATION_COMMAND_DELETE, command) && !deprecationEmitted) {
-    deprecationEmitted = true;
-
-    process.emitWarning(
-      /* eslint-disable-next-line max-len */
-      'The applicationCommandCreate event is deprecated. See https://github.com/discord/discord-api-docs/issues/3690 for more information.',
-      'DeprecationWarning',
-    );
-  }
+  client.emit(Events.APPLICATION_COMMAND_DELETE, command);
 };

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_DELETE.js
@@ -2,6 +2,8 @@
 
 const { Events } = require('../../../util/Constants');
 
+let deprecationEmitted = false;
+
 module.exports = (client, { d: data }) => {
   const commandManager = data.guild_id ? client.guilds.cache.get(data.guild_id)?.commands : client.application.commands;
   if (!commandManager) return;
@@ -14,6 +16,16 @@ module.exports = (client, { d: data }) => {
    * Emitted when a guild application command is deleted.
    * @event Client#applicationCommandDelete
    * @param {ApplicationCommand} command The command which was deleted
+   * @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information.
    */
-  client.emit(Events.APPLICATION_COMMAND_DELETE, command);
+
+  if (client.emit(Events.APPLICATION_COMMAND_DELETE, command) && !deprecationEmitted) {
+    deprecationEmitted = true;
+
+    process.emitWarning(
+      /* eslint-disable-next-line max-len */
+      'The applicationCommandCreate event is deprecated. See https://github.com/discord/discord-api-docs/issues/3690 for more information.',
+      'DeprecationWarning',
+    );
+  }
 };

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
@@ -2,8 +2,6 @@
 
 const { Events } = require('../../../util/Constants');
 
-let deprecationEmitted = false;
-
 module.exports = (client, { d: data }) => {
   const commandManager = data.guild_id ? client.guilds.cache.get(data.guild_id)?.commands : client.application.commands;
   if (!commandManager) return;
@@ -18,14 +16,5 @@ module.exports = (client, { d: data }) => {
    * @param {ApplicationCommand} newCommand The command after the update
    * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
    */
-
-  if (client.emit(Events.APPLICATION_COMMAND_UPDATE, oldCommand, newCommand) && !deprecationEmitted) {
-    deprecationEmitted = true;
-
-    process.emitWarning(
-      /* eslint-disable-next-line max-len */
-      'The applicationCommandCreate event is deprecated. See https://github.com/discord/discord-api-docs/issues/3690 for more information.',
-      'DeprecationWarning',
-    );
-  }
+  client.emit(Events.APPLICATION_COMMAND_UPDATE, oldCommand, newCommand);
 };

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
@@ -14,7 +14,7 @@ module.exports = (client, { d: data }) => {
    * @event Client#applicationCommandUpdate
    * @param {?ApplicationCommand} oldCommand The command before the update
    * @param {ApplicationCommand} newCommand The command after the update
-   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue} for more information.
    */
   client.emit(Events.APPLICATION_COMMAND_UPDATE, oldCommand, newCommand);
 };

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
@@ -16,7 +16,7 @@ module.exports = (client, { d: data }) => {
    * @event Client#applicationCommandUpdate
    * @param {?ApplicationCommand} oldCommand The command before the update
    * @param {ApplicationCommand} newCommand The command after the update
-   * @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information.
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
    */
 
   if (client.emit(Events.APPLICATION_COMMAND_UPDATE, oldCommand, newCommand) && !deprecationEmitted) {

--- a/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
+++ b/src/client/websocket/handlers/APPLICATION_COMMAND_UPDATE.js
@@ -2,6 +2,8 @@
 
 const { Events } = require('../../../util/Constants');
 
+let deprecationEmitted = false;
+
 module.exports = (client, { d: data }) => {
   const commandManager = data.guild_id ? client.guilds.cache.get(data.guild_id)?.commands : client.application.commands;
   if (!commandManager) return;
@@ -14,6 +16,16 @@ module.exports = (client, { d: data }) => {
    * @event Client#applicationCommandUpdate
    * @param {?ApplicationCommand} oldCommand The command before the update
    * @param {ApplicationCommand} newCommand The command after the update
+   * @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information.
    */
-  client.emit(Events.APPLICATION_COMMAND_UPDATE, oldCommand, newCommand);
+
+  if (client.emit(Events.APPLICATION_COMMAND_UPDATE, oldCommand, newCommand) && !deprecationEmitted) {
+    deprecationEmitted = true;
+
+    process.emitWarning(
+      /* eslint-disable-next-line max-len */
+      'The applicationCommandCreate event is deprecated. See https://github.com/discord/discord-api-docs/issues/3690 for more information.',
+      'DeprecationWarning',
+    );
+  }
 };

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -129,15 +129,15 @@ exports.Events = {
   API_REQUEST: 'apiRequest',
   CLIENT_READY: 'ready',
   /**
-   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue} for more information.
    */
   APPLICATION_COMMAND_CREATE: 'applicationCommandCreate',
   /**
-   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue} for more information.
    */
   APPLICATION_COMMAND_DELETE: 'applicationCommandDelete',
   /**
-   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue} for more information.
    */
   APPLICATION_COMMAND_UPDATE: 'applicationCommandUpdate',
   GUILD_CREATE: 'guildCreate',

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -229,9 +229,9 @@ exports.PartialTypes = keyMirror(['USER', 'CHANNEL', 'GUILD_MEMBER', 'MESSAGE', 
  * The type of a WebSocket message event, e.g. `MESSAGE_CREATE`. Here are the available events:
  * * READY
  * * RESUMED
- * * APPLICATION_COMMAND_CREATE
- * * APPLICATION_COMMAND_DELETE
- * * APPLICATION_COMMAND_UPDATE
+ * * APPLICATION_COMMAND_CREATE (deprecated)
+ * * APPLICATION_COMMAND_DELETE (deprecated)
+ * * APPLICATION_COMMAND_UPDATE (deprecated)
  * * GUILD_CREATE
  * * GUILD_DELETE
  * * GUILD_UPDATE

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -128,8 +128,17 @@ exports.Events = {
   API_RESPONSE: 'apiResponse',
   API_REQUEST: 'apiRequest',
   CLIENT_READY: 'ready',
+  /**
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
+   */
   APPLICATION_COMMAND_CREATE: 'applicationCommandCreate',
+  /**
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
+   */
   APPLICATION_COMMAND_DELETE: 'applicationCommandDelete',
+  /**
+   * @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information.
+   */
   APPLICATION_COMMAND_UPDATE: 'applicationCommandUpdate',
   GUILD_CREATE: 'guildCreate',
   GUILD_DELETE: 'guildDelete',

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3556,11 +3556,11 @@ export interface ChannelWebhookCreateOptions {
 export interface ClientEvents {
   apiResponse: [request: APIRequest, response: Response];
   apiRequest: [request: APIRequest];
-  /** @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
+  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information. */
   applicationCommandCreate: [command: ApplicationCommand];
-  /** @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
+  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information. */
   applicationCommandDelete: [command: ApplicationCommand];
-  /** @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
+  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information. */
   applicationCommandUpdate: [oldCommand: ApplicationCommand | null, newCommand: ApplicationCommand];
   channelCreate: [channel: GuildChannel];
   channelDelete: [channel: DMChannel | GuildChannel];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3802,11 +3802,11 @@ export interface ConstantsEvents {
   API_RESPONSE: 'apiResponse';
   API_REQUEST: 'apiRequest';
   CLIENT_READY: 'ready';
-  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
+  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information. */
   APPLICATION_COMMAND_CREATE: 'applicationCommandCreate';
-  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
+  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information. */
   APPLICATION_COMMAND_DELETE: 'applicationCommandDelete';
-  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
+  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690) for more information. */
   APPLICATION_COMMAND_UPDATE: 'applicationCommandUpdate';
   GUILD_CREATE: 'guildCreate';
   GUILD_DELETE: 'guildDelete';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3802,8 +3802,11 @@ export interface ConstantsEvents {
   API_RESPONSE: 'apiResponse';
   API_REQUEST: 'apiRequest';
   CLIENT_READY: 'ready';
+  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
   APPLICATION_COMMAND_CREATE: 'applicationCommandCreate';
+  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
   APPLICATION_COMMAND_DELETE: 'applicationCommandDelete';
+  /** @deprecated See [this issue](https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
   APPLICATION_COMMAND_UPDATE: 'applicationCommandUpdate';
   GUILD_CREATE: 'guildCreate';
   GUILD_DELETE: 'guildDelete';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3556,8 +3556,11 @@ export interface ChannelWebhookCreateOptions {
 export interface ClientEvents {
   apiResponse: [request: APIRequest, response: Response];
   apiRequest: [request: APIRequest];
+  /** @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
   applicationCommandCreate: [command: ApplicationCommand];
+  /** @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
   applicationCommandDelete: [command: ApplicationCommand];
+  /** @deprecated See {@link https://github.com/discord/discord-api-docs/issues/3690 this issue) for more information. */
   applicationCommandUpdate: [oldCommand: ApplicationCommand | null, newCommand: ApplicationCommand];
   channelCreate: [channel: GuildChannel];
   channelDelete: [channel: DMChannel | GuildChannel];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Deprecated the application command events as Discord no longer emits them.

I've linked the issue on Discord's GitHub issue tracker for more information in the deprecation warning.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
