### PR TITLE
fix(ThreadChannel): Require `sendable` for `unarchivable`

### DIFF
--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -487,7 +487,7 @@ class ThreadChannel extends Channel {
    * @readonly
    */
   get unarchivable() {
-    return this.archived && (this.locked ? this.manageable : this.sendable);
+    return this.archived && this.sendable && (!this.locked || this.manageable);
   }
 
   /**


### PR DESCRIPTION
Backports #7406 to version 13.