### PR TITLE
fix: properly serialize `undefined` values

### DIFF
--- a/packages/discord.js/src/util/Transformers.js
+++ b/packages/discord.js/src/util/Transformers.js
@@ -8,14 +8,11 @@ class Transformers extends null {
    * @param {*} obj The object to transform
    * @returns {*}
    */
-  static toSnakeCase(obj = {}) {
+  static toSnakeCase(obj) {
     if (typeof obj !== 'object' || !obj) return obj;
     if (Array.isArray(obj)) return obj.map(Transformers.toSnakeCase);
     return Object.fromEntries(
-      Object.entries(obj).map(([key, value]) => [
-        snakeCase(key),
-        typeof value === 'undefined' ? value : Transformers.toSnakeCase(value),
-      ]),
+      Object.entries(obj).map(([key, value]) => [snakeCase(key), Transformers.toSnakeCase(value)]),
     );
   }
 }

--- a/packages/discord.js/src/util/Transformers.js
+++ b/packages/discord.js/src/util/Transformers.js
@@ -12,7 +12,10 @@ class Transformers extends null {
     if (typeof obj !== 'object' || !obj) return obj;
     if (Array.isArray(obj)) return obj.map(Transformers.toSnakeCase);
     return Object.fromEntries(
-      Object.entries(obj).map(([key, value]) => [snakeCase(key), Transformers.toSnakeCase(value)]),
+      Object.entries(obj).map(([key, value]) => [
+        snakeCase(key),
+        typeof value === 'undefined' ? value : Transformers.toSnakeCase(value),
+      ]),
     );
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes an issue where if a value is explicitly set to `undefined`, it would be serialized as `{}`.

Closes #7510 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating