### PR TITLE
types: Fix auto archive duration type

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -13,6 +13,7 @@ const Webhook = require('../structures/Webhook');
 const { ThreadChannelTypes } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const Util = require('../util/Util');
+const { resolveAutoArchiveMaxLimit } = require('../util/Util');
 
 let cacheWarningEmitted = false;
 let storeChannelDeprecationEmitted = false;
@@ -262,14 +263,7 @@ class GuildChannelManager extends CachedManager {
     }
 
     let defaultAutoArchiveDuration = data.defaultAutoArchiveDuration;
-    if (defaultAutoArchiveDuration === 'MAX') {
-      defaultAutoArchiveDuration = 1440;
-      if (this.guild.features.includes('SEVEN_DAY_THREAD_ARCHIVE')) {
-        defaultAutoArchiveDuration = 10080;
-      } else if (this.guild.features.includes('THREE_DAY_THREAD_ARCHIVE')) {
-        defaultAutoArchiveDuration = 4320;
-      }
-    }
+    if (defaultAutoArchiveDuration === 'MAX') defaultAutoArchiveDuration = resolveAutoArchiveMaxLimit(this.guild);
 
     const newData = await this.client.rest.patch(Routes.channel(channel.id), {
       body: {

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -261,6 +261,16 @@ class GuildChannelManager extends CachedManager {
       }
     }
 
+    let defaultAutoArchiveDuration = data.defaultAutoArchiveDuration;
+    if (defaultAutoArchiveDuration === 'MAX') {
+      defaultAutoArchiveDuration = 1440;
+      if (this.guild.features.includes('SEVEN_DAY_THREAD_ARCHIVE')) {
+        defaultAutoArchiveDuration = 10080;
+      } else if (this.guild.features.includes('THREE_DAY_THREAD_ARCHIVE')) {
+        defaultAutoArchiveDuration = 4320;
+      }
+    }
+
     const newData = await this.client.rest.patch(Routes.channel(channel.id), {
       body: {
         name: (data.name ?? channel.name).trim(),
@@ -273,7 +283,7 @@ class GuildChannelManager extends CachedManager {
         parent_id: parent,
         lock_permissions: data.lockPermissions,
         rate_limit_per_user: data.rateLimitPerUser,
-        default_auto_archive_duration: data.defaultAutoArchiveDuration,
+        default_auto_archive_duration: defaultAutoArchiveDuration,
         permission_overwrites,
       },
       reason,

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -121,7 +121,7 @@ class ThreadManager extends CachedManager {
       resolvedType = type ?? resolvedType;
     }
 
-    if (autoArchiveDuration === 'MAX') resolveAutoArchiveMaxLimit(this.channel.guild);
+    if (autoArchiveDuration === 'MAX') autoArchiveDuration = resolveAutoArchiveMaxLimit(this.channel.guild);
 
     const data = await this.client.rest.post(Routes.threads(this.channel.id, startMessageId), {
       body: {

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -5,6 +5,7 @@ const { ChannelType, Routes } = require('discord-api-types/v10');
 const CachedManager = require('./CachedManager');
 const { TypeError } = require('../errors');
 const ThreadChannel = require('../structures/ThreadChannel');
+const { resolveAutoArchiveMaxLimit } = require('../util/Util');
 
 /**
  * Manages API methods for {@link ThreadChannel} objects and stores their cache.
@@ -119,14 +120,8 @@ class ThreadManager extends CachedManager {
     } else if (this.channel.type !== ChannelType.GuildNews) {
       resolvedType = type ?? resolvedType;
     }
-    if (autoArchiveDuration === 'MAX') {
-      autoArchiveDuration = 1440;
-      if (this.channel.guild.features.includes('SEVEN_DAY_THREAD_ARCHIVE')) {
-        autoArchiveDuration = 10080;
-      } else if (this.channel.guild.features.includes('THREE_DAY_THREAD_ARCHIVE')) {
-        autoArchiveDuration = 4320;
-      }
-    }
+
+    if (autoArchiveDuration === 'MAX') resolveAutoArchiveMaxLimit(this.channel.guild);
 
     const data = await this.client.rest.post(Routes.threads(this.channel.id, startMessageId), {
       body: {

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -69,7 +69,7 @@ class BaseGuildTextChannel extends GuildChannel {
     if ('default_auto_archive_duration' in data) {
       /**
        * The default auto archive duration for newly created threads in this channel
-       * @type {?ThreadAutoArchiveDuration}
+       * @type {?number}
        */
       this.defaultAutoArchiveDuration = data.default_auto_archive_duration;
     }

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -6,6 +6,7 @@ const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { RangeError } = require('../errors');
 const MessageManager = require('../managers/MessageManager');
 const ThreadMemberManager = require('../managers/ThreadMemberManager');
+const { resolveAutoArchiveMaxLimit } = require('../util/Util');
 
 /**
  * Represents a thread channel on Discord.
@@ -313,14 +314,8 @@ class ThreadChannel extends Channel {
    */
   async edit(data, reason) {
     let autoArchiveDuration = data.autoArchiveDuration;
-    if (data.autoArchiveDuration === 'MAX') {
-      autoArchiveDuration = 1440;
-      if (this.guild.features.includes('SEVEN_DAY_THREAD_ARCHIVE')) {
-        autoArchiveDuration = 10080;
-      } else if (this.guild.features.includes('THREE_DAY_THREAD_ARCHIVE')) {
-        autoArchiveDuration = 4320;
-      }
-    }
+    if (autoArchiveDuration === 'MAX') autoArchiveDuration = resolveAutoArchiveMaxLimit(this.guild);
+
     const newData = await this.client.rest.patch(Routes.channel(this.id), {
       body: {
         name: (data.name ?? this.name).trim(),

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -2,7 +2,7 @@
 
 const { parse } = require('node:path');
 const { Collection } = require('@discordjs/collection');
-const { ChannelType, RouteBases, Routes } = require('discord-api-types/v10');
+const { ChannelType, RouteBases, Routes, GuildFeature } = require('discord-api-types/v10');
 const { fetch } = require('undici');
 const Colors = require('./Colors');
 const { Error: DiscordError, RangeError, TypeError } = require('../errors');
@@ -560,6 +560,17 @@ class Util extends null {
    */
   static cleanCodeBlockContent(text) {
     return text.replaceAll('```', '`\u200b``');
+  }
+
+  /**
+   * Resolves the maximum time a guild's thread channels should automatcally archived in case of no recent activity.
+   * @param {Guild} guild The guild to resolve this limit from.
+   * @returns {number}
+   */
+  static resolveAutoArchiveMaxLimit({ features }) {
+    if (features.includes(GuildFeature.SevenDayThreadArchive)) return 10080;
+    if (features.includes(GuildFeature.ThreeDayThreadArchive)) return 4320;
+    return 1440;
   }
 }
 

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -563,7 +563,7 @@ class Util extends null {
   }
 
   /**
-   * Resolves the maximum time a guild's thread channels should automatcally archived in case of no recent activity.
+   * Resolves the maximum time a guild's thread channels should automatcally archive in case of no recent activity.
    * @param {Guild} guild The guild to resolve this limit from.
    * @returns {number}
    */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3672,7 +3672,7 @@ export interface ChannelData {
   rateLimitPerUser?: number;
   lockPermissions?: boolean;
   permissionOverwrites?: readonly OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
-  defaultAutoArchiveDuration?: ThreadAutoArchiveDuration;
+  defaultAutoArchiveDuration?: ThreadAutoArchiveDuration | 'MAX';
   rtcRegion?: string | null;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -462,7 +462,7 @@ export class BaseGuildTextChannel extends TextBasedChannelMixin(GuildChannel) {
   public createWebhook(name: string, options?: ChannelWebhookCreateOptions): Promise<Webhook>;
   public fetchInvites(cache?: boolean): Promise<Collection<string, Invite>>;
   public setDefaultAutoArchiveDuration(
-    defaultAutoArchiveDuration: ThreadAutoArchiveDuration,
+    defaultAutoArchiveDuration: ThreadAutoArchiveDuration | 'MAX',
     reason?: string,
   ): Promise<this>;
   public setNSFW(nsfw?: boolean, reason?: string): Promise<this>;
@@ -2393,7 +2393,7 @@ export class ThreadChannel extends TextBasedChannelMixin(Channel) {
   public fetchStarterMessage(options?: BaseFetchOptions): Promise<Message>;
   public setArchived(archived?: boolean, reason?: string): Promise<ThreadChannel>;
   public setAutoArchiveDuration(
-    autoArchiveDuration: ThreadAutoArchiveDuration,
+    autoArchiveDuration: ThreadAutoArchiveDuration | 'MAX',
     reason?: string,
   ): Promise<ThreadChannel>;
   public setInvitable(invitable?: boolean, reason?: string): Promise<ThreadChannel>;
@@ -5139,7 +5139,7 @@ export type TextChannelResolvable = Snowflake | TextChannel;
 
 export type TextBasedChannelResolvable = Snowflake | TextBasedChannel;
 
-export type ThreadAutoArchiveDuration = 60 | 1440 | 4320 | 10080 | 'MAX';
+export type ThreadAutoArchiveDuration = 60 | 1440 | 4320 | 10080;
 
 export type ThreadChannelResolvable = ThreadChannel | Snowflake;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Channels store the properties as numbers as-is from the API and the edit methods allow for a `MAX` helper. This pull request resolves #7687 and resolves supplying `MAX` via `GuildChannelManager#edit()` not working as intended.

Additionally, this paring has been refactored into a utility method for deduplication reasons.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
