### PR TITLE
refactor(AutocompleteInteraction): use rest param in respond

### DIFF
--- a/packages/discord.js/src/structures/AutocompleteInteraction.js
+++ b/packages/discord.js/src/structures/AutocompleteInteraction.js
@@ -60,20 +60,20 @@ class AutocompleteInteraction extends Interaction {
 
   /**
    * Sends results for the autocomplete of this interaction.
-   * @param {ApplicationCommandOptionChoice[]} options The options for the autocomplete
+   * @param {...ApplicationCommandOptionChoice} options The options for the autocomplete
    * @returns {Promise<void>}
    * @example
    * // respond to autocomplete interaction
-   * interaction.respond([
+   * interaction.respond(
    *  {
    *    name: 'Option 1',
    *    value: 'option1',
    *  },
-   * ])
+   * )
    *  .then(console.log)
    *  .catch(console.error);
    */
-  async respond(options) {
+  async respond(...options) {
     if (this.responded) throw new Error('INTERACTION_ALREADY_REPLIED');
 
     await this.client.rest.post(Routes.interactionCallback(this.id, this.token), {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -773,7 +773,7 @@ export class AutocompleteInteraction<Cached extends CacheType = CacheType> exten
   public inGuild(): this is AutocompleteInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is AutocompleteInteraction<'cached'>;
   public inRawGuild(): this is AutocompleteInteraction<'raw'>;
-  public respond(options: ApplicationCommandOptionChoice[]): Promise<void>;
+  public respond(...options: ApplicationCommandOptionChoice[]): Promise<void>;
 }
 
 export class CommandInteractionOptionResolver<Cached extends CacheType = CacheType> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
To make the lib consistent `AutocompleteInteraction#respond` will now take rest param instead of an array.
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
