### PR TITLE
Always require being sendable to be unarchivable

### DIFF
--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -517,7 +517,7 @@ class ThreadChannel extends Channel {
    * @readonly
    */
   get unarchivable() {
-    return this.archived && (this.locked ? this.manageable : this.sendable);
+    return this.archived && this.sendable && (!this.locked || this.manageable);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently `ThreadChannel.unarchivable` will return `true` when the thread is locked and you only have Manage Threads (`MANAGE_THREADS`) but not Send Messages in Threads (`SEND_MESSAGES_IN_THREADS`), although in fact you always need Send Messages in Threads to unarchive the thread.
This pull request will fix it by making `ThreadChannel.unarchivable` always check for `this.sendable` regardless of `this.locked`.

**Status and versioning classification:**
*(none)*
