### PR TITLE
fix(Shard): EventEmitter listener warning

### DIFF
--- a/packages/discord.js/src/sharding/Shard.js
+++ b/packages/discord.js/src/sharding/Shard.js
@@ -417,7 +417,7 @@ class Shard extends EventEmitter {
 
   /**
    * Increments max listeners by one for a given emitter, if they are not zero.
-   * @param {EventEmitter | process} emitter The emitter that emits the events.
+   * @param {EventEmitter|process} emitter The emitter that emits the events.
    * @private
    */
   incrementMaxListeners(emitter) {

--- a/packages/discord.js/src/sharding/Shard.js
+++ b/packages/discord.js/src/sharding/Shard.js
@@ -429,7 +429,7 @@ class Shard extends EventEmitter {
 
   /**
    * Decrements max listeners by one for a given emitter, if they are not zero.
-   * @param {EventEmitter | process} emitter The emitter that emits the events.
+   * @param {EventEmitter|process} emitter The emitter that emits the events.
    * @private
    */
   decrementMaxListeners(emitter) {

--- a/packages/discord.js/src/sharding/Shard.js
+++ b/packages/discord.js/src/sharding/Shard.js
@@ -417,7 +417,7 @@ class Shard extends EventEmitter {
 
   /**
    * Increments max listeners by one for a given emitter, if they are not zero.
-   * @param {EventEmitter | process} emitter
+   * @param {EventEmitter | process} emitter The emitter that emits the events.
    * @private
    */
   incrementMaxListeners(emitter) {
@@ -429,7 +429,7 @@ class Shard extends EventEmitter {
 
   /**
    * Decrements max listeners by one for a given emitter, if they are not zero.
-   * @param {EventEmitter | process} emitter
+   * @param {EventEmitter | process} emitter The emitter that emits the events.
    * @private
    */
   decrementMaxListeners(emitter) {

--- a/packages/discord.js/src/sharding/Shard.js
+++ b/packages/discord.js/src/sharding/Shard.js
@@ -417,6 +417,7 @@ class Shard extends EventEmitter {
 
   /**
    * Increments max listeners by one for a given emitter, if they are not zero.
+   * @param {EventEmitter | process} emitter
    * @private
    */
   incrementMaxListeners(emitter) {
@@ -428,6 +429,7 @@ class Shard extends EventEmitter {
 
   /**
    * Decrements max listeners by one for a given emitter, if they are not zero.
+   * @param {EventEmitter | process} emitter
    * @private
    */
   decrementMaxListeners(emitter) {

--- a/packages/discord.js/src/sharding/Shard.js
+++ b/packages/discord.js/src/sharding/Shard.js
@@ -249,14 +249,18 @@ class Shard extends EventEmitter {
       const listener = message => {
         if (message?._fetchProp !== prop) return;
         child.removeListener('message', listener);
+        this.decrementMaxListeners(child);
         this._fetches.delete(prop);
         if (!message._error) resolve(message._result);
         else reject(Util.makeError(message._error));
       };
+
+      this.incrementMaxListeners(child);
       child.on('message', listener);
 
       this.send({ _fetchProp: prop }).catch(err => {
         child.removeListener('message', listener);
+        this.decrementMaxListeners(child);
         this._fetches.delete(prop);
         reject(err);
       });
@@ -288,14 +292,18 @@ class Shard extends EventEmitter {
       const listener = message => {
         if (message?._eval !== _eval) return;
         child.removeListener('message', listener);
+        this.decrementMaxListeners(child);
         this._evals.delete(_eval);
         if (!message._error) resolve(message._result);
         else reject(Util.makeError(message._error));
       };
+
+      this.incrementMaxListeners(child);
       child.on('message', listener);
 
       this.send({ _eval }).catch(err => {
         child.removeListener('message', listener);
+        this.decrementMaxListeners(child);
         this._evals.delete(_eval);
         reject(err);
       });
@@ -405,6 +413,28 @@ class Shard extends EventEmitter {
     this._fetches.clear();
 
     if (respawn) this.spawn(timeout).catch(err => this.emit('error', err));
+  }
+
+  /**
+   * Increments max listeners by one for a given emitter, if they are not zero.
+   * @private
+   */
+  incrementMaxListeners(emitter) {
+    const maxListeners = emitter.getMaxListeners();
+    if (maxListeners !== 0) {
+      emitter.setMaxListeners(maxListeners + 1);
+    }
+  }
+
+  /**
+   * Decrements max listeners by one for a given emitter, if they are not zero.
+   * @private
+   */
+  decrementMaxListeners(emitter) {
+    const maxListeners = emitter.getMaxListeners();
+    if (maxListeners !== 0) {
+      emitter.setMaxListeners(maxListeners - 1);
+    }
   }
 }
 

--- a/packages/discord.js/src/sharding/ShardClientUtil.js
+++ b/packages/discord.js/src/sharding/ShardClientUtil.js
@@ -111,13 +111,16 @@ class ShardClientUtil {
       const listener = message => {
         if (message?._sFetchProp !== prop || message._sFetchPropShard !== shard) return;
         parent.removeListener('message', listener);
+        this.decrementMaxListeners(parent);
         if (!message._error) resolve(message._result);
         else reject(Util.makeError(message._error));
       };
+      this.incrementMaxListeners(parent);
       parent.on('message', listener);
 
       this.send({ _sFetchProp: prop, _sFetchPropShard: shard }).catch(err => {
         parent.removeListener('message', listener);
+        this.decrementMaxListeners(parent);
         reject(err);
       });
     });
@@ -146,13 +149,15 @@ class ShardClientUtil {
       const listener = message => {
         if (message?._sEval !== script || message._sEvalShard !== options.shard) return;
         parent.removeListener('message', listener);
+        this.decrementMaxListeners(parent);
         if (!message._error) resolve(message._result);
         else reject(Util.makeError(message._error));
       };
+      this.incrementMaxListeners(parent);
       parent.on('message', listener);
-
       this.send({ _sEval: script, _sEvalShard: options.shard }).catch(err => {
         parent.removeListener('message', listener);
+        this.decrementMaxListeners(parent);
         reject(err);
       });
     });
@@ -240,6 +245,28 @@ class ShardClientUtil {
     const shard = Number(BigInt(guildId) >> 22n) % shardCount;
     if (shard < 0) throw new Error('SHARDING_SHARD_MISCALCULATION', shard, guildId, shardCount);
     return shard;
+  }
+
+  /**
+   * Increments max listeners by one for a given emitter, if they are not zero.
+   * @private
+   */
+  incrementMaxListeners(emitter) {
+    const maxListeners = emitter.getMaxListeners();
+    if (maxListeners !== 0) {
+      emitter.setMaxListeners(maxListeners + 1);
+    }
+  }
+
+  /**
+   * Decrements max listeners by one for a given emitter, if they are not zero.
+   * @private
+   */
+  decrementMaxListeners(emitter) {
+    const maxListeners = emitter.getMaxListeners();
+    if (maxListeners !== 0) {
+      emitter.setMaxListeners(maxListeners - 1);
+    }
   }
 }
 

--- a/packages/discord.js/src/sharding/ShardClientUtil.js
+++ b/packages/discord.js/src/sharding/ShardClientUtil.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const process = require('node:process');
+const { EventEmitter } = require('node:stream');
 const { Error } = require('../errors');
 const { Events } = require('../util/Constants');
 const Util = require('../util/Util');
@@ -249,6 +250,7 @@ class ShardClientUtil {
 
   /**
    * Increments max listeners by one for a given emitter, if they are not zero.
+   * @param {EventEmitter | process} emitter
    * @private
    */
   incrementMaxListeners(emitter) {
@@ -260,6 +262,7 @@ class ShardClientUtil {
 
   /**
    * Decrements max listeners by one for a given emitter, if they are not zero.
+   * @param {EventEmitter | process} emitter
    * @private
    */
   decrementMaxListeners(emitter) {

--- a/packages/discord.js/src/sharding/ShardClientUtil.js
+++ b/packages/discord.js/src/sharding/ShardClientUtil.js
@@ -261,7 +261,7 @@ class ShardClientUtil {
 
   /**
    * Decrements max listeners by one for a given emitter, if they are not zero.
-   * @param {EventEmitter | process} emitter The emitter that emits the events.
+   * @param {EventEmitter|process} emitter The emitter that emits the events.
    * @private
    */
   decrementMaxListeners(emitter) {

--- a/packages/discord.js/src/sharding/ShardClientUtil.js
+++ b/packages/discord.js/src/sharding/ShardClientUtil.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const process = require('node:process');
-const { EventEmitter } = require('node:stream');
 const { Error } = require('../errors');
 const { Events } = require('../util/Constants');
 const Util = require('../util/Util');
@@ -250,7 +249,7 @@ class ShardClientUtil {
 
   /**
    * Increments max listeners by one for a given emitter, if they are not zero.
-   * @param {EventEmitter | process} emitter
+   * @param {EventEmitter | process} emitter The emitter that emits the events.
    * @private
    */
   incrementMaxListeners(emitter) {
@@ -262,7 +261,7 @@ class ShardClientUtil {
 
   /**
    * Decrements max listeners by one for a given emitter, if they are not zero.
-   * @param {EventEmitter | process} emitter
+   * @param {EventEmitter | process} emitter The emitter that emits the events.
    * @private
    */
   decrementMaxListeners(emitter) {

--- a/packages/discord.js/src/sharding/ShardClientUtil.js
+++ b/packages/discord.js/src/sharding/ShardClientUtil.js
@@ -249,7 +249,7 @@ class ShardClientUtil {
 
   /**
    * Increments max listeners by one for a given emitter, if they are not zero.
-   * @param {EventEmitter | process} emitter The emitter that emits the events.
+   * @param {EventEmitter|process} emitter The emitter that emits the events.
    * @private
    */
   incrementMaxListeners(emitter) {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2008,7 +2008,7 @@ export class ShardClientUtil {
   private constructor(client: Client, mode: ShardingManagerMode);
   private _handleMessage(message: unknown): void;
   private _respond(type: string, message: unknown): void;
-  private incrementMaxListeners(emitter: EventEmitter | ChildProcess): void
+  private incrementMaxListeners(emitter: EventEmitter | ChildProcess): void;
   private decrementMaxListeners(emitter: EventEmitter | ChildProcess): void;
 
   public client: Client;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1973,7 +1973,7 @@ export class Shard extends EventEmitter {
   private _fetches: Map<string, Promise<unknown>>;
   private _handleExit(respawn?: boolean, timeout?: number): void;
   private _handleMessage(message: unknown): void;
-  private incrementMaxListeners(emitter: EventEmitter | ChildProcess): void
+  private incrementMaxListeners(emitter: EventEmitter | ChildProcess): void;
   private decrementMaxListeners(emitter: EventEmitter | ChildProcess): void
 
   public args: string[];

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2009,7 +2009,7 @@ export class ShardClientUtil {
   private _handleMessage(message: unknown): void;
   private _respond(type: string, message: unknown): void;
   private incrementMaxListeners(emitter: EventEmitter | ChildProcess): void
-  private decrementMaxListeners(emitter: EventEmitter | ChildProcess): void
+  private decrementMaxListeners(emitter: EventEmitter | ChildProcess): void;
 
   public client: Client;
   public readonly count: number;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1973,6 +1973,8 @@ export class Shard extends EventEmitter {
   private _fetches: Map<string, Promise<unknown>>;
   private _handleExit(respawn?: boolean, timeout?: number): void;
   private _handleMessage(message: unknown): void;
+  private incrementMaxListeners(emitter: EventEmitter | ChildProcess): void
+  private decrementMaxListeners(emitter: EventEmitter | ChildProcess): void
 
   public args: string[];
   public execArgv: string[];
@@ -2006,6 +2008,8 @@ export class ShardClientUtil {
   private constructor(client: Client, mode: ShardingManagerMode);
   private _handleMessage(message: unknown): void;
   private _respond(type: string, message: unknown): void;
+  private incrementMaxListeners(emitter: EventEmitter | ChildProcess): void
+  private decrementMaxListeners(emitter: EventEmitter | ChildProcess): void
 
   public client: Client;
   public readonly count: number;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1974,7 +1974,7 @@ export class Shard extends EventEmitter {
   private _handleExit(respawn?: boolean, timeout?: number): void;
   private _handleMessage(message: unknown): void;
   private incrementMaxListeners(emitter: EventEmitter | ChildProcess): void;
-  private decrementMaxListeners(emitter: EventEmitter | ChildProcess): void
+  private decrementMaxListeners(emitter: EventEmitter | ChildProcess): void;
 
   public args: string[];
   public execArgv: string[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Attaching a message listener to the parent and child during the broadcastEval and fetchClientVlaues throws a `MaxListenersExceededWarning:`
ErrorLog: https://sourceb.in/GBCHPCxLr5
The above changes were tested for 24 hours+ and it fixed the warning for all of my shards.

**Status and versioning classification:**
Code changes have been tested against the Discord API, or there are no code changes
This PR changes the library's interface (methods or parameters added)