### PR TITLE
chore(build): disable tsup minification & add `"use strict";` banner to CJS bundles

### DIFF
--- a/packages/builders/tsup.config.ts
+++ b/packages/builders/tsup.config.ts
@@ -10,4 +10,11 @@ export const tsup: Options = {
 	skipNodeModulesBundle: true,
 	sourcemap: true,
 	target: 'es2021',
+	esbuildOptions: (options, context) => {
+		if (context.format === 'cjs') {
+			options.banner = {
+				js: '"use strict";',
+			};
+		}
+	},
 };

--- a/packages/builders/tsup.config.ts
+++ b/packages/builders/tsup.config.ts
@@ -5,7 +5,7 @@ export const tsup: Options = {
 	dts: true,
 	entryPoints: ['src/index.ts'],
 	format: ['esm', 'cjs'],
-	minify: true,
+	minify: false,
 	keepNames: true,
 	skipNodeModulesBundle: true,
 	sourcemap: true,

--- a/packages/collection/tsup.config.ts
+++ b/packages/collection/tsup.config.ts
@@ -11,4 +11,11 @@ export const tsup: Options = {
 	skipNodeModulesBundle: true,
 	sourcemap: true,
 	target: 'es2021',
+	esbuildOptions: (options, context) => {
+		if (context.format === 'cjs') {
+			options.banner = {
+				js: '"use strict";',
+			};
+		}
+	},
 };

--- a/packages/collection/tsup.config.ts
+++ b/packages/collection/tsup.config.ts
@@ -5,7 +5,7 @@ export const tsup: Options = {
 	dts: true,
 	entryPoints: ['src/index.ts'],
 	format: ['esm', 'cjs'],
-	minify: true,
+	minify: false,
 	// if false: causes Collection.constructor to be a minified value like: 'o'
 	keepNames: true,
 	skipNodeModulesBundle: true,

--- a/packages/rest/tsup.config.ts
+++ b/packages/rest/tsup.config.ts
@@ -10,4 +10,11 @@ export const tsup: Options = {
 	skipNodeModulesBundle: true,
 	sourcemap: true,
 	target: 'es2021',
+	esbuildOptions: (options, context) => {
+		if (context.format === 'cjs') {
+			options.banner = {
+				js: '"use strict";',
+			};
+		}
+	},
 };

--- a/packages/rest/tsup.config.ts
+++ b/packages/rest/tsup.config.ts
@@ -5,7 +5,7 @@ export const tsup: Options = {
 	dts: false,
 	entryPoints: ['src/index.ts'],
 	format: ['esm', 'cjs'],
-	minify: true,
+	minify: false,
 	keepNames: true,
 	skipNodeModulesBundle: true,
 	sourcemap: true,

--- a/packages/voice/tsup.config.ts
+++ b/packages/voice/tsup.config.ts
@@ -10,4 +10,11 @@ export default defineConfig({
 	skipNodeModulesBundle: true,
 	sourcemap: true,
 	target: 'es2021',
+	esbuildOptions: (options, context) => {
+		if (context.format === 'cjs') {
+			options.banner = {
+				js: '"use strict";',
+			};
+		}
+	},
 });

--- a/packages/voice/tsup.config.ts
+++ b/packages/voice/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	dts: true,
 	entryPoints: ['src/index.ts'],
 	format: ['esm', 'cjs'],
-	minify: true,
+	minify: false,
 	keepNames: true,
 	skipNodeModulesBundle: true,
 	sourcemap: true,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Minification of the output code makes it harder to debug code because it makes it near impossible to set breakpoints in the code that gets extracted to `node_modules`. Therefore, by disabling modifications we make it easier for advanced users to debug their code in case they run into issues. This in turn can also lead to better contributions and issues as causes and effects can be traced more easily. Furthermore, because we are not bundling for the web where size is actually of concern, there really is no big gain in minifying anyway.

Other than the minification change I also set the tsup option to add the `"use strict";` banner to CJS bundles, something I discovered how to do when @vladfrangu and @kyranet asked about that for @sapphire/shapeshift. I probably need not go into detail on why that's a good thing to have seeing as it's standard in all `discord.js` files.

To give some comparisons of the bundles lets look at `@discordjs/rest`:

ESM before: https://unpkg.com/browse/@discordjs/rest@0.4.0-dev.1648339702-520f471/dist/index.mjs
ESM after: https://gist.github.com/favna/1c130fb1c75c293a3ebfb165fb20effc#file-index-mjs

CJS before: https://unpkg.com/browse/@discordjs/rest@0.4.0-dev.1648339702-520f471/dist/index.js
CJS after: https://gist.github.com/favna/1c130fb1c75c293a3ebfb165fb20effc#file-index-js

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.