### PR TITLE
feat(StageInstance): Add support for associated guild event

### DIFF
--- a/packages/discord.js/src/structures/StageInstance.js
+++ b/packages/discord.js/src/structures/StageInstance.js
@@ -66,7 +66,7 @@ class StageInstance extends Base {
 
     if ('guild_scheduled_event_id' in data) {
       /**
-       * The associated scheduled event Id of this stage instance
+       * The associated guild scheduled event id of this stage instance
        * @type {?Snowflake}
        */
       this.guildScheduledEventId = data.guild_scheduled_event_id;
@@ -94,12 +94,12 @@ class StageInstance extends Base {
   }
 
   /**
-   * The associated scheduled event of this stage instance
+   * The associated guild scheduled event of this stage instance
    * @type {?GuildScheduledEvent}
    * @readonly
    */
   get scheduledEvent() {
-    return this.guild?.scheduledEvents.resolve(this.guildScheduledEventId);
+    return this.guild?.scheduledEvents.resolve(this.guildScheduledEventId) ?? null;
   }
 
   /**

--- a/packages/discord.js/src/structures/StageInstance.js
+++ b/packages/discord.js/src/structures/StageInstance.js
@@ -63,6 +63,16 @@ class StageInstance extends Base {
     } else {
       this.discoverableDisabled ??= null;
     }
+
+    if ('guild_scheduled_event_id' in data) {
+      /**
+       * The associated scheduled event Id of this stage instance
+       * @type {?Snowflake}
+       */
+      this.guildScheduledEventId = data.guild_scheduled_event_id;
+    } else {
+      this.guildScheduledEventId ??= null;
+    }
   }
 
   /**
@@ -81,6 +91,15 @@ class StageInstance extends Base {
    */
   get guild() {
     return this.client.guilds.resolve(this.guildId);
+  }
+
+  /**
+   * The associated scheduled event of this stage instance
+   * @type {?GuildScheduledEvent}
+   * @readonly
+   */
+  get scheduledEvent() {
+    return this.guild?.scheduledEvents.resolve(this.guildScheduledEventId);
   }
 
   /**

--- a/packages/discord.js/src/structures/StageInstance.js
+++ b/packages/discord.js/src/structures/StageInstance.js
@@ -98,7 +98,7 @@ class StageInstance extends Base {
    * @type {?GuildScheduledEvent}
    * @readonly
    */
-  get scheduledEvent() {
+  get guildScheduledEvent() {
     return this.guild?.scheduledEvents.resolve(this.guildScheduledEventId) ?? null;
   }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2014,7 +2014,7 @@ export class StageInstance extends Base {
   public guildScheduledEventId?: Snowflake;
   public get channel(): StageChannel | null;
   public get guild(): Guild | null;
-  public get scheduledEvent(): GuildScheduledEvent | null;
+  public get guildScheduledEvent(): GuildScheduledEvent | null;
   public edit(options: StageInstanceEditOptions): Promise<StageInstance>;
   public delete(): Promise<StageInstance>;
   public setTopic(topic: string): Promise<StageInstance>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2011,8 +2011,10 @@ export class StageInstance extends Base {
   public privacyLevel: StageInstancePrivacyLevel;
   /** @deprecated See https://github.com/discord/discord-api-docs/pull/4296 for more information */
   public discoverableDisabled: boolean | null;
+  public guildScheduledEventId?: Snowflake;
   public get channel(): StageChannel | null;
   public get guild(): Guild | null;
+  public get scheduledEvent(): GuildScheduledEvent | null;
   public edit(options: StageInstanceEditOptions): Promise<StageInstance>;
   public delete(): Promise<StageInstance>;
   public setTopic(topic: string): Promise<StageInstance>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds support to associated cached scheduled events with a stage instance if applicable.

- https://github.com/discord/discord-api-docs/pull/4583

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)