### PR TITLE
docs(Constants): fix typo "announcement"

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -723,7 +723,7 @@ exports.VerificationLevels = createEnum(['NONE', 'LOW', 'MEDIUM', 'HIGH', 'VERY_
  * * MESSAGE_ALREADY_HAS_THREAD
  * * THREAD_LOCKED
  * * MAXIMUM_ACTIVE_THREADS
- * * MAXIMUM_ACTIVE_ANNOUCEMENT_THREAD
+ * * MAXIMUM_ACTIVE_ANNOUNCEMENT_THREAD
  * @typedef {string} APIError
  * @see {@link https://discord.com/developers/docs/topics/opcodes-and-status-codes#json-json-error-codes}
  */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the typo "ANNOUCEMENT" to "ANNOUNCEMENT". The actual APIError has the correct spelling, just the docs that have a typo.

###### Did someone write that out by hand 🤔

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
