### PR TITLE
fix(MessageReaction): Cache myself when `MessageReaction#me` is `true`.

### DIFF
--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -34,7 +34,7 @@ class MessageReaction {
      * A manager of the users that have given this reaction
      * @type {ReactionUserManager}
      */
-    this.users = new ReactionUserManager(this);
+    this.users = new ReactionUserManager(this, this.me ? [client.user] : []);
 
     this._emoji = new ReactionEmoji(this, data.emoji);
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It is inconsistent that I am not cached in `ReactionUserManager` when `MessageReaction#me` is `true`.
So when I create a `ReactionUserManager`, I cache myself.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
