### PR TITLE
docs(InteractionCollector): Document channel option type

### DIFF
--- a/packages/discord.js/src/structures/InteractionCollector.js
+++ b/packages/discord.js/src/structures/InteractionCollector.js
@@ -6,7 +6,7 @@ const Events = require('../util/Events');
 
 /**
  * @typedef {CollectorOptions} InteractionCollectorOptions
- * @property {TextBasedChannelResolvable} [channel] The channel to listen to interactions from
+ * @property {TextBasedChannelsResolvable} [channel] The channel to listen to interactions from
  * @property {ComponentType} [componentType] The type of component to listen for
  * @property {GuildResolvable} [guild] The guild to listen to interactions from
  * @property {InteractionType} [interactionType] The type of interaction to listen for

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -66,6 +66,13 @@ exports.NonSystemMessageTypes = [
  */
 
 /**
+ * Data that resolves to give a text-based channel. This can be:
+ * * A text-based channel
+ * * A snowflake
+ * @typedef {TextBasedChannels|Snowflake} TextBasedChannelsResolvable
+ */
+
+/**
  * The types of channels that are text-based. The available types are:
  * * {@link ChannelType.DM}
  * * {@link ChannelType.GuildText}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Regression from #7452: `TextBasedChannelResolvable` did not exist.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
