### PR TITLE
feat(channel): add .url getter

### DIFF
--- a/packages/discord.js/src/structures/Channel.js
+++ b/packages/discord.js/src/structures/Channel.js
@@ -59,11 +59,11 @@ class Channel extends Base {
 
   /**
    * The URL to the channel
-   * @type {String}
+   * @type {string}
    * @readonly
    */
   get url() {
-    return `https://discord.com/channels/${this.isDM() ? "@me" : this.guild.id}/${this.id}`;
+    return `https://discord.com/channels/${this.isDM() ? '@me' : this.guild.id}/${this.id}`;
   }
 
   /**

--- a/packages/discord.js/src/structures/Channel.js
+++ b/packages/discord.js/src/structures/Channel.js
@@ -63,7 +63,7 @@ class Channel extends Base {
    * @readonly
    */
   get url() {
-    return `https://discord.com/channels/${this.isDMBased() ? '@me' : this.guild.id}/${this.id}`;
+    return `https://discord.com/channels/${this.isDMBased() ? '@me' : this.guildId}/${this.id}`;
   }
 
   /**

--- a/packages/discord.js/src/structures/Channel.js
+++ b/packages/discord.js/src/structures/Channel.js
@@ -58,6 +58,15 @@ class Channel extends Base {
   }
 
   /**
+   * The URL to the channel
+   * @type {String}
+   * @readonly
+   */
+  get url() {
+    return `https://discord.com/channels/${this.isDM() ? "@me" : this.guild.id}/${this.id}`;
+  }
+
+  /**
    * Whether this Channel is a partial
    * <info>This is always false outside of DM channels.</info>
    * @type {boolean}

--- a/packages/discord.js/src/structures/Channel.js
+++ b/packages/discord.js/src/structures/Channel.js
@@ -63,7 +63,7 @@ class Channel extends Base {
    * @readonly
    */
   get url() {
-    return `https://discord.com/channels/${this.isDM() ? '@me' : this.guild.id}/${this.id}`;
+    return `https://discord.com/channels/${this.isDMBased() ? '@me' : this.guild.id}/${this.id}`;
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -231,15 +231,6 @@ class ThreadChannel extends Channel {
   }
 
   /**
-   * The URL to the channel
-   * @type {string}
-   * @readonly
-   */
-  get url() {
-    return `https://discord.com/channels/${this.guild.id}/${this.parent.id}/${this.id}`;
-  }
-
-  /**
    * Makes the client user join the thread.
    * @returns {Promise<ThreadChannel>}
    */

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -230,6 +230,15 @@ class ThreadChannel extends Channel {
     return this.guild.channels.resolve(this.parentId);
   }
 
+    /**
+     * The URL to the channel
+     * @type {String}
+     * @readonly
+     */
+    get url() {
+      return `https://discord.com/channels/${this.guild.id}/${this.parent.id}/${this.id}`;
+    }
+
   /**
    * Makes the client user join the thread.
    * @returns {Promise<ThreadChannel>}

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -230,14 +230,14 @@ class ThreadChannel extends Channel {
     return this.guild.channels.resolve(this.parentId);
   }
 
-    /**
-     * The URL to the channel
-     * @type {String}
-     * @readonly
-     */
-    get url() {
-      return `https://discord.com/channels/${this.guild.id}/${this.parent.id}/${this.id}`;
-    }
+  /**
+   * The URL to the channel
+   * @type {string}
+   * @readonly
+   */
+  get url() {
+    return `https://discord.com/channels/${this.guild.id}/${this.parent.id}/${this.id}`;
+  }
 
   /**
    * Makes the client user join the thread.

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -491,6 +491,7 @@ export abstract class Channel extends Base {
   public id: Snowflake;
   public readonly partial: false;
   public type: ChannelType;
+  public url: string;
   public delete(): Promise<this>;
   public fetch(force?: boolean): Promise<this>;
   public isText(): this is TextChannel;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -491,7 +491,7 @@ export abstract class Channel extends Base {
   public id: Snowflake;
   public readonly partial: false;
   public type: ChannelType;
-  public url: string;
+  public readonly url: string;
   public delete(): Promise<this>;
   public fetch(force?: boolean): Promise<this>;
   public isText(): this is TextChannel;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This simply adds a `.url` getter on channels. This can be specifically useful when working with moving threads between 2 channels.

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
