### PR TITLE
docs(GuildStickerManager): fix create() example

### DIFF
--- a/src/managers/GuildStickerManager.js
+++ b/src/managers/GuildStickerManager.js
@@ -47,12 +47,12 @@ class GuildStickerManager extends CachedManager {
    * @returns {Promise<Sticker>} The created sticker
    * @example
    * // Create a new sticker from a URL
-   * guild.stickers.create('https://i.imgur.com/w3duR07.png', 'rip', '🪦')
+   * guild.stickers.create('https://i.imgur.com/w3duR07.png', 'rip', 'headstone')
    *   .then(sticker => console.log(`Created new sticker with name ${sticker.name}!`))
    *   .catch(console.error);
    * @example
    * // Create a new sticker from a file on your computer
-   * guild.stickers.create('./memes/banana.png', 'banana', '🍌')
+   * guild.stickers.create('./memes/banana.png', 'banana', 'banana')
    *   .then(sticker => console.log(`Created new sticker with name ${sticker.name}!`))
    *   .catch(console.error);
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The docs have improper examples and can result in confusion. The proper input for the `tags` parameter in `.create()` shouldnt take in a unicode emoji; as per Discord's docs and as indicated in the Discord.js docs itself in the tags description, the proper input should be the **string name** of a unicode emoji.
e.g. 🍌 should be "banana"

I was confused as to why when I would create a sticker, there would be no unicode emoji attached to it - until I read the actual discord docs and saw the error. With this fix in the docs, hopefully users - like me - won't become confused as to why there is no emoji representation of their sticker(s).

**What the discord.js docs promote:**
![](https://i.imgur.com/aIpGRJK.png)
![](https://i.imgur.com/fJ2X8OQ.png)
**What the actual input should be:**
![](https://i.imgur.com/u4WOslm.png)


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
