### PR TITLE
refactor(Actions): remove deleted maps

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -577,9 +577,6 @@ class Client extends BaseClient {
     if (typeof options.waitGuildTimeout !== 'number' || isNaN(options.waitGuildTimeout)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'waitGuildTimeout', 'a number');
     }
-    if (typeof options.restWsBridgeTimeout !== 'number' || isNaN(options.restWsBridgeTimeout)) {
-      throw new TypeError('CLIENT_INVALID_OPTION', 'restWsBridgeTimeout', 'a number');
-    }
     if (typeof options.restRequestTimeout !== 'number' || isNaN(options.restRequestTimeout)) {
       throw new TypeError('CLIENT_INVALID_OPTION', 'restRequestTimeout', 'a number');
     }

--- a/packages/discord.js/src/client/actions/ChannelDelete.js
+++ b/packages/discord.js/src/client/actions/ChannelDelete.js
@@ -7,11 +7,6 @@ const { deletedMessages } = require('../../structures/Message');
 const { Events } = require('../../util/Constants');
 
 class ChannelDeleteAction extends Action {
-  constructor(client) {
-    super(client);
-    this.deleted = new Map();
-  }
-
   handle(data) {
     const client = this.client;
     const channel = client.channels.cache.get(data.id);
@@ -31,8 +26,6 @@ class ChannelDeleteAction extends Action {
        */
       client.emit(Events.CHANNEL_DELETE, channel);
     }
-
-    return { channel };
   }
 }
 

--- a/packages/discord.js/src/client/actions/GuildDelete.js
+++ b/packages/discord.js/src/client/actions/GuildDelete.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { setTimeout } = require('node:timers');
 const Action = require('./Action');
 const { deletedGuilds } = require('../../structures/Guild');
 const { Events } = require('../../util/Constants');

--- a/packages/discord.js/src/client/actions/GuildDelete.js
+++ b/packages/discord.js/src/client/actions/GuildDelete.js
@@ -6,11 +6,6 @@ const { deletedGuilds } = require('../../structures/Guild');
 const { Events } = require('../../util/Constants');
 
 class GuildDeleteAction extends Action {
-  constructor(client) {
-    super(client);
-    this.deleted = new Map();
-  }
-
   handle(data) {
     const client = this.client;
 
@@ -29,9 +24,7 @@ class GuildDeleteAction extends Action {
 
         // Stops the GuildDelete packet thinking a guild was actually deleted,
         // handles emitting of event itself
-        return {
-          guild: null,
-        };
+        return;
       }
 
       for (const channel of guild.channels.cache.values()) this.client.channels._remove(channel.id);
@@ -47,18 +40,7 @@ class GuildDeleteAction extends Action {
        * @param {Guild} guild The guild that was deleted
        */
       client.emit(Events.GUILD_DELETE, guild);
-
-      this.deleted.set(guild.id, guild);
-      this.scheduleForDeletion(guild.id);
-    } else {
-      guild = this.deleted.get(data.id) ?? null;
     }
-
-    return { guild };
-  }
-
-  scheduleForDeletion(id) {
-    setTimeout(() => this.deleted.delete(id), this.client.options.restWsBridgeTimeout).unref();
   }
 }
 

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -1246,7 +1246,7 @@ class Guild extends AnonymousGuild {
   async leave() {
     if (this.ownerId === this.client.user.id) throw new Error('GUILD_OWNED');
     await this.client.api.users('@me').guilds(this.id).delete();
-    return this.client.actions.GuildDelete.handle({ id: this.id }).guild;
+    return this;
   }
 
   /**
@@ -1260,7 +1260,7 @@ class Guild extends AnonymousGuild {
    */
   async delete() {
     await this.client.api.guilds(this.id).delete();
-    return this.client.actions.GuildDelete.handle({ id: this.id }).guild;
+    return this;
   }
 
   /**

--- a/packages/discord.js/src/util/Options.js
+++ b/packages/discord.js/src/util/Options.js
@@ -52,8 +52,6 @@ const process = require('node:process');
  * they're missing all the data for a particular structure. See the "Partial Structures" topic on the
  * [guide](https://discordjs.guide/popular-topics/partials.html) for some
  * important usage information, as partials require you to put checks in place when handling data.
- * @property {number} [restWsBridgeTimeout=5000] Maximum time permitted between REST responses and their
- * corresponding WebSocket events
  * @property {number} [restTimeOffset=500] Extra time in milliseconds to wait before continuing to make REST
  * requests (higher values will reduce rate-limiting errors on bad connections)
  * @property {number} [restRequestTimeout=15000] Time to wait before cancelling a REST request, in milliseconds
@@ -139,7 +137,6 @@ class Options extends null {
       messageSweepInterval: 0,
       invalidRequestWarningInterval: 0,
       partials: [],
-      restWsBridgeTimeout: 5_000,
       restRequestTimeout: 15_000,
       restGlobalRateLimit: 0,
       retryLimit: 1,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3988,7 +3988,6 @@ export interface ClientOptions {
   allowedMentions?: MessageMentionOptions;
   invalidRequestWarningInterval?: number;
   partials?: PartialTypes[];
-  restWsBridgeTimeout?: number;
   restTimeOffset?: number;
   restRequestTimeout?: number;
   restGlobalRateLimit?: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This removes a map on `ChannelDelete` and `GuildDelete` actions which keeps track of the deleted guilds. This can be circumvented by not calling the handle method in the method and relying on the websocket event instead. I'm unsure if this will break anything, however from my testing everything still works as expected.

**Status and versioning classification:**

- Code changes have been tested against the Discord API
- Typings don't need updating