### PR TITLE
refactor(`Message`): use raw data storage for messages

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -129,6 +129,38 @@ class Message extends Base {
   }
 
   /**
+   * A list of embeds in the message - e.g. YouTube Player
+   * @type {Embed[]}
+   */
+  get embeds() {
+    return this._embeds ?? [];
+  }
+
+  /**
+   * A list of MessageActionRows in the message
+   * @type {ActionRow[]}
+   */
+  get components() {
+    return this._components ?? [];
+  }
+
+  /**
+   * A collection of attachments in the message - e.g. Pictures - mapped by their ids
+   * @type {Collection<Snowflake, MessageAttachment>}
+   */
+  get attachments() {
+    return this._attachments ?? new Collection();
+  }
+
+  /**
+   * A collection of stickers in the message
+   * @type {Collection<Snowflake, Sticker>}
+   */
+  get stickers() {
+    return this._stickers ?? new Collection();
+  }
+
+  /**
    * Whether or not the message was Text-To-Speech
    * @type {?boolean}
    * @readonly
@@ -425,44 +457,30 @@ class Message extends Base {
     }
 
     if (embeds) {
-      /**
-       * A list of embeds in the message - e.g. YouTube Player
-       * @type {Embed[]}
-       */
       this._embeds = embeds.map(e => new Embed(e));
