### PR TITLE
fix: unsafe embed builder field normalization

### DIFF
--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -1,15 +1,12 @@
 import type { APIMessageComponent, ComponentType } from 'discord-api-types/v9';
+import type { JSONEncodable } from '../util/jsonEncodable';
 
 /**
  * Represents a discord component
  */
-export interface Component {
+export interface Component extends JSONEncodable<APIMessageComponent> {
 	/**
 	 * The type of this component
 	 */
 	readonly type: ComponentType;
-	/**
-	 * Converts this component to an API-compatible JSON object
-	 */
-	toJSON: () => APIMessageComponent;
 }

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -28,3 +28,5 @@ export * from './interactions/slashCommands/options/user';
 
 export * as ContextMenuCommandAssertions from './interactions/contextMenuCommands/Assertions';
 export * from './interactions/contextMenuCommands/ContextMenuCommandBuilder';
+
+export * from './util/jsonEncodable';

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -8,7 +8,7 @@ import type {
 	APIEmbedThumbnail,
 	APIEmbedVideo,
 } from 'discord-api-types/v9';
-import { Embed } from './Embed';
+import type { JSONEncodable } from '../../util/jsonEncodable';
 
 export interface AuthorOptions {
 	name: string;
@@ -21,7 +21,7 @@ export interface FooterOptions {
 	iconURL?: string;
 }
 
-export class UnsafeEmbed implements APIEmbed {
+export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	/**
 	 * An array of fields of this embed
 	 */
@@ -126,7 +126,7 @@ export class UnsafeEmbed implements APIEmbed {
 	 * @param fields The fields to add
 	 */
 	public addFields(...fields: APIEmbedField[]): this {
-		this.fields.push(...Embed.normalizeFields(...fields));
+		this.fields.push(...UnsafeEmbed.normalizeFields(...fields));
 		return this;
 	}
 
@@ -138,7 +138,7 @@ export class UnsafeEmbed implements APIEmbed {
 	 * @param fields The replacing field objects
 	 */
 	public spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {
-		this.fields.splice(index, deleteCount, ...Embed.normalizeFields(...fields));
+		this.fields.splice(index, deleteCount, ...UnsafeEmbed.normalizeFields(...fields));
 		return this;
 	}
 

--- a/packages/builders/src/util/jsonEncodable.ts
+++ b/packages/builders/src/util/jsonEncodable.ts
@@ -1,0 +1,14 @@
+export interface JSONEncodable<T> {
+	/**
+	 * Transforms this object to its JSON format
+	 */
+	toJSON: () => T;
+}
+
+/**
+ * Indicates if an object is encodable or not.
+ * @param maybeEncodable The object to check against
+ */
+export function isJSONEncodable(maybeEncodable: unknown): maybeEncodable is JSONEncodable<unknown> {
+	return maybeEncodable !== null && typeof maybeEncodable === 'object' && 'toJSON' in maybeEncodable;
+}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Uses the unsafe field normalizer for unsafe embeds. Closes #7416

This also adds a new interface type: `JSONEncodable<T>`, for better type enforcement and reusability.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
