### PR TITLE
refactor(RoleManager): Move some methods over from Role

### DIFF
--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -219,9 +219,9 @@ class RoleManager extends CachedManager {
   }
 
   /**
-   * Deletes the role.
+   * Deletes a role.
    * @param {RoleResolvable} role The role to delete
-   * @param {string} [reason] Reason for deleting this role
+   * @param {string} [reason] Reason for deleting the role
    * @returns {Promise<Role>}
    * @example
    * // Delete a role

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -219,6 +219,24 @@ class RoleManager extends CachedManager {
   }
 
   /**
+   * Deletes the role.
+   * @param {RoleResolvable} role The role to delete
+   * @param {string} [reason] Reason for deleting this role
+   * @returns {Promise<Role>}
+   * @example
+   * // Delete a role
+   * guild.roles.delete('222079219327434752', 'The role needed to go')
+   *   .then(deleted => console.log(`Deleted role ${deleted.name}`))
+   *   .catch(console.error);
+   */
+  async delete(role, reason) {
+    const id = this.resolveId(role);
+    await this.client.api.guilds[this.guild.id].roles[id].delete({ reason });
+    this.client.actions.GuildRoleDelete.handle({ guild_id: this.guild.id, role_id: id });
+    return this;
+  }
+
+  /**
    * Batch-updates the guild's role positions
    * @param {GuildRolePosition[]} rolePositions Role positions to update
    * @returns {Promise<Guild>}
@@ -242,6 +260,21 @@ class RoleManager extends CachedManager {
       guild_id: this.guild.id,
       roles: rolePositions,
     }).guild;
+  }
+
+  /**
+   * Compares the positions of two roles.
+   * @param {RoleResolvable} role1 First role to compare
+   * @param {RoleResolvable} role2 Second role to compare
+   * @returns {number} Negative number if the first role's position is lower (second role's is higher),
+   * positive number if the first's is higher (second's is lower), 0 if equal
+   */
+  comparePositions(role1, role2) {
+    const resolvedRole1 = this.resolve(role1);
+    const resolvedRole2 = this.resolve(role2);
+    if (!resolvedRole1 || !resolvedRole2) throw new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake');
+    if (resolvedRole1.position === resolvedRole2.position) return resolvedRole2.id - resolvedRole1.id;
+    return resolvedRole1.position - resolvedRole2.position;
   }
 
   /**

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -273,7 +273,11 @@ class RoleManager extends CachedManager {
     const resolvedRole1 = this.resolve(role1);
     const resolvedRole2 = this.resolve(role2);
     if (!resolvedRole1 || !resolvedRole2) throw new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake');
-    if (resolvedRole1.position === resolvedRole2.position) return BigInt(resolvedRole2.id) - BigInt(resolvedRole1.id);
+
+    if (resolvedRole1.position === resolvedRole2.position) {
+      return Number(BigInt(resolvedRole2.id) - BigInt(resolvedRole1.id));
+    }
+
     return resolvedRole1.position - resolvedRole2.position;
   }
 

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -273,7 +273,7 @@ class RoleManager extends CachedManager {
     const resolvedRole1 = this.resolve(role1);
     const resolvedRole2 = this.resolve(role2);
     if (!resolvedRole1 || !resolvedRole2) throw new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake');
-    if (resolvedRole1.position === resolvedRole2.position) return resolvedRole2.id - resolvedRole1.id;
+    if (resolvedRole1.position === resolvedRole2.position) return BigInt(resolvedRole2.id) - BigInt(resolvedRole1.id);
     return resolvedRole1.position - resolvedRole2.position;
   }
 

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -222,7 +222,7 @@ class RoleManager extends CachedManager {
    * Deletes a role.
    * @param {RoleResolvable} role The role to delete
    * @param {string} [reason] Reason for deleting the role
-   * @returns {Promise<Role>}
+   * @returns {Promise<void>}
    * @example
    * // Delete a role
    * guild.roles.delete('222079219327434752', 'The role needed to go')
@@ -230,10 +230,9 @@ class RoleManager extends CachedManager {
    *   .catch(console.error);
    */
   async delete(role, reason) {
-    const resolvedRole = this.resolve(role);
-    await this.client.api.guilds[this.guild.id].roles[resolvedRole.id].delete({ reason });
-    this.client.actions.GuildRoleDelete.handle({ guild_id: this.guild.id, role_id: resolvedRole.id });
-    return resolvedRole;
+    const id = this.resolveId(role);
+    await this.client.api.guilds[this.guild.id].roles[id].delete({ reason });
+    this.client.actions.GuildRoleDelete.handle({ guild_id: this.guild.id, role_id: id });
   }
 
   /**

--- a/src/managers/RoleManager.js
+++ b/src/managers/RoleManager.js
@@ -230,10 +230,10 @@ class RoleManager extends CachedManager {
    *   .catch(console.error);
    */
   async delete(role, reason) {
-    const id = this.resolveId(role);
-    await this.client.api.guilds[this.guild.id].roles[id].delete({ reason });
-    this.client.actions.GuildRoleDelete.handle({ guild_id: this.guild.id, role_id: id });
-    return this;
+    const resolvedRole = this.resolve(role);
+    await this.client.api.guilds[this.guild.id].roles[resolvedRole.id].delete({ reason });
+    this.client.actions.GuildRoleDelete.handle({ guild_id: this.guild.id, role_id: resolvedRole.id });
+    return resolvedRole;
   }
 
   /**

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -406,8 +406,9 @@ class Role extends Base {
    *   .then(deleted => console.log(`Deleted role ${deleted.name}`))
    *   .catch(console.error);
    */
