### PR TITLE
types(ModalSubmitInteraction): fix `components` type

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1848,16 +1848,10 @@ export interface ModalMessageModalSubmitInteraction<Cached extends CacheType = C
   inRawGuild(): this is ModalMessageModalSubmitInteraction<'raw'>;
 }
 
-export interface ModalSubmitActionRow {
-  type: ComponentType.ActionRow;
-  components: ActionRow<TextInputComponent>[];
-}
-
 export class ModalSubmitInteraction<Cached extends CacheType = CacheType> extends Interaction<Cached> {
   private constructor(client: Client, data: APIModalSubmitInteraction);
   public readonly customId: string;
-  // TODO: fix this type when #7517 is implemented
-  public readonly components: ModalSubmitActionRow[];
+  public readonly components: ActionRow<ModalActionRowComponent>[];
   public readonly fields: ModalSubmitFieldsResolver;
   public deferred: boolean;
   public ephemeral: boolean | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes the `components` type in `ModalSubmitInteraction`, since #7517 is now implemented.
`ModalSubmitActionRow[]` -> `ActionRow<ModalActionRowComponent>[]`

**Status and versioning classification:**
