### PR TITLE
types: fix MessageMentions channel types

### DIFF
--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -161,20 +161,6 @@ class MessageMentions {
     let matches;
     while ((matches = this.constructor.CHANNELS_PATTERN.exec(this._content)) !== null) {
       const chan = this.client.channels.cache.get(matches[1]);
-      if (
-        ![
-          ChannelType.GuildText,
-          ChannelType.GuildVoice,
-          ChannelType.GuildNews,
-          ChannelType.GuildNewsThread,
-          ChannelType.GuildPublicThread,
-          ChannelType.GuildPrivateThread,
-          ChannelType.GuildStageVoice,
-        ].includes(chan.type)
-      ) {
-        // Go onto the next channel, as this one is not a text channel
-        continue;
-      }
       if (chan) this._channels.set(chan.id, chan);
     }
     return this._channels;

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { Collection } = require('@discordjs/collection');
-const { ChannelType } = require('discord-api-types');
 const Util = require('../util/Util');
 
 /**

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Collection } = require('@discordjs/collection');
+const { ChannelType } = require('discord-api-types');
 const Util = require('../util/Util');
 
 /**
@@ -160,6 +161,20 @@ class MessageMentions {
     let matches;
     while ((matches = this.constructor.CHANNELS_PATTERN.exec(this._content)) !== null) {
       const chan = this.client.channels.cache.get(matches[1]);
+      if (
+        ![
+          ChannelType.GuildText,
+          ChannelType.GuildVoice,
+          ChannelType.GuildNews,
+          ChannelType.GuildNewsThread,
+          ChannelType.GuildPublicThread,
+          ChannelType.GuildPrivateThread,
+          ChannelType.GuildStageVoice,
+        ].includes(chan.type)
+      ) {
+        // Go onto the next channel, as this one is not a text channel
+        continue;
+      }
       if (chan) this._channels.set(chan.id, chan);
     }
     return this._channels;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1677,11 +1677,11 @@ export class MessageMentions {
     everyone: boolean,
     repliedUser?: APIUser | User,
   );
-  private _channels: Collection<Snowflake, TextBasedChannel> | null;
+  private _channels: Collection<Snowflake, Exclude<TextBasedChannel, DMChannel> | VoiceBasedChannel> | null;
   private readonly _content: string;
   private _members: Collection<Snowflake, GuildMember> | null;
 
-  public readonly channels: Collection<Snowflake, TextBasedChannel>;
+  public readonly channels: Collection<Snowflake, Exclude<TextBasedChannel, DMChannel> | VoiceBasedChannel>;
   public readonly client: Client;
   public everyone: boolean;
   public readonly guild: Guild;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1677,11 +1677,11 @@ export class MessageMentions {
     everyone: boolean,
     repliedUser?: APIUser | User,
   );
-  private _channels: Collection<Snowflake, Exclude<TextBasedChannel, DMChannel> | VoiceBasedChannel> | null;
+  private _channels: Collection<Snowflake, AnyChannel> | null;
   private readonly _content: string;
   private _members: Collection<Snowflake, GuildMember> | null;
 
-  public readonly channels: Collection<Snowflake, Exclude<TextBasedChannel, DMChannel> | VoiceBasedChannel>;
+  public readonly channels: Collection<Snowflake, AnyChannel>;
   public readonly client: Client;
   public everyone: boolean;
   public readonly guild: Guild;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixed typings to allow for other channel types other than TextBasedChannel in MessageMentions.channels, such as voice. Also removed DMChannels from those types, as you cannot mention a DMChannel - the ID of a DMChannel is the user's ID, which is only valid under a user mention.

**Status and versioning classification:** Patch

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating