### PR TITLE
refactor(RichPresenceAssets): Remove non-breaking custom image support

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -382,8 +382,6 @@ class RichPresenceAssets {
           return `https://media.discordapp.net/${id}`;
         case 'spotify':
           return `https://i.scdn.co/image/${id}`;
-        case 'youtube':
-          return `https://i.ytimg.com/vi/${id}/hqdefault_live.jpg`;
         case 'twitch':
           return `https://static-cdn.jtvnw.net/previews-ttv/live_user_${id}.png`;
         default:


### PR DESCRIPTION
Due to #7635, YouTube has been removed from parsing here. The rest will be removed in version 14.