### PR TITLE
refactor: switch `xURL` to `xUrl`

### DIFF
--- a/packages/builders/__tests__/components/button.test.ts
+++ b/packages/builders/__tests__/components/button.test.ts
@@ -49,7 +49,7 @@ describe('Button Components', () => {
 				button.toJSON();
 			}).not.toThrowError();
 
-			expect(() => buttonComponent().setURL('https://google.com')).not.toThrowError();
+			expect(() => buttonComponent().setUrl('https://google.com')).not.toThrowError();
 		});
 
 		test('GIVEN invalid fields THEN build does throw', () => {
@@ -63,7 +63,7 @@ describe('Button Components', () => {
 					.setStyle(ButtonStyle.Primary)
 					.setDisabled(true)
 					.setLabel('test')
-					.setURL('https://google.com')
+					.setUrl('https://google.com')
 					.setEmoji({ name: 'test' });
 
 				button.toJSON();
@@ -91,7 +91,7 @@ describe('Button Components', () => {
 			}).toThrowError();
 
 			expect(() => {
-				const button = buttonComponent().setStyle(ButtonStyle.Primary).setLabel('test').setURL('https://google.com');
+				const button = buttonComponent().setStyle(ButtonStyle.Primary).setLabel('test').setUrl('https://google.com');
 				button.toJSON();
 			}).toThrowError();
 
@@ -107,7 +107,7 @@ describe('Button Components', () => {
 			// @ts-expect-error
 			expect(() => buttonComponent().setEmoji('foo')).toThrowError();
 
-			expect(() => buttonComponent().setURL('foobar')).toThrowError();
+			expect(() => buttonComponent().setUrl('foobar')).toThrowError();
 		});
 
 		test('GiVEN valid input THEN valid JSON outputs are given', () => {
@@ -140,7 +140,7 @@ describe('Button Components', () => {
 
 			expect(new ButtonComponent(linkData).toJSON()).toEqual(linkData);
 
-			expect(buttonComponent().setLabel(linkData.label).setDisabled(true).setURL(linkData.url));
+			expect(buttonComponent().setLabel(linkData.label).setDisabled(true).setUrl(linkData.url));
 		});
 	});
 });

--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -101,9 +101,9 @@ describe('Embed', () => {
 			});
 		});
 
