### PR TITLE
docs(MessageReference): Fix static link

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -293,7 +293,7 @@ class Message extends Base {
     /**
      * Reference data sent in a message that contains ids identifying the referenced message.
      * This can be present in the following types of message:
-     * * IS_CROSSPOST
+     * * Crossposted messages (IS_CROSSPOST {@link MessageFlags.FLAGS message flag})
      * * CHANNEL_FOLLOW_ADD
      * * CHANNEL_PINNED_MESSAGE
      * * REPLY

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -293,7 +293,7 @@ class Message extends Base {
     /**
      * Reference data sent in a message that contains ids identifying the referenced message.
      * This can be present in the following types of message:
-     * * Crossposted messages (IS_CROSSPOST {@link MessageFlags#FLAGS message flag})
+     * * IS_CROSSPOST
      * * CHANNEL_FOLLOW_ADD
      * * CHANNEL_PINNED_MESSAGE
      * * REPLY


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

First of all, `{@link MessageFlags#FLAGS message flag})` is an invalid redirect as it's a static link. Instead of correcting it, I removed the extra description as it seemed to fit the others. Feel free to request changes to only correct the redirect instead.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
