### PR TITLE
Add min/maxValue toJSDoc for ApplicationCommandOptionData

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -147,6 +147,8 @@ class ApplicationCommand extends Base {
    * @property {ChannelType[]|number[]} [channelTypes] When the option type is channel,
    * the allowed types of channels that can be selected
    * @property {number[]} [channel_types] When the option type is channel,
+   * @property {number} [minValue] When option type is number or integer the minimal allowed value
+   * @property {number} [maxValue] When option type is number or integer the maximal allowed value
    * the API data for allowed types of channels that can be selected
    * <warn>This is provided for compatibility with something like `@discordjs/builders`
    * and will be discarded when `channelTypes` is present</warn>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Added minValue and maxValue to the JSDoc for ApplicationCommandOptionData.
Support for them was added in https://github.com/discordjs/discord.js/pull/6855/files

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.