### PR TITLE
feat(ModalSubmitInteraction): add boolean properties

### DIFF
--- a/packages/discord.js/src/structures/ModalSubmitInteraction.js
+++ b/packages/discord.js/src/structures/ModalSubmitInteraction.js
@@ -49,6 +49,24 @@ class ModalSubmitInteraction extends Interaction {
     this.fields = new ModalSubmitFieldsResolver(this.components);
 
     /**
+     * Whether the reply to this interaction has been deferred
+     * @type {boolean}
+     */
+    this.deferred = false;
+
+    /**
+     * Whether this interaction has already been replied to
+     * @type {boolean}
+     */
+    this.replied = false;
+
+    /**
+     * Whether the reply to this interaction is ephemeral
+     * @type {?boolean}
+     */
+    this.ephemeral = null;
+
+    /**
      * An associated interaction webhook, can be used to further interact with this interaction
      * @type {InteractionWebhook}
      */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1772,6 +1772,9 @@ export class ModalSubmitInteraction<Cached extends CacheType = CacheType> extend
   // TODO: fix this type when #7517 is implemented
   public readonly components: ModalSubmitActionRow[];
   public readonly fields: ModalSubmitFieldsResolver;
+  public deferred: boolean;
+  public ephemeral: boolean | null;
+  public replied: boolean;
   public readonly webhook: InteractionWebhook;
   public reply(options: InteractionReplyOptions & { fetchReply: true }): Promise<GuildCacheMessage<Cached>>;
   public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
adds `deferred`, `replied` and `ephemeral` properties to `ModalSubmitInteraction`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
