### PR TITLE
types: fix *BitField.Flags properties

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -186,7 +186,7 @@ export class Activity {
 export type ActivityFlagsString = keyof typeof ActivityFlags;
 
 export class ActivityFlagsBitField extends BitField<ActivityFlagsString> {
-  public static Flags: ActivityFlags;
+  public static Flags: typeof ActivityFlags;
   public static resolve(bit?: BitFieldResolvable<ActivityFlagsString, number>): number;
 }
 
@@ -266,7 +266,7 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
 export type ApplicationResolvable = Application | Activity | Snowflake;
 
 export class ApplicationFlagsBitField extends BitField<ApplicationFlagsString> {
-  public static Flags: ApplicationFlags;
+  public static Flags: typeof ApplicationFlags;
   public static resolve(bit?: BitFieldResolvable<ApplicationFlagsString, number>): number;
 }
 
@@ -1266,7 +1266,7 @@ export class IntegrationApplication extends Application {
 export type GatewayIntentsString = keyof typeof GatewayIntentBits;
 
 export class IntentsBitField extends BitField<GatewayIntentsString> {
-  public static Flags: GatewayIntentBits;
+  public static Flags: typeof GatewayIntentBits;
   public static resolve(bit?: BitFieldResolvable<GatewayIntentsString, number>): number;
 }
 
@@ -1599,7 +1599,7 @@ export class MessageContextMenuCommandInteraction<
 export type MessageFlagsString = keyof typeof MessageFlags;
 
 export class MessageFlagsBitField extends BitField<MessageFlagsString> {
-  public static Flags: MessageFlags;
+  public static Flags: typeof MessageFlags;
   public static resolve(bit?: BitFieldResolvable<MessageFlagsString, number>): number;
 }
 
@@ -2108,7 +2108,7 @@ export class Sweepers {
 export type SystemChannelFlagsString = keyof typeof GuildSystemChannelFlags;
 
 export class SystemChannelFlagsBitField extends BitField<SystemChannelFlagsString> {
-  public static Flags: GuildSystemChannelFlags;
+  public static Flags: typeof GuildSystemChannelFlags;
   public static resolve(bit?: BitFieldResolvable<SystemChannelFlagsString, number>): number;
 }
 
@@ -2221,7 +2221,7 @@ export class ThreadMember extends Base {
 export type ThreadMemberFlagsString = keyof typeof ThreadMemberFlags;
 
 export class ThreadMemberFlagsBitField extends BitField<ThreadMemberFlagsString> {
-  public static Flags: ThreadMemberFlags;
+  public static Flags: typeof ThreadMemberFlags;
   public static resolve(bit?: BitFieldResolvable<ThreadMemberFlagsString, number>): number;
 }
 
@@ -2283,7 +2283,7 @@ export class UserContextMenuCommandInteraction<
 export type UserFlagsString = keyof typeof UserFlags;
 
 export class UserFlagsBitField extends BitField<UserFlagsString> {
-  public static Flags: UserFlags;
+  public static Flags: typeof UserFlags;
   public static resolve(bit?: BitFieldResolvable<UserFlagsString, number>): number;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1266,7 +1266,7 @@ export class IntegrationApplication extends Application {
 export type GatewayIntentsString = keyof typeof GatewayIntentBits;
 
 export class IntentsBitField extends BitField<GatewayIntentsString> {
-  public static flags: GatewayIntentBits;
+  public static Flags: GatewayIntentBits;
   public static resolve(bit?: BitFieldResolvable<GatewayIntentsString, number>): number;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -186,7 +186,7 @@ export class Activity {
 export type ActivityFlagsString = keyof typeof ActivityFlags;
 
 export class ActivityFlagsBitField extends BitField<ActivityFlagsString> {
-  public static flags: ActivityFlags;
+  public static Flags: ActivityFlags;
   public static resolve(bit?: BitFieldResolvable<ActivityFlagsString, number>): number;
 }
 
@@ -266,7 +266,7 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
 export type ApplicationResolvable = Application | Activity | Snowflake;
 
 export class ApplicationFlagsBitField extends BitField<ApplicationFlagsString> {
-  public static flags: ApplicationFlags;
+  public static Flags: ApplicationFlags;
   public static resolve(bit?: BitFieldResolvable<ApplicationFlagsString, number>): number;
 }
 
@@ -1599,7 +1599,7 @@ export class MessageContextMenuCommandInteraction<
 export type MessageFlagsString = keyof typeof MessageFlags;
 
 export class MessageFlagsBitField extends BitField<MessageFlagsString> {
-  public static flags: MessageFlags;
+  public static Flags: MessageFlags;
   public static resolve(bit?: BitFieldResolvable<MessageFlagsString, number>): number;
 }
 
@@ -1722,7 +1722,7 @@ export class PermissionsBitField extends BitField<PermissionsString, bigint> {
   public static All: bigint;
   public static Default: bigint;
   public static StageModerator: bigint;
-  public static flags: typeof PermissionFlagsBits;
+  public static Flags: typeof PermissionFlagsBits;
   public static resolve(permission?: PermissionResolvable): bigint;
 }
 
@@ -2108,7 +2108,7 @@ export class Sweepers {
 export type SystemChannelFlagsString = keyof typeof GuildSystemChannelFlags;
 
 export class SystemChannelFlagsBitField extends BitField<SystemChannelFlagsString> {
-  public static flags: GuildSystemChannelFlags;
+  public static Flags: GuildSystemChannelFlags;
   public static resolve(bit?: BitFieldResolvable<SystemChannelFlagsString, number>): number;
 }
 
@@ -2221,7 +2221,7 @@ export class ThreadMember extends Base {
 export type ThreadMemberFlagsString = keyof typeof ThreadMemberFlags;
 
 export class ThreadMemberFlagsBitField extends BitField<ThreadMemberFlagsString> {
-  public static flags: ThreadMemberFlags;
+  public static Flags: ThreadMemberFlags;
   public static resolve(bit?: BitFieldResolvable<ThreadMemberFlagsString, number>): number;
 }
 
@@ -2283,7 +2283,7 @@ export class UserContextMenuCommandInteraction<
 export type UserFlagsString = keyof typeof UserFlags;
 
 export class UserFlagsBitField extends BitField<UserFlagsString> {
-  public static flags: UserFlags;
+  public static Flags: UserFlags;
   public static resolve(bit?: BitFieldResolvable<UserFlagsString, number>): number;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the capitalization of *BitField.Flags properties from #7313, as well as their type (was missing `typeof` before the enum name)
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
