### PR TITLE
refactor(message): make constructor protected

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1501,7 +1501,7 @@ export interface MappedInteractionTypes<Cached extends boolean = boolean> {
 
 export class Message<Cached extends boolean = boolean> extends Base {
   private readonly _cacheType: Cached;
-  private constructor(client: Client, data: RawMessageData);
+  protected constructor(client: Client, data: RawMessageData);
   private _patch(data: RawPartialMessageData | RawMessageData): void;
 
   public activity: MessageActivity | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Ideally this should be merged after #7490 gets merged

This PR makes the constructor of `Message` protected, making it able to create extended classes out of it in a way that doesn't break the library. Since classes like `Interaction` have a protected constructor already, I don't see why `Message` should be kept as a private class.

This can be useful for safely extending the message class when the raw data is stored in `Message#data` (when #7490 gets merged), allowing you to do `new ExtendedMessage(client, message.data)` so you can add your own methods and properties.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
