### PR TITLE
docs(SlashCommandSubcommands): updating old links from Discord developer portal

### DIFF
--- a/packages/builders/src/interactions/slashCommands/SlashCommandSubcommands.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandSubcommands.ts
@@ -13,7 +13,7 @@ import type { ToAPIApplicationCommandOptions } from './SlashCommandBuilder';
 /**
  * Represents a folder for subcommands
  *
- * For more information, go to https://discord.com/developers/docs/interactions/slash-commands#subcommands-and-subcommand-groups
+ * For more information, go to https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups
  */
 @mix(SharedNameAndDescription)
 export class SlashCommandSubcommandGroupBuilder implements ToAPIApplicationCommandOptions {
@@ -75,7 +75,7 @@ export interface SlashCommandSubcommandGroupBuilder extends SharedNameAndDescrip
 /**
  * Represents a subcommand
  *
- * For more information, go to https://discord.com/developers/docs/interactions/slash-commands#subcommands-and-subcommand-groups
+ * For more information, go to https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups
  */
 @mix(SharedNameAndDescription, SharedSlashCommandOptions)
 export class SlashCommandSubcommandBuilder implements ToAPIApplicationCommandOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes the old Discord developer portal link `interactions/slash-commands` to the new page `interactions/application-commands`.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
