### PR TITLE
fix(Message): remove usage of `.deleted`

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -584,7 +584,7 @@ class Message extends Base {
    */
   get editable() {
     const precheck = Boolean(
-      this.author.id === this.client.user.id && !this.deleted && (!this.guild || this.channel?.viewable),
+      this.author.id === this.client.user.id && !deletedMessages.has(this) && (!this.guild || this.channel?.viewable),
     );
     // Regardless of permissions thread messages cannot be edited if
     // the thread is locked.
@@ -600,7 +600,7 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
-    if (this.deleted) {
+    if (deletedMessages.has(this)) {
       return false;
     }
     if (!this.guild) {
@@ -625,7 +625,7 @@ class Message extends Base {
     const { channel } = this;
     return Boolean(
       !this.system &&
-        !this.deleted &&
+        !deletedMessages.has(this) &&
         (!this.guild ||
           (channel?.viewable &&
             channel?.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false))),
@@ -661,7 +661,7 @@ class Message extends Base {
         this.type === 'DEFAULT' &&
         channel.viewable &&
         channel.permissionsFor(this.client.user)?.has(bitfield, false) &&
-        !this.deleted,
+        !deletedMessages.has(this),
     );
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes an oversight from #7107 that I noticed while rebasing #7092.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
