### PR TITLE
fix(ThreadMembersUpdate): Only emit added & removed thread members

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -96,6 +96,7 @@ body:
         - Message
         - Reaction
         - GuildScheduledEvent
+        - ThreadMember
       multiple: true
     validations:
       required: true

--- a/packages/discord.js/src/client/actions/Action.js
+++ b/packages/discord.js/src/client/actions/Action.js
@@ -110,6 +110,10 @@ class GenericAction {
       Partials.GuildScheduledEvent,
     );
   }
+
+  getThreadMember(id, manager) {
+    return this.getPayload({ user_id: id }, manager, id, Partials.ThreadMember, false);
+  }
 }
 
 module.exports = GenericAction;

--- a/packages/discord.js/src/client/actions/ThreadMembersUpdate.js
+++ b/packages/discord.js/src/client/actions/ThreadMembersUpdate.js
@@ -19,8 +19,8 @@ class ThreadMembersUpdateAction extends Action {
       );
 
       data.removed_member_ids?.reduce((removedMembersIds, removedMembersId) => {
-        const cachedThreadMember = thread.members.cache.get(removedMembersId);
-        if (cachedThreadMember) removedMembersIds.set(cachedThreadMember.id, cachedThreadMember);
+        const threadMember = this.getThreadMember(removedMembersId, thread.members);
+        if (threadMember) removedMembersIds.set(threadMember.id, threadMember);
         thread.members.cache.delete(removedMembersId);
         return removedMembersIds;
       }, removedMembers);

--- a/packages/discord.js/src/client/actions/ThreadMembersUpdate.js
+++ b/packages/discord.js/src/client/actions/ThreadMembersUpdate.js
@@ -33,10 +33,11 @@ class ThreadMembersUpdateAction extends Action {
       /**
        * Emitted whenever members are added or removed from a thread. Requires `GUILD_MEMBERS` privileged intent
        * @event Client#threadMembersUpdate
+       * @param {ThreadChannel} thread The thread where members got updated
        * @param {Collection<Snowflake, ThreadMember>} addedMembers The members that were added
        * @param {Collection<Snowflake, ThreadMember>} removedMembers The members that were removed
        */
-      client.emit(Events.ThreadMembersUpdate, addedMembers, removedMembers);
+      client.emit(Events.ThreadMembersUpdate, thread, addedMembers, removedMembers);
     }
     return {};
   }

--- a/packages/discord.js/src/client/actions/ThreadMembersUpdate.js
+++ b/packages/discord.js/src/client/actions/ThreadMembersUpdate.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Collection } = require('@discordjs/collection');
 const Action = require('./Action');
 const Events = require('../../util/Events');
 
@@ -8,24 +9,34 @@ class ThreadMembersUpdateAction extends Action {
     const client = this.client;
     const thread = client.channels.cache.get(data.id);
     if (thread) {
-      const old = thread.members.cache.clone();
       thread.memberCount = data.member_count;
+      const addedMembers = new Collection();
+      const removedMembers = new Collection();
 
-      data.added_members?.forEach(rawMember => {
-        thread.members._add(rawMember);
-      });
+      data.added_members?.reduce(
+        (_addedMembers, addedMember) => _addedMembers.set(addedMember.id, thread.members._add(addedMember)),
+        addedMembers,
+      );
 
-      data.removed_member_ids?.forEach(memberId => {
-        thread.members.cache.delete(memberId);
-      });
+      data.removed_member_ids?.reduce((removedMembersIds, removedMembersId) => {
+        const cachedThreadMember = thread.members.cache.get(removedMembersId);
+        if (cachedThreadMember) removedMembersIds.set(cachedThreadMember.id, cachedThreadMember);
+        thread.members.cache.delete(removedMembersId);
+        return removedMembersIds;
+      }, removedMembers);
+
+      if (addedMembers.size === 0 && removedMembers.size === 0) {
+        // Uncached thread member(s) left.
+        return {};
+      }
 
       /**
        * Emitted whenever members are added or removed from a thread. Requires `GUILD_MEMBERS` privileged intent
        * @event Client#threadMembersUpdate
-       * @param {Collection<Snowflake, ThreadMember>} oldMembers The members before the update
-       * @param {Collection<Snowflake, ThreadMember>} newMembers The members after the update
+       * @param {Collection<Snowflake, ThreadMember>} addedMembers The members that were added
+       * @param {Collection<Snowflake, ThreadMember>} removedMembers The members that were removed
        */
-      client.emit(Events.ThreadMembersUpdate, old, thread.members.cache);
+      client.emit(Events.ThreadMembersUpdate, addedMembers, removedMembers);
     }
     return {};
   }

