### PR TITLE
revert: refactor(invite): make `channel` a getter

### DIFF
--- a/packages/discord.js/src/structures/Invite.js
+++ b/packages/discord.js/src/structures/Invite.js
@@ -151,16 +151,12 @@ class Invite extends Base {
       this.targetType ??= null;
     }
 
-    if ('channel_id' in data) {
+    if ('channel' in data) {
       /**
-       * The channel's id this invite is for
-       * @type {?Snowflake}
+       * The channel this invite is for
+       * @type {?Channel}
        */
-      this.channelId = data.channel_id;
-    }
-
-    if (data.channel) {
-      this.channelId ??= data.channel.id;
+      this.channel = this.client.channels._add(data.channel, this.guild, { cache: false });
     }
 
     if ('created_at' in data) {
@@ -195,15 +191,6 @@ class Invite extends Base {
     } else {
       this.guildScheduledEvent ??= null;
     }
-  }
-
-  /**
-   * The channel this invite is for
-   * @type {Channel}
-   * @readonly
-   */
-  get channel() {
-    return this.client.channels.resolve(this.channelId);
   }
 
   /**
@@ -297,7 +284,6 @@ class Invite extends Base {
       presenceCount: false,
       memberCount: false,
       uses: false,
-      channel: 'channelId',
       inviter: 'inviterId',
       guild: 'guildId',
     });

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1363,8 +1363,7 @@ export class InteractionWebhook extends PartialWebhookMixin() {
 
 export class Invite extends Base {
   private constructor(client: Client, data: RawInviteData);
-  public readonly channel: NonThreadGuildBasedChannel | PartialGroupDMChannel;
-  public channelId: Snowflake | null;
+  public channel: NonThreadGuildBasedChannel | PartialGroupDMChannel;
   public code: string;
   public readonly deletable: boolean;
   public readonly createdAt: Date | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR makes Invite.channel a regular property again as PartialGroupDMChannels do not get cached, so it was impossible to obtain them. This also removes Invite#channelId as this is not documented on Discord's side and thus is not sent

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
