### PR TITLE
refactor(guildbanmanager)!: rename days option to deleteMessageDays

### DIFF
--- a/packages/discord.js/src/managers/GuildBanManager.js
+++ b/packages/discord.js/src/managers/GuildBanManager.js
@@ -120,7 +120,7 @@ class GuildBanManager extends CachedManager {
   /**
    * Options used to ban a user from a guild.
    * @typedef {Object} BanOptions
-   * @property {number} [days] Number of days of messages to delete, must be between 0 and 7, inclusive
+   * @property {number} [deleteMessageDays] Number of days of messages to delete, must be between 0 and 7, inclusive
    * @property {string} [reason] The reason for the ban
    */
 
@@ -142,7 +142,7 @@ class GuildBanManager extends CachedManager {
     const id = this.client.users.resolveId(user);
     if (!id) throw new Error('BAN_RESOLVE_ID', true);
     await this.client.rest.put(Routes.guildBan(this.guild.id, id), {
-      body: { delete_message_days: options.days },
+      body: { delete_message_days: options.deleteMessageDays },
       reason: options.reason,
     });
     if (user instanceof GuildMember) return user;

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -389,7 +389,7 @@ class GuildMemberManager extends CachedManager {
    *   .then(banInfo => console.log(`Banned ${banInfo.user?.tag ?? banInfo.tag ?? banInfo}`))
    *   .catch(console.error);
    */
-  ban(user, options = { days: 0 }) {
+  ban(user, options) {
     return this.guild.bans.create(user, options);
   }
 

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -348,7 +348,7 @@ class GuildMember extends Base {
    * @returns {Promise<GuildMember>}
    * @example
    * // ban a guild member
-   * guildMember.ban({ days: 7, reason: 'They deserved it' })
+   * guildMember.ban({ deleteMessageDays: 7, reason: 'They deserved it' })
    *   .then(console.log)
    *   .catch(console.error);
    */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3402,7 +3402,7 @@ export interface AwaitReactionsOptions extends ReactionCollectorOptions {
 }
 
 export interface BanOptions {
-  days?: number;
+  deleteMessageDays?: number;
   reason?: string;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR renamed the `days` option in BanOptions to `deleteMessageDays` to be inline with the API name and to avoid confusion with users thinking it's a way to tempban people, which it's not. It also removes the default of 0 since that's handled by the API (not documented, but it is 0)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
