### PR TITLE
types: make event emitters use mapped event types

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -609,6 +609,12 @@ export class ClientVoiceManager {
 
 export { Collection } from '@discordjs/collection';
 
+export interface CollectorEventTypes<K, V, F extends unknown[] = []> {
+  collect: [V, ...F];
+  dispose: [V, ...F];
+  end: [collected: Collection<K, V>];
+}
+
 export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmitter {
   protected constructor(client: Client, options?: CollectorOptions<[V, ...F]>);
   private _timeout: NodeJS.Timeout | null;
@@ -633,11 +639,15 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
   public abstract collect(...args: unknown[]): K | null | Promise<K | null>;
   public abstract dispose(...args: unknown[]): K | null;
 
-  public on(event: 'collect' | 'dispose', listener: (...args: [V, ...F]) => Awaitable<void>): this;
-  public on(event: 'end', listener: (collected: Collection<K, V>, reason: string) => Awaitable<void>): this;
+  public on<EventKey extends keyof CollectorEventTypes<K, V, F>>(
+    event: EventKey,
+    listener: (...args: CollectorEventTypes<K, V, F>[EventKey]) => Awaitable<void>,
+  ): this;
 
-  public once(event: 'collect' | 'dispose', listener: (...args: [V, ...F]) => Awaitable<void>): this;
-  public once(event: 'end', listener: (collected: Collection<K, V>, reason: string) => Awaitable<void>): this;
+  public once<EventKey extends keyof CollectorEventTypes<K, V, F>>(
+    event: EventKey,
+    listener: (...args: CollectorEventTypes<K, V, F>[EventKey]) => Awaitable<void>,
+  ): this;
 }
 
 export interface ApplicationCommandInteractionOptionResolver<Cached extends CacheType = CacheType>
@@ -1829,6 +1839,16 @@ export class SelectMenuInteraction<Cached extends CacheType = CacheType> extends
   public inRawGuild(): this is SelectMenuInteraction<'raw'>;
 }
 
