### PR TITLE
feat: allow emoji strings to be passed through constructors

### DIFF
--- a/packages/discord.js/src/structures/ButtonBuilder.js
+++ b/packages/discord.js/src/structures/ButtonBuilder.js
@@ -5,8 +5,10 @@ const Transformers = require('../util/Transformers');
 const Util = require('../util/Util');
 
 class ButtonBuilder extends BuildersButtonComponent {
-  constructor(data) {
-    super(Transformers.toSnakeCase(data));
+  constructor({ emoji, ...data }) {
+    super(
+      Transformers.toSnakeCase({ emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji, ...data }),
+    );
   }
 
   /**

--- a/packages/discord.js/src/structures/ButtonBuilder.js
+++ b/packages/discord.js/src/structures/ButtonBuilder.js
@@ -7,7 +7,7 @@ const Util = require('../util/Util');
 class ButtonBuilder extends BuildersButtonComponent {
   constructor({ emoji, ...data }) {
     super(
-      Transformers.toSnakeCase({ emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji, ...data }),
+      Transformers.toSnakeCase({ ...data, emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji }),
     );
   }
 

--- a/packages/discord.js/src/structures/SelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuBuilder.js
@@ -9,8 +9,8 @@ class SelectMenuBuilder extends BuildersSelectMenuComponent {
     super(
       Transformers.toSnakeCase({
         options: options.map(({ emoji, ...option }) => ({
-          emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji,
           ...option,
+          emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji,
         })),
         ...data,
       }),

--- a/packages/discord.js/src/structures/SelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuBuilder.js
@@ -2,10 +2,19 @@
 
 const { SelectMenuBuilder: BuildersSelectMenuComponent, isJSONEncodable } = require('@discordjs/builders');
 const Transformers = require('../util/Transformers');
+const Util = require('../util/Util');
 
 class SelectMenuBuilder extends BuildersSelectMenuComponent {
-  constructor(data) {
-    super(Transformers.toSnakeCase(data));
+  constructor({ options, ...data }) {
+    super(
+      Transformers.toSnakeCase({
+        options: options.map(({ emoji, ...option }) => ({
+          emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji,
+          ...option,
+        })),
+        ...data,
+      }),
+    );
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4679,7 +4679,7 @@ export interface MessageActivity {
 
 export interface BaseButtonComponentData extends BaseComponentData {
   disabled?: boolean;
-  emoji?: APIMessageComponentEmoji;
+  emoji?: ComponentEmojiResolvable;
   label?: string;
 }
 
@@ -4815,7 +4815,7 @@ export interface MessageSelectOption {
 export interface SelectMenuComponentOptionData {
   default?: boolean;
   description?: string;
-  emoji?: APIMessageComponentEmoji;
+  emoji?: ComponentEmojiResolvable;
   label: string;
   value: string;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the feature from #7616 to builder constructors

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
