### PR TITLE
fix(timestamps): account for timestamps of 0 when creating Dates

### DIFF
--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -266,7 +266,10 @@ class GuildMemberManager extends CachedManager {
     _data.roles &&= _data.roles.map(role => (role instanceof Role ? role.id : role));
 
     _data.communication_disabled_until =
-      _data.communicationDisabledUntil && new Date(_data.communicationDisabledUntil).toISOString();
+      // eslint-disable-next-line eqeqeq
+      _data.communicationDisabledUntil != null
+        ? new Date(_data.communicationDisabledUntil).toISOString()
+        : _data.communicationDisabledUntil;
 
     let endpoint = this.client.api.guilds(this.guild.id);
     if (id === this.client.user.id) {

--- a/packages/discord.js/src/structures/MessageEmbed.js
+++ b/packages/discord.js/src/structures/MessageEmbed.js
@@ -88,8 +88,8 @@ class MessageEmbed {
      * @type {?number}
      */
     // Date.parse() cannot be used here because data.timestamp might be a number
-    // Additionally, the nullish coalescing operator cannot be used here as we're checking for 0
-    this.timestamp = new Date(data.timestamp).getTime() || null;
+    // eslint-disable-next-line eqeqeq
+    this.timestamp = data.timestamp != null ? new Date(data.timestamp).getTime() : null;
 
     /**
      * Represents a field of a MessageEmbed
@@ -242,7 +242,7 @@ class MessageEmbed {
    * @readonly
    */
   get createdAt() {
-    return this.timestamp && new Date(this.timestamp);
+    return typeof this.timestamp === 'number' ? new Date(this.timestamp) : null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
For some reason, @kyranet's suggestion in #7218 was ignored so this PR fixes all instances where timestamps could be 0 on the library. I had to disable the eqeqeq rule for this in order to check for null and undefined timestamps but if you have a better idea please let me know.

Note about the change on the GuildMemberManager file: Discord throws an error when passing a timestamp that is more than 28 days in the past or the future, however, without this fix you'd be able to pass 0 and get no error, as the API would treat that as null which ends up doing the same thing but is not exactly the expected behavior. With this fix, we transform every timestamp into an ISO string and let Discord error when it should. I'll gladly undo this if you think it's necessary however

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
