### PR TITLE
docs: fix a typo and use milliseconds instead of ms

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -533,7 +533,7 @@ module.exports = Client;
  * ```
  * 64                                          22     17     12          0
  *  000000111011000111100001101001000101000000  00001  00000  000000000000
- *       number of ms since Discord epoch       worker  pid    increment
+ *  number of milliseconds since Discord epoch  worker  pid    increment
  * ```
  * @typedef {string} Snowflake
  */

--- a/packages/discord.js/src/rest/RateLimitError.js
+++ b/packages/discord.js/src/rest/RateLimitError.js
@@ -15,7 +15,7 @@ class RateLimitError extends Error {
     this.name = 'RateLimitError';
 
     /**
-     * Time until this rate limit ends, in ms
+     * Time until this rate limit ends, in milliseconds
      * @type {number}
      */
     this.timeout = timeout;

--- a/packages/discord.js/src/rest/RequestHandler.js
+++ b/packages/discord.js/src/rest/RequestHandler.js
@@ -280,7 +280,7 @@ class RequestHandler {
         /**
          * @typedef {Object} InvalidRequestWarningData
          * @property {number} count Number of invalid requests that have been made in the window
-         * @property {number} remainingTime Time in ms remaining before the count resets
+         * @property {number} remainingTime Time in milliseconds remaining before the count resets
          */
 
         /**

--- a/packages/discord.js/src/util/Options.js
+++ b/packages/discord.js/src/util/Options.js
@@ -5,7 +5,7 @@ const process = require('node:process');
 /**
  * Rate limit data
  * @typedef {Object} RateLimitData
- * @property {number} timeout Time until this rate limit ends, in ms
+ * @property {number} timeout Time until this rate limit ends, in milliseconds
  * @property {number} limit The maximum amount of requests of this endpoint
  * @property {string} method The HTTP method of this request
  * @property {string} path The path of the request relative to the HTTP endpoint
@@ -66,7 +66,7 @@ const process = require('node:process');
  * @property {PresenceData} [presence={}] Presence data to use upon login
  * @property {IntentsResolvable} intents Intents to enable for this connection
  * @property {number} [waitGuildTimeout=15_000] Time in milliseconds that Clients with the GUILDS intent should wait for
- * missing guilds to be recieved before starting the bot. If not specified, the default is 15 seconds.
+ * missing guilds to be received before starting the bot. If not specified, the default is 15 seconds.
  * @property {SweeperOptions} [sweepers={}] Options for cache sweeping
  * @property {WebsocketOptions} [ws] Options for the WebSocket
  * @property {HTTPOptions} [http] HTTP options

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -155,7 +155,7 @@ export interface InvalidRequestWarningData {
 	 */
 	count: number;
 	/**
-	 * Time in ms remaining before the count resets
+	 * Time in milliseconds remaining before the count resets
 	 */
 	remainingTime: number;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes the typo "recieved" to "received" and uses "milliseconds" instead of "ms" (only in docs).

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
