### PR TITLE
refactor: PresenceUpdate and demuxProbe

### DIFF
--- a/packages/discord.js/src/client/actions/PresenceUpdate.js
+++ b/packages/discord.js/src/client/actions/PresenceUpdate.js
@@ -6,10 +6,10 @@ const { Events } = require('../../util/Constants');
 class PresenceUpdateAction extends Action {
   handle(data) {
     let user = this.client.users.cache.get(data.user.id);
-    if (!user && data.user?.username) user = this.client.users._add(data.user);
+    if (!user && data.user.username) user = this.client.users._add(data.user);
     if (!user) return;
 
-    if (data.user?.username) {
+    if (data.user.username) {
       if (!user._equals(data.user)) this.client.actions.UserUpdate.handle(data.user);
     }
 

--- a/packages/voice/src/util/demuxProbe.ts
+++ b/packages/voice/src/util/demuxProbe.ts
@@ -48,8 +48,8 @@ export function demuxProbe(
 ): Promise<ProbeInfo> {
 	return new Promise((resolve, reject) => {
 		// Preconditions
-		if (stream.readableObjectMode) reject(new Error('Cannot probe a readable stream in object mode'));
-		if (stream.readableEnded) reject(new Error('Cannot probe a stream that has ended'));
+		if (stream.readableObjectMode) return reject(new Error('Cannot probe a readable stream in object mode'));
+		if (stream.readableEnded) return reject(new Error('Cannot probe a stream that has ended'));
 
 		let readBuffer = Buffer.alloc(0);
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In the `PresenceUpdate#handle` there are **null** checks at lines 9 and 12. It's redundant since at line 8 the `id` is accessed from `data.user` without any null check.

In the `demuxProbe` function, Execution falls through after this Promise 'reject' call. So adding a return statement after the reject to stop unintended code execution.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating