### PR TITLE
fix(gateway): use version 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const commands = [
 	},
 ];
 
-const rest = new REST({ version: '9' }).setToken('token');
+const rest = new REST({ version: '10' }).setToken('token');
 
 (async () => {
 	try {

--- a/packages/discord.js/README.md
+++ b/packages/discord.js/README.md
@@ -63,7 +63,7 @@ const commands = [
   },
 ];
 
-const rest = new REST({ version: '9' }).setToken('token');
+const rest = new REST({ version: '10' }).setToken('token');
 
 (async () => {
   try {

--- a/packages/discord.js/src/util/Options.js
+++ b/packages/discord.js/src/util/Options.js
@@ -87,7 +87,7 @@ class Options extends null {
           $browser: 'discord.js',
           $device: 'discord.js',
         },
-        version: 9,
+        version: 10,
       },
       rest: DefaultRestOptions,
       jsonTransformer: Transformers.toSnakeCase,

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -81,7 +81,7 @@ export interface RESTOptions {
 	userAgentAppendix: string;
 	/**
 	 * The version of the API to use
-	 * @default '9'
+	 * @default '10'
 	 */
 	version: string;
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Djs incorrectly defaulted to v9 instead of v10.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)