### PR TITLE
feat(VoiceChannel): Support `video_quality_mode`

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -223,6 +223,7 @@ class GuildChannelManager extends CachedManager {
    * @property {ThreadAutoArchiveDuration} [defaultAutoArchiveDuration]
    * The default auto archive duration for all new threads in this channel
    * @property {?string} [rtcRegion] The RTC region of the channel
+   * @property {?VideoQualityMode} [videoQualityMode] The camera video quality mode of the channel
    */
 
   /**
@@ -274,6 +275,7 @@ class GuildChannelManager extends CachedManager {
         bitrate: data.bitrate ?? channel.bitrate,
         user_limit: data.userLimit ?? channel.userLimit,
         rtc_region: data.rtcRegion ?? channel.rtcRegion,
+        video_quality_mode: data.videoQualityMode,
         parent_id: parent,
         lock_permissions: data.lockPermissions,
         rate_limit_per_user: data.rateLimitPerUser,

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -88,6 +88,7 @@ class GuildManager extends CachedManager {
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel
    * @property {?string} [rtcRegion] The RTC region of the channel
+   * @property {VideoQualityMode} [videoQualityMode] The camera video quality mode of the channel
    * @property {PartialOverwriteData[]} [permissionOverwrites]
    * Overwrites of the channel
    * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) of the channel in seconds
@@ -185,6 +186,8 @@ class GuildManager extends CachedManager {
       delete channel.rateLimitPerUser;
       channel.rtc_region = channel.rtcRegion;
       delete channel.rtcRegion;
+      channel.video_quality_mode = channel.videoQualityMode;
+      delete channel.videoQualityMode;
 
       if (!channel.permissionOverwrites) continue;
       for (const overwrite of channel.permissionOverwrites) {

--- a/packages/discord.js/src/structures/VoiceChannel.js
+++ b/packages/discord.js/src/structures/VoiceChannel.js
@@ -8,6 +8,20 @@ const BaseGuildVoiceChannel = require('./BaseGuildVoiceChannel');
  * @extends {BaseGuildVoiceChannel}
  */
 class VoiceChannel extends BaseGuildVoiceChannel {
+  _patch(data) {
+    super._patch(data);
+
+    if ('video_quality_mode' in data) {
+      /**
+       * The camera video quality mode of the channel.
+       * @type {?VideoQualityMode}
+       */
+      this.videoQualityMode = data.video_quality_mode;
+    } else {
+      this.videoQualityMode ??= null;
+    }
+  }
+
   /**
    * Whether the channel is joinable by the client user
    * @type {boolean}
@@ -64,6 +78,16 @@ class VoiceChannel extends BaseGuildVoiceChannel {
    */
   setUserLimit(userLimit, reason) {
     return this.edit({ userLimit }, reason);
+  }
+
+  /**
+   * Sets the camera video quality mode the channel.
+   * @param {VideoQualityMode} videoQualityMode The new camera video quality mode.
+   * @param {string} [reason] Reason for changing the camera video quality mode.
+   * @returns {Promise<VoiceChannel>}
+   */
+  setVideoQualityMode(videoQualityMode, reason) {
+    return this.edit({ videoQualityMode }, reason);
   }
 
   /**

--- a/packages/discord.js/src/structures/VoiceChannel.js
+++ b/packages/discord.js/src/structures/VoiceChannel.js
@@ -81,7 +81,7 @@ class VoiceChannel extends BaseGuildVoiceChannel {
   }
 
   /**
-   * Sets the camera video quality mode the channel.
+   * Sets the camera video quality mode of the channel.
    * @param {VideoQualityMode} videoQualityMode The new camera video quality mode.
    * @param {string} [reason] Reason for changing the camera video quality mode.
    * @returns {Promise<VoiceChannel>}

--- a/packages/discord.js/src/util/EnumResolvers.js
+++ b/packages/discord.js/src/util/EnumResolvers.js
@@ -21,6 +21,7 @@ const {
   GuildScheduledEventEntityType,
   IntegrationExpireBehavior,
   AuditLogEvent,
+  VideoQualityMode,
 } = require('discord-api-types/v10');
 
 function unknownKeyStrategy(val) {
@@ -781,6 +782,29 @@ class EnumResolvers extends null {
         return AuditLogEvent.ThreadUpdate;
       case 'THREAD_DELETE':
         return AuditLogEvent.ThreadDelete;
+      default:
+        return unknownKeyStrategy(key);
+    }
+  }
+
+  /**
+   * A string that can be resolved to a {@link VideoQualityMode} enum value. Here are the available types:
+   * * AUTO (automatic)
+   * * FULL (720p)
+   * @typedef {string} VideoQualityModeEnumResolvable
+   */
+
+  /**
+   * Resolves enum key to {@link VideoQualityMode} enum value
+   * @param {VideoQualityModeEnumResolvable|VideoQualityMode} key The key to lookup
+   * @returns {VideoQualityMode}
+   */
+  static resolveVideoQualityMode(key) {
+    switch (key) {
+      case 'AUTO':
+        return VideoQualityMode.Auto;
+      case 'FULL':
+        return VideoQualityMode.Full;
       default:
         return unknownKeyStrategy(key);
     }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -111,6 +111,7 @@ import {
   APIEmbedAuthor,
   APIEmbedFooter,
   APIEmbedImage,
+  VideoQualityMode,
 } from 'discord-api-types/v10';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -998,6 +999,7 @@ export class EnumResolvers extends null {
     key: IntegrationExpireBehaviorEnumResolvable | IntegrationExpireBehavior,
   ): IntegrationExpireBehavior;
   public static resolveAuditLogEvent(key: AuditLogEventEnumResolvable | AuditLogEvent): AuditLogEvent;
+  public static resolveVideoQualityMode(key: VideoQualityModeEnumResolvable | VideoQualityMode): VideoQualityMode;
 }
 
 export class DMChannel extends TextBasedChannelMixin(Channel, ['bulkDelete']) {
@@ -2569,10 +2571,12 @@ export type ComponentData =
   | ActionRowData<MessageActionRowComponentData | ModalActionRowComponentData>;
 
 export class VoiceChannel extends BaseGuildVoiceChannel {
+  public videoQualityMode: VideoQualityMode;
   public get speakable(): boolean;
   public type: ChannelType.GuildVoice;
   public setBitrate(bitrate: number, reason?: string): Promise<VoiceChannel>;
   public setUserLimit(userLimit: number, reason?: string): Promise<VoiceChannel>;
+  public setVideoQualityMode(videoQualityMode: VideoQualityMode, reason?: string): Promise<VoiceChannel>;
 }
 
 export class VoiceRegion {
@@ -3688,6 +3692,7 @@ export interface ChannelData {
   permissionOverwrites?: readonly OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
   defaultAutoArchiveDuration?: ThreadAutoArchiveDuration | 'MAX';
   rtcRegion?: string | null;
+  videoQualityMode?: VideoQualityMode | null;
 }
 
 export interface ChannelLogsQueryOptions {
@@ -4173,6 +4178,8 @@ export type AuditLogEventEnumResolvable =
   | 'THREAD_CREATE'
   | 'THREAD_UPDATE'
   | 'THREAD_DELETE';
+
+export type VideoQualityModeEnumResolvable = 'AUTO' | 'FULL';
 
 export interface ErrorEvent {
   error: unknown;
@@ -4914,6 +4921,7 @@ export interface PartialChannelData {
   bitrate?: number;
   userLimit?: number;
   rtcRegion?: string | null;
+  videoQualityMode?: VideoQualityMode;
   permissionOverwrites?: PartialOverwriteData[];
   rateLimitPerUser?: number;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Discord has [`video_quality_mode`](https://discord.com/developers/docs/resources/channel#channel-object) documented, but we have no support for it. No more will that be the case!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
