### PR TITLE
fix(MessageEmbed): createdAt field can be zero

### DIFF
--- a/packages/discord.js/src/structures/MessageEmbed.js
+++ b/packages/discord.js/src/structures/MessageEmbed.js
@@ -88,7 +88,7 @@ class MessageEmbed {
      * @type {?number}
      */
     // Date.parse() cannot be used here because data.timestamp might be a number
-    this.timestamp = 'timestamp' in data ? new Date(data.timestamp).getTime() : null;
+    this.timestamp = new Date(data.timestamp).getTime() || null;
 
     /**
      * Represents a field of a MessageEmbed
@@ -515,7 +515,7 @@ class MessageEmbed {
       type: 'rich',
       description: this.description,
       url: this.url,
-      timestamp: this.createdAt?.toISOString?.(),
+      timestamp: this.createdAt?.toISOString(),
       color: this.color,
       fields: this.fields,
       thumbnail: this.thumbnail,

--- a/packages/discord.js/src/structures/MessageEmbed.js
+++ b/packages/discord.js/src/structures/MessageEmbed.js
@@ -515,7 +515,7 @@ class MessageEmbed {
       type: 'rich',
       description: this.description,
       url: this.url,
-      timestamp: this.createdAt?.toISOString(),
+      timestamp: this.createdAt?.toISOString?.(),
       color: this.color,
       fields: this.fields,
       thumbnail: this.thumbnail,

--- a/packages/discord.js/src/structures/MessageEmbed.js
+++ b/packages/discord.js/src/structures/MessageEmbed.js
@@ -88,6 +88,7 @@ class MessageEmbed {
      * @type {?number}
      */
     // Date.parse() cannot be used here because data.timestamp might be a number
+    // Additionally, the nullish coalescing operator cannot be used here as we're checking for 0
     this.timestamp = new Date(data.timestamp).getTime() || null;
 
     /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
* #7108

After above PR, `createdAt` field can be a number 0. It will result in an error since `Number` class doesn't have `toISOString` method.

This PR changes the value of `timestamp` field, to deal with number zero.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