+export interface ShardEventTypes {
+  spawn: [child: ChildProcess];
+  death: [child: ChildProcess];
+  disconnect: [];
+  ready: [];
+  reconnection: [];
+  error: [error: Error];
+  message: [message: any];
+}
+
 export class Shard extends EventEmitter {
   private constructor(manager: ShardingManager, id: number);
   private _evals: Map<string, Promise<unknown>>;
@@ -1853,17 +1873,15 @@ export class Shard extends EventEmitter {
   public send(message: unknown): Promise<Shard>;
   public spawn(timeout?: number): Promise<ChildProcess>;
 
-  public on(event: 'spawn' | 'death', listener: (child: ChildProcess) => Awaitable<void>): this;
-  public on(event: 'disconnect' | 'ready' | 'reconnecting', listener: () => Awaitable<void>): this;
-  public on(event: 'error', listener: (error: Error) => Awaitable<void>): this;
-  public on(event: 'message', listener: (message: any) => Awaitable<void>): this;
-  public on(event: string, listener: (...args: any[]) => Awaitable<void>): this;
+  public on<K extends keyof ShardEventTypes>(
+    event: K,
+    listener: (...args: ShardEventTypes[K]) => Awaitable<void>,
+  ): this;
 
-  public once(event: 'spawn' | 'death', listener: (child: ChildProcess) => Awaitable<void>): this;
-  public once(event: 'disconnect' | 'ready' | 'reconnecting', listener: () => Awaitable<void>): this;
-  public once(event: 'error', listener: (error: Error) => Awaitable<void>): this;
-  public once(event: 'message', listener: (message: any) => Awaitable<void>): this;
-  public once(event: string, listener: (...args: any[]) => Awaitable<void>): this;
+  public once<K extends keyof ShardEventTypes>(
+    event: K,
+    listener: (...args: ShardEventTypes[K]) => Awaitable<void>,
+  ): this;
 }
 
 export class ShardClientUtil {
@@ -2352,6 +2370,14 @@ export class WebSocketManager extends EventEmitter {
   private triggerClientReady(): void;
 }
 
+export interface WebSocketShardEvents {
+  ready: [];
+  resumed: [];
+  invalidSession: [];
+  close: [event: CloseEvent];
+  allReady: [unavailableGuilds?: Set<Snowflake>];
+}
+
 export class WebSocketShard extends EventEmitter {
   private constructor(manager: WebSocketManager, id: number);
   private sequence: number;
@@ -2394,15 +2420,15 @@ export class WebSocketShard extends EventEmitter {
 
   public send(data: unknown, important?: boolean): void;
 
-  public on(event: 'ready' | 'resumed' | 'invalidSession', listener: () => Awaitable<void>): this;
-  public on(event: 'close', listener: (event: CloseEvent) => Awaitable<void>): this;
-  public on(event: 'allReady', listener: (unavailableGuilds?: Set<Snowflake>) => Awaitable<void>): this;
-  public on(event: string, listener: (...args: any[]) => Awaitable<void>): this;
+  public on<K extends keyof WebSocketShardEvents>(
+    event: K,
+    listener: (...args: WebSocketShardEvents[K]) => Awaitable<void>,
+  ): this;
 
-  public once(event: 'ready' | 'resumed' | 'invalidSession', listener: () => Awaitable<void>): this;
-  public once(event: 'close', listener: (event: CloseEvent) => Awaitable<void>): this;
-  public once(event: 'allReady', listener: (unavailableGuilds?: Set<Snowflake>) => Awaitable<void>): this;
-  public once(event: string, listener: (...args: any[]) => Awaitable<void>): this;
+  public once<K extends keyof WebSocketShardEvents>(
+    event: K,
+    listener: (...args: WebSocketShardEvents[K]) => Awaitable<void>,
+  ): this;
 }
 
 export class Widget extends Base {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -612,7 +612,7 @@ export { Collection } from '@discordjs/collection';
 export interface CollectorEventTypes<K, V, F extends unknown[] = []> {
   collect: [V, ...F];
   dispose: [V, ...F];
-  end: [collected: Collection<K, V>];
+  end: [collected: Collection<K, V>, reason: string];
 }
 
 export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmitter {

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -1140,13 +1140,19 @@ webSocketShard.on('close', event => {
 
 declare const collector: Collector<string, Interaction, string[]>;
 
-collector.on('collect', collected => {
+collector.on('collect', (collected, ...other) => {
   assertType<Interaction>(collected);
+  assertType<string[]>(other);
 });
 
-collector.on('dispose', (vals, ...another) => {
+collector.on('dispose', (vals, ...other) => {
   assertType<Interaction>(vals);
-  assertType<string[]>(another);
+  assertType<string[]>(other);
+});
+
+collector.on('end', (collection, reason) => {
+  assertType<Collection<string, Interaction>>(collection);
+  assertType<string>(reason);
 });
 
 assertType<Promise<number | null>>(shard.eval(c => c.readyTimestamp));

--- a/typings/tests.ts
+++ b/typings/tests.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from 'child_process';
 import type {
   APIGuildMember,
   APIInteractionGuildMember,
@@ -26,6 +27,7 @@ import {
   Client,
   ClientApplication,
   ClientUser,
+  CloseEvent,
   Collection,
   CommandInteraction,
   CommandInteractionOption,
@@ -81,6 +83,8 @@ import {
   Shard,
   ApplicationCommandAutocompleteOption,
   ApplicationCommandNumericOptionData,
+  WebSocketShard,
+  Collector,
 } from '.';
 import type { ApplicationCommandOptionTypes } from './enums';
 
@@ -1123,5 +1127,26 @@ client.on('interactionCreate', async interaction => {
 });
 
 declare const shard: Shard;
+
+shard.on('death', process => {
+  assertType<ChildProcess>(process);
+});
+
+declare const webSocketShard: WebSocketShard;
+
+webSocketShard.on('close', event => {
+  assertType<CloseEvent>(event);
+});
+
+declare const collector: Collector<string, Interaction, string[]>;
+
+collector.on('collect', collected => {
+  assertType<Interaction>(collected);
+});
+
+collector.on('dispose', (vals, ...another) => {
+  assertType<Interaction>(vals);
+  assertType<string[]>(another);
+});
 
 assertType<Promise<number | null>>(shard.eval(c => c.readyTimestamp));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Uses mapped types instead of manually declaring them twice within each class that extends `EventEmitter`. Similar to what `Client` already does for its events. 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
