### PR TITLE
docs(Componets): add TextInputComponentData

### DIFF
--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -42,5 +42,17 @@
  /
 
 /**
+ * @typedef {BaseComponentData} TextInputComponentData
+ * @property {string} customId The custom id of the text input
+ * @property {TextInputStyle} style The style of the text input
+ * @property {string} label The text that appears on top of the text input field
+ * @property {?number} minLength The minimum number of characters that can be entered in the text input
+ * @property {?number} maxLength The maximum number of characters that can be entered in the text input
+ * @property {?boolean} required Whether or not the text input is required or not
+ * @property {?string} value The pre-filled text in the text input
+ * @property {?string} placeholder Placeholder for the text input
+ */
+
+/**
  * @typedef {ActionRowData|ButtonComponentData|SelectMenuComponentData|TextInputComponentData} ComponentData
  */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`TextInputComponentData` is defined in the typings but not for the docs, it is referenced for `ComponentData` but never declared

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
