### PR TITLE
types: modals type and doc fixes

### DIFF
--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -42,5 +42,17 @@
  /
 
 /**
+ * @typedef {BaseComponentData} TextInputComponentData
+ * @property {string} customId The custom id of the text input
+ * @property {TextInputStyle} style The style of the text input
+ * @property {string} label The text that appears on top of the text input field
+ * @property {?number} minLength The minimum number of characters that can be entered in the text input
+ * @property {?number} maxLength The maximum number of characters that can be entered in the text input
+ * @property {?boolean} required Whether or not the text input is required or not
+ * @property {?string} value The pre-filled text in the text input
+ * @property {?string} placeholder Placeholder for the text input
+ */
+
+/**
  * @typedef {ActionRowData|ButtonComponentData|SelectMenuComponentData|TextInputComponentData} ComponentData
  */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1744,6 +1744,7 @@ export interface ModalFieldData {
 
 export class ModalSubmitFieldsResolver {
   constructor(components: ModalFieldData[][]);
+  public components: ModalFieldData[][];
   public fields: Collection<string, ModalFieldData>;
   public getField(customId: string): ModalFieldData;
   public getTextInputValue(customId: string): string;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3216,7 +3216,7 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
   lastMessageId: Snowflake | null;
   get lastMessage(): Message | null;
   lastPinTimestamp: number | null;
-  readonly lastPinAt: Date | null;
+  get lastPinAt(): Date | null;
   awaitMessageComponent<T extends MessageComponentType = ComponentType.ActionRow>(
     options?: AwaitMessageCollectorOptionsParams<T, true>,
   ): Promise<MappedInteractionTypes[T]>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- ModalSubmitFieldsResolver#components is documented but is not in the typings
- `TextInputComponentData` is defined in the typings but not for the docs, it is referenced for `ComponentData` but never declared
- ModalSubmitFieldsResolver#components is documented but is not in the typings

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
