### PR TITLE
types(Constants): add `NonSystemMessageTypes` property

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2809,6 +2809,12 @@ export class WelcomeScreen extends Base {
 
 //#region Constants
 
+export type NonSystemMessageType =
+  | MessageType.Default
+  | MessageType.Reply
+  | MessageType.ChatInputCommand
+  | MessageType.ContextMenuCommand;
+
 export const Constants: {
   Package: {
     name: string;
@@ -2831,8 +2837,7 @@ export const Constants: {
   ThreadChannelTypes: ThreadChannelType[];
   TextBasedChannelTypes: TextBasedChannelTypes[];
   VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
-  MessageTypes: MessageType[];
-  SystemMessageTypes: SystemMessageType[];
+  NonSystemMessageTypes: NonSystemMessageType[];
 };
 
 export const version: string;
@@ -5062,11 +5067,6 @@ export type ClientStatus = number;
 export type StickerResolvable = Sticker | Snowflake;
 
 export type SystemChannelFlagsResolvable = BitFieldResolvable<SystemChannelFlagsString, number>;
-
-export type SystemMessageType = Exclude<
-  MessageType,
-  MessageType.Default | MessageType.Reply | MessageType.ChatInputCommand | MessageType.ContextMenuCommand
->;
 
 export type StageChannelResolvable = StageChannel | Snowflake;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Correct `Constants` constant in the declaration file
- Add `Constants.NonSystemMessageTypes` and `NonSystemMessageType` type
- Remove `Constants.MessageTypes`, `Constants.SystemMessageTypes` and `SystemMessageType` type

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
