### PR TITLE
Revert "types(ApplicationCommandManager): Deprecate old `*Data` type …usages and allow camel cased dapi types to be used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@types/ws": "^8.2.0",
         "discord-api-types": "^0.25.0",
         "node-fetch": "^2.6.1",
-        "type-fest": "^2.5.3",
         "ws": "^8.2.3"
       },
       "devDependencies": {
@@ -3285,23 +3284,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001271",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
@@ -4306,9 +4288,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.25.0.tgz",
-      "integrity": "sha512-LS5TZAARsDVcJaljxplec25L9ampP2aY6rf1SFRowK66RTLdyVn0Gal3VsF+mYBhZDkeFd+awBNoJmUeECBoPQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.25.1.tgz",
+      "integrity": "sha512-8667foCE/tEP6+2ezQpWs6PL37jgPeun0rv75EMpJZaMaMYpm+OAld1gIqTH4swYc4wLIr99ELhsleVZ+NtYrQ==",
       "engines": {
         "node": ">=12"
       }
@@ -9051,6 +9033,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/meow/node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/meow/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -9099,6 +9098,15 @@
       "dependencies": {
         "p-limit": "^2.2.0"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/meow/node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10331,15 +10339,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -11820,6 +11819,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/tsd/node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tsd/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -11894,6 +11910,15 @@
       "dependencies": {
         "p-limit": "^2.2.0"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tsd/node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -12156,17 +12181,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.6.0.tgz",
-      "integrity": "sha512-XN1FDGGtaSDA6CFsCW5iolTQqFsnJ+ZF6JqSz0SqXoh4F8GY0xqUv5RYnTilpmL+sOH8OH4FX8tf9YyAPM2LDA==",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typedarray": {
@@ -15285,17 +15299,6 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
-    "camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
-      }
-    },
     "caniuse-lite": {
       "version": "1.0.30001271",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
@@ -16081,9 +16084,9 @@
       }
     },
     "discord-api-types": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.25.0.tgz",
-      "integrity": "sha512-LS5TZAARsDVcJaljxplec25L9ampP2aY6rf1SFRowK66RTLdyVn0Gal3VsF+mYBhZDkeFd+awBNoJmUeECBoPQ=="
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.25.1.tgz",
+      "integrity": "sha512-8667foCE/tEP6+2ezQpWs6PL37jgPeun0rv75EMpJZaMaMYpm+OAld1gIqTH4swYc4wLIr99ELhsleVZ+NtYrQ=="
     },
     "dmd": {
       "version": "4.0.6",
@@ -19713,6 +19716,17 @@
         "yargs-parser": "^20.2.3"
       },
       "dependencies": {
+        "camelcase-keys": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+          "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.3.1",
+            "map-obj": "^4.0.0",
+            "quick-lru": "^4.0.1"
+          }
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -19749,6 +19763,12 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
+        },
+        "quick-lru": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+          "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+          "dev": true
         },
         "read-pkg": {
           "version": "5.2.0",
@@ -20680,12 +20700,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
-    },
-    "quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "dev": true
     },
     "react-is": {
@@ -21847,6 +21861,17 @@
         "read-pkg-up": "^7.0.0"
       },
       "dependencies": {
+        "camelcase-keys": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+          "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.3.1",
+            "map-obj": "^4.0.0",
+            "quick-lru": "^4.0.1"
+          }
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -21903,6 +21928,12 @@
           "requires": {
             "p-limit": "^2.2.0"
           }
+        },
+        "quick-lru": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+          "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+          "dev": true
         },
         "read-pkg": {
           "version": "5.2.0",
@@ -22104,11 +22135,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
-    },
-    "type-fest": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.6.0.tgz",
-      "integrity": "sha512-XN1FDGGtaSDA6CFsCW5iolTQqFsnJ+ZF6JqSz0SqXoh4F8GY0xqUv5RYnTilpmL+sOH8OH4FX8tf9YyAPM2LDA=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "@types/ws": "^8.2.0",
     "discord-api-types": "^0.25.0",
     "node-fetch": "^2.6.1",
