### PR TITLE
feat(SnowflakeUtil): add `timestampFrom`

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -103,7 +103,7 @@ class ApplicationCommand extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/BaseGuild.js
+++ b/src/structures/BaseGuild.js
@@ -43,7 +43,7 @@ class BaseGuild extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/Channel.js
+++ b/src/structures/Channel.js
@@ -51,7 +51,7 @@ class Channel extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/Emoji.js
+++ b/src/structures/Emoji.js
@@ -68,7 +68,7 @@ class Emoji extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return this.id && SnowflakeUtil.deconstruct(this.id).timestamp;
+    return this.id && SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/GuildAuditLogs.js
+++ b/src/structures/GuildAuditLogs.js
@@ -586,7 +586,7 @@ class GuildAuditLogsEntry {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/GuildPreview.js
+++ b/src/structures/GuildPreview.js
@@ -110,7 +110,7 @@ class GuildPreview extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/Interaction.js
+++ b/src/structures/Interaction.js
@@ -82,7 +82,7 @@ class Interaction extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -59,7 +59,7 @@ class Message extends Base {
      * The timestamp the message was sent at
      * @type {number}
      */
-    this.createdTimestamp = SnowflakeUtil.deconstruct(this.id).timestamp;
+    this.createdTimestamp = SnowflakeUtil.timestampFrom(this.id);
 
     if ('type' in data) {
       /**

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -134,7 +134,7 @@ class Role extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/StageInstance.js
+++ b/src/structures/StageInstance.js
@@ -139,7 +139,7 @@ class StageInstance extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/Sticker.js
+++ b/src/structures/Sticker.js
@@ -125,7 +125,7 @@ class Sticker extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/StickerPack.js
+++ b/src/structures/StickerPack.js
@@ -61,7 +61,7 @@ class StickerPack extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/Team.js
+++ b/src/structures/Team.js
@@ -76,7 +76,7 @@ class Team extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -127,7 +127,7 @@ class User extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -379,7 +379,7 @@ class Webhook {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/interfaces/Application.js
+++ b/src/structures/interfaces/Application.js
@@ -60,7 +60,7 @@ class Application extends Base {
    * @readonly
    */
   get createdTimestamp() {
-    return SnowflakeUtil.deconstruct(this.id).timestamp;
+    return SnowflakeUtil.timestampFrom(this.id);
   }
 
   /**

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -294,7 +294,7 @@ class TextBasedChannel {
     if (Array.isArray(messages) || messages instanceof Collection) {
       let messageIds = messages instanceof Collection ? [...messages.keys()] : messages.map(m => m.id ?? m);
       if (filterOld) {
-        messageIds = messageIds.filter(id => Date.now() - SnowflakeUtil.deconstruct(id).timestamp < 1_209_600_000);
+        messageIds = messageIds.filter(id => Date.now() - SnowflakeUtil.timestampFrom(id) < 1_209_600_000);
       }
       if (messageIds.length === 0) return new Collection();
       if (messageIds.length === 1) {

--- a/src/util/SnowflakeUtil.js
+++ b/src/util/SnowflakeUtil.js
@@ -71,6 +71,15 @@ class SnowflakeUtil extends null {
   }
 
   /**
+   * Retrieves the timestamp field's value from a Discord snowflake.
+   * @param {Snowflake} snowflake Snowflake to get the timestamp value from
+   * @returns {number}
+   */
+  static timestampFrom(snowflake) {
+    return Number(BigInt(snowflake) >> 22n) + EPOCH;
+  }
+
+  /**
    * Discord's epoch value (2015-01-01T00:00:00.000Z).
    * @type {number}
    * @readonly

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1546,7 +1546,9 @@ export class MessageComponentInteraction<Cached extends CacheType = CacheType> e
   public static resolveType(type: MessageComponentTypeResolvable): MessageComponentType;
 }
 
-export class MessageContextMenuInteraction<Cached extends CacheType = CacheType> extends ContextMenuInteraction<Cached> {
+export class MessageContextMenuInteraction<
+  Cached extends CacheType = CacheType,
+> extends ContextMenuInteraction<Cached> {
   public readonly targetMessage: CacheTypeReducer<Cached, Message, APIMessage>;
   public inGuild(): this is MessageContextMenuInteraction<'present'>;
   public inCachedGuild(): this is MessageContextMenuInteraction<'cached'>;
@@ -1974,6 +1976,7 @@ export class SnowflakeUtil extends null {
   private constructor();
   public static deconstruct(snowflake: Snowflake): DeconstructedSnowflake;
   public static generate(timestamp?: number | Date): Snowflake;
+  public static timestampFrom(snowflake: Snowflake): number;
   public static readonly EPOCH: number;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Also refactors anything using `SnowflakeUtil.deconstruct(id).timestamp` to use this new utility. This continues the work in #7036.

`SnowflakeUtil.timestampFrom` is a performance-focused utility designed to skip a lot of the decoder's overhead, as shown in the chart below:

| Iterations | `deconstruct(id).timestamp` | New `timestampFrom` |     Diff |
| :--------: | :-------------------------: | :-----------------: | :------: |
|    `10000` |                     36.08ms |              4.29ms | **8.41** |
|   `100000` |                    191.35ms |             31.97ms | **5.99** |
|  `1000000` |                       1.83s |            264.89ms | **6.91** |

In retrospective, the `deconstruct` method in main is almost twice as fast as the one in 13.3.1, so we'll see a large performance boost in many `createdTimestamp` getters across the library in the next version :eyes:

*Also, something odd I noticed is that we don't read `data.timestamp` in `Message`, as the value it yields is identical to getting the `timestamp` field from the ID, perhaps we can remove the field and reduce memory usage for messages, as well as lazy calculate the value? Perhaps it was stored due to performance concerns since sweepers rely on `createdTimestamp`, but with this performance boost, it should be reasonably fast for the performance trade-off (?)*

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
