### PR TITLE
feat: add getters to builders

### DIFF
--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -142,6 +142,7 @@ exports.ReactionCollector = require('./structures/ReactionCollector');
 exports.ReactionEmoji = require('./structures/ReactionEmoji');
 exports.RichPresenceAssets = require('./structures/Presence').RichPresenceAssets;
 exports.Role = require('./structures/Role').Role;
+exports.SelectMenuOptionBuilder = require('./structures/SelectMenuOptionBuilder');
 exports.SelectMenuBuilder = require('./structures/SelectMenuBuilder');
 exports.SelectMenuComponent = require('./structures/SelectMenuComponent');
 exports.SelectMenuInteraction = require('./structures/SelectMenuInteraction');

--- a/packages/discord.js/src/structures/ButtonBuilder.js
+++ b/packages/discord.js/src/structures/ButtonBuilder.js
@@ -5,7 +5,7 @@ const Transformers = require('../util/Transformers');
 const Util = require('../util/Util');
 
 /**
- * Represents a button builder.
+ * A class to build button components to be sent through the API
  * @extends {BuildersButton}
  */
 class ButtonBuilder extends BuildersButton {
@@ -37,6 +37,71 @@ class ButtonBuilder extends BuildersButton {
       return new this(other.toJSON());
     }
     return new this(other);
+  }
+
+  /**
+   * A unique string to be sent in the interaction when clicked
+   * @type {string}
+   * @readonly
+   */
+  get customId() {
+    return this.data.custom_id ?? null;
+  }
+
+  /**
+   * Whether this button is currently disabled
+   * @type {boolean}
+   * @readonly
+   */
+  get disabled() {
+    return this.data.disabled ?? null;
+  }
+
+  /**
+   * Emoji for this button
+   * @type {?APIMessageComponentEmoji}
+   * @readonly
+   */
+  get emoji() {
+    return this.data.emoji ?? null;
+  }
+
+  /**
+   * The text to be displayed on this button
+   * @type {string}
+   * @readonly
+   */
+  get label() {
+    return this.data.label ?? null;
+  }
+
+  /**
+   * The style of a button represented as a number. This can be:
+   * * 1 - Primary
+   * * 2 - Secondary
+   * * 3 - Success
+   * * 4 - Danger
+   * * 5 - Link
+   * @see {@link https://discord.com/developers/docs/interactions/message-components#button-object-button-styles}
+   * @typedef {number} ButtonStyle
+   */
+
+  /**
+   * The style of this button
+   * @type {ButtonStyle}
+   * @readonly
+   */
+  get style() {
+    return this.data.style ?? null;
+  }
+
+  /**
+   * The URL this button links to, if it is a Link style button
+   * @type {string}
+   * @readonly
+   */
+  get url() {
+    return this.data.url ?? null;
   }
 }
 

