### PR TITLE
chore: commit scope name in lowercase

### DIFF
--- a/.github/COMMIT_CONVENTION.md
+++ b/.github/COMMIT_CONVENTION.md
@@ -15,13 +15,13 @@ Messages must be matched by the following regex:
 Appears under "Features" header, `GuildMember` subheader:
 
 ```
-feat(GuildMember): add 'tag' method
+feat(guildmember): add 'tag' method
 ```
 
 Appears under "Bug Fixes" header, `Guild` subheader, with a link to issue #28:
 
 ```
-fix(Guild): handle events correctly
+fix(guild): handle events correctly
 
 close #28
 ```
@@ -37,7 +37,7 @@ BREAKING CHANGE: The 'bar' option has been removed.
 The following commit and commit `667ecc1` do not appear in the changelog if they are under the same release. If not, the revert commit appears under the "Reverts" header.
 
 ```
-revert: feat(Managers): add Managers
+revert: feat(managers): add Managers
 
 This reverts commit 667ecc1654a317a13331b17617d973392f415f02.
 ```


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
After monorepo setup, commit scope name casing was changed to lowercase. But in [Commit_Convension](https://github.com/discordjs/discord.js/blob/main/.github/COMMIT_CONVENTION.md) page, the example is in Pascal case. So I changed the example 
**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
