### PR TITLE
fix: Handle partial data for `Typing#user`

### DIFF
--- a/packages/discord.js/src/managers/UserManager.js
+++ b/packages/discord.js/src/managers/UserManager.js
@@ -39,7 +39,7 @@ class UserManager extends CachedManager {
    * @private
    */
   dmChannel(userId) {
-    return this.client.channels.cache.find(c => c.type === ChannelType.DM && c.recipient.id === userId) ?? null;
+    return this.client.channels.cache.find(c => c.type === ChannelType.DM && c.recipientId === userId) ?? null;
   }
 
   /**

--- a/packages/discord.js/src/structures/DMChannel.js
+++ b/packages/discord.js/src/structures/DMChannel.js
@@ -1,10 +1,10 @@
 'use strict';
 
+const { userMention } = require('@discordjs/builders');
 const { ChannelType } = require('discord-api-types/v9');
 const { Channel } = require('./Channel');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const MessageManager = require('../managers/MessageManager');
-const { Formatters } = require('../util/Formatters');
 const Partials = require('../util/Partials');
 
 /**
@@ -98,7 +98,7 @@ class DMChannel extends Channel {
    * console.log(`Hello from ${channel}!`);
    */
   toString() {
-    return Formatters.userMention(this.recipientId);
+    return userMention(this.recipientId);
   }
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel

--- a/packages/discord.js/src/structures/DMChannel.js
+++ b/packages/discord.js/src/structures/DMChannel.js
@@ -72,6 +72,7 @@ class DMChannel extends Channel {
   /**
    * The recipient on the other end of the DM
    * @type {?User}
+   * @readonly
    */
   get recipient() {
     return this.client.users.resolve(this.recipientId);

--- a/packages/discord.js/src/structures/DMChannel.js
+++ b/packages/discord.js/src/structures/DMChannel.js
@@ -30,14 +30,16 @@ class DMChannel extends Channel {
     super._patch(data);
 
     if (data.recipients) {
+      const recipient = data.recipients[0];
+
       /**
        * The recipient's id
        * @type {Snowflake}
        */
-      this.recipientId = data.recipients[0].id;
+      this.recipientId = recipient.id;
 
-      if ('username' in data.recipients[0] || this.client.options.partials.includes(Partials.Users)) {
-        this.client.users._add(data.recipients[0]);
+      if ('username' in recipient || this.client.options.partials.includes(Partials.Users)) {
+        this.client.users._add(recipient);
       }
     }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -876,7 +876,8 @@ export class EnumResolvers extends null {
 export class DMChannel extends TextBasedChannelMixin(Channel, ['bulkDelete']) {
   private constructor(client: Client, data?: RawDMChannelData);
   public messages: MessageManager;
-  public recipient: User;
+  public recipientId: Snowflake;
+  public get recipient(): User | null;
   public type: ChannelType.DM;
   public fetch(force?: boolean): Promise<this>;
 }
@@ -2249,7 +2250,7 @@ export class ThreadMemberFlagsBitField extends BitField<ThreadMemberFlagsString>
 export class Typing extends Base {
   private constructor(channel: TextBasedChannel, user: PartialUser, data?: RawTypingData);
   public channel: TextBasedChannel;
-  public user: PartialUser;
+  public user: User | PartialUser;
   public startedTimestamp: number;
   public get startedAt(): Date;
   public get guild(): Guild | null;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -945,8 +945,9 @@ expectType<Promise<Collection<Snowflake, GuildEmoji>>>(guildEmojiManager.fetch(u
 expectType<Promise<GuildEmoji>>(guildEmojiManager.fetch('0'));
 
 declare const typing: Typing;
-expectType<PartialUser>(typing.user);
+expectType<User | PartialUser>(typing.user);
 if (typing.user.partial) expectType<null>(typing.user.username);
+if (!typing.user.partial) expectType<string>(typing.user.tag);
 
 expectType<TextBasedChannel>(typing.channel);
 if (typing.channel.partial) expectType<undefined>(typing.channel.lastMessageId);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As detailed in #7102, `Typing#user` had the potential to be an unwanted partial. This is because `DMChannel#_patch()` always adds the user, even if the data only contained the user id. Additionally, the typings weren't correct for this.

Since there is a possibility of not receiving the full recipient data, only the `recipientId` is now on the `DMChannel` class. `recipient` is now a getter. If the `USER` partial is specified or a full structure is received, we add the recipient to the cache which in turn will respectively emit `Client#typingStart`.

This fully resolves #7102.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
