### PR TITLE
feat(thread): add `newlyCreated` to `threadCreate` event

### DIFF
--- a/packages/discord.js/src/client/actions/ThreadCreate.js
+++ b/packages/discord.js/src/client/actions/ThreadCreate.js
@@ -13,6 +13,7 @@ class ThreadCreateAction extends Action {
        * Emitted whenever a thread is created or when the client user is added to a thread.
        * @event Client#threadCreate
        * @param {ThreadChannel} thread The thread that was created
+       * @param {boolean} newlyCreated Whether or not the thread was created or not
        */
       client.emit(Events.THREAD_CREATE, thread, data.newly_created ?? false);
     }

--- a/packages/discord.js/src/client/actions/ThreadCreate.js
+++ b/packages/discord.js/src/client/actions/ThreadCreate.js
@@ -13,7 +13,7 @@ class ThreadCreateAction extends Action {
        * Emitted whenever a thread is created or when the client user is added to a thread.
        * @event Client#threadCreate
        * @param {ThreadChannel} thread The thread that was created
-       * @param {boolean} newlyCreated Whether or not the thread was created or not
+       * @param {boolean} newlyCreated Whether the thread was newly created
        */
       client.emit(Events.THREAD_CREATE, thread, data.newly_created ?? false);
     }

--- a/packages/discord.js/src/client/actions/ThreadCreate.js
+++ b/packages/discord.js/src/client/actions/ThreadCreate.js
@@ -14,7 +14,7 @@ class ThreadCreateAction extends Action {
        * @event Client#threadCreate
        * @param {ThreadChannel} thread The thread that was created
        */
-      client.emit(Events.THREAD_CREATE, thread);
+      client.emit(Events.THREAD_CREATE, thread, data.newly_created ?? false);
     }
     return { thread };
   }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3514,7 +3514,7 @@ export interface ClientEvents {
   roleCreate: [role: Role];
   roleDelete: [role: Role];
   roleUpdate: [oldRole: Role, newRole: Role];
-  threadCreate: [thread: ThreadChannel];
+  threadCreate: [thread: ThreadChannel, newlyCreated: boolean];
   threadDelete: [thread: ThreadChannel];
   threadListSync: [threads: Collection<Snowflake, ThreadChannel>];
   threadMemberUpdate: [oldMember: ThreadMember, newMember: ThreadMember];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- https://github.com/discord/discord-api-docs/commit/1875d80011ea62bf555ce807459ccf97950291e9

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
