### PR TITLE
fix(Shard): V13 EventEmitter listener warning

### DIFF
--- a/src/sharding/ShardClientUtil.js
+++ b/src/sharding/ShardClientUtil.js
@@ -111,13 +111,16 @@ class ShardClientUtil {
       const listener = message => {
         if (message?._sFetchProp !== prop || message._sFetchPropShard !== shard) return;
         parent.removeListener('message', listener);
+        this.decrementMaxListeners(parent);
         if (!message._error) resolve(message._result);
         else reject(Util.makeError(message._error));
       };
+      this.incrementMaxListeners(parent);
       parent.on('message', listener);
 
       this.send({ _sFetchProp: prop, _sFetchPropShard: shard }).catch(err => {
         parent.removeListener('message', listener);
+        this.decrementMaxListeners(parent);
         reject(err);
       });
     });
@@ -146,13 +149,15 @@ class ShardClientUtil {
       const listener = message => {
         if (message?._sEval !== script || message._sEvalShard !== options.shard) return;
         parent.removeListener('message', listener);
+        this.decrementMaxListeners(parent);
         if (!message._error) resolve(message._result);
         else reject(Util.makeError(message._error));
       };
+      this.incrementMaxListeners(parent);
       parent.on('message', listener);
-
       this.send({ _sEval: script, _sEvalShard: options.shard }).catch(err => {
         parent.removeListener('message', listener);
+        this.decrementMaxListeners(parent);
         reject(err);
       });
     });
@@ -240,6 +245,30 @@ class ShardClientUtil {
     const shard = Number(BigInt(guildId) >> 22n) % shardCount;
     if (shard < 0) throw new Error('SHARDING_SHARD_MISCALCULATION', shard, guildId, shardCount);
     return shard;
+  }
+
+  /**
+   * Increments max listeners by one for a given emitter, if they are not zero.
+   * @param {EventEmitter|process} emitter The emitter that emits the events.
+   * @private
+   */
+  incrementMaxListeners(emitter) {
+    const maxListeners = emitter.getMaxListeners();
+    if (maxListeners !== 0) {
+      emitter.setMaxListeners(maxListeners + 1);
+    }
+  }
+
+  /**
+   * Decrements max listeners by one for a given emitter, if they are not zero.
+   * @param {EventEmitter|process} emitter The emitter that emits the events.
+   * @private
+   */
+  decrementMaxListeners(emitter) {
+    const maxListeners = emitter.getMaxListeners();
+    if (maxListeners !== 0) {
+      emitter.setMaxListeners(maxListeners - 1);
+    }
   }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2008,6 +2008,8 @@ export class Shard extends EventEmitter {
   private _fetches: Map<string, Promise<unknown>>;
   private _handleExit(respawn?: boolean, timeout?: number): void;
   private _handleMessage(message: unknown): void;
+  private incrementMaxListeners(emitter: EventEmitter | ChildProcess): void;
+  private decrementMaxListeners(emitter: EventEmitter | ChildProcess): void;
 
   public args: string[];
   public execArgv: string[];
@@ -2041,6 +2043,8 @@ export class ShardClientUtil {
   private constructor(client: Client, mode: ShardingManagerMode);
   private _handleMessage(message: unknown): void;
   private _respond(type: string, message: unknown): void;
+  private incrementMaxListeners(emitter: EventEmitter | ChildProcess): void;
+  private decrementMaxListeners(emitter: EventEmitter | ChildProcess): void;
 
   public client: Client;
   public readonly count: number;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Backports https://github.com/discordjs/discord.js/pull/7240 to version 13.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
