### PR TITLE
refactor(embeds): don't create new embed instances when unnecessary

### DIFF
--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -192,7 +192,9 @@ class MessagePayload {
       content,
       tts,
       nonce,
-      embeds: this.options.embeds?.map(embed => new MessageEmbed(embed).toJSON()),
+      embeds: this.options.embeds?.map(embed =>
+        (embed instanceof MessageEmbed ? embed : new MessageEmbed(embed)).toJSON(),
+      ),
       components,
       username,
       avatar_url: avatarURL,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Just like in #7140, this PR avoids creating new MessageEmbed instances when sending a message if the given embed is already a MessageEmbed object

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
