### PR TITLE
chore: disable scope-case rule for commitlint

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -5,6 +5,7 @@
 			2,
 			"always",
 			["chore", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test", "types", "typings"]
-		]
+		],
+		"scope-case": [0]
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Commits may have many casings for the scope: RequestHandler for classes, `somethingHere` for others, and the rule enforced lowercased scopes by default. This PR disables the rule altogether

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
