### PR TITLE
fix(dataresolver): ensure fetched file is convert to a buffer

### DIFF
--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Buffer } = require('node:buffer');
-const fs = require('node:fs');
+const fs = require('node:fs/promises');
 const path = require('node:path');
 const stream = require('node:stream');
 const fetch = require('node-fetch');
@@ -121,14 +121,11 @@ class DataResolver extends null {
         return res.buffer();
       }
 
-      return new Promise((resolve, reject) => {
-        const file = path.resolve(resource);
-        fs.stat(file, (err, stats) => {
-          if (err) return reject(err);
-          if (!stats.isFile()) return reject(new DiscordError('FILE_NOT_FOUND', file));
-          return resolve(fs.createReadStream(file));
-        });
-      });
+      const file = path.resolve(resource);
+
+      const stats = await fs.stat(file);
+      if (!stats.isFile()) throw new DiscordError('FILE_NOT_FOUND', file);
+      return fs.readFile(file);
     }
 
     throw new TypeError('REQ_RESOURCE_TYPE');

--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -67,7 +67,7 @@ class DataResolver extends null {
       return image;
     }
     const file = await this.resolveFile(image);
-    return DataResolver.resolveBase64(file);
+    return this.resolveBase64(file);
   }
 
   /**
@@ -118,7 +118,7 @@ class DataResolver extends null {
     if (typeof resource === 'string') {
       if (/^https?:\/\//.test(resource)) {
         const res = await fetch(resource);
-        return res.body;
+        return res.buffer();
       }
 
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
creating an emoji using a web URL is currently nonfunctional in `main` but working in `stable`.

`stable`->`main` removed `resolveFileAsBuffer` but `DataResolver.resolveBase64` still expected a Buffer,
and `resolveFile` provided a ReadableStream.

there's no reason to readd/reimplement that function since it only acted as an intermediary between those 2 other static methods, in this one specific case. so now `resolveFile` will directly return a Buffer, as the typing suggests it's supposed to.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

