### PR TITLE
fix: don't create new instances of builders classes

### DIFF
--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -3,6 +3,8 @@ import type { ButtonComponent, SelectMenuComponent } from '..';
 import type { Component } from './Component';
 import { createComponent } from './Components';
 
+export type MessageComponent = ActionRowComponent | ActionRow;
+
 export type ActionRowComponent = ButtonComponent | SelectMenuComponent;
 
 // TODO: Add valid form component types
@@ -10,7 +12,7 @@ export type ActionRowComponent = ButtonComponent | SelectMenuComponent;
 /**
  * Represents an action row component
  */
-export class ActionRow<T extends ActionRowComponent> implements Component {
+export class ActionRow<T extends ActionRowComponent = ActionRowComponent> implements Component {
 	public readonly components: T[] = [];
 	public readonly type = ComponentType.ActionRow;
 

--- a/packages/builders/src/components/Components.ts
+++ b/packages/builders/src/components/Components.ts
@@ -1,9 +1,9 @@
 import { APIMessageComponent, ComponentType } from 'discord-api-types/v9';
 import { ActionRow, ButtonComponent, Component, SelectMenuComponent } from '../index';
-import type { ActionRowComponent } from './ActionRow';
+import type { MessageComponent } from './ActionRow';
 
 export interface MappedComponentTypes {
-	[ComponentType.ActionRow]: ActionRow<ActionRowComponent>;
+	[ComponentType.ActionRow]: ActionRow;
 	[ComponentType.Button]: ButtonComponent;
 	[ComponentType.SelectMenu]: SelectMenuComponent;
 }
@@ -15,14 +15,15 @@ export interface MappedComponentTypes {
 export function createComponent<T extends keyof MappedComponentTypes>(
 	data: APIMessageComponent & { type: T },
 ): MappedComponentTypes[T];
-export function createComponent(data: APIMessageComponent): Component {
+export function createComponent<C extends MessageComponent>(data: C): C;
+export function createComponent(data: APIMessageComponent | MessageComponent): Component {
 	switch (data.type) {
 		case ComponentType.ActionRow:
-			return new ActionRow(data);
+			return data instanceof ActionRow ? data : new ActionRow(data);
 		case ComponentType.Button:
-			return new ButtonComponent(data);
+			return data instanceof ButtonComponent ? data : new ButtonComponent(data);
 		case ComponentType.SelectMenu:
-			return new SelectMenuComponent(data);
+			return data instanceof SelectMenuComponent ? data : new SelectMenuComponent(data);
 		default:
 			// @ts-expect-error
 			throw new Error(`Cannot serialize component type: ${data.type as number}`);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR makes it so that if a builders class is passed onto createComponent it is returned as-is, without creating a new instance of it so we can keep referencing it. Also changed types of ActionRow slightly to make it easier to type it

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
