### PR TITLE
fix: webhook typeguards should use string comparisons

### DIFF
--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -415,7 +415,7 @@ class Webhook {
    * @returns {boolean}
    */
   isChannelFollower() {
-    return this.type === WebhookTypes['Channel Follower'];
+    return this.type === 'Channel Follower';
   }
 
   /**
@@ -423,7 +423,7 @@ class Webhook {
    * @returns {boolean}
    */
   isIncoming() {
-    return this.type === WebhookTypes.Incoming;
+    return this.type === 'Incoming';
   }
 
   static applyToClass(structure, ignore = []) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the typeguards on webhook objects giving false negatives because it was compared against numbers instead of strings.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
