### PR TITLE
fix(GuildAuditLogs): typings and consistency

### DIFF
--- a/packages/discord.js/src/structures/GuildAuditLogs.js
+++ b/packages/discord.js/src/structures/GuildAuditLogs.js
@@ -14,19 +14,19 @@ const Util = require('../util/Util');
 
 /**
  * The target type of an entry. Here are the available types:
- * * GUILD
- * * CHANNEL
- * * USER
- * * ROLE
- * * INVITE
- * * WEBHOOK
- * * EMOJI
- * * MESSAGE
- * * INTEGRATION
- * * STAGE_INSTANCE
- * * STICKER
- * * THREAD
- * * GUILD_SCHEDULED_EVENT
+ * * Guild
+ * * Channel
+ * * User
+ * * Role
+ * * Invite
+ * * Webhook
+ * * Emoji
+ * * Message
+ * * Integration
+ * * StageInstance
+ * * Sticker
+ * * Thread
+ * * GuildScheduledEvent
  * @typedef {string} AuditLogTargetType
  */
 
@@ -36,21 +36,21 @@ const Util = require('../util/Util');
  * @type {Object<string, string>}
  */
 const Targets = {
-  ALL: 'ALL',
-  GUILD: 'GUILD',
-  GUILD_SCHEDULED_EVENT: 'GUILD_SCHEDULED_EVENT',
-  CHANNEL: 'CHANNEL',
-  USER: 'USER',
-  ROLE: 'ROLE',
-  INVITE: 'INVITE',
-  WEBHOOK: 'WEBHOOK',
-  EMOJI: 'EMOJI',
-  MESSAGE: 'MESSAGE',
-  INTEGRATION: 'INTEGRATION',
-  STAGE_INSTANCE: 'STAGE_INSTANCE',
-  STICKER: 'STICKER',
-  THREAD: 'THREAD',
-  UNKNOWN: 'UNKNOWN',
+  All: 'All',
+  Guild: 'Guild',
+  GuildScheduledEvent: 'GuildScheduledEvent',
+  Channel: 'Channel',
+  User: 'User',
+  Role: 'Role',
+  Invite: 'Invite',
+  Webhook: 'Webhook',
+  Emoji: 'Emoji',
+  Message: 'Message',
+  Integration: 'Integration',
+  StageInstance: 'StageInstance',
+  Sticker: 'Sticker',
+  Thread: 'Thread',
+  Unknown: 'Unknown',
 };
 
 /**
@@ -132,28 +132,28 @@ class GuildAuditLogs {
    * @returns {AuditLogTargetType}
    */
   static targetType(target) {
-    if (target < 10) return Targets.GUILD;
-    if (target < 20) return Targets.CHANNEL;
-    if (target < 30) return Targets.USER;
-    if (target < 40) return Targets.ROLE;
-    if (target < 50) return Targets.INVITE;
-    if (target < 60) return Targets.WEBHOOK;
-    if (target < 70) return Targets.EMOJI;
-    if (target < 80) return Targets.MESSAGE;
-    if (target < 83) return Targets.INTEGRATION;
-    if (target < 86) return Targets.STAGE_INSTANCE;
-    if (target < 100) return Targets.STICKER;
-    if (target < 110) return Targets.GUILD_SCHEDULED_EVENT;
-    if (target < 120) return Targets.THREAD;
-    return Targets.UNKNOWN;
+    if (target < 10) return Targets.Guild;
+    if (target < 20) return Targets.Channel;
+    if (target < 30) return Targets.User;
+    if (target < 40) return Targets.Role;
+    if (target < 50) return Targets.Invite;
+    if (target < 60) return Targets.Webhook;
+    if (target < 70) return Targets.Emoji;
+    if (target < 80) return Targets.Message;
+    if (target < 83) return Targets.Integration;
+    if (target < 86) return Targets.StageInstance;
+    if (target < 100) return Targets.Sticker;
+    if (target < 110) return Targets.GuildScheduledEvent;
+    if (target < 120) return Targets.Thread;
+    return Targets.Unknown;
   }
 
   /**
-   * The action type of an entry, e.g. `CREATE`. Here are the available types:
-   * * CREATE
-   * * DELETE
-   * * UPDATE
-   * * ALL
+   * The action type of an entry, e.g. `Create`. Here are the available types:
+   * * Create
+   * * Delete
+   * * Update
+   * * All
    * @typedef {string} AuditLogActionType
    */
 
@@ -181,7 +181,7 @@ class GuildAuditLogs {
         AuditLogEvent.ThreadCreate,
       ].includes(action)
     ) {
-      return 'CREATE';
+      return 'Create';
     }
 
     if (
@@ -206,7 +206,7 @@ class GuildAuditLogs {
         AuditLogEvent.ThreadDelete,
       ].includes(action)
     ) {
-      return 'DELETE';
+      return 'Delete';
     }
 
     if (
@@ -228,10 +228,10 @@ class GuildAuditLogs {
         AuditLogEvent.ThreadUpdate,
       ].includes(action)
     ) {
-      return 'UPDATE';
+      return 'Update';
     }
 
