### PR TITLE
voice: pass joinConfig.group to getVoiceConnection

### DIFF
--- a/packages/voice/__tests__/VoiceConnection.test.ts
+++ b/packages/voice/__tests__/VoiceConnection.test.ts
@@ -129,8 +129,8 @@ describe('createVoiceConnection', () => {
 
 		const stateSetter = jest.spyOn(existingVoiceConnection, 'state', 'set');
 
-		DataStore.getVoiceConnection.mockImplementation((guildId) =>
-			guildId === existingJoinConfig.guildId ? existingVoiceConnection : null,
+		DataStore.getVoiceConnection.mockImplementation((guildId, group = 'default') =>
+			guildId === existingJoinConfig.guildId && group === existingJoinConfig.group ? existingVoiceConnection : null,
 		);
 
 		const newAdapter = createFakeAdapter();
@@ -139,7 +139,7 @@ describe('createVoiceConnection', () => {
 			debug: false,
 			adapterCreator: newAdapter.creator,
 		});
-		expect(DataStore.getVoiceConnection).toHaveBeenCalledWith(newJoinConfig.guildId);
+		expect(DataStore.getVoiceConnection).toHaveBeenCalledWith(newJoinConfig.guildId, newJoinConfig.group);
 		expect(DataStore.trackVoiceConnection).not.toHaveBeenCalled();
 		expect(DataStore.untrackVoiceConnection).not.toHaveBeenCalled();
 		expect(newAdapter.creator).not.toHaveBeenCalled();
@@ -167,8 +167,8 @@ describe('createVoiceConnection', () => {
 
 		const rejoinSpy = jest.spyOn(existingVoiceConnection, 'rejoin');
 
-		DataStore.getVoiceConnection.mockImplementation((guildId) =>
-			guildId === existingJoinConfig.guildId ? existingVoiceConnection : null,
+		DataStore.getVoiceConnection.mockImplementation((guildId, group = 'default') =>
+			guildId === existingJoinConfig.guildId && group === existingJoinConfig.group ? existingVoiceConnection : null,
 		);
 
 		const newAdapter = createFakeAdapter();
@@ -178,7 +178,7 @@ describe('createVoiceConnection', () => {
 			debug: false,
 			adapterCreator: newAdapter.creator,
 		});
-		expect(DataStore.getVoiceConnection).toHaveBeenCalledWith(newJoinConfig.guildId);
+		expect(DataStore.getVoiceConnection).toHaveBeenCalledWith(newJoinConfig.guildId, newJoinConfig.group);
 		expect(DataStore.trackVoiceConnection).not.toHaveBeenCalled();
 		expect(DataStore.untrackVoiceConnection).not.toHaveBeenCalled();
 		expect(newAdapter.creator).not.toHaveBeenCalled();
@@ -198,8 +198,8 @@ describe('createVoiceConnection', () => {
 			adapterCreator: existingAdapter.creator,
 		});
 
-		DataStore.getVoiceConnection.mockImplementation((guildId) =>
-			guildId === existingJoinConfig.guildId ? existingVoiceConnection : null,
+		DataStore.getVoiceConnection.mockImplementation((guildId, group = 'default') =>
+			guildId === existingJoinConfig.guildId && group === existingJoinConfig.group ? existingVoiceConnection : null,
 		);
 
 		const newAdapter = createFakeAdapter();
@@ -209,7 +209,7 @@ describe('createVoiceConnection', () => {
 			debug: false,
 			adapterCreator: newAdapter.creator,
 		});
-		expect(DataStore.getVoiceConnection).toHaveBeenCalledWith(newJoinConfig.guildId);
+		expect(DataStore.getVoiceConnection).toHaveBeenCalledWith(newJoinConfig.guildId, newJoinConfig.group);
 		expect(DataStore.trackVoiceConnection).not.toHaveBeenCalled();
 		expect(DataStore.untrackVoiceConnection).not.toHaveBeenCalled();
 		expect(newAdapter.creator).not.toHaveBeenCalled();
@@ -473,8 +473,8 @@ describe('VoiceConnection#destroy', () => {
 
 	test('Cleans up in a valid, destroyable state', () => {
 		const { voiceConnection, joinConfig, adapter } = createFakeVoiceConnection();
-		DataStore.getVoiceConnection.mockImplementation((guildId) =>
-			joinConfig.guildId === guildId ? voiceConnection : undefined,
+		DataStore.getVoiceConnection.mockImplementation((guildId, group = 'default') =>
+			guildId === joinConfig.guildId && group === joinConfig.group ? voiceConnection : undefined,
 		);
 		const dummy = Symbol('dummy');
 		DataStore.createJoinVoiceChannelPayload.mockImplementation(() => dummy as any);

--- a/packages/voice/src/VoiceConnection.ts
+++ b/packages/voice/src/VoiceConnection.ts
@@ -533,7 +533,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
 		if (this.state.status === VoiceConnectionStatus.Destroyed) {
 			throw new Error('Cannot destroy VoiceConnection - it has already been destroyed');
 		}
-		if (getVoiceConnection(this.joinConfig.guildId) === this) {
+		if (getVoiceConnection(this.joinConfig.guildId, this.joinConfig.group) === this) {
 			untrackVoiceConnection(this);
 		}
 		if (adapterAvailable) {
@@ -692,7 +692,7 @@ export class VoiceConnection extends TypedEmitter<VoiceConnectionEvents> {
  */
 export function createVoiceConnection(joinConfig: JoinConfig, options: CreateVoiceConnectionOptions) {
 	const payload = createJoinVoiceChannelPayload(joinConfig);
-	const existing = getVoiceConnection(joinConfig.guildId);
+	const existing = getVoiceConnection(joinConfig.guildId, joinConfig.group);
 	if (existing && existing.state.status !== VoiceConnectionStatus.Destroyed) {
 		if (existing.state.status === VoiceConnectionStatus.Disconnected) {
 			existing.rejoin({


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR gets rid of a bug related to VoiceConnection groups introduced in [this PR](https://github.com/discordjs/voice/pull/147).

While `getVoiceConnection` takes second argument (`group`, defaults to `'default'`), in `createVoiceConnection` and `VoiceConnection.destroy()` it is called without `(this.)joinConfig.group`, ending up just trying to get VoiceConnection in 'default' group. This commit fixes this issue.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
