### PR TITLE
types: use discord-api-types `Locale`

### DIFF
--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -184,6 +184,7 @@ exports.GuildVerificationLevel = require('discord-api-types/v9').GuildVerificati
 exports.InteractionType = require('discord-api-types/v9').InteractionType;
 exports.InteractionResponseType = require('discord-api-types/v9').InteractionResponseType;
 exports.InviteTargetType = require('discord-api-types/v9').InviteTargetType;
+exports.Locale = require('discord-api-types/v9').Locale;
 exports.MessageType = require('discord-api-types/v9').MessageType;
 exports.MessageFlags = require('discord-api-types/v9').MessageFlags;
 exports.OAuth2Scopes = require('discord-api-types/v9').OAuth2Scopes;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5132,6 +5132,7 @@ export {
   InteractionType,
   InteractionResponseType,
   InviteTargetType,
+  Locale,
   MessageType,
   MessageFlags,
   OAuth2Scopes,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -60,6 +60,7 @@ import {
   GuildNSFWLevel,
   GuildPremiumTier,
   GuildVerificationLevel,
+  Locale,
   InteractionType,
   InviteTargetType,
   MessageType,
@@ -924,7 +925,7 @@ export class Guild extends AnonymousGuild {
   public members: GuildMemberManager;
   public mfaLevel: GuildMFALevel;
   public ownerId: Snowflake;
-  public preferredLocale: string;
+  public preferredLocale: Locale;
   public premiumProgressBarEnabled: boolean;
   public premiumTier: GuildPremiumTier;
   public presences: PresenceManager;
@@ -982,7 +983,7 @@ export class Guild extends AnonymousGuild {
   public setIcon(icon: BufferResolvable | Base64Resolvable | null, reason?: string): Promise<Guild>;
   public setName(name: string, reason?: string): Promise<Guild>;
   public setOwner(owner: GuildMemberResolvable, reason?: string): Promise<Guild>;
-  public setPreferredLocale(preferredLocale: string, reason?: string): Promise<Guild>;
+  public setPreferredLocale(preferredLocale: Locale, reason?: string): Promise<Guild>;
   public setPublicUpdatesChannel(publicUpdatesChannel: TextChannelResolvable | null, reason?: string): Promise<Guild>;
   public setRulesChannel(rulesChannel: TextChannelResolvable | null, reason?: string): Promise<Guild>;
   public setSplash(splash: BufferResolvable | Base64Resolvable | null, reason?: string): Promise<Guild>;
@@ -1328,8 +1329,8 @@ export class Interaction<Cached extends CacheType = CacheType> extends Base {
   public user: User;
   public version: number;
   public memberPermissions: CacheTypeReducer<Cached, Readonly<PermissionsBitField>>;
-  public locale: string;
-  public guildLocale: CacheTypeReducer<Cached, string, string, string>;
+  public locale: Locale;
+  public guildLocale: CacheTypeReducer<Cached, Locale>;
   public inGuild(): this is Interaction<'raw' | 'cached'>;
   public inCachedGuild(): this is Interaction<'cached'>;
   public inRawGuild(): this is Interaction<'raw'>;
@@ -4297,7 +4298,7 @@ export interface GuildEditData {
   banner?: BufferResolvable | Base64Resolvable | null;
   rulesChannel?: TextChannelResolvable;
   publicUpdatesChannel?: TextChannelResolvable;
-  preferredLocale?: string;
+  preferredLocale?: Locale;
   premiumProgressBarEnabled?: boolean;
   description?: string | null;
   features?: GuildFeature[];

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -15,6 +15,7 @@ import {
   ChannelType,
   InteractionType,
   GatewayIntentBits,
+  Locale,
   PermissionFlagsBits,
   AuditLogEvent,
   ButtonStyle,
@@ -1006,13 +1007,13 @@ client.on('interactionCreate', async interaction => {
     expectAssignable<GuildMember>(interaction.member);
     expectNotType<ChatInputCommandInteraction<'cached'>>(interaction);
     expectAssignable<Interaction>(interaction);
-    expectType<string>(interaction.guildLocale);
+    expectType<Locale>(interaction.guildLocale);
   } else if (interaction.inRawGuild()) {
     expectAssignable<APIInteractionGuildMember>(interaction.member);
     expectNotAssignable<Interaction<'cached'>>(interaction);
-    expectType<string>(interaction.guildLocale);
+    expectType<Locale>(interaction.guildLocale);
   } else if (interaction.inGuild()) {
-    expectType<string>(interaction.guildLocale);
+    expectType<Locale>(interaction.guildLocale);
   } else {
     expectType<APIInteractionGuildMember | GuildMember | null>(interaction.member);
     expectNotAssignable<Interaction<'cached'>>(interaction);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR replaces locale types definitions from `string` to `Locale` from discord-api-types.

**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