--- a/packages/discord.js/src/structures/Embed.js
+++ b/packages/discord.js/src/structures/Embed.js
@@ -3,7 +3,7 @@
 const isEqual = require('fast-deep-equal');
 
 /**
- * Represents an embed.
+ * Represents an Embed received from the API
  */
 class Embed {
   /**

--- a/packages/discord.js/src/structures/EmbedBuilder.js
+++ b/packages/discord.js/src/structures/EmbedBuilder.js
@@ -5,7 +5,7 @@ const Transformers = require('../util/Transformers');
 const Util = require('../util/Util');
 
 /**
- * Represents an embed builder.
+ * Class used to build embeds to be sent through the API
  * @extends {BuildersEmbed}
  */
 class EmbedBuilder extends BuildersEmbed {
@@ -32,6 +32,145 @@ class EmbedBuilder extends BuildersEmbed {
       return new this(other.toJSON());
     }
     return new this(other);
+  }
+
+  /**
+   * An array of fields of this embed
+   * @type {?Array<APIEmbedField>}
+   * @readonly
+   */
+  get fields() {
+    return this.data.fields ?? null;
+  }
+
+  /**
+   * The embed title
+   * @type {?string}
+   * @readonly
+   */
+  get title() {
+    return this.data.title ?? null;
+  }
+
+  /**
+   * The embed description
+   * @type {?string}
+   * @readonly
+   */
+  get description() {
+    return this.data.description ?? null;
+  }
+
+  /**
+   * The embed URL
+   * @type {?string}
+   * @readonly
+   */
+  get url() {
+    return this.data.url ?? null;
+  }
+
+  /**
+   * The embed color
+   * @type {?number}
+   * @readonly
+   */
+  get color() {
+    return this.data.color ?? null;
+  }
+
+  /**
+   * The timestamp of the embed in an ISO 8601 format
+   * @type {?string}
+   * @readonly
+   */
+  get timestamp() {
+    return this.data.timestamp ?? null;
+  }
+
+  /**
+   * The embed thumbnail data
+   * @type {?EmbedImageData}
+   * @readonly
+   */
+  get thumbnail() {
+    if (!this.data.thumbnail) return null;
+    return {
+      url: this.data.thumbnail.url,
+      proxyURL: this.data.thumbnail.proxy_url,
+      height: this.data.thumbnail.height,
+      width: this.data.thumbnail.width,
+    };
+  }
+
+  /**
+   * The embed image data
+   * @type {?EmbedImageData}
+   * @readonly
+   */
+  get image() {
+    if (!this.data.image) return null;
+    return {
+      url: this.data.image.url,
+      proxyURL: this.data.image.proxy_url,
+      height: this.data.image.height,
+      width: this.data.image.width,
+    };
+  }
+
+  /**
+   * The embed author data
+   * @type {?EmbedAuthorData}
+   * @readonly
+   */
+  get author() {
+    if (!this.data.author) return null;
+    return {
+      name: this.data.author.name,
+      url: this.data.author.url,
+      iconURL: this.data.author.icon_url,
+      proxyIconURL: this.data.author.proxy_icon_url,
+    };
+  }
+
+  /**
+   * The embed footer data
+   * @type {?EmbedFooterData}
+   * @readonly
+   */
+  get footer() {
+    if (!this.data.footer) return null;
+    return {
+      text: this.data.footer.text,
+      iconURL: this.data.footer.icon_url,
+      proxyIconURL: this.data.footer.proxy_icon_url,
+    };
+  }
+
+  /**
+   * The accumulated length for the embed title, description, fields, footer text, and author name
+   * @type {number}
+   * @readonly
+   */
+  get length() {
+    return (
+      (this.data.title?.length ?? 0) +
+      (this.data.description?.length ?? 0) +
+      (this.data.fields?.reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0) ?? 0) +
+      (this.data.footer?.text.length ?? 0) +
+      (this.data.author?.name.length ?? 0)
+    );
+  }
+
+  /**
+   * The hex color of the current color of the embed
+   * @type {?string}
+   * @readonly
+   */
+  get hexColor() {
+    return typeof this.data.color === 'number'
+      ? `#${this.data.color.toString(16).padStart(6, '0')}`
+      : this.data.color ?? null;
   }
 }
 

--- a/packages/discord.js/src/structures/SelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuBuilder.js
@@ -1,11 +1,15 @@
 'use strict';
 
-const { SelectMenuBuilder: BuildersSelectMenu, isJSONEncodable } = require('@discordjs/builders');
+const {
+  SelectMenuBuilder: BuildersSelectMenu,
+  isJSONEncodable,
+  SelectMenuOptionBuilder,
+} = require('@discordjs/builders');
 const Transformers = require('../util/Transformers');
 const Util = require('../util/Util');
 
 /**
- * Class used to build select menu components to be sent through the API
+ * Class used to build Select Menu components to be sent through the API
  * @extends {BuildersSelectMenu}
  */
 class SelectMenuBuilder extends BuildersSelectMenu {
@@ -19,6 +23,7 @@ class SelectMenuBuilder extends BuildersSelectMenu {
         })),
       }),
     );
+    this.options = this.data.options.map(option => new SelectMenuOptionBuilder(option));
   }
 
   /**
@@ -59,6 +64,51 @@ class SelectMenuBuilder extends BuildersSelectMenu {
       return new this(other.toJSON());
     }
     return new this(other);
+  }
+
+  /**
+   * Text to be displayed if nothing is selected on this select menu component
+   * @type {?string}
+   * @readonly
+   */
+  get placeholder() {
+    return this.data.placeholder ?? null;
+  }
+
+  /**
+   * The minimum number of items that must be chosen
+   * @type {?number}
+   * @readonly
+   */
+  get minValues() {
+    return this.data.min_values ?? null;
+  }
+
+  /**
+   * The maximum number of items that must be chosen
+   * @type {?number}
+   * @readonly
+   */
+  get maxValues() {
+    return this.data.max_values ?? null;
+  }
+
+  /**
+   * A developer-defined identifier for this select menu component
+   * @type {?string}
+   * @readonly
+   */
+  get customId() {
+    return this.data.custom_id ?? null;
+  }
+
+  /**
+   * Whether this select menu component is disabled
+   * @type {?boolean}
+   * @readonly
+   */
+  get disabled() {
+    return this.data.disabled ?? null;
   }
 }
 

--- a/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
@@ -5,7 +5,7 @@ const Transformers = require('../util/Transformers');
 const Util = require('../util/Util');
 
 /**
- * Represents a select menu option builder.
+ * Class used to build select menu options to be sent through the API
  * @extends {BuildersSelectMenuOption}
  */
 class SelectMenuOptionBuilder extends BuildersSelectMenuOption {
@@ -27,6 +27,51 @@ class SelectMenuOptionBuilder extends BuildersSelectMenuOption {
       return super.setEmoji(Util.parseEmoji(emoji));
     }
     return super.setEmoji(emoji);
+  }
+
+  /**
+   * The label of this select menu option
+   * @type {?string}
+   * @readonly
+   */
+  get label() {
+    return this.data.label ?? null;
+  }
+
+  /**
+   * The sent through the interaction when this option is picked
+   * @type {?string}
+   * @readonly
+   */
+  get value() {
+    return this.data.value ?? null;
+  }
+
+  /**
+   * The description of this select menu option
+   * @type {?string}
+   * @readonly
+   */
+  get description() {
+    return this.data.description ?? null;
+  }
+
+  /**
+   * The emoji displayed beside this select menu option
+   * @type {?APIMessageComponentEmoji}
+   * @readonly
+   */
+  get emoji() {
+    return this.data.emoji ?? null;
+  }
+
+  /**
+   * Whether this option is the default option in a select menu component
+   * @type {?boolean}
+   * @readonly
+   */
+  get default() {
+    return this.data.default ?? null;
   }
 }
 

--- a/packages/discord.js/src/structures/TextInputBuilder.js
+++ b/packages/discord.js/src/structures/TextInputBuilder.js
@@ -4,7 +4,7 @@ const { TextInputBuilder: BuildersTextInput, isJSONEncodable } = require('@disco
 const Transformers = require('../util/Transformers');
 
 /**
- * Represents a text input builder.
+ * Class used to build Text Input components to be sent through the API
  * @extends {BuildersTextInput}
  */
 class TextInputBuilder extends BuildersTextInput {
@@ -22,6 +22,87 @@ class TextInputBuilder extends BuildersTextInput {
       return new this(other.toJSON());
     }
     return new this(other);
+  }
+
+  /**
+   * A unique string to be sent in the interaction when submitted
+   * @type {?string}
+   * @readonly
+   */
+  get customId() {
+    return this.data.custom_id ?? null;
+  }
+
+  /**
+   * The text to be displayed above this text input field
+   * @type {?string}
+   * @readonly
+   */
+  get label() {
+    return this.data.label ?? null;
+  }
+
+  /**
+   * The style of a text input component represented by a number. This can be:
+   * * 1 - Short
+   * * 2 - Paragraph
+   * @typedef {number} TextInputStyle
+   */
+
+  /**
+   * The style of this text input field
+   * @type {?TextInputStyle}
+   * @readonly
+   */
+  get style() {
+    return this.data.style ?? null;
+  }
+
+  /**
+   * The maximum length the input on this text input field can have
+   * @type {?number}
+   * @readonly
+   */
+  get maxLength() {
+    return this.data.max_length ?? null;
+  }
+
+  /**
+   * The minimum length the input on this text input field can have
+   * @type {?number}
+   * @readonly
+   */
+  get minLength() {
+    return this.data.min_length ?? null;
+  }
+
+  /**
+   * Whether it is required to fill in this text input field
+   * @type {?boolean}
+   * @readonly
+   */
+  get required() {
+    return this.data.required ?? null;
+  }
+
+  /**
+   * The initial value displayed in this text input field.
+   * If not modified, this will be sent through the interaction, unlike the placeholder
+   * @type {?string}
+   * @readonly
+   */
+  get value() {
+    return this.data.value ?? null;
+  }
+
+  /**
+   * The text to be displayed on this text input field when no value has been set.
+   * Will appear greyed out in the Discord UI
+   * @type {?string}
+   * @readonly
+   */
+  get placeholder() {
+    return this.data.placeholder ?? null;
   }
 }
 

