### PR TITLE
chore: optimize Turbo pipelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"husky": "^7.0.4",
 		"lint-staged": "^12.1.7",
 		"prettier": "^2.5.1",
-		"turbo": "^1.0.24-canary.2"
+		"turbo": "^1.0.24"
 	},
 	"engines": {
 		"node": ">=16.9.0"
@@ -67,20 +67,33 @@
 				]
 			},
 			"test": {
+				"outputs": [
+					"coverage/**"
+				]
+			},
+			"rest#test": {
 				"dependsOn": [
-					"^build"
+					"build"
 				],
-				"outputs": []
+				"outputs": [
+					"coverage/**"
+				]
 			},
 			"lint": {
+				"outputs": []
+			},
+			"rest#lint": {
 				"dependsOn": [
-					"^build"
+					"build"
 				],
 				"outputs": []
 			},
 			"lint:fix": {
+				"outputs": []
+			},
+			"rest#lint:fix": {
 				"dependsOn": [
-					"^build"
+					"build"
 				],
 				"outputs": []
 			},

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -4,7 +4,7 @@
 	"description": "The REST API for discord.js",
 	"scripts": {
 		"build": "tsup && tsc --emitDeclarationOnly --incremental",
-		"test": " jest --pass-with-no-tests --collect-coverage",
+		"test": "jest --pass-with-no-tests --collect-coverage",
 		"lint": "eslint src __tests__ --ext mjs,js,ts",
 		"lint:fix": "eslint src __tests__ --ext mjs,js,ts --fix",
 		"format": "prettier --write .",

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -4,7 +4,7 @@
 	"description": "Implementation of the Discord Voice API for node.js",
 	"scripts": {
 		"build": "tsup && node scripts/postbuild.mjs",
-		"test": " jest --pass-with-no-tests --collect-coverage",
+		"test": "jest --pass-with-no-tests --collect-coverage",
 		"lint": "eslint src --ext mjs,js,ts",
 		"lint:fix": "eslint src --ext mjs,js,ts --fix",
 		"format": "prettier --write .",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7667,7 +7667,7 @@ turbo-windows-64@1.0.24:
   resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.0.24.tgz#5dd30b10110f2bb69caa479ddd72b4c471fb0dea"
   integrity sha512-YHAWha5XkW0Ate1HtwhzFD32kZFXtC8KB4ReEvHc9GM2inQob1ZinvktS0xi5MC5Sxl9+bObOWmsxeZPOgNCFA==
 
-turbo@^1.0.24-canary.2:
+turbo@^1.0.24:
   version "1.0.24"
   resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.0.24.tgz#5efdeb44aab2f5e97b24a3e0ed4a159bfcd0a877"
   integrity sha512-bfOr7iW48+chDl+yKiZ5FIWzXOF6xOIyrAGPaWI+I5CdD27IZCEGvqvTV/weaHvjLbV7otybHQ56XCybBlVjoA==


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `rest` package is the only one which requires the build script to run before testing or linting.
This changes the Turborepo pipeline to avoid running `build` to test/lint packages that don't require it.

Also, 2 unrelated formatting errors in the `test` scripts.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.