### PR TITLE
types(ActionRow): allow components to be passed to constructors

### DIFF
--- a/packages/discord.js/src/structures/ActionRow.js
+++ b/packages/discord.js/src/structures/ActionRow.js
@@ -4,9 +4,9 @@ const { ActionRow: BuildersActionRow, Component } = require('@discordjs/builders
 const Transformers = require('../util/Transformers');
 
 class ActionRow extends BuildersActionRow {
-  constructor({ components, ...data }) {
+  constructor({ components, ...data } = {}) {
     super({
-      components: components.map(c => (c instanceof Component ? c : Transformers.toSnakeCase(c))),
+      components: components?.map(c => (c instanceof Component ? c : Transformers.toSnakeCase(c))),
       ...Transformers.toSnakeCase(data),
     });
   }

--- a/packages/discord.js/src/structures/ActionRow.js
+++ b/packages/discord.js/src/structures/ActionRow.js
@@ -1,11 +1,14 @@
 'use strict';
 
-const { ActionRow: BuildersActionRow } = require('@discordjs/builders');
+const { ActionRow: BuildersActionRow, Component } = require('@discordjs/builders');
 const Transformers = require('../util/Transformers');
 
 class ActionRow extends BuildersActionRow {
-  constructor(data) {
-    super(Transformers.toSnakeCase(data));
+  constructor({ components, ...data }) {
+    super({
+      components: components.map(c => (c instanceof Component ? c : Transformers.toSnakeCase(c))),
+      ...Transformers.toSnakeCase(data),
+    });
   }
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -211,8 +211,13 @@ export interface BaseComponentData {
 export type MessageActionRowComponentData = ButtonComponentData | SelectMenuComponentData;
 export type ModalActionRowComponentData = TextInputComponentData;
 
-export interface ActionRowData<T extends MessageActionRowComponentData | ModalActionRowComponentData>
-  extends BaseComponentData {
+export interface ActionRowData<
+  T extends
+    | MessageActionRowComponentData
+    | ModalActionRowComponentData
+    | MessageActionRowComponent
+    | ModalActionRowComponent,
+> extends BaseComponentData {
   components: T[];
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -209,15 +209,14 @@ export interface BaseComponentData {
 }
 
 export type MessageActionRowComponentData = ButtonComponentData | SelectMenuComponentData;
+
 export type ModalActionRowComponentData = TextInputComponentData;
 
-export interface ActionRowData<
-  T extends
-    | MessageActionRowComponentData
-    | ModalActionRowComponentData
-    | MessageActionRowComponent
-    | ModalActionRowComponent,
-> extends BaseComponentData {
+export type ActionRowComponentData = MessageActionRowComponentData | ModalActionRowComponentData;
+
+export type ActionRowComponent = MessageActionRowComponent | ModalActionRowComponent;
+
+export interface ActionRowData<T extends ActionRowComponent | ActionRowComponentData> extends BaseComponentData {
   components: T[];
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR allows component classes to be passed to the components array of the action row constructor object

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
