### PR TITLE
fix(MessageEmbed): set footer to undefined

### DIFF
--- a/src/structures/MessageEmbed.js
+++ b/src/structures/MessageEmbed.js
@@ -430,7 +430,7 @@ class MessageEmbed {
    */
   setFooter(options, deprecatedIconURL) {
     if (options === null) {
-      this.footer = {};
+      this.footer = undefined;
       return this;
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If you set `embed.setFooter(null)` it set's footer to `{}`. When checking `MessageEmbed`.length, it checks `this.footer?.text.length`. In this case, footer is defined but footer.text isn't, so it'll throw an error `can't read property of undefined (reading length)`. 

In builder, it's correct, that's why after discussing in `library-discussion` I'm sending the pr in stable branch.
**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
