### PR TITLE
feat(scheduledevent): add support for event cover images

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -543,3 +543,8 @@ module.exports = Client;
  * @external ImageURLOptions
  * @see {@link https://discord.js.org/#/docs/rest/main/typedef/ImageURLOptions}
  */
+
+/**
+ * @external BaseImageURLOptions
+ * @see {@link https://discord.js.org/#/docs/rest/main/typedef/BaseImageURLOptions}
+ */

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -160,7 +160,6 @@ class GuildScheduledEvent extends Base {
     this.image = data.image ?? null;
   }
 
-  // TODO: Update for /rest merge if needed.
   /**
    * The URL of this scheduled event's cover image
    * @param {BaseMakeURLOptions} [options={}] Options for image URL

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -162,7 +162,7 @@ class GuildScheduledEvent extends Base {
 
   /**
    * The URL of this scheduled event's cover image
-   * @param {BaseMakeURLOptions} [options={}] Options for image URL
+   * @param {BaseImageURLOptions} [options={}] Options for image URL
    * @returns {?string}
    */
   coverImageURL(options = {}) {

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -152,6 +152,22 @@ class GuildScheduledEvent extends Base {
     } else {
       this.entityMetadata ??= null;
     }
+
+    /**
+     * The cover image hash for this scheduled event
+     * @type {?string}
+     */
+    this.image = data.image ?? null;
+  }
+
+  // TODO: Update for /rest merge if needed.
+  /**
+   * The URL of this scheduled event's cover image
+   * @param {BaseMakeURLOptions} [options={}] Options for image URL
+   * @returns {?string}
+   */
+  coverImageURL(options = {}) {
+    return this.image && this.client.rest.cdn.guildScheduledEventCover(this.id, this.image, options);
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -26,7 +26,7 @@ import {
   userMention,
 } from '@discordjs/builders';
 import { Collection } from '@discordjs/collection';
-import { ImageURLOptions, RawFile, REST, RESTOptions } from '@discordjs/rest';
+import { BaseImageURLOptions, ImageURLOptions, RawFile, REST, RESTOptions } from '@discordjs/rest';
 import {
   APIActionRowComponent,
   APIApplicationCommand,
@@ -1161,8 +1161,7 @@ export class GuildScheduledEvent<S extends GuildScheduledEventStatus = GuildSche
   public readonly guild: Guild | null;
   public readonly url: string;
   public readonly image: string | null;
-  // TODO: Update for /rest merge if needed
-  public coverImageURL(options?: unknown): string | null;
+  public coverImageURL(options?: Readonly<BaseImageURLOptions>): string | null;
   public createInviteURL(options?: CreateGuildScheduledEventInviteURLOptions): Promise<string>;
   public edit<T extends GuildScheduledEventSetStatusArg<S>>(
     options: GuildScheduledEventEditOptions<S, T>,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1160,6 +1160,9 @@ export class GuildScheduledEvent<S extends GuildScheduledEventStatus = GuildSche
   public readonly channel: VoiceChannel | StageChannel | null;
   public readonly guild: Guild | null;
   public readonly url: string;
+  public readonly image: string | null;
+  // TODO: Update for /rest merge if needed
+  public coverImageURL(options?: unknown): string | null;
   public createInviteURL(options?: CreateGuildScheduledEventInviteURLOptions): Promise<string>;
   public edit<T extends GuildScheduledEventSetStatusArg<S>>(
     options: GuildScheduledEventEditOptions<S, T>,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds `#image` and `#coverImageURL()` for getting the scheduled event cover image.

- https://github.com/discord/discord-api-docs/pull/4380

Depends on:
- https://github.com/discordjs/discord.js/pull/7298

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
