### PR TITLE
refactor(builders-methods): make methods consistent

### DIFF
--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -34,7 +34,7 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> implem
 	 * Sets the components in this action row
 	 * @param components The components to set this row to
 	 */
-	public setComponents(components: T[]) {
+	public setComponents(...components: T[]) {
 		Reflect.set(this, 'components', [...components]);
 		return this;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This makes builders methods such as `<Embed>addFields` and `<SlashCommand..Option>.addChoice`, `<ActionRow>.setComponents`, `<SlashCommand..Option>.setChoices` and `<Embed>.setFields` consistent 

now `<SlashCommand..Option>`'s `.setChoices`, `.addChoices`, `.addChoice` **all take in Objects** like the embed methods instead of a tuple array

`<SlashCommand..Option>`'s `.setChoices` and `addChoices` as well as `<ActionRow>.setComponents` all now take a *rest parameter* instead of an array of their respective inputs to be more consistent with methods such as `<Embed>.setFields`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
