### PR TITLE
feat: add `isRepliable` type guard to `InteractionResponses`

### DIFF
--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -187,6 +187,7 @@ class CommandInteraction extends Interaction {
   editReply() {}
   deleteReply() {}
   followUp() {}
+  isRepliable() {}
 }
 
 InteractionResponses.applyToClass(CommandInteraction, ['deferUpdate', 'update']);

--- a/packages/discord.js/src/structures/MessageComponentInteraction.js
+++ b/packages/discord.js/src/structures/MessageComponentInteraction.js
@@ -90,6 +90,7 @@ class MessageComponentInteraction extends Interaction {
   followUp() {}
   deferUpdate() {}
   update() {}
+  isRepliable() {}
 }
 
 InteractionResponses.applyToClass(MessageComponentInteraction);

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -225,6 +225,14 @@ class InteractionResponses {
     return options.fetchReply ? this.fetchReply() : undefined;
   }
 
+  /**
+   * Indicates whether this interaction can be replied to.
+   * @returns {boolean}
+   */
+  isRepliable() {
+    return !(this.deferred || this.replied);
+  }
+
   static applyToClass(structure, ignore = []) {
     const props = [
       'deferReply',
@@ -235,6 +243,7 @@ class InteractionResponses {
       'followUp',
       'deferUpdate',
       'update',
+      'isRepliable',
     ];
 
     for (const prop of props) {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -334,6 +334,7 @@ export abstract class CommandInteraction<Cached extends CacheType = CacheType> e
   public inGuild(): this is CommandInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is CommandInteraction<'cached'>;
   public inRawGuild(): this is CommandInteraction<'raw'>;
+  public isRepliable(): boolean;
   public deferReply(options: InteractionDeferReplyOptions & { fetchReply: true }): Promise<GuildCacheMessage<Cached>>;
   public deferReply(options?: InteractionDeferReplyOptions): Promise<void>;
   public deleteReply(): Promise<void>;
@@ -1575,6 +1576,7 @@ export class MessageComponentInteraction<Cached extends CacheType = CacheType> e
   public inGuild(): this is MessageComponentInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is MessageComponentInteraction<'cached'>;
   public inRawGuild(): this is MessageComponentInteraction<'raw'>;
+  public isRepliable(): boolean;
   public deferReply(options: InteractionDeferReplyOptions & { fetchReply: true }): Promise<GuildCacheMessage<Cached>>;
   public deferReply(options?: InteractionDeferReplyOptions): Promise<void>;
   public deferUpdate(options: InteractionDeferUpdateOptions & { fetchReply: true }): Promise<GuildCacheMessage<Cached>>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Addition to #7259. 

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
