### PR TITLE
feat(minor): add application_id to Webhook

### DIFF
--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -85,6 +85,16 @@ class Webhook {
       this.owner ??= null;
     }
 
+    if ('application_id' in data) {
+      /**
+       * The application that created this webhook
+       * @type {?Snowflake}
+       */
+      this.applicationId = data.application_id;
+    } else {
+      this.applicationId ??= null;
+    }
+
     if ('source_guild' in data) {
       /**
        * The source guild of the webhook

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -408,15 +408,18 @@ class Webhook {
    * @returns {boolean}
    */
   isUserCreated() {
-    return Boolean(this.owner);
+    if (this.type !== WebhookType.Incoming) return false;
+    if (!this.owner) return false;
+    if (this.owner.bot) return false;
+    return true;
   }
 
   /**
-   * Whether this webhook is created by an application and not a user.
+   * Whether this webhook is created by an application.
    * @returns {boolean}
    */
   isApplicationCreated() {
-    return Boolean(this.applicationId);
+    return this.type === WebhookType.Application;
   }
 
   /**

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -404,6 +404,22 @@ class Webhook {
   }
 
   /**
+   * Whether or not this webhook is created by a user
+   * @returns {boolean}
+   */
+  isUserCreated() {
+    return Boolean(this.owner);
+  }
+
+  /**
+   * Whether or not this webhook is created by an application and not a user
+   * @returns {boolean}
+   */
+  isApplicationCreated() {
+    return Boolean(this.applicationId);
+  }
+
+  /**
    * Whether or not this webhook is a channel follower webhook.
    * @returns {boolean}
    */

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -404,7 +404,7 @@ class Webhook {
   }
 
   /**
-   * Whether or not this webhook is created by a user
+   * Whether or not this webhook is created by a user.
    * @returns {boolean}
    */
   isUserCreated() {
@@ -412,7 +412,7 @@ class Webhook {
   }
 
   /**
-   * Whether or not this webhook is created by an application and not a user
+   * Whether or not this webhook is created by an application and not a user.
    * @returns {boolean}
    */
   isApplicationCreated() {

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -404,7 +404,7 @@ class Webhook {
   }
 
   /**
-   * Whether or not this webhook is created by a user.
+   * Whether this webhook is created by a user.
    * @returns {boolean}
    */
   isUserCreated() {
@@ -412,7 +412,7 @@ class Webhook {
   }
 
   /**
-   * Whether or not this webhook is created by an application and not a user.
+   * Whether this webhook is created by an application and not a user.
    * @returns {boolean}
    */
   isApplicationCreated() {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2461,7 +2461,7 @@ export class Webhook extends WebhookMixin() {
     token: string | null;
   };
   public isApplicationCreated(): this is this & {
-    type: WebhookType.Incoming;
+    type: WebhookType.Application;
     applicationId: Snowflake;
     owner: User | APIUser;
   };

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2453,7 +2453,7 @@ export class Webhook extends WebhookMixin() {
   public sourceChannel: NewsChannel | APIPartialChannel | null;
   public token: string | null;
   public type: WebhookType;
-  public application_id?: Snowflake;
+  public applicationId: Snowflake | null;
   public isIncoming(): this is this & { token: string };
   public isChannelFollower(): this is this & {
     sourceGuild: Guild | APIPartialGuild;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2455,18 +2455,25 @@ export class Webhook extends WebhookMixin() {
   public type: WebhookType;
   public applicationId: Snowflake | null;
   public isUserCreated(): this is this & {
+    type: WebhookType.Incoming;
     applicationId: null;
     owner: User | APIUser;
     token: null;
   };
   public isApplicationCreated(): this is this & {
+    type: WebhookType.Incoming;
     applicationId: Snowflake;
     owner: null;
   };
-  public isIncoming(): this is this & { token: string };
+  public isIncoming(): this is this & {
+    type: WebhookType.Incoming;
+    token: string;
+  };
   public isChannelFollower(): this is this & {
+    type: WebhookType.ChannelFollower;
     sourceGuild: Guild | APIPartialGuild;
     sourceChannel: NewsChannel | APIPartialChannel;
+    token: null;
   };
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2458,12 +2458,12 @@ export class Webhook extends WebhookMixin() {
     type: WebhookType.Incoming;
     applicationId: null;
     owner: User | APIUser;
-    token: null;
+    token: string | null;
   };
   public isApplicationCreated(): this is this & {
     type: WebhookType.Incoming;
     applicationId: Snowflake;
-    owner: null;
+    owner: User | APIUser;
   };
   public isIncoming(): this is this & {
     type: WebhookType.Incoming;
@@ -2474,6 +2474,8 @@ export class Webhook extends WebhookMixin() {
     sourceGuild: Guild | APIPartialGuild;
     sourceChannel: NewsChannel | APIPartialChannel;
     token: null;
+    applicationId: null;
+    owner: User | APIUser;
   };
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2453,6 +2453,7 @@ export class Webhook extends WebhookMixin() {
   public sourceChannel: NewsChannel | APIPartialChannel | null;
   public token: string | null;
   public type: WebhookType;
+  public application_id?: Snowflake;
   public isIncoming(): this is this & { token: string };
   public isChannelFollower(): this is this & {
     sourceGuild: Guild | APIPartialGuild;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2454,6 +2454,15 @@ export class Webhook extends WebhookMixin() {
   public token: string | null;
   public type: WebhookType;
   public applicationId: Snowflake | null;
+  public isUserCreated(): this is this & {
+    applicationId: null;
+    owner: User | APIUser;
+    token: null;
+  };
+  public isApplicationCreated(): this is this & {
+    applicationId: Snowflake;
+    owner: null;
+  };
   public isIncoming(): this is this & { token: string };
   public isChannelFollower(): this is this & {
     sourceGuild: Guild | APIPartialGuild;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add the `application_id` property to the Webhook class. It is available with the Discord API itself, however, it is not exposed in discord.js

**Status and versioning classification:** Minor

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)