### PR TITLE
fix(WebSocket): Remove application command handler

### DIFF
--- a/packages/discord.js/src/client/websocket/handlers/index.js
+++ b/packages/discord.js/src/client/websocket/handlers/index.js
@@ -3,9 +3,6 @@
 const handlers = Object.fromEntries([
   ['READY', require('./READY')],
   ['RESUMED', require('./RESUMED')],
-  ['APPLICATION_COMMAND_CREATE', require('./APPLICATION_COMMAND_CREATE')],
-  ['APPLICATION_COMMAND_DELETE', require('./APPLICATION_COMMAND_DELETE')],
-  ['APPLICATION_COMMAND_UPDATE', require('./APPLICATION_COMMAND_UPDATE')],
   ['GUILD_CREATE', require('./GUILD_CREATE')],
   ['GUILD_DELETE', require('./GUILD_DELETE')],
   ['GUILD_UPDATE', require('./GUILD_UPDATE')],


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
* #6492

After above pull request, all handlers related to application command have been completely removed.

This PR remove the remaining codes that handles removed event.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
