### PR TITLE
fix(typings): add missing ModalSubmitFieldsResolver#components

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1744,6 +1744,7 @@ export interface ModalFieldData {
 
 export class ModalSubmitFieldsResolver {
   constructor(components: ModalFieldData[][]);
+  public components: ModalFieldData[][];
   public fields: Collection<string, ModalFieldData>;
   public getField(customId: string): ModalFieldData;
   public getTextInputValue(customId: string): string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
ModalSubmitFieldsResolver#components is documented but is not in the typings

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
 - This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
