### PR TITLE
docs(locales): update Discord API docs link

### DIFF
--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -377,7 +377,7 @@ class Guild extends AnonymousGuild {
       /**
        * The preferred locale of the guild, defaults to `en-US`
        * @type {string}
-       * @see {@link https://discord.com/developers/docs/dispatch/field-values#predefined-field-values-accepted-locales}
+       * @see {@link https://discord.com/developers/docs/reference#locales}
        */
       this.preferredLocale = data.preferred_locale;
     }

--- a/packages/discord.js/src/structures/Interaction.js
+++ b/packages/discord.js/src/structures/Interaction.js
@@ -78,7 +78,7 @@ class Interaction extends Base {
     /**
      * The locale of the user who invoked this interaction
      * @type {string}
-     * @see {@link https://discord.com/developers/docs/dispatch/field-values#predefined-field-values-accepted-locales}
+     * @see {@link https://discord.com/developers/docs/reference#locales}
      */
     this.locale = data.locale;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Blame @advaith1 for moving this
Marking as a draft until the Discord API docs website has been updated with the new link, the commit has already been pushed on their repo though

- https://github.com/discord/discord-api-docs/pull/4335

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
