### PR TITLE
fix(BaseMessageComponent): don't create new class instances

### DIFF
--- a/src/structures/BaseMessageComponent.js
+++ b/src/structures/BaseMessageComponent.js
@@ -66,17 +66,17 @@ class BaseMessageComponent {
     switch (type) {
       case MessageComponentTypes.ACTION_ROW: {
         const MessageActionRow = require('./MessageActionRow');
-        component = new MessageActionRow(data, client);
+        component = data instanceof MessageActionRow ? data : new MessageActionRow(data, client);
         break;
       }
       case MessageComponentTypes.BUTTON: {
         const MessageButton = require('./MessageButton');
-        component = new MessageButton(data);
+        component = data instanceof MessageButton ? data : new MessageButton(data);
         break;
       }
       case MessageComponentTypes.SELECT_MENU: {
         const MessageSelectMenu = require('./MessageSelectMenu');
-        component = new MessageSelectMenu(data);
+        component = data instanceof MessageSelectMenu ? data : new MessageSelectMenu(data);
         break;
       }
       default:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Feel free to give the PR a better title as I didn't know what to call this but this basically resolves #7139 by returning the component instance in BaseMessageComponent#create when the received data is already a discord.js class

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
