### PR TITLE
types(embed): fix timestamp allowed types

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -484,7 +484,7 @@ export interface EmbedData {
   type?: EmbedType;
   description?: string;
   url?: string;
-  timestamp?: string;
+  timestamp?: string | number | Date;
   color?: number;
   footer?: EmbedFooterData;
   image?: EmbedImageData;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The constructor already accepts these types:
https://github.com/discordjs/discord.js/blob/c1b27f8eed8ea04a48bc106453892bddcdc6b73e/packages/builders/src/messages/embed/UnsafeEmbed.ts#L44
(speaking of that line, it could use a logical assignment if anyone wants a free PR)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
