### PR TITLE
fix(VoiceState): set streaming to false when the stream ended

### DIFF
--- a/src/structures/VoiceState.js
+++ b/src/structures/VoiceState.js
@@ -83,7 +83,9 @@ class VoiceState extends Base {
       this.sessionId ??= null;
     }
 
-    if ('self_stream' in data) {
+    // The self_stream is property is omitted if false, check for another property
+    // here to avoid incorrectly clearing this when partial data is specified
+    if ('self_video' in data) {
       /**
        * Whether this member is streaming using "Screen Share"
        * @type {boolean}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #6967 by checking for a different property (so partial updates, in case those happen, don't incorrectly clear it).
There is no reason I chose `self_video` over the others.
I added a comment explaining why it's done like that.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
