### PR TITLE
docs(StoreChannel): add deprecation warnings

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -9,7 +9,8 @@ const PermissionOverwrites = require('../structures/PermissionOverwrites');
 const ThreadChannel = require('../structures/ThreadChannel');
 const { ChannelTypes, ThreadChannelTypes } = require('../util/Constants');
 
-let cacheWarningEmitted = false;
+let cacheWarningEmitted = false,
+  storeChannelDeprecationEmitted = false;
 
 /**
  * Manages API methods for GuildChannels and stores their cache.
@@ -137,12 +138,22 @@ class GuildChannelManager extends CachedManager {
   ) {
     parent &&= this.client.channels.resolveId(parent);
     permissionOverwrites &&= permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
+    const intType = typeof type === 'number' ? type : ChannelTypes[type] ?? ChannelTypes.GUILD_TEXT;
+
+    if (intType === ChannelTypes.GUILD_STORE && !storeChannelDeprecationEmitted) {
+      storeChannelDeprecationEmitted = true;
+      process.emitWarning(
+        // eslint-disable-next-line max-len
+        'Creating store channels is deprecated by Discord and will stop working in March 2022. Check the docs for more info.',
+        'DeprecationWarning',
+      );
+    }
 
     const data = await this.client.api.guilds(this.guild.id).channels.post({
       data: {
         name,
         topic,
-        type: typeof type === 'number' ? type : ChannelTypes[type] ?? ChannelTypes.GUILD_TEXT,
+        type: intType,
         nsfw,
         bitrate,
         user_limit: userLimit,

--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -9,8 +9,8 @@ const PermissionOverwrites = require('../structures/PermissionOverwrites');
 const ThreadChannel = require('../structures/ThreadChannel');
 const { ChannelTypes, ThreadChannelTypes } = require('../util/Constants');
 
-let cacheWarningEmitted = false,
-  storeChannelDeprecationEmitted = false;
+let cacheWarningEmitted = false;
+let storeChannelDeprecationEmitted = false;
 
 /**
  * Manages API methods for GuildChannels and stores their cache.

--- a/src/structures/StoreChannel.js
+++ b/src/structures/StoreChannel.js
@@ -4,6 +4,9 @@ const GuildChannel = require('./GuildChannel');
 
 /**
  * Represents a guild store channel on Discord.
+ * <warn>Store channels are deprecated and will be removed from Discord in March 2022. See
+ * [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479)
+ * for more information.</warn>
  * @extends {GuildChannel}
  */
 class StoreChannel extends GuildChannel {

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -465,6 +465,9 @@ exports.ActivityTypes = createEnum(['PLAYING', 'STREAMING', 'LISTENING', 'WATCHI
  * * `GROUP_DM` - a group DM channel
  * * `GUILD_CATEGORY` - a guild category channel
  * * `GUILD_NEWS` - a guild news channel
+ * <warn>Store channels are deprecated and will be removed from Discord in March 2022. See
+ * [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479)
+ * for more information.</warn>
  * * `GUILD_STORE` - a guild store channel
  * * `GUILD_NEWS_THREAD` - a guild news channel's public thread channel
  * * `GUILD_PUBLIC_THREAD` - a guild text channel's public thread channel


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR continues the work started in #7072 by adding deprecation warnings to the docs and to GuildChannelManager#create when creating a store channel. Had to go slightly over the maximum length for the deprecation warning so if anyone has a suggestion that doesn't go over the limit I'll gladly replace it.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
