### PR TITLE
feat(options): Add support for custom JSON transformers

### DIFF
--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -6,7 +6,6 @@ const { MessageFlags } = require('discord-api-types/v9');
 const { RangeError } = require('../errors');
 const DataResolver = require('../util/DataResolver');
 const MessageFlagsBitField = require('../util/MessageFlagsBitField');
-const Transformers = require('../util/Transformers');
 const Util = require('../util/Util');
 
 /**
@@ -133,7 +132,7 @@ class MessagePayload {
     }
 
     const components = this.options.components?.map(c =>
-      isJSONEncodable(c) ? c.toJSON() : Transformers.toSnakeCase(c),
+      isJSONEncodable(c) ? c.toJSON() : this.target.client.options.jsonTransformer(c),
     );
 
     let username;
@@ -194,7 +193,7 @@ class MessagePayload {
       tts,
       nonce,
       embeds: this.options.embeds?.map(embed =>
-        embed instanceof Embed ? embed.toJSON() : Transformers.toSnakeCase(embed),
+        embed instanceof Embed ? embed.toJSON() : this.target.client.options.jsonTransformer(embed),
       ),
       components,
       username,

--- a/packages/discord.js/src/util/Options.js
+++ b/packages/discord.js/src/util/Options.js
@@ -2,6 +2,7 @@
 
 const process = require('node:process');
 const { DefaultRestOptions } = require('@discordjs/rest');
+const Transformers = require('./Transformers');
 
 /**
  * @typedef {Function} CacheFactory
@@ -35,6 +36,7 @@ const { DefaultRestOptions } = require('@discordjs/rest');
  * @property {SweeperOptions} [sweepers={}] Options for cache sweeping
  * @property {WebsocketOptions} [ws] Options for the WebSocket
  * @property {RESTOptions} [rest] Options for the REST manager
+ * @property {Function} [jsonTransformer] A function used to transform outgoing json data
  */
 
 /**
@@ -88,6 +90,7 @@ class Options extends null {
         version: 9,
       },
       rest: DefaultRestOptions,
+      jsonTransformer: Transformers.toSnakeCase,
     };
   }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3635,6 +3635,7 @@ export interface ClientOptions {
   sweepers?: SweeperOptions;
   ws?: WebSocketOptions;
   rest?: Partial<RESTOptions>;
+  jsonTransformer?: (obj: unknown) => unknown;
 }
 
 export type ClientPresenceStatus = 'online' | 'idle' | 'dnd';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The builder constructor json transformations can currently be opted out of if builders are imported from the external package. However there's currently no way to opt out of json transformation that occurs when djs sends outgoing requests. For example if a developer *always* uses snake_case for their json payloads the transformer is always used regardless if it's needed or not. 

With this PR they could avoid this with an identity function:
```ts
const client = new Client({ jsonTransformer: (obj) => obj });
```

This PR allows custom JSON transformer functions and adds an interface for controlling how json is transformed via a client option that takes a transform function.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