-    "type-fest": "^2.5.3",
     "ws": "^8.2.3"
   },
   "devDependencies": {

--- a/tslint.json
+++ b/tslint.json
@@ -24,7 +24,6 @@
     "array-type": [true, "array"],
     "one-line": false,
     "no-any-union": false,
-    "void-return": false,
-    "unified-signatures": false
+    "void-return": false
   }
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -45,7 +45,6 @@ import {
   APIUser,
   GatewayVoiceServerUpdateDispatchData,
   GatewayVoiceStateUpdateDispatchData,
-  RESTPatchAPIApplicationCommandJSONBody,
   RESTPostAPIApplicationCommandsJSONBody,
   Snowflake,
 } from 'discord-api-types/v9';
@@ -138,7 +137,6 @@ import {
   RawWidgetData,
   RawWidgetMemberData,
 } from './rawDataTypes';
-import type { CamelCasedPropertiesDeep } from 'type-fest';
 
 //#region Classes
 
@@ -215,7 +213,7 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
   public readonly manager: ApplicationCommandManager;
   public id: Snowflake;
   public name: string;
-  public options: Camelize<APIApplicationCommandOption>[];
+  public options: ApplicationCommandOption[];
   public permissions: ApplicationCommandPermissionsManager<
     PermissionsFetchType,
     PermissionsFetchType,
@@ -226,29 +224,23 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
   public type: ApplicationCommandType;
   public version: Snowflake;
   public delete(): Promise<ApplicationCommand<PermissionsFetchType>>;
-  /** @deprecated use `edit(Camelize<RESTPatchAPIApplicationCommandJSONBody>)` instead */
   public edit(data: ApplicationCommandData): Promise<ApplicationCommand<PermissionsFetchType>>;
-  public edit(
-    data: Camelize<RESTPatchAPIApplicationCommandJSONBody>,
-  ): Promise<ApplicationCommand<PermissionsFetchType>>;
   public equals(
-    command: ApplicationCommand | Camelize<RESTPatchAPIApplicationCommandJSONBody> | RawApplicationCommandData,
+    command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData,
     enforceOptionorder?: boolean,
   ): boolean;
   public static optionsEqual(
-    existing: Camelize<APIApplicationCommandOption>[],
-    options: Camelize<APIApplicationCommandOption>[] | APIApplicationCommandOption[],
+    existing: ApplicationCommandOption[],
+    options: ApplicationCommandOption[] | ApplicationCommandOptionData[] | APIApplicationCommandOption[],
     enforceOptionorder?: boolean,
   ): boolean;
   private static _optionEquals(
-    existing: Camelize<APIApplicationCommandOption>[],
-    options: Camelize<APIApplicationCommandOption>[] | APIApplicationCommandOption,
+    existing: ApplicationCommandOption,
+    options: ApplicationCommandOption | ApplicationCommandOptionData | APIApplicationCommandOption,
     enforceOptionorder?: boolean,
   ): boolean;
-  private static transformOption(option: Camelize<APIApplicationCommandOption>, received?: boolean): unknown;
-  private static transformCommand(
-    command: Camelize<RESTPostAPIApplicationCommandsJSONBody>,
-  ): RESTPostAPIApplicationCommandsJSONBody;
+  private static transformOption(option: ApplicationCommandOptionData, received?: boolean): unknown;
+  private static transformCommand(command: ApplicationCommandData): RESTPostAPIApplicationCommandsJSONBody;
   private static isAPICommandData(command: object): command is RESTPostAPIApplicationCommandsJSONBody;
 }
 
@@ -2342,8 +2334,10 @@ export class WebhookClient extends WebhookMixin(BaseClient) {
     options: string | MessagePayload | WebhookEditMessageOptions,
   ): Promise<APIMessage>;
   public fetchMessage(message: Snowflake, options?: WebhookFetchMessageOptions): Promise<APIMessage>;
