### PR TITLE
feat: re-export AuditLogEvent enum

### DIFF
--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -164,6 +164,7 @@ exports.ActivityType = require('discord-api-types/v9').ActivityType;
 exports.ApplicationCommandType = require('discord-api-types/v9').ApplicationCommandType;
 exports.ApplicationCommandOptionType = require('discord-api-types/v9').ApplicationCommandOptionType;
 exports.ApplicationCommandPermissionType = require('discord-api-types/v9').ApplicationCommandPermissionType;
+exports.AuditLogEvent = require('discord-api-types/v9').AuditLogEvent;
 exports.ButtonStyle = require('discord-api-types/v9').ButtonStyle;
 exports.ChannelType = require('discord-api-types/v9').ChannelType;
 exports.ComponentType = require('discord-api-types/v9').ComponentType;

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -691,7 +691,7 @@ class Guild extends AnonymousGuild {
    * @property {Snowflake|GuildAuditLogsEntry} [before] Only return entries before this entry
    * @property {number} [limit] The number of entries to return
    * @property {UserResolvable} [user] Only return entries for actions made by this user
-   * @property {AuditLogEvent|number} [type] Only return entries for this action type
+   * @property {?AuditLogEvent} [type] Only return entries for this action type
    */
 
   /**

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -691,7 +691,7 @@ class Guild extends AnonymousGuild {
    * @property {Snowflake|GuildAuditLogsEntry} [before] Only return entries before this entry
    * @property {number} [limit] The number of entries to return
    * @property {UserResolvable} [user] Only return entries for actions made by this user
-   * @property {AuditLogAction|number} [type] Only return entries for this action type
+   * @property {AuditLogEvent|number} [type] Only return entries for this action type
    */
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5111,6 +5111,7 @@ export {
   ApplicationCommandType,
   ApplicationCommandOptionType,
   ApplicationCommandPermissionType,
+  AuditLogEvent,
   ButtonStyle,
   ChannelType,
   ComponentType,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
the `AuditLogEvent` enum is currently not re-exported from discord-api-types like the other enums.
I also noticed the jsdoc for `GuildAuditLogsFetchOptions` not using this enum, the typings already do so.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
