### PR TITLE
fix(Util): ID sorting in `discordSort`

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -484,8 +484,8 @@ class Util extends null {
     return collection.sorted(
       (a, b) =>
         a.rawPosition - b.rawPosition ||
-        parseInt(b.id.slice(0, -10)) - parseInt(a.id.slice(0, -10)) ||
-        parseInt(b.id.slice(10)) - parseInt(a.id.slice(10)),
+        parseInt(a.id.slice(0, -10)) - parseInt(b.id.slice(0, -10)) ||
+        parseInt(a.id.slice(10)) - parseInt(b.id.slice(10)),
     );
   }
 


### PR DESCRIPTION
The Discord client sorts channels with the same position by ID, ascending. Previously `discordSort` would sort descending

**Please describe the changes this PR makes and why it should be merged:**

- Swapped sort order of `a` and `b` when sorting by ID (which is required when `rawPosition` is duplicate between the 2 channels

From testing, the client sorts ascending, but `discordSort` would sort descending

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- Typings don't need updating (Only values have changed)