### PR TITLE
refactor(UserManager): Move methods to the manager

### DIFF
--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -105,6 +105,17 @@ class UserManager extends CachedManager {
   }
 
   /**
+   * Sends a message to a user.
+   * @param {UserResolvable} user The UserResolvable to identify
+   * @param {string|MessagePayload|MessageOptions} options The options to provide
+   * @returns {Promise<Message>}
+   */
+
+  async send(user, options) {
+    return (await this.createDM(user)).send(options);
+  }
+
+  /**
    * Resolves a {@link UserResolvable} to a {@link User} object.
    * @param {UserResolvable} user The UserResolvable to identify
    * @returns {?User}

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -32,7 +32,7 @@ class UserManager extends CachedManager {
    */
 
   /**
-   * The DM between the client's user and this user
+   * The DM between the client's user and a user
    * @param {Snowflake} userId The user id
    * @returns {?DMChannel}
    * @private

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -32,6 +32,16 @@ class UserManager extends CachedManager {
    */
 
   /**
+   * The DM between the client's user and this user
+   * @param {Snowflake} userId The user id
+   * @returns {?DMChannel}
+   * @private
+   */
+  dmChannel(userId) {
+    return this.client.channels.cache.find(c => c.type === 'DM' && c.recipient.id === userId) ?? null;
+  }
+
+  /**
    * Creates a DM channel between the client and a user.
    * @param {UserResolvable} user The UserResolvable to identify
    * @param {BaseFetchOptions} [options] Additional options for this fetch
@@ -41,7 +51,7 @@ class UserManager extends CachedManager {
     const id = this.resolveId(user);
 
     if (!force) {
-      const dmChannel = this.client.channels.cache.find(c => c.type === 'DM' && c.recipient.id === id) ?? null;
+      const dmChannel = this.dmChannel(id);
       if (dmChannel && !dmChannel.partial) return dmChannel;
     }
 
@@ -60,7 +70,7 @@ class UserManager extends CachedManager {
    */
   async deleteDM(user) {
     const id = this.resolveId(user);
-    const dmChannel = this.client.channels.cache.find(c => c.type === 'DM' && c.recipient.id === id) ?? null;
+    const dmChannel = this.dmChannel(id);
     if (!dmChannel) throw new Error('USER_NO_DM_CHANNEL');
     await this.client.api.channels(dmChannel.id).delete();
     this.client.channels._remove(dmChannel.id);

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -68,16 +68,6 @@ class UserManager extends CachedManager {
   }
 
   /**
-   * Fetches a user's flags.
-   * @param {UserResolvable} user The UserResolvable to identify
-   * @param {BaseFetchOptions} [options] Additional options for this fetch
-   * @returns {Promise<UserFlags>}
-   */
-  async fetchFlags(user, options) {
-    return (await this.fetch(user, options)).flags;
-  }
-
-  /**
    * Obtains a user from Discord, or the user cache if it's already available.
    * @param {UserResolvable} user The user to fetch
    * @param {BaseFetchOptions} [options] Additional options for this fetch
@@ -92,6 +82,16 @@ class UserManager extends CachedManager {
 
     const data = await this.client.api.users(id).get();
     return this._add(data, cache);
+  }
+
+  /**
+   * Fetches a user's flags.
+   * @param {UserResolvable} user The UserResolvable to identify
+   * @param {BaseFetchOptions} [options] Additional options for this fetch
+   * @returns {Promise<UserFlags>}
+   */
+  async fetchFlags(user, options) {
+    return (await this.fetch(user, options)).flags;
   }
 
   /**

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -110,7 +110,6 @@ class UserManager extends CachedManager {
    * @param {string|MessagePayload|MessageOptions} options The options to provide
    * @returns {Promise<Message>}
    */
-
   async send(user, options) {
     return (await this.createDM(user)).send(options);
   }

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -42,7 +42,7 @@ class UserManager extends CachedManager {
   }
 
   /**
-   * Creates a DM channel between the client and a user.
+   * Creates a {@link DMChannel} between the client and a user.
    * @param {UserResolvable} user The UserResolvable to identify
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<DMChannel>}
@@ -64,7 +64,7 @@ class UserManager extends CachedManager {
   }
 
   /**
-   * Deletes a DM channel (if one exists) between the client and a user. Resolves with the channel if successful.
+   * Deletes a {@link DMChannel} (if one exists) between the client and a user. Resolves with the channel if successful.
    * @param {UserResolvable} user The UserResolvable to identify
    * @returns {Promise<DMChannel>}
    */

--- a/src/structures/GuildMember.js
+++ b/src/structures/GuildMember.js
@@ -300,10 +300,11 @@ class GuildMember extends Base {
 
   /**
    * Creates a DM channel between the client and this member.
+   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<DMChannel>}
    */
-  createDM() {
-    return this.user.createDM();
+  createDM(force = false) {
+    return this.user.createDM(force);
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -215,30 +215,16 @@ class User extends Base {
    * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<DMChannel>}
    */
-  async createDM(force = false) {
-    if (!force) {
-      const { dmChannel } = this;
-      if (dmChannel && !dmChannel.partial) return dmChannel;
-    }
-
-    const data = await this.client.api.users(this.client.user.id).channels.post({
-      data: {
-        recipient_id: this.id,
-      },
-    });
-    return this.client.channels._add(data);
+  createDM(force = false) {
+    return this.client.users.createDM(this.id, force);
   }
 
   /**
    * Deletes a DM channel (if one exists) between the client and the user. Resolves with the channel if successful.
    * @returns {Promise<DMChannel>}
    */
-  async deleteDM() {
-    const { dmChannel } = this;
-    if (!dmChannel) throw new Error('USER_NO_DM_CHANNEL');
-    await this.client.api.channels(dmChannel.id).delete();
-    this.client.channels._remove(dmChannel.id);
-    return dmChannel;
+  deleteDM() {
+    return this.client.users.deleteDM(this.id);
   }
 
   /**
@@ -285,11 +271,8 @@ class User extends Base {
    * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<UserFlags>}
    */
-  async fetchFlags(force = false) {
-    if (this.flags && !force) return this.flags;
-    const data = await this.client.api.users(this.id).get();
-    this._patch(data);
-    return this.flags;
+  fetchFlags(force = false) {
+    return this.client.users.fetchFlags(this.id, { force });
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -207,7 +207,7 @@ class User extends Base {
    * @readonly
    */
   get dmChannel() {
-    return this.client.channels.cache.find(c => c.type === 'DM' && c.recipient.id === this.id) ?? null;
+    return this.client.users.dmChannel(this.id);
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3069,7 +3069,10 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
 
 export class UserManager extends CachedManager<Snowflake, User, UserResolvable> {
   private constructor(client: Client, iterable?: Iterable<RawUserData>);
+  public createDM(user: UserResolvable, options?: BaseFetchOptions): Promise<DMChannel>;
+  public deleteDM(user: UserResolvable): Promise<DMChannel>;
   public fetch(user: UserResolvable, options?: BaseFetchOptions): Promise<User>;
+  public fetchFlags(user: UserResolvable, options?: BaseFetchOptions): Promise<UserFlags>;
 }
 
 export class VoiceStateManager extends CachedManager<Snowflake, VoiceState, typeof VoiceState> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3074,6 +3074,7 @@ export class UserManager extends CachedManager<Snowflake, User, UserResolvable> 
   public deleteDM(user: UserResolvable): Promise<DMChannel>;
   public fetch(user: UserResolvable, options?: BaseFetchOptions): Promise<User>;
   public fetchFlags(user: UserResolvable, options?: BaseFetchOptions): Promise<UserFlags>;
+  public send(user: UserResolvable, options: string | MessagePayload | MessageOptions): Promise<Message>;
 }
 
 export class VoiceStateManager extends CachedManager<Snowflake, VoiceState, typeof VoiceState> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3069,6 +3069,7 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
 
 export class UserManager extends CachedManager<Snowflake, User, UserResolvable> {
   private constructor(client: Client, iterable?: Iterable<RawUserData>);
+  private dmChannel(userId: Snowflake): DMChannel | null;
   public createDM(user: UserResolvable, options?: BaseFetchOptions): Promise<DMChannel>;
   public deleteDM(user: UserResolvable): Promise<DMChannel>;
   public fetch(user: UserResolvable, options?: BaseFetchOptions): Promise<User>;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2227,7 +2227,7 @@ export class User extends PartialTextBasedChannel(Base) {
   public username: string;
   public avatarURL(options?: ImageURLOptions): string | null;
   public bannerURL(options?: ImageURLOptions): string | null;
-  public createDM(): Promise<DMChannel>;
+  public createDM(force?: boolean): Promise<DMChannel>;
   public deleteDM(): Promise<DMChannel>;
   public displayAvatarURL(options?: ImageURLOptions): string;
   public equals(user: User): boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This moves the following methods to the manager:

- `createDM()`
- `deleteDM()`
- `fetchFlags()`

The `send()` method is also on the manager.

The `User` class isn't needed for these requests which in turn only made these possible via doing:

```JavaScript
<Client>.users.fetch("user_id").then(async user => {
  const dmChannel = await user.createDM();
  // ...
});
```

But now, only one API call will be made:

```JavaScript
<Client>.users.createDM("user_id").then(dmChannel => {
  // ...
});
```

A nice change from this is the `send()` method on the manager. To send a message to an uncached user, you would first have to fetch them (`UserManager#fetch()`) and then run `User#send()` which internally calls `User#createDM()`. That's 3 API requests, but on the manager, a DM is created first (`User#createDM()`) and then sent (`DMChannel#send()`). 1 less!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
