### PR TITLE
docs: add supported option types for autocomplete

### DIFF
--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -144,7 +144,9 @@ class ApplicationCommand extends Base {
    * @property {ApplicationCommandOptionType} type The type of the option
    * @property {string} name The name of the option
    * @property {string} description The description of the option
-   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or {@link ApplicationCommandType.Number} option
+   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a
+   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or
+   * {@link ApplicationCommandType.Number} option
    * @property {boolean} [required] Whether the option is required
    * @property {ApplicationCommandOptionChoice[]} [choices] The choices of the option for the user to pick from
    * @property {ApplicationCommandOptionData[]} [options] Additional options if this option is a subcommand (group)
@@ -346,7 +348,9 @@ class ApplicationCommand extends Base {
    * @property {string} name The name of the option
    * @property {string} description The description of the option
    * @property {boolean} [required] Whether the option is required
-   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or {@link ApplicationCommandType.Number} option
+   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a
+   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or
+   * {@link ApplicationCommandType.Number} option
    * @property {ApplicationCommandOptionChoice[]} [choices] The choices of the option for the user to pick from
    * @property {ApplicationCommandOption[]} [options] Additional options if this option is a subcommand (group)
    * @property {ChannelType[]} [channelTypes] When the option type is channel,

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -145,8 +145,8 @@ class ApplicationCommand extends Base {
    * @property {string} name The name of the option
    * @property {string} description The description of the option
    * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a
-   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or
-   * {@link ApplicationCommandType.Number} option
+   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandOptionType.Integer} or
+   * {@link ApplicationCommandOptionType.Number} option
    * @property {boolean} [required] Whether the option is required
    * @property {ApplicationCommandOptionChoice[]} [choices] The choices of the option for the user to pick from
    * @property {ApplicationCommandOptionData[]} [options] Additional options if this option is a subcommand (group)
@@ -349,8 +349,8 @@ class ApplicationCommand extends Base {
    * @property {string} description The description of the option
    * @property {boolean} [required] Whether the option is required
    * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a
-   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or
-   * {@link ApplicationCommandType.Number} option
+   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandOptionType.Integer} or
+   * {@link ApplicationCommandOptionType.Number} option
    * @property {ApplicationCommandOptionChoice[]} [choices] The choices of the option for the user to pick from
    * @property {ApplicationCommandOption[]} [options] Additional options if this option is a subcommand (group)
    * @property {ChannelType[]} [channelTypes] When the option type is channel,

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -144,7 +144,7 @@ class ApplicationCommand extends Base {
    * @property {ApplicationCommandOptionType} type The type of the option
    * @property {string} name The name of the option
    * @property {string} description The description of the option
-   * @property {boolean} [autocomplete] Whether the option is an autocomplete option
+   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or {@link ApplicationCommandType.Number} option
    * @property {boolean} [required] Whether the option is required
    * @property {ApplicationCommandOptionChoice[]} [choices] The choices of the option for the user to pick from
    * @property {ApplicationCommandOptionData[]} [options] Additional options if this option is a subcommand (group)
@@ -346,7 +346,7 @@ class ApplicationCommand extends Base {
    * @property {string} name The name of the option
    * @property {string} description The description of the option
    * @property {boolean} [required] Whether the option is required
-   * @property {boolean} [autocomplete] Whether the option is an autocomplete option
+   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or {@link ApplicationCommandType.Number} option
    * @property {ApplicationCommandOptionChoice[]} [choices] The choices of the option for the user to pick from
    * @property {ApplicationCommandOption[]} [options] Additional options if this option is a subcommand (group)
    * @property {ChannelType[]} [channelTypes] When the option type is channel,

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Collection } = require('@discordjs/collection');
+const { ApplicationCommandOptionType } = require('discord-api-types/v9');
 const Interaction = require('./Interaction');
 const InteractionWebhook = require('./InteractionWebhook');
 const InteractionResponses = require('./interfaces/InteractionResponses');
@@ -136,7 +137,7 @@ class CommandInteraction extends Interaction {
    * @typedef {Object} CommandInteractionOption
    * @property {string} name The name of the option
    * @property {ApplicationCommandOptionType} type The type of the option
-   * @property {boolean} [autocomplete] Whether the option is an autocomplete option
+   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or {@link ApplicationCommandType.Number} option
    * @property {string|number|boolean} [value] The value of the option
    * @property {CommandInteractionOption[]} [options] Additional options if this option is a
    * subcommand (group)

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { Collection } = require('@discordjs/collection');
-const { ApplicationCommandOptionType } = require('discord-api-types/v9');
 const Interaction = require('./Interaction');
 const InteractionWebhook = require('./InteractionWebhook');
 const InteractionResponses = require('./interfaces/InteractionResponses');

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -138,8 +138,8 @@ class CommandInteraction extends Interaction {
    * @property {string} name The name of the option
    * @property {ApplicationCommandOptionType} type The type of the option
    * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a 
-   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or 
-   * {@link ApplicationCommandType.Number} option
+   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandOptionType.Integer} or 
+   * {@link ApplicationCommandOptionType.Number} option
    * @property {string|number|boolean} [value] The value of the option
    * @property {CommandInteractionOption[]} [options] Additional options if this option is a
    * subcommand (group)

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -137,7 +137,9 @@ class CommandInteraction extends Interaction {
    * @typedef {Object} CommandInteractionOption
    * @property {string} name The name of the option
    * @property {ApplicationCommandOptionType} type The type of the option
-   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or {@link ApplicationCommandType.Number} option
+   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a 
+   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandType.Integer} or 
+   * {@link ApplicationCommandType.Number} option
    * @property {string|number|boolean} [value] The value of the option
    * @property {CommandInteractionOption[]} [options] Additional options if this option is a
    * subcommand (group)

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -136,8 +136,8 @@ class CommandInteraction extends Interaction {
    * @typedef {Object} CommandInteractionOption
    * @property {string} name The name of the option
    * @property {ApplicationCommandOptionType} type The type of the option
-   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a 
-   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandOptionType.Integer} or 
+   * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a
+   * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandOptionType.Integer} or
    * {@link ApplicationCommandOptionType.Number} option
    * @property {string|number|boolean} [value] The value of the option
    * @property {CommandInteractionOption[]} [options] Additional options if this option is a


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- https://github.com/discord/discord-api-docs/pull/4318

This PR documents the supported option types for autocomplete.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
