### PR TITLE
docs: Add back static properties and methods

### DIFF
--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -66,6 +66,7 @@ class GuildAuditLogsEntry {
   /**
    * Key mirror of all available audit log targets.
    * @type {Object<string, string>}
+   * @memberof GuildAuditLogsEntry
    */
   static Targets = Targets;
 

--- a/packages/discord.js/src/structures/GuildTemplate.js
+++ b/packages/discord.js/src/structures/GuildTemplate.js
@@ -14,6 +14,7 @@ class GuildTemplate extends Base {
   /**
    * Regular expression that globally matches guild template links
    * @type {RegExp}
+   * @memberof GuildTemplate
    */
   static GuildTemplatesPattern = /discord(?:app)?\.(?:com\/template|new)\/([\w-]{2,255})/gi;
 

--- a/packages/discord.js/src/structures/Invite.js
+++ b/packages/discord.js/src/structures/Invite.js
@@ -15,6 +15,7 @@ class Invite extends Base {
   /**
    * Regular expression that globally matches Discord invite links
    * @type {RegExp}
+   * @memberof Invite
    */
   static InvitesPattern = /discord(?:(?:app)?\.com\/invite|\.gg(?:\/invite)?)\/([\w-]{2,255})/gi;
 

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -10,24 +10,28 @@ class MessageMentions {
   /**
    * Regular expression that globally matches `@everyone` and `@here`
    * @type {RegExp}
+   * @memberof MessageMentions
    */
   static EveryonePattern = /@(everyone|here)/g;
 
   /**
    * Regular expression that globally matches user mentions like `<@81440962496172032>`
    * @type {RegExp}
+   * @memberof MessageMentions
    */
   static UsersPattern = /<@!?(\d{17,19})>/g;
 
   /**
    * Regular expression that globally matches role mentions like `<@&297577916114403338>`
    * @type {RegExp}
+   * @memberof MessageMentions
    */
   static RolesPattern = /<@&(\d{17,19})>/g;
 
   /**
    * Regular expression that globally matches channel mentions like `<#222079895583457280>`
    * @type {RegExp}
+   * @memberof MessageMentions
    */
   static ChannelsPattern = /<#(\d{17,19})>/g;
 

--- a/packages/discord.js/src/util/ActivityFlagsBitField.js
+++ b/packages/discord.js/src/util/ActivityFlagsBitField.js
@@ -11,6 +11,7 @@ class ActivityFlagsBitField extends BitField {
   /**
    * Numeric activity flags.
    * @type {ActivityFlags}
+   * @memberof ActivityFlagsBitField
    */
   static Flags = ActivityFlags;
 }

--- a/packages/discord.js/src/util/ApplicationFlagsBitField.js
+++ b/packages/discord.js/src/util/ApplicationFlagsBitField.js
@@ -11,6 +11,7 @@ class ApplicationFlagsBitField extends BitField {
   /**
    * Numeric application flags. All available properties:
    * @type {ApplicationFlags}
+   * @memberof ApplicationFlagsBitField
    */
   static Flags = ApplicationFlags;
 }

--- a/packages/discord.js/src/util/BitField.js
+++ b/packages/discord.js/src/util/BitField.js
@@ -10,12 +10,14 @@ class BitField {
    * Numeric bitfield flags.
    * <info>Defined in extension classes</info>
    * @type {Object}
+   * @memberof BitField
    * @abstract
    */
   static Flags = {};
 
   /**
    * @type {number|bigint}
+   * @memberof BitField
    * @private
    */
   static DefaultBit = 0;

--- a/packages/discord.js/src/util/Formatters.js
+++ b/packages/discord.js/src/util/Formatters.js
@@ -28,6 +28,7 @@ class Formatters extends null {
   /**
    * Formats the content into a block quote. This needs to be at the start of the line for Discord to format it.
    * @method blockQuote
+   * @memberof Formatters
    * @param {string} content The content to wrap.
    * @returns {string}
    */
@@ -36,6 +37,7 @@ class Formatters extends null {
   /**
    * Formats the content into bold text.
    * @method bold
+   * @memberof Formatters
    * @param {string} content The content to wrap.
    * @returns {string}
    */
@@ -44,6 +46,7 @@ class Formatters extends null {
   /**
    * Formats a channel id into a channel mention.
    * @method channelMention
+   * @memberof Formatters
    * @param {string} channelId The channel id to format.
    * @returns {string}
    */
@@ -52,6 +55,7 @@ class Formatters extends null {
   /**
    * Wraps the content inside a code block with an optional language.
    * @method codeBlock
+   * @memberof Formatters
    * @param {string} contentOrLanguage The language to use, content if a second parameter isn't provided.
    * @param {string} [content] The content to wrap.
    * @returns {string}
@@ -61,6 +65,8 @@ class Formatters extends null {
   /**
    * Formats an emoji id into a fully qualified emoji identifier
    * @method formatEmoji
+   * @memberof Formatters
+   * @memberof Formatters
    * @param {string} emojiId The emoji id to format.
    * @param {boolean} [animated] Whether the emoji is animated or not. Defaults to `false`
    * @returns {string}
@@ -70,6 +76,7 @@ class Formatters extends null {
   /**
    * Wraps the URL into `<>`, which stops it from embedding.
    * @method hideLinkEmbed
+   * @memberof Formatters
    * @param {string} content The content to wrap.
    * @returns {string}
    */
@@ -78,6 +85,7 @@ class Formatters extends null {
   /**
    * Formats the content and the URL into a masked URL with an optional title.
    * @method hyperlink
+   * @memberof Formatters
    * @param {string} content The content to display.
    * @param {string} url The URL the content links to.
    * @param {string} [title] The title shown when hovering on the masked link.
@@ -88,6 +96,7 @@ class Formatters extends null {
   /**
    * Wraps the content inside \`backticks\`, which formats it as inline code.
    * @method inlineCode
+   * @memberof Formatters
    * @param {string} content The content to wrap.
    * @returns {string}
    */
@@ -96,6 +105,7 @@ class Formatters extends null {
   /**
    * Formats the content into italic text.
    * @method italic
+   * @memberof Formatters
    * @param {string} content The content to wrap.
    * @returns {string}
    */
@@ -104,6 +114,7 @@ class Formatters extends null {
   /**
    * Formats a user id into a member-nickname mention.
    * @method memberNicknameMention
+   * @memberof Formatters
    * @param {string} memberId The user id to format.
    * @returns {string}
    */
@@ -112,6 +123,7 @@ class Formatters extends null {
   /**
    * Formats the content into a quote. This needs to be at the start of the line for Discord to format it.
    * @method quote
+   * @memberof Formatters
    * @param {string} content The content to wrap.
    * @returns {string}
    */
@@ -120,6 +132,7 @@ class Formatters extends null {
   /**
    * Formats a role id into a role mention.
    * @method roleMention
+   * @memberof Formatters
    * @param {string} roleId The role id to format.
    * @returns {string}
    */
@@ -128,6 +141,7 @@ class Formatters extends null {
   /**
    * Formats the content into spoiler text.
    * @method spoiler
+   * @memberof Formatters
    * @param {string} content The content to spoiler.
    * @returns {string}
    */
@@ -136,6 +150,7 @@ class Formatters extends null {
   /**
    * Formats the content into strike-through text.
    * @method strikethrough
+   * @memberof Formatters
    * @param {string} content The content to wrap.
    * @returns {string}
    */
@@ -144,6 +159,7 @@ class Formatters extends null {
   /**
    * Formats a date into a short date-time string.
    * @method time
+   * @memberof Formatters
    * @param {number|Date} [date] The date to format.
    * @param {TimestampStylesString} [style] The style to use.
    * @returns {string}
@@ -167,12 +183,14 @@ class Formatters extends null {
    * The message formatting timestamp
    * [styles](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles) supported by Discord.
    * @type {Object<string, TimestampStylesString>}
+   * @memberof Formatters
    */
   static TimestampStyles = TimestampStyles;
 
   /**
    * Formats the content into underscored text.
    * @method underscore
+   * @memberof Formatters
    * @param {string} content The content to wrap.
    * @returns {string}
    */
@@ -181,6 +199,7 @@ class Formatters extends null {
   /**
    * Formats a user id into a user mention.
    * @method userMention
+   * @memberof Formatters
    * @param {string} userId The user id to format.
    * @returns {string}
    */

--- a/packages/discord.js/src/util/IntentsBitField.js
+++ b/packages/discord.js/src/util/IntentsBitField.js
@@ -10,6 +10,7 @@ class IntentsBitField extends BitField {
   /**
    * Numeric WebSocket intents
    * @type {GatewayIntentBits}
+   * @memberof IntentsBitField
    */
   static Flags = GatewayIntentBits;
 }

--- a/packages/discord.js/src/util/MessageFlagsBitField.js
+++ b/packages/discord.js/src/util/MessageFlagsBitField.js
@@ -11,6 +11,7 @@ class MessageFlagsBitField extends BitField {
   /**
    * Numeric message flags.
    * @type {MessageFlags}
+   * @memberof MessageFlagsBitField
    */
   static Flags = MessageFlags;
 }

--- a/packages/discord.js/src/util/PermissionsBitField.js
+++ b/packages/discord.js/src/util/PermissionsBitField.js
@@ -13,6 +13,7 @@ class PermissionsBitField extends BitField {
   /**
    * Numeric permission flags.
    * @type {PermissionFlagsBits}
+   * @memberof PermissionsBitField
    * @see {@link https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags}
    */
   static Flags = PermissionFlagsBits;
@@ -20,22 +21,30 @@ class PermissionsBitField extends BitField {
   /**
    * Bitfield representing every permission combined
    * @type {bigint}
+   * @memberof PermissionsBitField
    */
   static All = Object.values(PermissionFlagsBits).reduce((all, p) => all | p, 0n);
 
   /**
    * Bitfield representing the default permissions for users
    * @type {bigint}
+   * @memberof PermissionsBitField
    */
   static Default = BigInt(104324673);
 
   /**
    * Bitfield representing the permissions required for moderators of stage channels
    * @type {bigint}
+   * @memberof PermissionsBitField
    */
   static StageModerator =
     PermissionFlagsBits.ManageChannels | PermissionFlagsBits.MuteMembers | PermissionFlagsBits.MoveMembers;
 
+  /**
+   * @type {bigint}
+   * @memberof PermissionsBitField
+   * @private
+   */
   static DefaultBit = BigInt(0);
 
   /**

--- a/packages/discord.js/src/util/SystemChannelFlagsBitField.js
+++ b/packages/discord.js/src/util/SystemChannelFlagsBitField.js
@@ -13,6 +13,7 @@ class SystemChannelFlagsBitField extends BitField {
   /**
    * Numeric system channel flags.
    * @type {GuildSystemChannelFlags}
+   * @memberof SystemChannelFlagsBitField
    */
   static Flags = GuildSystemChannelFlags;
 }

--- a/packages/discord.js/src/util/ThreadMemberFlagsBitField.js
+++ b/packages/discord.js/src/util/ThreadMemberFlagsBitField.js
@@ -10,6 +10,7 @@ class ThreadMemberFlagsBitField extends BitField {
   /**
    * Numeric thread member flags. There are currently no bitflags relevant to bots for this.
    * @type {Object<string, number>}
+   * @memberof ThreadMemberFlagsBitField
    */
   static Flags = {};
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Regression from #7701: Removing the `@memberof` JSDoc resulted in static properties being incorrectly documented from the instance and static methods no longer existing.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
