### PR TITLE
refactor(Dates): save timestamps everywhere and use Date.parse

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -197,7 +197,7 @@ class Client extends BaseClient {
    * @readonly
    */
   get uptime() {
-    return this.readyTimestamp ? Date.now() - this.readyTimestamp : null;
+    return this.readyTimestamp && Date.now() - this.readyTimestamp;
   }
 
   /**

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -162,11 +162,10 @@ class Client extends BaseClient {
     this.application = null;
 
     /**
-     * Time at which the client was last regarded as being in the `READY` state
-     * (each time the client disconnects and successfully reconnects, this will be overwritten)
-     * @type {?Date}
+     * Timestamp of the time the client was last `READY` at
+     * @type {?number}
      */
-    this.readyAt = null;
+    this.readyTimestamp = null;
   }
 
   /**
@@ -183,12 +182,13 @@ class Client extends BaseClient {
   }
 
   /**
-   * Timestamp of the time the client was last `READY` at
-   * @type {?number}
+   * Time at which the client was last regarded as being in the `READY` state
+   * (each time the client disconnects and successfully reconnects, this will be overwritten)
+   * @type {?Date}
    * @readonly
    */
-  get readyTimestamp() {
-    return this.readyAt?.getTime() ?? null;
+  get readyAt() {
+    return this.readyTimestamp && new Date(this.readyTimestamp);
   }
 
   /**
@@ -197,7 +197,7 @@ class Client extends BaseClient {
    * @readonly
    */
   get uptime() {
-    return this.readyAt ? Date.now() - this.readyAt : null;
+    return this.readyTimestamp ? Date.now() - this.readyTimestamp : null;
   }
 
   /**

--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -374,7 +374,7 @@ class WebSocketManager extends EventEmitter {
   triggerClientReady() {
     this.status = Status.READY;
 
-    this.client.readyAt = new Date();
+    this.client.readyTimestamp = Date.now();
 
     /**
      * Emitted when the client becomes ready to start working.

--- a/packages/discord.js/src/client/websocket/handlers/CHANNEL_PINS_UPDATE.js
+++ b/packages/discord.js/src/client/websocket/handlers/CHANNEL_PINS_UPDATE.js
@@ -4,7 +4,7 @@ const { Events } = require('../../../util/Constants');
 
 module.exports = (client, { d: data }) => {
   const channel = client.channels.cache.get(data.channel_id);
-  const time = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
+  const time = data.last_pin_timestamp ? Date.parse(data.last_pin_timestamp) : null;
 
   if (channel) {
     // Discord sends null for last_pin_timestamp if the last pinned message was removed

--- a/packages/discord.js/src/rest/RequestHandler.js
+++ b/packages/discord.js/src/rest/RequestHandler.js
@@ -16,7 +16,7 @@ function parseResponse(res) {
 }
 
 function getAPIOffset(serverDate) {
-  return new Date(serverDate).getTime() - Date.now();
+  return Date.parse(serverDate) - Date.now();
 }
 
 function calculateReset(reset, resetAfter, serverDate) {
@@ -24,7 +24,7 @@ function calculateReset(reset, resetAfter, serverDate) {
   if (resetAfter) {
     return Date.now() + Number(resetAfter) * 1_000;
   }
-  return new Date(Number(reset) * 1_000).getTime() - getAPIOffset(serverDate);
+  return Number(reset) * 1_000 - getAPIOffset(serverDate);
 }
 
 /* Invalid request limiting is done on a per-IP basis, not a per-token basis.
@@ -242,7 +242,7 @@ class RequestHandler {
 
       // https://github.com/discord/discord-api-docs/issues/182
       if (!resetAfter && request.route.includes('reactions')) {
-        this.reset = new Date(serverDate).getTime() - getAPIOffset(serverDate) + 250;
+        this.reset = Date.parse(serverDate) - getAPIOffset(serverDate) + 250;
       }
 
       // Handle retryAfter, which means we have actually hit a rate limit

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -66,7 +66,7 @@ class BaseGuildTextChannel extends GuildChannel {
        * The timestamp when the last pinned message was pinned, if there was one
        * @type {?number}
        */
-      this.lastPinTimestamp = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
+      this.lastPinTimestamp = data.last_pin_timestamp ? Date.parse(data.last_pin_timestamp) : null;
     }
 
     if ('default_auto_archive_duration' in data) {

--- a/packages/discord.js/src/structures/DMChannel.js
+++ b/packages/discord.js/src/structures/DMChannel.js
@@ -47,7 +47,7 @@ class DMChannel extends Channel {
        * The timestamp when the last pinned message was pinned, if there was one
        * @type {?number}
        */
-      this.lastPinTimestamp = new Date(data.last_pin_timestamp).getTime();
+      this.lastPinTimestamp = Date.parse(data.last_pin_timestamp);
     } else {
       this.lastPinTimestamp ??= null;
     }

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -329,7 +329,7 @@ class Guild extends AnonymousGuild {
        * The timestamp the client user joined the guild at
        * @type {number}
        */
-      this.joinedTimestamp = new Date(data.joined_at).getTime();
+      this.joinedTimestamp = Date.parse(data.joined_at);
     }
 
     if ('default_message_notifications' in data) {

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -84,9 +84,9 @@ class GuildMember extends Base {
     } else if (typeof this.avatar !== 'string') {
       this.avatar = null;
     }
-    if ('joined_at' in data) this.joinedTimestamp = new Date(data.joined_at).getTime();
+    if ('joined_at' in data) this.joinedTimestamp = Date.parse(data.joined_at);
     if ('premium_since' in data) {
-      this.premiumSinceTimestamp = data.premium_since ? new Date(data.premium_since).getTime() : null;
+      this.premiumSinceTimestamp = data.premium_since ? Date.parse(data.premium_since) : null;
     }
     if ('roles' in data) this._roles = data.roles;
     this.pending = data.pending ?? false;
@@ -186,7 +186,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get joinedAt() {
-    return this.joinedTimestamp ? new Date(this.joinedTimestamp) : null;
+    return this.joinedTimestamp && new Date(this.joinedTimestamp);
   }
 
   /**
@@ -204,7 +204,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get premiumSince() {
-    return this.premiumSinceTimestamp ? new Date(this.premiumSinceTimestamp) : null;
+    return this.premiumSinceTimestamp && new Date(this.premiumSinceTimestamp);
   }
 
   /**

--- a/packages/discord.js/src/structures/GuildTemplate.js
+++ b/packages/discord.js/src/structures/GuildTemplate.js
@@ -66,18 +66,18 @@ class GuildTemplate extends Base {
 
     if ('created_at' in data) {
       /**
-       * The time when this template was created at
-       * @type {Date}
+       * The timestamp of when this template was created at
+       * @type {number}
        */
-      this.createdAt = new Date(data.created_at);
+      this.createdTimestamp = Date.parse(data.created_at);
     }
 
     if ('updated_at' in data) {
       /**
-       * The time when this template was last synced to the guild
-       * @type {Date}
+       * The timestamp of when this template was last synced to the guild
+       * @type {number}
        */
-      this.updatedAt = new Date(data.updated_at);
+      this.updatedTimestamp = Date.parse(data.updated_at);
     }
 
     if ('source_guild_id' in data) {
@@ -180,21 +180,21 @@ class GuildTemplate extends Base {
   }
 
   /**
-   * The timestamp of when this template was created at
-   * @type {number}
+   * The time when this template was created at
+   * @type {Date}
    * @readonly
    */
-  get createdTimestamp() {
-    return this.createdAt.getTime();
+  get createdAt() {
+    return new Date(this.createdTimestamp);
   }
 
   /**
-   * The timestamp of when this template was last synced to the guild
-   * @type {number}
+   * The time when this template was last synced to the guild
+   * @type {Date}
    * @readonly
    */
-  get updatedTimestamp() {
-    return this.updatedAt.getTime();
+  get updatedAt() {
+    return new Date(this.updatedTimestamp);
   }
 
   /**

--- a/packages/discord.js/src/structures/Invite.js
+++ b/packages/discord.js/src/structures/Invite.js
@@ -192,12 +192,12 @@ class Invite extends Base {
        * The timestamp this invite was created at
        * @type {?number}
        */
-      this.createdTimestamp = new Date(data.created_at).getTime();
+      this.createdTimestamp = Date.parse(data.created_at);
     } else {
       this.createdTimestamp ??= null;
     }
 
-    if ('expires_at' in data) this._expiresTimestamp = new Date(data.expires_at).getTime();
+    if ('expires_at' in data) this._expiresTimestamp = Date.parse(data.expires_at);
     else this._expiresTimestamp ??= null;
 
     if ('stage_instance' in data) {
@@ -227,7 +227,7 @@ class Invite extends Base {
    * @readonly
    */
   get createdAt() {
-    return this.createdTimestamp ? new Date(this.createdTimestamp) : null;
+    return this.createdTimestamp && new Date(this.createdTimestamp);
   }
 
   /**
@@ -263,8 +263,7 @@ class Invite extends Base {
    * @readonly
    */
   get expiresAt() {
-    const { expiresTimestamp } = this;
-    return expiresTimestamp ? new Date(expiresTimestamp) : null;
+    return this.expiresTimestamp && new Date(this.expiresTimestamp);
   }
 
   /**

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -186,7 +186,7 @@ class Message extends Base {
        * The timestamp the message was last edited at (if applicable)
        * @type {?number}
        */
-      this.editedTimestamp = new Date(data.edited_timestamp).getTime();
+      this.editedTimestamp = Date.parse(data.edited_timestamp);
     } else {
       this.editedTimestamp ??= null;
     }
@@ -424,7 +424,7 @@ class Message extends Base {
    * @readonly
    */
   get editedAt() {
-    return this.editedTimestamp ? new Date(this.editedTimestamp) : null;
+    return this.editedTimestamp && new Date(this.editedTimestamp);
   }
 
   /**
@@ -943,8 +943,8 @@ class Message extends Base {
     if (equal && rawData) {
       equal =
         this.mentions.everyone === message.mentions.everyone &&
-        this.createdTimestamp === new Date(rawData.timestamp).getTime() &&
-        this.editedTimestamp === new Date(rawData.edited_timestamp).getTime();
+        this.createdTimestamp === Date.parse(rawData.timestamp) &&
+        this.editedTimestamp === Date.parse(rawData.edited_timestamp);
     }
 
     return equal;

--- a/packages/discord.js/src/structures/MessageEmbed.js
+++ b/packages/discord.js/src/structures/MessageEmbed.js
@@ -87,6 +87,7 @@ class MessageEmbed {
      * The timestamp of this embed
      * @type {?number}
      */
+    // Date.parse() cannot be used here because data.timestamp might be a number
     this.timestamp = 'timestamp' in data ? new Date(data.timestamp).getTime() : null;
 
     /**
@@ -240,7 +241,7 @@ class MessageEmbed {
    * @readonly
    */
   get createdAt() {
-    return this.timestamp ? new Date(this.timestamp) : null;
+    return this.timestamp && new Date(this.timestamp);
   }
 
   /**
@@ -514,7 +515,7 @@ class MessageEmbed {
       type: 'rich',
       description: this.description,
       url: this.url,
-      timestamp: this.timestamp && new Date(this.timestamp),
+      timestamp: this.createdAt?.toISOString(),
       color: this.color,
       fields: this.fields,
       thumbnail: this.thumbnail,

--- a/packages/discord.js/src/structures/Presence.js
+++ b/packages/discord.js/src/structures/Presence.js
@@ -271,7 +271,7 @@ class Activity {
      * Creation date of the activity
      * @type {number}
      */
-    this.createdTimestamp = new Date(data.created_at).getTime();
+    this.createdTimestamp = Date.parse(data.created_at);
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -99,7 +99,7 @@ class ThreadChannel extends Channel {
        * created</info>
        * @type {?number}
        */
-      this.archiveTimestamp = new Date(data.thread_metadata.archive_timestamp).getTime();
+      this.archiveTimestamp = Date.parse(data.thread_metadata.archive_timestamp);
     } else {
       this.locked ??= null;
       this.archived ??= null;
@@ -133,7 +133,7 @@ class ThreadChannel extends Channel {
        * The timestamp when the last pinned message was pinned, if there was one
        * @type {?number}
        */
-      this.lastPinTimestamp = data.last_pin_timestamp ? new Date(data.last_pin_timestamp).getTime() : null;
+      this.lastPinTimestamp = data.last_pin_timestamp ? Date.parse(data.last_pin_timestamp) : null;
     } else {
       this.lastPinTimestamp ??= null;
     }
@@ -192,8 +192,7 @@ class ThreadChannel extends Channel {
    * @readonly
    */
   get archivedAt() {
-    if (!this.archiveTimestamp) return null;
-    return new Date(this.archiveTimestamp);
+    return this.archiveTimestamp && new Date(this.archiveTimestamp);
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadMember.js
+++ b/packages/discord.js/src/structures/ThreadMember.js
@@ -33,7 +33,7 @@ class ThreadMember extends Base {
   }
 
   _patch(data) {
-    if ('join_timestamp' in data) this.joinedTimestamp = new Date(data.join_timestamp).getTime();
+    if ('join_timestamp' in data) this.joinedTimestamp = Date.parse(data.join_timestamp);
 
     if ('flags' in data) {
       /**
@@ -59,7 +59,7 @@ class ThreadMember extends Base {
    * @readonly
    */
   get joinedAt() {
-    return this.joinedTimestamp ? new Date(this.joinedTimestamp) : null;
+    return this.joinedTimestamp && new Date(this.joinedTimestamp);
   }
 
   /**

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -120,7 +120,7 @@ class VoiceState extends Base {
        * The time at which the member requested to speak. This property is specific to stage channels only.
        * @type {?number}
        */
-      this.requestToSpeakTimestamp = new Date(data.request_to_speak_timestamp).getTime();
+      this.requestToSpeakTimestamp = Date.parse(data.request_to_speak_timestamp);
     } else {
       this.requestToSpeakTimestamp ??= null;
     }

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -49,7 +49,7 @@ class TextBasedChannel {
    * @readonly
    */
   get lastPinAt() {
-    return this.lastPinTimestamp ? new Date(this.lastPinTimestamp) : null;
+    return this.lastPinTimestamp && new Date(this.lastPinTimestamp);
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -547,6 +547,8 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
   public options: ClientOptions;
   public readyAt: If<Ready, Date>;
   public readonly readyTimestamp: If<Ready, number>;
+  public readonly readyAt: If<Ready, Date>;
+  public readyTimestamp: If<Ready, number>;
   public sweepers: Sweepers;
   public shard: ShardClientUtil | null;
   public token: If<Ready, string, string | null>;
@@ -1200,8 +1202,8 @@ export class GuildScheduledEvent<S extends GuildScheduledEventStatus = GuildSche
 
 export class GuildTemplate extends Base {
   private constructor(client: Client, data: RawGuildTemplateData);
-  public readonly createdTimestamp: number;
-  public readonly updatedTimestamp: number;
+  public createdTimestamp: number;
+  public updatedTimestamp: number;
   public readonly url: string;
   public code: string;
   public name: string;
@@ -1209,8 +1211,8 @@ export class GuildTemplate extends Base {
   public usageCount: number;
   public creator: User;
   public creatorId: Snowflake;
-  public createdAt: Date;
-  public updatedAt: Date;
+  public readonly createdAt: Date;
+  public readonly updatedAt: Date;
   public guild: Guild | null;
   public guildId: Snowflake;
   public serializedGuild: APITemplateSerializedSourceGuild;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -545,8 +545,6 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
   public readonly emojis: BaseGuildEmojiManager;
   public guilds: GuildManager;
   public options: ClientOptions;
-  public readyAt: If<Ready, Date>;
-  public readonly readyTimestamp: If<Ready, number>;
   public readonly readyAt: If<Ready, Date>;
   public readyTimestamp: If<Ready, number>;
   public sweepers: Sweepers;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- `Client#readyAt`, `GuildTemplate#createdAt` and `GuildTemplate#updatedAt` are now getters as opposed to their timestamp counterparts which are now properties
- Change from `new Date(x).getTime()` to `Date.parse(x)` where applicable for improved performance
- Fixed the timestamp property on the result of `MessageEmbed#toJSON` which was a `Date` instance and not a string
- Consistent implementation of date getters

**Status and versioning classification:**

- Code changes have been (partially) tested against the Discord API
- I know how to update typings and have done so