### PR TITLE
docs(RoleManager): fix incorrect example

### DIFF
--- a/packages/discord.js/src/managers/RoleManager.js
+++ b/packages/discord.js/src/managers/RoleManager.js
@@ -227,7 +227,7 @@ class RoleManager extends CachedManager {
    * @example
    * // Delete a role
    * guild.roles.delete('222079219327434752', 'The role needed to go')
-   *   .then(deleted => console.log(`Deleted role ${deleted.name}`))
+   *   .then(() => console.log('Deleted the role'))
    *   .catch(console.error);
    */
   async delete(role, reason) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the example provided in `RoleManger#delete()` where `deleted` is used as a `Role` when it is `undefined`


**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

