### PR TITLE
This should solve the API hiccup instance

### DIFF
--- a/src/client/actions/MessageCreate.js
+++ b/src/client/actions/MessageCreate.js
@@ -11,7 +11,7 @@ class MessageCreateAction extends Action {
     const channel = this.getChannel(data);
     if (channel) {
       if (!channel.isText()) return {};
-
+      if(channel.messages == undefined) return;
       const existing = channel.messages.cache.get(data.id);
       if (existing) return { message: existing };
       const message = channel.messages._add(data);


### PR DESCRIPTION
This should solve the API hiccup instance, and allow the library to recover from it without throwing fatal errors.

**Please describe the changes this PR makes and why it should be merged:**

https://cdn.hyperz.net/main/4OB9Ap.png

It's a bad practice to not have common instances like this checked for when the API has a hiccup like it did a few moments ago and crashed bots that ran this function. This change will implement a fix for the above error. I am not the only person who got this error either.

Other: https://discord.com/channels/222078108977594368/824411059443204127/922550844195496047

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
