### PR TITLE
docs(messageattachment): fix `contentType` docs

### DIFF
--- a/packages/discord.js/src/structures/MessageAttachment.js
+++ b/packages/discord.js/src/structures/MessageAttachment.js
@@ -124,7 +124,7 @@ class MessageAttachment {
 
     if ('content_type' in data) {
       /**
-       * This media type of this attachment
+       * The media type of this attachment
        * @type {?string}
        */
       this.contentType = data.content_type;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes `MessageAttachment#contentType` docs.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
