### PR TITLE
fix: `AuthenticationFailed` error not thrown at login with invalid token

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -136,7 +136,7 @@ class WebSocketManager extends EventEmitter {
       shards: recommendedShards,
       session_start_limit: sessionStartLimit,
     } = await this.client.rest.get(Routes.gatewayBot()).catch(error => {
-      throw error.httpStatus === 401 ? invalidToken : error;
+      throw error.status === 401 ? invalidToken : error;
     });
 
     const { total, remaining } = sessionStartLimit;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes an issue with the `AuthenticationFailed` error, when trying to log in with an invalid bot token. Which causes the error not to be thrown and instead, a Discord API error (`401: Unauthorized`) is thrown, which does not specify anything about the token.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