+  /* tslint:disable:unified-signatures */
   /** @deprecated */
   public fetchMessage(message: Snowflake, cache?: boolean): Promise<APIMessage>;
+  /* tslint:enable:unified-signatures */
   public send(options: string | MessagePayload | WebhookMessageOptions): Promise<APIMessage>;
 }
 
@@ -2644,9 +2638,7 @@ export abstract class CachedManager<K, Holds, R> extends DataManager<K, Holds, R
   private _add(data: unknown, cache?: boolean, { id, extras }?: { id: K; extras: unknown[] }): Holds;
 }
 
-export type ApplicationCommandDataResolvable =
-  | Camelize<RESTPostAPIApplicationCommandsJSONBody>
-  | RESTPostAPIApplicationCommandsJSONBody;
+export type ApplicationCommandDataResolvable = ApplicationCommandData | RESTPostAPIApplicationCommandsJSONBody;
 
 export class ApplicationCommandManager<
   ApplicationCommandScope = ApplicationCommand<{ guild: GuildResolvable }>,
@@ -2662,18 +2654,7 @@ export class ApplicationCommandManager<
     null
   >;
   private commandPath({ id, guildId }: { id?: Snowflake; guildId?: Snowflake }): unknown;
-  /** @deprecated use `create(ApplicationCommandDataResolvable)` instead */
-  public create(
-    command: ApplicationCommandData | RESTPostAPIApplicationCommandsJSONBody,
-  ): Promise<ApplicationCommandScope>;
-  /** @deprecated use `create(ApplicationCommandDataResolvable, Snowflake)` instead */
-  public create(
-    command: ApplicationCommandData | RESTPostAPIApplicationCommandsJSONBody,
-    guildId: Snowflake,
-  ): Promise<ApplicationCommand>;
   public create(command: ApplicationCommandDataResolvable, guildId?: Snowflake): Promise<ApplicationCommandScope>;
-  /** @deprecated use `delete(ApplicationCommandDataResolvable, Snowflake?)` instead */
-  public delete(command: ApplicationCommandData, guildId?: Snowflake): Promise<ApplicationCommandScope | null>;
   public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<ApplicationCommandScope | null>;
   public edit(
     command: ApplicationCommandResolvable,
@@ -2694,20 +2675,13 @@ export class ApplicationCommandManager<
     id?: Snowflake,
     options?: FetchApplicationCommandOptions,
   ): Promise<Collection<Snowflake, ApplicationCommandScope>>;
-  /** @deprecated Use `set(ApplicationCommandResolvable)` instead */
-  public set(commands: ApplicationCommandData[]): Promise<Collection<Snowflake, ApplicationCommandScope>>;
-  /** @deprecated Use `set(ApplicationCommandResolvable, Snowflake)` instead */
-  public set(
-    commands: ApplicationCommandData[],
-    guildId: Snowflake,
-  ): Promise<Collection<Snowflake, ApplicationCommand>>;
   public set(commands: ApplicationCommandDataResolvable[]): Promise<Collection<Snowflake, ApplicationCommandScope>>;
   public set(
     commands: ApplicationCommandDataResolvable[],
     guildId: Snowflake,
   ): Promise<Collection<Snowflake, ApplicationCommand>>;
   private static transformCommand(
-    command: Camelize<RESTPostAPIApplicationCommandsJSONBody>,
+    command: ApplicationCommandData,
   ): Omit<APIApplicationCommand, 'id' | 'application_id' | 'guild_id'>;
 }
 
@@ -2772,9 +2746,7 @@ export class GuildApplicationCommandManager extends ApplicationCommandManager<Ap
   private constructor(guild: Guild, iterable?: Iterable<RawApplicationCommandData>);
   public guild: Guild;
   public create(command: ApplicationCommandDataResolvable): Promise<ApplicationCommand>;
