### PR TITLE
feat!: add CategoryChannelChildManager

### DIFF
--- a/packages/discord.js/src/managers/CategoryChannelChildManager.js
+++ b/packages/discord.js/src/managers/CategoryChannelChildManager.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const CachedManager = require('./CachedManager');
+const DataManager = require('./DataManager');
 const GuildChannel = require('../structures/GuildChannel');
 
 /**
  * Manages API methods for CategoryChannels' children and stores their cache.
- * @extends {CachedManager}
+ * @extends {DataManager}
  */
-class CategoryChannelChildManager extends CachedManager {
+class CategoryChannelChildManager extends DataManager {
   constructor(channel, iterable) {
     super(channel.client, GuildChannel, iterable);
     /**
@@ -15,12 +15,24 @@ class CategoryChannelChildManager extends CachedManager {
      * @type {CategoryChannel}
      */
     this.channel = channel;
+  }
 
-    /**
-     * The guild this manager belongs to
-     * @type {Guild}
-     */
-    this.guild = channel.guild;
+  /**
+   * The channels that are a part of this category
+   * @type {Collection<Snowflake, GuildChannel>}
+   * @readonly
+   */
+  get cache() {
+    return this.guild.channels.cache.filter(c => c.parentId === this.channel.id);
+  }
+
+  /**
+   * The guild this manager belongs to
+   * @type {Guild}
+   * @readonly
+   */
+  get guild() {
+    return this.channel.guild;
   }
 
   /**
@@ -51,15 +63,6 @@ class CategoryChannelChildManager extends CachedManager {
       ...options,
       parent: this.channel.id,
     });
-  }
-
-  /**
-   * The channels that are a part of this category
-   * @type {Collection<Snowflake, GuildChannel>}
-   * @readonly
-   */
-  get cache() {
-    return this.guild.channels.cache.filter(c => c.parentId === this.channel.id);
   }
 }
 

--- a/packages/discord.js/src/managers/CategoryChannelChildManager.js
+++ b/packages/discord.js/src/managers/CategoryChannelChildManager.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const CachedManager = require('./CachedManager');
+const GuildChannel = require('../structures/GuildChannel');
+
+/**
+ * Manages API methods for CategoryChannels' children and stores their cache.
+ * @extends {CachedManager}
+ */
+class CategoryChannelChildManager extends CachedManager {
+  constructor(channel, iterable) {
+    super(channel.client, GuildChannel, iterable);
+    /**
+     * The category channel this manager belongs to
+     * @type {CategoryChannel}
+     */
+    this.channel = channel;
+
+    /**
+     * The guild this manager belongs to
+     * @type {Guild}
+     */
+    this.guild = channel.guild;
+  }
+
+  /**
+   * Options for creating a channel using {@link CategoryChannel#createChannel}.
+   * @typedef {Object} CategoryCreateChannelOptions
+   * @property {ChannelType} [type=ChannelType.GuildText] The type of the new channel.
+   * @property {string} [topic] The topic for the new channel
+   * @property {boolean} [nsfw] Whether the new channel is NSFW
+   * @property {number} [bitrate] Bitrate of the new channel in bits (only voice)
+   * @property {number} [userLimit] Maximum amount of users allowed in the new channel (only voice)
+   * @property {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [permissionOverwrites]
+   * Permission overwrites of the new channel
+   * @property {number} [position] Position of the new channel
+   * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the new channel in seconds
+   * @property {string} [rtcRegion] The specific region of the new channel.
+   * @property {string} [reason] Reason for creating the new channel
+   */
+
+  /**
+   * Creates a new channel within this category.
+   * <info>You cannot create a channel of type {@link ChannelType.GuildCategory} inside a CategoryChannel.</info>
+   * @param {string} name The name of the new channel
+   * @param {CategoryCreateChannelOptions} options Options for creating the new channel
+   * @returns {Promise<GuildChannel>}
+   */
+  create(name, options) {
+    return this.guild.channels.create(name, {
+      ...options,
+      parent: this.channel.id,
+    });
+  }
+
+  /**
+   * The channels that are a part of this category
+   * @type {Collection<Snowflake, GuildChannel>}
+   * @readonly
+   */
+  get cache() {
+    return this.guild.channels.cache.filter(c => c.parentId === this.channel.id);
+  }
+}
+
+module.exports = CategoryChannelChildManager;

--- a/packages/discord.js/src/managers/CategoryChannelChildManager.js
+++ b/packages/discord.js/src/managers/CategoryChannelChildManager.js
@@ -8,8 +8,8 @@ const GuildChannel = require('../structures/GuildChannel');
  * @extends {DataManager}
  */
 class CategoryChannelChildManager extends DataManager {
-  constructor(channel, iterable) {
-    super(channel.client, GuildChannel, iterable);
+  constructor(channel) {
+    super(channel.client, GuildChannel);
     /**
      * The category channel this manager belongs to
      * @type {CategoryChannel}

--- a/packages/discord.js/src/managers/CategoryChannelChildManager.js
+++ b/packages/discord.js/src/managers/CategoryChannelChildManager.js
@@ -4,7 +4,7 @@ const DataManager = require('./DataManager');
 const GuildChannel = require('../structures/GuildChannel');
 
 /**
- * Manages API methods for CategoryChannels' children and stores their cache.
+ * Manages API methods for CategoryChannels' children.
  * @extends {DataManager}
  */
 class CategoryChannelChildManager extends DataManager {

--- a/packages/discord.js/src/structures/CategoryChannel.js
+++ b/packages/discord.js/src/structures/CategoryChannel.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const GuildChannel = require('./GuildChannel');
+const CategoryChannelChildManager = require('../managers/CategoryChannelChildManager');
 
 /**
  * Represents a guild category channel on Discord.
@@ -8,12 +9,12 @@ const GuildChannel = require('./GuildChannel');
  */
 class CategoryChannel extends GuildChannel {
   /**
-   * Channels that are a part of this category
-   * @type {Collection<Snowflake, GuildChannel>}
+   * A manager of the channels belonging to this category
+   * @type {CategoryChannelChildManager}
    * @readonly
    */
   get children() {
-    return this.guild.channels.cache.filter(c => c.parentId === this.id);
+    return new CategoryChannelChildManager(this);
   }
 
   /**
@@ -26,37 +27,6 @@ class CategoryChannel extends GuildChannel {
    * @param {SetParentOptions} [options={}] The options for setting the parent
    * @returns {Promise<GuildChannel>}
    */
-
-  /**
-   * Options for creating a channel using {@link CategoryChannel#createChannel}.
-   * @typedef {Object} CategoryCreateChannelOptions
-   * @property {ChannelType} [type=ChannelType.GuildText] The type of the new channel.
-   * @property {string} [topic] The topic for the new channel
-   * @property {boolean} [nsfw] Whether the new channel is NSFW
-   * @property {number} [bitrate] Bitrate of the new channel in bits (only voice)
-   * @property {number} [userLimit] Maximum amount of users allowed in the new channel (only voice)
-   * @property {OverwriteResolvable[]|Collection<Snowflake, OverwriteResolvable>} [permissionOverwrites]
-   * Permission overwrites of the new channel
-   * @property {number} [position] Position of the new channel
-   * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the new channel in seconds
-   * @property {string} [rtcRegion] The specific region of the new channel.
-   * @property {string} [reason] Reason for creating the new channel
-   */
-
-  /**
-   * Creates a new channel within this category.
-   * <info>You cannot create a channel of type {@link ChannelType.GuildCategory} inside a
-   * CategoryChannel.</info>
-   * @param {string} name The name of the new channel
-   * @param {CategoryCreateChannelOptions} options Options for creating the new channel
-   * @returns {Promise<GuildChannel>}
-   */
-  createChannel(name, options) {
-    return this.guild.channels.create(name, {
-      ...options,
-      parent: this.id,
-    });
-  }
 }
 
 module.exports = CategoryChannel;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2731,12 +2731,12 @@ export class BaseGuildEmojiManager extends CachedManager<Snowflake, GuildEmoji, 
   public resolveIdentifier(emoji: EmojiIdentifierResolvable): string | null;
 }
 
-export class CategoryChannelChildManager extends CachedManager<
+export class CategoryChannelChildManager extends DataManager<
   Snowflake,
   NonCategoryGuildBasedChannel,
   GuildChannelResolvable
 > {
-  private constructor(guild: Guild, iterable?: Iterable<RawGuildChannelData>);
+  private constructor(channel: CategoryChannel);
 
   public channel: CategoryChannel;
   public readonly guild: Guild;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -468,19 +468,8 @@ export type CategoryChannelType = Exclude<
 >;
 
 export class CategoryChannel extends GuildChannel {
-  public readonly children: Collection<Snowflake, Exclude<NonThreadGuildBasedChannel, CategoryChannel>>;
+  public readonly children: CategoryChannelChildManager;
   public type: ChannelType.GuildCategory;
-
-  public createChannel<T extends Exclude<CategoryChannelType, ChannelType.GuildStore>>(
-    name: string,
-    options: CategoryCreateChannelOptions & { type: T },
-  ): Promise<MappedChannelCategoryTypes[T]>;
-  /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
-  public createChannel(
-    name: string,
-    options: CategoryCreateChannelOptions & { type: ChannelType.GuildStore },
-  ): Promise<StoreChannel>;
-  public createChannel(name: string, options?: CategoryCreateChannelOptions): Promise<TextChannel>;
 }
 
 export type CategoryChannelResolvable = Snowflake | CategoryChannel;
@@ -2740,6 +2729,23 @@ export class ApplicationCommandPermissionsManager<
 export class BaseGuildEmojiManager extends CachedManager<Snowflake, GuildEmoji, EmojiResolvable> {
   protected constructor(client: Client, iterable?: Iterable<RawGuildEmojiData>);
   public resolveIdentifier(emoji: EmojiIdentifierResolvable): string | null;
+}
+
+export class CategoryChannelChildManager extends CachedManager<Snowflake, GuildChannel, GuildChannelResolvable> {
+  private constructor(guild: Guild, iterable?: Iterable<RawGuildChannelData>);
+
+  public channel: CategoryChannel;
+  public guild: Guild;
+  public create<T extends Exclude<CategoryChannelType, ChannelType.GuildStore>>(
+    name: string,
+    options: CategoryCreateChannelOptions & { type: T },
+  ): Promise<MappedChannelCategoryTypes[T]>;
+  /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
+  public create(
+    name: string,
+    options: CategoryCreateChannelOptions & { type: ChannelType.GuildStore },
+  ): Promise<StoreChannel>;
+  public create(name: string, options?: CategoryCreateChannelOptions): Promise<TextChannel>;
 }
 
 export class ChannelManager extends CachedManager<Snowflake, AnyChannel, ChannelResolvable> {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2731,7 +2731,11 @@ export class BaseGuildEmojiManager extends CachedManager<Snowflake, GuildEmoji, 
   public resolveIdentifier(emoji: EmojiIdentifierResolvable): string | null;
 }
 
-export class CategoryChannelChildManager extends CachedManager<Snowflake, GuildChannel, GuildChannelResolvable> {
+export class CategoryChannelChildManager extends CachedManager<
+  Snowflake,
+  NonCategoryGuildBasedChannel,
+  GuildChannelResolvable
+> {
   private constructor(guild: Guild, iterable?: Iterable<RawGuildChannelData>);
 
   public channel: CategoryChannel;
@@ -4935,6 +4939,8 @@ export type TextBasedChannelTypes = TextBasedChannel['type'];
 export type VoiceBasedChannel = Extract<AnyChannel, { bitrate: number }>;
 
 export type GuildBasedChannel = Extract<AnyChannel, { guild: Guild }>;
+
+export type NonCategoryGuildBasedChannel = Exclude<GuildBasedChannel, CategoryChannel>;
 
 export type NonThreadGuildBasedChannel = Exclude<GuildBasedChannel, ThreadChannel>;
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2739,7 +2739,7 @@ export class CategoryChannelChildManager extends CachedManager<
   private constructor(guild: Guild, iterable?: Iterable<RawGuildChannelData>);
 
   public channel: CategoryChannel;
-  public guild: Guild;
+  public readonly guild: Guild;
   public create<T extends Exclude<CategoryChannelType, ChannelType.GuildStore>>(
     name: string,
     options: CategoryCreateChannelOptions & { type: T },

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -100,6 +100,7 @@ import {
   Events,
   ShardEvents,
   Status,
+  CategoryChannelChildManager,
 } from '.';
 import { expectAssignable, expectDeprecated, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import { Embed } from '@discordjs/builders';
@@ -823,7 +824,7 @@ expectType<Message | null>(newsChannel.lastMessage);
 expectType<Message | null>(textChannel.lastMessage);
 
 expectDeprecated(storeChannel.clone());
-expectDeprecated(categoryChannel.createChannel('Store', { type: ChannelType.GuildStore }));
+expectDeprecated(categoryChannelChildManager.create('Store', { type: ChannelType.GuildStore }));
 expectDeprecated(guild.channels.create('Store', { type: ChannelType.GuildStore }));
 
 notPropertyOf(user, 'lastMessage');
@@ -903,15 +904,15 @@ expectType<Promise<Collection<Snowflake, ApplicationCommand>>>(guildApplicationC
 expectType<Promise<Collection<Snowflake, ApplicationCommand>>>(guildApplicationCommandManager.fetch(undefined, {}));
 expectType<Promise<ApplicationCommand>>(guildApplicationCommandManager.fetch('0'));
 
-declare const categoryChannel: CategoryChannel;
+declare const categoryChannelChildManager: CategoryChannelChildManager;
 {
-  expectType<Promise<VoiceChannel>>(categoryChannel.createChannel('name', { type: ChannelType.GuildVoice }));
-  expectType<Promise<TextChannel>>(categoryChannel.createChannel('name', { type: ChannelType.GuildText }));
-  expectType<Promise<NewsChannel>>(categoryChannel.createChannel('name', { type: ChannelType.GuildNews }));
-  expectDeprecated(categoryChannel.createChannel('name', { type: ChannelType.GuildStore }));
-  expectType<Promise<StageChannel>>(categoryChannel.createChannel('name', { type: ChannelType.GuildStageVoice }));
-  expectType<Promise<TextChannel>>(categoryChannel.createChannel('name', {}));
-  expectType<Promise<TextChannel>>(categoryChannel.createChannel('name'));
+  expectType<Promise<VoiceChannel>>(categoryChannelChildManager.create('name', { type: ChannelType.GuildVoice }));
+  expectType<Promise<TextChannel>>(categoryChannelChildManager.create('name', { type: ChannelType.GuildText }));
+  expectType<Promise<NewsChannel>>(categoryChannelChildManager.create('name', { type: ChannelType.GuildNews }));
+  expectDeprecated(categoryChannelChildManager.create('name', { type: ChannelType.GuildStore }));
+  expectType<Promise<StageChannel>>(categoryChannelChildManager.create('name', { type: ChannelType.GuildStageVoice }));
+  expectType<Promise<TextChannel>>(categoryChannelChildManager.create('name', {}));
+  expectType<Promise<TextChannel>>(categoryChannelChildManager.create('name'));
 }
 
 declare const guildChannelManager: GuildChannelManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes CategoryChannel#children to be a manager and moves CategoryChannel#createChannel to CategoryChannelChildManager#create. This allows for better organization and consistency with other methods in the library and also allows for easier expandability in the future

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
