### PR TITLE
types(ApplicationSubcommandData): allow `autocomplete` to be `true`

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3315,6 +3315,7 @@ export interface BaseApplicationCommandOptionsData {
   name: string;
   description: string;
   required?: boolean;
+  autocomplete?: never;
 }
 
 export interface UserApplicationCommandData extends BaseApplicationCommandData {
@@ -3347,7 +3348,7 @@ export interface ApplicationCommandChannelOption extends BaseApplicationCommandO
   channelTypes?: (keyof typeof ChannelTypes)[];
 }
 
-export interface ApplicationCommandAutocompleteOption extends BaseApplicationCommandOptionsData {
+export interface ApplicationCommandAutocompleteOption extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
   type:
     | 'STRING'
     | 'NUMBER'
@@ -3358,13 +3359,13 @@ export interface ApplicationCommandAutocompleteOption extends BaseApplicationCom
   autocomplete: true;
 }
 
-export interface ApplicationCommandChoicesData extends BaseApplicationCommandOptionsData {
+export interface ApplicationCommandChoicesData extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
   type: CommandOptionChoiceResolvableType;
   choices?: ApplicationCommandOptionChoice[];
   autocomplete?: false;
 }
 
-export interface ApplicationCommandChoicesOption extends BaseApplicationCommandOptionsData {
+export interface ApplicationCommandChoicesOption extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
   type: Exclude<CommandOptionChoiceResolvableType, ApplicationCommandOptionTypes>;
   choices?: ApplicationCommandOptionChoice[];
   autocomplete?: false;
@@ -3396,7 +3397,13 @@ export interface ApplicationCommandSubGroup extends Omit<BaseApplicationCommandO
 
 export interface ApplicationCommandSubCommandData extends Omit<BaseApplicationCommandOptionsData, 'required'> {
   type: 'SUB_COMMAND' | ApplicationCommandOptionTypes.SUB_COMMAND;
-  options?: (ApplicationCommandChoicesData | ApplicationCommandNonOptionsData | ApplicationCommandChannelOptionData)[];
+  options?: (
+    | ApplicationCommandChoicesData
+    | ApplicationCommandNonOptionsData
+    | ApplicationCommandChannelOptionData
+    | ApplicationCommandAutocompleteOption
+    | ApplicationCommandNumericOptionData
+  )[];
 }
 
 export interface ApplicationCommandSubCommand extends Omit<BaseApplicationCommandOptionsData, 'required'> {

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -79,6 +79,8 @@ import {
   User,
   VoiceChannel,
   Shard,
+  ApplicationCommandAutocompleteOption,
+  ApplicationCommandNumericOptionData,
 } from '.';
 import type { ApplicationCommandOptionTypes } from './enums';
 
@@ -454,8 +456,8 @@ const baseCommandOptionData = {
 assertType<ApplicationCommandOptionData>({
   ...baseCommandOptionData,
   type: 'STRING',
-  // @ts-expect-error
   autocomplete: true,
+  // @ts-expect-error
   choices: [],
 });
 
@@ -475,16 +477,16 @@ assertType<ApplicationCommandOptionData>({
 assertType<ApplicationCommandOptionData>({
   ...baseCommandOptionData,
   type: 'NUMBER',
-  // @ts-expect-error
   autocomplete: true,
+  // @ts-expect-error
   choices: [],
 });
 
 assertType<ApplicationCommandOptionData>({
   ...baseCommandOptionData,
   type: 'INTEGER',
-  // @ts-expect-error
   autocomplete: true,
+  // @ts-expect-error
   choices: [],
 });
 
@@ -893,7 +895,13 @@ declare const applicationSubCommandData: ApplicationCommandSubCommandData;
 
   // Check that only subcommands can have no subcommand or subcommand group sub-options.
   assertType<
-    | (ApplicationCommandChoicesData | ApplicationCommandNonOptionsData | ApplicationCommandChannelOptionData)[]
+    | (
+        | ApplicationCommandChoicesData
+        | ApplicationCommandNonOptionsData
+        | ApplicationCommandChannelOptionData
+        | ApplicationCommandAutocompleteOption
+        | ApplicationCommandNumericOptionData
+      )[]
     | undefined
   >(applicationSubCommandData.options);
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes #6979

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
