### PR TITLE
fix: messageReaction.me being false when it shouldn't

### DIFF
--- a/packages/discord.js/src/structures/MessageReaction.js
+++ b/packages/discord.js/src/structures/MessageReaction.js
@@ -113,7 +113,7 @@ class MessageReaction {
     if (this.partial) return;
     this.users.cache.set(user.id, user);
     if (!this.me || user.id !== this.message.client.user.id || this.count === 0) this.count++;
-    this.me ??= user.id === this.message.client.user.id;
+    this.me ||= user.id === this.message.client.user.id;
   }
 
   _remove(user) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes cases where the messageReaction.me is false when it shouldn't be.
fixes #7377 
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

Just a note I'm not sure if this is the right spot to pull to. Let me know if I messed this up.