### PR TITLE
chore: Emit deprecation messages

### DIFF
--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -34,6 +34,9 @@ const DataResolver = require('../util/DataResolver');
 const SystemChannelFlags = require('../util/SystemChannelFlags');
 const Util = require('../util/Util');
 
+let deprecationEmittedForSetChannelPositions = false;
+let deprecationEmittedForSetRolePositions = false;
+
 /**
  * Represents a guild (or a server) on Discord.
  * <info>It's recommended to see if a guild is available before performing operations or reading data from it. You can
@@ -1195,6 +1198,15 @@ class Guild extends AnonymousGuild {
    *   .catch(console.error);
    */
   setChannelPositions(channelPositions) {
+    if (!deprecationEmittedForSetChannelPositions) {
+      process.emitWarning(
+        'This method is deprecated. Use GuildChannelManager#setPositions instead.',
+        'DeprecationWarning',
+      );
+
+      deprecationEmittedForSetChannelPositions = true;
+    }
+
     return this.channels.setPositions(channelPositions);
   }
 
@@ -1216,6 +1228,11 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setRolePositions(rolePositions) {
+    if (!deprecationEmittedForSetRolePositions) {
+      process.emitWarning('This method is deprecated. Use RoleManager#setPositions instead.', 'DeprecationWarning');
+      deprecationEmittedForSetRolePositions = true;
+    }
+
     return this.roles.setPositions(rolePositions);
   }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1200,7 +1200,7 @@ class Guild extends AnonymousGuild {
   setChannelPositions(channelPositions) {
     if (!deprecationEmittedForSetChannelPositions) {
       process.emitWarning(
-        'This method (Guild#setChannelPositions) is deprecated. Use GuildChannelManager#setPositions instead.',
+        'The Guild#setChannelPositions method is deprecated. Use GuildChannelManager#setPositions instead.',
         'DeprecationWarning',
       );
 
@@ -1230,7 +1230,7 @@ class Guild extends AnonymousGuild {
   setRolePositions(rolePositions) {
     if (!deprecationEmittedForSetRolePositions) {
       process.emitWarning(
-        'This method (Guild#setRolePositions) is deprecated. Use RoleManager#setPositions instead.',
+        'The Guild#setRolePositions method is deprecated. Use RoleManager#setPositions instead.',
         'DeprecationWarning',
       );
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -1200,7 +1200,7 @@ class Guild extends AnonymousGuild {
   setChannelPositions(channelPositions) {
     if (!deprecationEmittedForSetChannelPositions) {
       process.emitWarning(
-        'This method is deprecated. Use GuildChannelManager#setPositions instead.',
+        'This method (Guild#setChannelPositions) is deprecated. Use GuildChannelManager#setPositions instead.',
         'DeprecationWarning',
       );
 
@@ -1229,7 +1229,11 @@ class Guild extends AnonymousGuild {
    */
   setRolePositions(rolePositions) {
     if (!deprecationEmittedForSetRolePositions) {
-      process.emitWarning('This method is deprecated. Use RoleManager#setPositions instead.', 'DeprecationWarning');
+      process.emitWarning(
+        'This method (Guild#setRolePositions) is deprecated. Use RoleManager#setPositions instead.',
+        'DeprecationWarning',
+      );
+
       deprecationEmittedForSetRolePositions = true;
     }
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -379,7 +379,8 @@ class MessageEmbed {
         (typeof deprecatedIconURL !== 'undefined' || typeof deprecatedURL !== 'undefined')
       ) {
         process.emitWarning(
-          "Passing strings for the URL or the icon's URL is deprecated. Pass a sole object instead.",
+          // eslint-disable-next-line max-len
+          "Passing strings for the URL or the icon's URL for MessageEmbed#setAuthor is deprecated. Pass a sole object instead.",
           'DeprecationWarning',
         );
 

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -3,6 +3,8 @@
 const { RangeError } = require('../errors');
 const Util = require('../util/Util');
 
+let deprecationEmittedForSetAuthor = false;
+
 /**
  * Represents an embed in a message (image/video preview, rich embed, etc.)
  */
@@ -372,6 +374,18 @@ class MessageEmbed {
     }
 
     if (typeof options === 'string') {
+      if (
+        !deprecationEmittedForSetAuthor &&
+        (typeof deprecatedIconURL !== 'undefined' || typeof deprecatedURL !== 'undefined')
+      ) {
+        process.emitWarning(
+          "Passing strings for the URL or the icon's URL is deprecated. Pass a sole object instead.",
+          'DeprecationWarning',
+        );
+
+        deprecationEmittedForSetAuthor = true;
+      }
+
       options = { name: options, url: deprecatedURL, iconURL: deprecatedIconURL };
     }
 

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -18,7 +18,11 @@ class VoiceChannel extends BaseGuildVoiceChannel {
    */
   get editable() {
     if (!deprecationEmittedForEditable) {
-      process.emitWarning('This getter is deprecated. Use VoiceChannel#manageable instead.', 'DeprecationWarning');
+      process.emitWarning(
+        'This getter (VoiceChannel#editable) is deprecated. Use VoiceChannel#manageable instead.',
+        'DeprecationWarning',
+      );
+
       deprecationEmittedForEditable = true;
     }
 

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -19,7 +19,7 @@ class VoiceChannel extends BaseGuildVoiceChannel {
   get editable() {
     if (!deprecationEmittedForEditable) {
       process.emitWarning(
-        'This getter (VoiceChannel#editable) is deprecated. Use VoiceChannel#manageable instead.',
+        'The VoiceChannel#editable getter is deprecated. Use VoiceChannel#manageable instead.',
         'DeprecationWarning',
       );
 

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -3,6 +3,8 @@
 const BaseGuildVoiceChannel = require('./BaseGuildVoiceChannel');
 const Permissions = require('../util/Permissions');
 
+let deprecationEmittedForEditable = false;
+
 /**
  * Represents a guild voice channel on Discord.
  * @extends {BaseGuildVoiceChannel}
@@ -15,6 +17,11 @@ class VoiceChannel extends BaseGuildVoiceChannel {
    * @deprecated Use {@link VoiceChannel#manageable} instead
    */
   get editable() {
+    if (!deprecationEmittedForEditable) {
+      process.emitWarning('This getter is deprecated. Use VoiceChannel#manageable instead.', 'DeprecationWarning');
+      deprecationEmittedForEditable = true;
+    }
+
     return this.manageable;
   }
 

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -6,6 +6,8 @@ const { WebhookTypes } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
 
+let deprecationEmittedForFetchMessage = false;
+
 /**
  * Represents a webhook.
  */
@@ -269,12 +271,21 @@ class Webhook {
    * Gets a message that was sent by this webhook.
    * @param {Snowflake|'@original'} message The id of the message to fetch
    * @param {WebhookFetchMessageOptions|boolean} [cacheOrOptions={}] The options to provide to fetch the message.
-   * A **deprecated** boolean may be passed instead to specify whether to cache the message.
+   * <warn>A **deprecated** boolean may be passed instead to specify whether to cache the message.</warn>
    * @returns {Promise<Message|APIMessage>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */
   async fetchMessage(message, cacheOrOptions = { cache: true }) {
     if (typeof cacheOrOptions === 'boolean') {
+      if (!deprecationEmittedForFetchMessage) {
+        process.emitWarning(
+          'Passing a boolean to cache the message in Webhook#fetchMessage is deprecated. Pass an object instead.',
+          'DeprecationWarning',
+        );
+
+        deprecationEmittedForFetchMessage = true;
+      }
+
       cacheOrOptions = { cache: cacheOrOptions };
     }
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -582,7 +582,7 @@ class Util extends null {
   static removeMentions(str) {
     if (!deprecationEmittedForRemoveMentions) {
       process.emitWarning(
-        'This method is deprecated. Utilise allowed mentions when sending a message instead.',
+        'This method (Util.removeMentions) is deprecated. Use MessageOptions#allowedMentions instead.',
         'DeprecationWarning',
       );
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -582,7 +582,7 @@ class Util extends null {
   static removeMentions(str) {
     if (!deprecationEmittedForRemoveMentions) {
       process.emitWarning(
-        'This method (Util.removeMentions) is deprecated. Use MessageOptions#allowedMentions instead.',
+        'The Util.removeMentions method is deprecated. Use MessageOptions#allowedMentions instead.',
         'DeprecationWarning',
       );
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -9,6 +9,8 @@ const { Error: DiscordError, RangeError, TypeError } = require('../errors');
 const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
 const isObject = d => typeof d === 'object' && d !== null;
 
+let deprecationEmittedForRemoveMentions = false;
+
 /**
  * Contains various general-purpose utility methods.
  */
@@ -578,6 +580,15 @@ class Util extends null {
    * @deprecated Use {@link BaseMessageOptions#allowedMentions} instead.
    */
   static removeMentions(str) {
+    if (!deprecationEmittedForRemoveMentions) {
+      process.emitWarning(
+        'This method is deprecated. Utilise allowed mentions when sending a message instead.',
+        'DeprecationWarning',
+      );
+
+      deprecationEmittedForRemoveMentions = true;
+    }
+
     return str.replaceAll('@', '@\u200b');
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pull request emits deprecation warnings to deprecated parts of the library.

This was not done for `MessageEmbed#type` as that was just a property (though it could technically be made into a getter?) and the application events that don't emit at all.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->