### PR TITLE
chore: Add `prefer-object-has-own` rule

### DIFF
--- a/packages/discord.js/.eslintrc.json
+++ b/packages/discord.js/.eslintrc.json
@@ -170,6 +170,7 @@
     "prefer-rest-params": "error",
     "prefer-spread": "error",
     "prefer-template": "error",
+    "prefer-object-has-own": "error",
     "rest-spread-spacing": "error",
     "template-curly-spacing": "error",
     "yield-star-spacing": "error",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Added the [`prefer-object-has-own`](https://eslint.org/docs/rules/prefer-object-has-own) rule.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
