### PR TITLE
Update BaseGuild.js with name Acronym Fix.

### DIFF
--- a/src/structures/BaseGuild.js
+++ b/src/structures/BaseGuild.js
@@ -61,10 +61,14 @@ class BaseGuild extends Base {
    * @readonly
    */
   get nameAcronym() {
-    return this.name
+    if (this.name) {
+      return this.name
       .replace(/'s /g, ' ')
       .replace(/\w+/g, e => e[0])
       .replace(/\s/g, '');
+    } else {
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes an issue I had, where the name acronym was basically crashing my entire project.

```
[WS => Shard 0] [READY] Session e6d65ca8846c560ff6643d54e9ee69d7.
[WS => Shard 0] [ReadyHeartbeat] Sending a heartbeat.
{"message":{"clientEvent":"debug","debugInfo":"[WS => Shard 0] Heartbeat acknowledged, latency of 2994ms.","type":"clientdebug"},"level":"debug","dd":{"service":"adora","version":"1.0.3"}}
[WS => Shard 0] Heartbeat acknowledged, latency of 2994ms.
/home/pi/adoracanary/node_modules/discord.js/src/structures/BaseGuild.js:65
      .replace(/'s /g, ' ')
       ^

TypeError: Cannot read properties of undefined (reading 'replace')
    at Guild.get nameAcronym [as nameAcronym] (/home/pi/adoracanary/node_modules/discord.js/src/structures/BaseGuild.js:65:8)
    at Function.flatten (/home/pi/adoracanary/node_modules/discord.js/src/util/Util.js:37:26)
    at Guild.toJSON (/home/pi/adoracanary/node_modules/discord.js/src/structures/Base.js:35:17)
    at Guild.toJSON (/home/pi/adoracanary/node_modules/discord.js/src/structures/Guild.js:1295:24)
    at JSON.stringify (<anonymous>)
    at stringify (/home/pi/adoracanary/node_modules/fast-safe-stringify/index.js:14:16)
    at Format.transform (/home/pi/adoracanary/node_modules/logform/json.js:28:21)
    at DerivedLogger._transform (/home/pi/adoracanary/node_modules/winston/lib/winston/logger.js:305:29)
    at DerivedLogger.Transform._read (/home/pi/adoracanary/node_modules/readable-stream/lib/_stream_transform.js:177:10)
    at DerivedLogger.Transform._write (/home/pi/adoracanary/node_modules/readable-stream/lib/_stream_transform.js:164:83)

Node.js v17.1.0
```

Yes my intents were on. I basically added this code and it fixed it lmfao

Feel free to add suggestions.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

