### PR TITLE
fix(MessageManager): Allow a string for `edit()`

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -115,7 +115,7 @@ class MessageManager extends CachedManager {
   /**
    * Edits a message, even if it's not cached.
    * @param {MessageResolvable} message The message to edit
-   * @param {MessageEditOptions|MessagePayload} options The options to edit the message
+   * @param {string|MessageEditOptions|MessagePayload} options The options to edit the message
    * @returns {Promise<Message>}
    */
   async edit(message, options) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2912,7 +2912,7 @@ export class MessageManager extends CachedManager<Snowflake, Message, MessageRes
   public cache: Collection<Snowflake, Message>;
   public crosspost(message: MessageResolvable): Promise<Message>;
   public delete(message: MessageResolvable): Promise<void>;
-  public edit(message: MessageResolvable, options: MessagePayload | MessageEditOptions): Promise<Message>;
+  public edit(message: MessageResolvable, options: string | MessagePayload | MessageEditOptions): Promise<Message>;
   public fetch(message: Snowflake, options?: BaseFetchOptions): Promise<Message>;
   public fetch(
     options?: ChannelLogsQueryOptions,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Well, `MessageManager#edit()`'s second parameter is not documented nor typed to take a string when it is possible and is already being done by the library.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
