### PR TITLE
chore(ThreadMemberManager): make `#fetch` only take one object parameter

### DIFF
--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -69,6 +69,7 @@ class ThreadManager extends CachedManager {
    * `GUILD_NEWS_THREAD`</warn>
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
    * <info>Can only be set when type will be `GUILD_PRIVATE_THREAD`</info>
+   * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the new channel in seconds
    */
 
   /**
@@ -104,6 +105,7 @@ class ThreadManager extends CachedManager {
     type,
     invitable,
     reason,
+    rateLimitPerUser,
   } = {}) {
     let path = this.client.api.channels(this.channel.id);
     if (type && typeof type !== 'string' && typeof type !== 'number') {
@@ -133,6 +135,7 @@ class ThreadManager extends CachedManager {
         auto_archive_duration: autoArchiveDuration,
         type: resolvedType,
         invitable: resolvedType === ChannelTypes.GUILD_PRIVATE_THREAD ? invitable : undefined,
+        rate_limit_per_user: rateLimitPerUser,
       },
       reason,
     });

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -69,7 +69,6 @@ class ThreadManager extends CachedManager {
    * `GUILD_NEWS_THREAD`</warn>
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
    * <info>Can only be set when type will be `GUILD_PRIVATE_THREAD`</info>
-   * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the new channel in seconds
    */
 
   /**
@@ -105,7 +104,6 @@ class ThreadManager extends CachedManager {
     type,
     invitable,
     reason,
-    rateLimitPerUser,
   } = {}) {
     let path = this.client.api.channels(this.channel.id);
     if (type && typeof type !== 'string' && typeof type !== 'number') {
@@ -135,7 +133,6 @@ class ThreadManager extends CachedManager {
         auto_archive_duration: autoArchiveDuration,
         type: resolvedType,
         invitable: resolvedType === ChannelTypes.GUILD_PRIVATE_THREAD ? invitable : undefined,
-        rate_limit_per_user: rateLimitPerUser,
       },
       reason,
     });

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -69,8 +69,7 @@ class ThreadManager extends CachedManager {
    * `GUILD_NEWS_THREAD`</warn>
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
    * <info>Can only be set when type will be `GUILD_PRIVATE_THREAD`</info>
-   * @property {number} [rateLimitPerUser] The amount of seconds a user has to wait before sending another
-   * message. <info>This value can be any integer between 1-21600</info>
+   * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the new channel in seconds
    */
 
   /**

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -69,7 +69,8 @@ class ThreadManager extends CachedManager {
    * `GUILD_NEWS_THREAD`</warn>
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
    * <info>Can only be set when type will be `GUILD_PRIVATE_THREAD`</info>
-   * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the new channel in seconds
+   * @property {number} [rateLimitPerUser] The amount of seconds a user has to wait before sending another
+   * message. <info>This value can be any integer between 1-21600</info>
    */
 
   /**

--- a/packages/discord.js/src/managers/ThreadMemberManager.js
+++ b/packages/discord.js/src/managers/ThreadMemberManager.js
@@ -5,8 +5,6 @@ const CachedManager = require('./CachedManager');
 const { TypeError } = require('../errors');
 const ThreadMember = require('../structures/ThreadMember');
 
-let deprecationEmittedForFetchMember = false;
-
 /**
  * Manages API methods for GuildMembers and stores their cache.
  * @extends {CachedManager}
@@ -116,18 +114,11 @@ class ThreadMemberManager extends CachedManager {
 
   /**
    * Fetches member(s) for the thread from Discord, requires access to the `GUILD_MEMBERS` gateway intent.
-   * @param {ThreadMemberFetchOptions} [options] Additional options for this fetch
+   * @param {ThreadMemberFetchOptions|boolean} [options] Additional options for this fetch, when a `boolean` is provided
+   * all members are fetched with `options.cache` set to the boolean value
    * @returns {Promise<ThreadMember|Collection<Snowflake, ThreadMember>>}
    */
   fetch({ member, cache = true, force = false } = {}) {
-    // eslint-disable-next-line prefer-rest-params
-    if (!deprecationEmittedForFetchMember && typeof arguments[0] === 'boolean') {
-      process.emitWarning(
-        'Passing a boolean as a parameter for ThreadMemberManager#fetch is deprecated. Pass a sole object instead.',
-        'DeprecationWarning',
-      );
-    }
-
     const id = this.resolveId(member);
     return id ? this._fetchOne(id, cache, force) : this._fetchMany(member ?? cache);
   }

--- a/packages/discord.js/src/managers/ThreadMemberManager.js
+++ b/packages/discord.js/src/managers/ThreadMemberManager.js
@@ -109,13 +109,10 @@ class ThreadMemberManager extends CachedManager {
 
   /**
    * Fetches member(s) for the thread from Discord, requires access to the `GUILD_MEMBERS` gateway intent.
-   * @param {UserResolvable|boolean} [member] The member to fetch. If `undefined`, all members
-   * in the thread are fetched, and will be cached based on `options.cache`. If boolean, this serves
-   * the purpose of `options.cache`.
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<ThreadMember|Collection<Snowflake, ThreadMember>>}
    */
-  fetch(member, { cache = true, force = false } = {}) {
+  fetch({ member, cache = true, force = false } = {}) {
     const id = this.resolveId(member);
     return id ? this._fetchOne(id, cache, force) : this._fetchMany(member ?? cache);
   }

--- a/packages/discord.js/src/managers/ThreadMemberManager.js
+++ b/packages/discord.js/src/managers/ThreadMemberManager.js
@@ -5,6 +5,8 @@ const CachedManager = require('./CachedManager');
 const { TypeError } = require('../errors');
 const ThreadMember = require('../structures/ThreadMember');
 
+let deprecationEmittedForFetchMember = false;
+
 /**
  * Manages API methods for GuildMembers and stores their cache.
  * @extends {CachedManager}
@@ -118,6 +120,14 @@ class ThreadMemberManager extends CachedManager {
    * @returns {Promise<ThreadMember|Collection<Snowflake, ThreadMember>>}
    */
   fetch({ member, cache = true, force = false } = {}) {
+    // eslint-disable-next-line prefer-rest-params
+    if (!deprecationEmittedForFetchMember && typeof arguments[0] === 'boolean') {
+      process.emitWarning(
+        'Passing a boolean as a parameter for ThreadMemberManager#fetch is deprecated. Pass a sole object instead.',
+        'DeprecationWarning',
+      );
+    }
+
     const id = this.resolveId(member);
     return id ? this._fetchOne(id, cache, force) : this._fetchMany(member ?? cache);
   }

--- a/packages/discord.js/src/managers/ThreadMemberManager.js
+++ b/packages/discord.js/src/managers/ThreadMemberManager.js
@@ -108,8 +108,13 @@ class ThreadMemberManager extends CachedManager {
   }
 
   /**
+   * @typedef {BaseFetchOptions} ThreadMemberFetchOptions
+   * @property {UserResolvable} [member] The specific user to fetch from the thread
+   */
+
+  /**
    * Fetches member(s) for the thread from Discord, requires access to the `GUILD_MEMBERS` gateway intent.
-   * @param {BaseFetchOptions} [options] Additional options for this fetch
+   * @param {ThreadMemberFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<ThreadMember|Collection<Snowflake, ThreadMember>>}
    */
   fetch({ member, cache = true, force = false } = {}) {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3246,7 +3246,6 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
   public thread: ThreadChannel;
   public add(member: UserResolvable | '@me', reason?: string): Promise<Snowflake>;
   public fetch(options?: ThreadMemberFetchOptions): Promise<ThreadMember>;
-  /** @deprecated Use `fetch(options)` instead. */
   public fetch(cache?: boolean): Promise<Collection<Snowflake, ThreadMember>>;
   public remove(id: Snowflake | '@me', reason?: string): Promise<Snowflake>;
 }
@@ -5603,7 +5602,6 @@ export interface ThreadCreateOptions<AllowedThreadType> extends StartThreadOptio
   startMessage?: MessageResolvable;
   type?: AllowedThreadType;
   invitable?: AllowedThreadType extends 'GUILD_PRIVATE_THREAD' | 12 ? boolean : never;
-  rateLimitPerUser?: number;
 }
 
 export interface ThreadEditData {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5602,6 +5602,7 @@ export interface ThreadCreateOptions<AllowedThreadType> extends StartThreadOptio
   startMessage?: MessageResolvable;
   type?: AllowedThreadType;
   invitable?: AllowedThreadType extends 'GUILD_PRIVATE_THREAD' | 12 ? boolean : never;
+  rateLimitPerUser?: number;
 }
 
 export interface ThreadEditData {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3245,8 +3245,8 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
   private constructor(thread: ThreadChannel, iterable?: Iterable<RawThreadMemberData>);
   public thread: ThreadChannel;
   public add(member: UserResolvable | '@me', reason?: string): Promise<Snowflake>;
-  public fetch(member?: UserResolvable, options?: BaseFetchOptions): Promise<ThreadMember>;
-  /** @deprecated Use `fetch(member, options)` instead. */
+  public fetch(options?: BaseFetchOptions & { member?: UserResolvable }): Promise<ThreadMember>;
+  /** @deprecated Use `fetch(options)` instead. */
   public fetch(cache?: boolean): Promise<Collection<Snowflake, ThreadMember>>;
   public remove(id: Snowflake | '@me', reason?: string): Promise<Snowflake>;
 }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3245,7 +3245,7 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
   private constructor(thread: ThreadChannel, iterable?: Iterable<RawThreadMemberData>);
   public thread: ThreadChannel;
   public add(member: UserResolvable | '@me', reason?: string): Promise<Snowflake>;
-  public fetch(options?: BaseFetchOptions & { member?: UserResolvable }): Promise<ThreadMember>;
+  public fetch(options?: ThreadMemberFetchOptions): Promise<ThreadMember>;
   /** @deprecated Use `fetch(options)` instead. */
   public fetch(cache?: boolean): Promise<Collection<Snowflake, ThreadMember>>;
   public remove(id: Snowflake | '@me', reason?: string): Promise<Snowflake>;
@@ -3762,6 +3762,10 @@ export type Base64String = string;
 export interface BaseFetchOptions {
   cache?: boolean;
   force?: boolean;
+}
+
+export interface ThreadMemberFetchOptions extends BaseFetchOptions {
+  member?: UserResolvable;
 }
 
 export interface BaseMessageComponentOptions {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -469,8 +469,8 @@ client.on('guildCreate', async g => {
   if (!channel) return;
 
   if (channel.isThread()) {
-    const fetchedMember = await channel.members.fetch('12345678');
-    expectType<ThreadMember>(fetchedMember);
+    const fetchedMember = await channel.members.fetch({ member: '12345678' });
+    assertType<ThreadMember>(fetchedMember);
     const fetchedMemberCol = await channel.members.fetch(true);
     expectDeprecated(await channel.members.fetch(true));
     expectType<Collection<Snowflake, ThreadMember>>(fetchedMemberCol);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

@Jiralite pointed out this one out

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
