### PR TITLE
fix(ShardingManager): fix respawnAll not passing delay correctly

### DIFF
--- a/src/sharding/ShardingManager.js
+++ b/src/sharding/ShardingManager.js
@@ -301,12 +301,12 @@ class ShardingManager extends EventEmitter {
   /**
    * Kills all running shards and respawns them.
    * @param {MultipleShardRespawnOptions} [options] Options for respawning shards
-   * @returns {Promise<Collection<string, Shard>>}
+   * @returns {Promise<Collection<number, Shard>>}
    */
   async respawnAll({ shardDelay = 5_000, respawnDelay = 500, timeout = 30_000 } = {}) {
     let s = 0;
     for (const shard of this.shards.values()) {
-      const promises = [shard.respawn({ respawnDelay, timeout })];
+      const promises = [shard.respawn({ delay: respawnDelay, timeout })];
       if (++s < this.shards.size && shardDelay > 0) promises.push(sleep(shardDelay));
       await Promise.all(promises); // eslint-disable-line no-await-in-loop
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Shard#respawn` takes `delay`, however, `ShardingManager#respawnAll` was passing `shardDelay`.

https://github.com/discordjs/discord.js/blob/25b84912351617f42de055ff0351286a0c9425da/src/sharding/Shard.js#L203

Also fixes the return type being keyed with strings when it's keyed with numbers (shard IDs).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