--- a/packages/discord.js/src/client/actions/ThreadMembersUpdate.js
+++ b/packages/discord.js/src/client/actions/ThreadMembersUpdate.js
@@ -14,7 +14,7 @@ class ThreadMembersUpdateAction extends Action {
       const removedMembers = new Collection();
 
       data.added_members?.reduce(
-        (_addedMembers, addedMember) => _addedMembers.set(addedMember.id, thread.members._add(addedMember)),
+        (_addedMembers, addedMember) => _addedMembers.set(addedMember.user_id, thread.members._add(addedMember)),
         addedMembers,
       );
 

--- a/packages/discord.js/src/structures/ThreadMember.js
+++ b/packages/discord.js/src/structures/ThreadMember.js
@@ -24,6 +24,12 @@ class ThreadMember extends Base {
     this.joinedTimestamp = null;
 
     /**
+     * The flags for this thread member. This will be `null` if partial.
+     * @type {?ThreadMemberFlagsBitField}
+     */
+    this.flags = null;
+
+    /**
      * The id of the thread member
      * @type {Snowflake}
      */
@@ -34,14 +40,16 @@ class ThreadMember extends Base {
 
   _patch(data) {
     if ('join_timestamp' in data) this.joinedTimestamp = Date.parse(data.join_timestamp);
+    if ('flags' in data) this.flags = new ThreadMemberFlagsBitField(data.flags).freeze();
+  }
 
-    if ('flags' in data) {
-      /**
-       * The flags for this thread member
-       * @type {ThreadMemberFlagsBitField}
-       */
-      this.flags = new ThreadMemberFlagsBitField(data.flags).freeze();
-    }
+  /**
+   * Whether this thread member is a partial
+   * @type {boolean}
+   * @readonly
+   */
+  get partial() {
+    return this.flags === null;
   }
 
   /**
@@ -78,6 +86,14 @@ class ThreadMember extends Base {
    */
   get manageable() {
     return !this.thread.archived && this.thread.editable;
+  }
+
+  /**
+   * Fetches this thread member. Requires access to the `GUILD_MEMBERS` gateway intent.
+   * @returns {Promise<ThreadMember>}
+   */
+  fetch() {
+    return this.thread.members.fetch({ member: this.id, force: true });
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadMember.js
+++ b/packages/discord.js/src/structures/ThreadMember.js
@@ -89,14 +89,6 @@ class ThreadMember extends Base {
   }
 
   /**
-   * Fetches this thread member. Requires access to the `GUILD_MEMBERS` gateway intent.
-   * @returns {Promise<ThreadMember>}
-   */
-  fetch() {
-    return this.thread.members.fetch({ member: this.id, force: true });
-  }
-
-  /**
    * Removes this member from the thread.
    * @param {string} [reason] Reason for removing the member
    * @returns {ThreadMember}

--- a/packages/discord.js/src/util/Partials.js
+++ b/packages/discord.js/src/util/Partials.js
@@ -2,4 +2,12 @@
 
 const { createEnum } = require('./Enums');
 
-module.exports = createEnum(['User', 'Channel', 'GuildMember', 'Message', 'Reaction', 'GuildScheduledEvent']);
+module.exports = createEnum([
+  'User',
+  'Channel',
+  'GuildMember',
+  'Message',
+  'Reaction',
+  'GuildScheduledEvent',
+  'ThreadMember',
+]);

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2330,7 +2330,6 @@ export class ThreadMember extends Base {
   public thread: ThreadChannel;
   public get user(): User | null;
   public get partial(): false;
-  public fetch(): Promise<ThreadMember>;
   public remove(reason?: string): Promise<ThreadMember>;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3662,8 +3662,8 @@ export interface ClientEvents {
   threadListSync: [threads: Collection<Snowflake, ThreadChannel>];
   threadMemberUpdate: [oldMember: ThreadMember, newMember: ThreadMember];
   threadMembersUpdate: [
-    oldMembers: Collection<Snowflake, ThreadMember>,
-    newMembers: Collection<Snowflake, ThreadMember>,
+    addedMembers: Collection<Snowflake, ThreadMember>,
+    removedMembers: Collection<Snowflake, ThreadMember>,
   ];
   threadUpdate: [oldThread: ThreadChannel, newThread: ThreadChannel];
   typingStart: [typing: Typing];

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3662,6 +3662,7 @@ export interface ClientEvents {
   threadListSync: [threads: Collection<Snowflake, ThreadChannel>];
   threadMemberUpdate: [oldMember: ThreadMember, newMember: ThreadMember];
   threadMembersUpdate: [
+    thread: ThreadChannel,
     addedMembers: Collection<Snowflake, ThreadMember>,
     removedMembers: Collection<Snowflake, ThreadMember>,
   ];

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2329,6 +2329,8 @@ export class ThreadMember extends Base {
   public get manageable(): boolean;
   public thread: ThreadChannel;
   public get user(): User | null;
+  public get partial(): false;
+  public fetch(): Promise<ThreadMember>;
   public remove(reason?: string): Promise<ThreadMember>;
 }
 
@@ -3280,7 +3282,7 @@ export interface AddGuildMemberOptions {
   fetchWhenExisting?: boolean;
 }
 
-export type AllowedPartial = User | Channel | GuildMember | Message | MessageReaction;
+export type AllowedPartial = User | Channel | GuildMember | Message | MessageReaction | ThreadMember;
 
 export type AllowedThreadTypeForNewsChannel = ChannelType.GuildNewsThread;
 
@@ -3664,7 +3666,7 @@ export interface ClientEvents {
   threadMembersUpdate: [
     thread: ThreadChannel,
     addedMembers: Collection<Snowflake, ThreadMember>,
-    removedMembers: Collection<Snowflake, ThreadMember>,
+    removedMembers: Collection<Snowflake, ThreadMember | PartialThreadMember>,
   ];
   threadUpdate: [oldThread: ThreadChannel, newThread: ThreadChannel];
   typingStart: [typing: Typing];
@@ -4869,6 +4871,8 @@ export interface PartialMessage
 
 export interface PartialMessageReaction extends Partialize<MessageReaction, 'count'> {}
 
+export interface PartialThreadMember extends Partialize<ThreadMember, 'flags' | 'joinedAt' | 'joinedTimestamp'> {}
+
 export interface PartialOverwriteData {
   id: Snowflake | number;
   type?: OverwriteType;
@@ -4887,6 +4891,7 @@ export enum Partials {
   Message,
   Reaction,
   GuildScheduledEvent,
+  ThreadMember,
 }
 
 export interface PartialUser extends Partialize<User, 'username' | 'tag' | 'discriminator'> {}

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -106,6 +106,7 @@ import {
   ActionRowData,
   MessageActionRowComponentData,
   PartialThreadMember,
+  ThreadMemberFlagsBitField,
 } from '.';
 import { expectAssignable, expectDeprecated, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import { Embed } from '@discordjs/builders';
@@ -718,15 +719,18 @@ client.on('messageCreate', async message => {
   });
 });
 
-client.on('threadMembersUpdate', async (thread, addedMembers, removedMembers) => {
   expectType<ThreadChannel>(thread);
   expectType<Collection<Snowflake, ThreadMember>>(addedMembers);
   expectType<Collection<Snowflake, ThreadMember | PartialThreadMember>>(removedMembers);
   const left = removedMembers.first();
+  if (!left) return;
 
-  if (left?.partial) {
+  if (left.partial) {
     expectType<PartialThreadMember>(left);
     expectType<null>(left.flags);
+  } else {
+    expectType<ThreadMember>(left);
+    expectType<ThreadMemberFlagsBitField>(left.flags);
   }
 });
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -719,6 +719,7 @@ client.on('messageCreate', async message => {
   });
 });
 
+client.on('threadMembersUpdate', (thread, addedMembers, removedMembers) => {
   expectType<ThreadChannel>(thread);
   expectType<Collection<Snowflake, ThreadMember>>(addedMembers);
   expectType<Collection<Snowflake, ThreadMember | PartialThreadMember>>(removedMembers);

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -722,15 +722,11 @@ client.on('threadMembersUpdate', async (thread, addedMembers, removedMembers) =>
   expectType<ThreadChannel>(thread);
   expectType<Collection<Snowflake, ThreadMember>>(addedMembers);
   expectType<Collection<Snowflake, ThreadMember | PartialThreadMember>>(removedMembers);
+  const left = removedMembers.first();
 
-  for (let removedMember of removedMembers.values()) {
-    if (removedMember.partial) {
-      expectType<PartialThreadMember>(removedMember);
-      expectType<null>(removedMember.flags);
-      removedMember = await removedMember.fetch();
-      expectNotType<PartialThreadMember>(removedMember);
-      expectNotType<null>(removedMember.flags);
-    }
+  if (left?.partial) {
+    expectType<PartialThreadMember>(left);
+    expectType<null>(left.flags);
   }
 });
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -105,6 +105,7 @@ import {
   CategoryChannelChildManager,
   ActionRowData,
   MessageActionRowComponentData,
+  PartialThreadMember,
 } from '.';
 import { expectAssignable, expectDeprecated, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import { Embed } from '@discordjs/builders';
@@ -715,6 +716,22 @@ client.on('messageCreate', async message => {
       return true;
     },
   });
+});
+
+client.on('threadMembersUpdate', async (thread, addedMembers, removedMembers) => {
+  expectType<ThreadChannel>(thread);
+  expectType<Collection<Snowflake, ThreadMember>>(addedMembers);
+  expectType<Collection<Snowflake, ThreadMember | PartialThreadMember>>(removedMembers);
+
+  for (let removedMember of removedMembers.values()) {
+    if (removedMember.partial) {
+      expectType<PartialThreadMember>(removedMember);
+      expectType<null>(removedMember.flags);
+      removedMember = await removedMember.fetch();
+      expectNotType<PartialThreadMember>(removedMember);
+      expectNotType<null>(removedMember.flags);
+    }
+  }
 });
 
 client.on('interactionCreate', async interaction => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As explained in #6513, the event may emit the **same** `oldMembers` and `newMembers` which was... not useful. It's not possible to tell what actually changed there - only that _something_ changed. This is due to discord.js always assuming the thread member leaving is cached.

I believe it'd be best to do nothing (like other events) if only uncached thread members leave. By doing this, the event does not fire as it would emit the same `Collection` for both parameters. We can utilise a new partial (`Partials.ThreadMember`) for people who still want that data. This solves that issue, but there is another.

discord.js emits these added & removed thread members alongside the existing thread member cache. Since Discord does not send the current thread members, this is susceptible to a caching issue where there may be some thread members in both payloads... or there may not. To find out what truly changed, you would have to perform operations on the received `Collection`s to find out the thread members that caused this gateway event to occur. Therefore, I removed this caching behaviour and aligned it to the API: only emitting the added & removed thread members.

Now, the event works like this:

```JavaScript
<Client>.on(Events.ThreadMembersUpdate, (thread, addedMembers, removedMembers) => {
  console.log(thread); // This is the thread where members got updated!
  
  if (addedMembers.size > 0) {
    // Only the members that were added are here.
  }

  if (removedMembers.size > 0) {
    // Only the members that were removed are here.
    if (removedMembers.first().partial) {
      // Uncached thread member left the thread.
      // This will be included with the new partial (`Partials.ThreadMember`).
    }
  }
});
```

The thread channel is being emitted too to avoid the user doing `addedMembers.first()?.thread ?? removedMembers.first().thread`. We already have the thread internally so it seemed reasonable to include it. Additionally, users can access the thread's member cache to do what they need as before.

Feedback is welcome and appreciated!

This resolves #6513.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
