### PR TITLE
feat: Slash command localization for builders

### DIFF
--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -443,14 +443,14 @@ describe('Slash Commands', () => {
 			});
 
 			test('GIVEN valid name localizations THEN valid data is stored', () => {
-				expect(getBuilder().setNameLocalization('en-US', 'foobar').nameLocalizations).toEqual(expectedSingleLocale);
-				expect(getBuilder().setNameLocalizations({ 'en-US': 'foobar', bg: 'test' }).nameLocalizations).toEqual(
+				expect(getBuilder().setNameLocalization('en-US', 'foobar').name_localizations).toEqual(expectedSingleLocale);
+				expect(getBuilder().setNameLocalizations({ 'en-US': 'foobar', bg: 'test' }).name_localizations).toEqual(
 					expectedMultipleLocales,
 				);
 				expect(
-					getBuilder().setNameLocalizations(new Map().set('en-US', 'foobar').set('bg', 'test')).nameLocalizations,
+					getBuilder().setNameLocalizations(new Map().set('en-US', 'foobar').set('bg', 'test')).name_localizations,
 				).toEqual(expectedMultipleLocales);
-				expect(getBuilder().setNameLocalizations(null).nameLocalizations).toBeUndefined;
+				expect(getBuilder().setNameLocalizations(null).name_localizations).toBeNull();
 			});
 
 			test('GIVEN valid description localizations THEN does not throw error', () => {
@@ -470,17 +470,17 @@ describe('Slash Commands', () => {
 			});
 
 			test('GIVEN valid description localizations THEN valid data is stored', () => {
-				expect(getBuilder().setDescriptionLocalization('en-US', 'foobar').descriptionLocalizations).toEqual(
+				expect(getBuilder().setDescriptionLocalization('en-US', 'foobar').description_localizations).toEqual(
 					expectedSingleLocale,
 				);
 				expect(
-					getBuilder().setDescriptionLocalizations({ 'en-US': 'foobar', bg: 'test' }).descriptionLocalizations,
+					getBuilder().setDescriptionLocalizations({ 'en-US': 'foobar', bg: 'test' }).description_localizations,
 				).toEqual(expectedMultipleLocales);
 				expect(
 					getBuilder().setDescriptionLocalizations(new Map().set('en-US', 'foobar').set('bg', 'test'))
-						.descriptionLocalizations,
+						.description_localizations,
 				).toEqual(expectedMultipleLocales);
-				expect(getBuilder().setDescriptionLocalizations(null).descriptionLocalizations).toBeUndefined();
+				expect(getBuilder().setDescriptionLocalizations(null).description_localizations).toBeNull();
 			});
 		});
 	});

