### PR TITLE
feat(threadchannel): add `createdTimestamp` field

### DIFF
--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -214,7 +214,7 @@ class ThreadChannel extends Channel {
    * @readonly
    */
   get createdAt() {
-    return this.createdTimestamp === null ? null : new Date(this.createdTimestamp);
+    return this.createdTimestamp && new Date(this.createdTimestamp);
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -110,7 +110,7 @@ class ThreadChannel extends Channel {
          */
         this.createTimestamp = Date.parse(data.thread_metadata.create_timestamp);
       } else {
-        this.createTimestamp = null;
+        this.createTimestamp ??= null;
       }
     } else {
       this.locked ??= null;

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -214,8 +214,16 @@ class ThreadChannel extends Channel {
    * @readonly
    */
   get createdAt() {
+    if (this.createdTimestamp !== null) {
+      return new Date(this.createdTimestamp);
+    }
+
     // Private threads can rely on their ID for creation date
-    return (this.createdTimestamp ??= this.type === ChannelType.PrivateThread ? super.createdTimestamp : null);
+    if (this.type === ChannelType.PrivateThread) {
+      return super.createdAt;
+    }
+
+    return null;
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -214,7 +214,7 @@ class ThreadChannel extends Channel {
    * @readonly
    */
   get createdAt() {
-    return this.createdTimestamp === null ? null : super.createdAt;
+    return this.createdTimestamp === null ? null : new Date(this.createdTimestamp);
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -526,7 +526,7 @@ class ThreadChannel extends Channel {
   }
 
   /**
-   * Whether or not this thread is a private thread or not
+   * Whether this thread is a private thread
    * @returns {boolean}
    */
   isPrivate() {

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -214,7 +214,8 @@ class ThreadChannel extends Channel {
    * @readonly
    */
   get createdAt() {
-    return this.createdTimestamp && new Date(this.createdTimestamp);
+    // Private threads can rely on their ID for creation date
+    return (this.createdTimestamp ??= this.type === ChannelType.PrivateThread ? super.createdTimestamp : null);
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -118,7 +118,7 @@ class ThreadChannel extends Channel {
       this.invitable ??= null;
     }
 
-    this.createdTimestamp ??= this.type === ChannelType.PrivateThread ? super.createdTimestamp : null;
+    this.createdTimestamp ??= this.type === ChannelType.GuildPrivateThread ? super.createdTimestamp : null;
 
     if ('owner_id' in data) {
       /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -101,6 +101,17 @@ class ThreadChannel extends Channel {
        * @type {?number}
        */
       this.archiveTimestamp = Date.parse(data.thread_metadata.archive_timestamp);
+
+      if ('create_timestamp' in data.thread_metadata) {
+        /**
+         * The timestamp when this thread was created. This isn't available for threads
+         * created before 2022-01-09
+         * @type {?number}
+         */
+        this.createTimestamp = Date.parse(data.thread_metadata.create_timestamp);
+      } else {
+        this.createTimestamp = null;
+      }
     } else {
       this.locked ??= null;
       this.archived ??= null;

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -213,16 +213,7 @@ class ThreadChannel extends Channel {
    * @readonly
    */
   get createdAt() {
-    if (this.createdTimestamp !== null) {
-      return new Date(this.createdTimestamp);
-    }
-
-    // Private threads can rely on their ID for creation date
-    if (this.type === ChannelType.PrivateThread) {
-      return super.createdAt;
-    }
-
-    return null;
+    return this.createdTimestamp && new Date(this.createdTimestamp);
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -110,7 +110,7 @@ class ThreadChannel extends Channel {
          */
         this.createdTimestamp = Date.parse(data.thread_metadata.create_timestamp);
       } else {
-        this.createTimestamp ??= null;
+        this.createdTimestamp ??= null;
       }
     } else {
       this.createdTimestamp ??= null;
@@ -206,6 +206,15 @@ class ThreadChannel extends Channel {
    */
   get archivedAt() {
     return this.archiveTimestamp && new Date(this.archiveTimestamp);
+  }
+
+  /**
+   * The time the thread was created at
+   * @type {?Date}
+   * @readonly
+   */
+  get createdAt() {
+    return this.createdTimestamp === null ? null : super.createdAt;
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -108,11 +108,12 @@ class ThreadChannel extends Channel {
          * created before 2022-01-09
          * @type {?number}
          */
-        this.createTimestamp = Date.parse(data.thread_metadata.create_timestamp);
+        this.createdTimestamp = Date.parse(data.thread_metadata.create_timestamp);
       } else {
         this.createTimestamp ??= null;
       }
     } else {
+      this.createdTimestamp ??= null;
       this.locked ??= null;
       this.archived ??= null;
       this.autoArchiveDuration ??= null;

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -109,17 +109,16 @@ class ThreadChannel extends Channel {
          * @type {?number}
          */
         this.createdTimestamp = Date.parse(data.thread_metadata.create_timestamp);
-      } else {
-        this.createdTimestamp ??= null;
       }
     } else {
-      this.createdTimestamp ??= null;
       this.locked ??= null;
       this.archived ??= null;
       this.autoArchiveDuration ??= null;
       this.archiveTimestamp ??= null;
       this.invitable ??= null;
     }
+
+    this.createdTimestamp ??= this.type === ChannelType.PrivateThread ? super.createdTimestamp : null;
 
     if ('owner_id' in data) {
       /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -526,6 +526,14 @@ class ThreadChannel extends Channel {
   }
 
   /**
+   * Whether or not this thread is a private thread or not
+   * @returns {boolean}
+   */
+  isPrivate() {
+    return this.type === ChannelType.GuildPrivateThread;
+  }
+
+  /**
    * Deletes this thread.
    * @param {string} [reason] Reason for deleting this thread
    * @returns {Promise<ThreadChannel>}

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -513,7 +513,7 @@ export type CategoryChannelResolvable = Snowflake | CategoryChannel;
 export abstract class Channel extends Base {
   public constructor(client: Client, data?: RawChannelData, immediatePatch?: boolean);
   public readonly createdAt: Date;
-  public readonly createdTimestamp: number;
+  public readonly createdTimestamp: number | null;
   public id: Snowflake;
   public readonly partial: false;
   public type: ChannelType;
@@ -1042,7 +1042,7 @@ export abstract class GuildChannel extends Channel {
   public constructor(guild: Guild, data?: RawGuildChannelData, client?: Client, immediatePatch?: boolean);
   private memberPermissions(member: GuildMember, checkAdmin: boolean): Readonly<Permissions>;
   private rolePermissions(role: Role, checkAdmin: boolean): Readonly<Permissions>;
-
+  public readonly createdTimestamp: number;
   public readonly calculatedPosition: number;
   public readonly deletable: boolean;
   public guild: Guild;
@@ -2212,7 +2212,7 @@ export class ThreadChannel extends TextBasedChannelMixin(Channel) {
   public archived: boolean | null;
   public readonly archivedAt: Date | null;
   public archiveTimestamp: number | null;
-  public createTimestamp: number | null;
+  public createdTimestamp: number | null;
   public autoArchiveDuration: ThreadAutoArchiveDuration | null;
   public readonly editable: boolean;
   public guild: Guild;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2212,6 +2212,7 @@ export class ThreadChannel extends TextBasedChannelMixin(Channel) {
   public archived: boolean | null;
   public readonly archivedAt: Date | null;
   public archiveTimestamp: number | null;
+  public createTimestamp: number | null;
   public autoArchiveDuration: ThreadAutoArchiveDuration | null;
   public readonly editable: boolean;
   public guild: Guild;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2238,6 +2238,11 @@ export class ThreadChannel extends TextBasedChannelMixin(Channel) {
   public rateLimitPerUser: number | null;
   public type: ThreadChannelType;
   public readonly unarchivable: boolean;
+  public isPrivate(): this is this & {
+    createdTimestamp: number;
+    createdAt: Date;
+    type: ChannelType.GuildPrivateThread;
+  };
   public delete(reason?: string): Promise<this>;
   public edit(data: ThreadEditData, reason?: string): Promise<ThreadChannel>;
   public join(): Promise<ThreadChannel>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -512,7 +512,7 @@ export type CategoryChannelResolvable = Snowflake | CategoryChannel;
 
 export abstract class Channel extends Base {
   public constructor(client: Client, data?: RawChannelData, immediatePatch?: boolean);
-  public readonly createdAt: Date;
+  public readonly createdAt: Date | null;
   public readonly createdTimestamp: number | null;
   public id: Snowflake;
   public readonly partial: false;
@@ -1042,6 +1042,7 @@ export abstract class GuildChannel extends Channel {
   public constructor(guild: Guild, data?: RawGuildChannelData, client?: Client, immediatePatch?: boolean);
   private memberPermissions(member: GuildMember, checkAdmin: boolean): Readonly<Permissions>;
   private rolePermissions(role: Role, checkAdmin: boolean): Readonly<Permissions>;
+  public readonly createdAt: Date;
   public readonly createdTimestamp: number;
   public readonly calculatedPosition: number;
   public readonly deletable: boolean;
@@ -2212,6 +2213,7 @@ export class ThreadChannel extends TextBasedChannelMixin(Channel) {
   public archived: boolean | null;
   public readonly archivedAt: Date | null;
   public archiveTimestamp: number | null;
+  public readonly createdAt: Date | null;
   public createdTimestamp: number | null;
   public autoArchiveDuration: ThreadAutoArchiveDuration | null;
   public readonly editable: boolean;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2239,8 +2239,8 @@ export class ThreadChannel extends TextBasedChannelMixin(Channel) {
   public type: ThreadChannelType;
   public readonly unarchivable: boolean;
   public isPrivate(): this is this & {
-    createdTimestamp: number;
-    createdAt: Date;
+    readonly createdTimestamp: number;
+    readonly createdAt: Date;
     type: ChannelType.GuildPrivateThread;
   };
   public delete(reason?: string): Promise<this>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This also adds an `isPrivate` type guard for threads.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)