### PR TITLE
fix(Sharding): properly handle errors in fetchClientValues

### DIFF
--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -247,7 +247,8 @@ class Shard extends EventEmitter {
         if (message?._fetchProp !== prop) return;
         child.removeListener('message', listener);
         this._fetches.delete(prop);
-        resolve(message._result);
+        if (!message._error) resolve(message._result);
+        else reject(Util.makeError(message._error));
       };
       child.on('message', listener);
 

--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -175,10 +175,14 @@ class ShardClientUtil {
   async _handleMessage(message) {
     if (!message) return;
     if (message._fetchProp) {
-      const props = message._fetchProp.split('.');
-      let value = this.client;
-      for (const prop of props) value = value[prop];
-      this._respond('fetchProp', { _fetchProp: message._fetchProp, _result: value });
+      try {
+        const props = message._fetchProp.split('.');
+        let value = this.client;
+        for (const prop of props) value = value[prop];
+        this._respond('fetchProp', { _fetchProp: message._fetchProp, _result: value });
+      } catch (err) {
+        this._respond('fetchProp', { _fetchProp: message._fetchProp, _error: Util.makePlainError(err) });
+      }
     } else if (message._eval) {
       try {
         this._respond('eval', { _eval: message._eval, _result: await this.client._eval(message._eval) });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes that an error occuring in `fetchClientValues` would be uncatachable and fatal when it should be propagated back to the caller. (Be that through `ShardClientValues#fetchClientValues` or `Shard#fetchClientValues`)

`ShardClientUtil#fetchClientValues` already was able to do this; No changes were required here.
`Shard#fetchClientValues` however wasn't.
As well as `ShardClientUtil#_handleMessage` which wouldn't try/catch at all here.

Fixes #6946 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

