### PR TITLE
feat(Collection): add merging functions

### DIFF
--- a/packages/collection/__tests__/collection.test.ts
+++ b/packages/collection/__tests__/collection.test.ts
@@ -460,3 +460,57 @@ describe('ensure() tests', () => {
 		expect(coll.size).toStrictEqual(2);
 	});
 });
+
+describe('merge() tests', () => {
+	const cL = new Collection([['L', 1], ['LR', 2]]);
+	const cR = new Collection([['R', 3], ['LR', 4]]);
+
+	test('merges two collection, with all keys together', () => {
+		const c = cL.merge(
+			cR,
+			(x) => ({ keep: true, value: `L${x}` }),
+			(y) => ({ keep: true, value: `R${y}` }),
+			(x, y) => ({ keep: true, value: `LR${x},${y}` })
+		);
+		expect(c.get('L')).toStrictEqual('L1');
+		expect(c.get('R')).toStrictEqual('R3');
+		expect(c.get('LR')).toStrictEqual('LR2,4');
+		expect(c.size).toStrictEqual(3);
+	});
+
+	test('merges two collection, removing left entries', () => {
+		const c = cL.merge(
+			cR,
+			() => ({ keep: false }),
+			(y) => ({ keep: true, value: `R${y}` }),
+			(x, y) => ({ keep: true, value: `LR${x},${y}` })
+		);
+		expect(c.get('R')).toStrictEqual('R3');
+		expect(c.get('LR')).toStrictEqual('LR2,4');
+		expect(c.size).toStrictEqual(2);
+	});
+
+	test('merges two collection, removing right entries', () => {
+		const c = cL.merge(
+			cR,
+			(x) => ({ keep: true, value: `L${x}` }),
+			() => ({ keep: false }),
+			(x, y) => ({ keep: true, value: `LR${x},${y}` })
+		);
+		expect(c.get('L')).toStrictEqual('L1');
+		expect(c.get('LR')).toStrictEqual('LR2,4');
+		expect(c.size).toStrictEqual(2);
+	});
+
+	test('merges two collection, removing in-both entries', () => {
+		const c = cL.merge(
+			cR,
+			(x) => ({ keep: true, value: `L${x}` }),
+			(y) => ({ keep: true, value: `R${y}` }),
+			() => ({ keep: false })
+		);
+		expect(c.get('L')).toStrictEqual('L1');
+		expect(c.get('R')).toStrictEqual('R3');
+		expect(c.size).toStrictEqual(2);
+	});
+});

