### PR TITLE
refactor(subcommandgroup): required default to false

### DIFF
--- a/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
+++ b/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
@@ -116,10 +116,10 @@ class CommandInteractionOptionResolver {
 
   /**
    * Gets the selected subcommand group.
-   * @param {boolean} [required=true] Whether to throw an error if there is no subcommand group.
+   * @param {boolean} [required=false] Whether to throw an error if there is no subcommand group.
    * @returns {?string} The name of the selected subcommand group, or null if not set and not required.
    */
-  getSubcommandGroup(required = true) {
+  getSubcommandGroup(required = false) {
     if (required && !this._group) {
       throw new TypeError('COMMAND_INTERACTION_OPTION_NO_SUB_COMMAND_GROUP');
     }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -688,8 +688,8 @@ export interface ApplicationCommandInteractionOptionResolver<Cached extends Cach
   extends CommandInteractionOptionResolver<Cached> {
   getSubcommand(required?: true): string;
   getSubcommand(required: boolean): string | null;
-  getSubcommandGroup(required?: true): string;
-  getSubcommandGroup(required: boolean): string | null;
+  getSubcommandGroup(required: true): string;
+  getSubcommandGroup(required?: boolean): string | null;
   getBoolean(name: string, required: true): boolean;
   getBoolean(name: string, required?: boolean): boolean | null;
   getChannel(name: string, required: true): NonNullable<CommandInteractionOption<Cached>['channel']>;
@@ -764,8 +764,8 @@ export class CommandInteractionOptionResolver<Cached extends CacheType = CacheTy
 
   public getSubcommand(required?: true): string;
   public getSubcommand(required: boolean): string | null;
-  public getSubcommandGroup(required?: true): string;
-  public getSubcommandGroup(required: boolean): string | null;
+  public getSubcommandGroup(required: true): string;
+  public getSubcommandGroup(required?: boolean): string | null;
   public getBoolean(name: string, required: true): boolean;
   public getBoolean(name: string, required?: boolean): boolean | null;
   public getChannel(name: string, required: true): NonNullable<CommandInteractionOption<Cached>['channel']>;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1118,8 +1118,8 @@ client.on('interactionCreate', async interaction => {
     expectType<string | null>(interaction.options.getSubcommand(booleanValue));
     expectType<string | null>(interaction.options.getSubcommand(false));
 
-    expectType<string>(interaction.options.getSubcommandGroup());
     expectType<string>(interaction.options.getSubcommandGroup(true));
+    expectType<string | null>(interaction.options.getSubcommandGroup());
     expectType<string | null>(interaction.options.getSubcommandGroup(booleanValue));
     expectType<string | null>(interaction.options.getSubcommandGroup(false));
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

All other getX methods required is default to false. But for `subCommand` and `subCommandGroup` it's true.
`getSubCommand` have a valid reason that it's default to true because if there is no subCommand then why you are trying to get the value. But `getSubCommandGroup` is different.

Here's an example of how it's different,
```js
{
name: "name",
description: "description",
type: 1,
options: []
},
{
name: "name-group",
description: "description",
type: 2,
options: [
      {
          name: "name",
          description: "description",
          type: 1,
          options: []
      },
]
},
```
Here when a user uses `name` subCommand (1st one) and I try to check which `name` command was used, so I'll check `interaction.options.getSubCommandGroup()` first,  but it'll throw error because group is empty, but I've a subCommandGroup for this command.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
