### PR TITLE
fix: allow camel-cased json components to be used in payloads

### DIFF
--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -53,6 +53,7 @@
     "@sapphire/snowflake": "^3.0.1",
     "@types/ws": "^8.2.2",
     "discord-api-types": "^0.26.1",
+    "humps": "^2.0.1",
     "node-fetch": "^2.6.7",
     "ws": "^8.4.2"
   },

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -197,7 +197,7 @@ class MessagePayload {
       content,
       tts,
       nonce,
-      embeds: this.options.embeds?.map(embed => (embed instanceof Embed ? embed : decamelize(embed))),
+      embeds: this.options.embeds?.map(embed => (embed instanceof Embed ? embed.toJSON() : decamelize(embed))),
       components,
       username,
       avatar_url: avatarURL,

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -132,13 +132,7 @@ class MessagePayload {
       }
     }
 
-    const components = this.options.components?.map(c => {
-      if ('toJSON' in c) {
-        c.toJSON();
-      }
-
-      return decamelize(c);
-    });
+    const components = this.options.components?.map(c => ('toJSON' in c ? c.toJSON() : decamelize(c)));
 
     let username;
     let avatarURL;

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const { Buffer } = require('node:buffer');
-const { createComponent, Embed } = require('@discordjs/builders');
+const { Embed } = require('@discordjs/builders');
 const { MessageFlags } = require('discord-api-types/v9');
+const { decamelize } = require('humps');
 const { RangeError } = require('../errors');
 const DataResolver = require('../util/DataResolver');
 const MessageFlagsBitField = require('../util/MessageFlagsBitField');
@@ -131,7 +132,13 @@ class MessagePayload {
       }
     }
 
-    const components = this.options.components?.map(c => createComponent(c).toJSON());
+    const components = this.options.components?.map(c => {
+      if ('toJSON' in c) {
+        c.toJSON();
+      }
+
+      return decamelize(c);
+    });
 
     let username;
     let avatarURL;
@@ -190,7 +197,7 @@ class MessagePayload {
       content,
       tts,
       nonce,
-      embeds: this.options.embeds?.map(embed => (embed instanceof Embed ? embed : new Embed(embed)).toJSON()),
+      embeds: this.options.embeds?.map(embed => (embed instanceof Embed ? embed : decamelize(embed))),
       components,
       username,
       avatar_url: avatarURL,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4391,6 +4391,11 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+humps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
+  integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
+
 husky@^7.0.4:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes a regression where sending in camelCased json objects in message payloads wouldn't work.

Closes #7376

Depends on:
- https://github.com/discordjs/discord.js/pull/7388

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
