### PR TITLE
fix(GuildAuditLog): Remove `Promise`s in constructor

### DIFF
--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -112,6 +112,7 @@ class Invite extends Base {
        * @type {?Snowflake}
        */
       this.inviterId = data.inviter_id;
+      this.inviter = this.client.users.resolve(data.inviter_id);
     } else {
       this.inviterId ??= null;
     }
@@ -121,7 +122,7 @@ class Invite extends Base {
        * The user who created this invite
        * @type {?User}
        */
-      this.inviter = this.client.users._add(data.inviter);
+      this.inviter ??= this.client.users._add(data.inviter);
       this.inviterId = data.inviter.id;
     } else {
       this.inviter ??= null;
@@ -171,6 +172,7 @@ class Invite extends Base {
        * @type {Snowflake}
        */
       this.channelId = data.channel_id;
+      this.channel = this.client.channels.cache.get(data.channel_id);
     }
 
     if ('channel' in data) {
@@ -178,7 +180,7 @@ class Invite extends Base {
        * The channel this invite is for
        * @type {Channel}
        */
-      this.channel = this.client.channels._add(data.channel, this.guild, { cache: false });
+      this.channel ??= this.client.channels._add(data.channel, this.guild, { cache: false });
       this.channelId ??= data.channel.id;
     }
 

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -111,7 +111,7 @@ class Invite extends Base {
        * The user's id who created this invite
        * @type {?Snowflake}
        */
-      this.inviterId = data.inviterId;
+      this.inviterId = data.inviter_id;
     } else {
       this.inviterId ??= null;
     }

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -106,12 +106,23 @@ class Invite extends Base {
       this.maxUses ??= null;
     }
 
+    if ('inviter_id' in data) {
+      /**
+       * The user's id who created this invite
+       * @type {?Snowflake}
+       */
+      this.inviterId = data.inviterId;
+    } else {
+      this.inviterId ??= null;
+    }
+
     if ('inviter' in data) {
       /**
        * The user who created this invite
        * @type {?User}
        */
       this.inviter = this.client.users._add(data.inviter);
+      this.inviterId = data.inviter.id;
     } else {
       this.inviter ??= null;
     }
@@ -154,12 +165,21 @@ class Invite extends Base {
       this.targetType ??= null;
     }
 
+    if ('channel_id' in data) {
+      /**
+       * The channel's id this invite is for
+       * @type {Snowflake}
+       */
+      this.channelId = data.channel_id;
+    }
+
     if ('channel' in data) {
       /**
        * The channel this invite is for
        * @type {Channel}
        */
       this.channel = this.client.channels._add(data.channel, this.guild, { cache: false });
+      this.channelId ??= data.channel.id;
     }
 
     if ('created_at' in data) {

--- a/src/structures/Invite.js
+++ b/src/structures/Invite.js
@@ -7,6 +7,8 @@ const { Error } = require('../errors');
 const { Endpoints } = require('../util/Constants');
 const Permissions = require('../util/Permissions');
 
+// TODO: Convert `inviter` and `channel` in this class to a getter.
+
 /**
  * Represents an invitation to a guild channel.
  * @extends {Base}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1295,6 +1295,7 @@ export class InteractionWebhook extends PartialWebhookMixin() {
 export class Invite extends Base {
   private constructor(client: Client, data: RawInviteData);
   public channel: GuildChannel | PartialGroupDMChannel;
+  public channelId: Snowflake;
   public code: string;
   public readonly deletable: boolean;
   public readonly createdAt: Date | null;
@@ -1303,6 +1304,7 @@ export class Invite extends Base {
   public readonly expiresTimestamp: number | null;
   public guild: InviteGuild | Guild | null;
   public inviter: User | null;
+  public inviterId: Snowflake | null;
   public maxAge: number | null;
   public maxUses: number | null;
   public memberCount: number;
@@ -4340,7 +4342,7 @@ export interface GuildAuditLogsEntryTargetField<TActionType extends GuildAuditLo
   USER: User | null;
   GUILD: Guild;
   WEBHOOK: Webhook;
-  INVITE: Invite | { [x: string]: unknown };
+  INVITE: Invite;
   MESSAGE: TActionType extends 'MESSAGE_BULK_DELETE' ? Guild | { id: Snowflake } : User;
   INTEGRATION: Integration;
   CHANNEL: GuildChannel | ThreadChannel | { id: Snowflake; [x: string]: unknown };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The constructor shouldn't be utilising `Promise`s, so I've removed them by checking the cache and defaulting to creating an `Invite`.

`changes` also included `channel_id` & `inviter_id` which weren't being stored in the `Invite` class. I think this would be a loss if we don't expose that data as at least the developer can fetch the user/resolve the channel themselves as full objects are not sent across.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
