### PR TITLE
rest: prefer arrayBuffer over buffer

### DIFF
--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -205,12 +205,12 @@ test('urlEncoded', async () => {
 		['code', 'very-invalid-code'],
 	]);
 	expect(
-		await api.post('/urlEncoded', {
+		new Uint8Array(await api.post('/urlEncoded', {
 			body,
 			passThroughBody: true,
 			auth: false,
-		}),
-	).toStrictEqual(Buffer.from(body.toString()));
+		}) as ArrayBuffer),
+	).toStrictEqual(new Uint8Array(Buffer.from(body.toString())));
 });
 
 test('postEcho', async () => {

--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -205,11 +205,13 @@ test('urlEncoded', async () => {
 		['code', 'very-invalid-code'],
 	]);
 	expect(
-		new Uint8Array(await api.post('/urlEncoded', {
-			body,
-			passThroughBody: true,
-			auth: false,
-		}) as ArrayBuffer),
+		new Uint8Array(
+			(await api.post('/urlEncoded', {
+				body,
+				passThroughBody: true,
+				auth: false,
+			})) as ArrayBuffer,
+		),
 	).toStrictEqual(new Uint8Array(Buffer.from(body.toString())));
 });
 

--- a/packages/rest/__tests__/RequestHandler.test.ts
+++ b/packages/rest/__tests__/RequestHandler.test.ts
@@ -261,11 +261,11 @@ test('Handle standard rate limits', async () => {
 	const [a, b, c] = [api.get('/standard'), api.get('/standard'), api.get('/standard')];
 	const uint8 = new Uint8Array();
 
-	expect(new Uint8Array(await a as ArrayBuffer)).toStrictEqual(uint8);
+	expect(new Uint8Array((await a) as ArrayBuffer)).toStrictEqual(uint8);
 	const previous1 = performance.now();
-	expect(new Uint8Array(await b as ArrayBuffer)).toStrictEqual(uint8);
+	expect(new Uint8Array((await b) as ArrayBuffer)).toStrictEqual(uint8);
 	const previous2 = performance.now();
-	expect(new Uint8Array(await c as ArrayBuffer)).toStrictEqual(uint8);
+	expect(new Uint8Array((await c) as ArrayBuffer)).toStrictEqual(uint8);
 	const now = performance.now();
 	expect(previous2).toBeGreaterThanOrEqual(previous1 + 250);
 	expect(now).toBeGreaterThanOrEqual(previous2 + 250);

--- a/packages/rest/__tests__/RequestHandler.test.ts
+++ b/packages/rest/__tests__/RequestHandler.test.ts
@@ -259,12 +259,13 @@ test('Significant Invalid Requests', async () => {
 
 test('Handle standard rate limits', async () => {
 	const [a, b, c] = [api.get('/standard'), api.get('/standard'), api.get('/standard')];
+	const uint8 = new Uint8Array();
 
-	expect(await a).toStrictEqual(Buffer.alloc(0));
+	expect(new Uint8Array(await a as ArrayBuffer)).toStrictEqual(uint8);
 	const previous1 = performance.now();
-	expect(await b).toStrictEqual(Buffer.alloc(0));
+	expect(new Uint8Array(await b as ArrayBuffer)).toStrictEqual(uint8);
 	const previous2 = performance.now();
-	expect(await c).toStrictEqual(Buffer.alloc(0));
+	expect(new Uint8Array(await c as ArrayBuffer)).toStrictEqual(uint8);
 	const now = performance.now();
 	expect(previous2).toBeGreaterThanOrEqual(previous1 + 250);
 	expect(now).toBeGreaterThanOrEqual(previous2 + 250);

--- a/packages/rest/src/lib/utils/utils.ts
+++ b/packages/rest/src/lib/utils/utils.ts
@@ -11,7 +11,7 @@ export function parseResponse(res: Response): Promise<unknown> {
 		return res.json();
 	}
 
-	return res.buffer();
+	return res.arrayBuffer();
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- `Response.buffer` is not a spec compliant method.
- Buffer only exists in node and it's just a wrapper for Uin8Arrays anyways.
- It's getting [removed](https://github.com/node-fetch/node-fetch/issues/1452) in v4, if its decided to stay with node-fetch and move towards ESM.

I have no idea if types need updating, sorry 😕 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
