### PR TITLE
refactor(MessageEmbed): Utilise an object approach for `.setAuthor()`

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -346,14 +346,28 @@ class MessageEmbed {
   }
 
   /**
+   * The options to provide for setting an author for a {@link MessageEmbed}.
+   * @typedef {Object} MessageEmbedAuthor
+   * @property {string} name The name of this author.
+   * @property {string} [url] The URL of this author.
+   * @property {string} [iconURL] The icon URL of this author.
+   */
+
+  // TODO: Remove the deprecated parameters.
+  /* eslint-disable-next-line valid-jsdoc */
+  /**
    * Sets the author of this embed.
-   * @param {string} name The name of the author
-   * @param {string} [iconURL] The icon URL of the author
-   * @param {string} [url] The URL of the author
+   * @param {string | MessageEmbedAuthor} options The options to provide for the author.
+   * A string may simply be provided if only the author name is desirable.
    * @returns {MessageEmbed}
    */
-  setAuthor(name, iconURL, url) {
-    this.author = { name: Util.verifyString(name, RangeError, 'EMBED_AUTHOR_NAME'), iconURL, url };
+  setAuthor(options = {}, deprecatedIconURL, deprecatedAuthorURL) {
+    if (typeof nameOrOptions === 'string') {
+      options = { name: options, url: deprecatedAuthorURL, iconURL: deprecatedIconURL };
+    }
+
+    const { name, url, iconURL } = options;
+    this.author = { name: Util.verifyString(name, RangeError, 'EMBED_AUTHOR_NAME'), url, iconURL };
     return this;
   }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -356,7 +356,7 @@ class MessageEmbed {
   // TODO: Remove the deprecated code in the following method and typings.
   /**
    * Sets the author of this embed.
-   * @param {string | EmbedAuthorData} options The options to provide for the author.
+   * @param {string|EmbedAuthorData} options The options to provide for the author.
    * A string may simply be provided if only the author name is desirable.
    * @param {string} [deprecatedIconURL] The icon URL of this author.
    * <warn>This parameter is **deprecated**. Use the `options` parameter instead.</warn>

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -347,7 +347,7 @@ class MessageEmbed {
 
   /**
    * The options to provide for setting an author for a {@link MessageEmbed}.
-   * @typedef {Object} MessageEmbedAuthor
+   * @typedef {Object} EmbedAuthorData
    * @property {string} name The name of this author.
    * @property {string} [url] The URL of this author.
    * @property {string} [iconURL] The icon URL of this author.
@@ -356,7 +356,7 @@ class MessageEmbed {
   // TODO: Remove the deprecated code in the following method and typings.
   /**
    * Sets the author of this embed.
-   * @param {string | MessageEmbedAuthor} options The options to provide for the author.
+   * @param {string | EmbedAuthorData} options The options to provide for the author.
    * A string may simply be provided if only the author name is desirable.
    * @param {string} [deprecatedIconURL] The icon URL of this author.
    * <warn>This parameter is **deprecated**. Use the `options` parameter instead.</warn>

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -359,12 +359,12 @@ class MessageEmbed {
    * @param {string | MessageEmbedAuthor} options The options to provide for the author.
    * A string may simply be provided if only the author name is desirable.
    * @param {string} [deprecatedIconURL] The icon URL of this author. This parameter is **deprecated**.
-   * @param {string} [deprecatedAuthorURL] The URL of this author. This parameter is **deprecated**.
+   * @param {string} [deprecatedURL] The URL of this author. This parameter is **deprecated**.
    * @returns {MessageEmbed}
    */
-  setAuthor(options = {}, deprecatedIconURL, deprecatedAuthorURL) {
+  setAuthor(options = {}, deprecatedIconURL, deprecatedURL) {
     if (typeof nameOrOptions === 'string') {
-      options = { name: options, url: deprecatedAuthorURL, iconURL: deprecatedIconURL };
+      options = { name: options, url: deprecatedURL, iconURL: deprecatedIconURL };
     }
 
     const { name, url, iconURL } = options;

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -358,8 +358,10 @@ class MessageEmbed {
    * Sets the author of this embed.
    * @param {string | MessageEmbedAuthor} options The options to provide for the author.
    * A string may simply be provided if only the author name is desirable.
-   * @param {string} [deprecatedIconURL] The icon URL of this author. This parameter is **deprecated**.
-   * @param {string} [deprecatedURL] The URL of this author. This parameter is **deprecated**.
+   * @param {string} [deprecatedIconURL] The icon URL of this author.
+   * <warn>This parameter is **deprecated**. Use the `options` parameter instead.</warn>
+   * @param {string} [deprecatedURL] The URL of this author.
+   * <warn>This parameter is **deprecated**. Use the `options` parameter instead.</warn>
    * @returns {MessageEmbed}
    */
   setAuthor(options = {}, deprecatedIconURL, deprecatedURL) {

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -356,15 +356,21 @@ class MessageEmbed {
   // TODO: Remove the deprecated code in the following method and typings.
   /**
    * Sets the author of this embed.
-   * @param {string|EmbedAuthorData} options The options to provide for the author.
+   * @param {string|EmbedAuthorData|null} options The options to provide for the author.
    * A string may simply be provided if only the author name is desirable.
+   * Provide `null` to remove the author data.
    * @param {string} [deprecatedIconURL] The icon URL of this author.
    * <warn>This parameter is **deprecated**. Use the `options` parameter instead.</warn>
    * @param {string} [deprecatedURL] The URL of this author.
    * <warn>This parameter is **deprecated**. Use the `options` parameter instead.</warn>
    * @returns {MessageEmbed}
    */
-  setAuthor(options = {}, deprecatedIconURL, deprecatedURL) {
+  setAuthor(options, deprecatedIconURL, deprecatedURL) {
+    if (options === null) {
+      this.author = {};
+      return this;
+    }
+
     if (typeof options === 'string') {
       options = { name: options, url: deprecatedURL, iconURL: deprecatedIconURL };
     }

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -358,8 +358,8 @@ class MessageEmbed {
    * Sets the author of this embed.
    * @param {string | MessageEmbedAuthor} options The options to provide for the author.
    * A string may simply be provided if only the author name is desirable.
-   * @param {string} [deprecatedIconURL] @deprecated test text
-   * @param {string} [deprecatedAuthorURL] @deprecated test text
+   * @param {string} [deprecatedIconURL] The icon URL of this author. This parameter is **deprecated**.
+   * @param {string} [deprecatedAuthorURL] The URL of this author. This parameter is **deprecated**.
    * @returns {MessageEmbed}
    */
   setAuthor(options = {}, deprecatedIconURL, deprecatedAuthorURL) {

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -363,7 +363,7 @@ class MessageEmbed {
    * @returns {MessageEmbed}
    */
   setAuthor(options = {}, deprecatedIconURL, deprecatedURL) {
-    if (typeof nameOrOptions === 'string') {
+    if (typeof options === 'string') {
       options = { name: options, url: deprecatedURL, iconURL: deprecatedIconURL };
     }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -353,12 +353,13 @@ class MessageEmbed {
    * @property {string} [iconURL] The icon URL of this author.
    */
 
-  // TODO: Remove the deprecated parameters.
-  /* eslint-disable-next-line valid-jsdoc */
+  // TODO: Remove the deprecated code in the following method and typings.
   /**
    * Sets the author of this embed.
    * @param {string | MessageEmbedAuthor} options The options to provide for the author.
    * A string may simply be provided if only the author name is desirable.
+   * @param {string} [deprecatedIconURL] @deprecated test text
+   * @param {string} [deprecatedAuthorURL] @deprecated test text
    * @returns {MessageEmbed}
    */
   setAuthor(options = {}, deprecatedIconURL, deprecatedAuthorURL) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1570,6 +1570,8 @@ export class MessageEmbed {
   public addField(name: string, value: string, inline?: boolean): this;
   public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
   public setFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
+  public setAuthor(options: string | EmbedAuthorData): this;
+  /** @deprecated */
   public setAuthor(name: string, iconURL?: string, url?: string): this;
   public setColor(color: ColorResolvable): this;
   public setDescription(description: string): this;
@@ -3973,6 +3975,12 @@ export type DynamicImageFormat = AllowedImageFormat | 'gif';
 export interface EditGuildTemplateOptions {
   name?: string;
   description?: string;
+}
+
+export interface EmbedAuthorData {
+  name: string;
+  url?: string;
+  iconURL?: string;
 }
 
 export interface EmbedField {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1570,7 +1570,7 @@ export class MessageEmbed {
   public addField(name: string, value: string, inline?: boolean): this;
   public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
   public setFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
-  public setAuthor(options: string | EmbedAuthorData): this;
+  public setAuthor(options: string | EmbedAuthorData | null): this;
   /** @deprecated Supply a lone object of interface {@link EmbedAuthorData} instead of more parameters. */
   public setAuthor(name: string, iconURL?: string, url?: string): this;
   public setColor(color: ColorResolvable): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1571,10 +1571,7 @@ export class MessageEmbed {
   public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
   public setFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
   public setAuthor(options: string | EmbedAuthorData): this;
-  /**
-   * @deprecated Supply a lone object instead of more parameters.
-   * See [the documentation](https://discord.js.org/#/docs/main/stable/class/MessageEmbed?scrollTo=setAuthor) on how to use this method moving forward.
-   */
+  /** @deprecated Supply a lone object of interface {@link EmbedAuthorData} instead of more parameters. */
   public setAuthor(name: string, iconURL?: string, url?: string): this;
   public setColor(color: ColorResolvable): this;
   public setDescription(description: string): this;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1571,7 +1571,10 @@ export class MessageEmbed {
   public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
   public setFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
   public setAuthor(options: string | EmbedAuthorData): this;
-  /** @deprecated */
+  /**
+   * @deprecated Supply a lone object instead of more parameters.
+   * See [the documentation](https://discord.js.org/#/docs/main/stable/class/MessageEmbed?scrollTo=setAuthor) on how to use this method moving forward.
+   */
   public setAuthor(name: string, iconURL?: string, url?: string): this;
   public setColor(color: ColorResolvable): this;
   public setDescription(description: string): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As described in #6963, accessing the last parameter when one did not need the parameter before led to an ungraceful situation. This pull request resolves #6963.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
