### PR TITLE
types(ColorResolvable): simplify string types

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3758,36 +3758,7 @@ export interface CollectorResetTimerOptions {
 }
 
 export type ColorResolvable =
-  | 'Default'
-  | 'White'
-  | 'Aqua'
-  | 'Green'
-  | 'Blue'
-  | 'Yellow'
-  | 'Purple'
-  | 'LuminousVividPink'
-  | 'Fuchsia'
-  | 'Gold'
-  | 'Orange'
-  | 'Red'
-  | 'Grey'
-  | 'Navy'
-  | 'DarkAqua'
-  | 'DarkGreen'
-  | 'DarkBlue'
-  | 'DarkPurple'
-  | 'DarkVividPink'
-  | 'DarkGold'
-  | 'DarkOrange'
-  | 'DarkRed'
-  | 'DarkGrey'
-  | 'DarkerGrey'
-  | 'LightGrey'
-  | 'DarkNavy'
-  | 'Blurple'
-  | 'Greyple'
-  | 'DarkButNotBlack'
-  | 'NotQuiteBlack'
+  | keyof typeof Colors
   | 'Random'
   | readonly [red: number, green: number, blue: number]
   | number


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR simplifies the ColorResolvable type by using the keys of the Colors object instead of hardcoding all the strings again

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
