### PR TITLE
fix: Backport `MessageReaction#me` being incorrectly `false`

### DIFF
--- a/src/structures/MessageReaction.js
+++ b/src/structures/MessageReaction.js
@@ -114,7 +114,7 @@ class MessageReaction {
     if (this.partial) return;
     this.users.cache.set(user.id, user);
     if (!this.me || user.id !== this.message.client.user.id || this.count === 0) this.count++;
-    this.me ??= user.id === this.message.client.user.id;
+    this.me ||= user.id === this.message.client.user.id;
   }
 
   _remove(user) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Backports #7378 to version 13.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
