### PR TITLE
refactor: make public builder props getters

### DIFF
--- a/packages/builders/__tests__/components/actionRow.test.ts
+++ b/packages/builders/__tests__/components/actionRow.test.ts
@@ -5,7 +5,7 @@ describe('Action Row Components', () => {
 	describe('Assertion Tests', () => {
 		test('GIVEN valid components THEN do not throw', () => {
 			expect(() => new ActionRow().addComponents(new ButtonComponent())).not.toThrowError();
-			expect(() => new ActionRow().setComponents(new ButtonComponent())).not.toThrowError();
+			expect(() => new ActionRow().setComponents([new ButtonComponent()])).not.toThrowError();
 		});
 
 		test('GIVEN valid JSON input THEN valid JSON output is given', () => {
@@ -84,10 +84,10 @@ describe('Action Row Components', () => {
 				.setCustomId('1234')
 				.setMaxValues(10)
 				.setMinValues(12)
-				.setOptions(
+				.setOptions([
 					new SelectMenuOption().setLabel('one').setValue('one'),
 					new SelectMenuOption().setLabel('two').setValue('two'),
-				);
+				]);
 
 			expect(new ActionRow().addComponents(button).toJSON()).toEqual(rowWithButtonData);
 			expect(new ActionRow().addComponents(selectMenu).toJSON()).toEqual(rowWithSelectMenuData);

--- a/packages/builders/__tests__/components/selectMenu.test.ts
+++ b/packages/builders/__tests__/components/selectMenu.test.ts
@@ -70,7 +70,6 @@ describe('Button Components', () => {
 			};
 
 			expect(
-				// @ts-expect-error
 				new SelectMenuComponent(selectMenuDataWithoutOptions)
 					.addOptions(new SelectMenuOption(selectMenuOptionData))
 					.toJSON(),

--- a/packages/builders/__tests__/components/selectMenu.test.ts
+++ b/packages/builders/__tests__/components/selectMenu.test.ts
@@ -55,17 +55,26 @@ describe('Button Components', () => {
 				description: 'test',
 			};
 
-			const selectMenuData: APISelectMenuComponent = {
+			const selectMenuDataWithoutOptions = {
 				type: ComponentType.SelectMenu,
 				custom_id: 'test',
 				max_values: 10,
 				min_values: 3,
 				disabled: true,
-				options: [selectMenuOptionData],
 				placeholder: 'test',
+			} as const;
+
+			const selectMenuData: APISelectMenuComponent = {
+				...selectMenuDataWithoutOptions,
+				options: [selectMenuOptionData],
 			};
 
-			expect(new SelectMenuComponent(selectMenuData).toJSON()).toEqual(selectMenuData);
+			expect(
+				// @ts-expect-error
+				new SelectMenuComponent(selectMenuDataWithoutOptions)
+					.addOptions(new SelectMenuOption(selectMenuOptionData))
+					.toJSON(),
+			).toEqual(selectMenuData);
 			expect(new SelectMenuOption(selectMenuOptionData).toJSON()).toEqual(selectMenuOptionData);
 		});
 	});

--- a/packages/builders/__tests__/components/selectMenu.test.ts
+++ b/packages/builders/__tests__/components/selectMenu.test.ts
@@ -23,7 +23,7 @@ describe('Button Components', () => {
 				.setEmoji({ name: 'test' })
 				.setDescription('description');
 			expect(() => selectMenu().addOptions(option)).not.toThrowError();
-			expect(() => selectMenu().setOptions(option)).not.toThrowError();
+			expect(() => selectMenu().setOptions([option])).not.toThrowError();
 		});
 
 		test('GIVEN invalid inputs THEN Select Menu does throw', () => {

--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -1,9 +1,7 @@
 import { Embed } from '../../src';
 import type { APIEmbed } from 'discord-api-types/v9';
 
-const emptyEmbed: APIEmbed = {
-	fields: [],
-};
+const emptyEmbed: APIEmbed = {};
 
 const alpha = 'abcdefghijklmnopqrstuvwxyz';
 

--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -1,7 +1,4 @@
 import { Embed } from '../../src';
-import type { APIEmbed } from 'discord-api-types/v9';
-
-const emptyEmbed: APIEmbed = {};
 
 const alpha = 'abcdefghijklmnopqrstuvwxyz';
 
@@ -29,21 +26,21 @@ describe('Embed', () => {
 	describe('Embed title', () => {
 		test('GIVEN an embed with a pre-defined title THEN return valid toJSON data', () => {
 			const embed = new Embed({ title: 'foo' });
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, title: 'foo' });
+			expect(embed.toJSON()).toStrictEqual({ title: 'foo' });
 		});
 
 		test('GIVEN an embed using Embed#setTitle THEN return valid toJSON data', () => {
 			const embed = new Embed();
 			embed.setTitle('foo');
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, title: 'foo' });
+			expect(embed.toJSON()).toStrictEqual({ title: 'foo' });
 		});
 
 		test('GIVEN an embed with a pre-defined title THEN unset title THEN return valid toJSON data', () => {
 			const embed = new Embed({ title: 'foo' });
 			embed.setTitle(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, title: undefined });
+			expect(embed.toJSON()).toStrictEqual({ title: undefined });
 		});
 
 		test('GIVEN an embed with an invalid title THEN throws error', () => {
@@ -55,22 +52,22 @@ describe('Embed', () => {
 
 	describe('Embed description', () => {
 		test('GIVEN an embed with a pre-defined description THEN return valid toJSON data', () => {
-			const embed = new Embed({ ...emptyEmbed, description: 'foo' });
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, description: 'foo' });
+			const embed = new Embed({ description: 'foo' });
+			expect(embed.toJSON()).toStrictEqual({ description: 'foo' });
 		});
 
 		test('GIVEN an embed using Embed#setDescription THEN return valid toJSON data', () => {
 			const embed = new Embed();
 			embed.setDescription('foo');
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, description: 'foo' });
+			expect(embed.toJSON()).toStrictEqual({ description: 'foo' });
 		});
 
 		test('GIVEN an embed with a pre-defined description THEN unset description THEN return valid toJSON data', () => {
 			const embed = new Embed({ description: 'foo' });
 			embed.setDescription(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, description: undefined });
+			expect(embed.toJSON()).toStrictEqual({ description: undefined });
 		});
 
 		test('GIVEN an embed with an invalid description THEN throws error', () => {
@@ -84,7 +81,6 @@ describe('Embed', () => {
 		test('GIVEN an embed with a pre-defined url THEN returns valid toJSON data', () => {
 			const embed = new Embed({ url: 'https://discord.js.org/' });
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				url: 'https://discord.js.org/',
 			});
 		});
@@ -94,7 +90,6 @@ describe('Embed', () => {
 			embed.setURL('https://discord.js.org/');
 
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				url: 'https://discord.js.org/',
 			});
 		});
@@ -103,7 +98,7 @@ describe('Embed', () => {
 			const embed = new Embed({ url: 'https://discord.js.org' });
 			embed.setURL(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, url: undefined });
+			expect(embed.toJSON()).toStrictEqual({ url: undefined });
 		});
 
 		test('GIVEN an embed with an invalid URL THEN throws error', () => {
@@ -116,21 +111,21 @@ describe('Embed', () => {
 	describe('Embed Color', () => {
 		test('GIVEN an embed with a pre-defined color THEN returns valid toJSON data', () => {
 			const embed = new Embed({ color: 0xff0000 });
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, color: 0xff0000 });
+			expect(embed.toJSON()).toStrictEqual({ color: 0xff0000 });
 		});
 
 		test('GIVEN an embed using Embed#setColor THEN returns valid toJSON data', () => {
 			const embed = new Embed();
 			embed.setColor(0xff0000);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, color: 0xff0000 });
+			expect(embed.toJSON()).toStrictEqual({ color: 0xff0000 });
 		});
 
 		test('GIVEN an embed with a pre-defined color THEN unset color THEN return valid toJSON data', () => {
 			const embed = new Embed({ color: 0xff0000 });
 			embed.setColor(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, color: undefined });
+			expect(embed.toJSON()).toStrictEqual({ color: undefined });
 		});
 
 		test('GIVEN an embed with an invalid color THEN throws error', () => {
@@ -146,35 +141,35 @@ describe('Embed', () => {
 
 		test('GIVEN an embed with a pre-defined timestamp THEN returns valid toJSON data', () => {
 			const embed = new Embed({ timestamp: now.toISOString() });
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, timestamp: now.toISOString() });
+			expect(embed.toJSON()).toStrictEqual({ timestamp: now.toISOString() });
 		});
 
 		test('given an embed using Embed#setTimestamp (with Date) THEN returns valid toJSON data', () => {
 			const embed = new Embed();
 			embed.setTimestamp(now);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, timestamp: now.toISOString() });
+			expect(embed.toJSON()).toStrictEqual({ timestamp: now.toISOString() });
 		});
 
 		test('GIVEN an embed using Embed#setTimestamp (with int) THEN returns valid toJSON data', () => {
 			const embed = new Embed();
 			embed.setTimestamp(now.getTime());
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, timestamp: now.toISOString() });
+			expect(embed.toJSON()).toStrictEqual({ timestamp: now.toISOString() });
 		});
 
 		test('GIVEN an embed using Embed#setTimestamp (default) THEN returns valid toJSON data', () => {
 			const embed = new Embed();
 			embed.setTimestamp();
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, timestamp: embed.timestamp });
+			expect(embed.toJSON()).toStrictEqual({ timestamp: embed.timestamp });
 		});
 
 		test('GIVEN an embed with a pre-defined timestamp THEN unset timestamp THEN return valid toJSON data', () => {
 			const embed = new Embed({ timestamp: now.toISOString() });
 			embed.setTimestamp(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, timestamp: undefined });
+			expect(embed.toJSON()).toStrictEqual({ timestamp: undefined });
 		});
 	});
 
@@ -182,7 +177,6 @@ describe('Embed', () => {
 		test('GIVEN an embed with a pre-defined thumbnail THEN returns valid toJSON data', () => {
 			const embed = new Embed({ thumbnail: { url: 'https://discord.js.org/static/logo.svg' } });
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				thumbnail: { url: 'https://discord.js.org/static/logo.svg' },
 			});
 		});
@@ -192,7 +186,6 @@ describe('Embed', () => {
 			embed.setThumbnail('https://discord.js.org/static/logo.svg');
 
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				thumbnail: { url: 'https://discord.js.org/static/logo.svg' },
 			});
 		});
@@ -201,7 +194,7 @@ describe('Embed', () => {
 			const embed = new Embed({ thumbnail: { url: 'https://discord.js.org/static/logo.svg' } });
 			embed.setThumbnail(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, thumbnail: undefined });
+			expect(embed.toJSON()).toStrictEqual({ thumbnail: undefined });
 		});
 
 		test('GIVEN an embed with an invalid thumbnail THEN throws error', () => {
@@ -215,7 +208,6 @@ describe('Embed', () => {
 		test('GIVEN an embed with a pre-defined image THEN returns valid toJSON data', () => {
 			const embed = new Embed({ image: { url: 'https://discord.js.org/static/logo.svg' } });
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				image: { url: 'https://discord.js.org/static/logo.svg' },
 			});
 		});
@@ -225,7 +217,6 @@ describe('Embed', () => {
 			embed.setImage('https://discord.js.org/static/logo.svg');
 
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				image: { url: 'https://discord.js.org/static/logo.svg' },
 			});
 		});
@@ -234,7 +225,7 @@ describe('Embed', () => {
 			const embed = new Embed({ image: { url: 'https://discord.js/org/static/logo.svg' } });
 			embed.setImage(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, image: undefined });
+			expect(embed.toJSON()).toStrictEqual({ image: undefined });
 		});
 
 		test('GIVEN an embed with an invalid image THEN throws error', () => {
@@ -250,7 +241,6 @@ describe('Embed', () => {
 				author: { name: 'Wumpus', icon_url: 'https://discord.js.org/static/logo.svg', url: 'https://discord.js.org' },
 			});
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				author: { name: 'Wumpus', icon_url: 'https://discord.js.org/static/logo.svg', url: 'https://discord.js.org' },
 			});
 		});
