### PR TITLE
refactor(GuildMember): throw better errors on #kickable and #bannable

### DIFF
--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -282,7 +282,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get kickable() {
-    if (!this.guild.me) return new Error('GUILD_UNCACHED_ME');
+    if (!this.guild.me) throw new Error('GUILD_UNCACHED_ME');
     return this.manageable && this.guild.me.permissions.has(Permissions.FLAGS.KICK_MEMBERS);
   }
 
@@ -292,7 +292,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get bannable() {
-    if (!this.guild.me) return new Error('GUILD_UNCACHED_ME');
+    if (!this.guild.me) throw new Error('GUILD_UNCACHED_ME');
     return this.manageable && this.guild.me.permissions.has(Permissions.FLAGS.BAN_MEMBERS);
   }
 

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -282,6 +282,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get kickable() {
+    if (!this.guild.me) return new Error('GUILD_UNCACHED_ME');
     return this.manageable && this.guild.me.permissions.has(Permissions.FLAGS.KICK_MEMBERS);
   }
 
@@ -291,6 +292,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get bannable() {
+    if (!this.guild.me) return new Error('GUILD_UNCACHED_ME');
     return this.manageable && this.guild.me.permissions.has(Permissions.FLAGS.BAN_MEMBERS);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR improves the error thrown on GuildMember#kickable and #bannable for when ClientUser's member object isn't cached.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
