### PR TITLE
fix(ReactionCollector): check for channel.threads

### DIFF
--- a/src/structures/ReactionCollector.js
+++ b/src/structures/ReactionCollector.js
@@ -187,7 +187,7 @@ class ReactionCollector extends Collector {
    * @returns {void}
    */
   _handleChannelDeletion(channel) {
-    if (channel.id === this.message.channelId || channel.id === this.message.channel.parentId) {
+    if (channel.id === this.message.channelId || channel.threads?.cache.has(this.message.channelId)) {
       this.stop('channelDelete');
     }
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Message#channel` becomes `null` when the channel is deleted, so we cannot rely on it for handling channel deletions of a thread's parent. However, we can do the reverse and check whether the message's channel ID is a thread contained by the deleted channel.

Fixes #7066

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
