### PR TITLE
fix(components): addMultiple/setMultiple accepting array and objects

### DIFF
--- a/packages/builders/__tests__/components/actionRow.test.ts
+++ b/packages/builders/__tests__/components/actionRow.test.ts
@@ -5,6 +5,8 @@ describe('Action Row Components', () => {
 	describe('Assertion Tests', () => {
 		test('GIVEN valid components THEN do not throw', () => {
 			expect(() => new ActionRow().addComponents(new ButtonComponent())).not.toThrowError();
+			expect(() => new ActionRow().addComponents([new ButtonComponent()])).not.toThrowError();
+			expect(() => new ActionRow().setComponents(new ButtonComponent())).not.toThrowError();
 			expect(() => new ActionRow().setComponents([new ButtonComponent()])).not.toThrowError();
 		});
 
@@ -89,8 +91,17 @@ describe('Action Row Components', () => {
 					new SelectMenuOption().setLabel('two').setValue('two'),
 				]);
 
+			// addComponents
 			expect(new ActionRow().addComponents(button).toJSON()).toEqual(rowWithButtonData);
+			expect(new ActionRow().addComponents([button]).toJSON()).toEqual(rowWithButtonData);
 			expect(new ActionRow().addComponents(selectMenu).toJSON()).toEqual(rowWithSelectMenuData);
+			expect(new ActionRow().addComponents([selectMenu]).toJSON()).toEqual(rowWithSelectMenuData);
+
+			// setComponents
+			expect(new ActionRow().setComponents(button).toJSON()).toEqual(rowWithButtonData);
+			expect(new ActionRow().setComponents([button]).toJSON()).toEqual(rowWithButtonData);
+			expect(new ActionRow().setComponents(selectMenu).toJSON()).toEqual(rowWithSelectMenuData);
+			expect(new ActionRow().setComponents([selectMenu]).toJSON()).toEqual(rowWithSelectMenuData);
 		});
 	});
 });

--- a/packages/builders/__tests__/components/selectMenu.test.ts
+++ b/packages/builders/__tests__/components/selectMenu.test.ts
@@ -23,6 +23,8 @@ describe('Button Components', () => {
 				.setEmoji({ name: 'test' })
 				.setDescription('description');
 			expect(() => selectMenu().addOptions(option)).not.toThrowError();
+			expect(() => selectMenu().addOptions([option])).not.toThrowError();
+			expect(() => selectMenu().setOptions(option)).not.toThrowError();
 			expect(() => selectMenu().setOptions([option])).not.toThrowError();
 		});
 

--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -353,9 +353,19 @@ describe('Embed', () => {
 			});
 		});
 
-		test('GIVEN an embed using Embed#addFields THEN returns valid toJSON data', () => {
+		test('GIVEN an embed using Embed#addFields with an object THEN returns valid toJSON data', () => {
 			const embed = new Embed();
 			embed.addFields({ name: 'foo', value: 'bar' });
+
+			expect(embed.toJSON()).toStrictEqual({
+				...emptyEmbed,
+				fields: [{ name: 'foo', value: 'bar', inline: undefined }],
+			});
+		});
+
+		test('GIVEN an embed using Embed#addFields with an array THEN returns valid toJSON data', () => {
+			const embed = new Embed();
+			embed.addFields([{ name: 'foo', value: 'bar' }]);
 
 			expect(embed.toJSON()).toStrictEqual({
 				...emptyEmbed,

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -25,8 +25,8 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> implem
 	 * @param components The components to add to this action row.
 	 * @returns
 	 */
-	public addComponents(...components: T[]) {
-		this.components.push(...components);
+	public addComponents(...components: T[] | T[][]) {
+		this.components.push(...(components.flat(2) as T[]));
 		return this;
 	}
 
@@ -34,8 +34,8 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> implem
 	 * Sets the components in this action row
 	 * @param components The components to set this row to
 	 */
-	public setComponents(components: T[]) {
-		Reflect.set(this, 'components', [...components]);
+	public setComponents(...components: T[] | T[][]) {
+		Reflect.set(this, 'components', [...components.flat(2)]);
 		return this;
 	}
 

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -75,8 +75,8 @@ export class UnsafeSelectMenuComponent implements Component {
 	 * @param options The options to add to this select menu
 	 * @returns
 	 */
-	public addOptions(...options: SelectMenuOption[]) {
-		this.options.push(...options);
+	public addOptions(...options: SelectMenuOption[] | SelectMenuOption[][]) {
+		this.options.push(...options.flat(2));
 		return this;
 	}
 
@@ -84,8 +84,8 @@ export class UnsafeSelectMenuComponent implements Component {
 	 * Sets the options on this select menu
 	 * @param options The options to set on this select menu
 	 */
-	public setOptions(options: SelectMenuOption[]) {
-		Reflect.set(this, 'options', [...options]);
+	public setOptions(...options: SelectMenuOption[] | SelectMenuOption[][]) {
+		Reflect.set(this, 'options', [...options.flat(2)]);
 		return this;
 	}
 

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -19,7 +19,8 @@ import { AuthorOptions, FooterOptions, UnsafeEmbed } from './UnsafeEmbed';
  * Represents an embed in a message (image/video preview, rich embed, etc.)
  */
 export class Embed extends UnsafeEmbed {
-	public override addFields(...fields: APIEmbedField[]): this {
+	public override addFields(...fields: APIEmbedField[] | APIEmbedField[][]): this {
+		fields = fields.flat(2);
 		// Ensure adding these fields won't exceed the 25 field limit
 		validateFieldLength(this.fields, fields.length);
 

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -125,8 +125,8 @@ export class UnsafeEmbed implements APIEmbed {
 	 *
 	 * @param fields The fields to add
 	 */
-	public addFields(...fields: APIEmbedField[]): this {
-		this.fields.push(...Embed.normalizeFields(...fields));
+	public addFields(...fields: APIEmbedField[] | APIEmbedField[][]): this {
+		this.fields.push(...Embed.normalizeFields(...fields.flat(2)));
 		return this;
 	}
 
@@ -146,8 +146,8 @@ export class UnsafeEmbed implements APIEmbed {
 	 * Sets the embed's fields (max 25).
 	 * @param fields The fields to set
 	 */
-	public setFields(...fields: APIEmbedField[]) {
-		this.spliceFields(0, this.fields.length, ...fields);
+	public setFields(...fields: APIEmbedField[] | APIEmbedField[][]) {
+		this.spliceFields(0, this.fields.length, ...fields.flat(2));
 		return this;
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR allows arrays in the following methods again:
```
SelectMenuComponent#addOptions
SelectMenuComponent#setOptions
ActionRow#addComponents
ActionRow#setComponents
Embed#addComponents
Embed#setComponents
```

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->