### PR TITLE
refactor: Remove VoiceChannel#editable

### DIFF
--- a/packages/discord.js/src/structures/VoiceChannel.js
+++ b/packages/discord.js/src/structures/VoiceChannel.js
@@ -1,35 +1,13 @@
 'use strict';
 
-const process = require('node:process');
 const BaseGuildVoiceChannel = require('./BaseGuildVoiceChannel');
 const Permissions = require('../util/Permissions');
-
-let deprecationEmittedForEditable = false;
 
 /**
  * Represents a guild voice channel on Discord.
  * @extends {BaseGuildVoiceChannel}
  */
 class VoiceChannel extends BaseGuildVoiceChannel {
-  /**
-   * Whether the channel is editable by the client user
-   * @type {boolean}
-   * @readonly
-   * @deprecated Use {@link VoiceChannel#manageable} instead
-   */
-  get editable() {
-    if (!deprecationEmittedForEditable) {
-      process.emitWarning(
-        'The VoiceChannel#editable getter is deprecated. Use VoiceChannel#manageable instead.',
-        'DeprecationWarning',
-      );
-
-      deprecationEmittedForEditable = true;
-    }
-
-    return this.manageable;
-  }
-
   /**
    * Whether the channel is joinable by the client user
    * @type {boolean}

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2398,8 +2398,6 @@ export class Formatters extends null {
 }
 
 export class VoiceChannel extends BaseGuildVoiceChannel {
-  /** @deprecated Use manageable instead */
-  public readonly editable: boolean;
   public readonly speakable: boolean;
   public type: 'GuildVoice';
   public setBitrate(bitrate: number, reason?: string): Promise<VoiceChannel>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes `VoiceChannel#editable` as it is superseded by `GuildChannel#manageable`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
