### PR TITLE
fix: add missing `UnsafeEmbedBuilder`

### DIFF
--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -208,6 +208,7 @@ exports.TextInputStyle = require('discord-api-types/v10').TextInputStyle;
 exports.UserFlags = require('discord-api-types/v10').UserFlags;
 exports.WebhookType = require('discord-api-types/v10').WebhookType;
 exports.UnsafeButtonBuilder = require('@discordjs/builders').UnsafeButtonBuilder;
+exports.UnsafeEmbedBuilder = require('@discordjs/builders').UnsafeEmbedBuilder;
 exports.UnsafeSelectMenuBuilder = require('@discordjs/builders').UnsafeSelectMenuBuilder;
 exports.UnsafeSelectMenuOptionBuilder = require('@discordjs/builders').UnsafeSelectMenuOptionBuilder;
 exports.DiscordAPIError = require('@discordjs/rest').DiscordAPIError;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds `UnsafeEmbedBuilder` export to `index.js`. It exported in `index.d.ts`, but not in `index.js`

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
