### PR TITLE
fix(GuildChannel): default to `this.rawPosition` in `clone()`

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -460,7 +460,7 @@ class GuildChannel extends Channel {
       bitrate: this.bitrate,
       userLimit: this.userLimit,
       rateLimitPerUser: this.rateLimitPerUser,
-      position: this.position,
+      position: this.rawPosition,
       reason: null,
       ...options,
     });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When cloning channels, the default value for `position` is `this.position`, which is different to discord's positions (stored as `rawPosition`), which sometimes puts the new channel far off from the correct position, where `rawPosition` would be more reliable as it would send the same value discord uses.

**Status and versioning classification:**
- Code changes have been tested against the Discord API
- Typings don't need updating
