### PR TITLE
refactor(SnowflakeUtil): clean up utils and improve perf

### DIFF
--- a/src/util/SnowflakeUtil.js
+++ b/src/util/SnowflakeUtil.js
@@ -1,10 +1,8 @@
 'use strict';
 
-const Util = require('./Util');
-
 // Discord epoch (2015-01-01T00:00:00.000Z)
 const EPOCH = 1_420_070_400_000;
-let INCREMENT = 0;
+let INCREMENT = 0n;
 
 /**
  * A container for useful snowflake-related methods.
@@ -36,11 +34,10 @@ class SnowflakeUtil extends null {
         `"timestamp" argument must be a number (received ${isNaN(timestamp) ? 'NaN' : typeof timestamp})`,
       );
     }
-    if (INCREMENT >= 4095) INCREMENT = 0;
-    const BINARY = `${(timestamp - EPOCH).toString(2).padStart(42, '0')}0000100000${(INCREMENT++)
-      .toString(2)
-      .padStart(12, '0')}`;
-    return Util.binaryToId(BINARY);
+    if (INCREMENT >= 4095n) INCREMENT = 0n;
+
+    // Assign WorkerId as 1 and ProcessId as 0:
+    return ((BigInt(timestamp - EPOCH) << 22n) | (1n << 17n) | INCREMENT++).toString();
   }
 
   /**
@@ -60,16 +57,16 @@ class SnowflakeUtil extends null {
    * @returns {DeconstructedSnowflake}
    */
   static deconstruct(snowflake) {
-    const BINARY = Util.idToBinary(snowflake).toString(2).padStart(64, '0');
+    const bigIntSnowflake = BigInt(snowflake);
     return {
-      timestamp: parseInt(BINARY.substring(0, 42), 2) + EPOCH,
+      timestamp: Number(bigIntSnowflake >> 22n) + EPOCH,
       get date() {
         return new Date(this.timestamp);
       },
-      workerId: parseInt(BINARY.substring(42, 47), 2),
-      processId: parseInt(BINARY.substring(47, 52), 2),
-      increment: parseInt(BINARY.substring(52, 64), 2),
-      binary: BINARY,
+      workerId: Number((bigIntSnowflake >> 17n) & 0b11111n),
+      processId: Number((bigIntSnowflake >> 12n) & 0b11111n),
+      increment: Number(bigIntSnowflake & 0b111111111111n),
+      binary: bigIntSnowflake.toString(2).padStart(64, '0'),
     };
   }
 

--- a/src/util/SnowflakeUtil.js
+++ b/src/util/SnowflakeUtil.js
@@ -2,7 +2,7 @@
 
 // Discord epoch (2015-01-01T00:00:00.000Z)
 const EPOCH = 1_420_070_400_000;
