### PR TITLE
refactor(InteractionCollector): simplify constructor logic

### DIFF
--- a/packages/discord.js/src/structures/InteractionCollector.js
+++ b/packages/discord.js/src/structures/InteractionCollector.js
@@ -51,7 +51,11 @@ class InteractionCollector extends Collector {
      * The guild from which to collect interactions, if provided
      * @type {?Snowflake}
      */
-    this.guildId = options.message?.guildId ?? options.message?.guild_id ?? this.client.guilds.resolveId(options.guild);
+    this.guildId =
+      options.message?.guildId ??
+      options.message?.guild_id ??
+      this.client.guilds.resolveId(options.channel?.guild) ??
+      this.client.guilds.resolveId(options.guild);
 
     /**
      * The type of interaction to collect

--- a/packages/discord.js/src/structures/InteractionCollector.js
+++ b/packages/discord.js/src/structures/InteractionCollector.js
@@ -45,19 +45,13 @@ class InteractionCollector extends Collector {
      * @type {?Snowflake}
      */
     this.channelId =
-      this.client.channels.resolveId(options.message?.channel) ??
-      options.message?.channel_id ??
-      this.client.channels.resolveId(options.channel);
+      options.message?.channelId ?? options.message?.channel_id ?? this.client.channels.resolveId(options.channel);
 
     /**
      * The guild from which to collect interactions, if provided
      * @type {?Snowflake}
      */
-    this.guildId =
-      this.client.guilds.resolveId(options.message?.guild) ??
-      options.message?.guild_id ??
-      this.client.guilds.resolveId(options.channel?.guild) ??
-      this.client.guilds.resolveId(options.guild);
+    this.guildId = options.message?.guildId ?? options.message?.guild_id ?? this.client.guilds.resolveId(options.guild);
 
     /**
      * The type of interaction to collect
@@ -83,7 +77,6 @@ class InteractionCollector extends Collector {
      */
     this.total = 0;
 
-    this.empty = this.empty.bind(this);
     this.client.incrementMaxListeners();
 
     const bulkDeleteListener = messages => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Message#channel` and `Message#guild` are getters which use `Message#channelId` and `Message#guildId` internally, so there is no need to invoke them and use `resolveId`
the `empty` method is currently bound for each `IntereactionCollector` even though it is not used in any listener, probably a copy-paste from [`ReactionCollector`](https://github.com/discordjs/discord.js/blob/main/packages/discord.js/src/structures/ReactionCollector.js#L49)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
