### PR TITLE
typings: include base class in `GuildVoiceChannelResolvable`

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4790,7 +4790,7 @@ export interface GuildScheduledEventUser<T> {
 
 export type GuildTemplateResolvable = string;
 
-export type GuildVoiceChannelResolvable = VoiceBasedChannel | Snowflake;
+export type GuildVoiceChannelResolvable = VoiceBasedChannel | BaseGuildVoiceChannel | Snowflake;
 
 export type HexColorString = `#${string}`;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently, something like this will throw type errors:

```ts
const channel: GuildChannel;
const member: GuildMember
if (channel.isVoice()) {
  member.voice.setChannel(channel);
}
```

because `isVoice` type guards channel to `BaseGuildVoiceChannel`, and `setChannel`'s takes `VoiceBasedChannel | Snowflake` which resolves to `VoiceChannel | StageChannel | string` - none of which are compatible with `BaseGuildVoiceChannel`.

I'm not sure this is the right approach in the long run, since I think there's something fundamentally wrong with how voice channels are typed compared to the typing of text channels, but this should work fine as a hotfix.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
