### PR TITLE
types(CategoryChannel): `createChannel` should default to a text channel

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -503,7 +503,7 @@ export class CategoryChannel extends GuildChannel {
   /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
   public createChannel(
     name: string,
-    options: CategoryCreateChannelOptions & { type: 'GUILD_STORE' },
+    options: CategoryCreateChannelOptions & { type: 'GUILD_STORE' | ChannelTypes.GUILD_STORE },
   ): Promise<StoreChannel>;
 
   public createChannel(

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -494,19 +494,21 @@ export type CategoryChannelTypes = ExcludeEnum<
 export class CategoryChannel extends GuildChannel {
   public readonly children: Collection<Snowflake, Exclude<NonThreadGuildBasedChannel, CategoryChannel>>;
   public type: 'GUILD_CATEGORY';
+
+  public createChannel<T extends Exclude<CategoryChannelTypes, 'GUILD_STORE'>>(
+    name: string,
+    options: CategoryCreateChannelOptions & { type: T },
+  ): Promise<MappedChannelCategoryTypes[T]>;
+
   /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
   public createChannel(
     name: string,
     options: CategoryCreateChannelOptions & { type: 'GUILD_STORE' },
   ): Promise<StoreChannel>;
-  public createChannel<T extends CategoryChannelTypes>(
-    name: string,
-    options: CategoryCreateChannelOptions & { type: T },
-  ): Promise<MappedChannelCategoryTypes[T]>;
 
   public createChannel(
     name: string,
-    options: CategoryCreateChannelOptions,
+    options?: CategoryCreateChannelOptions,
   ): Promise<Exclude<NonThreadGuildBasedChannel, CategoryChannel>>;
 }
 

--- a/typings/index.test-d.ts
+++ b/typings/index.test-d.ts
@@ -859,9 +859,8 @@ declare const categoryChannel: CategoryChannel;
   expectType<Promise<NewsChannel>>(categoryChannel.createChannel('name', { type: 'GUILD_NEWS' }));
   expectDeprecated(categoryChannel.createChannel('name', { type: 'GUILD_STORE' }));
   expectType<Promise<StageChannel>>(categoryChannel.createChannel('name', { type: 'GUILD_STAGE_VOICE' }));
-  expectType<Promise<TextChannel | VoiceChannel | NewsChannel | StoreChannel | StageChannel>>(
-    categoryChannel.createChannel('name', {}),
-  );
+  expectType<Promise<Exclude<NonThreadGuildBasedChannel, CategoryChannel>>>(categoryChannel.createChannel('name', {}));
+  expectType<Promise<Exclude<NonThreadGuildBasedChannel, CategoryChannel>>>(categoryChannel.createChannel('name'));
 }
 
 declare const guildChannelManager: GuildChannelManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes issue where if `type` isn't explicitly set in the options the return type wouldn't be a text channel.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
