### PR TITLE
types: Remove duplicate `GuildChannelOverwriteOptions` interface

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4198,11 +4198,6 @@ export type GuildAuditLogsTargets = {
 
 export type GuildBanResolvable = GuildBan | UserResolvable;
 
-export interface GuildChannelOverwriteOptions {
-  reason?: string;
-  type?: number;
-}
-
 export type GuildChannelResolvable = Snowflake | GuildBasedChannel;
 
 export interface GuildChannelCreateOptions extends Omit<CategoryCreateChannelOptions, 'type'> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There is a duplicate interface for this. The other one is after it:

https://github.com/discordjs/discord.js/blob/b936103395121cb21a8c616f669ddab1d2efb0f1/packages/discord.js/typings/index.d.ts#L4224-L4227

Seems to have been introduced from #5318.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
