### PR TITLE
feat(`Interaction`): add `.commandType` property to `CommandInteraction` and `AutocompleteInteraction`

### DIFF
--- a/packages/discord.js/src/structures/AutocompleteInteraction.js
+++ b/packages/discord.js/src/structures/AutocompleteInteraction.js
@@ -31,6 +31,12 @@ class AutocompleteInteraction extends Interaction {
     this.commandName = data.data.name;
 
     /**
+     * The invoked application command's type
+     * @type {ApplicationCommandType}
+     */
+    this.commandType = data.data.type;
+
+    /**
      * Whether this interaction has already received a response
      * @type {boolean}
      */

--- a/packages/discord.js/src/structures/AutocompleteInteraction.js
+++ b/packages/discord.js/src/structures/AutocompleteInteraction.js
@@ -32,7 +32,7 @@ class AutocompleteInteraction extends Interaction {
 
     /**
      * The invoked application command's type
-     * @type {ApplicationCommandType}
+     * @type {ApplicationCommandType.ChatInput}
      */
     this.commandType = data.data.type;
 

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -34,6 +34,12 @@ class CommandInteraction extends Interaction {
     this.commandName = data.data.name;
 
     /**
+     * The invoked application command's type
+     * @type {ApplicationCommandType}
+     */
+    this.commandType = data.data.type;
+
+    /**
      * Whether the reply to this interaction has been deferred
      * @type {boolean}
      */

--- a/packages/discord.js/src/structures/ContextMenuCommandInteraction.js
+++ b/packages/discord.js/src/structures/ContextMenuCommandInteraction.js
@@ -26,14 +26,6 @@ class ContextMenuCommandInteraction extends CommandInteraction {
      * @type {Snowflake}
      */
     this.targetId = data.data.target_id;
-
-    /**
-     * The type of the target of the interaction; either {@link ApplicationCommandType.User}
-     * or {@link ApplicationCommandType.Message}
-     * @type {ApplicationCommandType.User|ApplicationCommandType.Message}
-     * @deprecated Use {@link CommandInteraction.commandType} instead
-     */
-    this.targetType = data.data.type;
   }
 
   /**

--- a/packages/discord.js/src/structures/ContextMenuCommandInteraction.js
+++ b/packages/discord.js/src/structures/ContextMenuCommandInteraction.js
@@ -31,6 +31,7 @@ class ContextMenuCommandInteraction extends CommandInteraction {
      * The type of the target of the interaction; either {@link ApplicationCommandType.User}
      * or {@link ApplicationCommandType.Message}
      * @type {ApplicationCommandType.User|ApplicationCommandType.Message}
+     * @deprecated Use {@link CommandInteraction.commandType} instead
      */
     this.targetType = data.data.type;
   }

--- a/packages/discord.js/src/structures/Interaction.js
+++ b/packages/discord.js/src/structures/Interaction.js
@@ -162,7 +162,7 @@ class Interaction extends Base {
    * @returns {boolean}
    */
   isChatInputCommand() {
-    return this.isCommand() && typeof this.targetId === 'undefined';
+    return this.isCommand() && this.commandType === ApplicationCommandType.ChatInput;
   }
 
   /**
@@ -170,7 +170,7 @@ class Interaction extends Base {
    * @returns {boolean}
    */
   isContextMenuCommand() {
-    return this.isCommand() && typeof this.targetId !== 'undefined';
+    return this.isCommand() && [ApplicationCommandType.User, ApplicationCommandType.Message].includes(this.commandType);
   }
 
   /**
@@ -178,7 +178,7 @@ class Interaction extends Base {
    * @returns {boolean}
    */
   isUserContextMenuCommand() {
-    return this.isContextMenuCommand() && this.targetType === ApplicationCommandType.User;
+    return this.isContextMenuCommand() && this.commandType === ApplicationCommandType.User;
   }
 
   /**
@@ -186,7 +186,7 @@ class Interaction extends Base {
    * @returns {boolean}
    */
   isMessageContextMenuCommand() {
-    return this.isContextMenuCommand() && this.targetType === ApplicationCommandType.Message;
+    return this.isContextMenuCommand() && this.commandType === ApplicationCommandType.Message;
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -316,6 +316,7 @@ export abstract class CommandInteraction<Cached extends CacheType = CacheType> e
   public channelId: Snowflake;
   public commandId: Snowflake;
   public commandName: string;
+  public commandType: ApplicationCommandType;
   public deferred: boolean;
   public ephemeral: boolean | null;
   public replied: boolean;
@@ -773,6 +774,9 @@ export class ContextMenuCommandInteraction<Cached extends CacheType = CacheType>
     | 'getSubcommand'
   >;
   public targetId: Snowflake;
+  /**
+   * @deprecated Use {@see CommandInteraction.commandType} instead
+   */
   public targetType: Exclude<ApplicationCommandType, ApplicationCommandType.ChatInput>;
   public inGuild(): this is ContextMenuCommandInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is ContextMenuCommandInteraction<'cached'>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -694,6 +694,7 @@ export class AutocompleteInteraction<Cached extends CacheType = CacheType> exten
   public channelId: Snowflake;
   public commandId: Snowflake;
   public commandName: string;
+  public commandType: ApplicationCommandType.ChatInput;
   public responded: boolean;
   public options: Omit<CommandInteractionOptionResolver<Cached>, 'getMessage'>;
   public inGuild(): this is AutocompleteInteraction<'raw' | 'cached'>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -775,10 +775,6 @@ export class ContextMenuCommandInteraction<Cached extends CacheType = CacheType>
     | 'getSubcommand'
   >;
   public targetId: Snowflake;
-  /**
-   * @deprecated Use {@see CommandInteraction.commandType} instead
-   */
-  public targetType: Exclude<ApplicationCommandType, ApplicationCommandType.ChatInput>;
   public inGuild(): this is ContextMenuCommandInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is ContextMenuCommandInteraction<'cached'>;
   public inRawGuild(): this is ContextMenuCommandInteraction<'raw'>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
 Adds `CommandInteraction#commandType` and `AutocompleteInteraction#commandType` and removes `ContextMenuCommandInteraction#targetType`.

This PR moves `ContextMenuCommandInteraction#targetType` to `CommandInteraction#commandType` and introduces `AutocompleteInteraction#commandType` for forward-compatability.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)


<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
