### PR TITLE
fix(builders): make type optional in constructor

### DIFF
--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -16,7 +16,7 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> implem
 	public readonly components: T[] = [];
 	public readonly type = ComponentType.ActionRow;
 
-	public constructor(data?: APIActionRowComponent) {
+	public constructor(data?: APIActionRowComponent & { type?: ComponentType.ActionRow }) {
 		this.components = (data?.components.map(createComponent) ?? []) as T[];
 	}
 

--- a/packages/builders/src/components/Button.ts
+++ b/packages/builders/src/components/Button.ts
@@ -19,7 +19,7 @@ export class ButtonComponent implements Component {
 	public readonly custom_id!: string;
 	public readonly url!: string;
 
-	public constructor(data?: APIButtonComponent) {
+	public constructor(data?: APIButtonComponent & { type?: ComponentType.Button }) {
 		/* eslint-disable @typescript-eslint/non-nullable-type-assertion-style */
 		this.style = data?.style as ButtonStyle;
 		this.label = data?.label;

--- a/packages/builders/src/components/selectMenu/SelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/SelectMenu.ts
@@ -21,7 +21,7 @@ export class SelectMenuComponent implements Component {
 	public readonly custom_id!: string;
 	public readonly disabled?: boolean;
 
-	public constructor(data?: APISelectMenuComponent) {
+	public constructor(data?: APISelectMenuComponent & { type?: ComponentType.SelectMenu }) {
 		this.options = data?.options.map((option) => new SelectMenuOption(option)) ?? [];
 		this.placeholder = data?.placeholder;
 		this.min_values = data?.min_values;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Make property `type` in components constructor optional as it's not used by the class but just marked as constant.
I did a type intersection instead of using `Omit` because it caused problems with the Button class.

Close #7342

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.