### PR TITLE
chore: allow typescript to typecheck .d.ts files

### DIFF
--- a/packages/discord.js/tsconfig.json
+++ b/packages/discord.js/tsconfig.json
@@ -5,7 +5,6 @@
     "pretty": false,
 
     // Completeness
-    "skipDefaultLibCheck": true,
-    "skipLibCheck": false
+    "skipDefaultLibCheck": true
   }
 }

--- a/packages/discord.js/tsconfig.json
+++ b/packages/discord.js/tsconfig.json
@@ -5,6 +5,7 @@
     "pretty": false,
 
     // Completeness
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": false
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,9 +38,6 @@
 		"experimentalDecorators": true,
 		"lib": ["ESNext"],
 		"target": "ES2021",
-		"useDefineForClassFields": true,
-
-		// Completeness
-		"skipLibCheck": true
+		"useDefineForClassFields": true
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`skipLibCheck` needs to be false in discord.js.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
