### PR TITLE
fix: Make the followUp function error more clear

### DIFF
--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -161,7 +161,7 @@ class InteractionResponses {
    * @param {string|MessagePayload|InteractionReplyOptions} options The options for the reply
    * @returns {Promise<Message|APIMessage>}
    */
-  followUp(options) {
+  async followUp(options) {
     if (!this.deferred && !this.replied) throw new Error('INTERACTION_NOT_REPLIED');
     return this.webhook.send(options);
   }

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -162,7 +162,7 @@ class InteractionResponses {
    * @returns {Promise<Message|APIMessage>}
    */
   followUp(options) {
-    if(!this.deferred && !this.replied) throw new Error("INTERACTION_NOT_REPLIED");
+    if (!this.deferred && !this.replied) throw new Error('INTERACTION_NOT_REPLIED');
     return this.webhook.send(options);
   }
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -162,6 +162,7 @@ class InteractionResponses {
    * @returns {Promise<Message|APIMessage>}
    */
   followUp(options) {
+    if(!this.deferred && !this.replied) throw new Error("NO_INTERACTION_TO_FOLLOWUP");
     return this.webhook.send(options);
   }
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -161,8 +161,8 @@ class InteractionResponses {
    * @param {string|MessagePayload|InteractionReplyOptions} options The options for the reply
    * @returns {Promise<Message|APIMessage>}
    */
-  async followUp(options) {
-    if (!this.deferred && !this.replied) throw new Error('INTERACTION_NOT_REPLIED');
+  followUp(options) {
+    if (!this.deferred && !this.replied) return Promise.reject(new Error('INTERACTION_NOT_REPLIED'));
     return this.webhook.send(options);
   }
 

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -162,7 +162,7 @@ class InteractionResponses {
    * @returns {Promise<Message|APIMessage>}
    */
   followUp(options) {
-    if(!this.deferred && !this.replied) throw new Error("NO_INTERACTION_TO_FOLLOWUP");
+    if(!this.deferred && !this.replied) throw new Error("INTERACTION_NOT_REPLIED");
     return this.webhook.send(options);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

If a followUp is called when no interaction is deferred or replied will give a better error than "Unknown Webhook" 


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:

- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
