### PR TITLE
fix(Message): xable check ephemeral

### DIFF
--- a/src/structures/Message.js
+++ b/src/structures/Message.js
@@ -584,7 +584,10 @@ class Message extends Base {
    */
   get editable() {
     const precheck = Boolean(
-      this.author.id === this.client.user.id && !deletedMessages.has(this) && (!this.guild || this.channel?.viewable),
+      this.author.id === this.client.user.id &&
+        !deletedMessages.has(this) &&
+        !this.flags.has(MessageFlags.FLAGS.EPHEMERAL) &&
+        (!this.guildId || this.channel?.viewable),
     );
     // Regardless of permissions thread messages cannot be edited if
     // the thread is locked.
@@ -600,10 +603,10 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
-    if (deletedMessages.has(this)) {
+    if (deletedMessages.has(this) || this.flags.has(MessageFlags.FLAGS.EPHEMERAL)) {
       return false;
     }
-    if (!this.guild) {
+    if (!this.guildId) {
       return this.author.id === this.client.user.id;
     }
     // DMChannel does not have viewable property, so check viewable after proved that message is on a guild.
@@ -626,7 +629,8 @@ class Message extends Base {
     return Boolean(
       !this.system &&
         !deletedMessages.has(this) &&
-        (!this.guild ||
+        !this.flags.has(MessageFlags.FLAGS.EPHEMERAL) &&
+        (!this.guildId ||
           (channel?.viewable &&
             channel?.permissionsFor(this.client.user)?.has(Permissions.FLAGS.MANAGE_MESSAGES, false))),
     );


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
 - added checks for ephemeral in `Message#editable`, `Message#deletable` and `Message#pinnable`
 - since `Message#guild` is now a getter it should be more performant to check `!this.guildId` instead of `!this.guild` (I don't know if this change is considered out of scope for this PR)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
