### PR TITLE
types: Fix channel create overloads

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -499,7 +499,6 @@ export class CategoryChannel extends GuildChannel {
     name: string,
     options: CategoryCreateChannelOptions & { type: T },
   ): Promise<MappedChannelCategoryTypes[T]>;
-
   /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
   public createChannel(
     name: string,
@@ -2837,17 +2836,18 @@ export class GuildChannelManager extends CachedManager<Snowflake, GuildBasedChan
   private constructor(guild: Guild, iterable?: Iterable<RawGuildChannelData>);
   public readonly channelCountWithoutThreads: number;
   public guild: Guild;
-  /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
-  public create(
-    name: string,
-    options: GuildChannelCreateOptions & { type: ChannelType.GuildStore },
-  ): Promise<StoreChannel>;
-  /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
-  public create<T extends CategoryChannelType | ChannelType.GuildCategory>(
+
+  public create<T extends Exclude<GuildChannelTypes, ChannelType.GuildStore>>(
     name: string,
     options: GuildChannelCreateOptions & { type: T },
   ): Promise<MappedGuildChannelTypes[T]>;
-  public create(name: string, options: GuildChannelCreateOptions): Promise<NonThreadGuildBasedChannel>;
+  /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
+  public create(
+    name: string,
+    options: GuildChannelCreateOptions & { type: ChannelType.GuildStore | 'GuildStore' },
+  ): Promise<StoreChannel>;
+
+  public create(name: string, options?: GuildChannelCreateOptions): Promise<TextChannel>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<NonThreadGuildBasedChannel | null>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, NonThreadGuildBasedChannel>>;
   public setPositions(channelPositions: readonly ChannelPosition[]): Promise<Guild>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2844,7 +2844,7 @@ export class GuildChannelManager extends CachedManager<Snowflake, GuildBasedChan
   /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
   public create(
     name: string,
-    options: GuildChannelCreateOptions & { type: ChannelType.GuildStore | 'GuildStore' },
+    options: GuildChannelCreateOptions & { type: ChannelType.GuildStore },
   ): Promise<StoreChannel>;
 
   public create(name: string, options?: GuildChannelCreateOptions): Promise<TextChannel>;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -915,6 +915,8 @@ declare const guildChannelManager: GuildChannelManager;
 {
   type AnyChannel = TextChannel | VoiceChannel | CategoryChannel | NewsChannel | StoreChannel | StageChannel;
 
+  expectType<Promise<TextChannel>>(guildChannelManager.create('name'));
+  expectType<Promise<TextChannel>>(guildChannelManager.create('name', {}));
   expectType<Promise<VoiceChannel>>(guildChannelManager.create('name', { type: ChannelType.GuildVoice }));
   expectType<Promise<CategoryChannel>>(guildChannelManager.create('name', { type: ChannelType.GuildCategory }));
   expectType<Promise<TextChannel>>(guildChannelManager.create('name', { type: ChannelType.GuildText }));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There were issues with creating channels in TypeScript:

1. `<GuildChannelManager>.create()` always required two arguments
2. Hovering over `<GuildChannelManager>.create()` would always yield a deprecation notice, despite being none
3. `<GuildChannelManager>.create("name", {})` would not be a `TextChannel`
4. Only "GuildStore" and not the enumerable as well were being checked for in the deprecation notice

This pull request fixes those issues.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
