### PR TITLE
fix: missed enums and typings from #7290

### DIFF
--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -40,16 +40,16 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {string} name The name of the guild scheduled event
    * @property {DateResolvable} scheduledStartTime The time to schedule the event at
    * @property {DateResolvable} [scheduledEndTime] The time to end the event at
-   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External External}</warn>
+   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External}</warn>
    * @property {PrivacyLevel|number} privacyLevel The privacy level of the guild scheduled event
    * @property {GuildScheduledEventEntityType|number} entityType The scheduled entity type of the event
    * @property {string} [description] The description of the guild scheduled event
    * @property {GuildVoiceChannelResolvable} [channel] The channel of the guild scheduled event
-   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.StageInstance StageInstance} or
-   * {@link GuildScheduledEventEntityType.Voice Voice}</warn>
+   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.StageInstance} or
+   * {@link GuildScheduledEventEntityType.Voice}</warn>
    * @property {GuildScheduledEventEntityMetadataOptions} [entityMetadata] The entity metadata of the
    * guild scheduled event
-   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External External}</warn>
+   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External}</warn>
    * @property {string} [reason] The reason for creating the guild scheduled event
    */
 
@@ -57,7 +57,7 @@ class GuildScheduledEventManager extends CachedManager {
    * Options used to set entity metadata of a guild scheduled event.
    * @typedef {Object} GuildScheduledEventEntityMetadataOptions
    * @property {string} [location] The location of the guild scheduled event
-   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External External}</warn>
+   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External}</warn>
    */
 
   /**
@@ -170,7 +170,7 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {GuildScheduledEventEntityMetadataOptions} [entityMetadata] The entity metadata of the
    * guild scheduled event
    * <warn>This can be modified only if `entityType` of the `GuildScheduledEvent` to be edited is
-   * {@link GuildScheduledEventEntityType.External External}</warn>
+   * {@link GuildScheduledEventEntityType.External}</warn>
    * @property {string} [reason] The reason for editing the guild scheduled event
    */
 

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -1,11 +1,7 @@
 'use strict';
 
 const { Collection } = require('@discordjs/collection');
-const {
-  GuildScheduledEventPrivacyLevel,
-  GuildScheduledEventEntityType,
-  GuildScheduledEventStatus,
-} = require('discord-api-types/v9');
+const { GuildScheduledEventEntityType } = require('discord-api-types/v9');
 const CachedManager = require('./CachedManager');
 const { TypeError, Error } = require('../errors');
 const { GuildScheduledEvent } = require('../structures/GuildScheduledEvent');
@@ -44,16 +40,16 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {string} name The name of the guild scheduled event
    * @property {DateResolvable} scheduledStartTime The time to schedule the event at
    * @property {DateResolvable} [scheduledEndTime] The time to end the event at
-   * <warn>This is required if `entityType` is `GuildScheduledEventEntityType.External`</warn>
+   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External External}</warn>
    * @property {PrivacyLevel|number} privacyLevel The privacy level of the guild scheduled event
    * @property {GuildScheduledEventEntityType|number} entityType The scheduled entity type of the event
    * @property {string} [description] The description of the guild scheduled event
    * @property {GuildVoiceChannelResolvable} [channel] The channel of the guild scheduled event
-   * <warn>This is required if `entityType` is `GuildScheduledEventEntityType.StageInstance` or
-   * `GuildScheduledEventEntityType.Voice`</warn>
+   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.StageInstance StageInstance} or
+   * {@link GuildScheduledEventEntityType.Voice Voice}</warn>
    * @property {GuildScheduledEventEntityMetadataOptions} [entityMetadata] The entity metadata of the
    * guild scheduled event
-   * <warn>This is required if `entityType` is `GuildScheduledEventEntityType.External`</warn>
+   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External External}</warn>
    * @property {string} [reason] The reason for creating the guild scheduled event
    */
 
@@ -61,7 +57,7 @@ class GuildScheduledEventManager extends CachedManager {
    * Options used to set entity metadata of a guild scheduled event.
    * @typedef {Object} GuildScheduledEventEntityMetadataOptions
    * @property {string} [location] The location of the guild scheduled event
-   * <warn>This is required if `entityType` is `GuildScheduledEventEntityType.External`</warn>
+   * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External External}</warn>
    */
 
   /**
@@ -82,9 +78,6 @@ class GuildScheduledEventManager extends CachedManager {
       entityMetadata,
       reason,
     } = options;
-
-    if (typeof privacyLevel === 'string') privacyLevel = GuildScheduledEventPrivacyLevel[privacyLevel];
-    if (typeof entityType === 'string') entityType = GuildScheduledEventEntityType[entityType];
 
     let entity_metadata, channel_id;
     if (entityType === GuildScheduledEventEntityType.External) {
@@ -177,7 +170,7 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {GuildScheduledEventEntityMetadataOptions} [entityMetadata] The entity metadata of the
    * guild scheduled event
    * <warn>This can be modified only if `entityType` of the `GuildScheduledEvent` to be edited is
-   * `GuildScheduledEventEntityType.External`</warn>
+   * {@link GuildScheduledEventEntityType.External External}</warn>
    * @property {string} [reason] The reason for editing the guild scheduled event
    */
 
@@ -204,10 +197,6 @@ class GuildScheduledEventManager extends CachedManager {
       entityMetadata,
       reason,
     } = options;
