### PR TITLE
fix: only check `instanceof Component` once

### DIFF
--- a/packages/builders/src/components/Components.ts
+++ b/packages/builders/src/components/Components.ts
@@ -17,13 +17,17 @@ export function createComponent<T extends keyof MappedComponentTypes>(
 ): MappedComponentTypes[T];
 export function createComponent<C extends MessageComponent>(data: C): C;
 export function createComponent(data: APIMessageComponent | MessageComponent): Component {
+	if (data instanceof Component) {
+		return data;
+	}
+
 	switch (data.type) {
 		case ComponentType.ActionRow:
-			return (data instanceof ActionRow ? data : new ActionRow(data)) as Component;
+			return new ActionRow(data);
 		case ComponentType.Button:
-			return (data instanceof ButtonComponent ? data : new ButtonComponent(data)) as Component;
+			return new ButtonComponent(data);
 		case ComponentType.SelectMenu:
-			return (data instanceof SelectMenuComponent ? data : new SelectMenuComponent(data)) as Component;
+			return new SelectMenuComponent(data);
 		default:
 			// @ts-expect-error
 			throw new Error(`Cannot serialize component type: ${data.type as number}`);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously a check was done for each component type. This simplifies the logic to one check for a class-based component.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating