### PR TITLE
feat: rest hash and handler sweeping

### DIFF
--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -6,6 +6,7 @@ import type { AgentOptions } from 'node:https';
 import type { RequestInit, Response } from 'node-fetch';
 import type { HashData } from '../index';
 import type Collection from '@discordjs/collection';
+import type { IHandler } from './handlers/IHandler';
 
 /**
  * Options to be passed when creating the REST instance
@@ -86,6 +87,11 @@ export interface RESTOptions {
 	 * @default 86_400_000
 	 */
 	hashLifetime: number;
+	/**
+	 * The amount of time in milliseconds that passes between each hash sweep. (defaults to 1h)
+	 * @default 3_600_000
+	 */
+	handlerSweepInterval: number;
 }
 
 /**
@@ -181,6 +187,7 @@ export interface RestEvents {
 	newListener: [name: string, listener: (...args: any) => void];
 	removeListener: [name: string, listener: (...args: any) => void];
 	hashSweep: [sweptHashes: Collection<string, HashData>];
+	handlerSweep: [sweptHandlers: Collection<string, IHandler>];
 }
 
 export interface REST {

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -77,13 +77,13 @@ export interface RESTOptions {
 	 */
 	version: string;
 	/**
-	 * The amount of time in milliseconds that passes between each hash sweep
-	 * @default 3_600_000
+	 * The amount of time in milliseconds that passes between each hash sweep. (defaults to 4h)
+	 * @default 14_400_000
 	 */
 	hashSweepInterval: number;
 	/**
-	 * The maximum amount of time a hash can exist in milliseconds without being hit with a request
-	 * @default 21_600_000
+	 * The maximum amount of time a hash can exist in milliseconds without being hit with a request (defaults to 24h)
+	 * @default 86_400_000
 	 */
 	hashLifetime: number;
 }

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -4,7 +4,7 @@ import { InternalRequest, RequestData, RequestManager, RequestMethod, RouteLike 
 import { DefaultRestOptions, RESTEvents } from './utils/constants';
 import type { AgentOptions } from 'node:https';
 import type { RequestInit, Response } from 'node-fetch';
-import type { HashData } from '../index';
+import type { HashData } from './RequestManager';
 import type Collection from '@discordjs/collection';
 import type { IHandler } from './handlers/IHandler';
 

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -210,7 +210,7 @@ export class RequestManager extends EventEmitter {
 			validateMaxInterval(this.options.hashSweepInterval);
 			this.hashTimer = setInterval(() => {
 				// Only allocate a swept collection for event.
-				const sweptHashes: Collection<string, HashData> = new Collection<string, HashData>();
+				const sweptHashes = new Collection<string, HashData>();
 
 				const currentDate = Date.now();
 
@@ -242,7 +242,7 @@ export class RequestManager extends EventEmitter {
 		if (this.options.handlerSweepInterval !== 0 && this.options.handlerSweepInterval !== Infinity) {
 			validateMaxInterval(this.options.handlerSweepInterval);
 			this.handlerTimer = setInterval(() => {
-				const sweptHandlers: Collection<string, IHandler> = new Collection<string, IHandler>();
+				const sweptHandlers = new Collection<string, IHandler>();
 
 				// Begin sweeping handlers based on activity
 				this.handlers.sweep((v, k) => {

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -194,11 +194,7 @@ export class RequestManager extends EventEmitter {
 
 		setInterval(() => {
 			// Only allocate a swept collection if there are listeners
-			let sweptHashes: Collection<string, HashData> | null = null;
-			const isListeningToSweeps = this.listenerCount(RESTEvents.HashSweep) > 0;
-			if (isListeningToSweeps) {
-				sweptHashes = new Collection<string, HashData>();
-			}
+			const sweptHashes: Collection<string, HashData> | null = this.listenerCount(RESTEvents.HashSweep) > 0 ? new Collection<string, HashData>() : null;
 
 			const listeningToDebug = this.listenerCount(RESTEvents.Debug) > 0;
 			const curDate = Date.now();

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -192,7 +192,19 @@ export class RequestManager extends EventEmitter {
 		this.options.offset = Math.max(0, this.options.offset);
 		this.globalRemaining = this.options.globalRequestsPerSecond;
 
-		if (options.hashSweepInterval !== 0 && options.hashSweepInterval !== Infinity) {
+		// Start sweepers
+		this.setupSweepers();
+	}
+
+	private setupSweepers() {
+		const validateMaxInterval = (interval: number) => {
+			if (interval > 14_400_000) {
+				throw new Error('Cannot set an interval greate than 4 hours');
+			}
+		};
+
+		if (this.options.hashSweepInterval !== 0 && this.options.hashSweepInterval !== Infinity) {
+			validateMaxInterval(this.options.hashSweepInterval);
 			setInterval(() => {
 				// Only allocate a swept collection if there are listeners
 				const sweptHashes: Collection<string, HashData> = new Collection<string, HashData>();
@@ -224,7 +236,8 @@ export class RequestManager extends EventEmitter {
 			}, this.options.hashSweepInterval).unref();
 		}
 
-		if (options.handlerSweepInterval !== 0 && options.handlerSweepInterval !== Infinity) {
+		if (this.options.handlerSweepInterval !== 0 && this.options.handlerSweepInterval !== Infinity) {
+			validateMaxInterval(this.options.handlerSweepInterval);
 			setInterval(() => {
 				const sweptHandlers: Collection<string, IHandler> = new Collection<string, IHandler>();
 

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -199,7 +199,7 @@ export class RequestManager extends EventEmitter {
 	private setupSweepers() {
 		const validateMaxInterval = (interval: number) => {
 			if (interval > 14_400_000) {
-				throw new Error('Cannot set an interval greate than 4 hours');
+				throw new Error('Cannot set an interval greater than 4 hours');
 			}
 		};
 

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -209,9 +209,7 @@ export class RequestManager extends EventEmitter {
 		if (this.options.hashSweepInterval !== 0 && this.options.hashSweepInterval !== Infinity) {
 			validateMaxInterval(this.options.hashSweepInterval);
 			this.hashTimer = setInterval(() => {
-				// Only allocate a swept collection for event.
 				const sweptHashes = new Collection<string, HashData>();
-
 				const currentDate = Date.now();
 
 				// Begin sweeping hash based on lifetimes
@@ -410,14 +408,14 @@ export class RequestManager extends EventEmitter {
 	 * Stops the hash sweeping interval
 	 */
 	public clearHashSweeper() {
-		return clearInterval(this.hashTimer);
+		clearInterval(this.hashTimer);
 	}
 
 	/**
 	 * Stops the request handler sweeping interval
 	 */
 	public clearHandlerSweeper() {
-		return clearInterval(this.handlerTimer);
+		clearInterval(this.handlerTimer);
 	}
 
 	/**

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -194,7 +194,8 @@ export class RequestManager extends EventEmitter {
 
 		setInterval(() => {
 			// Only allocate a swept collection if there are listeners
-			const sweptHashes: Collection<string, HashData> | null = this.listenerCount(RESTEvents.HashSweep) > 0 ? new Collection<string, HashData>() : null;
+			const sweptHashes: Collection<string, HashData> | null =
+				this.listenerCount(RESTEvents.HashSweep) > 0 ? new Collection<string, HashData>() : null;
 
 			const listeningToDebug = this.listenerCount(RESTEvents.Debug) > 0;
 			const curDate = Date.now();
@@ -208,9 +209,9 @@ export class RequestManager extends EventEmitter {
 				const shouldSweep = Math.floor(curDate - v.lastAccess) > this.options.hashLifetime;
 
 				// Add hash to collection of swept hashes
-				if (shouldSweep && isListeningToSweeps) {
+				if (shouldSweep && sweptHashes) {
 					// Add to swept hashes
-					sweptHashes!.set(k, v);
+					sweptHashes.set(k, v);
 				}
 
 				if (listeningToDebug) {
@@ -221,8 +222,8 @@ export class RequestManager extends EventEmitter {
 			});
 
 			// Fire event
-			if (isListeningToSweeps) {
-				this.emit(RESTEvents.HashSweep, sweptHashes ?? new Collection<string, HashData>());
+			if (sweptHashes) {
+				this.emit(RESTEvents.HashSweep, sweptHashes);
 			}
 		}, this.options.hashSweepInterval).unref();
 	}

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -7,7 +7,7 @@ import type { RequestInit, BodyInit } from 'node-fetch';
 import type { IHandler } from './handlers/IHandler';
 import { SequentialHandler } from './handlers/SequentialHandler';
 import type { RESTOptions, RestEvents } from './REST';
-import { DefaultRestOptions, DefaultUserAgent } from './utils/constants';
+import { DefaultRestOptions, DefaultUserAgent, RESTEvents } from './utils/constants';
 
 let agent: Agent | null = null;
 
@@ -125,6 +125,16 @@ export interface RouteData {
 	original: RouteLike;
 }
 
+/**
+ * Represents a hash and its associated fields
+ *
+ * @internal
+ */
+export interface HashData {
+	value: string;
+	lastAccess: number;
+}
+
 export interface RequestManager {
 	on: (<K extends keyof RestEvents>(event: K, listener: (...args: RestEvents[K]) => void) => this) &
 		(<S extends string | symbol>(event: Exclude<S, keyof RestEvents>, listener: (...args: any[]) => void) => this);
@@ -164,7 +174,7 @@ export class RequestManager extends EventEmitter {
 	/**
 	 * API bucket hashes that are cached from provided routes
 	 */
-	public readonly hashes = new Collection<string, string>();
+	public readonly hashes = new Collection<string, HashData>();
 
 	/**
 	 * Request handlers created from the bucket hash and the major parameters
@@ -181,6 +191,43 @@ export class RequestManager extends EventEmitter {
 		this.options = { ...DefaultRestOptions, ...options };
 		this.options.offset = Math.max(0, this.options.offset);
 		this.globalRemaining = this.options.globalRequestsPerSecond;
+
+		setInterval(() => {
+			// Only allocate a swept collection if there are listeners
+			let sweptHashes: Collection<string, HashData> | null = null;
+			const isListeningToSweeps = this.listenerCount(RESTEvents.HashSweep) > 0;
+			if (isListeningToSweeps) {
+				sweptHashes = new Collection<string, HashData>();
+			}
+
+			const curDate = Date.now();
+
+			// Begin sweep hash based on lifetimes
+			this.hashes.sweep((v, k) => {
+				// `-1` indicates a global hash
+				if (v.lastAccess === -1) return false;
+
+				// Check if lifetime has been exceeded
+				const shouldSweep = Math.floor(curDate - v.lastAccess) > this.options.hashLifetime;
+
+				// Add hash to collection of swept hashes
+				if (shouldSweep && isListeningToSweeps) {
+					if (this.listenerCount(RESTEvents.Debug)) {
+						this.emit(RESTEvents.Debug, `Hash ${v.value} for ${k} swept due to lifetime being exceeded`);
+					}
+
+					// Add to swept hashes
+					sweptHashes!.set(k, v);
+				}
+
+				return shouldSweep;
+			});
+
+			// Fire event
+			if (isListeningToSweeps) {
+				this.emit(RESTEvents.HashSweep, sweptHashes ?? new Collection<string, HashData>());
+			}
+		}, this.options.hashSweepInterval).unref();
 	}
 
 	/**
@@ -201,12 +248,15 @@ export class RequestManager extends EventEmitter {
 		// Generalize the endpoint to its route data
 		const routeId = RequestManager.generateRouteData(request.fullRoute, request.method);
 		// Get the bucket hash for the generic route, or point to a global route otherwise
-		const hash =
-			this.hashes.get(`${request.method}:${routeId.bucketRoute}`) ?? `Global(${request.method}:${routeId.bucketRoute})`;
+		const hash = this.hashes.get(`${request.method}:${routeId.bucketRoute}`) ?? {
+			value: `Global(${request.method}:${routeId.bucketRoute})`,
+			lastAccess: -1,
+		};
 
 		// Get the request handler for the obtained hash, with its major parameter
 		const handler =
-			this.handlers.get(`${hash}:${routeId.majorParameter}`) ?? this.createHandler(hash, routeId.majorParameter);
+			this.handlers.get(`${hash.value}:${routeId.majorParameter}`) ??
+			this.createHandler(hash.value, routeId.majorParameter);
 
 		// Resolve the request into usable fetch/node-fetch options
 		const { url, fetchOptions } = this.resolveRequest(request);

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -200,6 +200,7 @@ export class RequestManager extends EventEmitter {
 				sweptHashes = new Collection<string, HashData>();
 			}
 
+			const listeningToDebug = this.listenerCount(RESTEvents.Debug) > 0;
 			const curDate = Date.now();
 
 			// Begin sweep hash based on lifetimes
@@ -212,12 +213,12 @@ export class RequestManager extends EventEmitter {
 
 				// Add hash to collection of swept hashes
 				if (shouldSweep && isListeningToSweeps) {
-					if (this.listenerCount(RESTEvents.Debug)) {
-						this.emit(RESTEvents.Debug, `Hash ${v.value} for ${k} swept due to lifetime being exceeded`);
-					}
-
 					// Add to swept hashes
 					sweptHashes!.set(k, v);
+				}
+
+				if (listeningToDebug) {
+					this.emit(RESTEvents.Debug, `Hash ${v.value} for ${k} swept due to lifetime being exceeded`);
 				}
 
 				return shouldSweep;

--- a/packages/rest/src/lib/handlers/IHandler.ts
+++ b/packages/rest/src/lib/handlers/IHandler.ts
@@ -8,4 +8,6 @@ export interface IHandler {
 		options: RequestInit,
 		bodyData: Pick<InternalRequest, 'files' | 'body'>,
 	) => Promise<unknown>;
+	readonly inactive: boolean;
+	readonly id: string;
 }

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -355,7 +355,16 @@ export class SequentialHandler {
 			// Let library users know when rate limit buckets have been updated
 			this.debug(['Received bucket hash update', `  Old Hash  : ${this.hash}`, `  New Hash  : ${hash}`].join('\n'));
 			// This queue will eventually be eliminated via attrition
-			this.manager.hashes.set(`${method}:${routeId.bucketRoute}`, hash);
+			this.manager.hashes.set(`${method}:${routeId.bucketRoute}`, { value: hash, lastAccess: Date.now() });
+		} else if (hash) {
+			// Handle the case where hash value doesn't change
+			// Fetch the hash data from the manager
+			const hashData = this.manager.hashes.get(`${method}:${routeId.bucketRoute}`);
+
+			// When fetched, update the last access of the hash
+			if (hashData) {
+				hashData.lastAccess = Date.now();
+			}
 		}
 
 		// Handle retryAfter, which means we have actually hit a rate limit

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -19,6 +19,8 @@ export const DefaultRestOptions: Required<RESTOptions> = {
 	timeout: 15_000,
 	userAgentAppendix: `Node.js ${process.version}`,
 	version: APIVersion,
+	hashSweepInterval: 3_600_000,
+	hashLifetime: 21_600_000,
 };
 
 /**
@@ -30,6 +32,7 @@ export const enum RESTEvents {
 	RateLimited = 'rateLimited',
 	Request = 'request',
 	Response = 'response',
+	HashSweep = 'hashSweep',
 }
 
 export const ALLOWED_EXTENSIONS = ['webp', 'png', 'jpg', 'jpeg', 'gif'] as const;

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -19,8 +19,8 @@ export const DefaultRestOptions: Required<RESTOptions> = {
 	timeout: 15_000,
 	userAgentAppendix: `Node.js ${process.version}`,
 	version: APIVersion,
-	hashSweepInterval: 3_600_000,
-	hashLifetime: 21_600_000,
+	hashSweepInterval: 14_400_000,
+	hashLifetime: 86_400_000, // 24 Hours
 };
 
 /**

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -19,8 +19,9 @@ export const DefaultRestOptions: Required<RESTOptions> = {
 	timeout: 15_000,
 	userAgentAppendix: `Node.js ${process.version}`,
 	version: APIVersion,
-	hashSweepInterval: 14_400_000,
+	hashSweepInterval: 14_400_000, // 4 Hours
 	hashLifetime: 86_400_000, // 24 Hours
+	handlerSweepInterval: 3_600_000, // 1 Hour
 };
 
 /**
@@ -33,6 +34,7 @@ export const enum RESTEvents {
 	Request = 'request',
 	Response = 'response',
 	HashSweep = 'hashSweep',
+	HandlerSweep = 'handlerSweep',
 }
 
 export const ALLOWED_EXTENSIONS = ['webp', 'png', 'jpg', 'jpeg', 'gif'] as const;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

See https://github.com/discordjs/discord.js-modules/issues/40

Sweeps hashes based on the lifetime of a given hash. Lifetimes are based on the last time a particular hash was used relative to the current data/time. In addition this sweeps inactive handlers.

This introduces new options for `REST`:
- `hashSweepInterval`: The delay before each hash sweep interval.
- `hashLifetime`: The maximum amount of time a hash can exist before being swept.
- `handlerSweepInterval`: The delay before each handler sweep interval

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)