### PR TITLE
refactor(guild): move `premiumSubscriptionCount` to `AnonymousGuild`

### DIFF
--- a/packages/discord.js/src/structures/AnonymousGuild.js
+++ b/packages/discord.js/src/structures/AnonymousGuild.js
@@ -63,6 +63,14 @@ class AnonymousGuild extends BaseGuild {
        */
       this.nsfwLevel = data.nsfw_level;
     }
+
+    if ('premium_subscription_count' in data) {
+      /**
+       * The total number of boosts for this server
+       * @type {?number}
+       */
+      this.premiumSubscriptionCount = data.premium_subscription_count;
+    }
   }
 
   /**

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -209,14 +209,6 @@ class Guild extends AnonymousGuild {
       this.premiumTier = data.premium_tier;
     }
 
-    if ('premium_subscription_count' in data) {
-      /**
-       * The total number of boosts for this server
-       * @type {?number}
-       */
-      this.premiumSubscriptionCount = data.premium_subscription_count;
-    }
-
     if ('widget_enabled' in data) {
       /**
        * Whether widget images are enabled on this guild

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -198,6 +198,7 @@ export abstract class AnonymousGuild extends BaseGuild {
   public banner: string | null;
   public description: string | null;
   public nsfwLevel: GuildNSFWLevel;
+  public premiumSubscriptionCount: number | null;
   public splash: string | null;
   public vanityURLCode: string | null;
   public verificationLevel: GuildVerificationLevel;
@@ -905,7 +906,6 @@ export class Guild extends AnonymousGuild {
   public mfaLevel: GuildMFALevel;
   public ownerId: Snowflake;
   public preferredLocale: string;
-  public premiumSubscriptionCount: number | null;
   public premiumProgressBarEnabled: boolean;
   public premiumTier: GuildPremiumTier;
   public presences: PresenceManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Moved the `premiumSubscriptionCount` property from the `Guild` to the `AnonymousGuild` structure as it is only being used as a base for both the `Guild` and `InviteGuild` structures
- https://github.com/discord/discord-api-docs/pull/4493

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
