### PR TITLE
refactor(GuildAuditLogs): Remove static build method

### DIFF
--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -733,7 +733,7 @@ class Guild extends AnonymousGuild {
     }
 
     const data = await this.client.rest.get(Routes.guildAuditLog(this.id), { query });
-    return GuildAuditLogs.build(this, data);
+    return new GuildAuditLogs(this, data);
   }
 
   /**

--- a/packages/discord.js/src/structures/GuildAuditLogs.js
+++ b/packages/discord.js/src/structures/GuildAuditLogs.js
@@ -66,16 +66,6 @@ class GuildAuditLogs {
     }
   }
 
-  /**
-   * Handles possible promises for entry targets.
-   * @returns {Promise<GuildAuditLogs>}
-   */
-  static async build(...args) {
-    const logs = new GuildAuditLogs(...args);
-    await Promise.all(logs.entries.map(e => e.target));
-    return logs;
-  }
-
   toJSON() {
     return Util.flatten(this);
   }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1131,7 +1131,6 @@ export class GuildAuditLogs<T extends GuildAuditLogsResolvable = null> {
   private integrations: Collection<Snowflake | string, Integration>;
   public entries: Collection<Snowflake, GuildAuditLogsEntry<T>>;
   public static Entry: typeof GuildAuditLogsEntry;
-  public static build(...args: unknown[]): Promise<GuildAuditLogs>;
   public toJSON(): unknown;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
After #1660 and #7089, there are no more possible `Promise`s in the constructor of `GuildAuditLogs` and `GuildAuditLogsEntry`. Therefore, this method is redundant.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
