### PR TITLE
fix(guildmember): check if member has administrator permission

### DIFF
--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -264,8 +264,8 @@ class GuildMember extends Base {
    */
   get moderatable() {
     return (
-      this.manageable &&
       !this.permissions.has(PermissionFlagsBits.Administrator) &&
+      this.manageable &&
       (this.guild.me?.permissions.has(PermissionFlagsBits.ModerateMembers) ?? false)
     );
   }

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -263,7 +263,11 @@ class GuildMember extends Base {
    * @readonly
    */
   get moderatable() {
-    return this.manageable && (this.guild.me?.permissions.has(PermissionFlagsBits.ModerateMembers) ?? false);
+    return (
+      this.manageable &&
+      !this.permissions.has(PermissionFlagsBits.Administrator) &&
+      (this.guild.me?.permissions.has(PermissionFlagsBits.ModerateMembers) ?? false)
+    );
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Discord doesn't allow to timeout a member, which has administrator permission, even if he is manageable.
I added check to `guildMember.moderatable` which returns false if member has `Administrator` permission

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
