### PR TITLE
types(showModal): align types with the documentation

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -352,7 +352,7 @@ export interface InteractionResponseFields<Cached extends CacheType = CacheType>
   deferReply(options?: InteractionDeferReplyOptions): Promise<void>;
   fetchReply(): Promise<GuildCacheMessage<Cached>>;
   followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<GuildCacheMessage<Cached>>;
-  showModal(modal: Modal): Promise<void>;
+  showModal(modal: Modal | ModalData | APIModalInteractionResponseCallbackData): Promise<void>;
 }
 
 export abstract class CommandInteraction<Cached extends CacheType = CacheType> extends Interaction<Cached> {
@@ -391,7 +391,7 @@ export abstract class CommandInteraction<Cached extends CacheType = CacheType> e
   public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<GuildCacheMessage<Cached>>;
   public reply(options: InteractionReplyOptions & { fetchReply: true }): Promise<GuildCacheMessage<Cached>>;
   public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
-  public showModal(modal: Modal): Promise<void>;
+  public showModal(modal: Modal | ModalData | APIModalInteractionResponseCallbackData): Promise<void>;
   private transformOption(
     option: APIApplicationCommandOption,
     resolved: APIApplicationCommandInteractionData['resolved'],
@@ -1647,7 +1647,7 @@ export class MessageComponentInteraction<Cached extends CacheType = CacheType> e
   public reply(options: string | MessagePayload | InteractionReplyOptions): Promise<void>;
   public update(options: InteractionUpdateOptions & { fetchReply: true }): Promise<GuildCacheMessage<Cached>>;
   public update(options: string | MessagePayload | InteractionUpdateOptions): Promise<void>;
-  public showModal(modal: Modal): Promise<void>;
+  public showModal(modal: Modal | ModalData | APIModalInteractionResponseCallbackData): Promise<void>;
 }
 
 export class MessageContextMenuCommandInteraction<

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -19,6 +19,7 @@ import {
   PermissionFlagsBits,
   AuditLogEvent,
   ButtonStyle,
+  TextInputStyle,
 } from 'discord-api-types/v9';
 import {
   ApplicationCommand,
@@ -58,6 +59,7 @@ import {
   MessageCollector,
   MessageComponentInteraction,
   MessageReaction,
+  Modal,
   NewsChannel,
   Options,
   PartialTextBasedChannelFields,
@@ -1353,3 +1355,25 @@ declare const chatInputInteraction: ChatInputCommandInteraction;
 
 expectType<MessageAttachment>(chatInputInteraction.options.getAttachment('attachment', true));
 expectType<MessageAttachment | null>(chatInputInteraction.options.getAttachment('attachment'));
+
+declare const modal: Modal;
+
+chatInputInteraction.showModal(modal);
+
+chatInputInteraction.showModal({
+  title: 'abc',
+  custom_id: 'abc',
+  components: [
+    {
+      components: [
+        {
+          custom_id: 'aa',
+          label: 'label',
+          style: TextInputStyle.Short,
+          type: ComponentType.TextInput,
+        },
+      ],
+      type: ComponentType.ActionRow,
+    },
+  ],
+});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
https://github.com/discordjs/discord.js/blob/6f7a3669568b7520c5e6c9ecbf7a95f85c3d1864/packages/discord.js/src/structures/interfaces/InteractionResponses.js#L237-L241

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
