### PR TITLE
fix(AnonymousGuild): Handle possibly missing `premium_subscription_count`

### DIFF
--- a/packages/discord.js/src/structures/AnonymousGuild.js
+++ b/packages/discord.js/src/structures/AnonymousGuild.js
@@ -70,6 +70,8 @@ class AnonymousGuild extends BaseGuild {
        * @type {?number}
        */
       this.premiumSubscriptionCount = data.premium_subscription_count;
+    } else {
+      this.premiumSubscriptionCount ??= null;
     }
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Guild#premiumSubscriptionCount` could be possibly `undefined` per [the documentation](https://discord.com/developers/docs/resources/guild#guild-object-guild-structure). A check has been added to ensure that it defaults to `null`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
