### PR TITLE
feat: add support for module: NodeNext in TS and ESM

### DIFF
--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -16,7 +16,8 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		"import": "./dist/index.mjs",
-		"require": "./dist/index.js"
+		"require": "./dist/index.js",
+		"types": "./dist/index.d.ts"
 	},
 	"directories": {
 		"lib": "src",

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -16,7 +16,8 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		"import": "./dist/index.mjs",
-		"require": "./dist/index.js"
+		"require": "./dist/index.js",
+		"types": "./dist/index.d.ts"
 	},
 	"directories": {
 		"lib": "src",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -16,7 +16,8 @@
 	"typings": "./dist/index.d.ts",
 	"exports": {
 		"import": "./dist/index.mjs",
-		"require": "./dist/index.js"
+		"require": "./dist/index.js",
+		"types": "./dist/index.d.ts"
 	},
 	"directories": {
 		"lib": "src",

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -16,7 +16,8 @@
 	"typings": "./dist/index.d.ts",
 	"exports": {
 		"import": "./dist/index.mjs",
-		"require": "./dist/index.js"
+		"require": "./dist/index.js",
+		"types": "./dist/index.d.ts"
 	},
 	"directories": {
 		"lib": "src",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Needed for TS@dev's module/moduleResolution: NodeNext

This doesn't affect discord.js because it doesn't have an exports mapping

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
