### PR TITLE
refactor(files): file data can be much more than buffer

### DIFF
--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -115,10 +115,10 @@ test('postFile empty', async () => {
 	});
 });
 
-test('postFile file', async () => {
+test('postFile file (string)', async () => {
 	expect(
 		await api.post('/postFile', {
-			files: [{ fileName: 'out.txt', rawBuffer: Buffer.from('Hello') }],
+			files: [{ fileName: 'out.txt', fileData: 'Hello' }],
 		}),
 	).toStrictEqual({
 		body: [
@@ -133,7 +133,7 @@ test('postFile file', async () => {
 test('postFile file and JSON', async () => {
 	expect(
 		await api.post('/postFile', {
-			files: [{ fileName: 'out.txt', rawBuffer: Buffer.from('Hello') }],
+			files: [{ fileName: 'out.txt', fileData: Buffer.from('Hello') }],
 			body: { foo: 'bar' },
 		}),
 	).toStrictEqual({
@@ -153,8 +153,8 @@ test('postFile files and JSON', async () => {
 	expect(
 		await api.post('/postFile', {
 			files: [
-				{ fileName: 'out.txt', rawBuffer: Buffer.from('Hello') },
-				{ fileName: 'out.txt', rawBuffer: Buffer.from('Hi') },
+				{ fileName: 'out.txt', fileData: Buffer.from('Hello') },
+				{ fileName: 'out.txt', fileData: Buffer.from('Hi') },
 			],
 			body: { files: [{ id: 0, description: 'test' }] },
 		}),
@@ -178,7 +178,7 @@ test('postFile files and JSON', async () => {
 test('postFile sticker and JSON', async () => {
 	expect(
 		await api.post('/postFile', {
-			files: [{ key: 'file', fileName: 'sticker.png', rawBuffer: Buffer.from('Sticker') }],
+			files: [{ key: 'file', fileName: 'sticker.png', fileData: Buffer.from('Sticker') }],
 			body: { foo: 'bar' },
 			appendToFormData: true,
 		}),

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -8,8 +8,6 @@ import type { IHandler } from './handlers/IHandler';
 import { SequentialHandler } from './handlers/SequentialHandler';
 import type { RESTOptions, RestEvents } from './REST';
 import { DefaultRestOptions, DefaultUserAgent } from './utils/constants';
-import type { ReadStream } from 'fs';
-import type { ServerResponse } from 'http';
 
 let agent: Agent | null = null;
 
@@ -30,7 +28,7 @@ export interface RawFile {
 	/**
 	 * The actual data for the file
 	 */
-	fileData: string | number | boolean | Buffer | ReadStream | ServerResponse;
+	fileData: string | number | boolean | Buffer;
 }
 
 /**

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -8,6 +8,8 @@ import type { IHandler } from './handlers/IHandler';
 import { SequentialHandler } from './handlers/SequentialHandler';
 import type { RESTOptions, RestEvents } from './REST';
 import { DefaultRestOptions, DefaultUserAgent } from './utils/constants';
+import type { ReadStream } from 'fs';
+import type { ServerResponse } from 'http';
 
 let agent: Agent | null = null;
 
@@ -28,7 +30,7 @@ export interface RawFile {
 	/**
 	 * The actual data for the file
 	 */
-	rawBuffer: Buffer;
+	fileData: string | number | boolean | Buffer | ReadStream | ServerResponse;
 }
 
 /**
@@ -280,7 +282,7 @@ export class RequestManager extends EventEmitter {
 
 			// Attach all files to the request
 			for (const [index, file] of request.files.entries()) {
-				formData.append(file.key ?? `files[${index}]`, file.rawBuffer, file.fileName);
+				formData.append(file.key ?? `files[${index}]`, file.fileData, file.fileName);
 			}
 
 			// If a JSON body was added as well, attach it to the form data, using payload_json unless otherwise specified


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The data for a file is directly appended to formdata, which accepts a multitude of types, not just a buffer, this corrects the types and changes the name of the property accordingly (not every single stream type is covered, but it is the natively supported set)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
