### PR TITLE
BaseClient: pass `captureRejections` option

### DIFF
--- a/packages/discord.js/src/client/BaseClient.js
+++ b/packages/discord.js/src/client/BaseClient.js
@@ -13,7 +13,7 @@ const Util = require('../util/Util');
  */
 class BaseClient extends EventEmitter {
   constructor(options = {}) {
-    super();
+    super({ captureRejections: true });
 
     if (typeof options !== 'object' || options === null) {
       throw new TypeError('INVALID_TYPE', 'options', 'object', true);

--- a/packages/discord.js/src/sharding/ShardClientUtil.js
+++ b/packages/discord.js/src/sharding/ShardClientUtil.js
@@ -210,6 +210,9 @@ class ShardClientUtil {
       error.stack = err.stack;
       /**
        * Emitted when the client encounters an error.
+       * <warn>Errors thrown within this event do not have a catch handler, it is
+       * recommended to not use async functions as `error` event handlers. See the
+       * [Node.js docs](https://nodejs.org/api/events.html#capture-rejections-of-promises) for details.</warn>
        * @event Client#error
        * @param {Error} error The error encountered
        */


### PR DESCRIPTION
- Currently, the Client class cannot properly handle async errors being 
  thrown.
- With this change, when an error is thrown within an event, Client will
  automatically emit an error event if a listener exists, or otherwise
  exits with an unhandledRejection as it currently does..

```js
client.on('ready', () => console.log('ready'));
client.on('error', (e) => console.error(e.message)); // "whoops"

client.on('messageCreate', async (m) => {
    // do some async task here that throws an error
    // this will no longer exit the program with an
    // unhandled rejection!
    throw new Error('whoops');
});
```
https://nodejs.org/api/events.html#capture-rejections-of-promises

This is experimental, but a [PR](https://github.com/nodejs/node/commit/9a85efaa7f5f22c6905bf47d672dd73738787437) has already been committed that removes the experimental status.

**Please describe the changes this PR makes and why it should be merged:**

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
