### PR TITLE
fix: Remove deprecation warning on `Message#cleanContent`

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -529,11 +529,7 @@ class Util extends null {
    * @deprecated Use {@link BaseMessageOptions#allowedMentions} instead.
    */
   static removeMentions(str) {
-    return Util._removeMentions(str, false);
-  }
-
-  static _removeMentions(str, fromCleanContent) {
-    if (!deprecationEmittedForRemoveMentions && !fromCleanContent) {
+    if (!deprecationEmittedForRemoveMentions) {
       process.emitWarning(
         'The Util.removeMentions method is deprecated. Use MessageOptions#allowedMentions instead.',
         'DeprecationWarning',
@@ -542,6 +538,10 @@ class Util extends null {
       deprecationEmittedForRemoveMentions = true;
     }
 
+    return Util._removeMentions(str);
+  }
+
+  static _removeMentions(str) {
     return str.replaceAll('@', '@\u200b');
   }
 
@@ -559,15 +559,15 @@ class Util extends null {
         const id = input.replace(/<|!|>|@/g, '');
         if (channel.type === 'DM') {
           const user = channel.client.users.cache.get(id);
-          return user ? Util._removeMentions(`@${user.username}`, true) : input;
+          return user ? Util._removeMentions(`@${user.username}`) : input;
         }
 
         const member = channel.guild.members.cache.get(id);
         if (member) {
-          return Util._removeMentions(`@${member.displayName}`, true);
+          return Util._removeMentions(`@${member.displayName}`);
         } else {
           const user = channel.client.users.cache.get(id);
-          return user ? Util._removeMentions(`@${user.username}`, true) : input;
+          return user ? Util._removeMentions(`@${user.username}`) : input;
         }
       })
       .replace(/<#[0-9]+>/g, input => {

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -529,7 +529,11 @@ class Util extends null {
    * @deprecated Use {@link BaseMessageOptions#allowedMentions} instead.
    */
   static removeMentions(str) {
-    if (!deprecationEmittedForRemoveMentions) {
+    return Util._removeMentions(str, false);
+  }
+
+  static _removeMentions(str, fromCleanContent) {
+    if (!deprecationEmittedForRemoveMentions && !fromCleanContent) {
       process.emitWarning(
         'The Util.removeMentions method is deprecated. Use MessageOptions#allowedMentions instead.',
         'DeprecationWarning',
@@ -555,15 +559,15 @@ class Util extends null {
         const id = input.replace(/<|!|>|@/g, '');
         if (channel.type === 'DM') {
           const user = channel.client.users.cache.get(id);
-          return user ? Util.removeMentions(`@${user.username}`) : input;
+          return user ? Util._removeMentions(`@${user.username}`, true) : input;
         }
 
         const member = channel.guild.members.cache.get(id);
         if (member) {
-          return Util.removeMentions(`@${member.displayName}`);
+          return Util._removeMentions(`@${member.displayName}`, true);
         } else {
           const user = channel.client.users.cache.get(id);
-          return user ? Util.removeMentions(`@${user.username}`) : input;
+          return user ? Util._removeMentions(`@${user.username}`, true) : input;
         }
       })
       .replace(/<#[0-9]+>/g, input => {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2416,7 +2416,7 @@ export class Util extends null {
   public static cleanContent(str: string, channel: TextBasedChannel): string;
   /** @deprecated Use {@link MessageOptions.allowedMentions} to control mentions in a message instead. */
   public static removeMentions(str: string): string;
-  private static _removeMentions(str: string, fromCleanContent: boolean): string;
+  private static _removeMentions(str: string): string;
   public static cloneObject(obj: unknown): unknown;
   public static discordSort<K, V extends { rawPosition: number; id: Snowflake }>(
     collection: Collection<K, V>,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2416,6 +2416,7 @@ export class Util extends null {
   public static cleanContent(str: string, channel: TextBasedChannel): string;
   /** @deprecated Use {@link MessageOptions.allowedMentions} to control mentions in a message instead. */
   public static removeMentions(str: string): string;
+  private static _removeMentions(str: string, fromCleanContent: boolean): string;
   public static cloneObject(obj: unknown): unknown;
   public static discordSort<K, V extends { rawPosition: number; id: Snowflake }>(
     collection: Collection<K, V>,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #7142.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
