### PR TITLE
docs(README): use "Discord server" instead of "Server"

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ See [the contribution guide](https://github.com/discordjs/discord.js/blob/main/.
 ## Help
 
 If you don't understand something in the documentation, you are experiencing problems, or you just need a gentle
-nudge in the right direction, please don't hesitate to join our official [discord.js Server](https://discord.gg/djs).
+nudge in the right direction, please don't hesitate to join our official [discord.js Discord server](https://discord.gg/djs).


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I don't know about you, but **discord.js Server** doesn't sound right to me, and it doesn't describe what type of server it is. Using **discord.js Discord server** adds a description to it, and makes it clearer for the readers to know what a Discord server is used for discord.js help.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
