### PR TITLE
fix(messagementions): fix `has` method

### DIFF
--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -196,7 +196,7 @@ class MessageMentions {
     }
     if (user && !ignoreEveryone && this.everyone) return true;
     if (!ignoreRoles) {
-      const member = this.guild ? this.guild.members.resolve(data) : null;
+      const member = this.guild?.members.resolve(data) ?? null;
       if (member) {
         for (const mentionedRole of this.roles.values()) if (member.roles.cache.has(mentionedRole.id)) return true;
       }

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -187,9 +187,8 @@ class MessageMentions {
     const user = this.client.users.resolve(data);
     const role = this.guild?.roles.resolve(data);
     const channel = this.client.channels.resolve(data);
-    const isDirect = user ?? role ?? channel;
 
-    if (!ignoreDirect && isDirect) {
+    if (!ignoreDirect) {
       if (this.users.has(user?.id)) return true;
       if (!ignoreRoles && this.roles.has(role?.id)) return true;
       if (this.channels.has(channel?.id)) return true;

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -172,8 +172,8 @@ class MessageMentions {
    * Options used to check for a mention.
    * @typedef {Object} MessageMentionsHasOptions
    * @property {boolean} [ignoreDirect=false] Whether to ignore direct mentions to the item
-   * @property {boolean} [ignoreRoles=false] Whether to ignore role mentions to the guild member
-   * @property {boolean} [ignoreRepliedUser=false] Whether to ignore replied user mention to the user
+   * @property {boolean} [ignoreRoles=false] Whether to ignore role mentions to a guild member
+   * @property {boolean} [ignoreRepliedUser=false] Whether to ignore replied user mention to a user
    * @property {boolean} [ignoreEveryone=false] Whether to ignore `@everyone`/`@here` mentions
    */
 

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -185,7 +185,7 @@ class MessageMentions {
    */
   has(data, { ignoreDirect = false, ignoreRoles = false, ignoreEveryone = false } = {}) {
     const user = this.client.users.resolve(data),
-      role = this.guild ? this.guild.roles.resolve(data) : null,
+      role = this.guild?.roles.resolve(data) ?? null,
       channel = this.client.channels.resolve(data),
       isDirect = user ?? role ?? channel;
 

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -184,7 +184,7 @@ class MessageMentions {
    * @param {MessageMentionsHasOptions} [options] The options for the check
    * @returns {boolean}
    */
-  has(data, { ignoreDirect = false, ignoreRoles = false, ignoreRepliedUser = true, ignoreEveryone = false } = {}) {
+  has(data, { ignoreDirect = false, ignoreRoles = false, ignoreRepliedUser = false, ignoreEveryone = false } = {}) {
     const user = this.client.users.resolve(data);
     const role = this.guild?.roles.resolve(data);
     const channel = this.client.channels.resolve(data);

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -179,7 +179,8 @@ class MessageMentions {
 
   /**
    * Checks if a user, guild member, role, or channel is mentioned.
-   * Takes into account user mentions, role mentions, channel mentions, replied user mention, and `@everyone`/`@here` mentions.
+   * Takes into account user mentions, role mentions, channel mentions,
+   * replied user mention, and `@everyone`/`@here` mentions.
    * @param {UserResolvable|RoleResolvable|ChannelResolvable} data The User/Role/Channel to check for
    * @param {MessageMentionsHasOptions} [options] The options for the check
    * @returns {boolean}

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -172,22 +172,24 @@ class MessageMentions {
    * Options used to check for a mention.
    * @typedef {Object} MessageMentionsHasOptions
    * @property {boolean} [ignoreDirect=false] Whether to ignore direct mentions to the item
-   * @property {boolean} [ignoreRoles=false] Whether to ignore role mentions to a guild member
+   * @property {boolean} [ignoreRoles=false] Whether to ignore role mentions to the item
+   * @property {boolean} [ignoreRepliedUser=false] Whether to ignore replied user mention to the item
    * @property {boolean} [ignoreEveryone=false] Whether to ignore everyone/here mentions
    */
 
   /**
    * Checks if a user, guild member, role, or channel is mentioned.
-   * Takes into account user mentions, role mentions, and `@everyone`/`@here` mentions.
+   * Takes into account user mentions, role mentions, channel mentions, replied user mention, and `@everyone`/`@here` mentions.
    * @param {UserResolvable|RoleResolvable|ChannelResolvable} data The User/Role/Channel to check for
    * @param {MessageMentionsHasOptions} [options] The options for the check
    * @returns {boolean}
    */
-  has(data, { ignoreDirect = false, ignoreRoles = false, ignoreEveryone = false } = {}) {
+  has(data, { ignoreDirect = false, ignoreRoles = false, ignoreRepliedUser = true, ignoreEveryone = false } = {}) {
     const user = this.client.users.resolve(data);
     const role = this.guild?.roles.resolve(data);
     const channel = this.client.channels.resolve(data);
 
+    if (!ignoreRepliedUser && this.repliedUser?.id === user?.id) return true;
     if (!ignoreDirect) {
       if (this.users.has(user?.id)) return true;
       if (!ignoreRoles && this.roles.has(role?.id)) return true;

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -185,7 +185,7 @@ class MessageMentions {
    */
   has(data, { ignoreDirect = false, ignoreRoles = false, ignoreEveryone = false } = {}) {
     const user = this.client.users.resolve(data);
-    const role = this.guild?.roles.resolve(data) ?? null;
+    const role = this.guild?.roles.resolve(data);
     const channel = this.client.channels.resolve(data);
     const isDirect = user ?? role ?? channel;
 
@@ -196,7 +196,7 @@ class MessageMentions {
     }
     if (user && !ignoreEveryone && this.everyone) return true;
     if (!ignoreRoles) {
-      const member = this.guild?.members.resolve(data) ?? null;
+      const member = this.guild?.members.resolve(data);
       if (member) {
         for (const mentionedRole of this.roles.values()) if (member.roles.cache.has(mentionedRole.id)) return true;
       }

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -184,10 +184,10 @@ class MessageMentions {
    * @returns {boolean}
    */
   has(data, { ignoreDirect = false, ignoreRoles = false, ignoreEveryone = false } = {}) {
-    const user = this.client.users.resolve(data),
-      role = this.guild?.roles.resolve(data) ?? null,
-      channel = this.client.channels.resolve(data),
-      isDirect = user ?? role ?? channel;
+    const user = this.client.users.resolve(data);
+    const role = this.guild?.roles.resolve(data) ?? null;
+    const channel = this.client.channels.resolve(data);
+    const isDirect = user ?? role ?? channel;
 
     if (!ignoreDirect && isDirect) {
       if (this.users.has(user?.id)) return true;

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -172,8 +172,8 @@ class MessageMentions {
    * Options used to check for a mention.
    * @typedef {Object} MessageMentionsHasOptions
    * @property {boolean} [ignoreDirect=false] Whether to ignore direct mentions to the item
-   * @property {boolean} [ignoreRoles=false] Whether to ignore role mentions to the item
-   * @property {boolean} [ignoreRepliedUser=false] Whether to ignore replied user mention to the item
+   * @property {boolean} [ignoreRoles=false] Whether to ignore role mentions to the guild member
+   * @property {boolean} [ignoreRepliedUser=false] Whether to ignore replied user mention to the user
    * @property {boolean} [ignoreEveryone=false] Whether to ignore everyone/here mentions
    */
 
@@ -193,7 +193,7 @@ class MessageMentions {
     if (!ignoreRepliedUser && this.users.has(this.repliedUser?.id) && this.repliedUser?.id === user?.id) return true;
     if (!ignoreDirect) {
       if (this.users.has(user?.id)) return true;
-      if (!ignoreRoles && this.roles.has(role?.id)) return true;
+      if (this.roles.has(role?.id)) return true;
       if (this.channels.has(channel?.id)) return true;
     }
     if (user && !ignoreEveryone && this.everyone) return true;

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -173,7 +173,7 @@ class MessageMentions {
    * @typedef {Object} MessageMentionsHasOptions
    * @property {boolean} [ignoreDirect=false] Whether to ignore direct mentions to the item
    * @property {boolean} [ignoreRoles=false] Whether to ignore role mentions to a guild member
-   * @property {boolean} [ignoreRepliedUser=false] Whether to ignore replied user mention to a user
+   * @property {boolean} [ignoreRepliedUser=false] Whether to ignore replied user mention to an user
    * @property {boolean} [ignoreEveryone=false] Whether to ignore `@everyone`/`@here` mentions
    */
 

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -190,7 +190,7 @@ class MessageMentions {
     const role = this.guild?.roles.resolve(data);
     const channel = this.client.channels.resolve(data);
 
-    if (!ignoreRepliedUser && this.repliedUser?.id === user?.id) return true;
+    if (!ignoreRepliedUser && this.users.has(this.repliedUser?.id) && this.repliedUser?.id === user?.id) return true;
     if (!ignoreDirect) {
       if (this.users.has(user?.id)) return true;
       if (!ignoreRoles && this.roles.has(role?.id)) return true;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4794,6 +4794,7 @@ export interface MessageInteraction {
 export interface MessageMentionsHasOptions {
   ignoreDirect?: boolean;
   ignoreRoles?: boolean;
+  ignoreRepliedUser?: boolean;
   ignoreEveryone?: boolean;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR corrects the logic of the MessageMentions#has method.

| Message    | User Mention | Role Mention | Channel Mention |
|------------|--------------|--------------|-----------------|
| <@id>      | true         | false        | false           |
| <@&id>     | true/false   | true         | false           |
| <#id>      | false        | false        | true            |
| @everyone  | true         | false        | false           |
| Reply | true/false   | false        | false           |

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
