### PR TITLE
docs(interaction): add locale list link

### DIFF
--- a/packages/discord.js/src/structures/Interaction.js
+++ b/packages/discord.js/src/structures/Interaction.js
@@ -78,6 +78,7 @@ class Interaction extends Base {
     /**
      * The locale of the user who invoked this interaction
      * @type {string}
+     * @see {@link https://discord.com/developers/docs/dispatch/field-values#predefined-field-values-accepted-locales}
      */
     this.locale = data.locale;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds a link to a list of all possible locales from Discord's documentation to Interaction#locale

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
