### PR TITLE
fix(GuildMemberManager): nick endpoint

### DIFF
--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -263,8 +263,10 @@ class GuildMemberManager extends CachedManager {
     }
     _data.roles &&= _data.roles.map(role => (role instanceof Role ? role.id : role));
 
-    _data.communication_disabled_until =
-      _data.communicationDisabledUntil && new Date(_data.communicationDisabledUntil).toISOString();
+    if (typeof _data.communicationDisabledUntil !== 'undefined') {
+      _data.communication_disabled_until =
+        _data.communicationDisabledUntil && new Date(_data.communicationDisabledUntil).toISOString();
+    }
 
     let endpoint = this.client.api.guilds(this.guild.id);
     if (id === this.client.user.id) {

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -263,9 +263,10 @@ class GuildMemberManager extends CachedManager {
     }
     _data.roles &&= _data.roles.map(role => (role instanceof Role ? role.id : role));
 
-    if (typeof _data.communicationDisabledUntil !== 'undefined') {
-      _data.communication_disabled_until =
-        _data.communicationDisabledUntil && new Date(_data.communicationDisabledUntil).toISOString();
+    if (_data.communicationDisabledUntil) {
+      _data.communication_disabled_until = new Date(_data.communicationDisabledUntil).toISOString();
+    } else if (_data.communicationDisabledUntil === null) {
+      _data.communication_disabled_until = null;
     }
 
     let endpoint = this.client.api.guilds(this.guild.id);

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -263,15 +263,12 @@ class GuildMemberManager extends CachedManager {
     }
     _data.roles &&= _data.roles.map(role => (role instanceof Role ? role.id : role));
 
-    if (_data.communicationDisabledUntil) {
-      _data.communication_disabled_until = new Date(_data.communicationDisabledUntil).toISOString();
-    } else if (_data.communicationDisabledUntil === null) {
-      _data.communication_disabled_until = null;
-    }
+    _data.communication_disabled_until =
+      _data.communicationDisabledUntil && new Date(_data.communicationDisabledUntil).toISOString();
 
     let endpoint = this.client.api.guilds(this.guild.id);
     if (id === this.client.user.id) {
-      const keys = Object.keys(_data);
+      const keys = Object.keys(data);
       if (keys.length === 1 && keys[0] === 'nick') endpoint = endpoint.members('@me');
       else endpoint = endpoint.members(id);
     } else {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#7104 introduced a regression to `Guild#me#setNickname` since `communication_disabled_until` is always added to `_data`, even if `communicationDisabledUntil` is `undefined`. Due to this `Object.keys(_data).length` will be 2 and the check in line 272/274 won't add `@me` to the endpoint.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
