### PR TITLE
refactor(Embed): change addField to match v13

### DIFF
--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -320,10 +320,10 @@ describe('Embed', () => {
 
 		test('GIVEN an embed using Embed#addField THEN returns valid toJSON data', () => {
 			const embed = new Embed();
-			embed.addField({ name: 'foo', value: 'bar' });
+			embed.addField('foo', 'bar');
 
 			expect(embed.toJSON()).toStrictEqual({
-				fields: [{ name: 'foo', value: 'bar' }],
+				fields: [{ name: 'foo', value: 'bar', inline: false }],
 			});
 		});
 

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -178,10 +178,12 @@ export class UnsafeEmbed implements Equatable<APIEmbed | UnsafeEmbed> {
 	/**
 	 * Adds a field to the embed (max 25)
 	 *
-	 * @param field The field to add.
+	 * @param name The name of the field (first line)
+	 * @param value The value of the field (second line)
+	 * @param inline Whether the field should be displayed inline with others
 	 */
-	public addField(field: APIEmbedField): this {
-		return this.addFields(field);
+	public addField(name: string, value: string, inline = false): this {
+		return this.addFields({ name, value, inline });
 	}
 
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

In order to avoid #7522, this PR makes #addField actually useful by allowing the user to pass each one of the parameters in the field individually, for better code readability and ease of writing this over and over, just like we had in v13. I'm making this PR because, as it sits, this method is useless when compared to #addFields, hence why the proposal to remove it, however, there are many scenarios where we indeed only want to add one field, so this method comes in handy. 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
