### PR TITLE
refactor: Remove boolean option for `Webhook#fetchMessage`

### DIFF
--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -273,7 +273,7 @@ class Webhook {
    * @returns {Promise<Message|APIMessage>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */
-  async fetchMessage(message, { cache = true, threadId } = { cache: true }) {
+  async fetchMessage(message, { cache = true, threadId } = {}) {
     if (!this.token) throw new Error('WEBHOOK_TOKEN_UNAVAILABLE');
 
     const data = await this.client.api

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -1,13 +1,10 @@
 'use strict';
 
-const process = require('node:process');
 const { DiscordSnowflake } = require('@sapphire/snowflake');
 const { WebhookType } = require('discord-api-types/v9');
 const MessagePayload = require('./MessagePayload');
 const { Error } = require('../errors');
 const DataResolver = require('../util/DataResolver');
-
-let deprecationEmittedForFetchMessage = false;
 
 /**
  * Represents a webhook.
@@ -272,25 +269,11 @@ class Webhook {
   /**
    * Gets a message that was sent by this webhook.
    * @param {Snowflake|'@original'} message The id of the message to fetch
-   * @param {WebhookFetchMessageOptions|boolean} [cacheOrOptions={}] The options to provide to fetch the message.
-   * <warn>A **deprecated** boolean may be passed instead to specify whether to cache the message.</warn>
+   * @param {WebhookFetchMessageOptions} [options={}] The options to provide to fetch the message.
    * @returns {Promise<Message|APIMessage>} Returns the raw message data if the webhook was instantiated as a
    * {@link WebhookClient} or if the channel is uncached, otherwise a {@link Message} will be returned
    */
-  async fetchMessage(message, cacheOrOptions = { cache: true }) {
-    if (typeof cacheOrOptions === 'boolean') {
-      if (!deprecationEmittedForFetchMessage) {
-        process.emitWarning(
-          'Passing a boolean to cache the message in Webhook#fetchMessage is deprecated. Pass an object instead.',
-          'DeprecationWarning',
-        );
-
-        deprecationEmittedForFetchMessage = true;
-      }
-
-      cacheOrOptions = { cache: cacheOrOptions };
-    }
-
+  async fetchMessage(message, { cache = true, threadId } = { cache: true }) {
     if (!this.token) throw new Error('WEBHOOK_TOKEN_UNAVAILABLE');
 
     const data = await this.client.api
@@ -298,11 +281,11 @@ class Webhook {
       .messages(message)
       .get({
         query: {
-          thread_id: cacheOrOptions.threadId,
+          thread_id: threadId,
         },
         auth: false,
       });
-    return this.client.channels?.cache.get(data.channel_id)?.messages._add(data, cacheOrOptions.cache) ?? data;
+    return this.client.channels?.cache.get(data.channel_id)?.messages._add(data, cache) ?? data;
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2473,10 +2473,6 @@ export class WebhookClient extends WebhookMixin(BaseClient) {
     options: string | MessagePayload | WebhookEditMessageOptions,
   ): Promise<APIMessage>;
   public fetchMessage(message: Snowflake, options?: WebhookFetchMessageOptions): Promise<APIMessage>;
-  /* tslint:disable:unified-signatures */
-  /** @deprecated */
-  public fetchMessage(message: Snowflake, cache?: boolean): Promise<APIMessage>;
-  /* tslint:enable:unified-signatures */
   public send(options: string | MessagePayload | WebhookMessageOptions): Promise<APIMessage>;
 }
 
@@ -3172,10 +3168,6 @@ export interface PartialWebhookFields {
     options: string | MessagePayload | WebhookEditMessageOptions,
   ): Promise<Message | APIMessage>;
   fetchMessage(message: Snowflake | '@original', options?: WebhookFetchMessageOptions): Promise<Message | APIMessage>;
-  /* tslint:disable:unified-signatures */
-  /** @deprecated */
-  fetchMessage(message: Snowflake | '@original', cache?: boolean): Promise<Message | APIMessage>;
-  /* tslint:enable:unified-signatures */
   send(options: string | MessagePayload | WebhookMessageOptions): Promise<Message | APIMessage>;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes the boolean option for `Webhook#fetchMessage` as it is superseded by `WebhookFetchMessageOptions`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
