### PR TITLE
types: Strengthen autocomplete option types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3343,15 +3343,14 @@ export interface ApplicationCommandChannelOption extends BaseApplicationCommandO
   channelTypes?: (keyof typeof ChannelTypes)[];
 }
 
-export interface ApplicationCommandStringAutocompleteOption
-  extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
-  type: 'STRING' | ApplicationCommandOptionTypes.STRING;
-  autocomplete: true;
-}
-
-export interface ApplicationCommandNumericAutocompleteOption
-  extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
-  type: 'NUMBER' | 'INTEGER' | ApplicationCommandOptionTypes.NUMBER | ApplicationCommandOptionTypes.INTEGER;
+export interface ApplicationCommandAutocompleteOption extends BaseApplicationCommandOptionsData {
+  type:
+    | 'STRING'
+    | 'NUMBER'
+    | 'INTEGER'
+    | ApplicationCommandOptionTypes.STRING
+    | ApplicationCommandOptionTypes.NUMBER
+    | ApplicationCommandOptionTypes.INTEGER;
   autocomplete: true;
 }
 
@@ -3401,8 +3400,7 @@ export type ApplicationCommandOptionData =
   | ApplicationCommandChannelOptionData
   | ApplicationCommandChoicesData
   | ApplicationCommandSubCommandData
-  | ApplicationCommandStringAutocompleteOption
-  | ApplicationCommandNumericAutocompleteOption;
+  | ApplicationCommandAutocompleteOption;
 
 export type ApplicationCommandOption =
   | ApplicationCommandSubGroup

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3311,7 +3311,6 @@ export interface BaseApplicationCommandOptionsData {
   name: string;
   description: string;
   required?: boolean;
-  autocomplete?: boolean;
 }
 
 export interface UserApplicationCommandData extends BaseApplicationCommandData {
@@ -3344,14 +3343,28 @@ export interface ApplicationCommandChannelOption extends BaseApplicationCommandO
   channelTypes?: (keyof typeof ChannelTypes)[];
 }
 
+export interface ApplicationCommandStringAutocompleteOption
+  extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
+  type: 'STRING' | ApplicationCommandOptionTypes.STRING;
+  autocomplete: true;
+}
+
+export interface ApplicationCommandNumericAutocompleteOption
+  extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
+  type: 'NUMBER' | 'INTEGER' | ApplicationCommandOptionTypes.NUMBER | ApplicationCommandOptionTypes.INTEGER;
+  autocomplete: true;
+}
+
 export interface ApplicationCommandChoicesData extends BaseApplicationCommandOptionsData {
   type: CommandOptionChoiceResolvableType;
   choices?: ApplicationCommandOptionChoice[];
+  autocomplete?: false;
 }
 
 export interface ApplicationCommandChoicesOption extends BaseApplicationCommandOptionsData {
   type: Exclude<CommandOptionChoiceResolvableType, ApplicationCommandOptionTypes>;
   choices?: ApplicationCommandOptionChoice[];
+  autocomplete?: false;
 }
 
 export interface ApplicationCommandSubGroupData extends Omit<BaseApplicationCommandOptionsData, 'required'> {
@@ -3387,7 +3400,9 @@ export type ApplicationCommandOptionData =
   | ApplicationCommandNonOptionsData
   | ApplicationCommandChannelOptionData
   | ApplicationCommandChoicesData
-  | ApplicationCommandSubCommandData;
+  | ApplicationCommandSubCommandData
+  | ApplicationCommandStringAutocompleteOption
+  | ApplicationCommandNumericAutocompleteOption;
 
 export type ApplicationCommandOption =
   | ApplicationCommandSubGroup

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -454,7 +454,7 @@ const baseCommandOptionData = {
 assertType<ApplicationCommandOptionData>({
   ...baseCommandOptionData,
   type: 'STRING',
-  // @ts-ignore
+  // @ts-expect-error
   autocomplete: true,
   choices: [],
 });

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -454,7 +454,7 @@ const baseCommandOptionData = {
 assertType<ApplicationCommandOptionData>({
   ...baseCommandOptionData,
   type: 'STRING',
-  // @ts-expect-error
+  // @ts-ignore
   autocomplete: true,
   choices: [],
 });

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -30,7 +30,6 @@ import {
   CommandInteraction,
   CommandInteractionOption,
   CommandInteractionOptionResolver,
-  CommandOptionChoiceResolvableType,
   CommandOptionNonChoiceResolvableType,
   Constants,
   ContextMenuInteraction,
@@ -447,6 +446,66 @@ client.on('ready', async () => {
 // This is to check that stuff is the right type
 declare const assertIsPromiseMember: (m: Promise<GuildMember>) => void;
 
+const baseCommandOptionData = {
+  name: 'test',
+  description: 'test',
+};
+
+assertType<ApplicationCommandOptionData>({
+  ...baseCommandOptionData,
+  type: 'STRING',
+  // @ts-expect-error
+  autocomplete: true,
+  choices: [],
+});
+
+assertType<ApplicationCommandOptionData>({
+  ...baseCommandOptionData,
+  type: 'STRING',
+  autocomplete: false,
+  choices: [],
+});
+
+assertType<ApplicationCommandOptionData>({
+  ...baseCommandOptionData,
+  type: 'STRING',
+  choices: [],
+});
+
+assertType<ApplicationCommandOptionData>({
+  ...baseCommandOptionData,
+  type: 'NUMBER',
+  // @ts-expect-error
+  autocomplete: true,
+  choices: [],
+});
+
+assertType<ApplicationCommandOptionData>({
+  ...baseCommandOptionData,
+  type: 'INTEGER',
+  // @ts-expect-error
+  autocomplete: true,
+  choices: [],
+});
+
+assertType<ApplicationCommandOptionData>({
+  ...baseCommandOptionData,
+  type: 'NUMBER',
+  autocomplete: true,
+});
+
+assertType<ApplicationCommandOptionData>({
+  ...baseCommandOptionData,
+  type: 'STRING',
+  autocomplete: true,
+});
+
+assertType<ApplicationCommandOptionData>({
+  ...baseCommandOptionData,
+  type: 'INTEGER',
+  autocomplete: true,
+});
+
 client.on('guildCreate', async g => {
   const channel = g.channels.cache.random();
   if (!channel) return;
@@ -817,12 +876,6 @@ declare const applicationNonChoiceOptionData: ApplicationCommandOptionData & {
 
   // @ts-expect-error
   applicationNonChoiceOptionData.choices;
-}
-
-declare const applicationChoiceOptionData: ApplicationCommandOptionData & { type: CommandOptionChoiceResolvableType };
-{
-  // Choices should be available.
-  applicationChoiceOptionData.choices;
 }
 
 declare const applicationSubGroupCommandData: ApplicationCommandSubGroupData;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Prevents combinations where `choices` and `autocomplete` are present, and instead makes them mutually exclusive props on `ApplicationCommandOptionData`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
