### PR TITLE
feat(EmbedBuilder): don't unset optional params if not passed

### DIFF
--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -83,7 +83,11 @@ export class UnsafeEmbedBuilder {
 			return this;
 		}
 
-		this.data.author = { name: options.name, url: options.url, icon_url: options.iconURL };
+		this.data.author = {
+			name: options.name,
+			url: options.url ?? this.data.author?.url,
+			icon_url: options.iconURL ?? this.data.author?.icon_url,
+		};
 		return this;
 	}
 
@@ -123,7 +127,7 @@ export class UnsafeEmbedBuilder {
 			return this;
 		}
 
-		this.data.footer = { text: options.text, icon_url: options.iconURL };
+		this.data.footer = { text: options.text, icon_url: options.iconURL ?? this.data.footer?.icon_url };
 		return this;
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR makes it so if you don't pass a value to Embed setter methods that take in an object that value doesn't get unset and instead keeps its old value.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
