### PR TITLE
refactor(embed): remove array support in favor of rest params

### DIFF
--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -311,10 +311,10 @@ describe('Embed', () => {
 	describe('Embed Fields', () => {
 		test('GIVEN an embed with a pre-defined field THEN returns valid toJSON data', () => {
 			const embed = new Embed({
-				fields: [{ name: 'foo', value: 'bar', inline: undefined }],
+				fields: [{ name: 'foo', value: 'bar' }],
 			});
 			expect(embed.toJSON()).toStrictEqual({
-				fields: [{ name: 'foo', value: 'bar', inline: undefined }],
+				fields: [{ name: 'foo', value: 'bar' }],
 			});
 		});
 
@@ -323,7 +323,7 @@ describe('Embed', () => {
 			embed.addField({ name: 'foo', value: 'bar' });
 
 			expect(embed.toJSON()).toStrictEqual({
-				fields: [{ name: 'foo', value: 'bar', inline: undefined }],
+				fields: [{ name: 'foo', value: 'bar' }],
 			});
 		});
 
@@ -332,7 +332,7 @@ describe('Embed', () => {
 			embed.addFields({ name: 'foo', value: 'bar' });
 
 			expect(embed.toJSON()).toStrictEqual({
-				fields: [{ name: 'foo', value: 'bar', inline: undefined }],
+				fields: [{ name: 'foo', value: 'bar' }],
 			});
 		});
 
@@ -341,7 +341,7 @@ describe('Embed', () => {
 			embed.addFields({ name: 'foo', value: 'bar' }, { name: 'foo', value: 'baz' });
 
 			expect(embed.spliceFields(0, 1).toJSON()).toStrictEqual({
-				fields: [{ name: 'foo', value: 'baz', inline: undefined }],
+				fields: [{ name: 'foo', value: 'baz' }],
 			});
 		});
 

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -4,9 +4,6 @@ import {
 	colorPredicate,
 	descriptionPredicate,
 	embedFieldsArrayPredicate,
-	fieldInlinePredicate,
-	fieldNamePredicate,
-	fieldValuePredicate,
 	footerTextPredicate,
 	timestampPredicate,
 	titlePredicate,
@@ -93,20 +90,5 @@ export class Embed extends UnsafeEmbed {
 	public override setURL(url: string | null): this {
 		// Data assertions
 		return super.setURL(urlPredicate.parse(url)!);
-	}
-
-	/**
-	 * Normalizes field input and resolves strings
-	 *
-	 * @param fields Fields to normalize
-	 */
-	public static override normalizeFields(...fields: APIEmbedField[]): APIEmbedField[] {
-		return fields.flat(Infinity).map((field) => {
-			fieldNamePredicate.parse(field.name);
-			fieldValuePredicate.parse(field.value);
-			fieldInlinePredicate.parse(field.inline);
-
-			return { name: field.name, value: field.value, inline: field.inline ?? undefined };
-		});
 	}
 }

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -190,7 +190,6 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 * @param fields The fields to add
 	 */
 	public addFields(...fields: APIEmbedField[]): this {
-		fields = UnsafeEmbed.normalizeFields(...fields);
 		if (this.data.fields) this.data.fields.push(...fields);
 		else this.data.fields = fields;
 		return this;
@@ -204,7 +203,6 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 * @param fields The replacing field objects
 	 */
 	public spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {
-		fields = UnsafeEmbed.normalizeFields(...fields);
 		if (this.data.fields) this.data.fields.splice(index, deleteCount, ...fields);
 		else this.data.fields = fields;
 		return this;
@@ -336,16 +334,5 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 		const data = other instanceof UnsafeEmbed ? other.data : other;
 		const { image, thumbnail, ...otherData } = data;
 		return isEqual(otherData, thisData) && image?.url === thisImage?.url && thumbnail?.url === thisThumbnail?.url;
-	}
-
-	/**
-	 * Normalizes field input and resolves strings
-	 *
-	 * @param fields Fields to normalize
-	 */
-	public static normalizeFields(...fields: APIEmbedField[]): APIEmbedField[] {
-		return fields
-			.flat(Infinity)
-			.map((field) => ({ name: field.name, value: field.value, inline: field.inline ?? undefined }));
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Other methods from builders do not support arrays either and it seems like it was a conscious decision https://github.com/discordjs/discord.js/pull/7395#discussion_r799831790

- removed support for arrays from `addFields()` and `spliceFields()`
- removed the `normalizeFields()` method as it no longer serves a purpose

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