@@ -264,7 +254,6 @@ describe('Embed', () => {
 			});
 
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				author: { name: 'Wumpus', icon_url: 'https://discord.js.org/static/logo.svg', url: 'https://discord.js.org' },
 			});
 		});
@@ -275,7 +264,7 @@ describe('Embed', () => {
 			});
 			embed.setAuthor(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, author: undefined });
+			expect(embed.toJSON()).toStrictEqual({ author: undefined });
 		});
 
 		test('GIVEN an embed with an invalid author name THEN throws error', () => {
@@ -291,7 +280,6 @@ describe('Embed', () => {
 				footer: { text: 'Wumpus', icon_url: 'https://discord.js.org/static/logo.svg' },
 			});
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				footer: { text: 'Wumpus', icon_url: 'https://discord.js.org/static/logo.svg' },
 			});
 		});
@@ -301,7 +289,6 @@ describe('Embed', () => {
 			embed.setFooter({ text: 'Wumpus', iconURL: 'https://discord.js.org/static/logo.svg' });
 
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				footer: { text: 'Wumpus', icon_url: 'https://discord.js.org/static/logo.svg' },
 			});
 		});
@@ -310,7 +297,7 @@ describe('Embed', () => {
 			const embed = new Embed({ footer: { text: 'Wumpus', icon_url: 'https://discord.js.org/static/logo.svg' } });
 			embed.setFooter(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, footer: undefined });
+			expect(embed.toJSON()).toStrictEqual({ footer: undefined });
 		});
 
 		test('GIVEN an embed with invalid footer text THEN throws error', () => {
@@ -326,7 +313,6 @@ describe('Embed', () => {
 				fields: [{ name: 'foo', value: 'bar', inline: undefined }],
 			});
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				fields: [{ name: 'foo', value: 'bar', inline: undefined }],
 			});
 		});
@@ -336,7 +322,6 @@ describe('Embed', () => {
 			embed.addField({ name: 'foo', value: 'bar' });
 
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				fields: [{ name: 'foo', value: 'bar', inline: undefined }],
 			});
 		});
@@ -346,7 +331,6 @@ describe('Embed', () => {
 			embed.addFields({ name: 'foo', value: 'bar' });
 
 			expect(embed.toJSON()).toStrictEqual({
-				...emptyEmbed,
 				fields: [{ name: 'foo', value: 'bar', inline: undefined }],
 			});
 		});
@@ -356,7 +340,6 @@ describe('Embed', () => {
 			embed.addFields({ name: 'foo', value: 'bar' }, { name: 'foo', value: 'baz' });
 
 			expect(embed.spliceFields(0, 1).toJSON()).toStrictEqual({
-				...emptyEmbed,
 				fields: [{ name: 'foo', value: 'baz', inline: undefined }],
 			});
 		});

--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -2,17 +2,7 @@ import { Embed } from '../../src';
 import type { APIEmbed } from 'discord-api-types/v9';
 
 const emptyEmbed: APIEmbed = {
-	author: undefined,
-	color: undefined,
-	description: undefined,
 	fields: [],
-	footer: undefined,
-	image: undefined,
-	provider: undefined,
-	thumbnail: undefined,
-	title: undefined,
-	url: undefined,
-	video: undefined,
 };
 
 const alpha = 'abcdefghijklmnopqrstuvwxyz';
@@ -55,7 +45,7 @@ describe('Embed', () => {
 			const embed = new Embed({ title: 'foo' });
 			embed.setTitle(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed });
+			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, title: undefined });
 		});
 
 		test('GIVEN an embed with an invalid title THEN throws error', () => {
@@ -82,7 +72,7 @@ describe('Embed', () => {
 			const embed = new Embed({ description: 'foo' });
 			embed.setDescription(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed });
+			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, description: undefined });
 		});
 
 		test('GIVEN an embed with an invalid description THEN throws error', () => {
@@ -115,7 +105,7 @@ describe('Embed', () => {
 			const embed = new Embed({ url: 'https://discord.js.org' });
 			embed.setURL(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed });
+			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, url: undefined });
 		});
 
 		test('GIVEN an embed with an invalid URL THEN throws error', () => {
@@ -142,7 +132,7 @@ describe('Embed', () => {
 			const embed = new Embed({ color: 0xff0000 });
 			embed.setColor(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed });
+			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, color: undefined });
 		});
 
 		test('GIVEN an embed with an invalid color THEN throws error', () => {
@@ -213,7 +203,7 @@ describe('Embed', () => {
 			const embed = new Embed({ thumbnail: { url: 'https://discord.js.org/static/logo.svg' } });
 			embed.setThumbnail(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed });
+			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, thumbnail: undefined });
 		});
 
 		test('GIVEN an embed with an invalid thumbnail THEN throws error', () => {
@@ -246,7 +236,7 @@ describe('Embed', () => {
 			const embed = new Embed({ image: { url: 'https://discord.js/org/static/logo.svg' } });
 			embed.setImage(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed });
+			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, image: undefined });
 		});
 
 		test('GIVEN an embed with an invalid image THEN throws error', () => {
@@ -287,7 +277,7 @@ describe('Embed', () => {
 			});
 			embed.setAuthor(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed });
+			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, author: undefined });
 		});
 
 		test('GIVEN an embed with an invalid author name THEN throws error', () => {
@@ -322,7 +312,7 @@ describe('Embed', () => {
 			const embed = new Embed({ footer: { text: 'Wumpus', icon_url: 'https://discord.js.org/static/logo.svg' } });
 			embed.setFooter(null);
 
-			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed });
+			expect(embed.toJSON()).toStrictEqual({ ...emptyEmbed, footer: undefined });
 		});
 
 		test('GIVEN an embed with invalid footer text THEN throws error', () => {

--- a/packages/builders/babel.config.js
+++ b/packages/builders/babel.config.js
@@ -12,12 +12,7 @@ module.exports = {
 				modules: 'commonjs',
 			},
 		],
-		[
-			'@babel/preset-typescript',
-			{
-				allowDeclareFields: true,
-			},
-		],
+		'@babel/preset-typescript',
 	],
 	plugins: ['babel-plugin-transform-typescript-metadata', ['@babel/plugin-proposal-decorators', { legacy: true }]],
 };

--- a/packages/builders/babel.config.js
+++ b/packages/builders/babel.config.js
@@ -12,7 +12,12 @@ module.exports = {
 				modules: 'commonjs',
 			},
 		],
-		'@babel/preset-typescript',
+		[
+			'@babel/preset-typescript',
+			{
+				allowDeclareFields: true,
+			},
+		],
 	],
 	plugins: ['babel-plugin-transform-typescript-metadata', ['@babel/plugin-proposal-decorators', { legacy: true }]],
 };

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -22,18 +22,9 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 > {
 	public readonly components: T[];
 
-	public constructor(data?: ActionRowData) {
-		// We don't destructure directly in the constructor because it can't properly
-		// handle possibly-undefined data, which causes invalid destructure runtime errors.
-		if (data?.components) {
-			const { components: initComponents, ...initData } = data;
-			super({ type: ComponentType.ActionRow, ...initData });
-		} else {
-			super({ type: ComponentType.ActionRow, ...data });
-		}
-
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		this.components = (data?.components?.map(createComponent) ?? []) as T[];
+	public constructor({ components, ...data }: ActionRowData = {}) {
+		super({ type: ComponentType.ActionRow, ...data });
+		this.components = (components?.map(createComponent) ?? []) as T[];
 	}
 
 	/**

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -1,6 +1,6 @@
-import { APIActionRowComponent, ComponentType } from 'discord-api-types/v9';
+import { type APIActionRowComponent, ComponentType } from 'discord-api-types/v9';
 import type { ButtonComponent, SelectMenuComponent } from '..';
-import type { Component } from './Component';
+import { Component } from './Component';
 import { createComponent } from './Components';
 
 export type MessageComponent = ActionRowComponent | ActionRow;
@@ -12,12 +12,18 @@ export type ActionRowComponent = ButtonComponent | SelectMenuComponent;
 /**
  * Represents an action row component
  */
-export class ActionRow<T extends ActionRowComponent = ActionRowComponent> implements Component {
+export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extends Component {
+	protected declare data: APIActionRowComponent;
 	public readonly components: T[] = [];
-	public readonly type = ComponentType.ActionRow;
 
 	public constructor(data?: APIActionRowComponent & { type?: ComponentType.ActionRow }) {
+		super(data);
+		this.data.type ??= ComponentType.ActionRow;
 		this.components = (data?.components.map(createComponent) ?? []) as T[];
+	}
+
+	public get type(): ComponentType.ActionRow {
+		return this.data.type;
 	}
 
 	/**
@@ -34,14 +40,15 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> implem
 	 * Sets the components in this action row
 	 * @param components The components to set this row to
 	 */
-	public setComponents(...components: T[]) {
-		Reflect.set(this, 'components', [...components]);
+	public setComponents(components: T[]) {
+		this.components.slice(0, this.components.length);
+		this.components.push(...components);
 		return this;
 	}
 
 	public toJSON(): APIActionRowComponent {
 		return {
-			...this,
+			...this.data,
 			components: this.components.map((component) => component.toJSON()),
 		};
 	}

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -1,4 +1,4 @@
-import { type APIActionRowComponent, ComponentType } from 'discord-api-types/v9';
+import { type APIActionRowComponent, ComponentType, APIMessageComponent } from 'discord-api-types/v9';
 import type { ButtonComponent, SelectMenuComponent } from '..';
 import { Component } from './Component';
 import { createComponent } from './Components';
@@ -9,17 +9,31 @@ export type ActionRowComponent = ButtonComponent | SelectMenuComponent;
 
 // TODO: Add valid form component types
 
+export interface ActionRowData extends Omit<APIActionRowComponent, 'type' | 'components'> {
+	type?: ComponentType.ActionRow;
+	components?: Exclude<APIMessageComponent, APIActionRowComponent>[];
+}
+
 /**
  * Represents an action row component
  */
 export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extends Component<
 	Omit<APIActionRowComponent, 'components'>
 > {
-	public readonly components: T[] = [];
+	public readonly components: T[];
 
-	public constructor({ components, ...data }: Omit<APIActionRowComponent, 'type'>) {
-		super({ type: ComponentType.ActionRow, ...data });
-		this.components = components.map(createComponent) as T[];
+	public constructor(data?: ActionRowData) {
+		// We don't destructure directly in the constructor because it can't properly
+		// handle possibly-undefined data, which causes invalid destructure runtime errors.
+		if (data?.components) {
+			const { components: initComponents, ...initData } = data;
+			super({ type: ComponentType.ActionRow, ...initData });
+		} else {
+			super({ type: ComponentType.ActionRow, ...data });
+		}
+
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		this.components = (data?.components?.map(createComponent) ?? []) as T[];
 	}
 
 	public get type(): ComponentType.ActionRow {

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -18,7 +18,7 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 
 	public constructor({ components, ...data }: Partial<APIActionRowComponent> = {}) {
 		super({ type: ComponentType.ActionRow, ...data });
-		this.components = (components?.map(createComponent) ?? []) as T[];
+		this.components = (components?.map((c) => createComponent(c)) ?? []) as T[];
 	}
 
 	/**

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -12,12 +12,14 @@ export type ActionRowComponent = ButtonComponent | SelectMenuComponent;
 /**
  * Represents an action row component
  */
-export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extends Component<APIActionRowComponent> {
+export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extends Component<
+	Omit<APIActionRowComponent, 'components'>
+> {
 	public readonly components: T[] = [];
 
-	public constructor(data?: APIActionRowComponent & { type?: ComponentType.ActionRow }) {
+	public constructor({ components, ...data }: Omit<APIActionRowComponent, 'type'>) {
 		super({ type: ComponentType.ActionRow, ...data });
-		this.components = (data?.components.map(createComponent) ?? []) as T[];
+		this.components = components.map(createComponent) as T[];
 	}
 
 	public get type(): ComponentType.ActionRow {

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -12,7 +12,7 @@ export type ActionRowComponent = ButtonComponent | SelectMenuComponent;
  * Represents an action row component
  */
 export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extends Component<
-	Omit<Partial<APIActionRowComponent>, 'components'>
+	Omit<Partial<APIActionRowComponent> & { type: ComponentType.ActionRow }, 'components'>
 > {
 	public readonly components: T[];
 
@@ -41,10 +41,9 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 	}
 
 	public toJSON(): APIActionRowComponent {
-		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		return {
 			...this.data,
 			components: this.components.map((component) => component.toJSON()),
-		} as APIActionRowComponent;
+		};
 	}
 }

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -12,8 +12,7 @@ export type ActionRowComponent = ButtonComponent | SelectMenuComponent;
 /**
  * Represents an action row component
  */
-export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extends Component {
-	protected declare data: APIActionRowComponent;
+export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extends Component<APIActionRowComponent> {
 	public readonly components: T[] = [];
 
 	public constructor(data?: APIActionRowComponent & { type?: ComponentType.ActionRow }) {

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -17,8 +17,7 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 	public readonly components: T[] = [];
 
 	public constructor(data?: APIActionRowComponent & { type?: ComponentType.ActionRow }) {
-		super(data);
-		this.data.type ??= ComponentType.ActionRow;
+		super({ type: ComponentType.ActionRow, ...data });
 		this.components = (data?.components.map(createComponent) ?? []) as T[];
 	}
 
@@ -41,8 +40,7 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 	 * @param components The components to set this row to
 	 */
 	public setComponents(components: T[]) {
-		this.components.slice(0, this.components.length);
-		this.components.push(...components);
+		this.components.splice(0, this.components.length, ...components);
 		return this;
 	}
 

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -1,4 +1,4 @@
-import { type APIActionRowComponent, ComponentType, APIMessageComponent } from 'discord-api-types/v9';
+import { type APIActionRowComponent, ComponentType } from 'discord-api-types/v9';
 import type { ButtonComponent, SelectMenuComponent } from '..';
 import { Component } from './Component';
 import { createComponent } from './Components';
@@ -8,21 +8,15 @@ export type MessageComponent = ActionRowComponent | ActionRow;
 export type ActionRowComponent = ButtonComponent | SelectMenuComponent;
 
 // TODO: Add valid form component types
-
-export interface ActionRowData extends Omit<APIActionRowComponent, 'type' | 'components'> {
-	type?: ComponentType.ActionRow;
-	components?: Exclude<APIMessageComponent, APIActionRowComponent>[];
-}
-
 /**
  * Represents an action row component
  */
 export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extends Component<
-	Omit<APIActionRowComponent, 'components'>
+	Omit<Partial<APIActionRowComponent>, 'components'>
 > {
 	public readonly components: T[];
 
-	public constructor({ components, ...data }: ActionRowData = {}) {
+	public constructor({ components, ...data }: Partial<APIActionRowComponent> = {}) {
 		super({ type: ComponentType.ActionRow, ...data });
 		this.components = (components?.map(createComponent) ?? []) as T[];
 	}
@@ -47,9 +41,10 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 	}
 
 	public toJSON(): APIActionRowComponent {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		return {
 			...this.data,
 			components: this.components.map((component) => component.toJSON()),
-		};
+		} as APIActionRowComponent;
 	}
 }

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -36,10 +36,6 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 		this.components = (data?.components?.map(createComponent) ?? []) as T[];
 	}
 
-	public get type(): ComponentType.ActionRow {
-		return this.data.type;
-	}
-
 	/**
 	 * Adds components to this action row.
 	 * @param components The components to add to this action row.

--- a/packages/builders/src/components/Assertions.ts
+++ b/packages/builders/src/components/Assertions.ts
@@ -40,7 +40,7 @@ export function validateRequiredSelectMenuOptionParameters(label?: string, value
 export const urlValidator = z.string().url();
 
 export function validateRequiredButtonParameters(
-	style: ButtonStyle,
+	style?: ButtonStyle,
 	label?: string,
 	emoji?: APIMessageComponentEmoji,
 	customId?: string,

--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -4,9 +4,20 @@ import type { JSONEncodable } from '../util/jsonEncodable';
 /**
  * Represents a discord component
  */
-export interface Component extends JSONEncodable<APIMessageComponent> {
+export abstract class Component implements JSONEncodable<APIMessageComponent> {
+	/**
+	 * The api data associated with this component
+	 */
+	protected data!: APIMessageComponent;
+
 	/**
 	 * The type of this component
 	 */
-	readonly type: ComponentType;
+	public abstract readonly type: ComponentType;
+
+	public constructor(data: APIMessageComponent & { type?: ComponentType } = {} as APIMessageComponent) {
+		this.data = data;
+	}
+
+	public abstract toJSON(): APIMessageComponent;
 }

--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -9,7 +9,7 @@ export abstract class Component<
 > implements JSONEncodable<APIMessageComponent>
 {
 	/**
-	 * The api data associated with this component
+	 * The API data associated with this component
 	 */
 	protected data: DataType;
 

--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -5,7 +5,7 @@ import type { APIBaseMessageComponent, APIMessageComponent, ComponentType } from
  * Represents a discord component
  */
 export abstract class Component<
-	DataType extends APIBaseMessageComponent<ComponentType> = APIBaseMessageComponent<ComponentType>,
+	DataType extends Partial<APIBaseMessageComponent<ComponentType>> = APIBaseMessageComponent<ComponentType>,
 > implements JSONEncodable<APIMessageComponent>
 {
 	/**

--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -5,7 +5,9 @@ import type { APIBaseMessageComponent, APIMessageComponent, ComponentType } from
  * Represents a discord component
  */
 export abstract class Component<
-	DataType extends Partial<APIBaseMessageComponent<ComponentType>> = APIBaseMessageComponent<ComponentType>,
+	DataType extends Partial<APIBaseMessageComponent<ComponentType>> & {
+		type: ComponentType;
+	} = APIBaseMessageComponent<ComponentType>,
 > implements JSONEncodable<APIMessageComponent>
 {
 	/**

--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -4,23 +4,26 @@ import type { APIBaseMessageComponent, APIMessageComponent, ComponentType } from
 /**
  * Represents a discord component
  */
-export abstract class Component implements JSONEncodable<APIMessageComponent> {
+export abstract class Component<
+	DataType extends APIBaseMessageComponent<ComponentType> = APIBaseMessageComponent<ComponentType>,
+> implements JSONEncodable<APIMessageComponent>
+{
 	/**
 	 * The api data associated with this component
 	 */
-	protected data: APIBaseMessageComponent<ComponentType>;
+	protected data: DataType;
 
 	/**
 	 * The type of this component
 	 */
 	public abstract readonly type: ComponentType;
 
-	public constructor(data: APIBaseMessageComponent<ComponentType>) {
-		this.data = data;
-	}
-
 	/**
 	 * Converts this component to an API-compatible JSON object
 	 */
 	public abstract toJSON(): APIMessageComponent;
+
+	public constructor(data: APIBaseMessageComponent<ComponentType>) {
+		this.data = data as DataType;
+	}
 }

--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -11,7 +11,7 @@ export abstract class Component<
 	/**
 	 * The API data associated with this component
 	 */
-	protected data: DataType;
+	protected readonly data: DataType;
 
 	/**
 	 * Converts this component to an API-compatible JSON object

--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -1,5 +1,5 @@
-import type { APIMessageComponent, ComponentType } from 'discord-api-types/v9';
 import type { JSONEncodable } from '../util/jsonEncodable';
+import type { APIBaseMessageComponent, APIMessageComponent, ComponentType } from 'discord-api-types/v9';
 
 /**
  * Represents a discord component
@@ -8,16 +8,19 @@ export abstract class Component implements JSONEncodable<APIMessageComponent> {
 	/**
 	 * The api data associated with this component
 	 */
-	protected data!: APIMessageComponent;
+	protected data: APIBaseMessageComponent<ComponentType>;
 
 	/**
 	 * The type of this component
 	 */
 	public abstract readonly type: ComponentType;
 
-	public constructor(data: APIMessageComponent & { type?: ComponentType } = {} as APIMessageComponent) {
+	public constructor(data: APIBaseMessageComponent<ComponentType>) {
 		this.data = data;
 	}
 
+	/**
+	 * Converts this component to an API-compatible JSON object
+	 */
 	public abstract toJSON(): APIMessageComponent;
 }

--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -23,7 +23,7 @@ export abstract class Component<
 	 */
 	public abstract toJSON(): APIMessageComponent;
 
-	public constructor(data: APIBaseMessageComponent<ComponentType>) {
-		this.data = data as DataType;
+	public constructor(data: DataType) {
+		this.data = data;
 	}
 }

--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -14,16 +14,18 @@ export abstract class Component<
 	protected data: DataType;
 
 	/**
-	 * The type of this component
-	 */
-	public abstract readonly type: ComponentType;
-
-	/**
 	 * Converts this component to an API-compatible JSON object
 	 */
 	public abstract toJSON(): APIMessageComponent;
 
 	public constructor(data: DataType) {
 		this.data = data;
+	}
+
+	/**
+	 * The type of this component
+	 */
+	public get type(): DataType['type'] {
+		return this.data.type;
 	}
 }

--- a/packages/builders/src/components/Components.ts
+++ b/packages/builders/src/components/Components.ts
@@ -19,11 +19,11 @@ export function createComponent<C extends MessageComponent>(data: C): C;
 export function createComponent(data: APIMessageComponent | MessageComponent): Component {
 	switch (data.type) {
 		case ComponentType.ActionRow:
-			return data instanceof ActionRow ? data : new ActionRow(data);
+			return (data instanceof ActionRow ? data : new ActionRow(data)) as Component;
 		case ComponentType.Button:
-			return data instanceof ButtonComponent ? data : new ButtonComponent(data);
+			return (data instanceof ButtonComponent ? data : new ButtonComponent(data)) as Component;
 		case ComponentType.SelectMenu:
-			return data instanceof SelectMenuComponent ? data : new SelectMenuComponent(data);
+			return (data instanceof SelectMenuComponent ? data : new SelectMenuComponent(data)) as Component;
 		default:
 			// @ts-expect-error
 			throw new Error(`Cannot serialize component type: ${data.type as number}`);

--- a/packages/builders/src/components/button/Button.ts
+++ b/packages/builders/src/components/button/Button.ts
@@ -36,7 +36,7 @@ export class ButtonComponent extends UnsafeButtonComponent {
 	}
 
 	public override toJSON(): APIButtonComponent {
-		validateRequiredButtonParameters(this.style, this.label, this.emoji, this.custom_id, this.url);
+		validateRequiredButtonParameters(this.style, this.label, this.emoji, this.customId, this.url);
 		return super.toJSON();
 	}
 }

--- a/packages/builders/src/components/button/Button.ts
+++ b/packages/builders/src/components/button/Button.ts
@@ -10,6 +10,9 @@ import {
 } from '../Assertions';
 import { UnsafeButtonComponent } from './UnsafeButton';
 
+/**
+ * Represents a validated button component
+ */
 export class ButtonComponent extends UnsafeButtonComponent {
 	public override setStyle(style: ButtonStyle) {
 		return super.setStyle(buttonStyleValidator.parse(style));

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -8,16 +8,12 @@ import {
 } from 'discord-api-types/v9';
 import { Component } from '../Component';
 
-export interface ButtonComponentData extends Omit<APIButtonComponent, 'type'> {
-	type?: ComponentType.Button;
-}
-
 /**
  * Represents a non-validated button component
  */
-export class UnsafeButtonComponent extends Component<APIButtonComponent> {
-	public constructor(data?: ButtonComponentData) {
-		super({ type: ComponentType.Button, ...data } as APIButtonComponent);
+export class UnsafeButtonComponent extends Component<Partial<APIButtonComponent>> {
+	public constructor(data?: Partial<APIButtonComponent>) {
+		super({ type: ComponentType.Button, ...data });
 	}
 
 	/**
@@ -117,8 +113,9 @@ export class UnsafeButtonComponent extends Component<APIButtonComponent> {
 	}
 
 	public toJSON(): APIButtonComponent {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		return {
 			...this.data,
-		};
+		} as APIButtonComponent;
 	}
 }

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -3,8 +3,8 @@ import {
 	ButtonStyle,
 	type APIMessageComponentEmoji,
 	type APIButtonComponent,
-	APIButtonComponentWithURL,
-	APIButtonComponentWithCustomId,
+	type APIButtonComponentWithURL,
+	type APIButtonComponentWithCustomId,
 } from 'discord-api-types/v9';
 import { Component } from '../Component';
 

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -12,36 +12,53 @@ export interface ButtonComponentData extends Omit<APIButtonComponent, 'type'> {
 	type?: ComponentType.Button;
 }
 
+/**
+ * Represents a non-validated button component
+ */
 export class UnsafeButtonComponent extends Component<APIButtonComponent> {
 	public constructor(data?: ButtonComponentData) {
 		super({ type: ComponentType.Button, ...data } as APIButtonComponent);
 	}
 
-	public get type(): ComponentType.Button {
-		return this.data.type;
-	}
-
+	/**
+	 * The style of this button
+	 */
 	public get style() {
 		return this.data.style;
 	}
 
+	/**
+	 * The label of this button
+	 */
 	public get label() {
 		return this.data.label;
 	}
 
+	/**
+	 * The emoji used in this button
+	 */
 	public get emoji() {
 		return this.data.emoji;
 	}
 
+	/**
+	 * Whether or not this button is disabled
+	 */
 	public get disabled() {
 		return this.data.disabled;
 	}
 
-	public get customId() {
+	/**
+	 * The custom ID of this button (only defined on non-link buttons)
+	 */
+	public get customId(): string | undefined {
 		return (this.data as APIButtonComponentWithCustomId).custom_id;
 	}
 
-	public get url() {
+	/**
+	 * The URL of this button (only defined on link buttons)
+	 */
+	public get url(): string | undefined {
 		return (this.data as APIButtonComponentWithURL).url;
 	}
 

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -11,7 +11,7 @@ import { Component } from '../Component';
 /**
  * Represents a non-validated button component
  */
-export class UnsafeButtonComponent extends Component<Partial<APIButtonComponent>> {
+export class UnsafeButtonComponent extends Component<Partial<APIButtonComponent> & { type: ComponentType.Button }> {
 	public constructor(data?: Partial<APIButtonComponent>) {
 		super({ type: ComponentType.Button, ...data });
 	}

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -8,9 +8,7 @@ import {
 } from 'discord-api-types/v9';
 import { Component } from '../Component';
 
-export class UnsafeButtonComponent extends Component {
-	protected declare data: APIButtonComponent;
-
+export class UnsafeButtonComponent extends Component<APIButtonComponent> {
 	public constructor(data?: APIButtonComponent) {
 		super({ type: ComponentType.Button, ...data });
 	}

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -8,8 +8,12 @@ import {
 } from 'discord-api-types/v9';
 import { Component } from '../Component';
 
+export interface ButtonComponentData extends Omit<APIButtonComponent, 'type'> {
+	type?: ComponentType.Button;
+}
+
 export class UnsafeButtonComponent extends Component<APIButtonComponent> {
-	public constructor(data?: Omit<APIButtonComponent, 'type'>) {
+	public constructor(data?: ButtonComponentData) {
 		super({ type: ComponentType.Button, ...data } as APIButtonComponent);
 	}
 

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -3,33 +3,45 @@ import {
 	ButtonStyle,
 	type APIMessageComponentEmoji,
 	type APIButtonComponent,
+	APIButtonComponentWithURL,
+	APIButtonComponentWithCustomId,
 } from 'discord-api-types/v9';
-import type { Component } from '../Component';
+import { Component } from '../Component';
 
-export class UnsafeButtonComponent implements Component {
-	public readonly type = ComponentType.Button as const;
-	public readonly style!: ButtonStyle;
-	public readonly label?: string;
-	public readonly emoji?: APIMessageComponentEmoji;
-	public readonly disabled?: boolean;
-	public readonly custom_id!: string;
-	public readonly url!: string;
+export class UnsafeButtonComponent extends Component {
+	protected declare data: APIButtonComponent;
 
 	public constructor(data?: APIButtonComponent & { type?: ComponentType.Button }) {
-		/* eslint-disable @typescript-eslint/non-nullable-type-assertion-style */
-		this.style = data?.style as ButtonStyle;
-		this.label = data?.label;
-		this.emoji = data?.emoji;
-		this.disabled = data?.disabled;
+		super(data);
+		this.data.type ??= ComponentType.Button;
+	}
 
-		// This if/else makes typescript happy
-		if (data?.style === ButtonStyle.Link) {
-			this.url = data.url;
-		} else {
-			this.custom_id = data?.custom_id as string;
-		}
+	public get type(): ComponentType.Button {
+		return this.data.type;
+	}
 
-		/* eslint-enable @typescript-eslint/non-nullable-type-assertion-style */
+	public get style() {
+		return this.data.style;
+	}
+
+	public get label() {
+		return this.data.label;
+	}
+
+	public get emoji() {
+		return this.data.emoji;
+	}
+
+	public get disabled() {
+		return this.data.disabled;
+	}
+
+	public get customId() {
+		return (this.data as APIButtonComponentWithCustomId).custom_id;
+	}
+
+	public get url() {
+		return (this.data as APIButtonComponentWithURL).url;
 	}
 
 	/**
@@ -37,7 +49,7 @@ export class UnsafeButtonComponent implements Component {
 	 * @param style The style of the button
 	 */
 	public setStyle(style: ButtonStyle) {
-		Reflect.set(this, 'style', style);
+		this.data.style = style;
 		return this;
 	}
 
@@ -46,7 +58,7 @@ export class UnsafeButtonComponent implements Component {
 	 * @param url The URL to open when this button is clicked
 	 */
 	public setURL(url: string) {
-		Reflect.set(this, 'url', url);
+		(this.data as APIButtonComponentWithURL).url = url;
 		return this;
 	}
 
@@ -55,7 +67,7 @@ export class UnsafeButtonComponent implements Component {
 	 * @param customId The custom ID to use for this button
 	 */
 	public setCustomId(customId: string) {
-		Reflect.set(this, 'custom_id', customId);
+		(this.data as APIButtonComponentWithCustomId).custom_id = customId;
 		return this;
 	}
 
@@ -64,7 +76,7 @@ export class UnsafeButtonComponent implements Component {
 	 * @param emoji The emoji to display on this button
 	 */
 	public setEmoji(emoji: APIMessageComponentEmoji) {
-		Reflect.set(this, 'emoji', emoji);
+		this.data.emoji = emoji;
 		return this;
 	}
 
@@ -73,7 +85,7 @@ export class UnsafeButtonComponent implements Component {
 	 * @param disabled Whether or not to disable this button or not
 	 */
 	public setDisabled(disabled: boolean) {
-		Reflect.set(this, 'disabled', disabled);
+		this.data.disabled = disabled;
 		return this;
 	}
 
@@ -82,13 +94,13 @@ export class UnsafeButtonComponent implements Component {
 	 * @param label The label to display on this button
 	 */
 	public setLabel(label: string) {
-		Reflect.set(this, 'label', label);
+		this.data.label = label;
 		return this;
 	}
 
 	public toJSON(): APIButtonComponent {
 		return {
-			...this,
+			...this.data,
 		};
 	}
 }

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -11,9 +11,8 @@ import { Component } from '../Component';
 export class UnsafeButtonComponent extends Component {
 	protected declare data: APIButtonComponent;
 
-	public constructor(data?: APIButtonComponent & { type?: ComponentType.Button }) {
-		super(data);
-		this.data.type ??= ComponentType.Button;
+	public constructor(data?: APIButtonComponent) {
+		super({ type: ComponentType.Button, ...data });
 	}
 
 	public get type(): ComponentType.Button {

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -42,14 +42,14 @@ export class UnsafeButtonComponent extends Component<APIButtonComponent> {
 	}
 
 	/**
-	 * Whether or not this button is disabled
+	 * Whether this button is disabled
 	 */
 	public get disabled() {
 		return this.data.disabled;
 	}
 
 	/**
-	 * The custom ID of this button (only defined on non-link buttons)
+	 * The custom id of this button (only defined on non-link buttons)
 	 */
 	public get customId(): string | undefined {
 		return (this.data as APIButtonComponentWithCustomId).custom_id;
@@ -82,7 +82,7 @@ export class UnsafeButtonComponent extends Component<APIButtonComponent> {
 
 	/**
 	 * Sets the custom Id for this button
-	 * @param customId The custom ID to use for this button
+	 * @param customId The custom id to use for this button
 	 */
 	public setCustomId(customId: string) {
 		(this.data as APIButtonComponentWithCustomId).custom_id = customId;

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -9,8 +9,8 @@ import {
 import { Component } from '../Component';
 
 export class UnsafeButtonComponent extends Component<APIButtonComponent> {
-	public constructor(data?: APIButtonComponent) {
-		super({ type: ComponentType.Button, ...data });
+	public constructor(data?: Omit<APIButtonComponent, 'type'>) {
+		super({ type: ComponentType.Button, ...data } as APIButtonComponent);
 	}
 
 	public get type(): ComponentType.Button {

--- a/packages/builders/src/components/selectMenu/SelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/SelectMenu.ts
@@ -9,7 +9,7 @@ import {
 import { UnsafeSelectMenuComponent } from './UnsafeSelectMenu';
 
 /**
- * Represents a select menu component
+ * Represents a validated select menu component
  */
 export class SelectMenuComponent extends UnsafeSelectMenuComponent {
 	public override setPlaceholder(placeholder: string) {

--- a/packages/builders/src/components/selectMenu/SelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/SelectMenu.ts
@@ -33,7 +33,7 @@ export class SelectMenuComponent extends UnsafeSelectMenuComponent {
 	}
 
 	public override toJSON(): APISelectMenuComponent {
-		validateRequiredSelectMenuParameters(this.options, this.custom_id);
+		validateRequiredSelectMenuParameters(this.options, this.customId);
 		return super.toJSON();
 	}
 }

--- a/packages/builders/src/components/selectMenu/SelectMenuOption.ts
+++ b/packages/builders/src/components/selectMenu/SelectMenuOption.ts
@@ -8,7 +8,7 @@ import {
 import { UnsafeSelectMenuOption } from './UnsafeSelectMenuOption';
 
 /**
- * Represents an option within a select menu component
+ * Represents a validated option within a select menu component
  */
 export class SelectMenuOption extends UnsafeSelectMenuOption {
 	public override setDescription(description: string) {

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -14,16 +14,9 @@ export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuCompo
 	public readonly options: UnsafeSelectMenuOption[];
 
 	public constructor(data?: SelectMenuComponentData) {
-		// We don't destructure directly in the constructor because it can't properly
-		// handle possibly-undefined data, which causes invalid destructure runtime errors.
-		if (data?.options) {
-			const { options, ...initData } = data;
-			super({ type: ComponentType.SelectMenu, ...initData });
-		} else {
-			super({ type: ComponentType.SelectMenu, ...data! });
-		}
-
-		this.options = data?.options?.map((o) => new UnsafeSelectMenuOption(o)) ?? [];
+		const { options, ...initData } = data ?? {};
+		super({ type: ComponentType.SelectMenu, ...initData } as APISelectMenuComponent);
+		this.options = options?.map((o) => new UnsafeSelectMenuOption(o)) ?? [];
 	}
 
 	/**

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -1,16 +1,29 @@
-import { ComponentType, type APISelectMenuComponent } from 'discord-api-types/v9';
+import { APISelectMenuOption, ComponentType, type APISelectMenuComponent } from 'discord-api-types/v9';
 import { Component } from '../Component';
 import { UnsafeSelectMenuOption } from './UnsafeSelectMenuOption';
+
+export interface SelectMenuComponentData extends Omit<APISelectMenuComponent, 'type' | 'options'> {
+	type?: ComponentType.SelectMenu;
+	options?: APISelectMenuOption[];
+}
 
 /**
  * Represents a non-validated select menu component
  */
 export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuComponent, 'options'>> {
-	public readonly options: UnsafeSelectMenuOption[] = [];
+	public readonly options: UnsafeSelectMenuOption[];
 
-	public constructor({ options, ...data }: Omit<APISelectMenuComponent, 'type'>) {
-		super({ type: ComponentType.SelectMenu, ...data });
-		this.options = options.map((o) => new UnsafeSelectMenuOption(o));
+	public constructor(data?: SelectMenuComponentData) {
+		// We don't destructure directly in the constructor because it can't properly
+		// handle possibly-undefined data, which causes invalid destructure runtime errors.
+		if (data?.options) {
+			const { options: initOptions, ...initData } = data;
+			super({ type: ComponentType.SelectMenu, ...initData });
+		} else {
+			super({ type: ComponentType.SelectMenu, ...data! });
+		}
+
+		this.options = data?.options?.map((o) => new UnsafeSelectMenuOption(o)) ?? [];
 	}
 
 	public get type(): ComponentType.SelectMenu {

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -1,17 +1,19 @@
-import { ComponentType, type APISelectMenuComponent } from 'discord-api-types/v9';
+import { APISelectMenuOption, ComponentType, type APISelectMenuComponent } from 'discord-api-types/v9';
 import { Component } from '../Component';
 import { UnsafeSelectMenuOption } from './UnsafeSelectMenuOption';
 
 /**
  * Represents a non-validated select menu component
  */
-export class UnsafeSelectMenuComponent extends Component {
-	protected declare data: APISelectMenuComponent;
+export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuComponent, 'options'>> {
 	public readonly options: UnsafeSelectMenuOption[] = [];
 
-	public constructor(data?: APISelectMenuComponent) {
-		super({ type: ComponentType.SelectMenu, options: [], ...data });
-		this.options = this.data.options.map((o) => new UnsafeSelectMenuOption(o));
+	public constructor(
+		data?: APISelectMenuComponent & { type?: ComponentType.SelectMenu; options?: APISelectMenuOption[] },
+	) {
+		super({ type: ComponentType.SelectMenu, ...data });
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+		this.options = data?.options?.map((o) => new UnsafeSelectMenuOption(o)) ?? [];
 	}
 
 	public get type(): ComponentType.SelectMenu {

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -1,4 +1,4 @@
-import { APISelectMenuOption, ComponentType, type APISelectMenuComponent } from 'discord-api-types/v9';
+import { ComponentType, type APISelectMenuComponent } from 'discord-api-types/v9';
 import { Component } from '../Component';
 import { UnsafeSelectMenuOption } from './UnsafeSelectMenuOption';
 
@@ -8,12 +8,9 @@ import { UnsafeSelectMenuOption } from './UnsafeSelectMenuOption';
 export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuComponent, 'options'>> {
 	public readonly options: UnsafeSelectMenuOption[] = [];
 
-	public constructor(
-		data?: APISelectMenuComponent & { type?: ComponentType.SelectMenu; options?: APISelectMenuOption[] },
-	) {
+	public constructor({ options, ...data }: Omit<APISelectMenuComponent, 'type'>) {
 		super({ type: ComponentType.SelectMenu, ...data });
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-		this.options = data?.options?.map((o) => new UnsafeSelectMenuOption(o)) ?? [];
+		this.options = options.map((o) => new UnsafeSelectMenuOption(o));
 	}
 
 	public get type(): ComponentType.SelectMenu {

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -17,7 +17,7 @@ export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuCompo
 		// We don't destructure directly in the constructor because it can't properly
 		// handle possibly-undefined data, which causes invalid destructure runtime errors.
 		if (data?.options) {
-			const { options: initOptions, ...initData } = data;
+			const { options, ...initData } = data;
 			super({ type: ComponentType.SelectMenu, ...initData });
 		} else {
 			super({ type: ComponentType.SelectMenu, ...data! });
@@ -69,7 +69,7 @@ export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuCompo
 	}
 
 	/**
-	 * Sets thes maximum values that must be selected in the select menu
+	 * Sets the maximum values that must be selected in the select menu
 	 * @param minValues The maximum values that must be selected
 	 */
 	public setMaxValues(maxValues: number) {

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -10,9 +10,7 @@ export class UnsafeSelectMenuComponent extends Component {
 	public readonly options: UnsafeSelectMenuOption[] = [];
 
 	public constructor(data?: APISelectMenuComponent) {
-		super(data);
-		this.data.type ??= ComponentType.SelectMenu;
-		this.data.options ??= [];
+		super({ type: ComponentType.SelectMenu, options: [], ...data });
 		this.options = this.data.options.map((o) => new UnsafeSelectMenuOption(o));
 	}
 
@@ -100,8 +98,7 @@ export class UnsafeSelectMenuComponent extends Component {
 	 * @param options The options to set on this select menu
 	 */
 	public setOptions(options: UnsafeSelectMenuOption[]) {
-		this.options.splice(0, this.options.length);
-		this.options.push(...options);
+		this.options.splice(0, this.options.length, ...options);
 		return this;
 	}
 

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -48,7 +48,7 @@ export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuCompo
 	}
 
 	/**
-	 * Whether or not this select menu is disabled
+	 * Whether this select menu is disabled
 	 */
 	public get disabled() {
 		return this.data.disabled;
@@ -83,7 +83,7 @@ export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuCompo
 
 	/**
 	 * Sets the custom Id for this select menu
-	 * @param customId The custom ID to use for this select menu
+	 * @param customId The custom id to use for this select menu
 	 */
 	public setCustomId(customId: string) {
 		this.data.custom_id = customId;

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -26,26 +26,37 @@ export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuCompo
 		this.options = data?.options?.map((o) => new UnsafeSelectMenuOption(o)) ?? [];
 	}
 
-	public get type(): ComponentType.SelectMenu {
-		return this.data.type;
-	}
-
+	/**
+	 * The placeholder for this select menu
+	 */
 	public get placeholder() {
 		return this.data.placeholder;
 	}
 
+	/**
+	 * The maximum amount of options that can be selected
+	 */
 	public get maxValues() {
 		return this.data.max_values;
 	}
 
+	/**
+	 * The minimum amount of options that must be selected
+	 */
 	public get minValues() {
 		return this.data.min_values;
 	}
 
+	/**
+	 * The custom ID of this select menu
+	 */
 	public get customId() {
 		return this.data.custom_id;
 	}
 
+	/**
+	 * Whether or not this select menu is disabled
+	 */
 	public get disabled() {
 		return this.data.disabled;
 	}

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -1,28 +1,43 @@
 import { ComponentType, type APISelectMenuComponent } from 'discord-api-types/v9';
-import type { Component } from '../Component';
-import { SelectMenuOption } from './SelectMenuOption';
+import { Component } from '../Component';
+import { UnsafeSelectMenuOption } from './UnsafeSelectMenuOption';
 
 /**
  * Represents a non-validated select menu component
  */
-export class UnsafeSelectMenuComponent implements Component {
-	public readonly type = ComponentType.SelectMenu as const;
-	public readonly options: SelectMenuOption[];
-	public readonly placeholder?: string;
-	public readonly min_values?: number;
-	public readonly max_values?: number;
-	public readonly custom_id!: string;
-	public readonly disabled?: boolean;
+export class UnsafeSelectMenuComponent extends Component {
+	protected declare data: APISelectMenuComponent;
+	public readonly options: UnsafeSelectMenuOption[] = [];
 
 	public constructor(data?: APISelectMenuComponent) {
-		this.options = data?.options.map((option) => new SelectMenuOption(option)) ?? [];
-		this.placeholder = data?.placeholder;
-		this.min_values = data?.min_values;
-		this.max_values = data?.max_values;
-		/* eslint-disable @typescript-eslint/non-nullable-type-assertion-style */
-		this.custom_id = data?.custom_id as string;
-		/* eslint-enable @typescript-eslint/non-nullable-type-assertion-style */
-		this.disabled = data?.disabled;
+		super(data);
+		this.data.type ??= ComponentType.SelectMenu;
+		this.data.options ??= [];
+		this.options = this.data.options.map((o) => new UnsafeSelectMenuOption(o));
+	}
+
+	public get type(): ComponentType.SelectMenu {
+		return this.data.type;
+	}
+
+	public get placeholder() {
+		return this.data.placeholder;
+	}
+
+	public get maxValues() {
+		return this.data.max_values;
+	}
+
+	public get minValues() {
+		return this.data.min_values;
+	}
+
+	public get customId() {
+		return this.data.custom_id;
+	}
+
+	public get disabled() {
+		return this.data.disabled;
 	}
 
 	/**
@@ -30,16 +45,16 @@ export class UnsafeSelectMenuComponent implements Component {
 	 * @param placeholder The placeholder to use for this select menu
 	 */
 	public setPlaceholder(placeholder: string) {
-		Reflect.set(this, 'placeholder', placeholder);
+		this.data.placeholder = placeholder;
 		return this;
 	}
 
 	/**
-	 * Sets thes minimum values that must be selected in the select menu
+	 * Sets the minimum values that must be selected in the select menu
 	 * @param minValues The minimum values that must be selected
 	 */
 	public setMinValues(minValues: number) {
-		Reflect.set(this, 'min_values', minValues);
+		this.data.min_values = minValues;
 		return this;
 	}
 
@@ -48,7 +63,7 @@ export class UnsafeSelectMenuComponent implements Component {
 	 * @param minValues The maximum values that must be selected
 	 */
 	public setMaxValues(maxValues: number) {
-		Reflect.set(this, 'max_values', maxValues);
+		this.data.max_values = maxValues;
 		return this;
 	}
 
@@ -57,7 +72,7 @@ export class UnsafeSelectMenuComponent implements Component {
 	 * @param customId The custom ID to use for this select menu
 	 */
 	public setCustomId(customId: string) {
-		Reflect.set(this, 'custom_id', customId);
+		this.data.custom_id = customId;
 		return this;
 	}
 
@@ -66,7 +81,7 @@ export class UnsafeSelectMenuComponent implements Component {
 	 * @param disabled Whether or not this select menu is disabled
 	 */
 	public setDisabled(disabled: boolean) {
-		Reflect.set(this, 'disabled', disabled);
+		this.data.disabled = disabled;
 		return this;
 	}
 
@@ -75,7 +90,7 @@ export class UnsafeSelectMenuComponent implements Component {
 	 * @param options The options to add to this select menu
 	 * @returns
 	 */
-	public addOptions(...options: SelectMenuOption[]) {
+	public addOptions(...options: UnsafeSelectMenuOption[]) {
 		this.options.push(...options);
 		return this;
 	}
@@ -84,15 +99,16 @@ export class UnsafeSelectMenuComponent implements Component {
 	 * Sets the options on this select menu
 	 * @param options The options to set on this select menu
 	 */
-	public setOptions(...options: SelectMenuOption[]) {
-		Reflect.set(this, 'options', [...options]);
+	public setOptions(options: UnsafeSelectMenuOption[]) {
+		this.options.splice(0, this.options.length);
+		this.options.push(...options);
 		return this;
 	}
 
 	public toJSON(): APISelectMenuComponent {
 		return {
-			...this,
-			options: this.options.map((option) => option.toJSON()),
+			...this.data,
+			options: this.options.map((o) => o.toJSON()),
 		};
 	}
 }

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -1,21 +1,16 @@
-import { APISelectMenuOption, ComponentType, type APISelectMenuComponent } from 'discord-api-types/v9';
+import { ComponentType, type APISelectMenuComponent } from 'discord-api-types/v9';
 import { Component } from '../Component';
 import { UnsafeSelectMenuOption } from './UnsafeSelectMenuOption';
-
-export interface SelectMenuComponentData extends Omit<APISelectMenuComponent, 'type' | 'options'> {
-	type?: ComponentType.SelectMenu;
-	options?: APISelectMenuOption[];
-}
 
 /**
  * Represents a non-validated select menu component
  */
-export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuComponent, 'options'>> {
+export class UnsafeSelectMenuComponent extends Component<Partial<Omit<APISelectMenuComponent, 'options'>>> {
 	public readonly options: UnsafeSelectMenuOption[];
 
-	public constructor(data?: SelectMenuComponentData) {
+	public constructor(data?: Partial<APISelectMenuComponent>) {
 		const { options, ...initData } = data ?? {};
-		super({ type: ComponentType.SelectMenu, ...initData } as APISelectMenuComponent);
+		super({ type: ComponentType.SelectMenu, ...initData });
 		this.options = options?.map((o) => new UnsafeSelectMenuOption(o)) ?? [];
 	}
 
@@ -119,9 +114,10 @@ export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuCompo
 	}
 
 	public toJSON(): APISelectMenuComponent {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		return {
 			...this.data,
 			options: this.options.map((o) => o.toJSON()),
-		};
+		} as APISelectMenuComponent;
 	}
 }

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -5,7 +5,9 @@ import { UnsafeSelectMenuOption } from './UnsafeSelectMenuOption';
 /**
  * Represents a non-validated select menu component
  */
-export class UnsafeSelectMenuComponent extends Component<Partial<Omit<APISelectMenuComponent, 'options'>>> {
+export class UnsafeSelectMenuComponent extends Component<
+	Partial<Omit<APISelectMenuComponent, 'options'>> & { type: ComponentType.SelectMenu }
+> {
 	public readonly options: UnsafeSelectMenuOption[];
 
 	public constructor(data?: Partial<APISelectMenuComponent>) {

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -41,7 +41,7 @@ export class UnsafeSelectMenuComponent extends Component<Omit<APISelectMenuCompo
 	}
 
 	/**
-	 * The custom ID of this select menu
+	 * The custom id of this select menu
 	 */
 	public get customId() {
 		return this.data.custom_id;

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenuOption.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenuOption.ts
@@ -4,7 +4,7 @@ import type { APIMessageComponentEmoji, APISelectMenuOption } from 'discord-api-
  * Represents a non-validated option within a select menu component
  */
 export class UnsafeSelectMenuOption {
-	public constructor(protected data: APISelectMenuOption = {} as APISelectMenuOption) {}
+	public constructor(protected data: Partial<APISelectMenuOption> = {}) {}
 
 	/**
 	 * The label for this option
@@ -87,8 +87,9 @@ export class UnsafeSelectMenuOption {
 	}
 
 	public toJSON(): APISelectMenuOption {
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		return {
 			...this.data,
-		};
+		} as APISelectMenuOption;
 	}
 }

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenuOption.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenuOption.ts
@@ -4,20 +4,26 @@ import type { APIMessageComponentEmoji, APISelectMenuOption } from 'discord-api-
  * Represents a non-validated option within a select menu component
  */
 export class UnsafeSelectMenuOption {
-	public readonly label!: string;
-	public readonly value!: string;
-	public readonly description?: string;
-	public readonly emoji?: APIMessageComponentEmoji;
-	public readonly default?: boolean;
+	public constructor(protected data: APISelectMenuOption = {} as APISelectMenuOption) {}
 
-	public constructor(data?: APISelectMenuOption) {
-		/* eslint-disable @typescript-eslint/non-nullable-type-assertion-style */
-		this.label = data?.label as string;
-		this.value = data?.value as string;
-		/* eslint-enable @typescript-eslint/non-nullable-type-assertion-style */
-		this.description = data?.description;
-		this.emoji = data?.emoji;
-		this.default = data?.default;
+	public get label() {
+		return this.data.label;
+	}
+
+	public get value() {
+		return this.data.value;
+	}
+
+	public get description() {
+		return this.data.description;
+	}
+
+	public get emoji() {
+		return this.data.emoji;
+	}
+
+	public get default() {
+		return this.data.default;
 	}
 
 	/**
@@ -25,7 +31,7 @@ export class UnsafeSelectMenuOption {
 	 * @param label The label to show on this option
 	 */
 	public setLabel(label: string) {
-		Reflect.set(this, 'label', label);
+		this.data.label = label;
 		return this;
 	}
 
@@ -34,7 +40,7 @@ export class UnsafeSelectMenuOption {
 	 * @param value The value of this option
 	 */
 	public setValue(value: string) {
-		Reflect.set(this, 'value', value);
+		this.data.value = value;
 		return this;
 	}
 
@@ -43,7 +49,7 @@ export class UnsafeSelectMenuOption {
 	 * @param description The description of this option
 	 */
 	public setDescription(description: string) {
-		Reflect.set(this, 'description', description);
+		this.data.description = description;
 		return this;
 	}
 
@@ -52,7 +58,7 @@ export class UnsafeSelectMenuOption {
 	 * @param isDefault Whether or not this option is selected by default
 	 */
 	public setDefault(isDefault: boolean) {
-		Reflect.set(this, 'default', isDefault);
+		this.data.default = isDefault;
 		return this;
 	}
 
@@ -61,13 +67,13 @@ export class UnsafeSelectMenuOption {
 	 * @param emoji The emoji to display on this button
 	 */
 	public setEmoji(emoji: APIMessageComponentEmoji) {
-		Reflect.set(this, 'emoji', emoji);
+		this.data.emoji = emoji;
 		return this;
 	}
 
 	public toJSON(): APISelectMenuOption {
 		return {
-			...this,
+			...this.data,
 		};
 	}
 }

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenuOption.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenuOption.ts
@@ -35,7 +35,7 @@ export class UnsafeSelectMenuOption {
 	}
 
 	/**
-	 * Whether or not this option is selected by default
+	 * Whether this option is selected by default
 	 */
 	public get default() {
 		return this.data.default;
@@ -70,7 +70,7 @@ export class UnsafeSelectMenuOption {
 
 	/**
 	 * Sets whether this option is selected by default
-	 * @param isDefault Whether or not this option is selected by default
+	 * @param isDefault Whether this option is selected by default
 	 */
 	public setDefault(isDefault: boolean) {
 		this.data.default = isDefault;

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenuOption.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenuOption.ts
@@ -6,22 +6,37 @@ import type { APIMessageComponentEmoji, APISelectMenuOption } from 'discord-api-
 export class UnsafeSelectMenuOption {
 	public constructor(protected data: APISelectMenuOption = {} as APISelectMenuOption) {}
 
+	/**
+	 * The label for this option
+	 */
 	public get label() {
 		return this.data.label;
 	}
 
+	/**
+	 * The value for this option
+	 */
 	public get value() {
 		return this.data.value;
 	}
 
+	/**
+	 * The description for this option
+	 */
 	public get description() {
 		return this.data.description;
 	}
 
+	/**
+	 * The emoji for this option
+	 */
 	public get emoji() {
 		return this.data.emoji;
 	}
 
+	/**
+	 * Whether or not this option is selected by default
+	 */
 	public get default() {
 		return this.data.default;
 	}

--- a/packages/builders/src/messages/embed/Assertions.ts
+++ b/packages/builders/src/messages/embed/Assertions.ts
@@ -17,8 +17,8 @@ export const embedFieldsArrayPredicate = embedFieldPredicate.array();
 
 export const fieldLengthPredicate = z.number().lte(25);
 
-export function validateFieldLength(fields: APIEmbedField[], amountAdding: number): void {
-	fieldLengthPredicate.parse(fields.length + amountAdding);
+export function validateFieldLength(fields: APIEmbedField[] | undefined, amountAdding: number): void {
+	fieldLengthPredicate.parse((fields?.length ?? 0) + amountAdding);
 }
 
 export const authorNamePredicate = fieldNamePredicate.nullable();

--- a/packages/builders/src/messages/embed/Assertions.ts
+++ b/packages/builders/src/messages/embed/Assertions.ts
@@ -17,8 +17,7 @@ export const embedFieldsArrayPredicate = embedFieldPredicate.array();
 
 export const fieldLengthPredicate = z.number().lte(25);
 
-export function validateFieldLength(fields: APIEmbedField[] | undefined, amountAdding: number): void {
-	if (!fields) return;
+export function validateFieldLength(fields: APIEmbedField[], amountAdding: number): void {
 	fieldLengthPredicate.parse(fields.length + amountAdding);
 }
 

--- a/packages/builders/src/messages/embed/Assertions.ts
+++ b/packages/builders/src/messages/embed/Assertions.ts
@@ -17,7 +17,7 @@ export const embedFieldsArrayPredicate = embedFieldPredicate.array();
 
 export const fieldLengthPredicate = z.number().lte(25);
 
-export function validateFieldLength(fields: APIEmbedField[] | undefined, amountAdding: number): void {
+export function validateFieldLength(amountAdding: number, fields?: APIEmbedField[]): void {
 	fieldLengthPredicate.parse((fields?.length ?? 0) + amountAdding);
 }
 

--- a/packages/builders/src/messages/embed/Assertions.ts
+++ b/packages/builders/src/messages/embed/Assertions.ts
@@ -17,7 +17,8 @@ export const embedFieldsArrayPredicate = embedFieldPredicate.array();
 
 export const fieldLengthPredicate = z.number().lte(25);
 
-export function validateFieldLength(fields: APIEmbedField[], amountAdding: number): void {
+export function validateFieldLength(fields: APIEmbedField[] | undefined, amountAdding: number): void {
+	if (!fields) return;
 	fieldLengthPredicate.parse(fields.length + amountAdding);
 }
 

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -21,7 +21,7 @@ import { EmbedAuthorOptions, EmbedFooterOptions, UnsafeEmbed } from './UnsafeEmb
 export class Embed extends UnsafeEmbed {
 	public override addFields(...fields: APIEmbedField[]): this {
 		// Ensure adding these fields won't exceed the 25 field limit
-		validateFieldLength(this.fields ?? [], fields.length);
+		validateFieldLength(this.fields, fields.length);
 
 		// Data assertions
 		return super.addFields(...embedFieldsArrayPredicate.parse(fields));
@@ -29,7 +29,7 @@ export class Embed extends UnsafeEmbed {
 
 	public override spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {
 		// Ensure adding these fields won't exceed the 25 field limit
-		validateFieldLength(this.fields ?? [], fields.length - deleteCount);
+		validateFieldLength(this.fields, fields.length - deleteCount);
 
 		// Data assertions
 		return super.spliceFields(index, deleteCount, ...embedFieldsArrayPredicate.parse(fields));

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -16,7 +16,7 @@ import {
 import { EmbedAuthorOptions, EmbedFooterOptions, UnsafeEmbed } from './UnsafeEmbed';
 
 /**
- * Represents an embed in a message (image/video preview, rich embed, etc.)
+ * Represents a validated embed in a message (image/video preview, rich embed, etc.)
  */
 export class Embed extends UnsafeEmbed {
 	public override addFields(...fields: APIEmbedField[]): this {

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -21,7 +21,7 @@ import { EmbedAuthorOptions, EmbedFooterOptions, UnsafeEmbed } from './UnsafeEmb
 export class Embed extends UnsafeEmbed {
 	public override addFields(...fields: APIEmbedField[]): this {
 		// Ensure adding these fields won't exceed the 25 field limit
-		validateFieldLength(this.fields, fields.length);
+		validateFieldLength(this.fields ?? [], fields.length);
 
 		// Data assertions
 		return super.addFields(...embedFieldsArrayPredicate.parse(fields));
@@ -29,7 +29,7 @@ export class Embed extends UnsafeEmbed {
 
 	public override spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {
 		// Ensure adding these fields won't exceed the 25 field limit
-		validateFieldLength(this.fields, fields.length - deleteCount);
+		validateFieldLength(this.fields ?? [], fields.length - deleteCount);
 
 		// Data assertions
 		return super.spliceFields(index, deleteCount, ...embedFieldsArrayPredicate.parse(fields));

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -13,7 +13,7 @@ import {
 	urlPredicate,
 	validateFieldLength,
 } from './Assertions';
-import { AuthorOptions, FooterOptions, UnsafeEmbed } from './UnsafeEmbed';
+import { EmbedAuthorOptions, EmbedFooterOptions, UnsafeEmbed } from './UnsafeEmbed';
 
 /**
  * Represents an embed in a message (image/video preview, rich embed, etc.)
@@ -35,7 +35,7 @@ export class Embed extends UnsafeEmbed {
 		return super.spliceFields(index, deleteCount, ...embedFieldsArrayPredicate.parse(fields));
 	}
 
-	public override setAuthor(options: AuthorOptions | null): this {
+	public override setAuthor(options: EmbedAuthorOptions | null): this {
 		if (options === null) {
 			return super.setAuthor(null);
 		}
@@ -58,7 +58,7 @@ export class Embed extends UnsafeEmbed {
 		return super.setDescription(descriptionPredicate.parse(description));
 	}
 
-	public override setFooter(options: FooterOptions | null): this {
+	public override setFooter(options: EmbedFooterOptions | null): this {
 		if (options === null) {
 			return super.setFooter(null);
 		}

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -21,7 +21,7 @@ import { EmbedAuthorOptions, EmbedFooterOptions, UnsafeEmbed } from './UnsafeEmb
 export class Embed extends UnsafeEmbed {
 	public override addFields(...fields: APIEmbedField[]): this {
 		// Ensure adding these fields won't exceed the 25 field limit
-		validateFieldLength(this.fields, fields.length);
+		validateFieldLength(fields.length, this.fields);
 
 		// Data assertions
 		return super.addFields(...embedFieldsArrayPredicate.parse(fields));
@@ -29,7 +29,7 @@ export class Embed extends UnsafeEmbed {
 
 	public override spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {
 		// Ensure adding these fields won't exceed the 25 field limit
-		validateFieldLength(this.fields, fields.length - deleteCount);
+		validateFieldLength(fields.length - deleteCount, this.fields);
 
 		// Data assertions
 		return super.spliceFields(index, deleteCount, ...embedFieldsArrayPredicate.parse(fields));

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -158,7 +158,7 @@ export class UnsafeEmbed {
 		return (
 			(this.data.title?.length ?? 0) +
 			(this.data.description?.length ?? 0) +
-			(this.data.fields ?? []).reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0) +
+			(this.data.fields?.reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0) ?? 0) +
 			(this.data.footer?.text.length ?? 0) +
 			(this.data.author?.name.length ?? 0)
 		);
@@ -179,8 +179,9 @@ export class UnsafeEmbed {
 	 * @param fields The fields to add
 	 */
 	public addFields(...fields: APIEmbedField[]): this {
-		this.data.fields ??= [];
-		this.data.fields.push(...UnsafeEmbed.normalizeFields(...fields));
+		fields = UnsafeEmbed.normalizeFields(...fields);
+		if (this.data.fields) this.data.fields.push(...fields);
+		else this.data.fields = fields;
 		return this;
 	}
 
@@ -192,7 +193,9 @@ export class UnsafeEmbed {
 	 * @param fields The replacing field objects
 	 */
 	public spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {
-		this.data.fields?.splice(index, deleteCount, ...UnsafeEmbed.normalizeFields(...fields));
+		fields = UnsafeEmbed.normalizeFields(...fields);
+		if (this.data.fields) this.data.fields.splice(index, deleteCount, ...fields);
+		else this.data.fields = fields;
 		return this;
 	}
 

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -9,11 +9,11 @@ import type {
 
 export interface IconData {
 	/**
-	 * The url of the icon
+	 * The URL of the icon
 	 */
 	iconURL?: string;
 	/**
-	 * The proxy url of the icon
+	 * The proxy URL of the icon
 	 */
 	proxyIconURL?: string;
 }
@@ -66,7 +66,7 @@ export class UnsafeEmbed {
 	}
 
 	/**
-	 * The embed url
+	 * The embed URL
 	 */
 	public get url() {
 		return this.data.url;
@@ -80,7 +80,7 @@ export class UnsafeEmbed {
 	}
 
 	/**
-	 * The timestamp of the embed in the ISO format
+	 * The timestamp of the embed in an ISO 8601 format
 	 */
 	public get timestamp() {
 		return this.data.timestamp;

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -1,14 +1,4 @@
-import type {
-	APIEmbed,
-	APIEmbedAuthor,
-	APIEmbedField,
-	APIEmbedFooter,
-	APIEmbedImage,
-	APIEmbedProvider,
-	APIEmbedThumbnail,
-	APIEmbedVideo,
-} from 'discord-api-types/v9';
-import type { JSONEncodable } from '../../util/jsonEncodable';
+import type { APIEmbed, APIEmbedField } from 'discord-api-types/v9';
 
 export interface AuthorOptions {
 	name: string;
@@ -21,81 +11,98 @@ export interface FooterOptions {
 	iconURL?: string;
 }
 
-export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
+export class UnsafeEmbed implements APIEmbed {
+	protected data!: APIEmbed;
+
+	public constructor(data: APIEmbed = {}) {
+		this.data = data;
+		this.data.fields = data.fields ?? [];
+
+		if (data.timestamp) this.data.timestamp = new Date(data.timestamp).toISOString();
+	}
+
 	/**
 	 * An array of fields of this embed
 	 */
-	public readonly fields: APIEmbedField[];
+	public get fields() {
+		return this.data.fields ?? [];
+	}
 
 	/**
 	 * The embed title
 	 */
-	public readonly title?: string;
+	public get title() {
+		return this.data.title;
+	}
 
 	/**
 	 * The embed description
 	 */
-	public readonly description?: string;
+	public get description() {
+		return this.data.description;
+	}
 
 	/**
 	 * The embed url
 	 */
-	public readonly url?: string;
+	public get url() {
+		return this.data.url;
+	}
 
 	/**
 	 * The embed color
 	 */
-	public readonly color?: number;
+	public get color() {
+		return this.data.color;
+	}
 
 	/**
 	 * The timestamp of the embed in the ISO format
 	 */
-	public readonly timestamp?: string;
+	public get timestamp() {
+		return this.data.timestamp;
+	}
 
 	/**
 	 * The embed thumbnail data
 	 */
-	public readonly thumbnail?: APIEmbedThumbnail;
+	public get thumbnail() {
+		return this.data.thumbnail;
+	}
 
 	/**
 	 * The embed image data
 	 */
-	public readonly image?: APIEmbedImage;
+	public get image() {
+		return this.data.image;
+	}
 
 	/**
 	 * Received video data
 	 */
-	public readonly video?: APIEmbedVideo;
+	public get video() {
+		return this.data.video;
+	}
 
 	/**
 	 * The embed author data
 	 */
-	public readonly author?: APIEmbedAuthor;
+	public get author() {
+		return this.data.author;
+	}
 
 	/**
 	 * Received data about the embed provider
 	 */
-	public readonly provider?: APIEmbedProvider;
+	public get provider() {
+		return this.data.provider;
+	}
 
 	/**
 	 * The embed footer data
 	 */
-	public readonly footer?: APIEmbedFooter;
-
-	public constructor(data: APIEmbed = {}) {
-		this.title = data.title;
-		this.description = data.description;
-		this.url = data.url;
-		this.color = data.color;
-		this.thumbnail = data.thumbnail;
-		this.image = data.image;
-		this.video = data.video;
-		this.author = data.author;
-		this.provider = data.provider;
-		this.footer = data.footer;
-		this.fields = data.fields ?? [];
-
-		if (data.timestamp) this.timestamp = new Date(data.timestamp).toISOString();
+	public get footer() {
+		return this.data.footer;
 	}
 
 	/**
@@ -158,11 +165,11 @@ export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	 */
 	public setAuthor(options: AuthorOptions | null): this {
 		if (options === null) {
-			Reflect.set(this, 'author', undefined);
+			this.data.author = undefined;
 			return this;
 		}
 
-		Reflect.set(this, 'author', { name: options.name, url: options.url, icon_url: options.iconURL });
+		this.data.author = { name: options.name, url: options.url, icon_url: options.iconURL };
 		return this;
 	}
 
@@ -172,7 +179,7 @@ export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	 * @param color The color of the embed
 	 */
 	public setColor(color: number | null): this {
-		Reflect.set(this, 'color', color ?? undefined);
+		this.data.color = color ?? undefined;
 		return this;
 	}
 
@@ -182,7 +189,7 @@ export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	 * @param description The description
 	 */
 	public setDescription(description: string | null): this {
-		Reflect.set(this, 'description', description ?? undefined);
+		this.data.description = description ?? undefined;
 		return this;
 	}
 
@@ -193,11 +200,11 @@ export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	 */
 	public setFooter(options: FooterOptions | null): this {
 		if (options === null) {
-			Reflect.set(this, 'footer', undefined);
+			this.data.footer = undefined;
 			return this;
 		}
 
-		Reflect.set(this, 'footer', { text: options.text, icon_url: options.iconURL });
+		this.data.footer = { text: options.text, icon_url: options.iconURL };
 		return this;
 	}
 
@@ -207,7 +214,7 @@ export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	 * @param url The URL of the image
 	 */
 	public setImage(url: string | null): this {
-		Reflect.set(this, 'image', url ? { url } : undefined);
+		this.data.image = url ? { url } : undefined;
 		return this;
 	}
 
@@ -217,7 +224,7 @@ export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	 * @param url The URL of the thumbnail
 	 */
 	public setThumbnail(url: string | null): this {
-		Reflect.set(this, 'thumbnail', url ? { url } : undefined);
+		this.data.thumbnail = url ? { url } : undefined;
 		return this;
 	}
 
@@ -227,7 +234,7 @@ export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	 * @param timestamp The timestamp or date
 	 */
 	public setTimestamp(timestamp: number | Date | null = Date.now()): this {
-		Reflect.set(this, 'timestamp', timestamp ? new Date(timestamp).toISOString() : undefined);
+		this.data.timestamp = timestamp ? new Date(timestamp).toISOString() : undefined;
 		return this;
 	}
 
@@ -237,7 +244,7 @@ export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	 * @param title The title
 	 */
 	public setTitle(title: string | null): this {
-		Reflect.set(this, 'title', title ?? undefined);
+		this.data.title = title ?? undefined;
 		return this;
 	}
 
@@ -247,7 +254,7 @@ export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	 * @param url The URL
 	 */
 	public setURL(url: string | null): this {
-		Reflect.set(this, 'url', url ?? undefined);
+		this.data.url = url ?? undefined;
 		return this;
 	}
 
@@ -255,7 +262,7 @@ export class UnsafeEmbed implements APIEmbed, JSONEncodable<APIEmbed> {
 	 * Transforms the embed to a plain object
 	 */
 	public toJSON(): APIEmbed {
-		return { ...this };
+		return { ...this.data };
 	}
 
 	/**

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -1,29 +1,41 @@
-import type { APIEmbed, APIEmbedField, APIEmbedVideo } from 'discord-api-types/v9';
+import type {
+	APIEmbed,
+	APIEmbedAuthor,
+	APIEmbedField,
+	APIEmbedFooter,
+	APIEmbedImage,
+	APIEmbedVideo,
+} from 'discord-api-types/v9';
 
-export interface EmbedAuthorData {
-	name: string;
-	url?: string;
+export interface IconData {
+	/**
+	 * The url of the icon
+	 */
 	iconURL?: string;
+	/**
+	 * The proxy url of the icon
+	 */
 	proxyIconURL?: string;
 }
+
+export type EmbedAuthorData = Omit<APIEmbedAuthor, 'icon_url' | 'proxy_icon_url'> & IconData;
 
 export type EmbedAuthorOptions = Omit<EmbedAuthorData, 'proxyIconURL'>;
 
-export interface EmbedFooterData {
-	text: string;
-	iconURL?: string;
-	proxyIconURL?: string;
-}
+export type EmbedFooterData = Omit<APIEmbedFooter, 'icon_url' | 'proxy_icon_url'> & IconData;
 
 export type EmbedFooterOptions = Omit<EmbedFooterData, 'proxyIconURL'>;
 
-export interface EmbedImageData {
-	url: string;
+export interface EmbedImageData extends Omit<APIEmbedImage, 'proxy_url'> {
+	/**
+	 * The proxy URL for the image
+	 */
 	proxyURL?: string;
-	height?: number;
-	width?: number;
 }
 
+/**
+ * Represents a non-validated embed in a message (image/video preview, rich embed, etc.)
+ */
 export class UnsafeEmbed {
 	protected data: APIEmbed;
 

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -36,7 +36,7 @@ export class UnsafeEmbed {
 	 * An array of fields of this embed
 	 */
 	public get fields() {
-		return this.data.fields ?? [];
+		return this.data.fields!;
 	}
 
 	/**

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -11,13 +11,11 @@ export interface FooterOptions {
 	iconURL?: string;
 }
 
-export class UnsafeEmbed implements APIEmbed {
+export class UnsafeEmbed {
 	protected data!: APIEmbed;
 
 	public constructor(data: APIEmbed = {}) {
-		this.data = data;
-		this.data.fields = data.fields ?? [];
-
+		this.data = { fields: [], ...data };
 		if (data.timestamp) this.data.timestamp = new Date(data.timestamp).toISOString();
 	}
 
@@ -67,14 +65,24 @@ export class UnsafeEmbed implements APIEmbed {
 	 * The embed thumbnail data
 	 */
 	public get thumbnail() {
-		return this.data.thumbnail;
+		return {
+			url: this.data.thumbnail?.url,
+			proxyURL: this.data.thumbnail?.proxy_url,
+			height: this.data.thumbnail?.height,
+			width: this.data.thumbnail?.width,
+		};
 	}
 
 	/**
 	 * The embed image data
 	 */
 	public get image() {
-		return this.data.image;
+		return {
+			url: this.data.image?.url,
+			proxyURL: this.data.image?.proxy_url,
+			height: this.data.image?.height,
+			width: this.data.image?.width,
+		};
 	}
 
 	/**
@@ -88,7 +96,12 @@ export class UnsafeEmbed implements APIEmbed {
 	 * The embed author data
 	 */
 	public get author() {
-		return this.data.author;
+		return {
+			name: this.data.author?.name,
+			url: this.data.author?.url,
+			iconURL: this.data.author?.icon_url,
+			proxyIconURL: this.data.author?.proxy_icon_url,
+		};
 	}
 
 	/**
@@ -102,7 +115,11 @@ export class UnsafeEmbed implements APIEmbed {
 	 * The embed footer data
 	 */
 	public get footer() {
-		return this.data.footer;
+		return {
+			text: this.data.footer?.text,
+			iconURL: this.data.footer?.icon_url,
+			proxyIconURL: this.data.footer?.proxy_icon_url,
+		};
 	}
 
 	/**
@@ -113,8 +130,8 @@ export class UnsafeEmbed implements APIEmbed {
 			(this.title?.length ?? 0) +
 			(this.description?.length ?? 0) +
 			this.fields.reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0) +
-			(this.footer?.text.length ?? 0) +
-			(this.author?.name.length ?? 0)
+			(this.footer.text?.length ?? 0) +
+			(this.author.name?.length ?? 0)
 		);
 	}
 

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -104,7 +104,6 @@ export class UnsafeEmbed {
 	 * Received video data
 	 */
 	public get video(): APIEmbedVideo | undefined {
-		if (!this.data.video) return undefined;
 		return this.data.video;
 	}
 
@@ -145,11 +144,11 @@ export class UnsafeEmbed {
 	 */
 	public get length(): number {
 		return (
-			(this.title?.length ?? 0) +
-			(this.description?.length ?? 0) +
-			(this.fields ?? []).reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0) +
-			(this.footer?.text.length ?? 0) +
-			(this.author?.name.length ?? 0)
+			(this.data.title?.length ?? 0) +
+			(this.data.description?.length ?? 0) +
+			(this.data.fields ?? []).reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0) +
+			(this.data.footer?.text.length ?? 0) +
+			(this.data.author?.name.length ?? 0)
 		);
 	}
 
@@ -168,8 +167,8 @@ export class UnsafeEmbed {
 	 * @param fields The fields to add
 	 */
 	public addFields(...fields: APIEmbedField[]): this {
-		if (!this.data.fields) this.data.fields = [];
-		this.fields?.push(...UnsafeEmbed.normalizeFields(...fields));
+		this.data.fields ??= [];
+		this.data.fields.push(...UnsafeEmbed.normalizeFields(...fields));
 		return this;
 	}
 
@@ -181,7 +180,7 @@ export class UnsafeEmbed {
 	 * @param fields The replacing field objects
 	 */
 	public spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {
-		this.fields?.splice(index, deleteCount, ...UnsafeEmbed.normalizeFields(...fields));
+		this.data.fields?.splice(index, deleteCount, ...UnsafeEmbed.normalizeFields(...fields));
 		return this;
 	}
 

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -1,18 +1,31 @@
-import type { APIEmbed, APIEmbedField } from 'discord-api-types/v9';
+import type { APIEmbed, APIEmbedField, APIEmbedVideo } from 'discord-api-types/v9';
 
-export interface AuthorOptions {
+export interface EmbedAuthorData {
 	name: string;
 	url?: string;
 	iconURL?: string;
+	proxyIconURL?: string;
 }
 
-export interface FooterOptions {
+export type EmbedAuthorOptions = Omit<EmbedAuthorData, 'proxyIconURL'>;
+
+export interface EmbedFooterData {
 	text: string;
 	iconURL?: string;
+	proxyIconURL?: string;
+}
+
+export type EmbedFooterOptions = Omit<EmbedFooterData, 'proxyIconURL'>;
+
+export interface EmbedImageData {
+	url: string;
+	proxyURL?: string;
+	height?: number;
+	width?: number;
 }
 
 export class UnsafeEmbed {
-	protected data!: APIEmbed;
+	protected data: APIEmbed;
 
 	public constructor(data: APIEmbed = {}) {
 		this.data = { fields: [], ...data };
@@ -64,43 +77,47 @@ export class UnsafeEmbed {
 	/**
 	 * The embed thumbnail data
 	 */
-	public get thumbnail() {
+	public get thumbnail(): EmbedImageData | undefined {
+		if (!this.data.thumbnail) return undefined;
 		return {
-			url: this.data.thumbnail?.url,
-			proxyURL: this.data.thumbnail?.proxy_url,
-			height: this.data.thumbnail?.height,
-			width: this.data.thumbnail?.width,
+			url: this.data.thumbnail.url,
+			proxyURL: this.data.thumbnail.proxy_url,
+			height: this.data.thumbnail.height,
+			width: this.data.thumbnail.width,
 		};
 	}
 
 	/**
 	 * The embed image data
 	 */
-	public get image() {
+	public get image(): EmbedImageData | undefined {
+		if (!this.data.image) return undefined;
 		return {
-			url: this.data.image?.url,
-			proxyURL: this.data.image?.proxy_url,
-			height: this.data.image?.height,
-			width: this.data.image?.width,
+			url: this.data.image.url,
+			proxyURL: this.data.image.proxy_url,
+			height: this.data.image.height,
+			width: this.data.image.width,
 		};
 	}
 
 	/**
 	 * Received video data
 	 */
-	public get video() {
+	public get video(): APIEmbedVideo | undefined {
+		if (!this.data.video) return undefined;
 		return this.data.video;
 	}
 
 	/**
 	 * The embed author data
 	 */
-	public get author() {
+	public get author(): EmbedAuthorData | undefined {
+		if (!this.data.author) return undefined;
 		return {
-			name: this.data.author?.name,
-			url: this.data.author?.url,
-			iconURL: this.data.author?.icon_url,
-			proxyIconURL: this.data.author?.proxy_icon_url,
+			name: this.data.author.name,
+			url: this.data.author.url,
+			iconURL: this.data.author.icon_url,
+			proxyIconURL: this.data.author.proxy_icon_url,
 		};
 	}
 
@@ -114,11 +131,12 @@ export class UnsafeEmbed {
 	/**
 	 * The embed footer data
 	 */
-	public get footer() {
+	public get footer(): EmbedFooterData | undefined {
+		if (!this.data.footer) return undefined;
 		return {
-			text: this.data.footer?.text,
-			iconURL: this.data.footer?.icon_url,
-			proxyIconURL: this.data.footer?.proxy_icon_url,
+			text: this.data.footer.text,
+			iconURL: this.data.footer.icon_url,
+			proxyIconURL: this.data.footer.proxy_icon_url,
 		};
 	}
 
@@ -130,8 +148,8 @@ export class UnsafeEmbed {
 			(this.title?.length ?? 0) +
 			(this.description?.length ?? 0) +
 			this.fields.reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0) +
-			(this.footer.text?.length ?? 0) +
-			(this.author.name?.length ?? 0)
+			(this.footer?.text.length ?? 0) +
+			(this.author?.name.length ?? 0)
 		);
 	}
 
@@ -180,7 +198,7 @@ export class UnsafeEmbed {
 	 *
 	 * @param options The options for the author
 	 */
-	public setAuthor(options: AuthorOptions | null): this {
+	public setAuthor(options: EmbedAuthorOptions | null): this {
 		if (options === null) {
 			this.data.author = undefined;
 			return this;
@@ -215,7 +233,7 @@ export class UnsafeEmbed {
 	 *
 	 * @param options The options for the footer
 	 */
-	public setFooter(options: FooterOptions | null): this {
+	public setFooter(options: EmbedFooterOptions | null): this {
 		if (options === null) {
 			this.data.footer = undefined;
 			return this;

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -28,7 +28,7 @@ export class UnsafeEmbed {
 	protected data: APIEmbed;
 
 	public constructor(data: APIEmbed = {}) {
-		this.data = { fields: [], ...data };
+		this.data = { ...data };
 		if (data.timestamp) this.data.timestamp = new Date(data.timestamp).toISOString();
 	}
 
@@ -36,7 +36,7 @@ export class UnsafeEmbed {
 	 * An array of fields of this embed
 	 */
 	public get fields() {
-		return this.data.fields!;
+		return this.data.fields;
 	}
 
 	/**
@@ -147,7 +147,7 @@ export class UnsafeEmbed {
 		return (
 			(this.title?.length ?? 0) +
 			(this.description?.length ?? 0) +
-			this.fields.reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0) +
+			(this.fields ?? []).reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0) +
 			(this.footer?.text.length ?? 0) +
 			(this.author?.name.length ?? 0)
 		);
@@ -168,7 +168,8 @@ export class UnsafeEmbed {
 	 * @param fields The fields to add
 	 */
 	public addFields(...fields: APIEmbedField[]): this {
-		this.fields.push(...UnsafeEmbed.normalizeFields(...fields));
+		if (!this.data.fields) this.data.fields = [];
+		this.fields?.push(...UnsafeEmbed.normalizeFields(...fields));
 		return this;
 	}
 
@@ -180,7 +181,7 @@ export class UnsafeEmbed {
 	 * @param fields The replacing field objects
 	 */
 	public spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {
-		this.fields.splice(index, deleteCount, ...UnsafeEmbed.normalizeFields(...fields));
+		this.fields?.splice(index, deleteCount, ...UnsafeEmbed.normalizeFields(...fields));
 		return this;
 	}
 
@@ -189,7 +190,7 @@ export class UnsafeEmbed {
 	 * @param fields The fields to set
 	 */
 	public setFields(...fields: APIEmbedField[]) {
-		this.spliceFields(0, this.fields.length, ...fields);
+		this.spliceFields(0, this.fields?.length ?? 0, ...fields);
 		return this;
 	}
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -723,7 +723,7 @@ client.on('interactionCreate', async interaction => {
 
   const button = new ButtonComponent();
 
-  const actionRow = new ActionRow<ActionRowComponent>({ type: ComponentType.ActionRow, components: [button] });
+  const actionRow = new ActionRow<ActionRowComponent>({ type: ComponentType.ActionRow, components: [button.toJSON()] });
 
   await interaction.reply({ content: 'Hi!', components: [actionRow] });
 


### PR DESCRIPTION
This is a replacement for the previous pr since gh is having trouble loading the diffs.

**Please describe the changes this PR makes and why it should be merged:**

Stores raw api data in a `data` object and allows access to builder properties via getters.

### Rationale

There's quite a few benefits in using getters for builders:

- Currently builders relies on `Reflect#set` which is much slower than direct prop assignment, in one benchmark [I did it was waaay slower than direct assignment](https://www.measurethat.net/Benchmarks/ShowResult/263962). Beyond performance `Reflect#set` is less typesafe since property keys are strings and it allows values to be set as `any`. This PR removes the usage of these methods, and preserves the `readonly` nature of the fields.

- The classes are now more flexible. For example, right now if we decided to add a field to any builder class, it would be outputted in `toJSON` simply because `toJSON` just spreads `this`: `{ ...this }`. In addition, since we now have getters we can do any computation *before* a value is returned unlike a regular field.

- Constructor assignment is easy, in some cases it's just assigning `this.data = data`. `toJSON` is straightforward as well, as it's essentially just returning a copy of `this.data`.

- Allows for idiomatic js/ts class field naming. The props are simply retrieved from `this.data` so they're not constrained to any naming conventions used by the API.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
