### PR TITLE
feat(scheduledevents): add image option

### DIFF
--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -51,7 +51,7 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {GuildScheduledEventEntityMetadataOptions} [entityMetadata] The entity metadata of the
    * guild scheduled event
    * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External}</warn>
-   * @property {?(BufferResolvable|Base64Resolvable)} [image] the cover image of the scheduled event
+   * @property {?(BufferResolvable|Base64Resolvable)} [image] The cover image of the guild scheduled event
    * @property {string} [reason] The reason for creating the guild scheduled event
    */
 
@@ -175,7 +175,7 @@ class GuildScheduledEventManager extends CachedManager {
    * guild scheduled event
    * <warn>This can be modified only if `entityType` of the `GuildScheduledEvent` to be edited is
    * {@link GuildScheduledEventEntityType.External}</warn>
-   * @property {?(BufferResolvable|Base64Resolvable)} [image] the cover image of the scheduled event
+   * @property {?(BufferResolvable|Base64Resolvable)} [image] The cover image of the guild scheduled event
    * @property {string} [reason] The reason for editing the guild scheduled event
    */
 

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -102,7 +102,7 @@ class GuildScheduledEventManager extends CachedManager {
         description,
         entity_type: entityType,
         entity_metadata,
-        image: image && await DataResolver.resolveImage(image),
+        image: image && (await DataResolver.resolveImage(image)),
       },
       reason,
     });
@@ -221,7 +221,7 @@ class GuildScheduledEventManager extends CachedManager {
         description,
         entity_type: entityType,
         status,
-        image: image && await DataResolver.resolveImage(image),
+        image: image && (await DataResolver.resolveImage(image)),
         entity_metadata,
       },
       reason,

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -102,7 +102,7 @@ class GuildScheduledEventManager extends CachedManager {
         description,
         entity_type: entityType,
         entity_metadata,
-        image: image ? await DataResolver.resolveImage(image) : undefined,
+        image: image && await DataResolver.resolveImage(image),
       },
       reason,
     });
@@ -221,7 +221,7 @@ class GuildScheduledEventManager extends CachedManager {
         description,
         entity_type: entityType,
         status,
-        image: image ? await DataResolver.resolveImage(image) : undefined,
+        image: image && await DataResolver.resolveImage(image),
         entity_metadata,
       },
       reason,

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -5,6 +5,7 @@ const { GuildScheduledEventEntityType, Routes } = require('discord-api-types/v9'
 const CachedManager = require('./CachedManager');
 const { TypeError, Error } = require('../errors');
 const { GuildScheduledEvent } = require('../structures/GuildScheduledEvent');
+const DataResolver = require('../util/DataResolver');
 
 /**
  * Manages API methods for GuildScheduledEvents and stores their cache.
@@ -50,6 +51,7 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {GuildScheduledEventEntityMetadataOptions} [entityMetadata] The entity metadata of the
    * guild scheduled event
    * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External}</warn>
+   * @property {?(BufferResolvable|Base64Resolvable)} [image] the cover image of the scheduled event
    * @property {string} [reason] The reason for creating the guild scheduled event
    */
 
@@ -77,6 +79,7 @@ class GuildScheduledEventManager extends CachedManager {
       scheduledEndTime,
       entityMetadata,
       reason,
+      image,
     } = options;
 
     let entity_metadata, channel_id;
@@ -99,6 +102,7 @@ class GuildScheduledEventManager extends CachedManager {
         description,
         entity_type: entityType,
         entity_metadata,
+        image: image ? await DataResolver.resolveImage(image) : undefined,
       },
       reason,
     });
@@ -171,6 +175,7 @@ class GuildScheduledEventManager extends CachedManager {
    * guild scheduled event
    * <warn>This can be modified only if `entityType` of the `GuildScheduledEvent` to be edited is
    * {@link GuildScheduledEventEntityType.External}</warn>
+   * @property {?(BufferResolvable|Base64Resolvable)} [image] the cover image of the scheduled event
    * @property {string} [reason] The reason for editing the guild scheduled event
    */
 
@@ -196,6 +201,7 @@ class GuildScheduledEventManager extends CachedManager {
       scheduledEndTime,
       entityMetadata,
       reason,
+      image,
     } = options;
 
     let entity_metadata;
@@ -215,6 +221,7 @@ class GuildScheduledEventManager extends CachedManager {
         description,
         entity_type: entityType,
         status,
+        image: image ? await DataResolver.resolveImage(image) : undefined,
         entity_metadata,
       },
       reason,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4338,6 +4338,7 @@ export interface GuildScheduledEventCreateOptions {
   description?: string;
   channel?: GuildVoiceChannelResolvable;
   entityMetadata?: GuildScheduledEventEntityMetadataOptions;
+  image?: BufferResolvable | Base64Resolvable | null;
   reason?: string;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

According to the [API docs](https://discord.com/developers/docs/resources/guild-scheduled-event#create-guild-scheduled-event), on `Create Guild Scheduled Event` and `Modify Guild Scheduled Event` an optional field image `image` can be added

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:

- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
