### PR TITLE
Availability of `guild.available`

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -103,13 +103,15 @@ class Guild extends AnonymousGuild {
      * @type {boolean}
      */
     this.deleted = false;
+    
+    /**
+     * Whether the guild is available to access. If it is not available, it indicates a server outage
+     * @type {boolean}
+     */
+    this.available = true;
 
     if (!data) return;
     if (data.unavailable) {
-      /**
-       * Whether the guild is available to access. If it is not available, it indicates a server outage
-       * @type {boolean}
-       */
       this.available = false;
     } else {
       this._patch(data);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As per the documentation, `<guild>.available` should be returning a Boolean. In some cases for a newly added guild, the property `available` is not defined. This has to be either defined, or the documentation needs to be changed.


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