+    } else {
+      this._embeds = this._embeds?.slice();
     }
 
     if (components) {
-      /**
-       * A list of MessageActionRows in the message
-       * @type {ActionRow[]}
-       */
       this._components = components.map(c => createComponent(c));
+    } else {
+      this._components = this._components?.slice();
     }
 
     if (attachments) {
-      /**
-       * A collection of attachments in the message - e.g. Pictures - mapped by their ids
-       * @type {Collection<Snowflake, MessageAttachment>}
-       */
-      this.attachments = new Collection();
-      if (data.attachments) {
-        for (const attachment of data.attachments) {
-          this.attachments.set(attachment.id, new MessageAttachment(attachment.url, attachment.filename, attachment));
-        }
+      this._attachments = new Collection();
+      for (const attachment of attachments) {
+        this._attachments.set(attachment.id, new MessageAttachment(attachment.url, attachment.filename, attachment));
       }
-    } else {
-      this.attachments = new Collection(this.attachments);
+    } else if (this._attachments) {
+      this._attachments = new Collection(this._attachments);
     }
 
     if (sticker_items || stickers) {
-      /**
-       * A collection of stickers in the message
-       * @type {Collection<Snowflake, Sticker>}
-       */
-      this.stickers = new Collection((sticker_items ?? stickers)?.map(s => [s.id, new Sticker(this.client, s)]));
-    } else {
-      this.stickers = new Collection(this.stickers);
+      this._stickers = new Collection((sticker_items ?? stickers)?.map(s => [s.id, new Sticker(this.client, s)]));
+    } else if (this._stickers) {
+      this._stickers = new Collection(this._stickers);
     }
 
     if (reactions) {
@@ -476,8 +494,6 @@ class Message extends Base {
           this.reactions._add(reaction);
         }
       }
-    } else {
-      this.reactions ??= new ReactionManager(this);
     }
 
     if (!this.mentions) {

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -92,7 +92,7 @@ class Message extends Base {
   }
 
   /**
-   * Whether or not this message was sent by Discord, not actually a user (e.g. pin notifications)
+   * Whether this message was sent by Discord, not actually a user (e.g. pin notifications)
    * @type {?boolean}
    * @readonly
    */
@@ -120,7 +120,7 @@ class Message extends Base {
   }
 
   /**
-   * Whether or not this message is pinned
+   * Whether this message is pinned
    * @type {?boolean}
    * @readonly
    */
@@ -161,7 +161,7 @@ class Message extends Base {
   }
 
   /**
-   * Whether or not the message was Text-To-Speech
+   * Whether the message was Text-To-Speech
    * @type {?boolean}
    * @readonly
    */
@@ -173,7 +173,7 @@ class Message extends Base {
    * A random number or string used for checking message delivery
    * <warn>This is only received after the message was sent successfully, and
    * lost if re-fetched</warn>
-   * @type {?string}
+   * @type {?(string|number)}
    * @readonly
    */
   get nonce() {
@@ -186,7 +186,7 @@ class Message extends Base {
    * @readonly
    */
   get editedTimestamp() {
-    if (this.data.edited_timestamp === undefined) return undefined;
+    if (this.data.edited_timestamp === undefined) return null;
     return Date.parse(this.data.edited_timestamp);
   }
 
@@ -292,7 +292,7 @@ class Message extends Base {
 
   /**
    * The channel that the message was sent in
-   * @type {TextChannel|DMChannel|NewsChannel|ThreadChannel}
+   * @type {TextBasedChannels}
    * @readonly
    */
   get channel() {

--- a/packages/discord.js/test/tester1000.js
+++ b/packages/discord.js/test/tester1000.js
@@ -40,9 +40,9 @@ const commands = {
 client.on('messageCreate', message => {
   if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-  message.content = message.content.replace(prefix, '').trim().split(' ');
+  message.data.content = message.content.replace(prefix, '').trim().split(' ');
   const command = message.content.shift();
-  message.content = message.content.join(' ');
+  message.data.content = message.content.join(' ');
 
   // eslint-disable-next-line no-console
   console.log('COMMAND', command, message.content);

--- a/packages/discord.js/test/tester2000.js
+++ b/packages/discord.js/test/tester2000.js
@@ -52,9 +52,9 @@ const commands = {
 client.on('messageCreate', message => {
   if (!message.content.startsWith(prefix) || message.author.bot) return;
 
-  message.content = message.content.replace(prefix, '').trim().split(' ');
+  message.data.content = message.content.replace(prefix, '').trim().split(' ');
   const command = message.content.shift();
-  message.content = message.content.join(' ');
+  message.data.content = message.content.join(' ');
 
   // eslint-disable-next-line no-console
   console.log('COMMAND', command, message.content);

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1498,46 +1498,60 @@ export class Message<Cached extends boolean = boolean> extends Base {
   private readonly _cacheType: Cached;
   private constructor(client: Client, data: RawMessageData);
   private _patch(data: RawPartialMessageData | RawMessageData): void;
-
-  public activity: MessageActivity | null;
-  public applicationId: Snowflake | null;
+  public data: Omit<
+    RawMessageData,
+    | 'embeds'
+    | 'components'
+    | 'mentions'
+    | 'mention_roles'
+    | 'mention_channels'
+    | 'mention_everyone'
+    | 'attachments'
+    | 'stickers'
+    | 'sticker_items'
+    | 'thread'
+    | 'member'
+    | 'reactions'
+  >;
+  public readonly activity: MessageActivity | null;
+  public readonly applicationId: Snowflake | null;
   public attachments: Collection<Snowflake, MessageAttachment>;
-  public author: User;
+  public readonly author: User;
   public readonly channel: If<Cached, GuildTextBasedChannel, TextBasedChannel>;
-  public channelId: Snowflake;
+  public readonly channelId: Snowflake;
   public readonly cleanContent: string;
   public components: ActionRow<ActionRowComponent>[];
-  public content: string;
+  public readonly content: string;
   public readonly createdAt: Date;
-  public createdTimestamp: number;
+  public readonly createdTimestamp: number;
   public readonly crosspostable: boolean;
   public readonly deletable: boolean;
   public readonly editable: boolean;
   public readonly editedAt: Date | null;
-  public editedTimestamp: number | null;
+  public readonly editedTimestamp: number | null;
   public embeds: Embed[];
-  public groupActivityApplication: ClientApplication | null;
-  public guildId: If<Cached, Snowflake>;
+  public readonly groupActivityApplication: ClientApplication | null;
+  public readonly guildId: If<Cached, Snowflake>;
   public readonly guild: If<Cached, Guild>;
   public readonly hasThread: boolean;
-  public id: Snowflake;
-  public interaction: MessageInteraction | null;
+  public readonly id: Snowflake;
+  public readonly interaction: MessageInteraction | null;
   public readonly member: GuildMember | null;
   public mentions: MessageMentions;
-  public nonce: string | number | null;
+  public readonly nonce: string | number | null;
   public readonly partial: false;
   public readonly pinnable: boolean;
-  public pinned: boolean;
+  public readonly pinned: boolean;
   public reactions: ReactionManager;
   public stickers: Collection<Snowflake, Sticker>;
-  public system: boolean;
+  public readonly system: boolean;
   public readonly thread: ThreadChannel | null;
-  public tts: boolean;
-  public type: MessageType;
+  public readonly tts: boolean;
+  public readonly type: MessageType;
   public readonly url: string;
-  public webhookId: Snowflake | null;
-  public flags: Readonly<MessageFlagsBitField>;
-  public reference: MessageReference | null;
+  public readonly webhookId: Snowflake | null;
+  public readonly flags: Readonly<MessageFlagsBitField>;
+  public readonly reference: MessageReference | null;
   public awaitMessageComponent<T extends ComponentType = ComponentType.ActionRow>(
     options?: AwaitMessageCollectorOptionsParams<T, Cached>,
   ): Promise<MappedInteractionTypes<Cached>[T]>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Caches applicable message data within an internal `data` field. Makes props of the data getters in the class instead of storing them.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)