### PR TITLE
feat(VoiceState): add edit method

### DIFF
--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -221,7 +221,9 @@ class VoiceState extends Base {
   async edit(data) {
     if (this.channel?.type !== ChannelType.GuildStageVoice) throw new Error('VOICE_NOT_STAGE_CHANNEL');
 
-    if (this.client.user.id !== this.id && typeof data.requestToSpeak !== 'undefined') {
+    const target = this.client.user.id === this.id ? '@me' : this.id;
+
+    if (target === '@me' && typeof data.requestToSpeak !== 'undefined') {
       throw new Error('VOICE_STATE_NOT_OWN');
     }
 
@@ -232,8 +234,6 @@ class VoiceState extends Base {
     if (!['boolean', 'undefined'].includes(typeof data.suppressed)) {
       throw new TypeError('VOICE_STATE_INVALID_TYPE', 'suppressed');
     }
-
-    const target = this.client.user.id === this.id ? '@me' : this.id;
 
     await this.client.rest.patch(Routes.guildVoiceState(this.guild.id, target), {
       body: {

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -271,7 +271,7 @@ class VoiceState extends Base {
    * // Making the client an audience member
    * guild.me.voice.setSuppressed(true);
    * @example
-   * // Inviting another user to speak\
+   * // Inviting another user to speak
    * voiceState.setSuppressed(false);
    * @example
    * // Moving another user to the audience, or cancelling their invite to speak

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -206,28 +206,55 @@ class VoiceState extends Base {
   }
 
   /**
+   * Data to edit the logged in user's own voice state with, when in a stage channel
+   * @typedef {Object} VoiceStateEditData
+   * @property {boolean} [requestToSpeak] Whether or not the client is requesting to become a speaker.
+   * @property {boolean} [suppressed] Whether or not the user should be suppressed.
+   */
+
+  /**
+   * Edits this voice state.
+   * Currently only available to the logged in user's own voice state and when in a stage channel
+   * @param {VoiceStateEditData} data The data to edit the voice state with
+   * @returns {Promise<VoiceState>}
+   */
+  async edit(data) {
+    if (this.channel?.type !== ChannelType.GuildStageVoice) throw new Error('VOICE_NOT_STAGE_CHANNEL');
+
+    if (this.client.user.id !== this.id) throw new Error('VOICE_STATE_NOT_OWN');
+
+    if (typeof data.requestToSpeak !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'requestToSpeak');
+
+    if (typeof data.suppressed !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'suppressed');
+
+    await this.client.rest.patch(Routes.guildVoiceState(this.guild.id), {
+      body: {
+        channel_id: this.channelId,
+        request_to_speak_timestamp: data.requestToSpeak
+          ? new Date().toISOString()
+          : data.requestToSpeak === false
+          ? null
+          : undefined,
+        suppress: data.suppressed,
+      },
+    });
+    return this;
+  }
+
+  /**
    * Toggles the request to speak in the channel.
    * Only applicable for stage channels and for the client's own voice state.
-   * @param {boolean} [request=true] Whether or not the client is requesting to become a speaker.
+   * @param {boolean} [requestToSpeak=true] Whether or not the client is requesting to become a speaker.
    * @example
    * // Making the client request to speak in a stage channel (raise its hand)
    * guild.me.voice.setRequestToSpeak(true);
    * @example
    * // Making the client cancel a request to speak
    * guild.me.voice.setRequestToSpeak(false);
-   * @returns {Promise<void>}
+   * @returns {Promise<VoiceState>}
    */
-  async setRequestToSpeak(request = true) {
-    if (this.channel?.type !== ChannelType.GuildStageVoice) throw new Error('VOICE_NOT_STAGE_CHANNEL');
-
-    if (this.client.user.id !== this.id) throw new Error('VOICE_STATE_NOT_OWN');
-
-    await this.client.rest.patch(Routes.guildVoiceState(this.guild.id), {
-      body: {
-        channel_id: this.channelId,
-        request_to_speak_timestamp: request ? new Date().toISOString() : null,
-      },
-    });
+  setRequestToSpeak(requestToSpeak = true) {
+    return this.edit({ requestToSpeak });
   }
 
   /**
@@ -240,26 +267,15 @@ class VoiceState extends Base {
    * // Making the client an audience member
    * guild.me.voice.setSuppressed(true);
    * @example
-   * // Inviting another user to speak
+   * // Inviting another user to speak\
    * voiceState.setSuppressed(false);
    * @example
    * // Moving another user to the audience, or cancelling their invite to speak
    * voiceState.setSuppressed(true);
-   * @returns {Promise<void>}
+   * @returns {Promise<VoiceState>}
    */
-  async setSuppressed(suppressed = true) {
-    if (typeof suppressed !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'suppressed');
-
-    if (this.channel?.type !== ChannelType.GuildStageVoice) throw new Error('VOICE_NOT_STAGE_CHANNEL');
-
-    const target = this.client.user.id === this.id ? '@me' : this.id;
-
-    await this.client.rest.patch(Routes.guildVoiceState(this.guild.id, target), {
-      body: {
-        channel_id: this.channelId,
-        suppress: suppressed,
-      },
-    });
+  setSuppressed(suppressed = true) {
+    return this.edit({ suppressed });
   }
 
   toJSON() {

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -223,7 +223,7 @@ class VoiceState extends Base {
 
     const target = this.client.user.id === this.id ? '@me' : this.id;
 
-    if (target === '@me' && typeof data.requestToSpeak !== 'undefined') {
+    if (target !== '@me' && typeof data.requestToSpeak !== 'undefined') {
       throw new Error('VOICE_STATE_NOT_OWN');
     }
 

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -223,9 +223,13 @@ class VoiceState extends Base {
 
     if (this.client.user.id !== this.id) throw new Error('VOICE_STATE_NOT_OWN');
 
-    if (typeof data.requestToSpeak !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'requestToSpeak');
+    if (!['boolean', 'undefined'].includes(typeof data.requestToSpeak)) {
+      throw new TypeError('VOICE_STATE_INVALID_TYPE', 'requestToSpeak');
+    }
 
-    if (typeof data.suppressed !== 'boolean') throw new TypeError('VOICE_STATE_INVALID_TYPE', 'suppressed');
+    if (!['boolean', 'undefined'].includes(typeof data.suppressed)) {
+      throw new TypeError('VOICE_STATE_INVALID_TYPE', 'suppressed');
+    }
 
     await this.client.rest.patch(Routes.guildVoiceState(this.guild.id), {
       body: {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2517,8 +2517,9 @@ export class VoiceState extends Base {
   public setMute(mute?: boolean, reason?: string): Promise<GuildMember>;
   public disconnect(reason?: string): Promise<GuildMember>;
   public setChannel(channel: GuildVoiceChannelResolvable | null, reason?: string): Promise<GuildMember>;
-  public setRequestToSpeak(request?: boolean): Promise<void>;
-  public setSuppressed(suppressed?: boolean): Promise<void>;
+  public setRequestToSpeak(request?: boolean): Promise<this>;
+  public setSuppressed(suppressed?: boolean): Promise<this>;
+  public edit(data: VoiceStateEditData): Promise<this>;
 }
 
 export class Webhook extends WebhookMixin() {
@@ -5128,6 +5129,11 @@ export interface Vanity {
 export type VoiceBasedChannelTypes = VoiceBasedChannel['type'];
 
 export type VoiceChannelResolvable = Snowflake | VoiceChannel;
+
+export interface VoiceStateEditData {
+  requestToSpeak?: boolean;
+  suppressed?: boolean;
+}
 
 export type WebhookClientData = WebhookClientDataIdWithToken | WebhookClientDataURL;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds a new method: VoiceState#edit to allow both editable parameters to be edited in 1 API call. It also changes the existing parameters to return the current voicestate instead of void like before

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
