### PR TITLE
types(Embed): add forgotten `footer` type

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -613,6 +613,7 @@ export class Embed {
   private constructor(data: APIEmbed);
   public readonly data: Readonly<APIEmbed>;
   public get fields(): APIEmbedField[] | null;
+  public get footer(): EmbedFooterData | null;
   public get title(): string | null;
   public get description(): string | null;
   public get url(): string | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds forgotten `footer` type to `Embed`

**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
