### PR TITLE
ci(documentation): add repository_owner check

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: Build documentation
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'discordjs'
     outputs:
       BRANCH_NAME: ${{ steps.env.outputs.BRANCH_NAME }}
       BRANCH_OR_TAG: ${{ steps.env.outputs.BRANCH_OR_TAG }}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#7175 tweaked the documentation CI which now requires the DJS_DOCS secret, which obviously doesn't exist on forks and thus causes the action to fail there. Despite not breaking anything on the main repo, this is a bit annoying for contributors so it's just a small QOL change to address that.
No other CI *needs* this fix since none of them fails without the required tokens but I could add them to prevent them from running if you wish

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