-  delete(reason) {
-    return this.guild.roles.delete(this.id, reason);
+  async delete(reason) {
+    await this.guild.roles.delete(this.id, reason);
+    return this;
   }
 
   /**

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -479,8 +479,7 @@ class Role extends Base {
       deprecationEmittedForComparePositions = true;
     }
 
-    if (role1.position === role2.position) return role2.id - role1.id;
-    return role1.position - role2.position;
+    return role1.guild.roles.comparePositions(role1, role2);
   }
 }
 

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Base = require('./Base');
-const { Error, TypeError } = require('../errors');
+const { Error } = require('../errors');
 const Permissions = require('../util/Permissions');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
 const Util = require('../util/Util');
@@ -207,9 +207,7 @@ class Role extends Base {
    * positive number if this one is higher (other's is lower), 0 if equal
    */
   comparePositionTo(role) {
-    role = this.guild.roles.resolve(role);
-    if (!role) throw new TypeError('INVALID_TYPE', 'role', 'Role nor a Snowflake');
-    return this.constructor.comparePositions(this, role);
+    return this.guild.roles.comparePositions(this, role);
   }
 
   /**
@@ -406,10 +404,8 @@ class Role extends Base {
    *   .then(deleted => console.log(`Deleted role ${deleted.name}`))
    *   .catch(console.error);
    */
-  async delete(reason) {
-    await this.client.api.guilds[this.guild.id].roles[this.id].delete({ reason });
-    this.client.actions.GuildRoleDelete.handle({ guild_id: this.guild.id, role_id: this.id });
-    return this;
+  delete(reason) {
+    return this.guild.roles.delete(this.id, reason);
   }
 
   /**
@@ -469,6 +465,7 @@ class Role extends Base {
    * @param {Role} role2 Second role to compare
    * @returns {number} Negative number if the first role's position is lower (second role's is higher),
    * positive number if the first's is higher (second's is lower), 0 if equal
+   * @deprecated Use {@link RoleManager#comparePositions} instead.
    */
   static comparePositions(role1, role2) {
     if (role1.position === role2.position) return role2.id - role1.id;

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -6,6 +6,8 @@ const Permissions = require('../util/Permissions');
 const SnowflakeUtil = require('../util/SnowflakeUtil');
 const Util = require('../util/Util');
 
+let deprecationEmittedForComparePositions = false;
+
 /**
  * @type {WeakSet<Role>}
  * @private
@@ -468,6 +470,15 @@ class Role extends Base {
    * @deprecated Use {@link RoleManager#comparePositions} instead.
    */
   static comparePositions(role1, role2) {
+    if (!deprecationEmittedForComparePositions) {
+      process.emitWarning(
+        'The Role.comparePositions method is deprecated. Use RoleManager#comparePositions instead.',
+        'DeprecationWarning',
+      );
+
+      deprecationEmittedForComparePositions = true;
+    }
+
     if (role1.position === role2.position) return role2.id - role1.id;
     return role1.position - role2.position;
   }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1866,6 +1866,7 @@ export class Role extends Base {
   public toJSON(): unknown;
   public toString(): RoleMention;
 
+  /** @deprecated Use {@link RoleManager.comparePositions} instead. */
   public static comparePositions(role1: Role, role2: Role): number;
 }
 
@@ -3035,7 +3036,9 @@ export class RoleManager extends CachedManager<Snowflake, Role, RoleResolvable> 
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, Role>>;
   public create(options?: CreateRoleOptions): Promise<Role>;
   public edit(role: RoleResolvable, options: RoleData, reason?: string): Promise<Role>;
+  public delete(role: RoleResolvable, reason?: string): Promise<Role>;
   public setPositions(rolePositions: readonly RolePosition[]): Promise<Guild>;
+  public comparePositions(role1: RoleResolvable, role2: RoleResolvable): number;
 }
 
 export class StageInstanceManager extends CachedManager<Snowflake, StageInstance, StageInstanceResolvable> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3036,7 +3036,7 @@ export class RoleManager extends CachedManager<Snowflake, Role, RoleResolvable> 
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, Role>>;
   public create(options?: CreateRoleOptions): Promise<Role>;
   public edit(role: RoleResolvable, options: RoleData, reason?: string): Promise<Role>;
-  public delete(role: RoleResolvable, reason?: string): Promise<Role>;
+  public delete(role: RoleResolvable, reason?: string): Promise<void>;
   public setPositions(rolePositions: readonly RolePosition[]): Promise<Guild>;
   public comparePositions(role1: RoleResolvable, role2: RoleResolvable): number;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This moves the following methods to the manager:

- `comparePositions()`
- `delete()`

The `RoleManager` can manage the `delete()` API method.

As for `Role.comparePositions()`... not too sure why it's a static method on `Role` to be honest. It would make more sense for this to be moved to the manager. The manager stores the cache of roles, so I believe this method may reside here nicely. It's also no longer a static method and accepts `RoleResolvable`s.

```JavaScript
// client is a Client
const guild = client.guilds.resolve("guild_id");
const role1 = guild.roles.resolve("role_id1");
const role2 = guild.roles.resolve("role_id2");

// Old way of using the method
const { Role } = require("discord.js");
Role.comparePositions(role1, role2);

// New way of using the method
guild.roles.comparePositions(role1, role2);
```


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