--- a/packages/discord.js/src/structures/TextInputComponent.js
+++ b/packages/discord.js/src/structures/TextInputComponent.js
@@ -3,7 +3,7 @@
 const Component = require('./Component');
 
 /**
- * Represents a text input component.
+ * Represents a text input component received from the API
  * @extends {Component}
  */
 class TextInputComponent extends Component {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -17,6 +17,7 @@ import {
   quote,
   roleMention,
   SelectMenuBuilder as BuilderSelectMenuComponent,
+  SelectMenuOptionBuilder as BuilderSelectMenuOption,
   TextInputBuilder as BuilderTextInputComponent,
   UnsafeSelectMenuOptionBuilder as BuildersSelectMenuOption,
   spoiler,
@@ -600,11 +601,22 @@ export class SelectMenuBuilder extends BuilderSelectMenuComponent {
     options: (BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption)[],
   ): this;
   public static from(other: JSONEncodable<APISelectMenuComponent> | APISelectMenuComponent): SelectMenuBuilder;
+  public readonly options: SelectMenuOptionBuilder[];
+  public get placeholder(): string | null;
+  public get maxValues(): number | null;
+  public get minValues(): number | null;
+  public get customId(): string | null;
+  public get disabled(): boolean | null;
 }
 
-export class SelectMenuOptionBuilder extends BuildersSelectMenuOption {
+export class SelectMenuOptionBuilder extends BuilderSelectMenuOption {
   public constructor(data?: SelectMenuComponentOptionData | APISelectMenuOption);
   public setEmoji(emoji: ComponentEmojiResolvable): this;
+  public get label(): string | null;
+  public get value(): string | null;
+  public get description(): string | null;
+  public get emoji(): APIMessageComponentEmoji | null;
+  public get default(): boolean | null;
 }
 
 export class ModalBuilder extends BuildersModal {
@@ -615,11 +627,24 @@ export class ModalBuilder extends BuildersModal {
 export class TextInputBuilder extends BuilderTextInputComponent {
   public constructor(data?: Partial<TextInputComponentData | APITextInputComponent>);
   public static from(other: JSONEncodable<APITextInputComponent> | APITextInputComponent): TextInputBuilder;
+  public get label(): string | null;
+  public get style(): TextInputStyle | null;
+  public get maxLength(): number | null;
+  public get minLength(): number | null;
+  public get required(): boolean | null;
+  public get value(): string | null;
+  public get placeholder(): string | null;
+  public get customId(): string | null;
 }
 
 export class TextInputComponent extends Component<APITextInputComponent> {
   public get customId(): string;
   public get value(): string;
+  public get style(): ButtonStyle | null;
+  public get label(): string | null;
+  public get emoji(): APIMessageComponentEmoji | null;
+  public get disabled(): boolean | null;
+  public get url(): string | null;
 }
 
 export class SelectMenuComponent extends Component<APISelectMenuComponent> {
@@ -674,18 +699,29 @@ export class EmbedBuilder extends BuildersEmbed {
   public constructor(data?: EmbedData | APIEmbed);
   public override setColor(color: ColorResolvable | null): this;
   public static from(other: JSONEncodable<APIEmbed> | APIEmbed): EmbedBuilder;
+  public get fields(): APIEmbedField[] | null;
+  public get title(): string | null;
+  public get description(): string | null;
+  public get url(): string | null;
+  public get color(): number | null;
+  public get timestamp(): string | null;
+  public get thumbnail(): EmbedImageData | null;
+  public get image(): EmbedImageData | null;
+  public get author(): EmbedAuthorData | null;
+  public get footer(): EmbedFooterData | null;
+  public get length(): number;
+  public get hexColor(): HexColorString | null;
 }
 
 export class Embed {
   private constructor(data: APIEmbed);
   public readonly data: Readonly<APIEmbed>;
   public get fields(): APIEmbedField[] | null;
-  public get footer(): EmbedFooterData | null;
   public get title(): string | null;
   public get description(): string | null;
   public get url(): string | null;
   public get color(): number | null;
-  public get hexColor(): string | null;
+  public get hexColor(): HexColorString | null;
   public get timestamp(): string | null;
   public get thumbnail(): EmbedImageData | null;
   public get image(): EmbedImageData | null;
@@ -693,6 +729,7 @@ export class Embed {
   public get provider(): EmbedProviderData | null;
   public get video(): EmbedVideoData | null;
   public get length(): number;
+  public get footer(): EmbedFooterData | null;
   public equals(other: Embed | APIEmbed): boolean;
   public toJSON(): APIEmbed;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds back getters to the builder classes in discord.js that were removed in #7584 as that PR didn't take into account the possibility of creating agnostic functions that accept builder instances as input and modify them according to their props. 
I also fixed the docs in some places related to this (aka component classes)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