--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -1,4 +1,4 @@
-import { APIApplicationCommandOptionChoice, ChannelType, LocaleString } from 'discord-api-types/v10';
+import { APIApplicationCommandOptionChoice, ChannelType } from 'discord-api-types/v10';
 import {
 	SlashCommandAssertions,
 	SlashCommandBooleanOption,
@@ -431,9 +431,6 @@ describe('Slash Commands', () => {
 			test('GIVEN valid name localizations THEN does not throw error', () => {
 				expect(() => getBuilder().setNameLocalization('en-US', 'foobar')).not.toThrowError();
 				expect(() => getBuilder().setNameLocalizations({ 'en-US': 'foobar' })).not.toThrowError();
-				expect(() =>
-					getBuilder().setNameLocalizations(new Map<LocaleString, string>().set('en-US', 'foobar')),
-				).not.toThrowError();
 			});
 
 			test('GIVEN valid name localizations THEN does not throw error', () => {
@@ -441,7 +438,6 @@ describe('Slash Commands', () => {
 				expect(() => getBuilder().setNameLocalization('en-U', 'foobar')).toThrowError();
 				// @ts-expect-error
 				expect(() => getBuilder().setNameLocalizations({ 'en-U': 'foobar' })).toThrowError();
-				expect(() => getBuilder().setNameLocalizations(new Map().set('en-U', 'foobar'))).toThrowError();
 			});
 
 			test('GIVEN valid name localizations THEN valid data is stored', () => {
@@ -449,9 +445,6 @@ describe('Slash Commands', () => {
 				expect(getBuilder().setNameLocalizations({ 'en-US': 'foobar', bg: 'test' }).name_localizations).toEqual(
 					expectedMultipleLocales,
 				);
-				expect(
-					getBuilder().setNameLocalizations(new Map().set('en-US', 'foobar').set('bg', 'test')).name_localizations,
-				).toEqual(expectedMultipleLocales);
 				expect(getBuilder().setNameLocalizations(null).name_localizations).toBeNull();
 				expect(getBuilder().setNameLocalization('en-US', null).name_localizations).toEqual({
 					'en-US': null,
@@ -461,7 +454,6 @@ describe('Slash Commands', () => {
 			test('GIVEN valid description localizations THEN does not throw error', () => {
 				expect(() => getBuilder().setDescriptionLocalization('en-US', 'foobar')).not.toThrowError();
 				expect(() => getBuilder().setDescriptionLocalizations({ 'en-US': 'foobar' })).not.toThrowError();
-				expect(() => getBuilder().setDescriptionLocalizations(new Map().set('en-US', 'foobar'))).not.toThrowError();
 			});
 
 			test('GIVEN valid description localizations THEN does not throw error', () => {
@@ -469,7 +461,6 @@ describe('Slash Commands', () => {
 				expect(() => getBuilder().setDescriptionLocalization('en-U', 'foobar')).toThrowError();
 				// @ts-expect-error
 				expect(() => getBuilder().setDescriptionLocalizations({ 'en-U': 'foobar' })).toThrowError();
-				expect(() => getBuilder().setDescriptionLocalizations(new Map().set('en-U', 'foobar'))).toThrowError();
 			});
 
 			test('GIVEN valid description localizations THEN valid data is stored', () => {
@@ -478,10 +469,6 @@ describe('Slash Commands', () => {
 				);
 				expect(
 					getBuilder().setDescriptionLocalizations({ 'en-US': 'foobar', bg: 'test' }).description_localizations,
-				).toEqual(expectedMultipleLocales);
-				expect(
-					getBuilder().setDescriptionLocalizations(new Map().set('en-US', 'foobar').set('bg', 'test'))
-						.description_localizations,
 				).toEqual(expectedMultipleLocales);
 				expect(getBuilder().setDescriptionLocalizations(null).description_localizations).toBeNull();
 				expect(getBuilder().setDescriptionLocalization('en-US', null).description_localizations).toEqual({

--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -431,7 +431,9 @@ describe('Slash Commands', () => {
 			test('GIVEN valid name localizations THEN does not throw error', () => {
 				expect(() => getBuilder().setNameLocalization('en-US', 'foobar')).not.toThrowError();
 				expect(() => getBuilder().setNameLocalizations({ 'en-US': 'foobar' })).not.toThrowError();
-				expect(() => getBuilder().setNameLocalizations(new Map().set('en-US', 'foobar'))).not.toThrowError();
+				expect(() =>
+					getBuilder().setNameLocalizations(new Map<LocaleString, string>().set('en-US', 'foobar')),
+				).not.toThrowError();
 			});
 
 			test('GIVEN valid name localizations THEN does not throw error', () => {
@@ -451,14 +453,15 @@ describe('Slash Commands', () => {
 					getBuilder().setNameLocalizations(new Map().set('en-US', 'foobar').set('bg', 'test')).name_localizations,
 				).toEqual(expectedMultipleLocales);
 				expect(getBuilder().setNameLocalizations(null).name_localizations).toBeNull();
+				expect(getBuilder().setNameLocalization('en-US', null).name_localizations).toEqual({
+					'en-US': null,
+				});
 			});
 
 			test('GIVEN valid description localizations THEN does not throw error', () => {
 				expect(() => getBuilder().setDescriptionLocalization('en-US', 'foobar')).not.toThrowError();
 				expect(() => getBuilder().setDescriptionLocalizations({ 'en-US': 'foobar' })).not.toThrowError();
-				expect(() =>
-					getBuilder().setDescriptionLocalizations(new Map<LocaleString, string>().set('en-US', 'foobar')),
-				).not.toThrowError();
+				expect(() => getBuilder().setDescriptionLocalizations(new Map().set('en-US', 'foobar'))).not.toThrowError();
 			});
 
 			test('GIVEN valid description localizations THEN does not throw error', () => {
@@ -481,6 +484,9 @@ describe('Slash Commands', () => {
 						.description_localizations,
 				).toEqual(expectedMultipleLocales);
 				expect(getBuilder().setDescriptionLocalizations(null).description_localizations).toBeNull();
+				expect(getBuilder().setDescriptionLocalization('en-US', null).description_localizations).toEqual({
+					'en-US': null,
+				});
 			});
 		});
 	});

--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -1,4 +1,4 @@
-import { APIApplicationCommandOptionChoice, ChannelType } from 'discord-api-types/v10';
+import { APIApplicationCommandOptionChoice, ChannelType, LocaleString } from 'discord-api-types/v10';
 import {
 	SlashCommandAssertions,
 	SlashCommandBooleanOption,
@@ -418,6 +418,69 @@ describe('Slash Commands', () => {
 		describe('Subcommand builder', () => {
 			test('GIVEN a valid subcommand with options THEN does not throw error', () => {
 				expect(() => getSubcommand().addBooleanOption(getBooleanOption()).toJSON()).not.toThrowError();
+			});
+		});
+
+		describe('Slash command localizations', () => {
+			const expectedSingleLocale = { 'en-US': 'foobar' };
+			const expectedMultipleLocales = {
+				...expectedSingleLocale,
+				bg: 'test',
+			};
+
+			test('GIVEN valid name localizations THEN does not throw error', () => {
+				expect(() => getBuilder().setNameLocalization('en-US', 'foobar')).not.toThrowError();
+				expect(() => getBuilder().setNameLocalizations({ 'en-US': 'foobar' })).not.toThrowError();
+				expect(() => getBuilder().setNameLocalizations(new Map().set('en-US', 'foobar'))).not.toThrowError();
+			});
+
+			test('GIVEN valid name localizations THEN does not throw error', () => {
+				// @ts-expect-error
+				expect(() => getBuilder().setNameLocalization('en-U', 'foobar')).toThrowError();
+				// @ts-expect-error
+				expect(() => getBuilder().setNameLocalizations({ 'en-U': 'foobar' })).toThrowError();
+				expect(() => getBuilder().setNameLocalizations(new Map().set('en-U', 'foobar'))).toThrowError();
+			});
+
+			test('GIVEN valid name localizations THEN valid data is stored', () => {
+				expect(getBuilder().setNameLocalization('en-US', 'foobar').nameLocalizations).toEqual(expectedSingleLocale);
+				expect(getBuilder().setNameLocalizations({ 'en-US': 'foobar', bg: 'test' }).nameLocalizations).toEqual(
+					expectedMultipleLocales,
+				);
+				expect(
+					getBuilder().setNameLocalizations(new Map().set('en-US', 'foobar').set('bg', 'test')).nameLocalizations,
+				).toEqual(expectedMultipleLocales);
+				expect(getBuilder().setNameLocalizations(null).nameLocalizations).toBeUndefined;
+			});
+
+			test('GIVEN valid description localizations THEN does not throw error', () => {
+				expect(() => getBuilder().setDescriptionLocalization('en-US', 'foobar')).not.toThrowError();
+				expect(() => getBuilder().setDescriptionLocalizations({ 'en-US': 'foobar' })).not.toThrowError();
+				expect(() =>
+					getBuilder().setDescriptionLocalizations(new Map<LocaleString, string>().set('en-US', 'foobar')),
+				).not.toThrowError();
+			});
+
+			test('GIVEN valid description localizations THEN does not throw error', () => {
+				// @ts-expect-error
+				expect(() => getBuilder().setDescriptionLocalization('en-U', 'foobar')).toThrowError();
+				// @ts-expect-error
+				expect(() => getBuilder().setDescriptionLocalizations({ 'en-U': 'foobar' })).toThrowError();
+				expect(() => getBuilder().setDescriptionLocalizations(new Map().set('en-U', 'foobar'))).toThrowError();
+			});
+
+			test('GIVEN valid description localizations THEN valid data is stored', () => {
+				expect(getBuilder().setDescriptionLocalization('en-US', 'foobar').descriptionLocalizations).toEqual(
+					expectedSingleLocale,
+				);
+				expect(
+					getBuilder().setDescriptionLocalizations({ 'en-US': 'foobar', bg: 'test' }).descriptionLocalizations,
+				).toEqual(expectedMultipleLocales);
+				expect(
+					getBuilder().setDescriptionLocalizations(new Map().set('en-US', 'foobar').set('bg', 'test'))
+						.descriptionLocalizations,
+				).toEqual(expectedMultipleLocales);
+				expect(getBuilder().setDescriptionLocalizations(null).descriptionLocalizations).toBeUndefined();
 			});
 		});
 	});

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -54,7 +54,7 @@
 	"dependencies": {
 		"@sapphire/shapeshift": "^2.0.0",
 		"@sindresorhus/is": "^4.4.0",
-		"discord-api-types": "^0.29.0",
+		"discord-api-types": "^0.30.0",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.0",
 		"tslib": "^2.3.1"

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -54,7 +54,7 @@
 	"dependencies": {
 		"@sapphire/shapeshift": "^2.0.0",
 		"@sindresorhus/is": "^4.4.0",
-		"discord-api-types": "^0.30.0",
+		"discord-api-types": "^0.31.0",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.0",
 		"tslib": "^2.3.1"

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -54,7 +54,7 @@
 	"dependencies": {
 		"@sapphire/shapeshift": "^2.0.0",
 		"@sindresorhus/is": "^4.4.0",
-		"discord-api-types": "^0.31.0",
+		"discord-api-types": "^0.31.1",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.0",
 		"tslib": "^2.3.1"

--- a/packages/builders/src/interactions/slashCommands/Assertions.ts
+++ b/packages/builders/src/interactions/slashCommands/Assertions.ts
@@ -1,5 +1,5 @@
 import is from '@sindresorhus/is';
-import type { APIApplicationCommandOptionChoice } from 'discord-api-types/v10';
+import { type APIApplicationCommandOptionChoice, Locale, type LocaleString } from 'discord-api-types/v10';
 import { s } from '@sapphire/shapeshift';
 import type { ApplicationCommandOptionBase } from './mixins/ApplicationCommandOptionBase';
 import type { ToAPIApplicationCommandOptions } from './SlashCommandBuilder';
@@ -15,12 +15,16 @@ export function validateName(name: unknown): asserts name is string {
 }
 
 const descriptionPredicate = s.string.lengthGe(1).lengthLe(100);
+const localePredicate = s.nativeEnum(Locale);
 
 export function validateDescription(description: unknown): asserts description is string {
 	descriptionPredicate.parse(description);
 }
 
 const maxArrayLengthPredicate = s.unknown.array.lengthLe(25);
+export function validateLocale(locale: unknown): asserts locale is LocaleString {
+	localePredicate.parse(locale);
+}
 
 export function validateMaxOptionsLength(options: unknown): asserts options is ToAPIApplicationCommandOptions[] {
 	maxArrayLengthPredicate.parse(options);

--- a/packages/builders/src/interactions/slashCommands/Assertions.ts
+++ b/packages/builders/src/interactions/slashCommands/Assertions.ts
@@ -1,5 +1,5 @@
 import is from '@sindresorhus/is';
-import { type APIApplicationCommandOptionChoice, Locale, type LocaleString } from 'discord-api-types/v10';
+import { type APIApplicationCommandOptionChoice, Locale } from 'discord-api-types/v10';
 import { s } from '@sapphire/shapeshift';
 import type { ApplicationCommandOptionBase } from './mixins/ApplicationCommandOptionBase';
 import type { ToAPIApplicationCommandOptions } from './SlashCommandBuilder';
@@ -22,8 +22,8 @@ export function validateDescription(description: unknown): asserts description i
 }
 
 const maxArrayLengthPredicate = s.unknown.array.lengthLe(25);
-export function validateLocale(locale: unknown): asserts locale is LocaleString {
-	localePredicate.parse(locale);
+export function validateLocale(locale: unknown) {
+	return localePredicate.parse(locale);
 }
 
 export function validateMaxOptionsLength(options: unknown): asserts options is ToAPIApplicationCommandOptions[] {

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -24,7 +24,7 @@ export class SlashCommandBuilder {
 	/**
 	 * The localized names for this command
 	 */
-	public readonly nameLocalizations?: Partial<Record<LocaleString, string>> = undefined;
+	public readonly name_localizations?: Partial<Record<LocaleString, string>> = undefined;
 
 	/**
 	 * The description of this slash command
@@ -34,7 +34,7 @@ export class SlashCommandBuilder {
 	/**
 	 * The localized descriptions for this command
 	 */
-	public readonly descriptionLocalizations?: Partial<Record<LocaleString, string>> = undefined;
+	public readonly description_localizations?: Partial<Record<LocaleString, string>> = undefined;
 
 	/**
 	 * The options of this slash command
@@ -58,10 +58,9 @@ export class SlashCommandBuilder {
 
 		return {
 			name: this.name,
-			// @ts-expect-error bump dapi-types
-			name_localizations: this.nameLocalizations,
+			name_localizations: this.name_localizations,
 			description: this.description,
-			description_localizations: this.descriptionLocalizations,
+			description_localizations: this.description_localizations,
 			options: this.options.map((option) => option.toJSON()),
 			default_permission: this.defaultPermission,
 		};

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -1,6 +1,6 @@
 import type {
 	APIApplicationCommandOption,
-	LocaleString,
+	LocalizationMap,
 	RESTPostAPIApplicationCommandsJSONBody,
 } from 'discord-api-types/v10';
 import { mix } from 'ts-mixer';
@@ -24,7 +24,7 @@ export class SlashCommandBuilder {
 	/**
 	 * The localized names for this command
 	 */
-	public readonly name_localizations?: Partial<Record<LocaleString, string>> = undefined;
+	public readonly name_localizations?: LocalizationMap;
 
 	/**
 	 * The description of this slash command
@@ -34,7 +34,7 @@ export class SlashCommandBuilder {
 	/**
 	 * The localized descriptions for this command
 	 */
-	public readonly description_localizations?: Partial<Record<LocaleString, string>> = undefined;
+	public readonly description_localizations?: LocalizationMap;
 
 	/**
 	 * The options of this slash command

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -1,4 +1,8 @@
-import type { APIApplicationCommandOption, RESTPostAPIApplicationCommandsJSONBody } from 'discord-api-types/v10';
+import type {
+	APIApplicationCommandOption,
+	LocaleString,
+	RESTPostAPIApplicationCommandsJSONBody,
+} from 'discord-api-types/v10';
 import { mix } from 'ts-mixer';
 import {
 	assertReturnOfBuilder,
@@ -18,9 +22,19 @@ export class SlashCommandBuilder {
 	public readonly name: string = undefined!;
 
 	/**
+	 * The localized names for this command
+	 */
+	public readonly nameLocalizations?: Partial<Record<LocaleString, string>> = undefined;
+
+	/**
 	 * The description of this slash command
 	 */
 	public readonly description: string = undefined!;
+
+	/**
+	 * The localized descriptions for this command
+	 */
+	public readonly descriptionLocalizations?: Partial<Record<LocaleString, string>> = undefined;
 
 	/**
 	 * The options of this slash command
@@ -44,7 +58,10 @@ export class SlashCommandBuilder {
 
 		return {
 			name: this.name,
+			// @ts-expect-error bump dapi-types
+			name_localizations: this.nameLocalizations,
 			description: this.description,
+			description_localizations: this.descriptionLocalizations,
 			options: this.options.map((option) => option.toJSON()),
 			default_permission: this.defaultPermission,
 		};

--- a/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -1,12 +1,12 @@
-import type { LocaleString } from 'discord-api-types/v10';
+import type { LocaleString, LocalizationMap } from 'discord-api-types/v10';
 import { flattenLocaleMap } from '../../../util/slashCommandUtil';
 import { validateDescription, validateLocale, validateName } from '../Assertions';
 
 export class SharedNameAndDescription {
 	public readonly name!: string;
-	public readonly nameLocalizations?: Partial<Record<LocaleString, string>> = undefined;
+	public readonly name_localizations?: LocalizationMap = undefined;
 	public readonly description!: string;
-	public readonly descriptionLocalizations?: Partial<Record<LocaleString, string>> = undefined;
+	public readonly description_localizations?: LocalizationMap = undefined;
 
 	/**
 	 * Sets the name
@@ -46,11 +46,11 @@ export class SharedNameAndDescription {
 		validateLocale(locale);
 		validateName(localizedName);
 
-		if (!this.nameLocalizations) {
-			Reflect.set(this, 'nameLocalizations', {});
+		if (!this.name_localizations) {
+			Reflect.set(this, 'name_localizations', {});
 		}
 
-		this.nameLocalizations![locale] = localizedName;
+		this.name_localizations![locale] = localizedName;
 		return this;
 	}
 
@@ -63,11 +63,11 @@ export class SharedNameAndDescription {
 		localizedNames: Partial<Record<LocaleString, string>> | Map<LocaleString, string> | null,
 	) {
 		if (localizedNames === null) {
-			Reflect.set(this, 'nameLocalizations', undefined);
+			Reflect.set(this, 'name_localizations', null);
 			return this;
 		}
 
-		Reflect.set(this, 'nameLocalizations', {});
+		Reflect.set(this, 'name_localizations', {});
 		flattenLocaleMap(localizedNames).forEach((args) => this.setNameLocalization(...args));
 		return this;
 	}
@@ -82,11 +82,11 @@ export class SharedNameAndDescription {
 		validateLocale(locale);
 		validateDescription(localizedDescription);
 
-		if (!this.descriptionLocalizations) {
-			Reflect.set(this, 'descriptionLocalizations', {});
+		if (!this.description_localizations) {
+			Reflect.set(this, 'description_localizations', {});
 		}
 
-		this.descriptionLocalizations![locale] = localizedDescription;
+		this.description_localizations![locale] = localizedDescription;
 		return this;
 	}
 
@@ -99,11 +99,11 @@ export class SharedNameAndDescription {
 		localizedDescriptions: Map<LocaleString, string> | Partial<Record<LocaleString, string>> | null,
 	) {
 		if (localizedDescriptions === null) {
-			Reflect.set(this, 'descriptionLocalizations', undefined);
+			Reflect.set(this, 'description_localizations', null);
 			return this;
 		}
 
-		Reflect.set(this, 'descriptionLocalizations', {});
+		Reflect.set(this, 'description_localizations', {});
 		flattenLocaleMap(localizedDescriptions).forEach((args) => this.setDescriptionLocalization(...args));
 		return this;
 	}

--- a/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -47,8 +47,6 @@ export class SharedNameAndDescription {
 			Reflect.set(this, 'name_localizations', {});
 		}
 
-		validateLocale(locale);
-
 		if (localizedName === null) {
 			this.name_localizations![locale] = null;
 			return this;
@@ -56,7 +54,7 @@ export class SharedNameAndDescription {
 
 		validateName(localizedName);
 
-		this.name_localizations![locale] = localizedName;
+		this.name_localizations![validateLocale(locale)] = localizedName;
 		return this;
 	}
 
@@ -87,8 +85,6 @@ export class SharedNameAndDescription {
 			Reflect.set(this, 'description_localizations', {});
 		}
 
-		validateLocale(locale);
-
 		if (localizedDescription === null) {
 			this.description_localizations![locale] = null;
 			return this;
@@ -96,7 +92,7 @@ export class SharedNameAndDescription {
 
 		validateDescription(localizedDescription);
 
-		this.description_localizations![locale] = localizedDescription;
+		this.description_localizations![validateLocale(locale)] = localizedDescription;
 		return this;
 	}
 

--- a/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -4,9 +4,9 @@ import { validateDescription, validateLocale, validateName } from '../Assertions
 
 export class SharedNameAndDescription {
 	public readonly name!: string;
-	public readonly name_localizations?: LocalizationMap = undefined;
+	public readonly name_localizations?: LocalizationMap;
 	public readonly description!: string;
-	public readonly description_localizations?: LocalizationMap = undefined;
+	public readonly description_localizations?: LocalizationMap;
 
 	/**
 	 * Sets the name
@@ -42,13 +42,19 @@ export class SharedNameAndDescription {
 	 * @param locale The locale to set a description for
 	 * @param localizedName The localized description for the given locale
 	 */
-	public setNameLocalization(locale: LocaleString, localizedName: string) {
-		validateLocale(locale);
-		validateName(localizedName);
-
+	public setNameLocalization(locale: LocaleString, localizedName: string | null) {
 		if (!this.name_localizations) {
 			Reflect.set(this, 'name_localizations', {});
 		}
+
+		validateLocale(locale);
+
+		if (localizedName === null) {
+			this.name_localizations![locale] = null;
+			return this;
+		}
+
+		validateName(localizedName);
 
 		this.name_localizations![locale] = localizedName;
 		return this;
@@ -59,9 +65,7 @@ export class SharedNameAndDescription {
 	 *
 	 * @param localizedNames The dictionary of localized descriptions to set
 	 */
-	public setNameLocalizations(
-		localizedNames: Partial<Record<LocaleString, string>> | Map<LocaleString, string> | null,
-	) {
+	public setNameLocalizations(localizedNames: Map<LocaleString, string> | LocalizationMap | null) {
 		if (localizedNames === null) {
 			Reflect.set(this, 'name_localizations', null);
 			return this;
@@ -78,13 +82,19 @@ export class SharedNameAndDescription {
 	 * @param locale The locale to set a description for
 	 * @param localizedDescription The localized description for the given locale
 	 */
-	public setDescriptionLocalization(locale: LocaleString, localizedDescription: string) {
-		validateLocale(locale);
-		validateDescription(localizedDescription);
-
+	public setDescriptionLocalization(locale: LocaleString, localizedDescription: string | null) {
 		if (!this.description_localizations) {
 			Reflect.set(this, 'description_localizations', {});
 		}
+
+		validateLocale(locale);
+
+		if (localizedDescription === null) {
+			this.description_localizations![locale] = null;
+			return this;
+		}
+
+		validateDescription(localizedDescription);
 
 		this.description_localizations![locale] = localizedDescription;
 		return this;

--- a/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -1,8 +1,12 @@
-import { validateDescription, validateName } from '../Assertions';
+import type { LocaleString } from 'discord-api-types/v10';
+import { flattenLocaleMap } from '../../../util/slashCommandUtil';
+import { validateDescription, validateLocale, validateName } from '../Assertions';
 
 export class SharedNameAndDescription {
 	public readonly name!: string;
+	public readonly nameLocalizations?: Partial<Record<LocaleString, string>> = undefined;
 	public readonly description!: string;
+	public readonly descriptionLocalizations?: Partial<Record<LocaleString, string>> = undefined;
 
 	/**
 	 * Sets the name
@@ -29,6 +33,78 @@ export class SharedNameAndDescription {
 
 		Reflect.set(this, 'description', description);
 
+		return this;
+	}
+
+	/**
+	 * Sets a name localization
+	 *
+	 * @param locale The locale to set a description for
+	 * @param localizedName The localized description for the given locale
+	 */
+	public setNameLocalization(locale: LocaleString, localizedName: string) {
+		validateLocale(locale);
+		validateName(localizedName);
+
+		if (!this.nameLocalizations) {
+			Reflect.set(this, 'nameLocalizations', {});
+		}
+
+		this.nameLocalizations![locale] = localizedName;
+		return this;
+	}
+
+	/**
+	 * Sets the name localizations
+	 *
+	 * @param localizedNames The dictionary of localized descriptions to set
+	 */
+	public setNameLocalizations(
+		localizedNames: Partial<Record<LocaleString, string>> | Map<LocaleString, string> | null,
+	) {
+		if (localizedNames === null) {
+			Reflect.set(this, 'nameLocalizations', undefined);
+			return this;
+		}
+
+		Reflect.set(this, 'nameLocalizations', {});
+		flattenLocaleMap(localizedNames).forEach((args) => this.setNameLocalization(...args));
+		return this;
+	}
+
+	/**
+	 * Sets a description localization
+	 *
+	 * @param locale The locale to set a description for
+	 * @param localizedDescription The localized description for the given locale
+	 */
+	public setDescriptionLocalization(locale: LocaleString, localizedDescription: string) {
+		validateLocale(locale);
+		validateDescription(localizedDescription);
+
+		if (!this.descriptionLocalizations) {
+			Reflect.set(this, 'descriptionLocalizations', {});
+		}
+
+		this.descriptionLocalizations![locale] = localizedDescription;
+		return this;
+	}
+
+	/**
+	 * Sets the description localizations
+	 *
+	 * @param localizedDescriptions The dictionary of localized descriptions to set
+	 */
+	public setDescriptionLocalizations(
+		localizedDescriptions: Map<LocaleString, string> | Partial<Record<LocaleString, string>> | null,
+	) {
+		if (localizedDescriptions === null) {
+			Reflect.set(this, 'descriptionLocalizations', undefined);
+			return this;
+		}
+
+		Reflect.set(this, 'descriptionLocalizations', {});
+		flattenLocaleMap(localizedDescriptions).forEach((args) => this.setDescriptionLocalization(...args));
 		return this;
 	}
 }

--- a/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -1,5 +1,4 @@
 import type { LocaleString, LocalizationMap } from 'discord-api-types/v10';
-import { flattenLocaleMap } from '../../../util/slashCommandUtil';
 import { validateDescription, validateLocale, validateName } from '../Assertions';
 
 export class SharedNameAndDescription {
@@ -63,14 +62,17 @@ export class SharedNameAndDescription {
 	 *
 	 * @param localizedNames The dictionary of localized descriptions to set
 	 */
-	public setNameLocalizations(localizedNames: Map<LocaleString, string> | LocalizationMap | null) {
+	public setNameLocalizations(localizedNames: LocalizationMap | null) {
 		if (localizedNames === null) {
 			Reflect.set(this, 'name_localizations', null);
 			return this;
 		}
 
 		Reflect.set(this, 'name_localizations', {});
-		flattenLocaleMap(localizedNames).forEach((args) => this.setNameLocalization(...args));
+
+		Object.entries(localizedNames).forEach((args) =>
+			this.setNameLocalization(...(args as [LocaleString, string | null])),
+		);
 		return this;
 	}
 
@@ -101,16 +103,16 @@ export class SharedNameAndDescription {
 	 *
 	 * @param localizedDescriptions The dictionary of localized descriptions to set
 	 */
-	public setDescriptionLocalizations(
-		localizedDescriptions: Map<LocaleString, string> | Partial<Record<LocaleString, string>> | null,
-	) {
+	public setDescriptionLocalizations(localizedDescriptions: LocalizationMap | null) {
 		if (localizedDescriptions === null) {
 			Reflect.set(this, 'description_localizations', null);
 			return this;
 		}
 
 		Reflect.set(this, 'description_localizations', {});
-		flattenLocaleMap(localizedDescriptions).forEach((args) => this.setDescriptionLocalization(...args));
+		Object.entries(localizedDescriptions).forEach((args) =>
+			this.setDescriptionLocalization(...(args as [LocaleString, string | null])),
+		);
 		return this;
 	}
 }

--- a/packages/builders/src/util/slashCommandUtil.ts
+++ b/packages/builders/src/util/slashCommandUtil.ts
@@ -1,8 +1,6 @@
-import type { LocaleString } from 'discord-api-types/v10';
+import type { LocaleString, LocalizationMap } from 'discord-api-types/v10';
 
-export function flattenLocaleMap(
-	localeMap: Map<LocaleString, string> | Partial<Record<LocaleString, string>>,
-): [LocaleString, string][] {
+export function flattenLocaleMap(localeMap: Map<LocaleString, string> | LocalizationMap): [LocaleString, string][] {
 	return localeMap instanceof Map
 		? [...localeMap.entries()]
 		: ([...Object.entries(localeMap)] as [LocaleString, string][]);

--- a/packages/builders/src/util/slashCommandUtil.ts
+++ b/packages/builders/src/util/slashCommandUtil.ts
@@ -1,0 +1,9 @@
+import type { LocaleString } from 'discord-api-types/v10';
+
+export function flattenLocaleMap(
+	localeMap: Map<LocaleString, string> | Partial<Record<LocaleString, string>>,
+): [LocaleString, string][] {
+	return localeMap instanceof Map
+		? [...localeMap.entries()]
+		: ([...Object.entries(localeMap)] as [LocaleString, string][]);
+}

--- a/packages/builders/src/util/slashCommandUtil.ts
+++ b/packages/builders/src/util/slashCommandUtil.ts
@@ -1,5 +1,0 @@
-import type { LocaleString, LocalizationMap } from 'discord-api-types/v10';
-
-export function flattenLocaleMap(localeMap: Map<LocaleString, string> | LocalizationMap): [LocaleString, string][] {
-	return localeMap instanceof Map ? [...localeMap.entries()] : (Object.entries(localeMap) as [LocaleString, string][]);
-}

--- a/packages/builders/src/util/slashCommandUtil.ts
+++ b/packages/builders/src/util/slashCommandUtil.ts
@@ -1,7 +1,5 @@
 import type { LocaleString, LocalizationMap } from 'discord-api-types/v10';
 
 export function flattenLocaleMap(localeMap: Map<LocaleString, string> | LocalizationMap): [LocaleString, string][] {
-	return localeMap instanceof Map
-		? [...localeMap.entries()]
-		: ([...Object.entries(localeMap)] as [LocaleString, string][]);
+	return localeMap instanceof Map ? [...localeMap.entries()] : (Object.entries(localeMap) as [LocaleString, string][]);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,7 +1765,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.11.0
     "@typescript-eslint/parser": ^5.11.0
     babel-plugin-transform-typescript-metadata: ^0.3.2
-    discord-api-types: ^0.30.0
+    discord-api-types: ^0.31.0
     eslint: ^8.9.0
     eslint-config-marine: ^9.3.2
     eslint-config-prettier: ^8.3.0
@@ -4426,13 +4426,6 @@ __metadata:
   version: 0.29.0
   resolution: "discord-api-types@npm:0.29.0"
   checksum: 1ca74693b4e9c611c3de17f604714425d81d537ee81669d040a8c37fb23fb634a6918dd7d21056ccb90a3f4741bc2750509f6c8dd922bf2b3ed544d18bd0f32a
-  languageName: node
-  linkType: hard
-
-"discord-api-types@npm:^0.30.0":
-  version: 0.30.0
-  resolution: "discord-api-types@npm:0.30.0"
-  checksum: c4b0afbc453b7ce6b570501f83a654591432eb2ce690681d2e6a9424d5f9687b7ef02dde02702e53562449c5cdcde500e92299a8158eb9bf67ad85c073788e72
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,7 +1765,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.11.0
     "@typescript-eslint/parser": ^5.11.0
     babel-plugin-transform-typescript-metadata: ^0.3.2
-    discord-api-types: ^0.31.0
+    discord-api-types: ^0.31.1
     eslint: ^8.9.0
     eslint-config-marine: ^9.3.2
     eslint-config-prettier: ^8.3.0
@@ -4433,6 +4433,13 @@ __metadata:
   version: 0.31.0
   resolution: "discord-api-types@npm:0.31.0"
   checksum: 7ac466df8f3b62ebfa18296ef8cbf7a35ae295b775184b01f4357409cff89aa4e85a67e7fb3363b4a4ff796ff7313865e0266706b3d7908ef2238147a196a806
+  languageName: node
+  linkType: hard
+
+"discord-api-types@npm:^0.31.1":
+  version: 0.31.1
+  resolution: "discord-api-types@npm:0.31.1"
+  checksum: 5a18e512b549b75d55892b0dbc2dc7c46526bee0d001b73d41d144f4653de847c96b9c57342a32479af738f46acd80ee21686dced9fe0184dcac86b669b31f18
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,7 +1765,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.11.0
     "@typescript-eslint/parser": ^5.11.0
     babel-plugin-transform-typescript-metadata: ^0.3.2
-    discord-api-types: ^0.29.0
+    discord-api-types: ^0.30.0
     eslint: ^8.9.0
     eslint-config-marine: ^9.3.2
     eslint-config-prettier: ^8.3.0
@@ -4426,6 +4426,13 @@ __metadata:
   version: 0.29.0
   resolution: "discord-api-types@npm:0.29.0"
   checksum: 1ca74693b4e9c611c3de17f604714425d81d537ee81669d040a8c37fb23fb634a6918dd7d21056ccb90a3f4741bc2750509f6c8dd922bf2b3ed544d18bd0f32a
+  languageName: node
+  linkType: hard
+
+"discord-api-types@npm:^0.30.0":
+  version: 0.30.0
+  resolution: "discord-api-types@npm:0.30.0"
+  checksum: c4b0afbc453b7ce6b570501f83a654591432eb2ce690681d2e6a9424d5f9687b7ef02dde02702e53562449c5cdcde500e92299a8158eb9bf67ad85c073788e72
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Allows builders to specific localizations dictionaries for `name` and `description`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
