### PR TITLE
fix: Prevent `NaN` for nullable timestamps

### DIFF
--- a/packages/discord.js/src/structures/Invite.js
+++ b/packages/discord.js/src/structures/Invite.js
@@ -188,8 +188,11 @@ class Invite extends Base {
       this.createdTimestamp ??= null;
     }
 
-    if ('expires_at' in data) this._expiresTimestamp = Date.parse(data.expires_at);
-    else this._expiresTimestamp ??= null;
+    if ('expires_at' in data) {
+      this._expiresTimestamp = data.expires_at && Date.parse(data.expires_at);
+    } else {
+      this._expiresTimestamp ??= null;
+    }
 
     if ('stage_instance' in data) {
       /**

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -121,9 +121,7 @@ class VoiceState extends Base {
        * The time at which the member requested to speak. This property is specific to stage channels only.
        * @type {?number}
        */
-      this.requestToSpeakTimestamp = data.request_to_speak_timestamp
-        ? Date.parse(data.request_to_speak_timestamp)
-        : null;
+      this.requestToSpeakTimestamp = data.request_to_speak_timestamp && Date.parse(data.request_to_speak_timestamp);
     } else {
       this.requestToSpeakTimestamp ??= null;
     }

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -121,7 +121,9 @@ class VoiceState extends Base {
        * The time at which the member requested to speak. This property is specific to stage channels only.
        * @type {?number}
        */
-      this.requestToSpeakTimestamp = Date.parse(data.request_to_speak_timestamp);
+      this.requestToSpeakTimestamp = data.request_to_speak_timestamp
+        ? Date.parse(data.request_to_speak_timestamp)
+        : null;
     } else {
       this.requestToSpeakTimestamp ??= null;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
These properties are potentially `null` which makes `Date.parse()` potentially return `NaN`. This pull request assures these properties to be `null` in this case.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
