### PR TITLE
fix: allow unsafe embeds to be serialized

### DIFF
--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Buffer } = require('node:buffer');
-const { Embed, isJSONEncodable } = require('@discordjs/builders');
+const { isJSONEncodable } = require('@discordjs/builders');
 const { MessageFlags } = require('discord-api-types/v9');
 const { RangeError } = require('../errors');
 const DataResolver = require('../util/DataResolver');
@@ -193,7 +193,7 @@ class MessagePayload {
       tts,
       nonce,
       embeds: this.options.embeds?.map(embed =>
-        embed instanceof Embed ? embed.toJSON() : this.target.client.options.jsonTransformer(embed),
+        isJSONEncodable(embed) ? embed.toJSON() : this.target.client.options.jsonTransformer(embed),
       ),
       components,
       username,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes issue where unsafe embeds wouldn't be serialized, but regular embeds would.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating