### PR TITLE
docs: Fix channel type creation default

### DIFF
--- a/packages/discord.js/src/structures/CategoryChannel.js
+++ b/packages/discord.js/src/structures/CategoryChannel.js
@@ -30,7 +30,7 @@ class CategoryChannel extends GuildChannel {
   /**
    * Options for creating a channel using {@link CategoryChannel#createChannel}.
    * @typedef {Object} CategoryCreateChannelOptions
-   * @property {ChannelType|number} [type='GUILD_TEXT'] The type of the new channel.
+   * @property {ChannelType|number} [type='GuildText'] The type of the new channel.
    * @property {string} [topic] The topic for the new channel
    * @property {boolean} [nsfw] Whether the new channel is NSFW
    * @property {number} [bitrate] Bitrate of the new channel in bits (only voice)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since #7077, the default has changed!

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
