### PR TITLE
Make options parameter to Client implementation class constructor optional, or possibly a blank object

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -500,7 +500,7 @@ export abstract class Channel extends Base {
 export type If<T extends boolean, A, B = null> = T extends true ? A : T extends false ? B : A | B;
 
 export class Client<Ready extends boolean = boolean> extends BaseClient {
-  public constructor(options: ClientOptions);
+  public constructor(options? : ClientOptions | {});
   private actions: unknown;
   private presence: ClientPresence;
   private _eval(script: string): unknown;


### PR DESCRIPTION
Hi.  New user.  Could be wrong.

Most of the tutorials I find show code like `const client = new Discord.client();`.

[The actual constructor implementation](https://github.com/discordjs/discord.js/blob/main/src/client/Client.js#L38) defers to a class inherited constructor superclass, [which offers a blank object as a default value](https://github.com/discordjs/discord.js/blob/main/src/client/BaseClient.js#L13).

The subordinate class never actually refers to the constructor argument again after calling the superclass; instead it refers to the class members, which were set by the parent method.

On these grounds, I believe that you intend to allow a user to be allowed to pass 

1. Nothing
2. A blank object

Currently, when running in TypeScript, you are required to pass a valid instance of `ClientOptions`, which means that as a new user you have to figure out what the hell an `Intent` is.

I think this isn't intentional.

I have made the parameter optional, and I have allowed the substitution of a blank object for the argument.

Please consider.  TY.

<br/><br/>

**Please describe the changes this PR makes and why it should be merged:**

Because the following seems unlikely to be intentional:

![image](https://user-images.githubusercontent.com/77482/144787637-de9965fd-bc36-4454-8bbb-bfdf95a4fa00.png)

<br/><br/>

**Status and versioning classification:**

- I know how to update typings and have done so ~~, or typings don't need updating~~
    - In fact this is 100% a typing change
- This PR changes the library's interface (methods or parameters added)
- ***this is arguable*** This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
    - The change is to be more permissive, in line with your existing JS usage and your own documentation