### PR TITLE
feat(Collector): add `ignore` event

### DIFF
--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -59,10 +59,10 @@ class Collector extends EventEmitter {
     this.collected = new Collection();
 
     /**
-     * The items filtered out by this collector
+     * The items that were not collected by this collector
      * @type {Collection}
      */
-    this.filtered = new Collection();
+    this.ignored = new Collection();
 
     /**
      * Whether this collector has finished collecting
@@ -121,14 +121,14 @@ class Collector extends EventEmitter {
           this._idletimeout = setTimeout(() => this.stop('idle'), this.options.idle).unref();
         }
       } else {
-        this.filtered.set(collectedId, args[0]);
+        this.ignored.set(collectedId, args[0]);
 
         /**
-         * Emitted whenever an element is filtered out of the collector.
-         * @event Collector#filtered
+         * Emitted whenever an element is not collected by the collector.
+         * @event Collector#ignore
          * @param {...*} args The arguments emitted by the listener
          */
-        this.emit('filtered', ...args);
+        this.emit('ignore', ...args);
       }
     }
     this.checkEnd();

--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -97,9 +97,9 @@ class Collector extends EventEmitter {
    */
   async handleCollect(...args) {
     const collectedId = await this.collect(...args);
-    const filterResult = await this.filter(...args, this.collected);
 
     if (collectedId) {
+      const filterResult = await this.filter(...args, this.collected);
       if (filterResult) {
         this.collected.set(collectedId, args[0]);
 

--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -59,12 +59,6 @@ class Collector extends EventEmitter {
     this.collected = new Collection();
 
     /**
-     * The items that were not collected by this collector
-     * @type {Collection}
-     */
-    this.ignored = new Collection();
-
-    /**
      * Whether this collector has finished collecting
      * @type {boolean}
      */
@@ -121,8 +115,6 @@ class Collector extends EventEmitter {
           this._idletimeout = setTimeout(() => this.stop('idle'), this.options.idle).unref();
         }
       } else {
-        this.ignored.set(collectedId, args[0]);
-
         /**
          * Emitted whenever an element is not collected by the collector.
          * @event Collector#ignore

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -802,7 +802,6 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
 
   public readonly client: Client;
   public collected: Collection<K, V>;
-  public ignored: Collection<K, V>;
   public ended: boolean;
   public abstract get endReason(): string | null;
   public filter: CollectorFilter<[V, ...F]>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -804,6 +804,7 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
   public ended: boolean;
   public abstract get endReason(): string | null;
   public filter: CollectorFilter<[V, ...F]>;
+  public onFiltered: CollectorOnFiltered<[V, ...F]>;
   public get next(): Promise<V>;
   public options: CollectorOptions<[V, ...F]>;
   public checkEnd(): boolean;
@@ -3824,8 +3825,11 @@ export interface CloseEvent {
 
 export type CollectorFilter<T extends unknown[]> = (...args: T) => boolean | Promise<boolean>;
 
+export type CollectorOnFiltered<T extends unknown[]> = (...args: T) => Awaitable<void>;
+
 export interface CollectorOptions<T extends unknown[]> {
   filter?: CollectorFilter<T>;
+  onFiltered?: CollectorOnFiltered<T>;
   time?: number;
   idle?: number;
   dispose?: boolean;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -790,6 +790,7 @@ export { Collection } from '@discordjs/collection';
 
 export interface CollectorEventTypes<K, V, F extends unknown[] = []> {
   collect: [V, ...F];
+  filtered: [V, ...F];
   dispose: [V, ...F];
   end: [collected: Collection<K, V>, reason: string];
 }
@@ -801,10 +802,10 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
 
   public readonly client: Client;
   public collected: Collection<K, V>;
+  public filtered: Collection<K, V>;
   public ended: boolean;
   public abstract get endReason(): string | null;
   public filter: CollectorFilter<[V, ...F]>;
-  public onFiltered: CollectorOnFiltered<[V, ...F]>;
   public get next(): Promise<V>;
   public options: CollectorOptions<[V, ...F]>;
   public checkEnd(): boolean;
@@ -1484,11 +1485,11 @@ export class InteractionCollector<T extends Interaction> extends Collector<Snowf
   public collect(interaction: Interaction): Snowflake;
   public empty(): void;
   public dispose(interaction: Interaction): Snowflake;
-  public on(event: 'collect' | 'dispose', listener: (interaction: T) => Awaitable<void>): this;
+  public on(event: 'collect' | 'dispose' | 'filtered', listener: (interaction: T) => Awaitable<void>): this;
   public on(event: 'end', listener: (collected: Collection<Snowflake, T>, reason: string) => Awaitable<void>): this;
   public on(event: string, listener: (...args: any[]) => Awaitable<void>): this;
 
-  public once(event: 'collect' | 'dispose', listener: (interaction: T) => Awaitable<void>): this;
+  public once(event: 'collect' | 'dispose' | 'filtered', listener: (interaction: T) => Awaitable<void>): this;
   public once(event: 'end', listener: (collected: Collection<Snowflake, T>, reason: string) => Awaitable<void>): this;
   public once(event: string, listener: (...args: any[]) => Awaitable<void>): this;
 }
@@ -1952,11 +1953,17 @@ export class ReactionCollector extends Collector<Snowflake | string, MessageReac
   public dispose(reaction: MessageReaction, user: User): Snowflake | string | null;
   public empty(): void;
 
-  public on(event: 'collect' | 'dispose' | 'remove', listener: (reaction: MessageReaction, user: User) => void): this;
+  public on(
+    event: 'collect' | 'dispose' | 'remove' | 'filtered',
+    listener: (reaction: MessageReaction, user: User) => void,
+  ): this;
   public on(event: 'end', listener: (collected: Collection<Snowflake, MessageReaction>, reason: string) => void): this;
   public on(event: string, listener: (...args: any[]) => void): this;
 
-  public once(event: 'collect' | 'dispose' | 'remove', listener: (reaction: MessageReaction, user: User) => void): this;
+  public once(
+    event: 'collect' | 'dispose' | 'remove' | 'filtered',
+    listener: (reaction: MessageReaction, user: User) => void,
+  ): this;
   public once(
     event: 'end',
     listener: (collected: Collection<Snowflake, MessageReaction>, reason: string) => void,
@@ -3825,11 +3832,8 @@ export interface CloseEvent {
 
 export type CollectorFilter<T extends unknown[]> = (...args: T) => boolean | Promise<boolean>;
 
-export type CollectorOnFiltered<T extends unknown[]> = (...args: T) => Awaitable<void>;
-
 export interface CollectorOptions<T extends unknown[]> {
   filter?: CollectorFilter<T>;
-  onFiltered?: CollectorOnFiltered<T>;
   time?: number;
   idle?: number;
   dispose?: boolean;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -790,7 +790,7 @@ export { Collection } from '@discordjs/collection';
 
 export interface CollectorEventTypes<K, V, F extends unknown[] = []> {
   collect: [V, ...F];
-  filtered: [V, ...F];
+  ignore: [V, ...F];
   dispose: [V, ...F];
   end: [collected: Collection<K, V>, reason: string];
 }
@@ -802,7 +802,7 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
 
   public readonly client: Client;
   public collected: Collection<K, V>;
-  public filtered: Collection<K, V>;
+  public ignore: Collection<K, V>;
   public ended: boolean;
   public abstract get endReason(): string | null;
   public filter: CollectorFilter<[V, ...F]>;
@@ -1485,11 +1485,11 @@ export class InteractionCollector<T extends Interaction> extends Collector<Snowf
   public collect(interaction: Interaction): Snowflake;
   public empty(): void;
   public dispose(interaction: Interaction): Snowflake;
-  public on(event: 'collect' | 'dispose' | 'filtered', listener: (interaction: T) => Awaitable<void>): this;
+  public on(event: 'collect' | 'dispose' | 'ignore', listener: (interaction: T) => Awaitable<void>): this;
   public on(event: 'end', listener: (collected: Collection<Snowflake, T>, reason: string) => Awaitable<void>): this;
   public on(event: string, listener: (...args: any[]) => Awaitable<void>): this;
 
-  public once(event: 'collect' | 'dispose' | 'filtered', listener: (interaction: T) => Awaitable<void>): this;
+  public once(event: 'collect' | 'dispose' | 'ignore', listener: (interaction: T) => Awaitable<void>): this;
   public once(event: 'end', listener: (collected: Collection<Snowflake, T>, reason: string) => Awaitable<void>): this;
   public once(event: string, listener: (...args: any[]) => Awaitable<void>): this;
 }
@@ -1954,14 +1954,14 @@ export class ReactionCollector extends Collector<Snowflake | string, MessageReac
   public empty(): void;
 
   public on(
-    event: 'collect' | 'dispose' | 'remove' | 'filtered',
+    event: 'collect' | 'dispose' | 'remove' | 'ignore',
     listener: (reaction: MessageReaction, user: User) => void,
   ): this;
   public on(event: 'end', listener: (collected: Collection<Snowflake, MessageReaction>, reason: string) => void): this;
   public on(event: string, listener: (...args: any[]) => void): this;
 
   public once(
-    event: 'collect' | 'dispose' | 'remove' | 'filtered',
+    event: 'collect' | 'dispose' | 'remove' | 'ignore',
     listener: (reaction: MessageReaction, user: User) => void,
   ): this;
   public once(

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -802,7 +802,7 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
 
   public readonly client: Client;
   public collected: Collection<K, V>;
-  public ignore: Collection<K, V>;
+  public ignored: Collection<K, V>;
   public ended: boolean;
   public abstract get endReason(): string | null;
   public filter: CollectorFilter<[V, ...F]>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds an option to the collector class with a function to be called when an item is filtered out of the collector, useful when working with interactions and sending error messages for unwanted ones.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
