### PR TITLE
fix(guild): fix typo accessing user instead of users

### DIFF
--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -718,7 +718,7 @@ class Guild extends AnonymousGuild {
     }
 
     if (options.user) {
-      const id = this.client.user.resolveId(options.user);
+      const id = this.client.users.resolveId(options.user);
       if (!id) throw new TypeError('INVALID_TYPE', 'user', 'UserResolvable');
       query.set('user_id', id);
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Typo, should be calling resolveId on the UserManager and not ClientUser
**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