-  /** @deprecated use `delete(ApplicationCommandDataResolvable, Snowflake?)` instead */
-  public delete(command: ApplicationCommandData, guildId?: Snowflake): Promise<ApplicationCommand | null>;
-  public delete(command: ApplicationCommandResolvable, guildId?: Snowflake): Promise<ApplicationCommand | null>;
+  public delete(command: ApplicationCommandResolvable): Promise<ApplicationCommand | null>;
   public edit(
     command: ApplicationCommandResolvable,
     data: ApplicationCommandDataResolvable,
@@ -2782,8 +2754,6 @@ export class GuildApplicationCommandManager extends ApplicationCommandManager<Ap
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<ApplicationCommand>;
   public fetch(options: BaseFetchOptions): Promise<Collection<Snowflake, ApplicationCommand>>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, ApplicationCommand>>;
-  /** @deprecated Use `set(ApplicationCommandResolvable)` instead */
-  public set(commands: ApplicationCommandData[]): Promise<Collection<Snowflake, ApplicationCommand>>;
   public set(commands: ApplicationCommandDataResolvable[]): Promise<Collection<Snowflake, ApplicationCommand>>;
 }
 
@@ -3102,8 +3072,10 @@ export interface PartialWebhookFields {
     options: string | MessagePayload | WebhookEditMessageOptions,
   ): Promise<Message | APIMessage>;
   fetchMessage(message: Snowflake | '@original', options?: WebhookFetchMessageOptions): Promise<Message | APIMessage>;
+  /* tslint:disable:unified-signatures */
   /** @deprecated */
   fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | APIMessage>;
+  /* tslint:enable:unified-signatures */
   send(options: string | MessagePayload | WebhookMessageOptions): Promise<Message | APIMessage>;
 }
 
@@ -3369,7 +3341,6 @@ export interface ChatInputApplicationCommandData extends BaseApplicationCommandD
   options?: ApplicationCommandOptionData[];
 }
 
-/** @deprecated use `Camelize<RESTPostApplicationCommandBody>` instead */
 export type ApplicationCommandData =
   | UserApplicationCommandData
   | MessageApplicationCommandData
@@ -3457,10 +3428,6 @@ export interface ApplicationCommandNonOptions extends BaseApplicationCommandOpti
   type: Exclude<CommandOptionNonChoiceResolvableType, ApplicationCommandOptionTypes>;
 }
 
-// Type alias since the lib name is very long.
-export type Camelize<T> = CamelCasedPropertiesDeep<T>;
-
-/** @deprecated Use `Camelize<APIApplicationCommandsOption>` instead. */
 export type ApplicationCommandOptionData =
   | ApplicationCommandSubGroupData
   | ApplicationCommandNonOptionsData
@@ -3470,7 +3437,6 @@ export type ApplicationCommandOptionData =
   | ApplicationCommandNumericOptionData
   | ApplicationCommandSubCommandData;
 
