### PR TITLE
types(WebhookMessageOptions): disallow stickers

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -758,6 +758,7 @@ class Message extends Base {
    * @typedef {BaseMessageOptions} ReplyMessageOptions
    * @property {boolean} [failIfNotExists=true] Whether to error if the referenced message
    * does not exist (creates a standard message in this case when false)
+   * @property {StickerResolvable[]} [stickers=[]] Stickers to send in the message
    */
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -65,7 +65,6 @@ class TextBasedChannel {
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to send with the message
    * @property {MessageActionRow[]|MessageActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
-   * @property {StickerResolvable[]} [stickers=[]] Stickers to send in the message
    * @property {MessageAttachment[]} [attachments] Attachments to send in the message
    */
 
@@ -73,6 +72,7 @@ class TextBasedChannel {
    * Options provided when sending or editing a message.
    * @typedef {BaseMessageOptions} MessageOptions
    * @property {ReplyOptions} [reply] The options for replying to a message
+   * @property {StickerResolvable[]} [stickers=[]] Stickers to send in the message
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5168,7 +5168,7 @@ export interface WebhookFetchMessageOptions {
   threadId?: Snowflake;
 }
 
-export interface WebhookMessageOptions extends Omit<MessageOptions, 'reply'> {
+export interface WebhookMessageOptions extends Omit<MessageOptions, 'reply' | 'stickers'> {
   username?: string;
   avatarURL?: string;
   threadId?: Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR removes the ability to send stickers in webhook messages from the docs and the types as this is not resolved by Discord and results in an empty message when sent with nothing else.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
