### PR TITLE
feat(ThreadManager): add slowmode option on thread creation

### DIFF
--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -69,8 +69,7 @@ class ThreadManager extends CachedManager {
    * `GUILD_NEWS_THREAD`</warn>
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
    * <info>Can only be set when type will be `GUILD_PRIVATE_THREAD`</info>
-   * @property {number} [rateLimitPerUser] The amount of seconds a user has to wait before sending another
-   * message. <info>This value can be any integer between 1-21600</info>
+   * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the new channel in seconds
    */
 
   /**

--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -69,6 +69,8 @@ class ThreadManager extends CachedManager {
    * `GUILD_NEWS_THREAD`</warn>
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
    * <info>Can only be set when type will be `GUILD_PRIVATE_THREAD`</info>
+   * @property {number} [rateLimitPerUser] The amount of seconds a user has to wait before sending another
+   * message. <info>This value can be any integer between 1-21600</info>
    */
 
   /**
@@ -104,6 +106,7 @@ class ThreadManager extends CachedManager {
     type,
     invitable,
     reason,
+    rateLimitPerUser,
   } = {}) {
     let path = this.client.api.channels(this.channel.id);
     if (type && typeof type !== 'string' && typeof type !== 'number') {
@@ -133,6 +136,7 @@ class ThreadManager extends CachedManager {
         auto_archive_duration: autoArchiveDuration,
         type: resolvedType,
         invitable: resolvedType === ChannelTypes.GUILD_PRIVATE_THREAD ? invitable : undefined,
+        rate_limit_per_user: rateLimitPerUser,
       },
       reason,
     });

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -797,6 +797,7 @@ class Message extends Base {
    * @property {ThreadAutoArchiveDuration} [autoArchiveDuration=this.channel.defaultAutoArchiveDuration] The amount of
    * time (in minutes) after which the thread should automatically archive in case of no recent activity
    * @property {string} [reason] Reason for creating the thread
+   * @property {number} rateLimitPerUser The rate limit per user (slowmode) for the thread in seconds
    */
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -797,7 +797,7 @@ class Message extends Base {
    * @property {ThreadAutoArchiveDuration} [autoArchiveDuration=this.channel.defaultAutoArchiveDuration] The amount of
    * time (in minutes) after which the thread should automatically archive in case of no recent activity
    * @property {string} [reason] Reason for creating the thread
-   * @property {number} rateLimitPerUser The rate limit per user (slowmode) for the thread in seconds
+   * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the thread in seconds
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5091,6 +5091,7 @@ export interface ThreadCreateOptions<AllowedThreadType> extends StartThreadOptio
   startMessage?: MessageResolvable;
   type?: AllowedThreadType;
   invitable?: AllowedThreadType extends 'GUILD_PRIVATE_THREAD' | 12 ? boolean : never;
+  rateLimitPerUser?: number;
 }
 
 export interface ThreadEditData {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5034,6 +5034,7 @@ export interface StartThreadOptions {
   name: string;
   autoArchiveDuration?: ThreadAutoArchiveDuration;
   reason?: string;
+  rateLimitPerUser?: number;
 }
 
 export type Status = number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Allows newly created threads to specify the amount of time a user has to wait before sending a consecutive message.

- https://github.com/discord/discord-api-docs/commit/d56be860c5dd4c04e80337556d82eb3a04f971a2

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
