### PR TITLE
fix(Permissions): toArray shouldn't check admin

### DIFF
--- a/src/util/Permissions.js
+++ b/src/util/Permissions.js
@@ -31,7 +31,7 @@ class Permissions extends BitField {
    * @returns {string[]}
    */
   missing(bits, checkAdmin = true) {
-    return checkAdmin && this.has(this.constructor.FLAGS.ADMINISTRATOR) ? [] : super.missing(bits, checkAdmin);
+    return checkAdmin && this.has(this.constructor.FLAGS.ADMINISTRATOR) ? [] : super.missing(bits);
   }
 
   /**
@@ -52,6 +52,14 @@ class Permissions extends BitField {
    */
   has(permission, checkAdmin = true) {
     return (checkAdmin && super.has(this.constructor.FLAGS.ADMINISTRATOR)) || super.has(permission);
+  }
+
+  /**
+   * Gets an {@link Array} of bitfield names based on the permissions available.
+   * @returns {string[]}
+   */
+  toArray() {
+    return super.toArray(false);
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1851,7 +1851,7 @@ export class Permissions extends BitField<PermissionString, bigint> {
   public has(permission: PermissionResolvable, checkAdmin?: boolean): boolean;
   public missing(bits: BitFieldResolvable<PermissionString, bigint>, checkAdmin?: boolean): PermissionString[];
   public serialize(checkAdmin?: boolean): Record<PermissionString, boolean>;
-  public toArray(checkAdmin?: boolean): PermissionString[];
+  public toArray(): PermissionString[];
 
   public static ALL: bigint;
   public static DEFAULT: bigint;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When a member is an administrator, he does have all permissions but it's still possible to add/remove other permissions. Although it doesn't have any effect, the bitfield is still different and the `toArray()` method should return the permissions of the bitfield.
This can be done by passing `false` to the `toArray()` call.
This change also resolves #6267, which seems a regression added in #5911.

I've also considered defaulting the `checkAdmin` parameter to false in `Permissions#toArray()` but it would be inconsistent with other methods and useless as I don't see any use case where an array with all the flags is needed for an administrator and could be confused with a person with really every permission.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating