### PR TITLE
Fix(types): Allow Date object in`MessageEmbed.timestamp` 

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1691,7 +1691,7 @@ export class MessageEmbed {
   public readonly length: number;
   public provider: MessageEmbedProvider | null;
   public thumbnail: MessageEmbedThumbnail | null;
-  public timestamp: number | null;
+  public timestamp: number | Date | null;
   public title: string | null;
   /** @deprecated */
   public type: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
In raw `MessageEmbed` object, Allow `MessageEmbed.timestamp` to use Date object
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
