### PR TITLE
types(Collection): union types on `intersect` and `difference`

### DIFF
--- a/packages/collection/src/index.ts
+++ b/packages/collection/src/index.ts
@@ -629,8 +629,8 @@ export class Collection<K, V> extends Map<K, V> {
 	 *
 	 * @param other The other Collection to filter against
 	 */
-	public intersect(other: Collection<K, V>) {
-		const coll = new this.constructor[Symbol.species]<K, V>();
+	public intersect<T>(other: Collection<K, T>): Collection<K, T> {
+		const coll = new this.constructor[Symbol.species]<K, T>();
 		for (const [k, v] of other) {
 			if (this.has(k)) coll.set(k, v);
 		}
@@ -642,8 +642,8 @@ export class Collection<K, V> extends Map<K, V> {
 	 *
 	 * @param other The other Collection to filter against
 	 */
-	public difference(other: Collection<K, V>) {
-		const coll = new this.constructor[Symbol.species]<K, V>();
+	public difference<T>(other: Collection<K, T>): Collection<K, V | T> {
+		const coll = new this.constructor[Symbol.species]<K, V | T>();
 		for (const [k, v] of other) {
 			if (!this.has(k)) coll.set(k, v);
 		}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`intersect` and `difference` can now accept collections with different value types.

**Status and versioning classification:**
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating