### PR TITLE
fix(typings): sweepStageInstances typo

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2228,7 +2228,7 @@ export class Sweepers {
   public sweepReactions(
     filter: CollectionSweepFilter<SweeperDefinitions['reactions'][0], SweeperDefinitions['reactions'][1]>,
   ): number;
-  public sweepStageInstnaces(
+  public sweepStageInstances(
     filter: CollectionSweepFilter<SweeperDefinitions['stageInstances'][0], SweeperDefinitions['stageInstances'][1]>,
   ): number;
   public sweepStickers(


### PR DESCRIPTION

**Please describe the changes this PR makes and why it should be merged:**
Fixed type problem 
`sweepStageInstances` was miswritten to  `sweepStageInstnaces` in `index.d.ts` (typings)

**Status and versioning classification:**

- there are no code changes
- I know how to update typings and have done so
