### PR TITLE
fix: Remove Modal export

### DIFF
--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -128,7 +128,6 @@ exports.MessageContextMenuCommandInteraction = require('./structures/MessageCont
 exports.MessageMentions = require('./structures/MessageMentions');
 exports.MessagePayload = require('./structures/MessagePayload');
 exports.MessageReaction = require('./structures/MessageReaction');
-exports.Modal = require('./structures/Modal');
 exports.ModalSubmitInteraction = require('./structures/ModalSubmitInteraction');
 exports.ModalSubmitFieldsResolver = require('./structures/ModalSubmitFieldsResolver');
 exports.NewsChannel = require('./structures/NewsChannel');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The file no longer exists. Importing `ModalBuilder` is the replacement - this was left over.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
