### PR TITLE
fix(builders): allow negative min/max value of number/integer option

### DIFF
--- a/packages/builders/__tests__/interactions/SlashCommands/Options.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/Options.test.ts
@@ -39,7 +39,7 @@ const getIntegerOption = () =>
 		.setName('owo')
 		.setDescription('Testing 123')
 		.setRequired(true)
-		.setMinValue(1)
+		.setMinValue(-1)
 		.setMaxValue(10);
 
 const getNumberOption = () =>
@@ -47,7 +47,7 @@ const getNumberOption = () =>
 		.setName('owo')
 		.setDescription('Testing 123')
 		.setRequired(true)
-		.setMinValue(1)
+		.setMinValue(-1.23)
 		.setMaxValue(10);
 
 const getUserOption = () => new SlashCommandUserOption().setName('owo').setDescription('Testing 123').setRequired(true);
@@ -84,7 +84,7 @@ describe('Application Command toJSON() results', () => {
 			type: ApplicationCommandOptionType.Integer,
 			required: true,
 			max_value: 10,
-			min_value: 1,
+			min_value: -1,
 		});
 
 		expect(getIntegerOption().setAutocomplete(true).setChoices().toJSON()).toEqual<APIApplicationCommandIntegerOption>({
@@ -93,7 +93,7 @@ describe('Application Command toJSON() results', () => {
 			type: ApplicationCommandOptionType.Integer,
 			required: true,
 			max_value: 10,
-			min_value: 1,
+			min_value: -1,
 			autocomplete: true,
 			// @ts-expect-error TODO: you *can* send an empty array with autocomplete: true, should correct that in types
 			choices: [],
@@ -107,7 +107,7 @@ describe('Application Command toJSON() results', () => {
 			type: ApplicationCommandOptionType.Integer,
 			required: true,
 			max_value: 10,
-			min_value: 1,
+			min_value: -1,
 			choices: [{ name: 'uwu', value: 1 }],
 		});
 	});
@@ -128,7 +128,7 @@ describe('Application Command toJSON() results', () => {
 			type: ApplicationCommandOptionType.Number,
 			required: true,
 			max_value: 10,
-			min_value: 1,
+			min_value: -1.23,
 		});
 
 		expect(getNumberOption().setAutocomplete(true).setChoices().toJSON()).toEqual<APIApplicationCommandNumberOption>({
@@ -137,7 +137,7 @@ describe('Application Command toJSON() results', () => {
 			type: ApplicationCommandOptionType.Number,
 			required: true,
 			max_value: 10,
-			min_value: 1,
+			min_value: -1.23,
 			autocomplete: true,
 			// @ts-expect-error TODO: you *can* send an empty array with autocomplete: true, should correct that in types
 			choices: [],
@@ -149,7 +149,7 @@ describe('Application Command toJSON() results', () => {
 			type: ApplicationCommandOptionType.Number,
 			required: true,
 			max_value: 10,
-			min_value: 1,
+			min_value: -1.23,
 			choices: [{ name: 'uwu', value: 1 }],
 		});
 	});

--- a/packages/builders/src/interactions/slashCommands/options/integer.ts
+++ b/packages/builders/src/interactions/slashCommands/options/integer.ts
@@ -5,7 +5,7 @@ import { ApplicationCommandNumericOptionMinMaxValueMixin } from '../mixins/Appli
 import { ApplicationCommandOptionBase } from '../mixins/ApplicationCommandOptionBase';
 import { ApplicationCommandOptionWithChoicesAndAutocompleteMixin } from '../mixins/ApplicationCommandOptionWithChoicesAndAutocompleteMixin';
 
-const numberValidator = z.number().int().nonnegative();
+const numberValidator = z.number().int();
 
 @mix(ApplicationCommandNumericOptionMinMaxValueMixin, ApplicationCommandOptionWithChoicesAndAutocompleteMixin)
 export class SlashCommandIntegerOption

--- a/packages/builders/src/interactions/slashCommands/options/number.ts
+++ b/packages/builders/src/interactions/slashCommands/options/number.ts
@@ -5,7 +5,7 @@ import { ApplicationCommandNumericOptionMinMaxValueMixin } from '../mixins/Appli
 import { ApplicationCommandOptionBase } from '../mixins/ApplicationCommandOptionBase';
 import { ApplicationCommandOptionWithChoicesAndAutocompleteMixin } from '../mixins/ApplicationCommandOptionWithChoicesAndAutocompleteMixin';
 
-const numberValidator = z.number().nonnegative();
+const numberValidator = z.number();
 
 @mix(ApplicationCommandNumericOptionMinMaxValueMixin, ApplicationCommandOptionWithChoicesAndAutocompleteMixin)
 export class SlashCommandNumberOption


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Min/max value of number/integer options allow any double/integer between -2^53 and 2^53 
[Documentation - Application Command Option Type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
