### PR TITLE
fix: avoid sending bot auth on token endpoints

### DIFF
--- a/src/structures/AutocompleteInteraction.js
+++ b/src/structures/AutocompleteInteraction.js
@@ -99,6 +99,7 @@ class AutocompleteInteraction extends Interaction {
           choices: options,
         },
       },
+      auth: false,
     });
     this.responded = true;
   }

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -249,6 +249,7 @@ class Webhook {
     const data = await this.client.api.webhooks(this.id, channel ? undefined : this.token).patch({
       data: { name, avatar, channel_id: channel },
       reason,
+      auth: !this.token || Boolean(channel),
     });
 
     this.name = data.name;
@@ -287,6 +288,7 @@ class Webhook {
         query: {
           thread_id: cacheOrOptions.threadId,
         },
+        auth: false,
       });
     return this.client.channels?.cache.get(data.channel_id)?.messages._add(data, cacheOrOptions.cache) ?? data;
   }
@@ -317,6 +319,7 @@ class Webhook {
         query: {
           thread_id: messagePayload.options.threadId,
         },
+        auth: false,
       });
 
     const messageManager = this.client.channels?.cache.get(d.channel_id)?.messages;
@@ -336,7 +339,7 @@ class Webhook {
    * @returns {Promise<void>}
    */
   async delete(reason) {
-    await this.client.api.webhooks(this.id, this.token).delete({ reason });
+    await this.client.api.webhooks(this.id, this.token).delete({ reason, auth: !this.token });
   }
 
   /**
@@ -355,6 +358,7 @@ class Webhook {
         query: {
           thread_id: threadId,
         },
+        auth: false,
       });
   }
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -61,6 +61,7 @@ class InteractionResponses {
           flags: options.ephemeral ? MessageFlags.FLAGS.EPHEMERAL : undefined,
         },
       },
+      auth: false,
     });
     this.deferred = true;
 
@@ -101,6 +102,7 @@ class InteractionResponses {
         data,
       },
       files,
+      auth: false,
     });
     this.replied = true;
 
@@ -179,6 +181,7 @@ class InteractionResponses {
       data: {
         type: InteractionResponseTypes.DEFERRED_MESSAGE_UPDATE,
       },
+      auth: false,
     });
     this.deferred = true;
 
@@ -213,6 +216,7 @@ class InteractionResponses {
         data,
       },
       files,
+      auth: false,
     });
     this.replied = true;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes requests that use a token to authorize themselves to not use bot auth (Authorization header).

See: https://github.com/discord/discord-api-docs/issues/4142 (this might be fixed on Discord's end, but definitely can't hurt to be fixed here [too])

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

