### PR TITLE
refactor(EmbedBuilder): allow hex strings in setColor

### DIFF
--- a/packages/discord.js/src/structures/EmbedBuilder.js
+++ b/packages/discord.js/src/structures/EmbedBuilder.js
@@ -2,6 +2,7 @@
 
 const { EmbedBuilder: BuildersEmbed, isJSONEncodable } = require('@discordjs/builders');
 const Transformers = require('../util/Transformers');
+const Util = require('../util/Util');
 
 class EmbedBuilder extends BuildersEmbed {
   constructor(data) {
@@ -18,6 +19,18 @@ class EmbedBuilder extends BuildersEmbed {
       return new this(other.toJSON());
     }
     return new this(other);
+  }
+
+  /**
+   * Sets the color of this embed
+   * @param {ColorResolvable} color The color of the embed
+   * @returns {Embed}
+   */
+  setColor(color) {
+    if (color === null) {
+      return super.setColor(null);
+    }
+    return super.setColor(Util.resolveColor(color));
   }
 }
 

--- a/packages/discord.js/src/structures/EmbedBuilder.js
+++ b/packages/discord.js/src/structures/EmbedBuilder.js
@@ -23,7 +23,7 @@ class EmbedBuilder extends BuildersEmbed {
 
   /**
    * Sets the color of this embed
-   * @param {ColorResolvable} color The color of the embed
+   * @param {?ColorResolvable} color The color of the embed
    * @returns {Embed}
    */
   setColor(color) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#7593 but for `EmbedBuilder` instead of `Embed`, following up #7662 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)