### PR TITLE
refactor(Embed): remove add field

### DIFF
--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -318,15 +318,6 @@ describe('Embed', () => {
 			});
 		});
 
-		test('GIVEN an embed using Embed#addField THEN returns valid toJSON data', () => {
-			const embed = new Embed();
-			embed.addField({ name: 'foo', value: 'bar' });
-
-			expect(embed.toJSON()).toStrictEqual({
-				fields: [{ name: 'foo', value: 'bar' }],
-			});
-		});
-
 		test('GIVEN an embed using Embed#addFields THEN returns valid toJSON data', () => {
 			const embed = new Embed();
 			embed.addFields({ name: 'foo', value: 'bar' });

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -176,15 +176,6 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	}
 
 	/**
-	 * Adds a field to the embed (max 25)
-	 *
-	 * @param field The field to add.
-	 */
-	public addField(field: APIEmbedField): this {
-		return this.addFields(field);
-	}
-
-	/**
 	 * Adds fields to the embed (max 25)
 	 *
 	 * @param fields The fields to add


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR removes `Embed#addField` in favour of `Embed#addFields` because you are just saving a `s` when using `addField`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->


For those who don't wanna replace all `addField` manually can try this regex replace. You can ofc make a better one but using these 2 also works fine. Idk how can I use condition in replace string else it can be simplified to one regex using `?` after inline.

```js
// 1. use this one first
// regex
.addField\(((.|[\n])*?),((.|[\n])*?),(.*true)\)
//replace with
.addFileds({name: $1, value: $3, inline: $5})
```

```js
// 2. use this one after replacing all inline fields
//regex
.addField\(((.|[\n])*?),((.|[\n])*?)\)
//replace with
.addFileds({name: $1, value: $3})
```

cross verify before replacing.