### PR TITLE
fix: Pass `force` correctly

### DIFF
--- a/packages/discord.js/src/structures/DMChannel.js
+++ b/packages/discord.js/src/structures/DMChannel.js
@@ -86,7 +86,7 @@ class DMChannel extends Channel {
    * @returns {Promise<DMChannel>}
    */
   fetch(force = true) {
-    return this.client.users.createDM(this.recipientId, force);
+    return this.client.users.createDM(this.recipientId, { force });
   }
 
   /**

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -210,7 +210,7 @@ class User extends Base {
    * @returns {Promise<DMChannel>}
    */
   createDM(force = false) {
-    return this.client.users.createDM(this.id, force);
+    return this.client.users.createDM(this.id, { force });
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
These methods passed `force` as a boolean. However, the second parameter is an object:

https://github.com/discordjs/discord.js/blob/520f471ac56cbc01402b79197333a8a34c4ac5c9/packages/discord.js/src/managers/UserManager.js#L45-L51

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