--- a/packages/collection/__tests__/collection.test.ts
+++ b/packages/collection/__tests__/collection.test.ts
@@ -462,15 +462,21 @@ describe('ensure() tests', () => {
 });
 
 describe('merge() tests', () => {
-	const cL = new Collection([['L', 1], ['LR', 2]]);
-	const cR = new Collection([['R', 3], ['LR', 4]]);
+	const cL = new Collection([
+		['L', 1],
+		['LR', 2],
+	]);
+	const cR = new Collection([
+		['R', 3],
+		['LR', 4],
+	]);
 
 	test('merges two collection, with all keys together', () => {
 		const c = cL.merge(
 			cR,
 			(x) => ({ keep: true, value: `L${x}` }),
 			(y) => ({ keep: true, value: `R${y}` }),
-			(x, y) => ({ keep: true, value: `LR${x},${y}` })
+			(x, y) => ({ keep: true, value: `LR${x},${y}` }),
 		);
 		expect(c.get('L')).toStrictEqual('L1');
 		expect(c.get('R')).toStrictEqual('R3');
@@ -483,7 +489,7 @@ describe('merge() tests', () => {
 			cR,
 			() => ({ keep: false }),
 			(y) => ({ keep: true, value: `R${y}` }),
-			(x, y) => ({ keep: true, value: `LR${x},${y}` })
+			(x, y) => ({ keep: true, value: `LR${x},${y}` }),
 		);
 		expect(c.get('R')).toStrictEqual('R3');
 		expect(c.get('LR')).toStrictEqual('LR2,4');
@@ -495,7 +501,7 @@ describe('merge() tests', () => {
 			cR,
 			(x) => ({ keep: true, value: `L${x}` }),
 			() => ({ keep: false }),
-			(x, y) => ({ keep: true, value: `LR${x},${y}` })
+			(x, y) => ({ keep: true, value: `LR${x},${y}` }),
 		);
 		expect(c.get('L')).toStrictEqual('L1');
 		expect(c.get('LR')).toStrictEqual('LR2,4');
@@ -507,10 +513,42 @@ describe('merge() tests', () => {
 			cR,
 			(x) => ({ keep: true, value: `L${x}` }),
 			(y) => ({ keep: true, value: `R${y}` }),
-			() => ({ keep: false })
+			() => ({ keep: false }),
 		);
 		expect(c.get('L')).toStrictEqual('L1');
 		expect(c.get('R')).toStrictEqual('R3');
 		expect(c.size).toStrictEqual(2);
+	});
+});
+
+describe('combineEntries() tests', () => {
+	test('it adds entries together', () => {
+		const c = Collection.combineEntries(
+			[
+				['a', 1],
+				['b', 2],
+				['a', 2],
+			],
+			(x, y) => x + y,
+		);
+		expect([...c]).toStrictEqual([
+			['a', 3],
+			['b', 2],
+		]);
+	});
+
+	test('it really goes through all the entries', () => {
+		const c = Collection.combineEntries(
+			[
+				['a', [1]],
+				['b', [2]],
+				['a', [2]],
+			],
+			(x, y) => x.concat(y),
+		);
+		expect([...c]).toStrictEqual([
+			['a', [1, 2]],
+			['b', [2]],
+		]);
 	});
 });

--- a/packages/collection/src/index.ts
+++ b/packages/collection/src/index.ts
@@ -695,7 +695,7 @@ export class Collection<K, V> extends Map<K, V> {
 		other: ReadonlyCollection<K, T>,
 		whenInSelf: (value: V, key: K) => Keep<R>,
 		whenInOther: (valueOther: T, key: K) => Keep<R>,
-		whenInBoth: (value: V, valueOther: T, key: K) => Keep<R>
+		whenInBoth: (value: V, valueOther: T, key: K) => Keep<R>,
 	): Collection<K, R> {
 		const coll = new this.constructor[Symbol.species]<K, R>();
 		const keys = new Set([...this.keys(), ...other.keys()]);
@@ -738,7 +738,36 @@ export class Collection<K, V> extends Map<K, V> {
 	private static defaultSort<V>(firstValue: V, secondValue: V): number {
 		return Number(firstValue > secondValue) || Number(firstValue === secondValue) - 1;
 	}
+
+	/**
+	 * Creates a Collection from a list of entries.
+	 * @param entries The list of entries
+	 * @param combine Function to combine an existing entry with a new one
+	 *
+	 * @example
+	 * Collection.combineEntries([["a", 1], ["b", 2], ["a", 2]], (x, y) => x + y);
+	 * // returns Collection { "a" => 3, "b" => 2 }
+	 */
+	public static combineEntries<K, V>(
+		entries: Iterable<[K, V]>,
+		combine: (firstValue: V, secondValue: V, key: K) => V,
+	): Collection<K, V> {
+		const coll = new Collection<K, V>();
+		for (const [k, v] of entries) {
+			if (coll.has(k)) {
+				coll.set(k, combine(coll.get(k)!, v, k));
+			} else {
+				coll.set(k, v);
+			}
+		}
+		return coll;
+	}
 }
+
+/**
+ * @internal
+ */
+export type Keep<V> = { keep: true; value: V } | { keep: false };
 
 /**
  * @internal

--- a/packages/collection/src/index.ts
+++ b/packages/collection/src/index.ts
@@ -700,13 +700,16 @@ export class Collection<K, V> extends Map<K, V> {
 		const coll = new this.constructor[Symbol.species]<K, R>();
 		const keys = new Set([...this.keys(), ...other.keys()]);
 		for (const k of keys) {
-			if (this.has(k) && other.has(k)) {
+			const hasInSelf = this.has(k);
+			const hasInOther = other.has(k);
+
+			if (hasInSelf && hasInOther) {
 				const r = whenInBoth(this.get(k)!, other.get(k)!, k);
 				if (r.keep) coll.set(k, r.value);
-			} else if (this.has(k)) {
+			} else if (hasInSelf) {
 				const r = whenInSelf(this.get(k)!, k);
 				if (r.keep) coll.set(k, r.value);
-			} else if (other.has(k)) {
+			} else if (hasInOther) {
 				const r = whenInOther(other.get(k)!, k);
 				if (r.keep) coll.set(k, r.value);
 			}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

#7211 removes a use-case from `intersection`, so might as well just cover them all with `merge`.
Then `combineEntries` is basically `merge` but for a bunch of entries instead of two collections.

Prior art [here](https://hackage.haskell.org/package/containers-0.6.4.1/docs/Data-Map-Lazy.html#v:intersection) and [here](https://hackage.haskell.org/package/containers-0.6.4.1/docs/Data-Map-Merge-Lazy.html#v:merge) and [here](https://hackage.haskell.org/package/containers-0.6.4.1/docs/Data-Map-Lazy.html#v:fromListWith).

@suneettipirneni 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
