### PR TITLE
chore(GuildMemberManager): Update nick path

### DIFF
--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -252,7 +252,7 @@ class GuildMemberManager extends CachedManager {
     let endpoint = this.client.api.guilds(this.guild.id);
     if (id === this.client.user.id) {
       const keys = Object.keys(_data);
-      if (keys.length === 1 && keys[0] === 'nick') endpoint = endpoint.members('@me').nick;
+      if (keys.length === 1 && keys[0] === 'nick') endpoint = endpoint.members('@me');
       else endpoint = endpoint.members(id);
     } else {
       endpoint = endpoint.members(id);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
To edit the client's nickname in a guild, it was using [this path](https://discord.com/developers/docs/resources/guild#modify-current-user-nick) which has been marked as deprecated. The correct path to use is right above it.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
