### PR TITLE
docs(Sweepers): fix typo

### DIFF
--- a/src/util/Sweepers.js
+++ b/src/util/Sweepers.js
@@ -353,7 +353,7 @@ class Sweepers {
 
   /**
    * Creates a sweep filter that sweeps outdated messages (edits taken into account)
-   * @param {number} [lifetime=3600] How long ago a message has to hvae been sent or  edited to be valid for sweeping
+   * @param {number} [lifetime=3600] How long ago a message has to have been sent or edited to be valid for sweeping
    * @returns {GlobalSweepFilter}
    */
   static outdatedMessageSweepFilter(lifetime = 3600) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes the typo "hvae" to "have" and removes an extra space which were both introduced in [#6825](https://github.com/discordjs/discord.js/pull/6825).


**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
