### PR TITLE
fix(RequestHandler): only reset tokens for authenticated 401s

### DIFF
--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -245,7 +245,7 @@ test('Request and Response Events', async () => {
 			method: 'get',
 			path: '/request',
 			route: '/request',
-			data: { files: undefined, body: undefined },
+			data: { files: undefined, body: undefined, auth: true },
 			retries: 0,
 		}) as APIRequest,
 	);
@@ -254,7 +254,7 @@ test('Request and Response Events', async () => {
 			method: 'get',
 			path: '/request',
 			route: '/request',
-			data: { files: undefined, body: undefined },
+			data: { files: undefined, body: undefined, auth: true },
 			retries: 0,
 		}) as APIRequest,
 		expect.objectContaining({ status: 200, statusText: 'OK' }) as Response,

--- a/packages/rest/__tests__/RequestHandler.test.ts
+++ b/packages/rest/__tests__/RequestHandler.test.ts
@@ -357,9 +357,19 @@ test('Bad Request', async () => {
 });
 
 test('Unauthorized', async () => {
+	const setTokenSpy = jest.spyOn(invalidAuthApi.requestManager, 'setToken');
+
+	// Ensure authless requests don't reset the token
+	const promiseWithoutTokenClear = invalidAuthApi.get('/unauthorized', { auth: false });
+	await expect(promiseWithoutTokenClear).rejects.toThrowError('401: Unauthorized');
+	await expect(promiseWithoutTokenClear).rejects.toBeInstanceOf(DiscordAPIError);
+	expect(setTokenSpy).not.toHaveBeenCalled();
+
+	// Ensure authed requests do reset the token
 	const promise = invalidAuthApi.get('/unauthorized');
 	await expect(promise).rejects.toThrowError('401: Unauthorized');
 	await expect(promise).rejects.toBeInstanceOf(DiscordAPIError);
+	expect(setTokenSpy).toHaveBeenCalledTimes(1);
 });
 
 test('Reject on RateLimit', async () => {

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -160,7 +160,7 @@ export interface APIRequest {
 	/**
 	 * The data that was used to form the body of this request
 	 */
-	data: Pick<InternalRequest, 'files' | 'body'>;
+	data: Pick<InternalRequest, 'files' | 'body' | 'auth'>;
 	/**
 	 * The number of times this request has been attempted
 	 */

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -1,6 +1,13 @@
 import { EventEmitter } from 'node:events';
 import { CDN } from './CDN';
-import { InternalRequest, RequestData, RequestManager, RequestMethod, RouteLike } from './RequestManager';
+import {
+	HandlerRequestData,
+	InternalRequest,
+	RequestData,
+	RequestManager,
+	RequestMethod,
+	RouteLike,
+} from './RequestManager';
 import { DefaultRestOptions, RESTEvents } from './utils/constants';
 import type { AgentOptions } from 'node:https';
 import type { RequestInit, Response } from 'node-fetch';
@@ -160,7 +167,7 @@ export interface APIRequest {
 	/**
 	 * The data that was used to form the body of this request
 	 */
-	data: Pick<InternalRequest, 'files' | 'body' | 'auth'>;
+	data: HandlerRequestData;
 	/**
 	 * The number of times this request has been attempted
 	 */

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -290,10 +290,16 @@ export class RequestManager extends EventEmitter {
 			this.createHandler(hash.value, routeId.majorParameter);
 
 		// Resolve the request into usable fetch/node-fetch options
-		const { url, fetchOptions } = this.resolveRequest(request);
+		const { url, fetchOptions, isAuthenticated } = this.resolveRequest(request);
 
 		// Queue the request
-		return handler.queueRequest(routeId, url, fetchOptions, { body: request.body, files: request.files });
+		return handler.queueRequest(
+			routeId,
+			url,
+			fetchOptions,
+			{ body: request.body, files: request.files },
+			isAuthenticated,
+		);
 	}
 
 	/**
@@ -315,7 +321,11 @@ export class RequestManager extends EventEmitter {
 	 * Formats the request data to a usable format for fetch
 	 * @param request The request data
 	 */
-	private resolveRequest(request: InternalRequest): { url: string; fetchOptions: RequestInit } {
+	private resolveRequest(request: InternalRequest): {
+		url: string;
+		fetchOptions: RequestInit;
+		isAuthenticated: boolean;
+	} {
 		const { options } = this;
 
 		this.agent ??= options.api.startsWith('https')
@@ -406,7 +416,7 @@ export class RequestManager extends EventEmitter {
 			method: request.method,
 		};
 
-		return { url, fetchOptions };
+		return { url, fetchOptions, isAuthenticated: request.auth !== false };
 	}
 
 	/**

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -113,6 +113,8 @@ export interface InternalRequest extends RequestData {
 	fullRoute: RouteLike;
 }
 
+export type HandlerRequestData = Pick<InternalRequest, 'files' | 'body' | 'auth'>;
+
 /**
  * Parsed route data for an endpoint
  *

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -293,13 +293,11 @@ export class RequestManager extends EventEmitter {
 		const { url, fetchOptions, isAuthenticated } = this.resolveRequest(request);
 
 		// Queue the request
-		return handler.queueRequest(
-			routeId,
-			url,
-			fetchOptions,
-			{ body: request.body, files: request.files },
-			isAuthenticated,
-		);
+		return handler.queueRequest(routeId, url, fetchOptions, {
+			body: request.body,
+			files: request.files,
+			auth: isAuthenticated,
+		});
 	}
 
 	/**

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -319,10 +319,7 @@ export class RequestManager extends EventEmitter {
 	 * Formats the request data to a usable format for fetch
 	 * @param request The request data
 	 */
-	private resolveRequest(request: InternalRequest): {
-		url: string;
-		fetchOptions: RequestInit;
-	} {
+	private resolveRequest(request: InternalRequest): { url: string; fetchOptions: RequestInit } {
 		const { options } = this;
 
 		this.agent ??= options.api.startsWith('https')

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -290,13 +290,13 @@ export class RequestManager extends EventEmitter {
 			this.createHandler(hash.value, routeId.majorParameter);
 
 		// Resolve the request into usable fetch/node-fetch options
-		const { url, fetchOptions, isAuthenticated } = this.resolveRequest(request);
+		const { url, fetchOptions } = this.resolveRequest(request);
 
 		// Queue the request
 		return handler.queueRequest(routeId, url, fetchOptions, {
 			body: request.body,
 			files: request.files,
-			auth: isAuthenticated,
+			auth: request.auth !== false,
 		});
 	}
 
@@ -322,7 +322,6 @@ export class RequestManager extends EventEmitter {
 	private resolveRequest(request: InternalRequest): {
 		url: string;
 		fetchOptions: RequestInit;
-		isAuthenticated: boolean;
 	} {
 		const { options } = this;
 
@@ -414,7 +413,7 @@ export class RequestManager extends EventEmitter {
 			method: request.method,
 		};
 
-		return { url, fetchOptions, isAuthenticated: request.auth !== false };
+		return { url, fetchOptions };
 	}
 
 	/**

--- a/packages/rest/src/lib/handlers/IHandler.ts
+++ b/packages/rest/src/lib/handlers/IHandler.ts
@@ -6,9 +6,9 @@ export interface IHandler {
 		routeId: RouteData,
 		url: string,
 		options: RequestInit,
-		bodyData: Pick<InternalRequest, 'files' | 'body'>,
-		isAuthenticated: boolean,
+		requestData: Pick<InternalRequest, 'files' | 'body' | 'auth'>,
 	) => Promise<unknown>;
-	readonly inactive: boolean;
+	// eslint-disable-next-line @typescript-eslint/method-signature-style -- This is meant to be a getter returning a bool
+	get inactive(): boolean;
 	readonly id: string;
 }

--- a/packages/rest/src/lib/handlers/IHandler.ts
+++ b/packages/rest/src/lib/handlers/IHandler.ts
@@ -7,6 +7,7 @@ export interface IHandler {
 		url: string,
 		options: RequestInit,
 		bodyData: Pick<InternalRequest, 'files' | 'body'>,
+		isAuthenticated: boolean,
 	) => Promise<unknown>;
 	readonly inactive: boolean;
 	readonly id: string;

--- a/packages/rest/src/lib/handlers/IHandler.ts
+++ b/packages/rest/src/lib/handlers/IHandler.ts
@@ -1,12 +1,12 @@
 import type { RequestInit } from 'node-fetch';
-import type { InternalRequest, RouteData } from '../RequestManager';
+import type { HandlerRequestData, RouteData } from '../RequestManager';
 
 export interface IHandler {
 	queueRequest: (
 		routeId: RouteData,
 		url: string,
 		options: RequestInit,
-		requestData: Pick<InternalRequest, 'files' | 'body' | 'auth'>,
+		requestData: HandlerRequestData,
 	) => Promise<unknown>;
 	// eslint-disable-next-line @typescript-eslint/method-signature-style -- This is meant to be a getter returning a bool
 	get inactive(): boolean;

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -4,7 +4,7 @@ import fetch, { RequestInit, Response } from 'node-fetch';
 import { DiscordAPIError, DiscordErrorData, OAuthErrorData } from '../errors/DiscordAPIError';
 import { HTTPError } from '../errors/HTTPError';
 import { RateLimitError } from '../errors/RateLimitError';
-import type { InternalRequest, RequestManager, RouteData } from '../RequestManager';
+import type { HandlerRequestData, RequestManager, RouteData } from '../RequestManager';
 import { RESTEvents } from '../utils/constants';
 import { hasSublimit, parseResponse } from '../utils/utils';
 import type { RateLimitData } from '../REST';
@@ -169,7 +169,7 @@ export class SequentialHandler implements IHandler {
 		routeId: RouteData,
 		url: string,
 		options: RequestInit,
-		requestData: Pick<InternalRequest, 'files' | 'body' | 'auth'>,
+		requestData: HandlerRequestData,
 	): Promise<unknown> {
 		let queue = this.#asyncQueue;
 		let queueType = QueueType.Standard;
@@ -226,7 +226,7 @@ export class SequentialHandler implements IHandler {
 		routeId: RouteData,
 		url: string,
 		options: RequestInit,
-		requestData: Pick<InternalRequest, 'files' | 'body' | 'auth'>,
+		requestData: HandlerRequestData,
 		retries = 0,
 	): Promise<unknown> {
 		/*

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -163,7 +163,7 @@ export class SequentialHandler implements IHandler {
 	 * @param routeId The generalized api route with literal ids for major parameters
 	 * @param url The url to do the request on
 	 * @param options All the information needed to make a request
-	 * @param requestData The data that was used to form the body, passed to any errors generated and for determining whether to sublimit
+	 * @param requestData Extra data from the user's request needed for errors and additional processing
 	 */
 	public async queueRequest(
 		routeId: RouteData,
@@ -219,7 +219,7 @@ export class SequentialHandler implements IHandler {
 	 * @param routeId The generalized api route with literal ids for major parameters
 	 * @param url The fully resolved url to make the request to
 	 * @param options The node-fetch options needed to make the request
-	 * @param requestData The data that was used to form the body, passed to any errors generated
+	 * @param requestData Extra data from the user's request needed for errors and additional processing
 	 * @param retries The number of retries this request has already attempted (recursion)
 	 */
 	private async runRequest(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes https://github.com/discordjs/discord.js/issues/7492 by resetting the token only when an authorized request fails with a 401.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
