### PR TITLE
feat(ApplicationCommand): add setX methods for easier editing

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -189,7 +189,7 @@ class ApplicationCommand extends Base {
   }
 
   /**
-   * Edits the default permission of this ApplicationCommand.
+   * Edits the default permission of this ApplicationCommand
    * @param {boolean} [defaultPermission=true] The default permission for this command
    * @returns {Promise<ApplicationCommand>}
    */

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -171,6 +171,42 @@ class ApplicationCommand extends Base {
   }
 
   /**
+   * Edits the name of this ApplicationCommand
+   * @param {string} name The new name of the command
+   * @returns {Promise<ApplicationCommand>}
+   */
+  setName(name) {
+    return this.edit({ name });
+  }
+
+  /**
+   * Edits the description of this ApplicationCommand
+   * @param {string} description The new description of the command
+   * @returns {Promise<ApplicationCommand>}
+   */
+  setDescription(description) {
+    return this.edit({ description });
+  }
+
+  /**
+   * Edits the default permission of this ApplicationCommand.
+   * @param {boolean} [defaultPermission=true] The default permission for this command
+   * @returns {Promise<ApplicationCommand>}
+   */
+  setDefaultPermission(defaultPermission = true) {
+    return this.edit({ defaultPermission });
+  }
+
+  /**
+   * Edits the options of this ApplicationCommand
+   * @param {ApplicationCommandOptionData[]} options The options to set for this command
+   * @returns {Promise<ApplicationCommand>}
+   */
+  setOptions(options) {
+    return this.edit({ options });
+  }
+
+  /**
    * Deletes this command.
    * @returns {Promise<ApplicationCommand>}
    * @example

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -226,6 +226,10 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
   public version: Snowflake;
   public delete(): Promise<ApplicationCommand<PermissionsFetchType>>;
   public edit(data: ApplicationCommandData): Promise<ApplicationCommand<PermissionsFetchType>>;
+  public setName(name: string): Promise<ApplicationCommand<PermissionsFetchType>>;
+  public setDescription(description: string): Promise<ApplicationCommand<PermissionsFetchType>>;
+  public setDefaultPermission(defaultPermission?: boolean): Promise<ApplicationCommand<PermissionsFetchType>>;
+  public setOptions(options: ApplicationCommandOptionData[]): Promise<ApplicationCommand<PermissionsFetchType>>;
   public equals(
     command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData,
     enforceOptionorder?: boolean,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds 4 new methods to ApplicationCommand to make it easier to edit them. These are setName, setDescription, setDefaultPermission and setOptions. Although the edit method says that type conversions are supported, this does not seem to be the case when testing with the API so I decided not to add a setType method.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
