### PR TITLE
fix(Util): fix sorting for GuildChannels

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -483,9 +483,10 @@ class Util extends null {
    */
   static discordSort(collection) {
     return collection.sorted((a, b) => {
+      if (a.rawPosition !== b.rawPosition) return a.rawPosition - b.rawPosition;
       const aId = BigInt(a.id);
       const bId = BigInt(b.id);
-      return a.rawPosition - b.rawPosition || Number(a instanceof GuildChannel ? aId - bId : bId - aId);
+      return Number(a instanceof GuildChannel ? aId - bId : bId - aId);
     });
   }
 

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -482,12 +482,12 @@ class Util extends null {
    * @returns {Collection}
    */
   static discordSort(collection) {
-    return collection.sorted((a, b) => {
-      if (a.rawPosition !== b.rawPosition) return a.rawPosition - b.rawPosition;
-      const aId = BigInt(a.id);
-      const bId = BigInt(b.id);
-      return Number(a instanceof GuildChannel ? aId - bId : bId - aId);
-    });
+    const isGuildChannel = collection.first() instanceof GuildChannel;
+    return collection.sorted(
+      isGuildChannel
+        ? (a, b) => a.rawPosition - b.rawPosition || Number(BigInt(a.id) - BigInt(b.id))
+        : (a, b) => a.rawPosition - b.rawPosition || Number(BigInt(b.id) - BigInt(a.id)),
+    );
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -6,6 +6,7 @@ const fetch = require('node-fetch');
 const { Colors, Endpoints } = require('./Constants');
 const Options = require('./Options');
 const { Error: DiscordError, RangeError, TypeError } = require('../errors');
+const GuildChannel = require('../structures/GuildChannel');
 const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
 const isObject = d => typeof d === 'object' && d !== null;
 
@@ -481,12 +482,11 @@ class Util extends null {
    * @returns {Collection}
    */
   static discordSort(collection) {
-    return collection.sorted(
-      (a, b) =>
-        a.rawPosition - b.rawPosition ||
-        parseInt(b.id.slice(0, -10)) - parseInt(a.id.slice(0, -10)) ||
-        parseInt(b.id.slice(10)) - parseInt(a.id.slice(10)),
-    );
+    return collection.sorted((a, b) => {
+      const aId = BigInt(a.id);
+      const bId = BigInt(b.id);
+      return a.rawPosition - b.rawPosition || Number(a instanceof GuildChannel ? aId - bId : bId - aId);
+    });
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -6,7 +6,6 @@ const fetch = require('node-fetch');
 const { Colors, Endpoints } = require('./Constants');
 const Options = require('./Options');
 const { Error: DiscordError, RangeError, TypeError } = require('../errors');
-const GuildChannel = require('../structures/GuildChannel');
 const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
 const isObject = d => typeof d === 'object' && d !== null;
 
@@ -657,3 +656,6 @@ class Util extends null {
 }
 
 module.exports = Util;
+
+// Fixes Circular
+const GuildChannel = require('../structures/GuildChannel');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Util#discordSort` sorts Ids descending when the `rawPosition` is the same, which is consistent with `Role` sorting, but is not for `GuildChannel` sorting, which sorts Ids ascending

**Status and versioning classification:**

- Typings don't need updating

~~Note: I've been unable to test the changes nor some similar versions, due to issues as I mentioned [here](https://discord.com/channels/222078108977594368/682166281826598932/909663555312291920); I'm not sure what I'm doing wrong, as I've only modified the required files and this method, but it seems to break the entire `Util` exports
I've just decided to create this PR in the hopes that someone else with more experience can fix these mistakes~~
Issues resolved, changes tested