### PR TITLE
Fix(WebhookClient): Error [WEBHOOK_URL_INVALID]: The provided webhook URL is not valid

### DIFF
--- a/src/client/WebhookClient.js
+++ b/src/client/WebhookClient.js
@@ -30,7 +30,7 @@ class WebhookClient extends BaseClient {
     if ('url' in data) {
       const url = data.url.match(
         // eslint-disable-next-line no-useless-escape
-        /^https?:\/\/(?:canary|ptb)?\.?discord\.com\/api\/webhooks(?:\/v[0-9]\d*)?\/([^\/]+)\/([^\/]+)/i,
+        /^https?:\/\/(?:canary|ptb)?\.?discord(?:app)?\.com\/api\/webhooks(?:\/v[0-9]\d*)?\/([^\/]+)\/([^\/]+)/i,
       );
 
       if (!url || url.length <= 1) throw new Error('WEBHOOK_URL_INVALID');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Webhook URL seems to have changed from https://discord.com to https://discordapp.com causing the WebhookClient creation to fail.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
