### PR TITLE
feat(channel): add isDMBased typeguard

### DIFF
--- a/packages/discord.js/src/structures/Channel.js
+++ b/packages/discord.js/src/structures/Channel.js
@@ -182,6 +182,14 @@ class Channel extends Base {
   }
 
   /**
+   * Indicates whether this channel is DM-based (either a {@link DMChannel} or a {@link GroupDMChannel}).
+   * @returns {boolean}
+   */
+  isDMBased() {
+    return [ChannelType.DM, ChannelType.GroupDM].includes(this.type);
+  }
+
+  /**
    * Indicates whether this channel is {@link BaseGuildVoiceChannel voice-based}.
    * @returns {boolean}
    */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1688,6 +1688,7 @@ export class OAuth2Guild extends BaseGuild {
 
 export class PartialGroupDMChannel extends Channel {
   private constructor(client: Client, data: RawPartialGroupDMChannelData);
+  public type: ChannelType.GroupDM;
   public name: string | null;
   public icon: string | null;
   public recipients: PartialRecipient[];

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -502,6 +502,7 @@ export abstract class Channel extends Base {
   public isThread(): this is ThreadChannel;
   public isStage(): this is StageChannel;
   public isTextBased(): this is TextBasedChannel;
+  public isDMBased(): this is PartialGroupDMChannel | DMChannel;
   public isVoiceBased(): this is VoiceBasedChannel;
   public toString(): ChannelMention;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds a new typeguard to Channel to ensure a channel is DM-based, aka it's either a DM or a group DM. Along with that, this also adds the GroupDM channel type to the PartialGroupDM class as that was previously missing

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