-		test('GIVEN an embed using Embed#setURL THEN returns valid toJSON data', () => {
+		test('GIVEN an embed using Embed#setUrl THEN returns valid toJSON data', () => {
 			const embed = new Embed();
-			embed.setURL('https://discord.js.org/');
+			embed.setUrl('https://discord.js.org/');
 
 			expect(embed.toJSON()).toStrictEqual({
 				...emptyEmbed,
@@ -113,7 +113,7 @@ describe('Embed', () => {
 
 		test('GIVEN an embed with a pre-defined title THEN unset title THEN return valid toJSON data', () => {
 			const embed = new Embed({ url: 'https://discord.js.org' });
-			embed.setURL(null);
+			embed.setUrl(null);
 
 			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed });
 		});
@@ -121,7 +121,7 @@ describe('Embed', () => {
 		test('GIVEN an embed with an invalid URL THEN throws error', () => {
 			const embed = new Embed();
 
-			expect(() => embed.setURL('owo')).toThrowError();
+			expect(() => embed.setUrl('owo')).toThrowError();
 		});
 	});
 
@@ -271,7 +271,7 @@ describe('Embed', () => {
 			const embed = new Embed();
 			embed.setAuthor({
 				name: 'Wumpus',
-				iconURL: 'https://discord.js.org/static/logo.svg',
+				iconUrl: 'https://discord.js.org/static/logo.svg',
 				url: 'https://discord.js.org',
 			});
 
@@ -310,7 +310,7 @@ describe('Embed', () => {
 
 		test('GIVEN an embed using Embed#setAuthor THEN returns valid toJSON data', () => {
 			const embed = new Embed();
-			embed.setFooter({ text: 'Wumpus', iconURL: 'https://discord.js.org/static/logo.svg' });
+			embed.setFooter({ text: 'Wumpus', iconUrl: 'https://discord.js.org/static/logo.svg' });
 
 			expect(embed.toJSON()).toStrictEqual({
 				...emptyEmbed,

--- a/packages/builders/src/components/Button.ts
+++ b/packages/builders/src/components/Button.ts
@@ -50,7 +50,7 @@ export class ButtonComponent implements Component {
 	 * Sets the URL for this button
 	 * @param url The URL to open when this button is clicked
 	 */
-	public setURL(url: string) {
+	public setUrl(url: string) {
 		urlValidator.parse(url);
 		Reflect.set(this, 'url', url);
 		return this;

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -26,12 +26,12 @@ import {
 export interface AuthorOptions {
 	name: string;
 	url?: string;
-	iconURL?: string;
+	iconUrl?: string;
 }
 
 export interface FooterOptions {
 	text: string;
-	iconURL?: string;
+	iconUrl?: string;
 }
 
 /**
@@ -190,13 +190,13 @@ export class Embed implements APIEmbed {
 			return this;
 		}
 
-		const { name, iconURL, url } = options;
+		const { name, iconUrl, url } = options;
 		// Data assertions
 		authorNamePredicate.parse(name);
-		urlPredicate.parse(iconURL);
+		urlPredicate.parse(iconUrl);
 		urlPredicate.parse(url);
 
-		Reflect.set(this, 'author', { name, url, icon_url: iconURL });
+		Reflect.set(this, 'author', { name, url, icon_url: iconUrl });
 		return this;
 	}
 
@@ -237,12 +237,12 @@ export class Embed implements APIEmbed {
 			return this;
 		}
 
-		const { text, iconURL } = options;
+		const { text, iconUrl } = options;
 		// Data assertions
 		footerTextPredicate.parse(text);
-		urlPredicate.parse(iconURL);
+		urlPredicate.parse(iconUrl);
 
-		Reflect.set(this, 'footer', { text, icon_url: iconURL });
+		Reflect.set(this, 'footer', { text, icon_url: iconUrl });
 		return this;
 	}
 
@@ -303,7 +303,7 @@ export class Embed implements APIEmbed {
 	 *
 	 * @param url The URL
 	 */
-	public setURL(url: string | null): this {
+	public setUrl(url: string | null): this {
 		// Data assertions
 		urlPredicate.parse(url);
 

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -540,11 +540,11 @@ module.exports = Client;
  */
 
 /**
- * @external ImageURLOptions
- * @see {@link https://discord.js.org/#/docs/rest/main/typedef/ImageURLOptions}
+ * @external ImageUrlOptions
+ * @see {@link https://discord.js.org/#/docs/rest/main/typedef/ImageUrlOptions}
  */
 
 /**
- * @external BaseImageURLOptions
- * @see {@link https://discord.js.org/#/docs/rest/main/typedef/BaseImageURLOptions}
+ * @external BaseImageUrlOptions
+ * @see {@link https://discord.js.org/#/docs/rest/main/typedef/BaseImageUrlOptions}
  */

--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -128,7 +128,7 @@ class WebSocketManager extends EventEmitter {
   async connect() {
     const invalidToken = new Error(WSCodes[4004]);
     const {
-      url: gatewayURL,
+      url: gatewayUrl,
       shards: recommendedShards,
       session_start_limit: sessionStartLimit,
     } = await this.client.rest.get(Routes.gatewayBot()).catch(error => {
@@ -138,14 +138,14 @@ class WebSocketManager extends EventEmitter {
     const { total, remaining } = sessionStartLimit;
 
     this.debug(`Fetched Gateway Information
-    URL: ${gatewayURL}
+    URL: ${gatewayUrl}
     Recommended Shards: ${recommendedShards}`);
 
     this.debug(`Session Limit Information
     Total: ${total}
     Remaining: ${remaining}`);
 
-    this.gateway = `${gatewayURL}/`;
+    this.gateway = `${gatewayUrl}/`;
 
     let { shards } = this.client.options;
 

--- a/packages/discord.js/src/managers/RoleManager.js
+++ b/packages/discord.js/src/managers/RoleManager.js
@@ -139,8 +139,8 @@ class RoleManager extends CachedManager {
     color &&= resolveColor(color);
     if (typeof permissions !== 'undefined') permissions = new PermissionsBitField(permissions);
     if (icon) {
-      const guildEmojiURL = this.guild.emojis.resolve(icon)?.url;
-      icon = guildEmojiURL ? await DataResolver.resolveImage(guildEmojiURL) : await DataResolver.resolveImage(icon);
+      const guildEmojiUrl = this.guild.emojis.resolve(icon)?.url;
+      icon = guildEmojiUrl ? await DataResolver.resolveImage(guildEmojiUrl) : await DataResolver.resolveImage(icon);
       if (typeof icon !== 'string') icon = undefined;
     }
 
@@ -186,8 +186,8 @@ class RoleManager extends CachedManager {
 
     let icon = data.icon;
     if (icon) {
-      const guildEmojiURL = this.guild.emojis.resolve(icon)?.url;
-      icon = guildEmojiURL ? await DataResolver.resolveImage(guildEmojiURL) : await DataResolver.resolveImage(icon);
+      const guildEmojiUrl = this.guild.emojis.resolve(icon)?.url;
+      icon = guildEmojiUrl ? await DataResolver.resolveImage(guildEmojiUrl) : await DataResolver.resolveImage(icon);
       if (typeof icon !== 'string') icon = undefined;
     }
 

--- a/packages/discord.js/src/structures/AnonymousGuild.js
+++ b/packages/discord.js/src/structures/AnonymousGuild.js
@@ -53,7 +53,7 @@ class AnonymousGuild extends BaseGuild {
        * The vanity invite code of the guild, if any
        * @type {?string}
        */
-      this.vanityURLCode = data.vanity_url_code;
+      this.vanityUrlCode = data.vanity_url_code;
     }
 
     if ('nsfw_level' in data) {
@@ -67,19 +67,19 @@ class AnonymousGuild extends BaseGuild {
 
   /**
    * The URL to this guild's banner.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  bannerURL(options = {}) {
+  bannerUrl(options = {}) {
     return this.banner && this.client.rest.cdn.banner(this.id, this.banner, options);
   }
 
   /**
    * The URL to this guild's invite splash image.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  splashURL(options = {}) {
+  splashUrl(options = {}) {
     return this.splash && this.client.rest.cdn.splash(this.id, this.splash, options);
   }
 }

--- a/packages/discord.js/src/structures/BaseGuild.js
+++ b/packages/discord.js/src/structures/BaseGuild.js
@@ -88,10 +88,10 @@ class BaseGuild extends Base {
 
   /**
    * The URL to this guild's icon.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  iconURL(options = {}) {
+  iconUrl(options = {}) {
     return this.icon && this.client.rest.cdn.icon(this.id, this.icon, options);
   }
 

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -349,7 +349,7 @@ class Guild extends AnonymousGuild {
      * <info>You will need to fetch this parameter using {@link Guild#fetchVanityData} if you want to receive it</info>
      * @type {?number}
      */
-    this.vanityURLUses ??= null;
+    this.vanityUrlUses ??= null;
 
     if ('rules_channel_id' in data) {
       /**
@@ -474,10 +474,10 @@ class Guild extends AnonymousGuild {
 
   /**
    * The URL to this guild's discovery splash image.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  discoverySplashURL(options = {}) {
+  discoverySplashUrl(options = {}) {
     return this.discoverySplash && this.client.rest.cdn.discoverySplash(this.id, this.discoverySplash, options);
   }
 
@@ -653,8 +653,8 @@ class Guild extends AnonymousGuild {
       throw new Error('VANITY_URL');
     }
     const data = await this.client.rest.get(Routes.guildVanityUrl(this.id));
-    this.vanityURLCode = data.code;
-    this.vanityURLUses = data.uses;
+    this.vanityUrlCode = data.code;
+    this.vanityUrlUses = data.uses;
 
     return data;
   }
@@ -1254,10 +1254,10 @@ class Guild extends AnonymousGuild {
       presences: false,
       voiceStates: false,
     });
-    json.iconURL = this.iconURL();
-    json.splashURL = this.splashURL();
-    json.discoverySplashURL = this.discoverySplashURL();
-    json.bannerURL = this.bannerURL();
+    json.iconUrl = this.iconUrl();
+    json.splashUrl = this.splashUrl();
+    json.discoverySplashUrl = this.discoverySplashUrl();
+    json.bannerUrl = this.bannerUrl();
     return json;
   }
 

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -124,21 +124,21 @@ class GuildMember extends Base {
 
   /**
    * A link to the member's guild avatar.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  avatarURL(options = {}) {
+  avatarUrl(options = {}) {
     return this.avatar && this.client.rest.cdn.guildMemberAvatar(this.guild.id, this.id, this.avatar, options);
   }
 
   /**
    * A link to the member's guild avatar if they have one.
-   * Otherwise, a link to their {@link User#displayAvatarURL} will be returned.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * Otherwise, a link to their {@link User#displayAvatarUrl} will be returned.
+   * @param {ImageUrlOptions} [options={}] Options for the Image URL
    * @returns {string}
    */
-  displayAvatarURL(options) {
-    return this.avatarURL(options) ?? this.user.displayAvatarURL(options);
+  displayAvatarUrl(options) {
+    return this.avatarUrl(options) ?? this.user.displayAvatarUrl(options);
   }
 
   /**
@@ -428,8 +428,8 @@ class GuildMember extends Base {
       displayName: true,
       roles: true,
     });
-    json.avatarURL = this.avatarURL();
-    json.displayAvatarURL = this.displayAvatarURL();
+    json.avatarUrl = this.avatarUrl();
+    json.displayAvatarUrl = this.displayAvatarUrl();
     return json;
   }
 

--- a/packages/discord.js/src/structures/GuildPreview.js
+++ b/packages/discord.js/src/structures/GuildPreview.js
@@ -135,28 +135,28 @@ class GuildPreview extends Base {
 
   /**
    * The URL to this guild's splash.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  splashURL(options = {}) {
+  splashUrl(options = {}) {
     return this.splash && this.client.rest.cdn.splash(this.id, this.splash, options);
   }
 
   /**
    * The URL to this guild's discovery splash.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  discoverySplashURL(options = {}) {
+  discoverySplashUrl(options = {}) {
     return this.discoverySplash && this.client.rest.cdn.discoverySplash(this.id, this.discoverySplash, options);
   }
 
   /**
    * The URL to this guild's icon.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  iconURL(options = {}) {
+  iconUrl(options = {}) {
     return this.icon && this.client.rest.cdn.icon(this.id, this.icon, options);
   }
 
@@ -183,8 +183,8 @@ class GuildPreview extends Base {
 
   toJSON() {
     const json = super.toJSON();
-    json.iconURL = this.iconURL();
-    json.splashURL = this.splashURL();
+    json.iconUrl = this.iconUrl();
+    json.splashUrl = this.splashUrl();
     return json;
   }
 }

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -162,10 +162,10 @@ class GuildScheduledEvent extends Base {
 
   /**
    * The URL of this scheduled event's cover image
-   * @param {BaseImageURLOptions} [options={}] Options for image URL
+   * @param {BaseImageUrlOptions} [options={}] Options for image URL
    * @returns {?string}
    */
-  coverImageURL(options = {}) {
+  coverImageUrl(options = {}) {
     return this.image && this.client.rest.cdn.guildScheduledEventCover(this.id, this.image, options);
   }
 
@@ -235,7 +235,7 @@ class GuildScheduledEvent extends Base {
 
   /**
    * Options used to create an invite URL to a {@link GuildScheduledEvent}
-   * @typedef {CreateInviteOptions} CreateGuildScheduledEventInviteURLOptions
+   * @typedef {CreateInviteOptions} CreateGuildScheduledEventInviteUrlOptions
    * @property {GuildInvitableChannelResolvable} [channel] The channel to create the invite in.
    * <warn>This is required when the `entityType` of `GuildScheduledEvent` is
    * {@link GuildScheduledEventEntityType.External}, gets ignored otherwise</warn>
@@ -243,10 +243,10 @@ class GuildScheduledEvent extends Base {
 
   /**
    * Creates an invite URL to this guild scheduled event.
-   * @param {CreateGuildScheduledEventInviteURLOptions} [options] The options to create the invite
+   * @param {CreateGuildScheduledEventInviteUrlOptions} [options] The options to create the invite
    * @returns {Promise<string>}
    */
-  async createInviteURL(options) {
+  async createInviteUrl(options) {
     let channelId = this.channelId;
     if (this.entityType === GuildScheduledEventEntityType.External) {
       if (!options?.channel) throw new Error('INVITE_OPTIONS_MISSING_CHANNEL');

--- a/packages/discord.js/src/structures/IntegrationApplication.js
+++ b/packages/discord.js/src/structures/IntegrationApplication.js
@@ -25,9 +25,9 @@ class IntegrationApplication extends Application {
        * The URL of the application's terms of service
        * @type {?string}
        */
-      this.termsOfServiceURL = data.terms_of_service_url;
+      this.termsOfServiceUrl = data.terms_of_service_url;
     } else {
-      this.termsOfServiceURL ??= null;
+      this.termsOfServiceUrl ??= null;
     }
 
     if ('privacy_policy_url' in data) {
@@ -35,9 +35,9 @@ class IntegrationApplication extends Application {
        * The URL of the application's privacy policy
        * @type {?string}
        */
-      this.privacyPolicyURL = data.privacy_policy_url;
+      this.privacyPolicyUrl = data.privacy_policy_url;
     } else {
-      this.privacyPolicyURL ??= null;
+      this.privacyPolicyUrl ??= null;
     }
 
     if ('rpc_origins' in data) {

--- a/packages/discord.js/src/structures/MessageAttachment.js
+++ b/packages/discord.js/src/structures/MessageAttachment.js
@@ -99,7 +99,7 @@ class MessageAttachment {
        * The Proxy URL to this attachment
        * @type {string}
        */
-      this.proxyURL = data.proxy_url;
+      this.proxyUrl = data.proxy_url;
     }
 
     if ('height' in data) {

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -134,10 +134,10 @@ class MessagePayload {
     const components = this.options.components?.map(c => createComponent(c).toJSON());
 
     let username;
-    let avatarURL;
+    let avatarUrl;
     if (isWebhook) {
       username = this.options.username ?? this.target.name;
-      if (this.options.avatarURL) avatarURL = this.options.avatarURL;
+      if (this.options.avatarUrl) avatarUrl = this.options.avatarUrl;
     }
 
     let flags;
@@ -193,7 +193,7 @@ class MessagePayload {
       embeds: this.options.embeds?.map(embed => (embed instanceof Embed ? embed : new Embed(embed)).toJSON()),
       components,
       username,
-      avatar_url: avatarURL,
+      avatar_url: avatarUrl,
       allowed_mentions:
         typeof content === 'undefined' && typeof message_reference === 'undefined' ? undefined : allowedMentions,
       flags,

--- a/packages/discord.js/src/structures/PartialGroupDMChannel.js
+++ b/packages/discord.js/src/structures/PartialGroupDMChannel.js
@@ -38,10 +38,10 @@ class PartialGroupDMChannel extends Channel {
 
   /**
    * The URL to this channel's icon.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  iconURL(options = {}) {
+  iconUrl(options = {}) {
     return this.icon && this.client.rest.cdn.channelIcon(this.id, this.icon, options);
   }
 

--- a/packages/discord.js/src/structures/Presence.js
+++ b/packages/discord.js/src/structures/Presence.js
@@ -346,10 +346,10 @@ class RichPresenceAssets {
 
   /**
    * Gets the URL of the small image asset
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  smallImageURL(options = {}) {
+  smallImageUrl(options = {}) {
     if (!this.smallImage) return null;
     if (this.smallImage.includes(':')) {
       const [platform, id] = this.smallImage.split(':');
@@ -366,10 +366,10 @@ class RichPresenceAssets {
 
   /**
    * Gets the URL of the large image asset
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  largeImageURL(options = {}) {
+  largeImageUrl(options = {}) {
     if (!this.largeImage) return null;
     if (this.largeImage.includes(':')) {
       const [platform, id] = this.largeImage.split(':');

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -393,10 +393,10 @@ class Role extends Base {
 
   /**
    * A link to the role's icon
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  iconURL(options = {}) {
+  iconUrl(options = {}) {
     return this.icon && this.client.rest.cdn.roleIcon(this.id, this.icon, options);
   }
 

--- a/packages/discord.js/src/structures/StickerPack.js
+++ b/packages/discord.js/src/structures/StickerPack.js
@@ -84,10 +84,10 @@ class StickerPack extends Base {
 
   /**
    * The URL to this sticker pack's banner.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  bannerURL(options = {}) {
+  bannerUrl(options = {}) {
     return this.bannerId && this.client.rest.cdn.stickerPackBanner(this.bannerId, options);
   }
 }

--- a/packages/discord.js/src/structures/Team.js
+++ b/packages/discord.js/src/structures/Team.js
@@ -90,10 +90,10 @@ class Team extends Base {
 
   /**
    * A link to the team's icon.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  iconURL(options = {}) {
+  iconUrl(options = {}) {
     return this.icon && this.client.rest.cdn.teamIcon(this.id, this.icon, options);
   }
 

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -140,10 +140,10 @@ class User extends Base {
 
   /**
    * A link to the user's avatar.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  avatarURL(options = {}) {
+  avatarUrl(options = {}) {
     return this.avatar && this.client.rest.cdn.avatar(this.id, this.avatar, options);
   }
 
@@ -152,18 +152,18 @@ class User extends Base {
    * @type {string}
    * @readonly
    */
-  get defaultAvatarURL() {
+  get defaultAvatarUrl() {
     return this.client.rest.cdn.defaultAvatar(this.discriminator % 5);
   }
 
   /**
    * A link to the user's avatar if they have one.
    * Otherwise a link to their default avatar will be returned.
-   * @param {ImageURLOptions} [options={}] Options for the Image URL
+   * @param {ImageUrlOptions} [options={}] Options for the Image URL
    * @returns {string}
    */
-  displayAvatarURL(options) {
-    return this.avatarURL(options) ?? this.defaultAvatarURL;
+  displayAvatarUrl(options) {
+    return this.avatarUrl(options) ?? this.defaultAvatarUrl;
   }
 
   /**
@@ -179,10 +179,10 @@ class User extends Base {
 
   /**
    * A link to the user's banner. See {@link User#banner} for more info
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  bannerURL(options = {}) {
+  bannerUrl(options = {}) {
     return this.banner && this.client.rest.cdn.banner(this.id, this.banner, options);
   }
 
@@ -293,15 +293,15 @@ class User extends Base {
     const json = super.toJSON(
       {
         createdTimestamp: true,
-        defaultAvatarURL: true,
+        defaultAvatarUrl: true,
         hexAccentColor: true,
         tag: true,
       },
       ...props,
     );
-    json.avatarURL = this.avatarURL();
-    json.displayAvatarURL = this.displayAvatarURL();
-    json.bannerURL = this.banner ? this.bannerURL() : this.banner;
+    json.avatarUrl = this.avatarUrl();
+    json.displayAvatarUrl = this.displayAvatarUrl();
+    json.bannerUrl = this.banner ? this.bannerUrl() : this.banner;
     return json;
   }
 

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -120,7 +120,7 @@ class Webhook {
    * Options that can be passed into send.
    * @typedef {BaseMessageOptions} WebhookMessageOptions
    * @property {string} [username=this.name] Username override for the message
-   * @property {string} [avatarURL] Avatar URL override for the message
+   * @property {string} [avatarUrl] Avatar URL override for the message
    * @property {Snowflake} [threadId] The id of the thread in the channel to send to.
    * <info>For interaction webhooks, this property is ignored</info>
    * @property {MessageFlags} [flags] Which flags to set for the message. Only `SUPPRESS_EMBEDS` can be set.
@@ -401,10 +401,10 @@ class Webhook {
 
   /**
    * A link to the webhook's avatar.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  avatarURL(options = {}) {
+  avatarUrl(options = {}) {
     return this.avatar && this.client.rest.cdn.avatar(this.id, this.avatar, options);
   }
 

--- a/packages/discord.js/src/structures/WidgetMember.js
+++ b/packages/discord.js/src/structures/WidgetMember.js
@@ -85,7 +85,7 @@ class WidgetMember extends Base {
      * The avatar URL of the member.
      * @type {string}
      */
-    this.avatarURL = data.avatar_url;
+    this.avatarUrl = data.avatar_url;
 
     /**
      * The activity of the member.

--- a/packages/discord.js/src/structures/interfaces/Application.js
+++ b/packages/discord.js/src/structures/interfaces/Application.js
@@ -71,19 +71,19 @@ class Application extends Base {
 
   /**
    * A link to the application's icon.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  iconURL(options = {}) {
+  iconUrl(options = {}) {
     return this.icon && this.client.rest.cdn.appIcon(this.id, this.icon, options);
   }
 
   /**
    * A link to this application's cover image.
-   * @param {ImageURLOptions} [options={}] Options for the image URL
+   * @param {ImageUrlOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  coverURL(options = {}) {
+  coverUrl(options = {}) {
     return this.cover && this.client.rest.cdn.appIcon(this.id, this.cover, options);
   }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -26,7 +26,7 @@ import {
   userMention,
 } from '@discordjs/builders';
 import { Collection } from '@discordjs/collection';
-import { BaseImageURLOptions, ImageURLOptions, RawFile, REST, RESTOptions } from '@discordjs/rest';
+import { BaseImageUrlOptions, ImageUrlOptions, RawFile, REST, RESTOptions } from '@discordjs/rest';
 import {
   APIActionRowComponent,
   APIApplicationCommand,
@@ -196,10 +196,10 @@ export abstract class AnonymousGuild extends BaseGuild {
   public description: string | null;
   public nsfwLevel: GuildNSFWLevel;
   public splash: string | null;
-  public vanityURLCode: string | null;
+  public vanityUrlCode: string | null;
   public verificationLevel: GuildVerificationLevel;
-  public bannerURL(options?: ImageURLOptions): string | null;
-  public splashURL(options?: ImageURLOptions): string | null;
+  public bannerUrl(options?: ImageUrlOptions): string | null;
+  public splashUrl(options?: ImageUrlOptions): string | null;
 }
 
 export abstract class Application extends Base {
@@ -210,8 +210,8 @@ export abstract class Application extends Base {
   public icon: string | null;
   public id: Snowflake;
   public name: string | null;
-  public coverURL(options?: ImageURLOptions): string | null;
-  public iconURL(options?: ImageURLOptions): string | null;
+  public coverUrl(options?: ImageUrlOptions): string | null;
+  public iconUrl(options?: ImageUrlOptions): string | null;
   public toJSON(): unknown;
   public toString(): string | null;
 }
@@ -363,7 +363,7 @@ export abstract class BaseGuild extends Base {
   public readonly partnered: boolean;
   public readonly verified: boolean;
   public fetch(): Promise<Guild>;
-  public iconURL(options?: ImageURLOptions): string | null;
+  public iconUrl(options?: ImageUrlOptions): string | null;
   public toString(): string;
 }
 
@@ -918,7 +918,7 @@ export class Guild extends AnonymousGuild {
   public readonly systemChannel: TextChannel | null;
   public systemChannelFlags: Readonly<SystemChannelFlagsBitField>;
   public systemChannelId: Snowflake | null;
-  public vanityURLUses: number | null;
+  public vanityUrlUses: number | null;
   public readonly voiceAdapterCreator: InternalDiscordGatewayAdapterCreator;
   public readonly voiceStates: VoiceStateManager;
   public readonly widgetChannel: TextChannel | null;
@@ -927,7 +927,7 @@ export class Guild extends AnonymousGuild {
   public readonly maximumBitrate: number;
   public createTemplate(name: string, description?: string): Promise<GuildTemplate>;
   public delete(): Promise<Guild>;
-  public discoverySplashURL(options?: ImageURLOptions): string | null;
+  public discoverySplashUrl(options?: ImageUrlOptions): string | null;
   public edit(data: GuildEditData, reason?: string): Promise<Guild>;
   public editWelcomeScreen(data: WelcomeScreenEditData): Promise<WelcomeScreen>;
   public equals(guild: Guild): boolean;
@@ -1106,14 +1106,14 @@ export class GuildMember extends PartialTextBasedChannel(Base) {
   public readonly roles: GuildMemberRoleManager;
   public user: User;
   public readonly voice: VoiceState;
-  public avatarURL(options?: ImageURLOptions): string | null;
+  public avatarUrl(options?: ImageUrlOptions): string | null;
   public ban(options?: BanOptions): Promise<GuildMember>;
   public disableCommunicationUntil(timeout: DateResolvable | null, reason?: string): Promise<GuildMember>;
   public timeout(timeout: number | null, reason?: string): Promise<GuildMember>;
   public fetch(force?: boolean): Promise<GuildMember>;
   public createDM(force?: boolean): Promise<DMChannel>;
   public deleteDM(): Promise<DMChannel>;
-  public displayAvatarURL(options?: ImageURLOptions): string;
+  public displayAvatarUrl(options?: ImageUrlOptions): string;
   public edit(data: GuildMemberEditData, reason?: string): Promise<GuildMember>;
   public isCommunicationDisabled(): this is GuildMember & {
     communicationDisabledUntilTimestamp: number;
@@ -1142,9 +1142,9 @@ export class GuildPreview extends Base {
   public id: Snowflake;
   public name: string;
   public splash: string | null;
-  public discoverySplashURL(options?: ImageURLOptions): string | null;
-  public iconURL(options?: ImageURLOptions): string | null;
-  public splashURL(options?: ImageURLOptions): string | null;
+  public discoverySplashUrl(options?: ImageUrlOptions): string | null;
+  public iconUrl(options?: ImageUrlOptions): string | null;
+  public splashUrl(options?: ImageUrlOptions): string | null;
   public fetch(): Promise<GuildPreview>;
   public toJSON(): unknown;
   public toString(): string;
@@ -1175,8 +1175,8 @@ export class GuildScheduledEvent<S extends GuildScheduledEventStatus = GuildSche
   public readonly guild: Guild | null;
   public readonly url: string;
   public readonly image: string | null;
-  public coverImageURL(options?: Readonly<BaseImageURLOptions>): string | null;
-  public createInviteURL(options?: CreateGuildScheduledEventInviteURLOptions): Promise<string>;
+  public coverImageUrl(options?: Readonly<BaseImageUrlOptions>): string | null;
+  public createInviteUrl(options?: CreateGuildScheduledEventInviteUrlOptions): Promise<string>;
   public edit<T extends GuildScheduledEventSetStatusArg<S>>(
     options: GuildScheduledEventEditOptions<S, T>,
   ): Promise<GuildScheduledEvent<T>>;
@@ -1256,8 +1256,8 @@ export class Integration extends Base {
 export class IntegrationApplication extends Application {
   private constructor(client: Client, data: RawIntegrationApplicationData);
   public bot: User | null;
-  public termsOfServiceURL: string | null;
-  public privacyPolicyURL: string | null;
+  public termsOfServiceUrl: string | null;
+  public privacyPolicyUrl: string | null;
   public rpcOrigins: string[];
   public summary: string | null;
   public hook: boolean | null;
@@ -1528,7 +1528,7 @@ export class MessageAttachment {
   public height: number | null;
   public id: Snowflake;
   public name: string | null;
-  public proxyURL: string;
+  public proxyUrl: string;
   public size: number;
   public readonly spoiler: boolean;
   public url: string;
@@ -1692,7 +1692,7 @@ export class PartialGroupDMChannel extends Channel {
   public name: string | null;
   public icon: string | null;
   public recipients: PartialRecipient[];
-  public iconURL(options?: ImageURLOptions): string | null;
+  public iconUrl(options?: ImageUrlOptions): string | null;
 }
 
 export class PermissionOverwrites extends Base {
@@ -1782,8 +1782,8 @@ export class RichPresenceAssets {
   public largeText: string | null;
   public smallImage: Snowflake | null;
   public smallText: string | null;
-  public largeImageURL(options?: ImageURLOptions): string | null;
-  public smallImageURL(options?: ImageURLOptions): string | null;
+  public largeImageUrl(options?: ImageUrlOptions): string | null;
+  public smallImageUrl(options?: ImageUrlOptions): string | null;
 }
 
 export class Role extends Base {
@@ -1810,7 +1810,7 @@ export class Role extends Base {
   public delete(reason?: string): Promise<Role>;
   public edit(data: RoleData, reason?: string): Promise<Role>;
   public equals(role: Role): boolean;
-  public iconURL(options?: ImageURLOptions): string | null;
+  public iconUrl(options?: ImageUrlOptions): string | null;
   public permissionsIn(
     channel: NonThreadGuildBasedChannel | Snowflake,
     checkAdmin?: boolean,
@@ -2031,7 +2031,7 @@ export class StickerPack extends Base {
   public name: string;
   public skuId: Snowflake;
   public stickers: Collection<Snowflake, Sticker>;
-  public bannerURL(options?: ImageURLOptions): string | null;
+  public bannerUrl(options?: ImageUrlOptions): string | null;
 }
 
 /** @deprecated See [Self-serve Game Selling Deprecation](https://support-dev.discord.com/hc/en-us/articles/4414590563479) for more information */
@@ -2126,7 +2126,7 @@ export class Team extends Base {
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
 
-  public iconURL(options?: ImageURLOptions): string | null;
+  public iconUrl(options?: ImageUrlOptions): string | null;
   public toJSON(): unknown;
   public toString(): string;
 }
@@ -2252,7 +2252,7 @@ export class User extends PartialTextBasedChannel(Base) {
   public readonly createdAt: Date;
   public readonly createdTimestamp: number;
   public discriminator: string;
-  public readonly defaultAvatarURL: string;
+  public readonly defaultAvatarUrl: string;
   public readonly dmChannel: DMChannel | null;
   public flags: Readonly<UserFlagsBitField> | null;
   public readonly hexAccentColor: HexColorString | null | undefined;
@@ -2261,11 +2261,11 @@ export class User extends PartialTextBasedChannel(Base) {
   public system: boolean;
   public readonly tag: string;
   public username: string;
-  public avatarURL(options?: ImageURLOptions): string | null;
-  public bannerURL(options?: ImageURLOptions): string | null | undefined;
+  public avatarUrl(options?: ImageUrlOptions): string | null;
+  public bannerUrl(options?: ImageUrlOptions): string | null | undefined;
   public createDM(force?: boolean): Promise<DMChannel>;
   public deleteDM(): Promise<DMChannel>;
-  public displayAvatarURL(options?: ImageURLOptions): string;
+  public displayAvatarUrl(options?: ImageUrlOptions): string;
   public equals(user: User): boolean;
   public fetch(force?: boolean): Promise<User>;
   public fetchFlags(force?: boolean): Promise<UserFlagsBitField>;
@@ -2397,7 +2397,7 @@ export class VoiceState extends Base {
 export class Webhook extends WebhookMixin() {
   private constructor(client: Client, data?: RawWebhookData);
   public avatar: string;
-  public avatarURL(options?: ImageURLOptions): string | null;
+  public avatarUrl(options?: ImageUrlOptions): string | null;
   public channelId: Snowflake;
   public client: Client;
   public guildId: Snowflake;
@@ -2558,7 +2558,7 @@ export class WidgetMember extends Base {
   public selfMute: boolean | null;
   public suppress: boolean | null;
   public channelId: Snowflake | null;
-  public avatarURL: string;
+  public avatarUrl: string;
   public activity: WidgetActivity | null;
 }
 
@@ -3793,7 +3793,7 @@ export interface ConstantsStatus {
   DISCONNECTED: 5;
 }
 
-export interface CreateGuildScheduledEventInviteURLOptions extends CreateInviteOptions {
+export interface CreateGuildScheduledEventInviteUrlOptions extends CreateInviteOptions {
   channel?: GuildInvitableChannelResolvable;
 }
 
@@ -3823,7 +3823,7 @@ export interface EditGuildTemplateOptions {
 export interface EmbedAuthorData {
   name: string;
   url?: string;
-  iconURL?: string;
+  iconUrl?: string;
 }
 
 export interface EmbedField {
@@ -3840,7 +3840,7 @@ export interface EmbedFieldData {
 
 export interface EmbedFooterData {
   text: string;
-  iconURL?: string;
+  iconUrl?: string;
 }
 
 export type EmojiIdentifierResolvable = string | EmojiResolvable;
@@ -4454,7 +4454,7 @@ export interface InteractionDeferReplyOptions {
 
 export type InteractionDeferUpdateOptions = Omit<InteractionDeferReplyOptions, 'ephemeral'>;
 
-export interface InteractionReplyOptions extends Omit<WebhookMessageOptions, 'username' | 'avatarURL' | 'flags'> {
+export interface InteractionReplyOptions extends Omit<WebhookMessageOptions, 'username' | 'avatarUrl' | 'flags'> {
   ephemeral?: boolean;
   fetchReply?: boolean;
   flags?: BitFieldResolvable<Extract<MessageFlagsString, 'SuppressEmbeds' | 'Ephemeral'>, number>;
@@ -5020,14 +5020,14 @@ export type VoiceBasedChannelTypes = VoiceBasedChannel['type'];
 
 export type VoiceChannelResolvable = Snowflake | VoiceChannel;
 
-export type WebhookClientData = WebhookClientDataIdWithToken | WebhookClientDataURL;
+export type WebhookClientData = WebhookClientDataIdWithToken | WebhookClientDataUrl;
 
 export interface WebhookClientDataIdWithToken {
   id: Snowflake;
   token: string;
 }
 
-export interface WebhookClientDataURL {
+export interface WebhookClientDataUrl {
   url: string;
 }
 
@@ -5051,7 +5051,7 @@ export interface WebhookFetchMessageOptions {
 
 export interface WebhookMessageOptions extends Omit<MessageOptions, 'reply' | 'stickers'> {
   username?: string;
-  avatarURL?: string;
+  avatarUrl?: string;
   threadId?: Snowflake;
 }
 

--- a/packages/rest/__tests__/CDN.test.ts
+++ b/packages/rest/__tests__/CDN.test.ts
@@ -98,16 +98,16 @@ test('teamIcon default', () => {
 	expect(cdn.teamIcon(id, hash)).toBe(`${base}/team-icons/${id}/${hash}.webp`);
 });
 
-test('makeURL throws on invalid size', () => {
+test('makeUrl throws on invalid size', () => {
 	// @ts-expect-error: Invalid size
 	expect(() => cdn.avatar(id, animatedHash, { size: 5 })).toThrow(RangeError);
 });
 
-test('makeURL throws on invalid extension', () => {
+test('makeUrl throws on invalid extension', () => {
 	// @ts-expect-error: Invalid extension
 	expect(() => cdn.avatar(id, animatedHash, { extension: 'tif', forceStatic: true })).toThrow(RangeError);
 });
 
-test('makeURL valid size', () => {
+test('makeUrl valid size', () => {
 	expect(cdn.avatar(id, animatedHash, { size: 512 })).toBe(`${base}/avatars/${id}/${animatedHash}.gif?size=512`);
 });

--- a/packages/rest/src/lib/CDN.ts
+++ b/packages/rest/src/lib/CDN.ts
@@ -11,7 +11,7 @@ import {
 /**
  * The options used for image URLs
  */
-export interface BaseImageURLOptions {
+export interface BaseImageUrlOptions {
 	/**
 	 * The extension to use for the image URL
 	 * @default 'webp'
@@ -26,7 +26,7 @@ export interface BaseImageURLOptions {
 /**
  * The options used for image URLs with animated content
  */
-export interface ImageURLOptions extends BaseImageURLOptions {
+export interface ImageUrlOptions extends BaseImageUrlOptions {
 	/**
 	 * Whether or not to prefer the static version of an image asset.
 	 */
@@ -36,7 +36,7 @@ export interface ImageURLOptions extends BaseImageURLOptions {
 /**
  * The options to use when making a CDN URL
  */
-export interface MakeURLOptions {
+export interface MakeUrlOptions {
 	/**
 	 * The extension to use for the image URL
 	 * @default 'webp'
@@ -64,8 +64,8 @@ export class CDN {
 	 * @param assetHash The hash provided by Discord for this asset
 	 * @param options Optional options for the asset
 	 */
-	public appAsset(clientId: string, assetHash: string, options?: Readonly<BaseImageURLOptions>): string {
-		return this.makeURL(`/app-assets/${clientId}/${assetHash}`, options);
+	public appAsset(clientId: string, assetHash: string, options?: Readonly<BaseImageUrlOptions>): string {
+		return this.makeUrl(`/app-assets/${clientId}/${assetHash}`, options);
 	}
 
 	/**
@@ -74,8 +74,8 @@ export class CDN {
 	 * @param iconHash The hash provided by Discord for this icon
 	 * @param options Optional options for the icon
 	 */
-	public appIcon(clientId: string, iconHash: string, options?: Readonly<BaseImageURLOptions>): string {
-		return this.makeURL(`/app-icons/${clientId}/${iconHash}`, options);
+	public appIcon(clientId: string, iconHash: string, options?: Readonly<BaseImageUrlOptions>): string {
+		return this.makeUrl(`/app-icons/${clientId}/${iconHash}`, options);
 	}
 
 	/**
@@ -84,8 +84,8 @@ export class CDN {
 	 * @param avatarHash The hash provided by Discord for this avatar
 	 * @param options Optional options for the avatar
 	 */
-	public avatar(id: string, avatarHash: string, options?: Readonly<ImageURLOptions>): string {
-		return this.dynamicMakeURL(`/avatars/${id}/${avatarHash}`, avatarHash, options);
+	public avatar(id: string, avatarHash: string, options?: Readonly<ImageUrlOptions>): string {
+		return this.dynamicMakeUrl(`/avatars/${id}/${avatarHash}`, avatarHash, options);
 	}
 
 	/**
@@ -94,8 +94,8 @@ export class CDN {
 	 * @param bannerHash The hash provided by Discord for this banner
 	 * @param options Optional options for the banner
 	 */
-	public banner(id: string, bannerHash: string, options?: Readonly<ImageURLOptions>): string {
-		return this.dynamicMakeURL(`/banners/${id}/${bannerHash}`, bannerHash, options);
+	public banner(id: string, bannerHash: string, options?: Readonly<ImageUrlOptions>): string {
+		return this.dynamicMakeUrl(`/banners/${id}/${bannerHash}`, bannerHash, options);
 	}
 
 	/**
@@ -104,8 +104,8 @@ export class CDN {
 	 * @param iconHash The hash provided by Discord for this channel
 	 * @param options Optional options for the icon
 	 */
-	public channelIcon(channelId: string, iconHash: string, options?: Readonly<BaseImageURLOptions>): string {
-		return this.makeURL(`/channel-icons/${channelId}/${iconHash}`, options);
+	public channelIcon(channelId: string, iconHash: string, options?: Readonly<BaseImageUrlOptions>): string {
+		return this.makeUrl(`/channel-icons/${channelId}/${iconHash}`, options);
 	}
 
 	/**
@@ -113,7 +113,7 @@ export class CDN {
 	 * @param discriminator The discriminator modulo 5
 	 */
 	public defaultAvatar(discriminator: number): string {
-		return this.makeURL(`/embed/avatars/${discriminator}`);
+		return this.makeUrl(`/embed/avatars/${discriminator}`);
 	}
 
 	/**
@@ -122,8 +122,8 @@ export class CDN {
 	 * @param splashHash The hash provided by Discord for this splash
 	 * @param options Optional options for the splash
 	 */
-	public discoverySplash(guildId: string, splashHash: string, options?: Readonly<BaseImageURLOptions>): string {
-		return this.makeURL(`/discovery-splashes/${guildId}/${splashHash}`, options);
+	public discoverySplash(guildId: string, splashHash: string, options?: Readonly<BaseImageUrlOptions>): string {
+		return this.makeUrl(`/discovery-splashes/${guildId}/${splashHash}`, options);
 	}
 
 	/**
@@ -132,7 +132,7 @@ export class CDN {
 	 * @param extension The extension of the emoji
 	 */
 	public emoji(emojiId: string, extension?: ImageExtension): string {
-		return this.makeURL(`/emojis/${emojiId}`, { extension });
+		return this.makeUrl(`/emojis/${emojiId}`, { extension });
 	}
 
 	/**
@@ -146,9 +146,9 @@ export class CDN {
 		guildId: string,
 		userId: string,
 		avatarHash: string,
-		options?: Readonly<ImageURLOptions>,
+		options?: Readonly<ImageUrlOptions>,
 	): string {
-		return this.dynamicMakeURL(`/guilds/${guildId}/users/${userId}/avatars/${avatarHash}`, avatarHash, options);
+		return this.dynamicMakeUrl(`/guilds/${guildId}/users/${userId}/avatars/${avatarHash}`, avatarHash, options);
 	}
 
 	/**
@@ -157,8 +157,8 @@ export class CDN {
 	 * @param iconHash The hash provided by Discord for this icon
 	 * @param options Optional options for the icon
 	 */
-	public icon(id: string, iconHash: string, options?: Readonly<ImageURLOptions>): string {
-		return this.dynamicMakeURL(`/icons/${id}/${iconHash}`, iconHash, options);
+	public icon(id: string, iconHash: string, options?: Readonly<ImageUrlOptions>): string {
+		return this.dynamicMakeUrl(`/icons/${id}/${iconHash}`, iconHash, options);
 	}
 
 	/**
@@ -167,8 +167,8 @@ export class CDN {
 	 * @param roleIconHash The hash provided by Discord for this role icon
 	 * @param options Optional options for the role icon
 	 */
-	public roleIcon(roleId: string, roleIconHash: string, options?: Readonly<BaseImageURLOptions>): string {
-		return this.makeURL(`/role-icons/${roleId}/${roleIconHash}`, options);
+	public roleIcon(roleId: string, roleIconHash: string, options?: Readonly<BaseImageUrlOptions>): string {
+		return this.makeUrl(`/role-icons/${roleId}/${roleIconHash}`, options);
 	}
 
 	/**
@@ -177,8 +177,8 @@ export class CDN {
 	 * @param splashHash The hash provided by Discord for this splash
 	 * @param options Optional options for the splash
 	 */
-	public splash(guildId: string, splashHash: string, options?: Readonly<BaseImageURLOptions>): string {
-		return this.makeURL(`/splashes/${guildId}/${splashHash}`, options);
+	public splash(guildId: string, splashHash: string, options?: Readonly<BaseImageUrlOptions>): string {
+		return this.makeUrl(`/splashes/${guildId}/${splashHash}`, options);
 	}
 
 	/**
@@ -187,7 +187,7 @@ export class CDN {
 	 * @param extension The extension of the sticker
 	 */
 	public sticker(stickerId: string, extension?: StickerExtension): string {
-		return this.makeURL(`/stickers/${stickerId}`, {
+		return this.makeUrl(`/stickers/${stickerId}`, {
 			allowedExtensions: ALLOWED_STICKER_EXTENSIONS,
 			extension: extension ?? 'png', // Stickers cannot have a `.webp` extension, so we default to a `.png`
 		});
@@ -198,8 +198,8 @@ export class CDN {
 	 * @param bannerId The banner id
 	 * @param options Optional options for the banner
 	 */
-	public stickerPackBanner(bannerId: string, options?: Readonly<BaseImageURLOptions>): string {
-		return this.makeURL(`/app-assets/710982414301790216/store/${bannerId}`, options);
+	public stickerPackBanner(bannerId: string, options?: Readonly<BaseImageUrlOptions>): string {
+		return this.makeUrl(`/app-assets/710982414301790216/store/${bannerId}`, options);
 	}
 
 	/**
@@ -208,8 +208,8 @@ export class CDN {
 	 * @param iconHash The hash provided by Discord for this icon
 	 * @param options Optional options for the icon
 	 */
-	public teamIcon(teamId: string, iconHash: string, options?: Readonly<BaseImageURLOptions>): string {
-		return this.makeURL(`/team-icons/${teamId}/${iconHash}`, options);
+	public teamIcon(teamId: string, iconHash: string, options?: Readonly<BaseImageUrlOptions>): string {
+		return this.makeUrl(`/team-icons/${teamId}/${iconHash}`, options);
 	}
 
 	/**
@@ -221,9 +221,9 @@ export class CDN {
 	public guildScheduledEventCover(
 		scheduledEventId: string,
 		coverHash: string,
-		options?: Readonly<BaseImageURLOptions>,
+		options?: Readonly<BaseImageUrlOptions>,
 	): string {
-		return this.makeURL(`/guild-events/${scheduledEventId}/${coverHash}`, options);
+		return this.makeUrl(`/guild-events/${scheduledEventId}/${coverHash}`, options);
 	}
 
 	/**
@@ -232,12 +232,12 @@ export class CDN {
 	 * @param hash The hash provided by Discord for this icon
 	 * @param options Optional options for the link
 	 */
-	private dynamicMakeURL(
+	private dynamicMakeUrl(
 		route: string,
 		hash: string,
-		{ forceStatic = false, ...options }: Readonly<ImageURLOptions> = {},
+		{ forceStatic = false, ...options }: Readonly<ImageUrlOptions> = {},
 	): string {
-		return this.makeURL(route, !forceStatic && hash.startsWith('a_') ? { ...options, extension: 'gif' } : options);
+		return this.makeUrl(route, !forceStatic && hash.startsWith('a_') ? { ...options, extension: 'gif' } : options);
 	}
 
 	/**
@@ -245,9 +245,9 @@ export class CDN {
 	 * @param route The base cdn route
 	 * @param options The extension/size options for the link
 	 */
-	private makeURL(
+	private makeUrl(
 		route: string,
-		{ allowedExtensions = ALLOWED_EXTENSIONS, extension = 'webp', size }: Readonly<MakeURLOptions> = {},
+		{ allowedExtensions = ALLOWED_EXTENSIONS, extension = 'webp', size }: Readonly<MakeUrlOptions> = {},
 	): string {
 		extension = String(extension).toLowerCase();
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Bringing back the discussion from #6036! **But why?!?** This change has been made under a number of factors:

1. A `snakeCase` function converts `iconURL` as `icon_u_r_l`, so if we want to support such utility seamlessly, we would need to pass `iconUrl`. In this case, a name casing mismatch happens as the property is `iconURL` inside the builder methods while `icon_url` in the constructor. For consistency, we can use and adopt `iconUrl`, this way it's the same casing for both the utility function and the chainable methods.

    This means that this code is now possible:
    ```javascript
    new Embed(snakeCase({
      description: 'Some description',
      footer: {
        text: 'Hello there',
        iconUrl: user.displayAvatarUrl(),
      },
    }));
    ```

    Or alternatively:
    ```javascript
    new Embed({
      description: 'Some description',
      footer: snakeCase({
        text: 'Hello there',
        iconUrl: user.displayAvatarUrl(),
      }),
    });
    ```

1. There are several things in the JavaScript ecosystem which uses `Url`, mostly from Firefox but also supported in other places:
    - https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/events/UrlFilter
    - https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history/addUrl
    - https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/history/deleteUrl
    - https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/extension/setUpdateUrlData
    - https://developer.mozilla.org/en-US/docs/Web/WebDriver/Capabilities/webSocketUrl

    So `xUrl` isn't that unknown in JavaScript, despite `URL` and `URLSearchParams` existing.

1. We are switching to TypeScript soon, which is a language created by the creators of C#, and as such, they share a lot of the naming conventions (see types, interfaces, enums, and namespaces) on top of what they already shared (PascalCase for classes, camelCase for local variables). However, something JavaScript falls short on is having a proper and solid set of rules that define whether or not names should be capitalized or not. Fortunately, C# does, so we can take advantage of this to provide a consistent name casing, as seen below:

    > When using acronyms, use Pascal case or camel case for acronyms more than two characters long. For example, use HtmlButton or htmlButton. However, you should capitalize acronyms that consist of only two characters, such as `System.IO` instead of `System.Io`.
    From: https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-1.1/141e06ef(v=vs.71)?redirectedfrom=MSDN

1. Easier to read, now this is subjective, but let me bring some examples:
    - `CreateGuildScheduledEventInviteURLOptions` -> `CreateGuildScheduledEventInviteUrlOptions`
    - `ImageURLOptions` -> `ImageUrlOptions`
    - `StaticImageURLOptions` -> `StaticImageUrlOptions`
    - `bannerURL()` -> `bannerUrl()`
    - `splashURL()` -> `splashUrl()`
    - `iconURL()` -> `iconUrl()`

As a standalone word, we can still use `URL` (aka uppercase), but if it's joined with other words, I'd argue we should go for .NET's rules and replacing PascalCase to camelCase where applicable. After all, they are pretty solid and promote consistency in a way that's widely recognized by many developers and is free of doubts.

*After all, we used .NET's rules alongside JS's adoption of `Id` to approve the aforementioned PR.*

~~I'll also update `discord-api-types` to reflect the naming change from this PR in a bit!~~ Done! https://github.com/discordjs/discord-api-types/pull/313

**Status and versioning classification:**

<!--
- Code changes have been tested against the Discord API, or there are no code changes
-->
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