-/** @deprecated use `Camelize<APIApplicationCommandOption>` instead */
 export type ApplicationCommandOption =
   | ApplicationCommandSubGroup
   | ApplicationCommandNonOptions

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -1,4 +1,5 @@
-import {
+import type { ChildProcess } from 'child_process';
+import type {
   APIInteractionGuildMember,
   APIMessage,
   APIPartialChannel,
@@ -6,21 +7,15 @@ import {
   APIInteractionDataResolvedGuildMember,
   APIInteractionDataResolvedChannel,
   APIRole,
-  ChannelType,
-  ApplicationCommandOptionType,
-  APIApplicationCommand,
-  APIApplicationCommandOption,
-  APIApplicationCommandSubCommandOptions,
 } from 'discord-api-types/v9';
-import type { ChildProcess } from 'node:child_process';
 import {
   ApplicationCommand,
-  ApplicationCommandChannelOptionData,
-  ApplicationCommandChoicesData,
+  ApplicationCommandData,
   ApplicationCommandManager,
-  ApplicationCommandNonOptionsData,
+  ApplicationCommandOptionData,
   ApplicationCommandResolvable,
   ApplicationCommandSubCommandData,
+  ApplicationCommandSubGroupData,
   BaseCommandInteraction,
   ButtonInteraction,
   CacheType,
@@ -33,6 +28,7 @@ import {
   CommandInteraction,
   CommandInteractionOption,
   CommandInteractionOptionResolver,
+  CommandOptionNonChoiceResolvableType,
   Constants,
   ContextMenuInteraction,
   DMChannel,
@@ -81,9 +77,6 @@ import {
   User,
   VoiceChannel,
   Shard,
-  Camelize,
-  ApplicationCommandAutocompleteOption,
-  ApplicationCommandNumericOptionData,
   WebSocketShard,
   Collector,
 } from '.';
@@ -693,20 +686,6 @@ client.login('absolutely-valid-token');
 // Test client conditional types
 client.on('ready', client => {
   expectType<Client<true>>(client);
-
-  // Test camelized post command data.
-  client.application.commands.create({
-    name: 'Foo',
-    description: 'Bar',
-    options: [
-      {
-        name: 'test',
-        description: 'test',
-        type: ApplicationCommandOptionType.Channel,
-        channelTypes: [ChannelType.GuildCategory],
-      },
-    ],
-  });
 });
 
 declare const loggedInClient: Client<true>;
@@ -804,7 +783,7 @@ expectType<1>(Constants.Status.CONNECTING);
 expectType<0>(Constants.Opcodes.DISPATCH);
 expectType<2>(Constants.ClientApplicationAssetTypes.BIG);
 
-declare const applicationCommandData: Camelize<APIApplicationCommand>;
+declare const applicationCommandData: ApplicationCommandData;
 declare const applicationCommandResolvable: ApplicationCommandResolvable;
 declare const applicationCommandManager: ApplicationCommandManager;
 {
@@ -826,29 +805,22 @@ declare const applicationCommandManager: ApplicationCommandManager;
   );
 }
 
-declare const applicationSubGroupCommandData: Camelize<APIApplicationCommandSubCommandOptions>;
+declare const applicationNonChoiceOptionData: ApplicationCommandOptionData & {
+  type: CommandOptionNonChoiceResolvableType;
+};
 {
-  expectType<ApplicationCommandOptionType.Subcommand | ApplicationCommandOptionType.SubcommandGroup>(
-    applicationSubGroupCommandData.type,
-  );
-  expectAssignable<APIApplicationCommandOption[] | undefined>(applicationSubGroupCommandData.options);
+  // Options aren't allowed on this command type.
+
+  // @ts-expect-error
+  applicationNonChoiceOptionData.choices;
 }
 
-declare const applicationSubCommandData: ApplicationCommandSubCommandData;
+declare const applicationSubGroupCommandData: ApplicationCommandSubGroupData;
 {
-  expectType<'SUB_COMMAND' | ApplicationCommandOptionTypes.SUB_COMMAND>(applicationSubCommandData.type);
-
-  // Check that only subcommands can have no subcommand or subcommand group sub-options.
-  expectType<
-    | (
-        | ApplicationCommandChoicesData
-        | ApplicationCommandNonOptionsData
-        | ApplicationCommandChannelOptionData
-        | ApplicationCommandAutocompleteOption
-        | ApplicationCommandNumericOptionData
-      )[]
-    | undefined
-  >(applicationSubCommandData.options);
+  expectType<'SUB_COMMAND_GROUP' | ApplicationCommandOptionTypes.SUB_COMMAND_GROUP>(
+    applicationSubGroupCommandData.type,
+  );
+  expectType<ApplicationCommandSubCommandData[] | undefined>(applicationSubGroupCommandData.options);
 }
 
 declare const guildApplicationCommandManager: GuildApplicationCommandManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This reverts commit 2c91c488e8d00444ec0a14049654cdb496f2e757.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
