### PR TITLE
refactor(Util): replace `Util.delayFor` with `tp.setTimeout`

### DIFF
--- a/src/client/websocket/WebSocketManager.js
+++ b/src/client/websocket/WebSocketManager.js
@@ -1,13 +1,13 @@
 'use strict';
 
 const EventEmitter = require('node:events');
+const { setTimeout: sleep } = require('node:timers/promises');
 const { Collection } = require('@discordjs/collection');
 const { RPCErrorCodes } = require('discord-api-types/v9');
 const WebSocketShard = require('./WebSocketShard');
 const PacketHandlers = require('./handlers');
 const { Error } = require('../../errors');
 const { Events, ShardEvents, Status, WSCodes, WSEvents } = require('../../util/Constants');
-const Util = require('../../util/Util');
 
 const BeforeReadyWhitelist = [
   WSEvents.READY,
@@ -258,7 +258,7 @@ class WebSocketManager extends EventEmitter {
     // If we have more shards, add a 5s delay
     if (this.shardQueue.size) {
       this.debug(`Shard Queue Size: ${this.shardQueue.size}; continuing in 5 seconds...`);
-      await Util.delayFor(5_000);
+      await sleep(5_000);
       return this.createShards();
     }
 
@@ -279,7 +279,7 @@ class WebSocketManager extends EventEmitter {
       this.debug(`Couldn't reconnect or fetch information about the gateway. ${error}`);
       if (error.httpStatus !== 401) {
         this.debug(`Possible network error occurred. Retrying in 5s...`);
-        await Util.delayFor(5_000);
+        await sleep(5_000);
         this.reconnecting = false;
         return this.reconnect();
       }

--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { setTimeout: sleep } = require('node:timers/promises');
 const { AsyncQueue } = require('@sapphire/async-queue');
 const DiscordAPIError = require('./DiscordAPIError');
 const HTTPError = require('./HTTPError');
@@ -7,7 +8,6 @@ const RateLimitError = require('./RateLimitError');
 const {
   Events: { DEBUG, RATE_LIMIT, INVALID_REQUEST_WARNING, API_RESPONSE, API_REQUEST },
 } = require('../util/Constants');
-const Util = require('../util/Util');
 
 function parseResponse(res) {
   if (res.headers.get('content-type').startsWith('application/json')) return res.json();
@@ -145,7 +145,7 @@ class RequestHandler {
         }
         delayPromise = this.manager.globalDelay;
       } else {
-        delayPromise = Util.delayFor(timeout);
+        delayPromise = sleep(timeout);
       }
 
       // Determine whether a RateLimitError should be thrown
@@ -333,7 +333,7 @@ class RequestHandler {
 
         // If caused by a sublimit, wait it out here so other requests on the route can be handled
         if (sublimitTimeout) {
-          await Util.delayFor(sublimitTimeout);
+          await sleep(sublimitTimeout);
         }
         return this.execute(request);
       }

--- a/src/sharding/Shard.js
+++ b/src/sharding/Shard.js
@@ -2,6 +2,7 @@
 
 const EventEmitter = require('node:events');
 const path = require('node:path');
+const { setTimeout: sleep } = require('node:timers/promises');
 const { Error } = require('../errors');
 const Util = require('../util/Util');
 let childProcess = null;
@@ -201,7 +202,7 @@ class Shard extends EventEmitter {
    */
   async respawn({ delay = 500, timeout = 30_000 } = {}) {
     this.kill();
-    if (delay > 0) await Util.delayFor(delay);
+    if (delay > 0) await sleep(delay);
     return this.spawn(timeout);
   }
 

--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('node:events');
 const fs = require('node:fs');
 const path = require('node:path');
+const { setTimeout: sleep } = require('node:timers/promises');
 const { Collection } = require('@discordjs/collection');
 const Shard = require('./Shard');
 const { Error, TypeError, RangeError } = require('../errors');
@@ -214,7 +215,7 @@ class ShardingManager extends EventEmitter {
       const promises = [];
       const shard = this.createShard(shardId);
       promises.push(shard.spawn(timeout));
-      if (delay > 0 && this.shards.size !== this.shardList.length) promises.push(Util.delayFor(delay));
+      if (delay > 0 && this.shards.size !== this.shardList.length) promises.push(sleep(delay));
       await Promise.all(promises); // eslint-disable-line no-await-in-loop
     }
 
@@ -306,7 +307,7 @@ class ShardingManager extends EventEmitter {
     let s = 0;
     for (const shard of this.shards.values()) {
       const promises = [shard.respawn({ respawnDelay, timeout })];
-      if (++s < this.shards.size && shardDelay > 0) promises.push(Util.delayFor(shardDelay));
+      if (++s < this.shards.size && shardDelay > 0) promises.push(sleep(shardDelay));
       await Promise.all(promises); // eslint-disable-line no-await-in-loop
     }
     return this.shards;

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -588,18 +588,6 @@ class Util extends null {
   }
 
   /**
-   * Creates a Promise that resolves after a specified duration.
-   * @param {number} ms How long to wait before resolving (in milliseconds)
-   * @returns {Promise<void>}
-   * @private
-   */
-  static delayFor(ms) {
-    return new Promise(resolve => {
-      setTimeout(resolve, ms);
-    });
-  }
-
-  /**
    * Creates a sweep filter that sweeps archived threads
    * @param {number} [lifetime=14400] How long a thread has to be archived to be valid for sweeping
    * @returns {SweepFilter}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2257,7 +2257,6 @@ export class Util extends null {
   /** @deprecated Use {@link MessageOptions.allowedMentions} to control mentions in a message instead. */
   public static removeMentions(str: string): string;
   public static cloneObject(obj: unknown): unknown;
-  public static delayFor(ms: number): Promise<void>;
   public static discordSort<K, V extends { rawPosition: number; id: Snowflake }>(
     collection: Collection<K, V>,
   ): Collection<K, V>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Similar to #7036, this PR removes `Util.delayFor` in favor of built-ins (`node:timers/promises` exports a promisified `setTimeout`, which we import as `sleep` to avoid ESLint issues and naming conflicts).

This PR is also not `semver: major` because `Util.delayFor` is marked as `@private`, despite the typings saying it's public.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
