### PR TITLE
refactor(embed): allow hex strings in `setColor()`

### DIFF
--- a/packages/discord.js/src/structures/Embed.js
+++ b/packages/discord.js/src/structures/Embed.js
@@ -4,11 +4,19 @@ const { Embed: BuildersEmbed } = require('@discordjs/builders');
 const Transformers = require('../util/Transformers');
 const { Util } = require('../util/Util');
 
+/**
+ * Represents an embed object
+ */
 class Embed extends BuildersEmbed {
   constructor(data) {
     super(Transformers.toSnakeCase(data));
   }
 
+  /**
+   * Sets the color of this embed
+   * @param {ColorResolvable} color The color of the embed
+   * @returns {Embed}
+   */
   setColor(color) {
     if (color === null) {
       return super.setColor(null);

--- a/packages/discord.js/src/structures/Embed.js
+++ b/packages/discord.js/src/structures/Embed.js
@@ -2,10 +2,18 @@
 
 const { Embed: BuildersEmbed } = require('@discordjs/builders');
 const Transformers = require('../util/Transformers');
+const { Util } = require('../util/Util');
 
 class Embed extends BuildersEmbed {
   constructor(data) {
     super(Transformers.toSnakeCase(data));
+  }
+
+  setColor(color) {
+    if (color === null) {
+      return super.setColor(null);
+    }
+    return super.setColor(Util.resolveColor(color));
   }
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -542,6 +542,7 @@ export interface EmbedProviderData {
 
 export class Embed extends BuildersEmbed {
   public constructor(data?: EmbedData | APIEmbed);
+  public override setColor(color: ColorResolvable | null): this;
 }
 
 export interface MappedChannelCategoryTypes {
@@ -3775,7 +3776,7 @@ export type ColorResolvable =
   | 'DarkButNotBlack'
   | 'NotQuiteBlack'
   | 'Random'
-  | readonly [number, number, number]
+  | readonly [red: number, green: number, blue: number]
   | number
   | HexColorString;
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -105,9 +105,9 @@ import {
   CategoryChannelChildManager,
   ActionRowData,
   MessageActionRowComponentData,
+  Embed,
 } from '.';
 import { expectAssignable, expectDeprecated, expectNotAssignable, expectNotType, expectType } from 'tsd';
-import { Embed } from '@discordjs/builders';
 
 // Test type transformation:
 declare const serialize: <T>(value: T) => Serialized<T>;
@@ -1339,6 +1339,11 @@ new SelectMenuComponent({
 new ButtonComponent({
   style: ButtonStyle.Danger,
 });
+
+// @ts-expect-error
+new Embed().setColor('abc');
+
+new Embed().setColor('#ffffff');
 
 expectNotAssignable<ActionRowData<MessageActionRowComponentData>>({
   type: ComponentType.ActionRow,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Originally I had assumed hex number literals would suffice over hex strings. However, many external services may return colors as hex strings because it's a popular format. This PR allows hex strings to be passed into `setColor` for discord.js embed builders.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
