### PR TITLE
fix: Support `reason` in `setRTCRegion` helpers

### DIFF
--- a/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
@@ -82,17 +82,18 @@ class BaseGuildVoiceChannel extends GuildChannel {
 
   /**
    * Sets the RTC region of the channel.
-   * @param {?string} region The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {?string} rtcRegion The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {string} [reason] The reason for modifying this region.
    * @returns {Promise<BaseGuildVoiceChannel>}
    * @example
-   * // Set the RTC region to europe
-   * channel.setRTCRegion('europe');
+   * // Set the RTC region to sydney
+   * channel.setRTCRegion('sydney');
    * @example
    * // Remove a fixed region for this channel - let Discord decide automatically
-   * channel.setRTCRegion(null);
+   * channel.setRTCRegion(null, 'We want to let Discord decide.');
    */
-  setRTCRegion(region) {
-    return this.edit({ rtcRegion: region });
+  setRTCRegion(rtcRegion, reason) {
+    return this.edit({ rtcRegion }, reason);
   }
 
   /**

--- a/packages/discord.js/src/structures/StageChannel.js
+++ b/packages/discord.js/src/structures/StageChannel.js
@@ -55,14 +55,15 @@ class StageChannel extends BaseGuildVoiceChannel {
   /**
    * Sets the RTC region of the channel.
    * @name StageChannel#setRTCRegion
-   * @param {?string} region The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {?string} rtcRegion The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {string} [reason] The reason for modifying this region.
    * @returns {Promise<StageChannel>}
    * @example
-   * // Set the RTC region to europe
-   * stageChannel.setRTCRegion('europe');
+   * // Set the RTC region to sydney
+   * stageChannel.setRTCRegion('sydney');
    * @example
    * // Remove a fixed region for this channel - let Discord decide automatically
-   * stageChannel.setRTCRegion(null);
+   * stageChannel.setRTCRegion(null, 'We want to let Discord decide.');
    */
 }
 

--- a/packages/discord.js/src/structures/VoiceChannel.js
+++ b/packages/discord.js/src/structures/VoiceChannel.js
@@ -69,14 +69,15 @@ class VoiceChannel extends BaseGuildVoiceChannel {
   /**
    * Sets the RTC region of the channel.
    * @name VoiceChannel#setRTCRegion
-   * @param {?string} region The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {?string} rtcRegion The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {string} [reason] The reason for modifying this region.
    * @returns {Promise<VoiceChannel>}
    * @example
-   * // Set the RTC region to europe
-   * voiceChannel.setRTCRegion('europe');
+   * // Set the RTC region to sydney
+   * voiceChannel.setRTCRegion('sydney');
    * @example
    * // Remove a fixed region for this channel - let Discord decide automatically
-   * voiceChannel.setRTCRegion(null);
+   * voiceChannel.setRTCRegion(null, 'We want to let Discord decide.');
    */
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -483,7 +483,7 @@ export class BaseGuildVoiceChannel extends GuildChannel {
   public bitrate: number;
   public userLimit: number;
   public createInvite(options?: CreateInviteOptions): Promise<Invite>;
-  public setRTCRegion(region: string | null): Promise<this>;
+  public setRTCRegion(rtcRegion: string | null, reason?: string): Promise<this>;
   public fetchInvites(cache?: boolean): Promise<Collection<string, Invite>>;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This field supports the `X-Audit-Log-Reason` header but was not being used in the helper methods. This has now been added in. Additionally, I have modified the examples to use `sydney` instead of `europe` as `europe` is not a valid region.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
