### PR TITLE
ci(publish-dev): only build dependencies when releasing

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -41,6 +41,7 @@ jobs:
         run: yarn --immutable
 
       - name: Build dependencies
+        if: steps.pre-release.outputs.release == 'true'
         run: yarn build --cache-dir=".turbo"
 
       - name: Deprecate old versions


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a bug causing publish-dev workflows to fail when the targeted commit has been published already.

(Seems to have been introduced with e07c3743375e2bf4470818f6d20c269edce7b7a1)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
