### PR TITLE
refactor: remove obsolete builder methods 

### DIFF
--- a/packages/builders/__tests__/interactions/SlashCommands/Options.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/Options.test.ts
@@ -100,7 +100,7 @@ describe('Application Command toJSON() results', () => {
 		});
 
 		expect(
-			getIntegerOption().addChoice({ name: 'uwu', value: 1 }).toJSON(),
+			getIntegerOption().addChoices({ name: 'uwu', value: 1 }).toJSON(),
 		).toEqual<APIApplicationCommandIntegerOption>({
 			name: 'owo',
 			description: 'Testing 123',
@@ -143,15 +143,17 @@ describe('Application Command toJSON() results', () => {
 			choices: [],
 		});
 
-		expect(getNumberOption().addChoice({ name: 'uwu', value: 1 }).toJSON()).toEqual<APIApplicationCommandNumberOption>({
-			name: 'owo',
-			description: 'Testing 123',
-			type: ApplicationCommandOptionType.Number,
-			required: true,
-			max_value: 10,
-			min_value: -1.23,
-			choices: [{ name: 'uwu', value: 1 }],
-		});
+		expect(getNumberOption().addChoices({ name: 'uwu', value: 1 }).toJSON()).toEqual<APIApplicationCommandNumberOption>(
+			{
+				name: 'owo',
+				description: 'Testing 123',
+				type: ApplicationCommandOptionType.Number,
+				required: true,
+				max_value: 10,
+				min_value: -1.23,
+				choices: [{ name: 'uwu', value: 1 }],
+			},
+		);
 	});
 
 	test('GIVEN a role option THEN calling toJSON should return a valid JSON', () => {
@@ -182,7 +184,7 @@ describe('Application Command toJSON() results', () => {
 		});
 
 		expect(
-			getStringOption().addChoice({ name: 'uwu', value: '1' }).toJSON(),
+			getStringOption().addChoices({ name: 'uwu', value: '1' }).toJSON(),
 		).toEqual<APIApplicationCommandStringOption>({
 			name: 'owo',
 			description: 'Testing 123',

--- a/packages/builders/__tests__/interactions/SlashCommands/Options.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/Options.test.ts
@@ -29,7 +29,7 @@ const getChannelOption = () =>
 		.setName('owo')
 		.setDescription('Testing 123')
 		.setRequired(true)
-		.addChannelType(ChannelType.GuildText);
+		.addChannelTypes(ChannelType.GuildText);
 
 const getStringOption = () =>
 	new SlashCommandStringOption().setName('owo').setDescription('Testing 123').setRequired(true);

--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -177,31 +177,25 @@ describe('Slash Commands', () => {
 			test('GIVEN a builder with both choices and autocomplete THEN does throw an error', () => {
 				expect(() =>
 					getBuilder().addStringOption(
-						// @ts-expect-error Checking if check works JS-side too
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
-						getStringOption().setAutocomplete(true).addChoices(['Fancy Pants', 'fp_1']),
+						getStringOption().setAutocomplete(true).addChoices({ name: 'Fancy Pants', value: 'fp_1' }),
 					),
 				).toThrowError();
 
 				expect(() =>
 					getBuilder().addStringOption(
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
 						getStringOption()
 							.setAutocomplete(true)
-							// @ts-expect-error Checking if check works JS-side too
-							.addChoices([
-								['Fancy Pants', 'fp_1'],
-								['Fancy Shoes', 'fs_1'],
-								['The Whole shebang', 'all'],
-							]),
+							.addChoices(
+								{ name: 'Fancy Pants', value: 'fp_1' },
+								{ name: 'Fancy Shoes', value: 'fs_1' },
+								{ name: 'The Whole shebang', value: 'all' },
+							),
 					),
 				).toThrowError();
 
 				expect(() =>
 					getBuilder().addStringOption(
-						// @ts-expect-error Checking if check works JS-side too
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
-						getStringOption().addChoices(['Fancy Pants', 'fp_1']).setAutocomplete(true),
+						getStringOption().addChoices({ name: 'Fancy Pants', value: 'fp_1' }).setAutocomplete(true),
 					),
 				).toThrowError();
 
@@ -229,20 +223,20 @@ describe('Slash Commands', () => {
 
 			test('GIVEN a builder with valid channel options and channel_types THEN does not throw an error', () => {
 				expect(() =>
-					getBuilder().addChannelOption(getChannelOption().addChannelType(ChannelType.GuildText)),
+					getBuilder().addChannelOption(getChannelOption().addChannelTypes(ChannelType.GuildText)),
 				).not.toThrowError();
 
 				expect(() => {
 					getBuilder().addChannelOption(
-						getChannelOption().addChannelTypes([ChannelType.GuildNews, ChannelType.GuildText]),
+						getChannelOption().addChannelTypes(ChannelType.GuildNews, ChannelType.GuildText),
 					);
 				}).not.toThrowError();
 			});
 
 			test('GIVEN a builder with valid channel options and channel_types THEN does throw an error', () => {
-				expect(() => getBuilder().addChannelOption(getChannelOption().addChannelType(100))).toThrowError();
+				expect(() => getBuilder().addChannelOption(getChannelOption().addChannelTypes(100))).toThrowError();
 
-				expect(() => getBuilder().addChannelOption(getChannelOption().addChannelTypes([100, 200]))).toThrowError();
+				expect(() => getBuilder().addChannelOption(getChannelOption().addChannelTypes(100, 200))).toThrowError();
 			});
 
 			test('GIVEN a builder with invalid number min/max options THEN does throw an error', () => {

--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -87,18 +87,16 @@ describe('Slash Commands', () => {
 		test('GIVEN valid array of options or choices THEN does not throw error', () => {
 			expect(() => SlashCommandAssertions.validateMaxOptionsLength([])).not.toThrowError();
 
-			expect(() => SlashCommandAssertions.validateMaxChoicesLength([])).not.toThrowError();
+			expect(() => SlashCommandAssertions.validateChoicesLength(25, [])).not.toThrowError();
 		});
 
 		test('GIVEN invalid options or choices THEN throw error', () => {
 			expect(() => SlashCommandAssertions.validateMaxOptionsLength(null)).toThrowError();
 
-			expect(() => SlashCommandAssertions.validateMaxChoicesLength(null)).toThrowError();
-
 			// Given an array that's too big
 			expect(() => SlashCommandAssertions.validateMaxOptionsLength(largeArray)).toThrowError();
 
-			expect(() => SlashCommandAssertions.validateMaxChoicesLength(largeArray)).toThrowError();
+			expect(() => SlashCommandAssertions.validateChoicesLength(1, largeArray)).toThrowError();
 		});
 
 		test('GIVEN valid required parameters THEN does not throw error', () => {
@@ -181,7 +179,7 @@ describe('Slash Commands', () => {
 					getBuilder().addStringOption(
 						// @ts-expect-error Checking if check works JS-side too
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
-						getStringOption().setAutocomplete(true).addChoice('Fancy Pants', 'fp_1'),
+						getStringOption().setAutocomplete(true).addChoices(['Fancy Pants', 'fp_1']),
 					),
 				).toThrowError();
 
@@ -203,7 +201,7 @@ describe('Slash Commands', () => {
 					getBuilder().addStringOption(
 						// @ts-expect-error Checking if check works JS-side too
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
-						getStringOption().addChoice('Fancy Pants', 'fp_1').setAutocomplete(true),
+						getStringOption().addChoices(['Fancy Pants', 'fp_1']).setAutocomplete(true),
 					),
 				).toThrowError();
 

--- a/packages/builders/docs/examples/Slash Command Builders.md
+++ b/packages/builders/docs/examples/Slash Command Builders.md
@@ -34,11 +34,6 @@ const boopCommand = new SlashCommandBuilder()
 			.setName('boop_reminder')
 			.setDescription('How often should we remind you to boop the user')
 			.addChoices({ name: 'Every day', value: 1 }, { name: 'Weekly', value: 7 })
-			// Or, if you prefer adding more choices at once, you can use an array
-			.addChoices(
-				['Every three months', 90],
-				['Yearly', 365],
-			),
 	);
 
 // Get the final raw data that can be sent to Discord

--- a/packages/builders/docs/examples/Slash Command Builders.md
+++ b/packages/builders/docs/examples/Slash Command Builders.md
@@ -33,13 +33,12 @@ const boopCommand = new SlashCommandBuilder()
 		option
 			.setName('boop_reminder')
 			.setDescription('How often should we remind you to boop the user')
-			.addChoice('Every day', 1)
-			.addChoice('Weekly', 7)
+			.addChoices({ name: 'Every day', value: 1 }, { name: 'Weekly', value: 7 })
 			// Or, if you prefer adding more choices at once, you can use an array
-			.addChoices([
+			.addChoices(
 				['Every three months', 90],
 				['Yearly', 365],
-			]),
+			),
 	);
 
 // Get the final raw data that can be sent to Discord

--- a/packages/builders/docs/examples/Slash Command Builders.md
+++ b/packages/builders/docs/examples/Slash Command Builders.md
@@ -33,7 +33,7 @@ const boopCommand = new SlashCommandBuilder()
 		option
 			.setName('boop_reminder')
 			.setDescription('How often should we remind you to boop the user')
-			.addChoices({ name: 'Every day', value: 1 }, { name: 'Weekly', value: 7 })
+			.addChoices({ name: 'Every day', value: 1 }, { name: 'Weekly', value: 7 }),
 	);
 
 // Get the final raw data that can be sent to Discord
@@ -65,11 +65,11 @@ const pointsCommand = new SlashCommandBuilder()
 						option
 							.setName('action')
 							.setDescription('What action should be taken with the users points?')
-							.addChoices([
-								['Add points', 'add'],
-								['Remove points', 'remove'],
-								['Reset points', 'reset'],
-							])
+							.addChoices(
+								{ name: 'Add points', value: 'add' },
+								{ name: 'Remove points', value: 'remove' },
+								{ name: 'Reset points', value: 'reset' },
+							)
 							.setRequired(true),
 					)
 					.addIntegerOption((option) => option.setName('points').setDescription('Points to add or remove')),

--- a/packages/builders/src/interactions/slashCommands/Assertions.ts
+++ b/packages/builders/src/interactions/slashCommands/Assertions.ts
@@ -52,8 +52,10 @@ export function validateRequired(required: unknown): asserts required is boolean
 	booleanPredicate.parse(required);
 }
 
-export function validateMaxChoicesLength(choices: APIApplicationCommandOptionChoice[]) {
-	maxArrayLengthPredicate.parse(choices);
+const choicesLengthPredicate = z.number().lte(25);
+
+export function validateChoicesLength(amountAdding: number, choices?: APIApplicationCommandOptionChoice[]): void {
+	choicesLengthPredicate.parse((choices?.length ?? 0) + amountAdding);
 }
 
 export function assertReturnOfBuilder<

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionChannelTypesMixin.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionChannelTypesMixin.ts
@@ -16,40 +16,33 @@ const allowedChannelTypes = [
 
 export type ApplicationCommandOptionAllowedChannelTypes = typeof allowedChannelTypes[number];
 
-const channelTypePredicate = z.union(
-	allowedChannelTypes.map((type) => z.literal(type)) as [
-		ZodLiteral<ChannelType>,
-		ZodLiteral<ChannelType>,
-		...ZodLiteral<ChannelType>[]
-	],
+const channelTypesPredicate = z.array(
+	z.union(
+		allowedChannelTypes.map((type) => z.literal(type)) as [
+			ZodLiteral<ChannelType>,
+			ZodLiteral<ChannelType>,
+			...ZodLiteral<ChannelType>[]
+		],
+	),
 );
 
 export class ApplicationCommandOptionChannelTypesMixin {
 	public readonly channel_types?: ApplicationCommandOptionAllowedChannelTypes[];
 
 	/**
-	 * Adds a channel type to this option
-	 *
-	 * @param channelType The type of channel to allow
-	 */
-	public addChannelType(channelType: ApplicationCommandOptionAllowedChannelTypes) {
-		if (this.channel_types === undefined) {
-			Reflect.set(this, 'channel_types', []);
-		}
-
-		channelTypePredicate.parse(channelType);
-		this.channel_types!.push(channelType);
-
-		return this;
-	}
-
-	/**
 	 * Adds channel types to this option
 	 *
 	 * @param channelTypes The channel types to add
 	 */
-	public addChannelTypes(channelTypes: ApplicationCommandOptionAllowedChannelTypes[]) {
-		channelTypes.forEach((channelType) => this.addChannelType(channelType));
+	public addChannelTypes(...channelTypes: ApplicationCommandOptionAllowedChannelTypes[]) {
+		if (this.channel_types === undefined) {
+			Reflect.set(this, 'channel_types', []);
+		}
+
+		channelTypesPredicate.parse(channelTypes);
+
+		this.channel_types!.push(...channelTypes);
+
 		return this;
 	}
 }

--- a/packages/builders/src/interactions/slashCommands/mixins/SharedSlashCommandOptions.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/SharedSlashCommandOptions.ts
@@ -85,13 +85,13 @@ export class SharedSlashCommandOptions<ShouldOmitSubcommandFunctions = true> {
 		input:
 			| SlashCommandStringOption
 			| Omit<SlashCommandStringOption, 'setAutocomplete'>
-			| Omit<SlashCommandStringOption, 'addChoice' | 'addChoices'>
+			| Omit<SlashCommandStringOption, 'addChoices'>
 			| ((
 					builder: SlashCommandStringOption,
 			  ) =>
 					| SlashCommandStringOption
 					| Omit<SlashCommandStringOption, 'setAutocomplete'>
-					| Omit<SlashCommandStringOption, 'addChoice' | 'addChoices'>),
+					| Omit<SlashCommandStringOption, 'addChoices'>),
 	) {
 		return this._sharedAddOptionMethod(input, SlashCommandStringOption);
 	}
@@ -105,13 +105,13 @@ export class SharedSlashCommandOptions<ShouldOmitSubcommandFunctions = true> {
 		input:
 			| SlashCommandIntegerOption
 			| Omit<SlashCommandIntegerOption, 'setAutocomplete'>
-			| Omit<SlashCommandIntegerOption, 'addChoice' | 'addChoices'>
+			| Omit<SlashCommandIntegerOption, 'addChoices'>
 			| ((
 					builder: SlashCommandIntegerOption,
 			  ) =>
 					| SlashCommandIntegerOption
 					| Omit<SlashCommandIntegerOption, 'setAutocomplete'>
-					| Omit<SlashCommandIntegerOption, 'addChoice' | 'addChoices'>),
+					| Omit<SlashCommandIntegerOption, 'addChoices'>),
 	) {
 		return this._sharedAddOptionMethod(input, SlashCommandIntegerOption);
 	}
@@ -125,13 +125,13 @@ export class SharedSlashCommandOptions<ShouldOmitSubcommandFunctions = true> {
 		input:
 			| SlashCommandNumberOption
 			| Omit<SlashCommandNumberOption, 'setAutocomplete'>
-			| Omit<SlashCommandNumberOption, 'addChoice' | 'addChoices'>
+			| Omit<SlashCommandNumberOption, 'addChoices'>
 			| ((
 					builder: SlashCommandNumberOption,
 			  ) =>
 					| SlashCommandNumberOption
 					| Omit<SlashCommandNumberOption, 'setAutocomplete'>
-					| Omit<SlashCommandNumberOption, 'addChoice' | 'addChoices'>),
+					| Omit<SlashCommandNumberOption, 'addChoices'>),
 	) {
 		return this._sharedAddOptionMethod(input, SlashCommandNumberOption);
 	}
@@ -140,8 +140,8 @@ export class SharedSlashCommandOptions<ShouldOmitSubcommandFunctions = true> {
 		input:
 			| T
 			| Omit<T, 'setAutocomplete'>
-			| Omit<T, 'addChoice' | 'addChoices'>
-			| ((builder: T) => T | Omit<T, 'setAutocomplete'> | Omit<T, 'addChoice' | 'addChoices'>),
+			| Omit<T, 'addChoices'>
+			| ((builder: T) => T | Omit<T, 'setAutocomplete'> | Omit<T, 'addChoices'>),
 		Instance: new () => T,
 	): ShouldOmitSubcommandFunctions extends true ? Omit<this, 'addSubcommand' | 'addSubcommandGroup'> : this {
 		const { options } = this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Removed `ApplicationCommandOptionChannelTypesMixin#addChannelType()`
- Removed `ApplicationCommandOptionWithChoicesAndAutocompleteMixin#addChoice()`
- `ApplicationCommandOptionChannelTypesMixin#addChannelTypes()` only accepts rest parameters instead of an array

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
