### PR TITLE
refactor(requestmanager): use timestampfrom

### DIFF
--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -447,8 +447,8 @@ export class RequestManager extends EventEmitter {
 		// https://github.com/discord/discord-api-docs/issues/1295
 		if (method === RequestMethod.Delete && baseRoute === '/channels/:id/messages/:id') {
 			const id = /\d{16,19}$/.exec(endpoint)![0];
-			const snowflake = DiscordSnowflake.deconstruct(id);
-			if (Date.now() - Number(snowflake.timestamp) > 1000 * 60 * 60 * 24 * 14) {
+			const timestamp = DiscordSnowflake.timestampFrom(id);
+			if (Date.now() - timestamp > 1000 * 60 * 60 * 24 * 14) {
 				exceptions += '/Delete Old Message';
 			}
 		}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
replaces the last occurrence of  `DiscordSnowflake.deconstruct().timestamp` with `DiscordSnowflake.timestampFrom()`


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
