### PR TITLE
docs: add external builder docs links

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -644,7 +644,7 @@ class Message extends Base {
    * @property {MessageAttachment[]} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to add to the message
-   * @property {MessageActionRow[]|MessageActionRowOptions[]} [components]
+   * @property {ActionRow[]|MessageActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */
 

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -644,7 +644,7 @@ class Message extends Base {
    * @property {MessageAttachment[]} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to add to the message
-   * @property {ActionRow[]|MessageActionRowOptions[]} [components]
+   * @property {ActionRow[]|ActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */
 

--- a/packages/discord.js/src/structures/MessageComponentInteraction.js
+++ b/packages/discord.js/src/structures/MessageComponentInteraction.js
@@ -105,3 +105,28 @@ module.exports = MessageComponentInteraction;
  * @external APIMessageButton
  * @see {@link https://discord.com/developers/docs/interactions/message-components#button-object}
  */
+
+/**
+ * @external ButtonComponent
+ * @see {@link https://discord.js.org/#/docs/builders/main/class/ButtonComponent}
+ */
+
+/**
+ * @external SelectMenuComponent
+ * @see {@link https://discord.js.org/#/docs/builders/main/class/SelectMenuComponent}
+ */
+
+/**
+ * @external SelectMenuOption
+ * @see {@link https://discord.js.org/#/docs/builders/main/class/SelectMenuComponent}
+ */
+
+/**
+ * @external ActionRow
+ * @see {@link https://discord.js.org/#/docs/builders/main/class/ActionRow}
+ */
+
+/**
+ * @external Embed
+ * @see {@link https://discord.js.org/#/docs/builders/main/class/Embed}
+ */

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -134,7 +134,7 @@ class Webhook {
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
    * @property {MessageAttachment[]} [attachments] Attachments to send with the message
-   * @property {MessageActionRow[]|MessageActionRowOptions[]} [components]
+   * @property {ActionRow[]|MessageActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    * @property {Snowflake} [threadId] The id of the thread this message belongs to
    * <info>For interaction webhooks, this property is ignored</info>

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -134,7 +134,7 @@ class Webhook {
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
    * @property {MessageAttachment[]} [attachments] Attachments to send with the message
-   * @property {ActionRow[]|MessageActionRowOptions[]} [components]
+   * @property {ActionRow[]|ActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    * @property {Snowflake} [threadId] The id of the thread this message belongs to
    * <info>For interaction webhooks, this property is ignored</info>

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -62,7 +62,7 @@ class TextBasedChannel {
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to send with the message
-   * @property {MessageActionRow[]|MessageActionRowOptions[]} [components]
+   * @property {ActionRow[]|MessageActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    * @property {MessageAttachment[]} [attachments] Attachments to send in the message
    */

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -62,7 +62,7 @@ class TextBasedChannel {
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
    * @property {FileOptions[]|BufferResolvable[]|MessageAttachment[]} [files] Files to send with the message
-   * @property {ActionRow[]|MessageActionRowOptions[]} [components]
+   * @property {ActionRow[]|ActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    * @property {MessageAttachment[]} [attachments] Attachments to send in the message
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Makes the docs links for builders in djs clickable.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
