### PR TITLE
ci: dont run auto-deprecated and publish-dev on forks

### DIFF
--- a/.github/workflows/auto-deprecate.yml
+++ b/.github/workflows/auto-deprecate.yml
@@ -7,6 +7,7 @@ jobs:
   auto-deprecate:
     name: npm auto deprecate
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'discordjs'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -7,6 +7,7 @@ jobs:
   npm:
     name: npm
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'discordjs'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#7205, but for the auto-deprecate and publish-dev workflows
I'm not sure why the publish-dev script is [failing on my fork](https://github.com/almeidx/discord.js/actions/runs/1704256979), but there's no reason for it to be run there anyway. The same goes for auto-deprecate

**Edit**: Just found out you can simply disable actions from running on forks. Went with that instead. Feel free to close this if you don't want changes to the workflows

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