-let INCREMENT = 0n;
+let INCREMENT = BigInt(0);
 
 /**
  * A container for useful snowflake-related methods.
@@ -34,7 +34,7 @@ class SnowflakeUtil extends null {
         `"timestamp" argument must be a number (received ${isNaN(timestamp) ? 'NaN' : typeof timestamp})`,
       );
     }
-    if (INCREMENT >= 4095n) INCREMENT = 0n;
+    if (INCREMENT >= 4095n) INCREMENT = BigInt(0);
 
     // Assign WorkerId as 1 and ProcessId as 0:
     return ((BigInt(timestamp - EPOCH) << 22n) | (1n << 17n) | INCREMENT++).toString();

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -523,57 +523,6 @@ class Util extends null {
   }
 
   /**
-   * Transforms a snowflake from a decimal string to a bit string.
-   * @param {Snowflake} num Snowflake to be transformed
-   * @returns {string}
-   * @private
-   */
-  static idToBinary(num) {
-    let bin = '';
-    let high = parseInt(num.slice(0, -10)) || 0;
-    let low = parseInt(num.slice(-10));
-    while (low > 0 || high > 0) {
-      bin = String(low & 1) + bin;
-      low = Math.floor(low / 2);
-      if (high > 0) {
-        low += 5_000_000_000 * (high % 2);
-        high = Math.floor(high / 2);
-      }
-    }
-    return bin;
-  }
-
-  /**
-   * Transforms a snowflake from a bit string to a decimal string.
-   * @param {string} num Bit string to be transformed
-   * @returns {Snowflake}
-   * @private
-   */
-  static binaryToId(num) {
-    let dec = '';
-
-    while (num.length > 50) {
-      const high = parseInt(num.slice(0, -32), 2);
-      const low = parseInt((high % 10).toString(2) + num.slice(-32), 2);
-
-      dec = (low % 10).toString() + dec;
-      num =
-        Math.floor(high / 10).toString(2) +
-        Math.floor(low / 10)
-          .toString(2)
-          .padStart(32, '0');
-    }
-
-    num = parseInt(num, 2);
-    while (num > 0) {
-      dec = (num % 10).toString() + dec;
-      num = Math.floor(num / 10);
-    }
-
-    return dec;
-  }
-
-  /**
    * Breaks user, role and everyone/here mentions by adding a zero width space after every @ character
    * @param {string} str The string to sanitize
    * @returns {string}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2197,7 +2197,6 @@ export class Util extends null {
   private constructor();
   public static archivedThreadSweepFilter<K, V>(lifetime?: number): SweepFilter<K, V>;
   public static basename(path: string, ext?: string): string;
-  public static binaryToId(num: string): Snowflake;
   public static cleanContent(str: string, channel: TextBasedChannels): string;
   /** @deprecated Use {@link MessageOptions.allowedMentions} to control mentions in a message instead. */
   public static removeMentions(str: string): string;
@@ -2217,7 +2216,6 @@ export class Util extends null {
   public static cleanCodeBlockContent(text: string): string;
   public static fetchRecommendedShards(token: string, options?: FetchRecommendedShardsOptions): Promise<number>;
   public static flatten(obj: unknown, ...props: Record<string, boolean | string>[]): unknown;
-  public static idToBinary(num: Snowflake): string;
   public static makeError(obj: MakeErrorOptions): Error;
   public static makePlainError(err: Error): MakeErrorOptions;
   public static mergeDefault(def: unknown, given: unknown): unknown;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removes two unneeded private utilities (`Util.binaryToId` and `Util.idToBinary`) and increases the performance of `SnowflakeUtil.generate` and `SnowflakeUtil.deconstruct`:

| Iterations | Old `deconstruct` | New `deconstruct` |     Diff | Old `generate` | New `generate` |      Diff |
| :--------: | :---------------: | :---------------: | :------: | :------------: | :------------: | :-------: |
|    `10000` |           44.40ms |           26.15ms | **1.70** |        97.67ms |        14.64ms |  **6.67** |
|   `100000` |          400.57ms |          209.11ms | **1.92** |       746.16ms |        85.01ms |  **8.78** |
|  `1000000` |             3.68s |             2.07s | **1.78** |          7.72s |       479.30ms | **16.10** |

`SnowflakeUtil.deconstruct` is used in a total of 17 places: `ApplicationCommand`, `BaseGuild`, `Channel`, `Emoji`, `GuildAuditLogs`, `GuildPreview`, `Interaction`, `Message`, `Role`, `StageInstance`, `Sticker`, `StickerPack`, `Team`, `User`, `Webhook`, `Application`, and `TextBasedChannel`, to get the timestamp from a snowflake ID given by Discord. `Snowflake.generate` is used to generate the nonce in `GuildMemberManager`.

I could also make `SnowflakeUtil.getTimestamp(Snowflake)` to offer a +4 times faster alternative to `SnowflakeUtil.deconstruct(Snowflake).timestamp`, skipping allocations and a lot of overhead.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
