### PR TITLE
feat: Backport `MessageMentions` channel type fixes

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1734,11 +1734,11 @@ export class MessageMentions {
     everyone: boolean,
     repliedUser?: APIUser | User,
   );
-  private _channels: Collection<Snowflake, TextBasedChannel> | null;
+  private _channels: Collection<Snowflake, AnyChannel> | null;
   private readonly _content: string;
   private _members: Collection<Snowflake, GuildMember> | null;
 
-  public readonly channels: Collection<Snowflake, TextBasedChannel>;
+  public readonly channels: Collection<Snowflake, AnyChannel>;
   public readonly client: Client;
   public everyone: boolean;
   public readonly guild: Guild;


### PR DESCRIPTION
Backports #7316 to version 13.