### PR TITLE
refactor(Guild): remove duplicate methods

### DIFF
--- a/src/structures/AnonymousGuild.js
+++ b/src/structures/AnonymousGuild.js
@@ -68,22 +68,20 @@ class AnonymousGuild extends BaseGuild {
 
   /**
    * The URL to this guild's banner.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   bannerURL({ format, size } = {}) {
-    if (!this.banner) return null;
-    return this.client.rest.cdn.Banner(this.id, this.banner, format, size);
+    return this.banner && this.client.rest.cdn.Banner(this.id, this.banner, format, size);
   }
 
   /**
    * The URL to this guild's invite splash image.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
    * @returns {?string}
    */
   splashURL({ format, size } = {}) {
-    if (!this.splash) return null;
-    return this.client.rest.cdn.Splash(this.id, this.splash, format, size);
+    return this.splash && this.client.rest.cdn.Splash(this.id, this.splash, format, size);
   }
 }
 

--- a/src/structures/Guild.js
+++ b/src/structures/Guild.js
@@ -480,30 +480,12 @@ class Guild extends AnonymousGuild {
   }
 
   /**
-   * The URL to this guild's banner.
-   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
-   * @returns {?string}
-   */
-  bannerURL({ format, size } = {}) {
-    return this.banner && this.client.rest.cdn.Banner(this.id, this.banner, format, size);
-  }
-
-  /**
    * The time the client user joined the guild
    * @type {Date}
    * @readonly
    */
   get joinedAt() {
     return new Date(this.joinedTimestamp);
-  }
-
-  /**
-   * The URL to this guild's invite splash image.
-   * @param {StaticImageURLOptions} [options={}] Options for the Image URL
-   * @returns {?string}
-   */
-  splashURL({ format, size } = {}) {
-    return this.splash && this.client.rest.cdn.Splash(this.id, this.splash, format, size);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This removes two methods from the `Guild` class that are inherited by `AnonymousGuild`, as well as fixing the parameter type there.

**Status and versioning classification:**

- Typings don't need updating