### PR TITLE
fix(MessagePayload): prevent spread of `undefined`

### DIFF
--- a/src/structures/MessagePayload.js
+++ b/src/structures/MessagePayload.js
@@ -182,7 +182,7 @@ class MessagePayload {
       description: file.description,
     }));
     if (Array.isArray(this.options.attachments)) {
-      this.options.attachments.push(...attachments);
+      this.options.attachments.push(...(attachments ?? []));
     } else {
       this.options.attachments = attachments;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When passing `attachments: []` to `MessageOptions` and no `files` (to clear all attachments in a message edit), this code would result on the following logic to be executed:

```javascript
const attachments = this.options.files?.map((file, index) => ({
  id: index.toString(),
  description: file.description,
}));
if (Array.isArray(this.options.attachments) /* true */) {
  this.options.attachments.push(...attachments /* undefined */);
} else {
  this.options.attachments = attachments;
}
```

When spreading `undefined`, a `TypeError` is thrown with the message `undefined is not iterable (cannot read property undefined)` on Node.js v16.3.0.

Defaulting attachments to an empty array in that branch resolves the issue with the minimal impact possible.

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- Code changes have been tested against the Discord API, or there are no code changes
