### PR TITLE
feat(Message): allow message react method to accept array of emojis

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -713,7 +713,7 @@ class Message extends Base {
 
   /**
    * Adds a reaction to the message.
-   * @param {EmojiIdentifierResolvable} emoji The emoji to react with
+   * @param {EmojiIdentifierResolvable|Array<EmojiIdentifierResolvable>} emoji The emoji(s) to react with
    * @returns {Promise<MessageReaction>}
    * @example
    * // React to a message with a unicode emoji
@@ -728,7 +728,14 @@ class Message extends Base {
    */
   async react(emoji) {
     if (!this.channel) throw new Error('CHANNEL_NOT_CACHED');
-    await this.channel.messages.react(this.id, emoji);
+
+    if (Array.isArray(emoji)) {
+      emoji.map(async e => {
+        await this.channel.messages.react(this.id, e);
+      });
+    } else {
+      await this.channel.messages.react(this.id, emoji);
+    }
 
     return this.client.actions.MessageReactionAdd.handle(
       {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1572,7 +1572,7 @@ export class Message<Cached extends boolean = boolean> extends Base {
   public crosspost(): Promise<Message>;
   public fetch(force?: boolean): Promise<Message>;
   public pin(reason?: string): Promise<Message>;
-  public react(emoji: EmojiIdentifierResolvable): Promise<MessageReaction>;
+  public react(emoji: EmojiIdentifierResolvable | Array<EmojiIdentifierResolvable>): Promise<MessageReaction>;
   public removeAttachments(): Promise<Message>;
   public reply(options: string | MessagePayload | ReplyMessageOptions): Promise<Message>;
   public resolveComponent(customId: string): MessageActionRowComponent | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allows `<Message>.react()` method to accept an array of emojis. It will previne codes like this one:
```diff
- <Message>.react('🟩');
- <Message>.react('🟨');
- <Message>.react('🟥');
+ <Message>.react(['🟩', '🟨', '🟥']);
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)