### PR TITLE
types: use mapped enums instead of overloads

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -487,7 +487,7 @@ export type CategoryChannelTypes = ExcludeEnum<
 export class CategoryChannel extends GuildChannel {
   public readonly children: Collection<Snowflake, GuildChannel>;
   public type: 'GUILD_CATEGORY';
-  /** @deprecated */
+  /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
   public createChannel(
     name: string,
     options: CategoryCreateChannelOptions & { type: 'GUILD_STORE' },
@@ -2848,7 +2848,7 @@ export class GuildChannelManager extends CachedManager<
   private constructor(guild: Guild, iterable?: Iterable<RawGuildChannelData>);
   public readonly channelCountWithoutThreads: number;
   public guild: Guild;
-  /** @deprecated */
+  /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
   public create(name: string, options: GuildChannelCreateOptions & { type: 'GUILD_STORE' }): Promise<StoreChannel>;
   public create<T extends GuildChannelTypes>(
     name: string,

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -752,7 +752,6 @@ declare const threadChannel: ThreadChannel;
 declare const newsChannel: NewsChannel;
 declare const textChannel: TextChannel;
 declare const storeChannel: StoreChannel;
-declare const categoryChannel: CategoryChannel;
 declare const voiceChannel: VoiceChannel;
 declare const guild: Guild;
 declare const user: User;
@@ -843,6 +842,18 @@ declare const guildApplicationCommandManager: GuildApplicationCommandManager;
 expectType<Promise<Collection<Snowflake, ApplicationCommand>>>(guildApplicationCommandManager.fetch());
 expectType<Promise<Collection<Snowflake, ApplicationCommand>>>(guildApplicationCommandManager.fetch(undefined, {}));
 expectType<Promise<ApplicationCommand>>(guildApplicationCommandManager.fetch('0'));
+
+declare const categoryChannel: CategoryChannel;
+{
+  expectType<Promise<VoiceChannel>>(categoryChannel.createChannel('name', { type: 'GUILD_VOICE' }));
+  expectType<Promise<TextChannel>>(categoryChannel.createChannel('name', { type: 'GUILD_TEXT' }));
+  expectType<Promise<NewsChannel>>(categoryChannel.createChannel('name', { type: 'GUILD_NEWS' }));
+  expectDeprecated(categoryChannel.createChannel('name', { type: 'GUILD_STORE' }));
+  expectType<Promise<StageChannel>>(categoryChannel.createChannel('name', { type: 'GUILD_STAGE_VOICE' }));
+  expectType<Promise<TextChannel | VoiceChannel | NewsChannel | StoreChannel | StageChannel>>(
+    categoryChannel.createChannel('name', {}),
+  );
+}
 
 declare const guildChannelManager: GuildChannelManager;
 {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR goes through and removes any places where manual overloads are being used instead of mapped types. It also slims down that amount of type-logic needed for these functions.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
