### PR TITLE
refactor: use `Readonly` types in builders where applicable

### DIFF
--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -36,7 +36,7 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 	 * Sets the components in this action row
 	 * @param components The components to set this row to
 	 */
-	public setComponents(...components: ReadonlyArray<Readonly<T>>) {
+	public setComponents(...components: readonly Readonly<T>[]) {
 		this.components.splice(0, this.components.length, ...components);
 		return this;
 	}

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -17,7 +17,7 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 > {
 	public readonly components: T[];
 
-	public constructor({ components, ...data }: Partial<APIActionRowComponent<APIMessageComponent>> = {}) {
+	public constructor({ components, ...data }: Readonly<Partial<APIActionRowComponent<APIMessageComponent>>> = {}) {
 		super({ type: ComponentType.ActionRow, ...data });
 		this.components = (components?.map((c) => createComponent(c)) ?? []) as T[];
 	}
@@ -27,7 +27,7 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 	 * @param components The components to add to this action row.
 	 * @returns
 	 */
-	public addComponents(...components: T[]) {
+	public addComponents(...components: ReadonlyArray<Readonly<T>>) {
 		this.components.push(...components);
 		return this;
 	}
@@ -36,7 +36,7 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 	 * Sets the components in this action row
 	 * @param components The components to set this row to
 	 */
-	public setComponents(...components: T[]) {
+	public setComponents(...components: ReadonlyArray<Readonly<T>>) {
 		this.components.splice(0, this.components.length, ...components);
 		return this;
 	}
@@ -48,7 +48,7 @@ export class ActionRow<T extends ActionRowComponent = ActionRowComponent> extend
 		};
 	}
 
-	public equals(other: APIActionRowComponent<APIMessageComponent> | ActionRow) {
+	public equals(other: Readonly<APIActionRowComponent<APIMessageComponent> | ActionRow>) {
 		if (other instanceof ActionRow) {
 			return isEqual(other.data, this.data) && isEqual(other.components, this.components);
 		}

--- a/packages/builders/src/components/Component.ts
+++ b/packages/builders/src/components/Component.ts
@@ -23,7 +23,7 @@ export abstract class Component<
 
 	public abstract toJSON(): APIMessageComponent;
 
-	public abstract equals(other: Component | APIActionRowComponentTypes): boolean;
+	public abstract equals(other: Readonly<Component | APIActionRowComponentTypes>): boolean;
 
 	public constructor(data: DataType) {
 		this.data = data;

--- a/packages/builders/src/components/button/UnsafeButton.ts
+++ b/packages/builders/src/components/button/UnsafeButton.ts
@@ -13,7 +13,7 @@ import isEqual from 'fast-deep-equal';
  * Represents a non-validated button component
  */
 export class UnsafeButtonComponent extends Component<Partial<APIButtonComponent> & { type: ComponentType.Button }> {
-	public constructor(data?: Partial<APIButtonComponent>) {
+	public constructor(data?: Readonly<Partial<APIButtonComponent>>) {
 		super({ type: ComponentType.Button, ...data });
 	}
 
@@ -34,7 +34,7 @@ export class UnsafeButtonComponent extends Component<Partial<APIButtonComponent>
 	/**
 	 * The emoji used in this button
 	 */
-	public get emoji() {
+	public get emoji(): Readonly<APIMessageComponentEmoji> | undefined {
 		return this.data.emoji;
 	}
 
@@ -90,7 +90,7 @@ export class UnsafeButtonComponent extends Component<Partial<APIButtonComponent>
 	 * Sets the emoji to display on this button
 	 * @param emoji The emoji to display on this button
 	 */
-	public setEmoji(emoji: APIMessageComponentEmoji) {
+	public setEmoji(emoji: Readonly<APIMessageComponentEmoji>) {
 		this.data.emoji = emoji;
 		return this;
 	}
@@ -120,7 +120,7 @@ export class UnsafeButtonComponent extends Component<Partial<APIButtonComponent>
 		} as APIButtonComponent;
 	}
 
-	public equals(other: APIButtonComponent | UnsafeButtonComponent) {
+	public equals(other: Readonly<APIButtonComponent | UnsafeButtonComponent>) {
 		if (other instanceof UnsafeButtonComponent) {
 			return isEqual(other.data, this.data);
 		}

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -102,7 +102,7 @@ export class UnsafeSelectMenuComponent extends Component<
 	 * @param options The options to add to this select menu
 	 * @returns
 	 */
-	public addOptions(...options: ReadonlyArray<Readonly<UnsafeSelectMenuOption | APISelectMenuOption>>) {
+	public addOptions(...options: readonly Readonly<UnsafeSelectMenuOption | APISelectMenuOption>[]) {
 		this.options.push(
 			...options.map((option) =>
 				option instanceof UnsafeSelectMenuOption ? option : new UnsafeSelectMenuOption(option),
@@ -115,7 +115,7 @@ export class UnsafeSelectMenuComponent extends Component<
 	 * Sets the options on this select menu
 	 * @param options The options to set on this select menu
 	 */
-	public setOptions(...options: ReadonlyArray<Readonly<UnsafeSelectMenuOption | APISelectMenuOption>>) {
+	public setOptions(...options: readonly Readonly<UnsafeSelectMenuOption | APISelectMenuOption>[]) {
 		this.options.splice(
 			0,
 			this.options.length,

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -11,7 +11,7 @@ export class UnsafeSelectMenuComponent extends Component<
 > {
 	public readonly options: UnsafeSelectMenuOption[];
 
-	public constructor(data?: Partial<APISelectMenuComponent>) {
+	public constructor(data?: Readonly<Partial<APISelectMenuComponent>>) {
 		const { options, ...initData } = data ?? {};
 		super({ type: ComponentType.SelectMenu, ...initData });
 		this.options = options?.map((o) => new UnsafeSelectMenuOption(o)) ?? [];
@@ -102,7 +102,7 @@ export class UnsafeSelectMenuComponent extends Component<
 	 * @param options The options to add to this select menu
 	 * @returns
 	 */
-	public addOptions(...options: (UnsafeSelectMenuOption | APISelectMenuOption)[]) {
+	public addOptions(...options: ReadonlyArray<Readonly<UnsafeSelectMenuOption | APISelectMenuOption>>) {
 		this.options.push(
 			...options.map((option) =>
 				option instanceof UnsafeSelectMenuOption ? option : new UnsafeSelectMenuOption(option),
@@ -115,7 +115,7 @@ export class UnsafeSelectMenuComponent extends Component<
 	 * Sets the options on this select menu
 	 * @param options The options to set on this select menu
 	 */
-	public setOptions(...options: (UnsafeSelectMenuOption | APISelectMenuOption)[]) {
+	public setOptions(...options: ReadonlyArray<Readonly<UnsafeSelectMenuOption | APISelectMenuOption>>) {
 		this.options.splice(
 			0,
 			this.options.length,
@@ -134,7 +134,7 @@ export class UnsafeSelectMenuComponent extends Component<
 		} as APISelectMenuComponent;
 	}
 
-	public equals(other: APISelectMenuComponent | UnsafeSelectMenuComponent): boolean {
+	public equals(other: Readonly<APISelectMenuComponent | UnsafeSelectMenuComponent>): boolean {
 		if (other instanceof UnsafeSelectMenuComponent) {
 			return isEqual(other.data, this.data) && isEqual(other.options, this.options);
 		}

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenuOption.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenuOption.ts
@@ -30,7 +30,7 @@ export class UnsafeSelectMenuOption {
 	/**
 	 * The emoji for this option
 	 */
-	public get emoji() {
+	public get emoji(): Readonly<APIMessageComponentEmoji> | undefined {
 		return this.data.emoji;
 	}
 
@@ -81,7 +81,7 @@ export class UnsafeSelectMenuOption {
 	 * Sets the emoji to display on this button
 	 * @param emoji The emoji to display on this button
 	 */
-	public setEmoji(emoji: APIMessageComponentEmoji) {
+	public setEmoji(emoji: Readonly<APIMessageComponentEmoji>) {
 		this.data.emoji = emoji;
 		return this;
 	}

--- a/packages/builders/src/messages/embed/Assertions.ts
+++ b/packages/builders/src/messages/embed/Assertions.ts
@@ -17,7 +17,7 @@ export const embedFieldsArrayPredicate = embedFieldPredicate.array();
 
 export const fieldLengthPredicate = z.number().lte(25);
 
-export function validateFieldLength(amountAdding: number, fields?: APIEmbedField[]): void {
+export function validateFieldLength(amountAdding: number, fields?: ReadonlyArray<Readonly<APIEmbedField>>): void {
 	fieldLengthPredicate.parse((fields?.length ?? 0) + amountAdding);
 }
 

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -4,6 +4,7 @@ import type {
 	APIEmbedField,
 	APIEmbedFooter,
 	APIEmbedImage,
+	APIEmbedProvider,
 	APIEmbedVideo,
 } from 'discord-api-types/v9';
 import type { Equatable } from '../../util/equatable';
@@ -51,7 +52,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	/**
 	 * An array of fields of this embed
 	 */
-	public get fields() {
+	public get fields(): ReadonlyArray<APIEmbedField> | undefined {
 		return this.data.fields;
 	}
 
@@ -93,7 +94,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	/**
 	 * The embed thumbnail data
 	 */
-	public get thumbnail(): EmbedImageData | undefined {
+	public get thumbnail(): Readonly<EmbedImageData> | undefined {
 		if (!this.data.thumbnail) return undefined;
 		return {
 			url: this.data.thumbnail.url,
@@ -106,7 +107,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	/**
 	 * The embed image data
 	 */
-	public get image(): EmbedImageData | undefined {
+	public get image(): Readonly<EmbedImageData> | undefined {
 		if (!this.data.image) return undefined;
 		return {
 			url: this.data.image.url,
@@ -119,14 +120,14 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	/**
 	 * Received video data
 	 */
-	public get video(): APIEmbedVideo | undefined {
+	public get video(): Readonly<APIEmbedVideo> | undefined {
 		return this.data.video;
 	}
 
 	/**
 	 * The embed author data
 	 */
-	public get author(): EmbedAuthorData | undefined {
+	public get author(): Readonly<EmbedAuthorData> | undefined {
 		if (!this.data.author) return undefined;
 		return {
 			name: this.data.author.name,
@@ -139,14 +140,14 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	/**
 	 * Received data about the embed provider
 	 */
-	public get provider() {
+	public get provider(): Readonly<APIEmbedProvider> | undefined {
 		return this.data.provider;
 	}
 
 	/**
 	 * The embed footer data
 	 */
-	public get footer(): EmbedFooterData | undefined {
+	public get footer(): Readonly<EmbedFooterData> | undefined {
 		if (!this.data.footer) return undefined;
 		return {
 			text: this.data.footer.text,
@@ -189,10 +190,10 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 *
 	 * @param fields The fields to add
 	 */
-	public addFields(...fields: APIEmbedField[]): this {
+	public addFields(...fields: ReadonlyArray<Readonly<APIEmbedField>>): this {
 		fields = UnsafeEmbed.normalizeFields(...fields);
 		if (this.data.fields) this.data.fields.push(...fields);
-		else this.data.fields = fields;
+		else this.data.fields = [...fields];
 		return this;
 	}
 
@@ -203,10 +204,10 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 * @param deleteCount The number of fields to remove
 	 * @param fields The replacing field objects
 	 */
-	public spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {
+	public spliceFields(index: number, deleteCount: number, ...fields: ReadonlyArray<Readonly<APIEmbedField>>): this {
 		fields = UnsafeEmbed.normalizeFields(...fields);
 		if (this.data.fields) this.data.fields.splice(index, deleteCount, ...fields);
-		else this.data.fields = fields;
+		else this.data.fields = [...fields];
 		return this;
 	}
 
@@ -214,7 +215,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 * Sets the embed's fields (max 25).
 	 * @param fields The fields to set
 	 */
-	public setFields(...fields: APIEmbedField[]) {
+	public setFields(...fields: ReadonlyArray<Readonly<APIEmbedField>>) {
 		this.spliceFields(0, this.fields?.length ?? 0, ...fields);
 		return this;
 	}
@@ -224,7 +225,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 *
 	 * @param options The options for the author
 	 */
-	public setAuthor(options: EmbedAuthorOptions | null): this {
+	public setAuthor(options: Readonly<EmbedAuthorOptions> | null): this {
 		if (options === null) {
 			this.data.author = undefined;
 			return this;
@@ -264,7 +265,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 *
 	 * @param options The options for the footer
 	 */
-	public setFooter(options: EmbedFooterOptions | null): this {
+	public setFooter(options: Readonly<EmbedFooterOptions> | null): this {
 		if (options === null) {
 			this.data.footer = undefined;
 			return this;
@@ -299,7 +300,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 *
 	 * @param timestamp The timestamp or date
 	 */
-	public setTimestamp(timestamp: number | Date | null = Date.now()): this {
+	public setTimestamp(timestamp: number | Readonly<Date> | null = Date.now()): this {
 		this.data.timestamp = timestamp ? new Date(timestamp).toISOString() : undefined;
 		return this;
 	}
@@ -331,7 +332,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 		return { ...this.data };
 	}
 
-	public equals(other: UnsafeEmbed | APIEmbed) {
+	public equals(other: Readonly<UnsafeEmbed | APIEmbed>) {
 		const { image: thisImage, thumbnail: thisThumbnail, ...thisData } = this.data;
 		const data = other instanceof UnsafeEmbed ? other.data : other;
 		const { image, thumbnail, ...otherData } = data;
@@ -343,7 +344,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 *
 	 * @param fields Fields to normalize
 	 */
-	public static normalizeFields(...fields: APIEmbedField[]): APIEmbedField[] {
+	public static normalizeFields(...fields: ReadonlyArray<Readonly<APIEmbedField>>): APIEmbedField[] {
 		return fields
 			.flat(Infinity)
 			.map((field) => ({ name: field.name, value: field.value, inline: field.inline ?? undefined }));

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -52,7 +52,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	/**
 	 * An array of fields of this embed
 	 */
-	public get fields(): ReadonlyArray<APIEmbedField> | undefined {
+	public get fields(): readonly Readonly<APIEmbedField>[] | undefined {
 		return this.data.fields;
 	}
 
@@ -181,7 +181,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 *
 	 * @param field The field to add.
 	 */
-	public addField(field: APIEmbedField): this {
+	public addField(field: Readonly<APIEmbedField>): this {
 		return this.addFields(field);
 	}
 
@@ -190,7 +190,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 *
 	 * @param fields The fields to add
 	 */
-	public addFields(...fields: ReadonlyArray<Readonly<APIEmbedField>>): this {
+	public addFields(...fields: readonly Readonly<APIEmbedField>[]): this {
 		fields = UnsafeEmbed.normalizeFields(...fields);
 		if (this.data.fields) this.data.fields.push(...fields);
 		else this.data.fields = [...fields];
@@ -204,7 +204,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 * @param deleteCount The number of fields to remove
 	 * @param fields The replacing field objects
 	 */
-	public spliceFields(index: number, deleteCount: number, ...fields: ReadonlyArray<Readonly<APIEmbedField>>): this {
+	public spliceFields(index: number, deleteCount: number, ...fields: readonly Readonly<APIEmbedField>[]): this {
 		fields = UnsafeEmbed.normalizeFields(...fields);
 		if (this.data.fields) this.data.fields.splice(index, deleteCount, ...fields);
 		else this.data.fields = [...fields];
@@ -215,7 +215,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 * Sets the embed's fields (max 25).
 	 * @param fields The fields to set
 	 */
-	public setFields(...fields: ReadonlyArray<Readonly<APIEmbedField>>) {
+	public setFields(...fields: readonly Readonly<APIEmbedField>[]) {
 		this.spliceFields(0, this.fields?.length ?? 0, ...fields);
 		return this;
 	}
@@ -344,7 +344,7 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	 *
 	 * @param fields Fields to normalize
 	 */
-	public static normalizeFields(...fields: ReadonlyArray<Readonly<APIEmbedField>>): APIEmbedField[] {
+	public static normalizeFields(...fields: readonly Readonly<APIEmbedField>[]): APIEmbedField[] {
 		return fields
 			.flat(Infinity)
 			.map((field) => ({ name: field.name, value: field.value, inline: field.inline ?? undefined }));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Changes return types and some parameter types to use readonly inputs/outputs.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
