### PR TITLE
docs: ApplicationCommandData typedef

### DIFF
--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -127,8 +127,9 @@ class ApplicationCommand extends Base {
   /**
    * Data for creating or editing an application command.
    * @typedef {Object} ApplicationCommandData
-   * @property {string} name The name of the command, must be in all lowercase if type is CHAT_INPUT
-   * @property {string} description The description of the command, if type is CHAT_INPUT
+   * @property {string} name The name of the command, must be in all lowercase if type is
+   * {@link ApplicationCommandType.ChatInput}
+   * @property {string} description The description of the command, if type is {@link ApplicationCommandType.ChatInput}
    * @property {ApplicationCommandType} [type=ApplicationCommandType.ChatInput] The type of the command
    * @property {ApplicationCommandOptionData[]} [options] Options for the command
    * @property {boolean} [defaultPermission=true] Whether the command is enabled by default when the app is added to a guild

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -132,7 +132,8 @@ class ApplicationCommand extends Base {
    * @property {string} description The description of the command, if type is {@link ApplicationCommandType.ChatInput}
    * @property {ApplicationCommandType} [type=ApplicationCommandType.ChatInput] The type of the command
    * @property {ApplicationCommandOptionData[]} [options] Options for the command
-   * @property {boolean} [defaultPermission=true] Whether the command is enabled by default when the app is added to a guild
+   * @property {boolean} [defaultPermission=true] Whether the command is enabled by default when the app is added to a
+   * guild
    */
 
   /**

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -129,7 +129,7 @@ class ApplicationCommand extends Base {
    * @typedef {Object} ApplicationCommandData
    * @property {string} name The name of the command, must be in all lowercase if type is CHAT_INPUT
    * @property {string} description The description of the command, if type is CHAT_INPUT
-   * @property {ApplicationCommandType} [type="CHAT_INPUT"] The type of the command
+   * @property {ApplicationCommandType} [type=ApplicationCommandType.ChatInput] The type of the command
    * @property {ApplicationCommandOptionData[]} [options] Options for the command
    * @property {boolean} [defaultPermission=true] Whether the command is enabled by default when the app is added to a guild
    */

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -127,9 +127,9 @@ class ApplicationCommand extends Base {
   /**
    * Data for creating or editing an application command.
    * @typedef {Object} ApplicationCommandData
-   * @property {string} name The name of the command
-   * @property {string} description The description of the command
-   * @property {ApplicationCommandType} [type] The type of the command
+   * @property {string} name The name of the command, must be in all lowercase if type is CHAT_INPUT
+   * @property {string} description The description of the command, if type is CHAT_INPUT
+   * @property {ApplicationCommandType} [type="CHAT_INPUT"] The type of the command
    * @property {ApplicationCommandOptionData[]} [options] Options for the command
    * @property {boolean} [defaultPermission] Whether the command is enabled by default when the app is added to a guild
    */

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -131,7 +131,7 @@ class ApplicationCommand extends Base {
    * @property {string} description The description of the command, if type is CHAT_INPUT
    * @property {ApplicationCommandType} [type="CHAT_INPUT"] The type of the command
    * @property {ApplicationCommandOptionData[]} [options] Options for the command
-   * @property {boolean} [defaultPermission] Whether the command is enabled by default when the app is added to a guild
+   * @property {boolean} [defaultPermission=true] Whether the command is enabled by default when the app is added to a guild
    */
 
   /**


### PR DESCRIPTION
Updated ApplicationCommandData documentation to add default value of `type`, that `description` only is used on CHAT_INPUT and that the name must be in all lowercase when used in a CHAT_INPUT

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