-
-    if (typeof privacyLevel === 'string') privacyLevel = GuildScheduledEventPrivacyLevel[privacyLevel];
-    if (typeof entityType === 'string') entityType = GuildScheduledEventEntityType[entityType];
-    if (typeof status === 'string') status = GuildScheduledEventStatus[status];
 
     let entity_metadata;
     if (entityMetadata) {

--- a/packages/discord.js/src/managers/StageInstanceManager.js
+++ b/packages/discord.js/src/managers/StageInstanceManager.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { GuildScheduledEventPrivacyLevel } = require('discord-api-types/v9');
 const CachedManager = require('./CachedManager');
 const { TypeError, Error } = require('../errors');
 const { StageInstance } = require('../structures/StageInstance');
@@ -59,8 +58,6 @@ class StageInstanceManager extends CachedManager {
     if (!channelId) throw new Error('STAGE_CHANNEL_RESOLVE');
     if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
     let { topic, privacyLevel } = options;
-
-    privacyLevel &&= typeof privacyLevel === 'number' ? privacyLevel : GuildScheduledEventPrivacyLevel[privacyLevel];
 
     const data = await this.client.api['stage-instances'].post({
       data: {
@@ -121,8 +118,6 @@ class StageInstanceManager extends CachedManager {
     if (!channelId) throw new Error('STAGE_CHANNEL_RESOLVE');
 
     let { topic, privacyLevel } = options;
-
-    privacyLevel &&= typeof privacyLevel === 'number' ? privacyLevel : GuildScheduledEventPrivacyLevel[privacyLevel];
 
     const data = await this.client.api('stage-instances', channelId).patch({
       data: {

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -65,11 +65,11 @@ class ThreadManager extends CachedManager {
    * @property {MessageResolvable} [startMessage] The message to start a thread from. <warn>If this is defined then type
    * of thread gets automatically defined and cannot be changed. The provided `type` field will be ignored</warn>
    * @property {ThreadChannelTypes|number} [type] The type of thread to create.
-   * Defaults to {@link ChannelType.GuildPublicThread GuildPublicThread} if created in a {@link TextChannel}
+   * Defaults to {@link ChannelType.GuildPublicThread} if created in a {@link TextChannel}
    * <warn>When creating threads in a {@link NewsChannel} this is ignored and is always
-   * {@link ChannelType.GuildNewsThread GuildNewsThread}</warn>
+   * {@link ChannelType.GuildNewsThread}</warn>
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
-   * <info>Can only be set when type will be {@link ChannelType.GuildPrivateThread GuildPrivateThread}</info>
+   * <info>Can only be set when type will be {@link ChannelType.GuildPrivateThread}</info>
    * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the new channel in seconds
    */
 

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -64,11 +64,12 @@ class ThreadManager extends CachedManager {
    * @typedef {StartThreadOptions} ThreadCreateOptions
    * @property {MessageResolvable} [startMessage] The message to start a thread from. <warn>If this is defined then type
    * of thread gets automatically defined and cannot be changed. The provided `type` field will be ignored</warn>
-   * @property {ThreadChannelTypes|number} [type] The type of thread to create. Defaults to `GUILD_PUBLIC_THREAD` if
-   * created in a {@link TextChannel} <warn>When creating threads in a {@link NewsChannel} this is ignored and is always
-   * `GUILD_NEWS_THREAD`</warn>
+   * @property {ThreadChannelTypes|number} [type] The type of thread to create.
+   * Defaults to {@link ChannelType.GuildPublicThread GuildPublicThread} if created in a {@link TextChannel}
+   * <warn>When creating threads in a {@link NewsChannel} this is ignored and is always
+   * {@link ChannelType.GuildNewsThread GuildNewsThread}</warn>
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
-   * <info>Can only be set when type will be `GUILD_PRIVATE_THREAD`</info>
+   * <info>Can only be set when type will be {@link ChannelType.GuildPrivateThread GuildPrivateThread}</info>
    * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the new channel in seconds
    */
 

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -150,10 +150,10 @@ class ApplicationCommand extends Base {
    * @property {ApplicationCommandOptionData[]} [options] Additional options if this option is a subcommand (group)
    * @property {ChannelType[]} [channelTypes] When the option type is channel,
    * the allowed types of channels that can be selected
-   * @property {number} [minValue] The minimum value for an {@link ApplicationCommandOptionType.Integer Integer} or
-   * {@link ApplicationCommandOptionType.Number Number} option
-   * @property {number} [maxValue] The maximum value for an {@link ApplicationCommandOptionType.Integer Integer} or
-   * {@link ApplicationCommandOptionType.Number Number} option
+   * @property {number} [minValue] The minimum value for an {@link ApplicationCommandOptionType.Integer} or
+   * {@link ApplicationCommandOptionType.Number} option
+   * @property {number} [maxValue] The maximum value for an {@link ApplicationCommandOptionType.Integer} or
+   * {@link ApplicationCommandOptionType.Number} option
    */
 
   /**
@@ -351,10 +351,10 @@ class ApplicationCommand extends Base {
    * @property {ApplicationCommandOption[]} [options] Additional options if this option is a subcommand (group)
    * @property {ChannelType[]} [channelTypes] When the option type is channel,
    * the allowed types of channels that can be selected
-   * @property {number} [minValue] The minimum value for an {@link ApplicationCommandOptionType.Integer Integer} or
-   * {@link ApplicationCommandOptionType.Number Number} option
-   * @property {number} [maxValue] The maximum value for an {@link ApplicationCommandOptionType.Integer Integer} or
-   * {@link ApplicationCommandOptionType.Number Number} option
+   * @property {number} [minValue] The minimum value for an {@link ApplicationCommandOptionType.Integer} or
+   * {@link ApplicationCommandOptionType.Number} option
+   * @property {number} [maxValue] The maximum value for an {@link ApplicationCommandOptionType.Integer} or
+   * {@link ApplicationCommandOptionType.Number} option
    */
 
   /**

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { DiscordSnowflake } = require('@sapphire/snowflake');
-const { ApplicationCommandOptionType, ChannelType } = require('discord-api-types/v9');
+const { ApplicationCommandOptionType } = require('discord-api-types/v9');
 const Base = require('./Base');
 const ApplicationCommandPermissionsManager = require('../managers/ApplicationCommandPermissionsManager');
 
@@ -141,17 +141,19 @@ class ApplicationCommand extends Base {
    * <warn>Note that providing a value for the `camelCase` counterpart for any `snake_case` property
    * will discard the provided `snake_case` property.</warn>
    * @typedef {Object} ApplicationCommandOptionData
-   * @property {ApplicationCommandOptionType|number} type The type of the option
+   * @property {ApplicationCommandOptionType} type The type of the option
    * @property {string} name The name of the option
    * @property {string} description The description of the option
    * @property {boolean} [autocomplete] Whether the option is an autocomplete option
    * @property {boolean} [required] Whether the option is required
    * @property {ApplicationCommandOptionChoice[]} [choices] The choices of the option for the user to pick from
    * @property {ApplicationCommandOptionData[]} [options] Additional options if this option is a subcommand (group)
-   * @property {ChannelType[]|number[]} [channelTypes] When the option type is channel,
+   * @property {ChannelType[]} [channelTypes] When the option type is channel,
    * the allowed types of channels that can be selected
-   * @property {number} [minValue] The minimum value for an `INTEGER` or `NUMBER` option
-   * @property {number} [maxValue] The maximum value for an `INTEGER` or `NUMBER` option
+   * @property {number} [minValue] The minimum value for an {@link ApplicationCommandOptionType.Integer Integer} or
+   * {@link ApplicationCommandOptionType.Number Number} option
+   * @property {number} [maxValue] The maximum value for an {@link ApplicationCommandOptionType.Integer Integer} or
+   * {@link ApplicationCommandOptionType.Number Number} option
    */
 
   /**
@@ -349,8 +351,10 @@ class ApplicationCommand extends Base {
    * @property {ApplicationCommandOption[]} [options] Additional options if this option is a subcommand (group)
    * @property {ChannelType[]} [channelTypes] When the option type is channel,
    * the allowed types of channels that can be selected
-   * @property {number} [minValue] The minimum value for an `INTEGER` or `NUMBER` option
-   * @property {number} [maxValue] The maximum value for an `INTEGER` or `NUMBER` option
+   * @property {number} [minValue] The minimum value for an {@link ApplicationCommandOptionType.Integer Integer} or
+   * {@link ApplicationCommandOptionType.Number Number} option
+   * @property {number} [maxValue] The maximum value for an {@link ApplicationCommandOptionType.Integer Integer} or
+   * {@link ApplicationCommandOptionType.Number Number} option
    */
 
   /**
@@ -384,11 +388,7 @@ class ApplicationCommand extends Base {
       autocomplete: option.autocomplete,
       choices: option.choices,
       options: option.options?.map(o => this.transformOption(o, received)),
-      [channelTypesKey]: received
-        ? option.channel_types?.map(type => ChannelType[type])
-        : option.channelTypes?.map(type => (typeof type === 'string' ? ChannelType[type] : type)) ??
-          // When transforming to API data, accept API data
-          option.channel_types,
+      [channelTypesKey]: option.channelTypes ?? option.channel_types,
       [minValueKey]: option.minValue ?? option.min_value,
       [maxValueKey]: option.maxValue ?? option.max_value,
     };

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -187,9 +187,10 @@ class BaseGuildTextChannel extends GuildChannel {
    * @property {number} [maxUses=0] Maximum number of uses
    * @property {boolean} [unique=false] Create a unique invite, or use an existing one with similar settings
    * @property {UserResolvable} [targetUser] The user whose stream to display for this invite,
-   * required if `targetType` is `STREAM`, the user must be streaming in the channel
+   * required if `targetType` is {@link InviteTargetType.Stream Stream}, the user must be streaming in the channel
    * @property {ApplicationResolvable} [targetApplication] The embedded application to open for this invite,
-   * required if `targetType` is `EMBEDDED_APPLICATION`, the application must have the `EMBEDDED` flag
+   * required if `targetType` is {@link InviteTargetType.Stream Stream}, the application must have the
+   * {@link InviteTargetType.EmbeddedApplication EmbeddedApplication} flag
    * @property {InviteTargetType} [targetType] The type of the target for this voice channel invite
    * @property {string} [reason] The reason for creating the invite
    */

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -187,10 +187,10 @@ class BaseGuildTextChannel extends GuildChannel {
    * @property {number} [maxUses=0] Maximum number of uses
    * @property {boolean} [unique=false] Create a unique invite, or use an existing one with similar settings
    * @property {UserResolvable} [targetUser] The user whose stream to display for this invite,
-   * required if `targetType` is {@link InviteTargetType.Stream Stream}, the user must be streaming in the channel
+   * required if `targetType` is {@link InviteTargetType.Stream}, the user must be streaming in the channel
    * @property {ApplicationResolvable} [targetApplication] The embedded application to open for this invite,
-   * required if `targetType` is {@link InviteTargetType.Stream Stream}, the application must have the
-   * {@link InviteTargetType.EmbeddedApplication EmbeddedApplication} flag
+   * required if `targetType` is {@link InviteTargetType.Stream}, the application must have the
+   * {@link InviteTargetType.EmbeddedApplication} flag
    * @property {InviteTargetType} [targetType] The type of the target for this voice channel invite
    * @property {string} [reason] The reason for creating the invite
    */

--- a/packages/discord.js/src/structures/CategoryChannel.js
+++ b/packages/discord.js/src/structures/CategoryChannel.js
@@ -45,7 +45,8 @@ class CategoryChannel extends GuildChannel {
 
   /**
    * Creates a new channel within this category.
-   * <info>You cannot create a channel of type `GUILD_CATEGORY` inside a CategoryChannel.</info>
+   * <info>You cannot create a channel of type {@link ChannelType.GuildCategory GuildCategory} inside a
+   * CategoryChannel.</info>
    * @param {string} name The name of the new channel
    * @param {CategoryCreateChannelOptions} options Options for creating the new channel
    * @returns {Promise<GuildChannel>}

--- a/packages/discord.js/src/structures/CategoryChannel.js
+++ b/packages/discord.js/src/structures/CategoryChannel.js
@@ -45,7 +45,7 @@ class CategoryChannel extends GuildChannel {
 
   /**
    * Creates a new channel within this category.
-   * <info>You cannot create a channel of type {@link ChannelType.GuildCategory GuildCategory} inside a
+   * <info>You cannot create a channel of type {@link ChannelType.GuildCategory} inside a
    * CategoryChannel.</info>
    * @param {string} name The name of the new channel
    * @param {CategoryCreateChannelOptions} options Options for creating the new channel

--- a/packages/discord.js/src/structures/ContextMenuCommandInteraction.js
+++ b/packages/discord.js/src/structures/ContextMenuCommandInteraction.js
@@ -28,7 +28,8 @@ class ContextMenuCommandInteraction extends CommandInteraction {
     this.targetId = data.data.target_id;
 
     /**
-     * The type of the target of the interaction; either `.User` or `.Message`
+     * The type of the target of the interaction; either {@link ApplicationCommandType.User User}
+     * or {@link ApplicationCommandType.Message Message}
      * @type {ApplicationCommandType.User|ApplicationCommandType.Message}
      */
     this.targetType = data.data.type;

--- a/packages/discord.js/src/structures/ContextMenuCommandInteraction.js
+++ b/packages/discord.js/src/structures/ContextMenuCommandInteraction.js
@@ -28,8 +28,8 @@ class ContextMenuCommandInteraction extends CommandInteraction {
     this.targetId = data.data.target_id;
 
     /**
-     * The type of the target of the interaction; either {@link ApplicationCommandType.User User}
-     * or {@link ApplicationCommandType.Message Message}
+     * The type of the target of the interaction; either {@link ApplicationCommandType.User}
+     * or {@link ApplicationCommandType.Message}
      * @type {ApplicationCommandType.User|ApplicationCommandType.Message}
      */
     this.targetType = data.data.type;

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -971,7 +971,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Edits the verification level of the guild.
-   * @param {VerificationLevel|number} verificationLevel The new verification level of the guild
+   * @param {VerificationLevel} verificationLevel The new verification level of the guild
    * @param {string} [reason] Reason for changing the guild's verification level
    * @returns {Promise<Guild>}
    * @example

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -33,7 +33,7 @@ class GuildScheduledEvent extends Base {
     if ('channel_id' in data) {
       /**
        * The channel id in which the scheduled event will be hosted,
-       * or `null` if entity type is {@link GuildScheduledEventEntityType.External External}
+       * or `null` if entity type is {@link GuildScheduledEventEntityType.External}
        * @type {?Snowflake}
        */
       this.channelId = data.channel_id;
@@ -224,7 +224,7 @@ class GuildScheduledEvent extends Base {
    * @typedef {CreateInviteOptions} CreateGuildScheduledEventInviteURLOptions
    * @property {GuildInvitableChannelResolvable} [channel] The channel to create the invite in.
    * <warn>This is required when the `entityType` of `GuildScheduledEvent` is
-   * {@link GuildScheduledEventEntityType.External External}, gets ignored otherwise</warn>
+   * {@link GuildScheduledEventEntityType.External}, gets ignored otherwise</warn>
    */
 
   /**
@@ -385,7 +385,7 @@ class GuildScheduledEvent extends Base {
   }
 
   /**
-   * Indicates whether this guild scheduled event has an {@link GuildScheduledEventStatus.Active Active} status.
+   * Indicates whether this guild scheduled event has an {@link GuildScheduledEventStatus.Active} status.
    * @returns {boolean}
    */
   isActive() {
@@ -393,7 +393,7 @@ class GuildScheduledEvent extends Base {
   }
 
   /**
-   * Indicates whether this guild scheduled event has a {@link GuildScheduledEventStatus.Canceled Canceled} status.
+   * Indicates whether this guild scheduled event has a {@link GuildScheduledEventStatus.Canceled} status.
    * @returns {boolean}
    */
   isCanceled() {
@@ -401,7 +401,7 @@ class GuildScheduledEvent extends Base {
   }
 
   /**
-   * Indicates whether this guild scheduled event has a {@link GuildScheduledEventStatus.Completed Completed} status.
+   * Indicates whether this guild scheduled event has a {@link GuildScheduledEventStatus.Completed} status.
    * @returns {boolean}
    */
   isCompleted() {
@@ -409,7 +409,7 @@ class GuildScheduledEvent extends Base {
   }
 
   /**
-   * Indicates whether this guild scheduled event has a {@link GuildScheduledEventStatus.Scheduled Scheduled} status.
+   * Indicates whether this guild scheduled event has a {@link GuildScheduledEventStatus.Scheduled} status.
    * @returns {boolean}
    */
   isScheduled() {

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -1,11 +1,7 @@
 'use strict';
 
 const { DiscordSnowflake } = require('@sapphire/snowflake');
-const {
-  GuildScheduledEventPrivacyLevel,
-  GuildScheduledEventStatus,
-  GuildScheduledEventEntityType,
-} = require('discord-api-types/v9');
+const { GuildScheduledEventStatus, GuildScheduledEventEntityType } = require('discord-api-types/v9');
 const Base = require('./Base');
 const { Error } = require('../errors');
 const { Endpoints } = require('../util/Constants');
@@ -36,7 +32,8 @@ class GuildScheduledEvent extends Base {
   _patch(data) {
     if ('channel_id' in data) {
       /**
-       * The channel id in which the scheduled event will be hosted, or `null` if entity type is `EXTERNAL`
+       * The channel id in which the scheduled event will be hosted,
+       * or `null` if entity type is {@link GuildScheduledEventEntityType.External External}
        * @type {?Snowflake}
        */
       this.channelId = data.channel_id;
@@ -86,21 +83,21 @@ class GuildScheduledEvent extends Base {
 
     /**
      * The privacy level of the guild scheduled event
-     * @type {PrivacyLevel}
+     * @type {GuildScheduledEventPrivacyLevel}
      */
-    this.privacyLevel = GuildScheduledEventPrivacyLevel[data.privacy_level];
+    this.privacyLevel = data.privacy_level;
 
     /**
      * The status of the guild scheduled event
      * @type {GuildScheduledEventStatus}
      */
-    this.status = GuildScheduledEventStatus[data.status];
+    this.status = data.status;
 
     /**
      * The type of hosting entity associated with the scheduled event
      * @type {GuildScheduledEventEntityType}
      */
-    this.entityType = GuildScheduledEventEntityType[data.entity_type];
+    this.entityType = data.entity_type;
 
     if ('entity_id' in data) {
       /**
@@ -226,7 +223,8 @@ class GuildScheduledEvent extends Base {
    * Options used to create an invite URL to a {@link GuildScheduledEvent}
    * @typedef {CreateInviteOptions} CreateGuildScheduledEventInviteURLOptions
    * @property {GuildInvitableChannelResolvable} [channel] The channel to create the invite in.
-   * <warn>This is required when the `entityType` of `GuildScheduledEvent` is `EXTERNAL`, gets ignored otherwise</warn>
+   * <warn>This is required when the `entityType` of `GuildScheduledEvent` is
+   * {@link GuildScheduledEventEntityType.External External}, gets ignored otherwise</warn>
    */
 
   /**
@@ -387,35 +385,35 @@ class GuildScheduledEvent extends Base {
   }
 
   /**
-   * Indicates whether this guild scheduled event has an `ACTIVE` status.
+   * Indicates whether this guild scheduled event has an {@link GuildScheduledEventStatus.Active Active} status.
    * @returns {boolean}
    */
   isActive() {
-    return GuildScheduledEventStatus[this.status] === GuildScheduledEventStatus.Active;
+    return this.status === GuildScheduledEventStatus.Active;
   }
 
   /**
-   * Indicates whether this guild scheduled event has a `CANCELED` status.
+   * Indicates whether this guild scheduled event has a {@link GuildScheduledEventStatus.Canceled Canceled} status.
    * @returns {boolean}
    */
   isCanceled() {
-    return GuildScheduledEventStatus[this.status] === GuildScheduledEventStatus.Canceled;
+    return this.status === GuildScheduledEventStatus.Canceled;
   }
 
   /**
-   * Indicates whether this guild scheduled event has a `COMPLETED` status.
+   * Indicates whether this guild scheduled event has a {@link GuildScheduledEventStatus.Completed Completed} status.
    * @returns {boolean}
    */
   isCompleted() {
-    return GuildScheduledEventStatus[this.status] === GuildScheduledEventStatus.Completed;
+    return this.status === GuildScheduledEventStatus.Completed;
   }
 
   /**
-   * Indicates whether this guild scheduled event has a `SCHEDULED` status.
+   * Indicates whether this guild scheduled event has a {@link GuildScheduledEventStatus.Scheduled Scheduled} status.
    * @returns {boolean}
    */
   isScheduled() {
-    return GuildScheduledEventStatus[this.status] === GuildScheduledEventStatus.Scheduled;
+    return this.status === GuildScheduledEventStatus.Scheduled;
   }
 }
 

--- a/packages/discord.js/src/structures/InteractionCollector.js
+++ b/packages/discord.js/src/structures/InteractionCollector.js
@@ -1,14 +1,13 @@
 'use strict';
 
 const { Collection } = require('@discordjs/collection');
-const { InteractionType, ComponentType } = require('discord-api-types/v9');
 const Collector = require('./interfaces/Collector');
 const { Events } = require('../util/Constants');
 
 /**
  * @typedef {CollectorOptions} InteractionCollectorOptions
  * @property {TextBasedChannels} [channel] The channel to listen to interactions from
- * @property {MessageComponentType} [componentType] The type of component to listen for
+ * @property {ComponentType} [componentType] The type of component to listen for
  * @property {Guild} [guild] The guild to listen to interactions from
  * @property {InteractionType} [interactionType] The type of interaction to listen for
  * @property {number} [max] The maximum total amount of interactions to collect
@@ -64,17 +63,13 @@ class InteractionCollector extends Collector {
      * The type of interaction to collect
      * @type {?InteractionType}
      */
-    this.interactionType =
-      typeof options.interactionType === 'number'
-        ? InteractionType[options.interactionType]
-        : options.interactionType ?? null;
+    this.interactionType = options.interactionType ?? null;
 
     /**
      * The type of component to collect
-     * @type {?MessageComponentType}
+     * @type {?ComponentType}
      */
-    this.componentType =
-      typeof options.componentType === 'number' ? ComponentType[options.componentType] : options.componentType ?? null;
+    this.componentType = options.componentType ?? null;
 
     /**
      * The users that have interacted with this collector

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -289,10 +289,10 @@ class Message extends Base {
      * Reference data sent in a message that contains ids identifying the referenced message.
      * This can be present in the following types of message:
      * * Crossposted messages (IS_CROSSPOST {@link MessageFlags.FLAGS message flag})
-     * * {@link MessageType.ChannelFollowAdd ChannelFollowAdd}
-     * * {@link MessageType.ChannelPinnedMessage ChannelPinnedMessage}
-     * * {@link MessageType.Reply Reply}
-     * * {@link MessageType.ThreadStarterMessage ThreadStarterMessage}
+     * * {@link MessageType.ChannelFollowAdd}
+     * * {@link MessageType.ChannelPinnedMessage}
+     * * {@link MessageType.Reply}
+     * * {@link MessageType.ThreadStarterMessage}
      * @see {@link https://discord.com/developers/docs/resources/channel#message-types}
      * @typedef {Object} MessageReference
      * @property {Snowflake} channelId The channel's id the message was referenced

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -289,10 +289,10 @@ class Message extends Base {
      * Reference data sent in a message that contains ids identifying the referenced message.
      * This can be present in the following types of message:
      * * Crossposted messages (IS_CROSSPOST {@link MessageFlags.FLAGS message flag})
-     * * CHANNEL_FOLLOW_ADD
-     * * CHANNEL_PINNED_MESSAGE
-     * * REPLY
-     * * THREAD_STARTER_MESSAGE
+     * * {@link MessageType.ChannelFollowAdd ChannelFollowAdd}
+     * * {@link MessageType.ChannelPinnedMessage ChannelPinnedMessage}
+     * * {@link MessageType.Reply Reply}
+     * * {@link MessageType.ThreadStarterMessage ThreadStarterMessage}
      * @see {@link https://discord.com/developers/docs/resources/channel#message-types}
      * @typedef {Object} MessageReference
      * @property {Snowflake} channelId The channel's id the message was referenced
@@ -483,7 +483,7 @@ class Message extends Base {
 
   /**
    * @typedef {CollectorOptions} MessageComponentCollectorOptions
-   * @property {MessageComponentType} [componentType] The type of component to listen for
+   * @property {ComponentType} [componentType] The type of component to listen for
    * @property {number} [max] The maximum total amount of interactions to collect
    * @property {number} [maxComponents] The maximum number of components to collect
    * @property {number} [maxUsers] The maximum number of users to interact
@@ -513,7 +513,7 @@ class Message extends Base {
    * @typedef {Object} AwaitMessageComponentOptions
    * @property {CollectorFilter} [filter] The filter applied to this collector
    * @property {number} [time] Time to wait for an interaction before rejecting
-   * @property {MessageComponentType} [componentType] The type of component interaction to collect
+   * @property {ComponentType} [componentType] The type of component interaction to collect
    */
 
   /**

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -156,7 +156,7 @@ class Sticker extends Base {
 
   /**
    * A link to the sticker
-   * <info>If the sticker's format is {@link StickerFormatType.Lottie Lottie}, it returns
+   * <info>If the sticker's format is {@link StickerFormatType.Lottie}, it returns
    * the URL of the Lottie JSON file.</info>
    * @type {string}
    */

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -156,7 +156,8 @@ class Sticker extends Base {
 
   /**
    * A link to the sticker
-   * <info>If the sticker's format is LOTTIE, it returns the URL of the Lottie JSON file.</info>
+   * <info>If the sticker's format is {@link StickerFormatType.Lottie Lottie}, it returns
+   * the URL of the Lottie JSON file.</info>
    * @type {string}
    */
   get url() {

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -272,7 +272,7 @@ class ThreadChannel extends Channel {
    * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the thread in seconds
    * @property {boolean} [locked] Whether the thread is locked
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to a thread
-   * <info>Can only be edited on `GUILD_PRIVATE_THREAD`</info>
+   * <info>Can only be edited on {@link ChannelType.GuildPrivateThread GuildPrivateThread}</info>
    */
 
   /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -272,7 +272,7 @@ class ThreadChannel extends Channel {
    * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the thread in seconds
    * @property {boolean} [locked] Whether the thread is locked
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to a thread
-   * <info>Can only be edited on {@link ChannelType.GuildPrivateThread GuildPrivateThread}</info>
+   * <info>Can only be edited on {@link ChannelType.GuildPrivateThread}</info>
    */
 
   /**

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -423,10 +423,10 @@ exports.SweeperKeys = [
 
 /**
  * The types of messages that are not `System`. The available types are:
- * * `MessageType.Default`
- * * `MessageType.Reply`
- * * `MessageType.ChatInputCommand`
- * * `MessageType.ContextMenuCommand`
+ * * {@link MessageType.Default Default}
+ * * {@link MessageType.Reply Reply}
+ * * {@link MessageType.ChatInputCommand ChatInputCommand}
+ * * {@link MessageType.ContextMenuCommand ContextMenuCommand}
  * @typedef {MessageType[]} NonSystemMessageTypes
  */
 exports.NonSystemMessageTypes = [
@@ -447,12 +447,12 @@ exports.NonSystemMessageTypes = [
 
 /**
  * The types of channels that are text-based. The available types are:
- * * `ChannelType.DM`
- * * `ChannelType.GuildText`
- * * `ChannelType.GuildNews`
- * * `ChannelType.GuildNewsThread`
- * * `ChannelType.GuildPublicThread`
- * * `ChannelType.GuildPrivateThread`
+ * * {@link ChannelType.DM DM}
+ * * {@link ChannelType.GuildText GuildText}
+ * * {@link ChannelType.GuildNews GuildNews}
+ * * {@link ChannelType.GuildNewsThread GuildNewsThread}
+ * * {@link ChannelType.GuildPublicThread GuildPublicThread}
+ * * {@link ChannelType.GuildPrivateThread GuildPrivateThread}
  * @typedef {ChannelType} TextBasedChannelTypes
  */
 exports.TextBasedChannelTypes = [
@@ -466,9 +466,9 @@ exports.TextBasedChannelTypes = [
 
 /**
  * The types of channels that are threads. The available types are:
- * * `ChannelType.GuildNewsThread`
- * * `ChannelType.GuildPublicThread`
- * * `ChannelType.GuildPrivateThread`
+ * * {@link ChannelType.GuildNewsThread GuildNewsThread}
+ * * {@link ChannelType.GuildPublicThread GuildPublicThread}
+ * * {@link ChannelType.GuildPrivateThread GuildPrivateThread}
  * @typedef {ChannelType[]} ThreadChannelTypes
  */
 exports.ThreadChannelTypes = [
@@ -479,8 +479,8 @@ exports.ThreadChannelTypes = [
 
 /**
  * The types of channels that are voice-based. The available types are:
- * * `ChannelType.GuildVoice`
- * * `ChannelType.GuildStageVoice`
+ * * {@link ChannelType.GuildVoice GuildVoice}
+ * * {@link ChannelType.GuildStageVoice GuildStageVoice}
  * @typedef {ChannelType[]} VoiceBasedChannelTypes
  */
 exports.VoiceBasedChannelTypes = [ChannelType.GuildVoice, ChannelType.GuildStageVoice];

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -423,10 +423,10 @@ exports.SweeperKeys = [
 
 /**
  * The types of messages that are not `System`. The available types are:
- * * {@link MessageType.Default Default}
- * * {@link MessageType.Reply Reply}
- * * {@link MessageType.ChatInputCommand ChatInputCommand}
- * * {@link MessageType.ContextMenuCommand ContextMenuCommand}
+ * * {@link MessageType.Default}
+ * * {@link MessageType.Reply}
+ * * {@link MessageType.ChatInputCommand}
+ * * {@link MessageType.ContextMenuCommand}
  * @typedef {MessageType[]} NonSystemMessageTypes
  */
 exports.NonSystemMessageTypes = [
@@ -447,12 +447,12 @@ exports.NonSystemMessageTypes = [
 
 /**
  * The types of channels that are text-based. The available types are:
- * * {@link ChannelType.DM DM}
- * * {@link ChannelType.GuildText GuildText}
- * * {@link ChannelType.GuildNews GuildNews}
- * * {@link ChannelType.GuildNewsThread GuildNewsThread}
- * * {@link ChannelType.GuildPublicThread GuildPublicThread}
- * * {@link ChannelType.GuildPrivateThread GuildPrivateThread}
+ * * {@link ChannelType.DM}
+ * * {@link ChannelType.GuildText}
+ * * {@link ChannelType.GuildNews}
+ * * {@link ChannelType.GuildNewsThread}
+ * * {@link ChannelType.GuildPublicThread}
+ * * {@link ChannelType.GuildPrivateThread}
  * @typedef {ChannelType} TextBasedChannelTypes
  */
 exports.TextBasedChannelTypes = [
@@ -466,9 +466,9 @@ exports.TextBasedChannelTypes = [
 
 /**
  * The types of channels that are threads. The available types are:
- * * {@link ChannelType.GuildNewsThread GuildNewsThread}
- * * {@link ChannelType.GuildPublicThread GuildPublicThread}
- * * {@link ChannelType.GuildPrivateThread GuildPrivateThread}
+ * * {@link ChannelType.GuildNewsThread}
+ * * {@link ChannelType.GuildPublicThread}
+ * * {@link ChannelType.GuildPrivateThread}
  * @typedef {ChannelType[]} ThreadChannelTypes
  */
 exports.ThreadChannelTypes = [
@@ -479,8 +479,8 @@ exports.ThreadChannelTypes = [
 
 /**
  * The types of channels that are voice-based. The available types are:
- * * {@link ChannelType.GuildVoice GuildVoice}
- * * {@link ChannelType.GuildStageVoice GuildStageVoice}
+ * * {@link ChannelType.GuildVoice}
+ * * {@link ChannelType.GuildStageVoice}
  * @typedef {ChannelType[]} VoiceBasedChannelTypes
  */
 exports.VoiceBasedChannelTypes = [ChannelType.GuildVoice, ChannelType.GuildStageVoice];

--- a/packages/discord.js/src/util/EnumResolvers.js
+++ b/packages/discord.js/src/util/EnumResolvers.js
@@ -9,6 +9,16 @@ const {
   ChannelType,
   ApplicationCommandPermissionType,
   MessageType,
+  GuildNSFWLevel,
+  GuildVerificationLevel,
+  GuildDefaultMessageNotifications,
+  GuildExplicitContentFilter,
+  GuildPremiumTier,
+  GuildScheduledEventStatus,
+  StageInstancePrivacyLevel,
+  GuildMFALevel,
+  TeamMemberMembershipState,
+  GuildScheduledEventEntityType,
 } = require('discord-api-types/v9');
 
 function unknownKeyStrategy(val) {
@@ -17,7 +27,7 @@ function unknownKeyStrategy(val) {
 
 class EnumResolvers extends null {
   /**
-   * Resolves enum key to `ChannelType` enum value
+   * Resolves enum key to {@link ChannelType} enum value
    * @param {string|ChannelType} key The key to resolve
    * @returns {ChannelType}
    */
@@ -49,7 +59,7 @@ class EnumResolvers extends null {
   }
 
   /**
-   * Resolves enum key to `InteractionType` enum value
+   * Resolves enum key to {@link InteractionType} enum value
    * @param {string|InteractionType} key The key to resolve
    * @returns {InteractionType}
    */
@@ -69,7 +79,7 @@ class EnumResolvers extends null {
   }
 
   /**
-   * Resolves enum key to `ApplicationCommandType` enum value
+   * Resolves enum key to {@link ApplicationCommandType} enum value
    * @param {string|ApplicationCommandType} key The key to resolve
    * @returns {ApplicationCommandType}
    */
@@ -87,7 +97,7 @@ class EnumResolvers extends null {
   }
 
   /**
-   * Resolves enum key to `ApplicationCommandOptionType` enum value
+   * Resolves enum key to {@link ApplicationCommandOptionType} enum value
    * @param {string|ApplicationCommandOptionType} key The key to resolve
    * @returns {ApplicationCommandOptionType}
    */
@@ -119,7 +129,7 @@ class EnumResolvers extends null {
   }
 
   /**
-   * Resolves enum key to `ApplicationCommandPermissionType` enum value
+   * Resolves enum key to {@link ApplicationCommandPermissionType} enum value
    * @param {string|ApplicationCommandPermissionType} key The key to resolve
    * @returns {ApplicationCommandPermissionType}
    */
@@ -135,7 +145,7 @@ class EnumResolvers extends null {
   }
 
   /**
-   * Resolves enum key to `ComponentType` enum value
+   * Resolves enum key to {@link ComponentType} enum value
    * @param {string|ComponentType} key The key to resolve
    * @returns {ComponentType}
    */
@@ -153,7 +163,7 @@ class EnumResolvers extends null {
   }
 
   /**
-   * Resolves enum key to `ButtonStyle` enum value
+   * Resolves enum key to {@link ButtonStyle} enum value
    * @param {string|ButtonStyle} key The key to resolve
    * @returns {ButtonStyle}
    */
@@ -175,7 +185,7 @@ class EnumResolvers extends null {
   }
 
   /**
-   * Resolves enum key to `MessageType` enum value
+   * Resolves enum key to {@link MessageType} enum value
    * @param {string|MessageType} key The key to lookup
    * @returns {MessageType}
    */
@@ -227,6 +237,188 @@ class EnumResolvers extends null {
         return MessageType.GuildInviteReminder;
       case 'CONTEXT_MENU_COMMAND':
         return MessageType.ContextMenuCommand;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * Resolves enum key to {@link GuildNSFWLevel} enum value
+   * @param {string|GuildNSFWLevel} key The key to lookup
+   * @returns {GuildNSFWLevel}
+   */
+  static resolveGuildNSFWLevel(key) {
+    switch (key) {
+      case 'DEFAULT':
+        return GuildNSFWLevel.Default;
+      case 'EXPLICIT':
+        return GuildNSFWLevel.Explicit;
+      case 'SAFE':
+        return GuildNSFWLevel.Safe;
+      case 'AGE_RESTRICTED':
+        return GuildNSFWLevel.AgeRestricted;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * Resolves enum key to {@link GuildVerificationLevel} enum value
+   * @param {string|GuildVerificationLevel} key The key to lookup
+   * @returns {GuildVerificationLevel}
+   */
+  static resolveGuildVerificationLevel(key) {
+    switch (key) {
+      case 'NONE':
+        return GuildVerificationLevel.None;
+      case 'LOW':
+        return GuildVerificationLevel.Low;
+      case 'MEDIUM':
+        return GuildVerificationLevel.Medium;
+      case 'HIGH':
+        return GuildVerificationLevel.High;
+      case 'VERY_HIGH':
+        return GuildVerificationLevel.VeryHigh;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * Resolves enum key to {@link GuildDefaultMessageNotifications} enum value
+   * @param {string|GuildDefaultMessageNotifications} key The key to lookup
+   * @returns {GuildDefaultMessageNotifications}
+   */
+  static resolveGuildDefaultMessageNotifications(key) {
+    switch (key) {
+      case 'ALL_MESSAGES':
+        return GuildDefaultMessageNotifications.AllMessages;
+      case 'ONLY_MENTIONS':
+        return GuildDefaultMessageNotifications.OnlyMentions;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * Resolves enum key to {@link GuildExplicitContentFilter} enum value
+   * @param {string|GuildExplicitContentFilter} key The key to lookup
+   * @returns {GuildExplicitContentFilter}
+   */
+  static resolveGuildExplicitContentFilter(key) {
+    switch (key) {
+      case 'DISABLED':
+        return GuildExplicitContentFilter.Disabled;
+      case 'MEMBERS_WITHOUT_ROLES':
+        return GuildExplicitContentFilter.MembersWithoutRoles;
+      case 'ALL_MEMBERS':
+        return GuildExplicitContentFilter.AllMembers;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * Resolves enum key to {@link GuildPremiumTier} enum value
+   * @param {string|GuildPremiumTier} key The key to lookup
+   * @returns {GuildPremiumTier}
+   */
+  static resolveGuildPremiumTier(key) {
+    switch (key) {
+      case 'NONE':
+        return GuildPremiumTier.None;
+      case 'TIER_1':
+        return GuildPremiumTier.Tier1;
+      case 'TIER_2':
+        return GuildPremiumTier.Tier2;
+      case 'TIER_3':
+        return GuildPremiumTier.Tier3;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * Resolves enum key to {@link GuildScheduledEventStatus} enum value
+   * @param {string|GuildScheduledEventStatus} key The key to lookup
+   * @returns {GuildScheduledEventStatus}
+   */
+  static resolveGuildScheduledEventStatus(key) {
+    switch (key) {
+      case 'SCHEDULED':
+        return GuildScheduledEventStatus.Scheduled;
+      case 'ACTIVE':
+        return GuildScheduledEventStatus.Active;
+      case 'COMPLETED':
+        return GuildScheduledEventStatus.Completed;
+      case 'CANCELED':
+        return GuildScheduledEventStatus.Canceled;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * Resolves enum key to {@link StageInstancePrivacyLevel} enum value
+   * @param {string|StageInstancePrivacyLevel} key The key to lookup
+   * @returns {StageInstancePrivacyLevel}
+   */
+  static resolveStageInstancePrivacyLevel(key) {
+    switch (key) {
+      case 'PUBLIC':
+        return StageInstancePrivacyLevel.Public;
+      case 'GUILD_ONLY':
+        return StageInstancePrivacyLevel.GuildOnly;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * Resolves enum key to {@link GuildMFALevel} enum value
+   * @param {string|GuildMFALevel} key The key to lookup
+   * @returns {GuildMFALevel}
+   */
+  static resolveGuildMFALevel(key) {
+    switch (key) {
+      case 'NONE':
+        return GuildMFALevel.None;
+      case 'ELEVATED':
+        return GuildMFALevel.Elevated;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * Resolves enum key to {@link TeamMemberMembershipState} enum value
+   * @param {string|TeamMemberMembershipState} key The key to lookup
+   * @returns {TeamMemberMembershipState}
+   */
+  static resolveTeamMemberMembershipState(key) {
+    switch (key) {
+      case 'INVITED':
+        return TeamMemberMembershipState.Invited;
+      case 'ACCEPTED':
+        return TeamMemberMembershipState.Accepted;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * Resolves enum key to {@link GuildScheduledEventEntityType} enum value
+   * @param {string|GuildScheduledEventEntityType} key The key to lookup
+   * @returns {GuildScheduledEventEntityType}
+   */
+  static resolveGuildScheduledEventEntityType(key) {
+    switch (key) {
+      case 'STAGE_INSTANCE':
+        return GuildScheduledEventEntityType.StageInstance;
+      case 'VOICE':
+        return GuildScheduledEventEntityType.Voice;
+      case 'External':
+        return GuildScheduledEventEntityType.External;
       default:
         return unknownKeyStrategy(key);
     }

--- a/packages/discord.js/src/util/EnumResolvers.js
+++ b/packages/discord.js/src/util/EnumResolvers.js
@@ -417,7 +417,7 @@ class EnumResolvers extends null {
         return GuildScheduledEventEntityType.StageInstance;
       case 'VOICE':
         return GuildScheduledEventEntityType.Voice;
-      case 'External':
+      case 'EXTERNAL':
         return GuildScheduledEventEntityType.External;
       default:
         return unknownKeyStrategy(key);

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -30,7 +30,6 @@ import {
   APIApplicationCommand,
   APIApplicationCommandInteractionData,
   APIApplicationCommandOption,
-  APIApplicationCommandPermission,
   APIAuditLogChange,
   APIButtonComponent,
   APIEmbed,
@@ -57,7 +56,6 @@ import {
   GuildNSFWLevel,
   GuildPremiumTier,
   GuildVerificationLevel,
-  InteractionResponseType,
   InteractionType,
   InviteTargetType,
   MessageType,
@@ -67,7 +65,6 @@ import {
   StickerFormatType,
   StickerType,
   TeamMemberMembershipState,
-  UserPremiumType,
   WebhookType,
   OverwriteType,
   GuildExplicitContentFilter,
@@ -76,11 +73,9 @@ import {
   ApplicationCommandOptionType,
   ApplicationCommandType,
   ActivityType,
-  AuditLogEvent,
   GuildScheduledEventEntityType,
   GuildScheduledEventPrivacyLevel,
   GuildScheduledEventStatus,
-  RESTJSONErrorCodes,
 } from 'discord-api-types/v9';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -188,10 +183,10 @@ export abstract class AnonymousGuild extends BaseGuild {
   protected constructor(client: Client, data: RawAnonymousGuildData, immediatePatch?: boolean);
   public banner: string | null;
   public description: string | null;
-  public nsfwLevel: GuildNSFWLevelKey;
+  public nsfwLevel: GuildNSFWLevel;
   public splash: string | null;
   public vanityURLCode: string | null;
-  public verificationLevel: GuildVerificationLevelKey;
+  public verificationLevel: GuildVerificationLevel;
   public bannerURL(options?: ImageURLOptions): string | null;
   public splashURL(options?: ImageURLOptions): string | null;
 }
@@ -467,7 +462,7 @@ export class ButtonInteraction<Cached extends CacheType = CacheType> extends Mes
     ButtonComponent | APIButtonComponent,
     ButtonComponent | APIButtonComponent
   >;
-  public componentType: 'Button';
+  public componentType: ComponentType.Button;
   public inGuild(): this is ButtonInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is ButtonInteraction<'cached'>;
   public inRawGuild(): this is ButtonInteraction<'raw'>;
@@ -843,6 +838,20 @@ export class EnumResolvers extends null {
   public static resolveComponentType(key: string | ComponentType): ComponentType;
   public static resolveButtonStyle(key: string | ButtonStyle): ButtonStyle;
   public static resolveMessageType(key: string | MessageType): MessageType;
+  public static resolveGuildNSFWLevel(key: string | GuildNSFWLevel): GuildNSFWLevel;
+  public static resolveGuildVerificationLevel(key: string | GuildVerificationLevel): GuildVerificationLevel;
+  public static resolveGuildDefaultMessageNotifications(
+    key: string | GuildDefaultMessageNotifications,
+  ): GuildDefaultMessageNotifications;
+  public static resolveGuildExplicitContentFilter(key: string | GuildExplicitContentFilter): GuildExplicitContentFilter;
+  public static resolveGuildPremiumTier(key: string | GuildPremiumTier): GuildPremiumTier;
+  public static resolveGuildScheduledEventStatus(key: string | GuildScheduledEventStatus): GuildScheduledEventStatus;
+  public static resolveStageInstancePrivacyLevel(key: string | StageInstancePrivacyLevel): StageInstancePrivacyLevel;
+  public static resolveGuildMFALevel(key: string | GuildMFALevel): GuildMFALevel;
+  public static resolveTeamMemberMembershipState(key: string | TeamMemberMembershipState): TeamMemberMembershipState;
+  public static resolveGuildScheduledEventEntityType(
+    key: string | GuildScheduledEventEntityType,
+  ): GuildScheduledEventEntityType;
 }
 
 export class DiscordAPIError extends Error {
@@ -892,10 +901,10 @@ export class Guild extends AnonymousGuild {
   public bans: GuildBanManager;
   public channels: GuildChannelManager;
   public commands: GuildApplicationCommandManager;
-  public defaultMessageNotifications: GuildDefaultMessageNotificationsKey | number;
+  public defaultMessageNotifications: GuildDefaultMessageNotifications;
   public discoverySplash: string | null;
   public emojis: GuildEmojiManager;
-  public explicitContentFilter: GuildExplicitContentFilterKey;
+  public explicitContentFilter: GuildExplicitContentFilter;
   public invites: GuildInviteManager;
   public readonly joinedAt: Date;
   public joinedTimestamp: number;
@@ -910,7 +919,7 @@ export class Guild extends AnonymousGuild {
   public preferredLocale: string;
   public premiumSubscriptionCount: number | null;
   public premiumProgressBarEnabled: boolean;
-  public premiumTier: PremiumTier;
+  public premiumTier: GuildPremiumTier;
   public presences: PresenceManager;
   public readonly publicUpdatesChannel: TextChannel | null;
   public publicUpdatesChannelId: Snowflake | null;
@@ -955,17 +964,14 @@ export class Guild extends AnonymousGuild {
   public setAFKTimeout(afkTimeout: number, reason?: string): Promise<Guild>;
   public setBanner(banner: BufferResolvable | Base64Resolvable | null, reason?: string): Promise<Guild>;
   public setDefaultMessageNotifications(
-    defaultMessageNotifications: GuildDefaultMessageNotificationsKey | number,
+    defaultMessageNotifications: GuildDefaultMessageNotifications,
     reason?: string,
   ): Promise<Guild>;
   public setDiscoverySplash(
     discoverySplash: BufferResolvable | Base64Resolvable | null,
     reason?: string,
   ): Promise<Guild>;
-  public setExplicitContentFilter(
-    explicitContentFilter: GuildExplicitContentFilterKey | number,
-    reason?: string,
-  ): Promise<Guild>;
+  public setExplicitContentFilter(explicitContentFilter: GuildExplicitContentFilter, reason?: string): Promise<Guild>;
   public setIcon(icon: BufferResolvable | Base64Resolvable | null, reason?: string): Promise<Guild>;
   public setName(name: string, reason?: string): Promise<Guild>;
   public setOwner(owner: GuildMemberResolvable, reason?: string): Promise<Guild>;
@@ -975,7 +981,7 @@ export class Guild extends AnonymousGuild {
   public setSplash(splash: BufferResolvable | Base64Resolvable | null, reason?: string): Promise<Guild>;
   public setSystemChannel(systemChannel: TextChannelResolvable | null, reason?: string): Promise<Guild>;
   public setSystemChannelFlags(systemChannelFlags: SystemChannelFlagsResolvable, reason?: string): Promise<Guild>;
-  public setVerificationLevel(verificationLevel: GuildVerificationLevelKey | number, reason?: string): Promise<Guild>;
+  public setVerificationLevel(verificationLevel: GuildVerificationLevel, reason?: string): Promise<Guild>;
   public setPremiumProgressBarEnabled(enabled?: boolean, reason?: string): Promise<Guild>;
   public setWidgetSettings(settings: GuildWidgetSettingsData, reason?: string): Promise<Guild>;
   public toJSON(): unknown;
@@ -1159,7 +1165,7 @@ export class GuildPreview extends Base {
   public toString(): string;
 }
 
-export class GuildScheduledEvent<S extends GuildScheduledEventStatusKey = GuildScheduledEventStatusKey> extends Base {
+export class GuildScheduledEvent<S extends GuildScheduledEventStatus = GuildScheduledEventStatus> extends Base {
   private constructor(client: Client, data: RawGuildScheduledEventData);
   public id: Snowflake;
   public guildId: Snowflake;
@@ -1201,10 +1207,10 @@ export class GuildScheduledEvent<S extends GuildScheduledEventStatusKey = GuildS
     options?: T,
   ): Promise<GuildScheduledEventManagerFetchSubscribersResult<T>>;
   public toString(): string;
-  public isActive(): this is GuildScheduledEvent<'Active'>;
-  public isCanceled(): this is GuildScheduledEvent<'Canceled'>;
-  public isCompleted(): this is GuildScheduledEvent<'Completed'>;
-  public isScheduled(): this is GuildScheduledEvent<'Scheduled'>;
+  public isActive(): this is GuildScheduledEvent<GuildScheduledEventStatus.Active>;
+  public isCanceled(): this is GuildScheduledEvent<GuildScheduledEventStatus.Canceled>;
+  public isCompleted(): this is GuildScheduledEvent<GuildScheduledEventStatus.Completed>;
+  public isScheduled(): this is GuildScheduledEvent<GuildScheduledEventStatus.Scheduled>;
 }
 
 export class GuildTemplate extends Base {
@@ -1585,7 +1591,7 @@ export class MessageComponentInteraction<Cached extends CacheType = CacheType> e
     ActionRowComponent | Exclude<APIMessageComponent, APIActionRowComponent>,
     ActionRowComponent | Exclude<APIMessageComponent, APIActionRowComponent>
   >;
-  public componentType: Exclude<keyof typeof ComponentType, 'ActionRow'>;
+  public componentType: Exclude<ComponentType, ComponentType.ActionRow>;
   public customId: string;
   public channelId: Snowflake;
   public deferred: boolean;
@@ -1897,7 +1903,7 @@ export class SelectMenuInteraction<Cached extends CacheType = CacheType> extends
     SelectMenuComponent | APISelectMenuComponent,
     SelectMenuComponent | APISelectMenuComponent
   >;
-  public componentType: 'SelectMenu';
+  public componentType: ComponentType.SelectMenu;
   public values: string[];
   public inGuild(): this is SelectMenuInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is SelectMenuInteraction<'cached'>;
@@ -2042,7 +2048,7 @@ export class StageInstance extends Base {
   public guildId: Snowflake;
   public channelId: Snowflake;
   public topic: string;
-  public privacyLevel: StageInstancePrivacyLevelKey;
+  public privacyLevel: StageInstancePrivacyLevel;
   /** @deprecated See https://github.com/discord/discord-api-docs/pull/4296 for more information */
   public discoverableDisabled: boolean | null;
   public readonly channel: StageChannel | null;
@@ -2195,7 +2201,7 @@ export class TeamMember extends Base {
   public team: Team;
   public readonly id: Snowflake;
   public permissions: string[];
-  public membershipState: TeamMemberMembershipStateKey;
+  public membershipState: TeamMemberMembershipState;
   public user: User;
 
   public toString(): UserMention;
@@ -2935,7 +2941,7 @@ export class GuildScheduledEventManager extends CachedManager<
   public fetch<
     T extends GuildScheduledEventResolvable | FetchGuildScheduledEventOptions | FetchGuildScheduledEventsOptions,
   >(options?: T): Promise<GuildScheduledEventManagerFetchResult<T>>;
-  public edit<S extends GuildScheduledEventStatusKey, T extends GuildScheduledEventSetStatusArg<S>>(
+  public edit<S extends GuildScheduledEventStatus, T extends GuildScheduledEventSetStatusArg<S>>(
     guildScheduledEvent: GuildScheduledEventResolvable,
     options: GuildScheduledEventEditOptions<S, T>,
   ): Promise<GuildScheduledEvent<T>>;
@@ -3256,16 +3262,16 @@ export interface BaseApplicationCommandOptionsData {
 }
 
 export interface UserApplicationCommandData extends BaseApplicationCommandData {
-  type: 'User' | ApplicationCommandType.User;
+  type: ApplicationCommandType.User;
 }
 
 export interface MessageApplicationCommandData extends BaseApplicationCommandData {
-  type: 'Message' | ApplicationCommandType.Message;
+  type: ApplicationCommandType.Message;
 }
 
 export interface ChatInputApplicationCommandData extends BaseApplicationCommandData {
   description: string;
-  type?: 'ChatInput' | ApplicationCommandType.ChatInput;
+  type?: ApplicationCommandType.ChatInput;
   options?: ApplicationCommandOptionData[];
 }
 
@@ -3276,20 +3282,17 @@ export type ApplicationCommandData =
 
 export interface ApplicationCommandChannelOptionData extends BaseApplicationCommandOptionsData {
   type: CommandOptionChannelResolvableType;
-  channelTypes?: (keyof typeof ChannelType)[];
-  channel_types?: (keyof typeof ChannelType)[];
+  channelTypes?: ChannelType[];
+  channel_types?: ChannelType[];
 }
 
 export interface ApplicationCommandChannelOption extends BaseApplicationCommandOptionsData {
   type: ApplicationCommandOptionType.Channel;
-  channelTypes?: (keyof typeof ChannelType)[];
+  channelTypes?: ChannelType[];
 }
 
 export interface ApplicationCommandAutocompleteOption extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
   type:
-    | 'String'
-    | 'Number'
-    | 'Integer'
     | ApplicationCommandOptionType.String
     | ApplicationCommandOptionType.Number
     | ApplicationCommandOptionType.Integer;
@@ -3323,17 +3326,17 @@ export interface ApplicationCommandNumericOption extends ApplicationCommandChoic
 }
 
 export interface ApplicationCommandSubGroupData extends Omit<BaseApplicationCommandOptionsData, 'required'> {
-  type: 'SubcommandGroup' | ApplicationCommandOptionType.SubcommandGroup;
+  type: ApplicationCommandOptionType.SubcommandGroup;
   options?: ApplicationCommandSubCommandData[];
 }
 
 export interface ApplicationCommandSubGroup extends Omit<BaseApplicationCommandOptionsData, 'required'> {
-  type: 'SubcommandGroup';
+  type: ApplicationCommandOptionType.SubcommandGroup;
   options?: ApplicationCommandSubCommand[];
 }
 
 export interface ApplicationCommandSubCommandData extends Omit<BaseApplicationCommandOptionsData, 'required'> {
-  type: 'Subcommand' | ApplicationCommandOptionType.Subcommand;
+  type: ApplicationCommandOptionType.Subcommand;
   options?: (
     | ApplicationCommandChoicesData
     | ApplicationCommandNonOptionsData
@@ -3344,7 +3347,7 @@ export interface ApplicationCommandSubCommandData extends Omit<BaseApplicationCo
 }
 
 export interface ApplicationCommandSubCommand extends Omit<BaseApplicationCommandOptionsData, 'required'> {
-  type: 'Subcommand';
+  type: ApplicationCommandOptionType.Subcommand;
   options?: (ApplicationCommandChoicesOption | ApplicationCommandNonOptions | ApplicationCommandChannelOption)[];
 }
 
@@ -3911,19 +3914,17 @@ export interface CreateRoleOptions extends RoleData {
 
 export interface StageInstanceCreateOptions {
   topic: string;
-  privacyLevel?: StageInstancePrivacyLevelKey | number;
+  privacyLevel?: StageInstancePrivacyLevel;
 }
 
 export interface CrosspostedChannel {
   channelId: Snowflake;
   guildId: Snowflake;
-  type: keyof typeof ChannelType;
+  type: ChannelType;
   name: string;
 }
 
 export type DateResolvable = Date | number | string;
-
-export type GuildDefaultMessageNotificationsKey = keyof typeof GuildDefaultMessageNotifications;
 
 export interface EditGuildTemplateOptions {
   name?: string;
@@ -3975,8 +3976,6 @@ export interface EscapeMarkdownOptions {
   inlineCodeContent?: boolean;
   codeBlockContent?: boolean;
 }
-
-export type GuildExplicitContentFilterKey = keyof typeof GuildExplicitContentFilter;
 
 export interface FetchApplicationCommandOptions extends BaseFetchOptions {
   guildId?: Snowflake;
@@ -4275,13 +4274,13 @@ export interface GuildCreateOptions {
   afkChannelId?: Snowflake | number;
   afkTimeout?: number;
   channels?: PartialChannelData[];
-  defaultMessageNotifications?: GuildDefaultMessageNotificationsKey | number;
-  explicitContentFilter?: GuildExplicitContentFilterKey | number;
+  defaultMessageNotifications?: GuildDefaultMessageNotifications;
+  explicitContentFilter?: GuildExplicitContentFilter;
   icon?: BufferResolvable | Base64Resolvable | null;
   roles?: PartialRoleData[];
   systemChannelFlags?: SystemChannelFlagsResolvable;
   systemChannelId?: Snowflake | number;
-  verificationLevel?: GuildVerificationLevelKey | number;
+  verificationLevel?: GuildVerificationLevel;
 }
 
 export interface GuildWidgetSettings {
@@ -4291,9 +4290,9 @@ export interface GuildWidgetSettings {
 
 export interface GuildEditData {
   name?: string;
-  verificationLevel?: GuildVerificationLevelKey | number;
-  explicitContentFilter?: GuildExplicitContentFilterKey | number;
-  defaultMessageNotifications?: GuildDefaultMessageNotificationsKey | number;
+  verificationLevel?: GuildVerificationLevel;
+  explicitContentFilter?: GuildExplicitContentFilter;
+  defaultMessageNotifications?: GuildDefaultMessageNotifications;
   afkChannel?: VoiceChannelResolvable;
   systemChannel?: TextChannelResolvable;
   systemChannelFlags?: SystemChannelFlagsResolvable;
@@ -4408,7 +4407,7 @@ export interface GuildScheduledEventCreateOptions {
 }
 
 export interface GuildScheduledEventEditOptions<
-  S extends GuildScheduledEventStatusKey,
+  S extends GuildScheduledEventStatus,
   T extends GuildScheduledEventSetStatusArg<S>,
 > extends Omit<Partial<GuildScheduledEventCreateOptions>, 'channel'> {
   channel?: GuildVoiceChannelResolvable | null;
@@ -4436,13 +4435,12 @@ export type GuildScheduledEventManagerFetchSubscribersResult<T extends FetchGuil
 
 export type GuildScheduledEventResolvable = Snowflake | GuildScheduledEvent;
 
-export type GuildScheduledEventSetStatusArg<T extends GuildScheduledEventStatusKey> = T extends 'Scheduled'
-  ? 'Active' | 'Canceled'
-  : T extends 'Active'
-  ? 'Completed'
-  : never;
-
-export type GuildScheduledEventStatusKey = keyof typeof GuildScheduledEventStatus;
+export type GuildScheduledEventSetStatusArg<T extends GuildScheduledEventStatus> =
+  T extends GuildScheduledEventStatus.Scheduled
+    ? GuildScheduledEventStatus.Active | GuildScheduledEventStatus.Canceled
+    : T extends GuildScheduledEventStatus.Active
+    ? GuildScheduledEventStatus.Completed
+    : never;
 
 export interface GuildScheduledEventUser<T> {
   guildScheduledEventId: Snowflake;
@@ -4595,8 +4593,6 @@ export interface MakeErrorOptions {
 }
 
 export type MemberMention = UserMention | `<@!${Snowflake}>`;
-
-export type TeamMemberMembershipStateKey = keyof typeof TeamMemberMembershipState;
 
 export type ActionRowComponentOptions =
   | (Required<BaseMessageComponentOptions> & MessageButtonOptions)
@@ -4832,8 +4828,6 @@ export interface MultipleShardSpawnOptions {
   timeout?: number;
 }
 
-export type GuildNSFWLevelKey = keyof typeof GuildNSFWLevel;
-
 export interface OverwriteData {
   allow?: PermissionResolvable;
   deny?: PermissionResolvable;
@@ -4901,8 +4895,6 @@ export type RecursiveReadonlyArray<T> = ReadonlyArray<T | RecursiveReadonlyArray
 export interface PartialRecipient {
   username: string;
 }
-
-export type PremiumTier = keyof typeof GuildPremiumTier;
 
 export interface PresenceData {
   status?: PresenceStatusData;
@@ -4979,8 +4971,6 @@ export interface PartialUser extends Partialize<User, 'username' | 'tag' | 'disc
 export type PresenceStatusData = ClientPresenceStatus | 'invisible';
 
 export type PresenceStatus = PresenceStatusData | 'offline';
-
-export type StageInstancePrivacyLevelKey = keyof typeof StageInstancePrivacyLevel;
 
 export interface RateLimitData {
   timeout: number;
@@ -5089,11 +5079,7 @@ export interface StartThreadOptions {
 
 export type Status = number;
 
-export type StickerFormatKey = keyof typeof StickerFormatType;
-
 export type StickerResolvable = Sticker | Snowflake;
-
-export type StickerKey = keyof typeof StickerType;
 
 export type SystemChannelFlagsString =
   | 'SUPPRESS_JOIN_NOTIFICATIONS'
@@ -5112,7 +5098,7 @@ export type StageChannelResolvable = StageChannel | Snowflake;
 
 export interface StageInstanceEditOptions {
   topic?: string;
-  privacyLevel?: StageInstancePrivacyLevelKey | number;
+  privacyLevel?: StageInstancePrivacyLevel;
 }
 
 export type SweeperKey = keyof SweeperDefinitions;
@@ -5236,8 +5222,6 @@ export interface Vanity {
   code: string | null;
   uses: number;
 }
-
-export type GuildVerificationLevelKey = keyof typeof GuildVerificationLevel;
 
 export type VoiceBasedChannelTypes = VoiceBasedChannel['type'];
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -891,7 +891,7 @@ declare const applicationNonChoiceOptionData: ApplicationCommandOptionData & {
 
 declare const applicationSubGroupCommandData: ApplicationCommandSubGroupData;
 {
-  expectType<'SubcommandGroup' | ApplicationCommandOptionType.SubcommandGroup>(applicationSubGroupCommandData.type);
+  expectType<ApplicationCommandOptionType.SubcommandGroup>(applicationSubGroupCommandData.type);
   expectType<ApplicationCommandSubCommandData[] | undefined>(applicationSubGroupCommandData.options);
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Some typings are out of date and a few enums are still being converted to strings. I also `{@link}`ed the enums in the JSDocs, if you want me to revert that I will.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
