### PR TITLE
fix(invite): add back channelId property

### DIFF
--- a/packages/discord.js/src/structures/Invite.js
+++ b/packages/discord.js/src/structures/Invite.js
@@ -151,12 +151,24 @@ class Invite extends Base {
       this.targetType ??= null;
     }
 
+    if ('channel_id' in data) {
+      /**
+       * The id of the channel this invite is for
+       * @type {?Snowflake}
+       */
+      this.channelId = data.channel_id;
+    }
+
     if ('channel' in data) {
       /**
        * The channel this invite is for
        * @type {?Channel}
        */
-      this.channel = this.client.channels._add(data.channel, this.guild, { cache: false });
+      this.channel =
+        this.client.channels._add(data.channel, this.guild, { cache: false }) ??
+        this.client.channels.resolve(this.channelId);
+
+      this.channelId ??= data.channel.id;
     }
 
     if ('created_at' in data) {
@@ -285,6 +297,7 @@ class Invite extends Base {
       presenceCount: false,
       memberCount: false,
       uses: false,
+      channel: 'channelId',
       inviter: 'inviterId',
       guild: 'guildId',
     });

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1382,6 +1382,7 @@ export class InteractionWebhook extends PartialWebhookMixin() {
 export class Invite extends Base {
   private constructor(client: Client, data: RawInviteData);
   public channel: NonThreadGuildBasedChannel | PartialGroupDMChannel;
+  public channelId: Snowflake | null;
   public code: string;
   public get deletable(): boolean;
   public get createdAt(): Date | null;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1381,7 +1381,7 @@ export class InteractionWebhook extends PartialWebhookMixin() {
 
 export class Invite extends Base {
   private constructor(client: Client, data: RawInviteData);
-  public channel: NonThreadGuildBasedChannel | PartialGroupDMChannel;
+  public channel: NonThreadGuildBasedChannel | PartialGroupDMChannel | null;
   public channelId: Snowflake | null;
   public code: string;
   public get deletable(): boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes a dumb regression from #7365 that removed the possibility of getting the channel id of an invite retrieved from audit logs. Both channel and channelId are still nullable, but this just covers another edge case that went unnoticed in that PR

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
