### PR TITLE
docs: fix example about filter options

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -449,8 +449,8 @@ class Message extends Base {
    * @returns {ReactionCollector}
    * @example
    * // Create a reaction collector
-   * const filter = (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someId';
-   * const collector = message.createReactionCollector({ filter, time: 15_000 });
+   * const reactionFilter = (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someId';
+   * const collector = message.createReactionCollector({ filter: reactionFilter, time: 15_000 });
    * collector.on('collect', r => console.log(`Collected ${r.emoji.name}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
@@ -471,8 +471,8 @@ class Message extends Base {
    * @returns {Promise<Collection<string | Snowflake, MessageReaction>>}
    * @example
    * // Create a reaction collector
-   * const filter = (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someId'
-   * message.awaitReactions({ filter, time: 15_000 })
+   * const reactionFilter = (reaction, user) => reaction.emoji.name === '👌' && user.id === 'someId'
+   * message.awaitReactions({ filter: reactionFilter, time: 15_000 })
    *   .then(collected => console.log(`Collected ${collected.size} reactions`))
    *   .catch(console.error);
    */
@@ -500,8 +500,8 @@ class Message extends Base {
    * @returns {InteractionCollector}
    * @example
    * // Create a message component interaction collector
-   * const filter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
-   * const collector = message.createMessageComponentCollector({ filter, time: 15_000 });
+   * const interactionFilter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
+   * const collector = message.createMessageComponentCollector({ filter: interactionFilter, time: 15_000 });
    * collector.on('collect', i => console.log(`Collected ${i.customId}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
@@ -528,8 +528,8 @@ class Message extends Base {
    * @returns {Promise<MessageComponentInteraction>}
    * @example
    * // Collect a message component interaction
-   * const filter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
-   * message.awaitMessageComponent({ filter, time: 15_000 })
+   * const interactionFilter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
+   * message.awaitMessageComponent({ filter: interactionFilter, time: 15_000 })
    *   .then(interaction => console.log(`${interaction.customId} was clicked!`))
    *   .catch(console.error);
    */

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -194,8 +194,8 @@ class TextBasedChannel {
    * @returns {MessageCollector}
    * @example
    * // Create a message collector
-   * const filter = m => m.content.includes('discord');
-   * const collector = channel.createMessageCollector({ filter, time: 15_000 });
+   * const messageFilter = m => m.content.includes('discord');
+   * const collector = channel.createMessageCollector({ filter: messageFilter, time: 15_000 });
    * collector.on('collect', m => console.log(`Collected ${m.content}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
@@ -216,9 +216,9 @@ class TextBasedChannel {
    * @returns {Promise<Collection<Snowflake, Message>>}
    * @example
    * // Await !vote messages
-   * const filter = m => m.content.startsWith('!vote');
+   * const messageFilter = m => m.content.startsWith('!vote');
    * // Errors: ['time'] treats ending because of the time limit as an error
-   * channel.awaitMessages({ filter, max: 4, time: 60_000, errors: ['time'] })
+   * channel.awaitMessages({ filter: messageFilter, max: 4, time: 60_000, errors: ['time'] })
    *   .then(collected => console.log(collected.size))
    *   .catch(collected => console.log(`After a minute, only ${collected.size} out of 4 voted.`));
    */
@@ -241,8 +241,8 @@ class TextBasedChannel {
    * @returns {InteractionCollector}
    * @example
    * // Create a button interaction collector
-   * const filter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
-   * const collector = channel.createMessageComponentCollector({ filter, time: 15_000 });
+   * const interactionFilter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
+   * const collector = channel.createMessageComponentCollector({ filter: interactionFilter, time: 15_000 });
    * collector.on('collect', i => console.log(`Collected ${i.customId}`));
    * collector.on('end', collected => console.log(`Collected ${collected.size} items`));
    */
@@ -261,8 +261,8 @@ class TextBasedChannel {
    * @returns {Promise<MessageComponentInteraction>}
    * @example
    * // Collect a message component interaction
-   * const filter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
-   * channel.awaitMessageComponent({ filter, time: 15_000 })
+   * const messageFilter = (interaction) => interaction.customId === 'button' && interaction.user.id === 'someId';
+   * channel.awaitMessageComponent({ filter: messageFilter, time: 15_000 })
    *   .then(interaction => console.log(`${interaction.customId} was clicked!`))
    *   .catch(console.error);
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In docs(example: [message.awaitReactions()](https://discord.js.org/#/docs/discord.js/stable/class/Message?scrollTo=awaitReactions)), filter is first argument and no used cologne. However, this is undesirable because it causes malfunction.
ref: https://github.com/InkoHX/vm2-discordjs/pull/50/commits/32056dbdc3c2f87fc9f413dc122794dc74d0d35a

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
- I know how to update typings and have done so, or typings don't need updating
