### PR TITLE
types: allow component classes in action row data

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -225,7 +225,7 @@ export class ActionRow<
 > extends BuilderActionRow<T> {
   constructor(
     data?:
-      | ActionRowData<MessageActionRowComponentData | ModalActionRowComponentData>
+      | ActionRowData<MessageActionRowComponentData | ModalActionRowComponentData | ActionRowComponent>
       | (Omit<APIActionRowComponent<APIMessageActionRowComponent | APIModalActionRowComponent>, 'type'> & {
           type?: ComponentType.ActionRow;
         }),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes regression where action row data no longer accepted component classes.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating