### PR TITLE
refactor!: remove redundant API defaults

### DIFF
--- a/packages/discord.js/src/managers/GuildBanManager.js
+++ b/packages/discord.js/src/managers/GuildBanManager.js
@@ -120,7 +120,7 @@ class GuildBanManager extends CachedManager {
   /**
    * Options used to ban a user from a guild.
    * @typedef {Object} BanOptions
-   * @property {number} [days=0] Number of days of messages to delete, must be between 0 and 7, inclusive
+   * @property {number} [days] Number of days of messages to delete, must be between 0 and 7, inclusive
    * @property {string} [reason] The reason for the ban
    */
 
@@ -137,7 +137,7 @@ class GuildBanManager extends CachedManager {
    *   .then(banInfo => console.log(`Banned ${banInfo.user?.tag ?? banInfo.tag ?? banInfo}`))
    *   .catch(console.error);
    */
-  async create(user, options = { days: 0 }) {
+  async create(user, options = {}) {
     if (typeof options !== 'object') throw new TypeError('INVALID_TYPE', 'options', 'object', true);
     const id = this.client.users.resolveId(user);
     if (!id) throw new Error('BAN_RESOLVE_ID', true);

--- a/packages/discord.js/src/managers/GuildInviteManager.js
+++ b/packages/discord.js/src/managers/GuildInviteManager.js
@@ -178,7 +178,7 @@ class GuildInviteManager extends CachedManager {
    */
   async create(
     channel,
-    { temporary = false, maxAge = 86400, maxUses = 0, unique, targetUser, targetApplication, targetType, reason } = {},
+    { temporary, maxAge, maxUses, unique, targetUser, targetApplication, targetType, reason } = {},
   ) {
     const id = this.guild.channels.resolveId(channel);
     if (!id) throw new Error('GUILD_CHANNEL_RESOLVE');

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -250,7 +250,7 @@ class GuildManager extends CachedManager {
    * @typedef {Object} FetchGuildsOptions
    * @property {Snowflake} [before] Get guilds before this guild id
    * @property {Snowflake} [after] Get guilds after this guild id
-   * @property {number} [limit=200] Maximum number of guilds to request (1-200)
+   * @property {number} [limit] Maximum number of guilds to request (1-200)
    */
 
   /**

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -194,7 +194,7 @@ class GuildMemberManager extends CachedManager {
    * Options used for searching guild members.
    * @typedef {Object} GuildSearchMembersOptions
    * @property {string} query Filter members whose username or nickname start with this query
-   * @property {number} [limit=1] Maximum number of members to search
+   * @property {number} [limit] Maximum number of members to search
    * @property {boolean} [cache=true] Whether or not to cache the fetched member(s)
    */
 
@@ -203,7 +203,7 @@ class GuildMemberManager extends CachedManager {
    * @param {GuildSearchMembersOptions} options Options for searching members
    * @returns {Promise<Collection<Snowflake, GuildMember>>}
    */
-  async search({ query, limit = 1, cache = true } = {}) {
+  async search({ query, limit, cache = true } = {}) {
     const data = await this.client.rest.get(Routes.guildMembersSearch(this.guild.id), {
       query: new URLSearchParams({ query, limit }),
     });
@@ -214,7 +214,7 @@ class GuildMemberManager extends CachedManager {
    * Options used for listing guild members.
    * @typedef {Object} GuildListMembersOptions
    * @property {Snowflake} [after] Limit fetching members to those with an id greater than the supplied id
-   * @property {number} [limit=1] Maximum number of members to list
+   * @property {number} [limit] Maximum number of members to list
    * @property {boolean} [cache=true] Whether or not to cache the fetched member(s)
    */
 
@@ -223,7 +223,7 @@ class GuildMemberManager extends CachedManager {
    * @param {GuildListMembersOptions} [options] Options for listing members
    * @returns {Promise<Collection<Snowflake, GuildMember>>}
    */
-  async list({ after, limit = 1, cache = true } = {}) {
+  async list({ after, limit, cache = true } = {}) {
     const query = new URLSearchParams({ limit });
     if (after) {
       query.set('after', after);
@@ -298,9 +298,9 @@ class GuildMemberManager extends CachedManager {
    * <info>It's recommended to set {@link GuildPruneMembersOptions#count options.count}
    * to `false` for large guilds.</info>
    * @typedef {Object} GuildPruneMembersOptions
-   * @property {number} [days=7] Number of days of inactivity required to kick
+   * @property {number} [days] Number of days of inactivity required to kick
    * @property {boolean} [dry=false] Get the number of users that will be kicked, without actually kicking them
-   * @property {boolean} [count=true] Whether or not to return the number of users that have been kicked.
+   * @property {boolean} [count] Whether or not to return the number of users that have been kicked.
    * @property {RoleResolvable[]} [roles] Array of roles to bypass the "...and no roles" constraint when pruning
    * @property {string} [reason] Reason for this prune
    */
@@ -325,7 +325,7 @@ class GuildMemberManager extends CachedManager {
    *    .then(pruned => console.log(`I just pruned ${pruned} people!`))
    *    .catch(console.error);
    */
-  async prune({ days = 7, dry = false, count: compute_prune_count = true, roles = [], reason } = {}) {
+  async prune({ days, dry = false, count: compute_prune_count, roles = [], reason } = {}) {
     if (typeof days !== 'number') throw new TypeError('PRUNE_DAYS_TYPE');
 
     const query = { days };

--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -37,7 +37,7 @@ class MessageManager extends CachedManager {
    * The parameters to pass in when requesting previous messages from a channel. `around`, `before` and
    * `after` are mutually exclusive. All the parameters are optional.
    * @typedef {Object} ChannelLogsQueryOptions
-   * @property {number} [limit=50] Number of messages to acquire
+   * @property {number} [limit] Number of messages to acquire
    * @property {Snowflake} [before] The message's id to get the messages that were posted before it
    * @property {Snowflake} [after] The message's id to get the messages that were posted after it
    * @property {Snowflake} [around] The message's id to get the messages that were posted around it

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -173,11 +173,11 @@ class BaseGuildTextChannel extends GuildChannel {
   /**
    * Options used to create an invite to a guild channel.
    * @typedef {Object} CreateInviteOptions
-   * @property {boolean} [temporary=false] Whether members that joined via the invite should be automatically
+   * @property {boolean} [temporary] Whether members that joined via the invite should be automatically
    * kicked after 24 hours if they have not yet received a role
-   * @property {number} [maxAge=86400] How long the invite should last (in seconds, 0 for forever)
-   * @property {number} [maxUses=0] Maximum number of uses
-   * @property {boolean} [unique=false] Create a unique invite, or use an existing one with similar settings
+   * @property {number} [maxAge] How long the invite should last (in seconds, 0 for forever)
+   * @property {number} [maxUses] Maximum number of uses
+   * @property {boolean} [unique] Create a unique invite, or use an existing one with similar settings
    * @property {UserResolvable} [targetUser] The user whose stream to display for this invite,
    * required if `targetType` is {@link InviteTargetType.Stream}, the user must be streaming in the channel
    * @property {ApplicationResolvable} [targetApplication] The embedded application to open for this invite,

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -757,8 +757,8 @@ class Message extends Base {
   /**
    * Options provided when sending a message as an inline reply.
    * @typedef {BaseMessageOptions} ReplyMessageOptions
-   * @property {boolean} [failIfNotExists=true] Whether to error if the referenced message
-   * does not exist (creates a standard message in this case when false)
+   * @property {boolean} [failIfNotExists=this.client.options.failIfNotExists] Whether to error if the referenced
+   * message does not exist (creates a standard message in this case when false)
    * @property {StickerResolvable[]} [stickers=[]] Stickers to send in the message
    */
 

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -103,8 +103,8 @@ class TextBasedChannel {
    * Options for sending a message with a reply.
    * @typedef {Object} ReplyOptions
    * @property {MessageResolvable} messageReference The message to reply to (must be in the same channel and not system)
-   * @property {boolean} [failIfNotExists=true] Whether to error if the referenced message
-   * does not exist (creates a standard message in this case when false)
+   * @property {boolean} [failIfNotExists=this.client.options.failIfNotExists] Whether to error if the referenced
+   * message does not exist (creates a standard message in this case when false)
    */
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes all defaults strictly defined in discord.js that were the exact same as the API ones. I left out some that didn't have documentation on Discord's side simply because I couldn't be bothered to test those, so I only removed the ones I'm 100% sure are redundant. Let me know if I missed any

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
