### PR TITLE
fix(StickerPack): Nullify `bannerId`

### DIFF
--- a/src/structures/StickerPack.js
+++ b/src/structures/StickerPack.js
@@ -85,10 +85,10 @@ class StickerPack extends Base {
   /**
    * The URL to this sticker pack's banner.
    * @param {StaticImageURLOptions} [options={}] Options for the Image URL
-   * @returns {string}
+   * @returns {?string}
    */
   bannerURL({ format, size } = {}) {
-    return this.client.rest.cdn.StickerPackBanner(this.bannerId, format, size);
+    return this.bannerId && this.client.rest.cdn.StickerPackBanner(this.bannerId, format, size);
   }
 }
 

--- a/src/structures/StickerPack.js
+++ b/src/structures/StickerPack.js
@@ -50,9 +50,9 @@ class StickerPack extends Base {
 
     /**
      * The id of the sticker pack's banner image
-     * @type {Snowflake}
+     * @type {?Snowflake}
      */
-    this.bannerId = pack.banner_asset_id;
+    this.bannerId = pack.banner_asset_id ?? null;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2104,7 +2104,7 @@ export class StickerPack extends Base {
   public name: string;
   public skuId: Snowflake;
   public stickers: Collection<Snowflake, Sticker>;
-  public bannerURL(options?: StaticImageURLOptions): string;
+  public bannerURL(options?: StaticImageURLOptions): string | null;
 }
 
 /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2096,7 +2096,7 @@ export class StickerPack extends Base {
   private constructor(client: Client, data: RawStickerPackData);
   public readonly createdTimestamp: number;
   public readonly createdAt: Date;
-  public bannerId: Snowflake;
+  public bannerId: Snowflake | null;
   public readonly coverSticker: Sticker | null;
   public coverStickerId: Snowflake | null;
   public description: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The Snowsgiving Surprise Pack does not have a `banner_asset_id`, so this is `undefined`. Was also just documented as such:

- https://github.com/discord/discord-api-docs/pull/4245

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