-    return 'ALL';
+    return 'All';
   }
 
   toJSON() {
@@ -376,20 +376,20 @@ class GuildAuditLogsEntry {
      * @type {?AuditLogEntryTarget}
      */
     this.target = null;
-    if (targetType === Targets.UNKNOWN) {
+    if (targetType === Targets.Unknown) {
       this.target = this.changes.reduce((o, c) => {
         o[c.key] = c.new ?? c.old;
         return o;
       }, {});
       this.target.id = data.target_id;
-      // MEMBER_DISCONNECT and similar types do not provide a target_id.
-    } else if (targetType === Targets.USER && data.target_id) {
+      // MemberDisconnect and similar types do not provide a target_id.
+    } else if (targetType === Targets.User && data.target_id) {
       this.target = guild.client.options.partials.includes(Partials.User)
         ? guild.client.users._add({ id: data.target_id })
         : guild.client.users.cache.get(data.target_id);
-    } else if (targetType === Targets.GUILD) {
+    } else if (targetType === Targets.Guild) {
       this.target = guild.client.guilds.cache.get(data.target_id);
-    } else if (targetType === Targets.WEBHOOK) {
+    } else if (targetType === Targets.Webhook) {
       this.target =
         logs.webhooks.get(data.target_id) ??
         new Webhook(
@@ -405,7 +405,7 @@ class GuildAuditLogsEntry {
             },
           ),
         );
-    } else if (targetType === Targets.INVITE) {
+    } else if (targetType === Targets.Invite) {
       let change = this.changes.find(c => c.key === 'code');
       change = change.new ?? change.old;
 
@@ -421,13 +421,13 @@ class GuildAuditLogsEntry {
             { guild },
           ),
         );
-    } else if (targetType === Targets.MESSAGE) {
-      // Discord sends a channel id for the MESSAGE_BULK_DELETE action type.
+    } else if (targetType === Targets.Message) {
+      // Discord sends a channel id for the MessageBulkDelete action type.
       this.target =
         data.action_type === AuditLogEvent.MessageBulkDelete
           ? guild.channels.cache.get(data.target_id) ?? { id: data.target_id }
           : guild.client.users.cache.get(data.target_id);
-    } else if (targetType === Targets.INTEGRATION) {
+    } else if (targetType === Targets.Integration) {
       this.target =
         logs.integrations.get(data.target_id) ??
         new Integration(
@@ -441,7 +441,7 @@ class GuildAuditLogsEntry {
           ),
           guild,
         );
-    } else if (targetType === Targets.CHANNEL || targetType === Targets.THREAD) {
+    } else if (targetType === Targets.Channel || targetType === Targets.Thread) {
       this.target =
         guild.channels.cache.get(data.target_id) ??
         this.changes.reduce(
@@ -451,7 +451,7 @@ class GuildAuditLogsEntry {
           },
           { id: data.target_id },
         );
-    } else if (targetType === Targets.STAGE_INSTANCE) {
+    } else if (targetType === Targets.StageInstance) {
       this.target =
         guild.stageInstances.cache.get(data.target_id) ??
         new StageInstance(
@@ -468,7 +468,7 @@ class GuildAuditLogsEntry {
             },
           ),
         );
-    } else if (targetType === Targets.STICKER) {
+    } else if (targetType === Targets.Sticker) {
       this.target =
         guild.stickers.cache.get(data.target_id) ??
         new Sticker(
@@ -481,7 +481,7 @@ class GuildAuditLogsEntry {
             { id: data.target_id },
           ),
         );
-    } else if (targetType === Targets.GUILD_SCHEDULED_EVENT) {
+    } else if (targetType === Targets.GuildScheduledEvent) {
       this.target =
         guild.scheduledEvents.cache.get(data.target_id) ??
         new GuildScheduledEvent(

--- a/packages/discord.js/src/util/EnumResolvers.js
+++ b/packages/discord.js/src/util/EnumResolvers.js
@@ -20,6 +20,7 @@ const {
   TeamMemberMembershipState,
   GuildScheduledEventEntityType,
   IntegrationExpireBehavior,
+  AuditLogEvent,
 } = require('discord-api-types/v9');
 
 function unknownKeyStrategy(val) {
@@ -629,6 +630,157 @@ class EnumResolvers extends null {
         return IntegrationExpireBehavior.RemoveRole;
       case 'KICK':
         return IntegrationExpireBehavior.Kick;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * A string that can be resolved to a {@link AuditLogEvent} enum value. Here are the available types:
+   * * GUILD_UPDATE
+   * * CHANNEL_CREATE
+   * * CHANNEL_UPDATE
+   * * CHANNEL_DELETE
+   * * CHANNEL_OVERWRITE_CREATE
+   * * CHANNEL_OVERWRITE_UPDATE
+   * * CHANNEL_OVERWRITE_DELETE
+   * * MEMBER_KICK
+   * * MEMBER_PRUNE
+   * * MEMBER_BAN_ADD
+   * * MEMBER_BAN_REMOVE
+   * * MEMBER_UPDATE
+   * * MEMBER_ROLE_UPDATE
+   * * MEMBER_MOVE
+   * * MEMBER_DISCONNECT
+   * * BOT_ADD
+   * * ROLE_CREATE
+   * * ROLE_UPDATE
+   * * ROLE_DELETE
+   * * INVITE_CREATE
+   * * INVITE_UPDATE
+   * * INVITE_DELETE
+   * * WEBHOOK_CREATE
+   * * WEBHOOK_UPDATE
+   * * WEBHOOK_DELETE
+   * * INTEGRATION_CREATE
+   * * INTEGRATION_UPDATE
+   * * INTEGRATION_DELETE
+   * * STAGE_INSTANCE_CREATE
+   * * STAGE_INSTANCE_UPDATE
+   * * STAGE_INSTANCE_DELETE
+   * * STICKER_CREATE
+   * * STICKER_UPDATE
+   * * STICKER_DELETE
+   * * GUILD_SCHEDULED_EVENT_CREATE
+   * * GUILD_SCHEDULED_EVENT_UPDATE
+   * * GUILD_SCHEDULED_EVENT_DELETE
+   * * THREAD_CREATE
+   * * THREAD_UPDATE
+   * * THREAD_DELETE
+   * @typedef {string} AuditLogEventEnumResolvable
+   */
+
+  /**
+   * Resolves enum key to {@link AuditLogEvent} enum value
+   * @param {AuditLogEventEnumResolvable|AuditLogEvent} key The key to lookup
+   * @returns {AuditLogEvent}
+   */
+  static resolveAuditLogEvent(key) {
+    switch (key) {
+      case 'GUILD_UPDATE':
+        return AuditLogEvent.GuildUpdate;
+      case 'CHANNEL_CREATE':
+        return AuditLogEvent.ChannelCreate;
+      case 'CHANNEL_UPDATE':
+        return AuditLogEvent.ChannelUpdate;
+      case 'CHANNEL_DELETE':
+        return AuditLogEvent.ChannelDelete;
+      case 'CHANNEL_OVERWRITE_CREATE':
+        return AuditLogEvent.ChannelOverwriteCreate;
+      case 'CHANNEL_OVERWRITE_UPDATE':
+        return AuditLogEvent.ChannelOverwriteUpdate;
+      case 'CHANNEL_OVERWRITE_DELETE':
+        return AuditLogEvent.ChannelOverwriteDelete;
+      case 'MEMBER_KICK':
+        return AuditLogEvent.MemberKick;
+      case 'MEMBER_PRUNE':
+        return AuditLogEvent.MemberPrune;
+      case 'MEMBER_BAN_ADD':
+        return AuditLogEvent.MemberBanAdd;
+      case 'MEMBER_BAN_REMOVE':
+        return AuditLogEvent.MemberBanRemove;
+      case 'MEMBER_UPDATE':
+        return AuditLogEvent.MemberUpdate;
+      case 'MEMBER_ROLE_UPDATE':
+        return AuditLogEvent.MemberRoleUpdate;
+      case 'MEMBER_MOVE':
+        return AuditLogEvent.MemberMove;
+      case 'MEMBER_DISCONNECT':
+        return AuditLogEvent.MemberDisconnect;
+      case 'BOT_ADD':
+        return AuditLogEvent.BotAdd;
+      case 'ROLE_CREATE':
+        return AuditLogEvent.RoleCreate;
+      case 'ROLE_UPDATE':
+        return AuditLogEvent.RoleUpdate;
+      case 'ROLE_DELETE':
+        return AuditLogEvent.RoleDelete;
+      case 'INVITE_CREATE':
+        return AuditLogEvent.InviteCreate;
+      case 'INVITE_UPDATE':
+        return AuditLogEvent.InviteUpdate;
+      case 'INVITE_DELETE':
+        return AuditLogEvent.InviteDelete;
+      case 'WEBHOOK_CREATE':
+        return AuditLogEvent.WebhookCreate;
+      case 'WEBHOOK_UPDATE':
+        return AuditLogEvent.WebhookUpdate;
+      case 'WEBHOOK_DELETE':
+        return AuditLogEvent.WebhookDelete;
+      case 'EMOJI_CREATE':
+        return AuditLogEvent.EmojiCreate;
+      case 'EMOJI_UPDATE':
+        return AuditLogEvent.EmojiUpdate;
+      case 'EMOJI_DELETE':
+        return AuditLogEvent.EmojiDelete;
+      case 'MESSAGE_DELETE':
+        return AuditLogEvent.MessageDelete;
+      case 'MESSAGE_BULK_DELETE':
+        return AuditLogEvent.MessageBulkDelete;
+      case 'MESSAGE_PIN':
+        return AuditLogEvent.MessagePin;
+      case 'MESSAGE_UNPIN':
+        return AuditLogEvent.MessageUnpin;
+      case 'INTEGRATION_CREATE':
+        return AuditLogEvent.IntegrationCreate;
+      case 'INTEGRATION_UPDATE':
+        return AuditLogEvent.IntegrationUpdate;
+      case 'INTEGRATION_DELETE':
+        return AuditLogEvent.IntegrationDelete;
+      case 'STAGE_INSTANCE_CREATE':
+        return AuditLogEvent.StageInstanceCreate;
+      case 'STAGE_INSTANCE_UPDATE':
+        return AuditLogEvent.StageInstanceUpdate;
+      case 'STAGE_INSTANCE_DELETE':
+        return AuditLogEvent.StageInstanceDelete;
+      case 'STICKER_CREATE':
+        return AuditLogEvent.StickerCreate;
+      case 'STICKER_UPDATE':
+        return AuditLogEvent.StickerUpdate;
+      case 'STICKER_DELETE':
+        return AuditLogEvent.StickerDelete;
+      case 'GUILD_SCHEDULED_EVENT_CREATE':
+        return AuditLogEvent.GuildScheduledEventCreate;
+      case 'GUILD_SCHEDULED_EVENT_UPDATE':
+        return AuditLogEvent.GuildScheduledEventUpdate;
+      case 'GUILD_SCHEDULED_EVENT_DELETE':
+        return AuditLogEvent.GuildScheduledEventDelete;
+      case 'THREAD_CREATE':
+        return AuditLogEvent.ThreadCreate;
+      case 'THREAD_UPDATE':
+        return AuditLogEvent.ThreadUpdate;
+      case 'THREAD_DELETE':
+        return AuditLogEvent.ThreadDelete;
       default:
         return unknownKeyStrategy(key);
     }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -90,6 +90,7 @@ import {
   GuildSystemChannelFlags,
   GatewayIntentBits,
   ActivityFlags,
+  AuditLogEvent,
 } from 'discord-api-types/v9';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -851,6 +852,7 @@ export class EnumResolvers extends null {
   public static resolveIntegrationExpireBehavior(
     key: IntegrationExpireBehaviorEnumResolvable | IntegrationExpireBehavior,
   ): IntegrationExpireBehavior;
+  public static resolveAuditLogEvent(key: AuditLogEventEnumResolvable | AuditLogEvent): AuditLogEvent;
 }
 
 export class DMChannel extends TextBasedChannelMixin(Channel, ['bulkDelete']) {
@@ -935,7 +937,7 @@ export class Guild extends AnonymousGuild {
   public edit(data: GuildEditData, reason?: string): Promise<Guild>;
   public editWelcomeScreen(data: WelcomeScreenEditData): Promise<WelcomeScreen>;
   public equals(guild: Guild): boolean;
-  public fetchAuditLogs<T extends GuildAuditLogsResolvable = 'All'>(
+  public fetchAuditLogs<T extends GuildAuditLogsResolvable = null>(
     options?: GuildAuditLogsFetchOptions<T>,
   ): Promise<GuildAuditLogs<T>>;
   public fetchIntegrations(): Promise<Collection<Snowflake | string, Integration>>;
@@ -975,14 +977,13 @@ export class Guild extends AnonymousGuild {
   public toJSON(): unknown;
 }
 
-export class GuildAuditLogs<T extends GuildAuditLogsResolvable = 'All'> {
+export class GuildAuditLogs<T extends GuildAuditLogsResolvable = null> {
   private constructor(guild: Guild, data: RawGuildAuditLogData);
   private webhooks: Collection<Snowflake, Webhook>;
   private integrations: Collection<Snowflake | string, Integration>;
 
   public entries: Collection<Snowflake, GuildAuditLogsEntry<T>>;
 
-  public static Actions: GuildAuditLogsActions;
   public static Targets: GuildAuditLogsTargets;
   public static Entry: typeof GuildAuditLogsEntry;
   public static actionType(action: number): GuildAuditLogsActionType;
@@ -992,12 +993,8 @@ export class GuildAuditLogs<T extends GuildAuditLogsResolvable = 'All'> {
 }
 
 export class GuildAuditLogsEntry<
-  TActionRaw extends GuildAuditLogsResolvable = 'All',
-  TAction = TActionRaw extends keyof GuildAuditLogsIds
-    ? GuildAuditLogsIds[TActionRaw]
-    : TActionRaw extends null
-    ? 'All'
-    : TActionRaw,
+  TActionRaw extends GuildAuditLogsResolvable = null,
+  TAction = TActionRaw,
   TActionType extends GuildAuditLogsActionType = TAction extends keyof GuildAuditLogsTypes
     ? GuildAuditLogsTypes[TAction][1]
     : 'All',
@@ -3922,6 +3919,48 @@ export type GuildScheduledEventEntityTypeEnumResolvable = 'STAGE_INSTANCE' | 'VO
 
 export type IntegrationExpireBehaviorEnumResolvable = 'REMOVE_ROLE' | 'KICK';
 
+export type AuditLogEventEnumResolvable =
+  | 'GUILD_UPDATE'
+  | 'CHANNEL_CREATE'
+  | 'CHANNEL_UPDATE'
+  | 'CHANNEL_DELETE'
+  | 'CHANNEL_OVERWRITE_CREATE'
+  | 'CHANNEL_OVERWRITE_UPDATE'
+  | 'CHANNEL_OVERWRITE_DELETE'
+  | 'MEMBER_KICK'
+  | 'MEMBER_PRUNE'
+  | 'MEMBER_BAN_ADD'
+  | 'MEMBER_BAN_REMOVE'
+  | 'MEMBER_UPDATE'
+  | 'MEMBER_ROLE_UPDATE'
+  | 'MEMBER_MOVE'
+  | 'MEMBER_DISCONNECT'
+  | 'BOT_ADD'
+  | 'ROLE_CREATE'
+  | 'ROLE_UPDATE'
+  | 'ROLE_DELETE'
+  | 'INVITE_CREATE'
+  | 'INVITE_UPDATE'
+  | 'INVITE_DELETE'
+  | 'WEBHOOK_CREATE'
+  | 'WEBHOOK_UPDATE'
+  | 'WEBHOOK_DELETE'
+  | 'INTEGRATION_CREATE'
+  | 'INTEGRATION_UPDATE'
+  | 'INTEGRATION_DELETE'
+  | 'STAGE_INSTANCE_CREATE'
+  | 'STAGE_INSTANCE_UPDATE'
+  | 'STAGE_INSTANCE_DELETE'
+  | 'STICKER_CREATE'
+  | 'STICKER_UPDATE'
+  | 'STICKER_DELETE'
+  | 'GUILD_SCHEDULED_EVENT_CREATE'
+  | 'GUILD_SCHEDULED_EVENT_UPDATE'
+  | 'GUILD_SCHEDULED_EVENT_DELETE'
+  | 'THREAD_CREATE'
+  | 'THREAD_UPDATE'
+  | 'THREAD_DELETE';
+
 export interface ErrorEvent {
   error: unknown;
   message: string;
@@ -4042,137 +4081,83 @@ export interface GuildApplicationCommandPermissionData {
 }
 
 interface GuildAuditLogsTypes {
-  GuildUpdate: ['Guild', 'Update'];
-  ChannelCreate: ['Channel', 'Create'];
-  ChannelUpdate: ['Channel', 'Update'];
-  ChannelDelete: ['Channel', 'Delete'];
-  ChannelOverwriteCreate: ['Channel', 'Create'];
-  ChannelOverwriteUpdate: ['Channel', 'Update'];
-  ChannelOverwriteDelete: ['Channel', 'Delete'];
-  MemberKick: ['User', 'Delete'];
-  MemberPrune: ['User', 'Delete'];
-  MemberBanAdd: ['User', 'Delete'];
-  MemberBanRemove: ['User', 'Create'];
-  MemberUpdate: ['User', 'Update'];
-  MemberRoleUpdate: ['User', 'Update'];
-  MemberMove: ['User', 'Update'];
-  MemberDisconnect: ['User', 'Delete'];
-  BotAdd: ['User', 'Create'];
-  RoleCreate: ['Role', 'Create'];
-  RoleUpdate: ['Role', 'Update'];
-  RoleDelete: ['Role', 'Delete'];
-  InviteCreate: ['Invite', 'Create'];
-  InviteUpdate: ['Invite', 'Update'];
-  InviteDelete: ['Invite', 'Delete'];
-  WebhookCreate: ['Webhook', 'Create'];
-  WebhookUpdate: ['Webhook', 'Update'];
-  WebhookDelete: ['Webhook', 'Delete'];
-  EmojiCreate: ['Emoji', 'Create'];
-  EmojiUpdate: ['Emoji', 'Update'];
-  EmojiDelete: ['Emoji', 'Delete'];
-  MessageDelete: ['Message', 'Delete'];
-  MessageBulkDelete: ['Message', 'Delete'];
-  MessagePin: ['Message', 'Create'];
-  MessageUnpin: ['Message', 'Delete'];
-  IntegrationCreate: ['Integration', 'Create'];
-  IntegrationUpdate: ['Integration', 'Update'];
-  IntegrationDelete: ['Integration', 'Delete'];
-  StageInstanceCreate: ['StageInstance', 'Create'];
-  StageInstanceUpdate: ['StageInstance', 'Update'];
-  StageInstanceDelete: ['StageInstance', 'Delete'];
-  StickerCreate: ['Sticker', 'Create'];
-  StickerUpdate: ['Sticker', 'Update'];
-  StickerDelete: ['Sticker', 'Delete'];
-  GuildScheduledEventCreate: ['GuildScheduledEvent', 'Create'];
-  GuildScheduledEventUpdate: ['GuildScheduledEvent', 'Update'];
-  GuildScheduledEventDelete: ['GuildScheduledEvent', 'Delete'];
-  ThreadCreate: ['Thread', 'Create'];
-  ThreadUpdate: ['Thread', 'Update'];
-  ThreadDelete: ['Thread', 'Delete'];
+  [AuditLogEvent.GuildUpdate]: ['Guild', 'Update'];
+  [AuditLogEvent.ChannelCreate]: ['Channel', 'Create'];
+  [AuditLogEvent.ChannelUpdate]: ['Channel', 'Update'];
+  [AuditLogEvent.ChannelDelete]: ['Channel', 'Delete'];
+  [AuditLogEvent.ChannelOverwriteCreate]: ['Channel', 'Create'];
+  [AuditLogEvent.ChannelOverwriteUpdate]: ['Channel', 'Update'];
+  [AuditLogEvent.ChannelOverwriteDelete]: ['Channel', 'Delete'];
+  [AuditLogEvent.MemberKick]: ['User', 'Delete'];
+  [AuditLogEvent.MemberPrune]: ['User', 'Delete'];
+  [AuditLogEvent.MemberBanAdd]: ['User', 'Delete'];
+  [AuditLogEvent.MemberBanRemove]: ['User', 'Create'];
+  [AuditLogEvent.MemberUpdate]: ['User', 'Update'];
+  [AuditLogEvent.MemberRoleUpdate]: ['User', 'Update'];
+  [AuditLogEvent.MemberMove]: ['User', 'Update'];
+  [AuditLogEvent.MemberDisconnect]: ['User', 'Delete'];
+  [AuditLogEvent.BotAdd]: ['User', 'Create'];
+  [AuditLogEvent.RoleCreate]: ['Role', 'Create'];
+  [AuditLogEvent.RoleUpdate]: ['Role', 'Update'];
+  [AuditLogEvent.RoleDelete]: ['Role', 'Delete'];
+  [AuditLogEvent.InviteCreate]: ['Invite', 'Create'];
+  [AuditLogEvent.InviteUpdate]: ['Invite', 'Update'];
+  [AuditLogEvent.InviteDelete]: ['Invite', 'Delete'];
+  [AuditLogEvent.WebhookCreate]: ['Webhook', 'Create'];
+  [AuditLogEvent.WebhookUpdate]: ['Webhook', 'Update'];
+  [AuditLogEvent.WebhookDelete]: ['Webhook', 'Delete'];
+  [AuditLogEvent.EmojiCreate]: ['Emoji', 'Create'];
+  [AuditLogEvent.EmojiUpdate]: ['Emoji', 'Update'];
+  [AuditLogEvent.EmojiDelete]: ['Emoji', 'Delete'];
+  [AuditLogEvent.MessageDelete]: ['Message', 'Delete'];
+  [AuditLogEvent.MessageBulkDelete]: ['Message', 'Delete'];
+  [AuditLogEvent.MessagePin]: ['Message', 'Create'];
+  [AuditLogEvent.MessageUnpin]: ['Message', 'Delete'];
+  [AuditLogEvent.IntegrationCreate]: ['Integration', 'Create'];
+  [AuditLogEvent.IntegrationUpdate]: ['Integration', 'Update'];
+  [AuditLogEvent.IntegrationDelete]: ['Integration', 'Delete'];
+  [AuditLogEvent.StageInstanceCreate]: ['StageInstance', 'Create'];
+  [AuditLogEvent.StageInstanceUpdate]: ['StageInstance', 'Update'];
+  [AuditLogEvent.StageInstanceDelete]: ['StageInstance', 'Delete'];
+  [AuditLogEvent.StickerCreate]: ['Sticker', 'Create'];
+  [AuditLogEvent.StickerUpdate]: ['Sticker', 'Update'];
+  [AuditLogEvent.StickerDelete]: ['Sticker', 'Delete'];
+  [AuditLogEvent.GuildScheduledEventCreate]: ['GuildScheduledEvent', 'Create'];
+  [AuditLogEvent.GuildScheduledEventUpdate]: ['GuildScheduledEvent', 'Update'];
+  [AuditLogEvent.GuildScheduledEventDelete]: ['GuildScheduledEvent', 'Delete'];
+  [AuditLogEvent.ThreadCreate]: ['Thread', 'Create'];
+  [AuditLogEvent.ThreadUpdate]: ['Thread', 'Update'];
+  [AuditLogEvent.ThreadDelete]: ['Thread', 'Delete'];
 }
-
-export interface GuildAuditLogsIds {
-  1: 'GuildUpdate';
-  10: 'ChannelCreate';
-  11: 'ChannelUpdate';
-  12: 'ChannelDelete';
-  13: 'ChannelOverwriteCreate';
-  14: 'ChannelOverwriteUpdate';
-  15: 'ChannelOverwriteDelete';
-  20: 'MemberKick';
-  21: 'MemberPrune';
-  22: 'MemberBanAdd';
-  23: 'MemberBanRemove';
-  24: 'MemberUpdate';
-  25: 'MemberRoleUpdate';
-  26: 'MemberMove';
-  27: 'MemberDisconnect';
-  28: 'BotAdd';
-  30: 'RoleCreate';
-  31: 'RoleUpdate';
-  32: 'RoleDelete';
-  40: 'InviteCreate';
-  41: 'InviteUpdate';
-  42: 'InviteDelete';
-  50: 'WebhookCreate';
-  51: 'WebhookUpdate';
-  52: 'WebhookDelete';
-  60: 'EmojiCreate';
-  61: 'EmojiUpdate';
-  62: 'EmojiDelete';
-  72: 'MessageDelete';
-  73: 'MessageBulkDelete';
-  74: 'MessagePin';
-  75: 'MessageUnpin';
-  80: 'IntegrationCreate';
-  81: 'IntegrationUpdate';
-  82: 'IntegrationDelete';
-  83: 'StageInstanceCreate';
-  84: 'StageInstanceUpdate';
-  85: 'StageInstanceDelete';
-  90: 'StickerCreate';
-  91: 'StickerUpdate';
-  92: 'StickerDelete';
-  100: 'GuildScheduledEventCreate';
-  101: 'GuildScheduledEventUpdate';
-  102: 'GuildScheduledEventDelete';
-  110: 'ThreadCreate';
-  111: 'ThreadUpdate';
-  112: 'ThreadDelete';
-}
-
-export type GuildAuditLogsActions = { [Key in keyof GuildAuditLogsIds as GuildAuditLogsIds[Key]]: Key } & { All: null };
-
-export type GuildAuditLogsAction = keyof GuildAuditLogsActions;
 
 export type GuildAuditLogsActionType = GuildAuditLogsTypes[keyof GuildAuditLogsTypes][1] | 'All';
 
 export interface GuildAuditLogsEntryExtraField {
-  MemberPrune: { removed: number; days: number };
-  MemberMove: { channel: VoiceBasedChannel | { id: Snowflake }; count: number };
-  MessageDelete: { channel: GuildTextBasedChannel | { id: Snowflake }; count: number };
-  MessageBulkDelete: { channel: GuildTextBasedChannel | { id: Snowflake }; count: number };
-  MessagePin: { channel: GuildTextBasedChannel | { id: Snowflake }; messageId: Snowflake };
-  MessageUnpin: { channel: GuildTextBasedChannel | { id: Snowflake }; messageId: Snowflake };
-  MemberDisconnect: { count: number };
-  ChannelOverwriteCreate:
+  [AuditLogEvent.MemberPrune]: { removed: number; days: number };
+  [AuditLogEvent.MemberMove]: { channel: VoiceBasedChannel | { id: Snowflake }; count: number };
+  [AuditLogEvent.MessageDelete]: { channel: GuildTextBasedChannel | { id: Snowflake }; count: number };
+  [AuditLogEvent.MessageBulkDelete]: { channel: GuildTextBasedChannel | { id: Snowflake }; count: number };
+  [AuditLogEvent.MessagePin]: { channel: GuildTextBasedChannel | { id: Snowflake }; messageId: Snowflake };
+  [AuditLogEvent.MessageUnpin]: { channel: GuildTextBasedChannel | { id: Snowflake }; messageId: Snowflake };
+  [AuditLogEvent.MemberDisconnect]: { count: number };
+  [AuditLogEvent.ChannelOverwriteCreate]:
     | Role
     | GuildMember
     | { id: Snowflake; name: string; type: 'Role' }
     | { id: Snowflake; type: 'Member' };
-  ChannelOverwriteUpdate:
+  [AuditLogEvent.ChannelOverwriteUpdate]:
     | Role
     | GuildMember
     | { id: Snowflake; name: string; type: 'Role' }
     | { id: Snowflake; type: 'Member' };
-  ChannelOverwriteDelete:
+  [AuditLogEvent.ChannelOverwriteDelete]:
     | Role
     | GuildMember
     | { id: Snowflake; name: string; type: OverwriteType.Role }
     | { id: Snowflake; type: OverwriteType.Member };
-  StageInstanceCreate: StageChannel | { id: Snowflake };
-  StageInstanceDelete: StageChannel | { id: Snowflake };
-  StageInstanceUpdate: StageChannel | { id: Snowflake };
+  [AuditLogEvent.StageInstanceCreate]: StageChannel | { id: Snowflake };
+  [AuditLogEvent.StageInstanceDelete]: StageChannel | { id: Snowflake };
+  [AuditLogEvent.StageInstanceUpdate]: StageChannel | { id: Snowflake };
 }
 
 export interface GuildAuditLogsEntryTargetField<TActionType extends GuildAuditLogsActionType> {
@@ -4180,7 +4165,7 @@ export interface GuildAuditLogsEntryTargetField<TActionType extends GuildAuditLo
   Guild: Guild;
   Webhook: Webhook;
   Invite: Invite;
-  Message: TActionType extends 'MESSAGE_BULK_DELETE' ? Guild | { id: Snowflake } : User;
+  Message: TActionType extends AuditLogEvent.MessageBulkDelete ? Guild | { id: Snowflake } : User;
   Integration: Integration;
   Channel: NonThreadGuildBasedChannel | { id: Snowflake; [x: string]: unknown };
   Thread: ThreadChannel | { id: Snowflake; [x: string]: unknown };
@@ -4196,12 +4181,12 @@ export interface GuildAuditLogsFetchOptions<T extends GuildAuditLogsResolvable> 
   type?: T;
 }
 
-export type GuildAuditLogsResolvable = keyof GuildAuditLogsIds | GuildAuditLogsAction | null;
+export type GuildAuditLogsResolvable = AuditLogEvent | null;
 
 export type GuildAuditLogsTarget = GuildAuditLogsTypes[keyof GuildAuditLogsTypes][0] | 'All' | 'Unknown';
 
 export type GuildAuditLogsTargets = {
-  [key in GuildAuditLogsTarget]?: string;
+  [key in GuildAuditLogsTarget]: GuildAuditLogsTarget;
 };
 
 export type GuildBanResolvable = GuildBan | UserResolvable;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -993,8 +993,7 @@ export class GuildAuditLogs<T extends GuildAuditLogsResolvable = null> {
 }
 
 export class GuildAuditLogsEntry<
-  TActionRaw extends GuildAuditLogsResolvable = null,
-  TAction = TActionRaw,
+  TAction extends GuildAuditLogsResolvable = null,
   TActionType extends GuildAuditLogsActionType = TAction extends keyof GuildAuditLogsTypes
     ? GuildAuditLogsTypes[TAction][1]
     : 'All',

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -16,8 +16,8 @@ import {
   InteractionType,
   GatewayIntentBits,
   PermissionFlagsBits,
+  AuditLogEvent,
 } from 'discord-api-types/v9';
-import { AuditLogEvent } from 'discord-api-types/v9';
 import {
   ApplicationCommand,
   ApplicationCommandData,

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1225,79 +1225,51 @@ collector.on('end', (collection, reason) => {
 expectType<Promise<number | null>>(shard.eval(c => c.readyTimestamp));
 
 // Test audit logs
-expectType<Promise<GuildAuditLogs<'MemberKick'>>>(guild.fetchAuditLogs({ type: 'MemberKick' }));
-expectAssignable<Promise<GuildAuditLogs<AuditLogEvent.MemberKick>>>(
-  guild.fetchAuditLogs({ type: GuildAuditLogs.Actions.MemberKick }),
-);
 expectType<Promise<GuildAuditLogs<AuditLogEvent.MemberKick>>>(guild.fetchAuditLogs({ type: AuditLogEvent.MemberKick }));
 
-expectType<Promise<GuildAuditLogs<'ChannelCreate'>>>(guild.fetchAuditLogs({ type: 'ChannelCreate' }));
-expectAssignable<Promise<GuildAuditLogs<AuditLogEvent.ChannelCreate>>>(
-  guild.fetchAuditLogs({ type: GuildAuditLogs.Actions.ChannelCreate }),
-);
 expectType<Promise<GuildAuditLogs<AuditLogEvent.ChannelCreate>>>(
   guild.fetchAuditLogs({ type: AuditLogEvent.ChannelCreate }),
 );
 
-expectType<Promise<GuildAuditLogs<'IntegrationUpdate'>>>(guild.fetchAuditLogs({ type: 'IntegrationUpdate' }));
-expectAssignable<Promise<GuildAuditLogs<AuditLogEvent.IntegrationUpdate>>>(
-  guild.fetchAuditLogs({ type: GuildAuditLogs.Actions.IntegrationUpdate }),
-);
 expectType<Promise<GuildAuditLogs<AuditLogEvent.IntegrationUpdate>>>(
   guild.fetchAuditLogs({ type: AuditLogEvent.IntegrationUpdate }),
 );
 
-expectType<Promise<GuildAuditLogs<'All'>>>(guild.fetchAuditLogs({ type: 'All' }));
-expectType<Promise<GuildAuditLogs<null>>>(guild.fetchAuditLogs({ type: GuildAuditLogs.Actions.All }));
-expectType<Promise<GuildAuditLogs<'All'>>>(guild.fetchAuditLogs());
+expectType<Promise<GuildAuditLogs<null>>>(guild.fetchAuditLogs({ type: null }));
+expectType<Promise<GuildAuditLogs<null>>>(guild.fetchAuditLogs());
 
-expectType<Promise<GuildAuditLogsEntry<'MemberKick', 'MemberKick', 'Delete', 'User'> | undefined>>(
-  guild.fetchAuditLogs({ type: 'MemberKick' }).then(al => al.entries.first()),
-);
-expectType<Promise<GuildAuditLogsEntry<'MemberKick', 'MemberKick', 'Delete', 'User'> | undefined>>(
-  guild.fetchAuditLogs({ type: GuildAuditLogs.Actions.MemberKick }).then(al => al.entries.first()),
-);
-expectAssignable<Promise<GuildAuditLogsEntry<'MemberKick', 'MemberKick', 'Delete', 'User'> | undefined>>(
-  guild.fetchAuditLogs({ type: AuditLogEvent.MemberKick }).then(al => al.entries.first()),
-);
+expectType<
+  Promise<GuildAuditLogsEntry<AuditLogEvent.MemberKick, AuditLogEvent.MemberKick, 'Delete', 'User'> | undefined>
+>(guild.fetchAuditLogs({ type: AuditLogEvent.MemberKick }).then(al => al.entries.first()));
+expectAssignable<
+  Promise<GuildAuditLogsEntry<AuditLogEvent.MemberKick, AuditLogEvent.MemberKick, 'Delete', 'User'> | undefined>
+>(guild.fetchAuditLogs({ type: AuditLogEvent.MemberKick }).then(al => al.entries.first()));
 
-expectType<Promise<GuildAuditLogsEntry<'All', 'All', 'All', 'Unknown'> | undefined>>(
-  guild.fetchAuditLogs({ type: 'All' }).then(al => al.entries.first()),
-);
-expectType<Promise<GuildAuditLogsEntry<'All', 'All', 'All', 'Unknown'> | undefined>>(
-  guild.fetchAuditLogs({ type: GuildAuditLogs.Actions.All }).then(al => al.entries.first()),
-);
-expectType<Promise<GuildAuditLogsEntry<'All', 'All', 'All', 'Unknown'> | undefined>>(
+expectType<Promise<GuildAuditLogsEntry<null, null, 'All', 'Unknown'> | undefined>>(
   guild.fetchAuditLogs({ type: null }).then(al => al.entries.first()),
 );
-expectType<Promise<GuildAuditLogsEntry<'All', 'All', 'All', 'Unknown'> | undefined>>(
+expectType<Promise<GuildAuditLogsEntry<null, null, 'All', 'Unknown'> | undefined>>(
   guild.fetchAuditLogs().then(al => al.entries.first()),
 );
 
 expectType<Promise<null | undefined>>(
-  guild.fetchAuditLogs({ type: 'MemberKick' }).then(al => al.entries.first()?.extra),
-);
-expectType<Promise<null | undefined>>(
   guild.fetchAuditLogs({ type: AuditLogEvent.MemberKick }).then(al => al.entries.first()?.extra),
 );
 expectType<Promise<StageChannel | { id: Snowflake } | undefined>>(
-  guild.fetchAuditLogs({ type: 'StageInstanceCreate' }).then(al => al.entries.first()?.extra),
+  guild.fetchAuditLogs({ type: AuditLogEvent.StageInstanceCreate }).then(al => al.entries.first()?.extra),
 );
 expectType<Promise<{ channel: GuildTextBasedChannel | { id: Snowflake }; count: number } | undefined>>(
-  guild.fetchAuditLogs({ type: 'MessageDelete' }).then(al => al.entries.first()?.extra),
+  guild.fetchAuditLogs({ type: AuditLogEvent.MessageDelete }).then(al => al.entries.first()?.extra),
 );
 
-expectType<Promise<User | null | undefined>>(
-  guild.fetchAuditLogs({ type: 'MemberKick' }).then(al => al.entries.first()?.target),
-);
 expectType<Promise<User | null | undefined>>(
   guild.fetchAuditLogs({ type: AuditLogEvent.MemberKick }).then(al => al.entries.first()?.target),
 );
 expectType<Promise<StageInstance | undefined>>(
-  guild.fetchAuditLogs({ type: 'StageInstanceCreate' }).then(al => al.entries.first()?.target),
+  guild.fetchAuditLogs({ type: AuditLogEvent.StageInstanceCreate }).then(al => al.entries.first()?.target),
 );
 expectType<Promise<User | undefined>>(
-  guild.fetchAuditLogs({ type: 'MessageDelete' }).then(al => al.entries.first()?.target),
+  guild.fetchAuditLogs({ type: AuditLogEvent.MessageDelete }).then(al => al.entries.first()?.target),
 );
 
 expectType<Promise<User | undefined>>(

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1238,17 +1238,17 @@ expectType<Promise<GuildAuditLogs<AuditLogEvent.IntegrationUpdate>>>(
 expectType<Promise<GuildAuditLogs<null>>>(guild.fetchAuditLogs({ type: null }));
 expectType<Promise<GuildAuditLogs<null>>>(guild.fetchAuditLogs());
 
-expectType<
-  Promise<GuildAuditLogsEntry<AuditLogEvent.MemberKick, AuditLogEvent.MemberKick, 'Delete', 'User'> | undefined>
->(guild.fetchAuditLogs({ type: AuditLogEvent.MemberKick }).then(al => al.entries.first()));
-expectAssignable<
-  Promise<GuildAuditLogsEntry<AuditLogEvent.MemberKick, AuditLogEvent.MemberKick, 'Delete', 'User'> | undefined>
->(guild.fetchAuditLogs({ type: AuditLogEvent.MemberKick }).then(al => al.entries.first()));
+expectType<Promise<GuildAuditLogsEntry<AuditLogEvent.MemberKick, 'Delete', 'User'> | undefined>>(
+  guild.fetchAuditLogs({ type: AuditLogEvent.MemberKick }).then(al => al.entries.first()),
+);
+expectAssignable<Promise<GuildAuditLogsEntry<AuditLogEvent.MemberKick, 'Delete', 'User'> | undefined>>(
+  guild.fetchAuditLogs({ type: AuditLogEvent.MemberKick }).then(al => al.entries.first()),
+);
 
-expectType<Promise<GuildAuditLogsEntry<null, null, 'All', 'Unknown'> | undefined>>(
+expectType<Promise<GuildAuditLogsEntry<null, 'All', 'Unknown'> | undefined>>(
   guild.fetchAuditLogs({ type: null }).then(al => al.entries.first()),
 );
-expectType<Promise<GuildAuditLogsEntry<null, null, 'All', 'Unknown'> | undefined>>(
+expectType<Promise<GuildAuditLogsEntry<null, 'All', 'Unknown'> | undefined>>(
   guild.fetchAuditLogs().then(al => al.entries.first()),
 );
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1272,11 +1272,6 @@ expectType<Promise<User | undefined>>(
   guild.fetchAuditLogs({ type: AuditLogEvent.MessageDelete }).then(al => al.entries.first()?.target),
 );
 
-expectType<Promise<User | undefined>>(
-  // @ts-expect-error Invalid audit log ID
-  guild.fetchAuditLogs({ type: 2000 }).then(al => al.entries.first()?.target),
-);
-
 declare const TextBasedChannel: TextBasedChannel;
 declare const TextBasedChannelTypes: TextBasedChannelTypes;
 declare const VoiceBasedChannel: VoiceBasedChannel;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Changes GuildAuditLogs typings to be accurate, adds AuditLogEvent to EnumResolvers, and updates tests.

Unfortunately, I had to remove one of the tests since [typescript doesn't play well](https://github.com/microsoft/TypeScript/issues/30629) with numeric enums. 

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->