### PR TITLE
refactor(MessageEmbed): Deprecate strings for `setAuthor()` (completely) and `setFooter()`

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -4,6 +4,9 @@ const { RangeError } = require('../errors');
 const Util = require('../util/Util');
 
 let deprecationEmittedForSetAuthor = false;
+let deprecationEmittedForSetFooter = false;
+
+// TODO: Remove the deprecated code for `setAuthor()` and `setMethod()`.
 
 /**
  * Represents an embed in a message (image/video preview, rich embed, etc.)
@@ -355,11 +358,9 @@ class MessageEmbed {
    * @property {string} [iconURL] The icon URL of this author.
    */
 
-  // TODO: Remove the deprecated code in the following method and typings.
   /**
    * Sets the author of this embed.
    * @param {string|EmbedAuthorData|null} options The options to provide for the author.
-   * A string may simply be provided if only the author name is desirable.
    * Provide `null` to remove the author data.
    * @param {string} [deprecatedIconURL] The icon URL of this author.
    * <warn>This parameter is **deprecated**. Use the `options` parameter instead.</warn>
@@ -374,13 +375,9 @@ class MessageEmbed {
     }
 
     if (typeof options === 'string') {
-      if (
-        !deprecationEmittedForSetAuthor &&
-        (typeof deprecatedIconURL !== 'undefined' || typeof deprecatedURL !== 'undefined')
-      ) {
+      if (!deprecationEmittedForSetAuthor) {
         process.emitWarning(
-          // eslint-disable-next-line max-len
-          "Passing strings for the URL or the icon's URL for MessageEmbed#setAuthor is deprecated. Pass a sole object instead.",
+          'Passing strings for MessageEmbed#setAuthor is deprecated. Pass a sole object instead.',
           'DeprecationWarning',
         );
 
@@ -416,12 +413,40 @@ class MessageEmbed {
   }
 
   /**
+   * The options to provide for setting a footer for a {@link MessageEmbed}.
+   * @typedef {Object} EmbedFooterData
+   * @property {string} text The text of the footer.
+   * @property {string} [iconURL] The icon URL of the footer.
+   */
+
+  /**
    * Sets the footer of this embed.
-   * @param {string} text The text of the footer
-   * @param {string} [iconURL] The icon URL of the footer
+   * @param {string|EmbedFooterData|null} options The options to provide for the footer.
+   * Provide `null` to remove the footer data.
+   * @param {string} [deprecatedIconURL] The icon URL of this footer.
+   * <warn>This parameter is **deprecated**. Use the `options` parameter instead.</warn>
    * @returns {MessageEmbed}
    */
-  setFooter(text, iconURL) {
+  setFooter(options, deprecatedIconURL) {
+    if (options === null) {
+      this.footer = {};
+      return this;
+    }
+
+    if (typeof options === 'string') {
+      if (!deprecationEmittedForSetFooter) {
+        process.emitWarning(
+          'Passing strings for MessageEmbed#setFooter is deprecated. Pass a sole object instead.',
+          'DeprecationWarning',
+        );
+
+        deprecationEmittedForSetFooter = true;
+      }
+
+      options = { text: options, iconURL: deprecatedIconURL };
+    }
+
+    const { text, iconURL } = options;
     this.footer = { text: Util.verifyString(text, RangeError, 'EMBED_FOOTER_TEXT'), iconURL };
     return this;
   }

--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -6,7 +6,7 @@ const Util = require('../util/Util');
 let deprecationEmittedForSetAuthor = false;
 let deprecationEmittedForSetFooter = false;
 
-// TODO: Remove the deprecated code for `setAuthor()` and `setMethod()`.
+// TODO: Remove the deprecated code for `setAuthor()` and `setFooter()`.
 
 /**
  * Represents an embed in a message (image/video preview, rich embed, etc.)

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4316,7 +4316,7 @@ export interface EmbedFieldData {
 }
 
 export interface EmbedFooterData {
-  name: string;
+  text: string;
   iconURL?: string;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1689,11 +1689,13 @@ export class MessageEmbed {
   public addField(name: string, value: string, inline?: boolean): this;
   public addFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
   public setFields(...fields: EmbedFieldData[] | EmbedFieldData[][]): this;
-  public setAuthor(options: string | EmbedAuthorData | null): this;
-  /** @deprecated Supply a lone object of interface {@link EmbedAuthorData} instead of more parameters. */
+  public setAuthor(options: EmbedAuthorData | null): this;
+  /** @deprecated Supply a lone object of interface {@link EmbedAuthorData} instead. */
   public setAuthor(name: string, iconURL?: string, url?: string): this;
   public setColor(color: ColorResolvable): this;
   public setDescription(description: string): this;
+  public setFooter(options: EmbedFooterData | null): this;
+  /** @deprecated Supply a lone object of interface {@link EmbedFooterData} instead. */
   public setFooter(text: string, iconURL?: string): this;
   public setImage(url: string): this;
   public setThumbnail(url: string): this;
@@ -4311,6 +4313,11 @@ export interface EmbedFieldData {
   name: string;
   value: string;
   inline?: boolean;
+}
+
+export interface EmbedFooterData {
+  name: string;
+  iconURL?: string;
 }
 
 export type EmojiIdentifierResolvable = string | EmojiResolvable;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Due to #7067, `setAuthor()` and `setFooter()` should only passing objects and not strings as per the builder's implementation. This pull request deprecates the passing of strings.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
