### PR TITLE
fix(MessageManager): do not use `client.emojis`

### DIFF
--- a/src/managers/MessageManager.js
+++ b/src/managers/MessageManager.js
@@ -5,6 +5,7 @@ const CachedManager = require('./CachedManager');
 const { TypeError } = require('../errors');
 const Message = require('../structures/Message');
 const MessagePayload = require('../structures/MessagePayload');
+const Util = require('../util/Util');
 
 /**
  * Manages API methods for Messages and holds their cache.
@@ -186,11 +187,15 @@ class MessageManager extends CachedManager {
     message = this.resolveId(message);
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
-    emoji = this.client.emojis.resolveIdentifier(emoji);
+    emoji = Util.resolvePartialEmoji(emoji);
     if (!emoji) throw new TypeError('EMOJI_TYPE', 'emoji', 'EmojiIdentifierResolvable');
 
+    const emojiId = emoji.id
+      ? `${emoji.animated ? 'a:' : ''}${emoji.name}:${emoji.id}`
+      : encodeURIComponent(emoji.name);
+
     // eslint-disable-next-line newline-per-chained-call
-    await this.client.api.channels(this.channel.id).messages(message).reactions(emoji, '@me').put();
+    await this.client.api.channels(this.channel.id).messages(message).reactions(emojiId, '@me').put();
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #6248

Tested with the following inputs, and all worked just fine:

- `message.react('<:CrowOfJudgement:697940233710338148>');`
- `message.react(':CrowOfJudgement:697940233710338148');`
- `message.react('CrowOfJudgement:697940233710338148');`
- `message.react('697940233710338148');`
- `message.react('😄');`
- `message.react('%F0%9F%98%84');`
- `message.react(message.guild.emojis.cache.first());`
- `message.react({ id: '697940233710338148' });`
- `message.react({ name: '😄' });`

The only case that didn't was passing an encoded emoji inside `{ name }`, since it gets `encodeURIComponent`'d twice:

- `message.react({ name: '%F0%9F%98%84' });`

However, this doesn't work in latest stable (13.3.1), so it's not breaking anything.

**Question**: Should I deprecate `BaseGuildEmojiManager#resolveIdentifier`? With this PR, the library will not longer use this method. However, we do not offer a public alternative (`Util.resolvePartialEmoji` and `Util.parseEmoji` are both private).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
