### PR TITLE
refactor(files): remove redundant file property names

### DIFF
--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -119,7 +119,7 @@ test('postFile empty', async () => {
 test('postFile file (string)', async () => {
 	expect(
 		await api.post('/postFile', {
-			files: [{ fileName: 'out.txt', fileData: 'Hello' }],
+			files: [{ name: 'out.txt', data: 'Hello' }],
 		}),
 	).toStrictEqual({
 		body: [
@@ -134,7 +134,7 @@ test('postFile file (string)', async () => {
 test('postFile file and JSON', async () => {
 	expect(
 		await api.post('/postFile', {
-			files: [{ fileName: 'out.txt', fileData: Buffer.from('Hello') }],
+			files: [{ name: 'out.txt', data: Buffer.from('Hello') }],
 			body: { foo: 'bar' },
 		}),
 	).toStrictEqual({
@@ -154,8 +154,8 @@ test('postFile files and JSON', async () => {
 	expect(
 		await api.post('/postFile', {
 			files: [
-				{ fileName: 'out.txt', fileData: Buffer.from('Hello') },
-				{ fileName: 'out.txt', fileData: Buffer.from('Hi') },
+				{ name: 'out.txt', data: Buffer.from('Hello') },
+				{ name: 'out.txt', data: Buffer.from('Hi') },
 			],
 			body: { files: [{ id: 0, description: 'test' }] },
 		}),
@@ -179,7 +179,7 @@ test('postFile files and JSON', async () => {
 test('postFile sticker and JSON', async () => {
 	expect(
 		await api.post('/postFile', {
-			files: [{ key: 'file', fileName: 'sticker.png', fileData: Buffer.from('Sticker') }],
+			files: [{ key: 'file', name: 'sticker.png', data: Buffer.from('Sticker') }],
 			body: { foo: 'bar' },
 			appendToFormData: true,
 		}),

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -17,7 +17,7 @@ export interface RawFile {
 	/**
 	 * The name of the file
 	 */
-	fileName: string;
+	name: string;
 	/**
 	 * An explicit key to use for key of the formdata field for this file.
 	 * When not provided, the index of the file in the files array is used in the form `files[${index}]`.
@@ -27,7 +27,7 @@ export interface RawFile {
 	/**
 	 * The actual data for the file
 	 */
-	fileData: string | number | boolean | Buffer;
+	data: string | number | boolean | Buffer;
 }
 
 /**
@@ -366,7 +366,7 @@ export class RequestManager extends EventEmitter {
 
 			// Attach all files to the request
 			for (const [index, file] of request.files.entries()) {
-				formData.append(file.key ?? `files[${index}]`, file.fileData, file.fileName);
+				formData.append(file.key ?? `files[${index}]`, file.data, file.name);
 			}
 
 			// If a JSON body was added as well, attach it to the form data, using payload_json unless otherwise specified


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removes the now redundant file descriptor in file properties (this ones on me)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
