### PR TITLE
feat(modal): add `awaitModalSubmit`

### DIFF
--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -204,6 +204,7 @@ class CommandInteraction extends Interaction {
   deleteReply() {}
   followUp() {}
   showModal() {}
+  awaitModal() {}
 }
 
 InteractionResponses.applyToClass(CommandInteraction, ['deferUpdate', 'update']);

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -204,7 +204,7 @@ class CommandInteraction extends Interaction {
   deleteReply() {}
   followUp() {}
   showModal() {}
-  awaitModal() {}
+  awaitModalSubmit() {}
 }
 
 InteractionResponses.applyToClass(CommandInteraction, ['deferUpdate', 'update']);

--- a/packages/discord.js/src/structures/MessageComponentInteraction.js
+++ b/packages/discord.js/src/structures/MessageComponentInteraction.js
@@ -91,6 +91,7 @@ class MessageComponentInteraction extends Interaction {
   deferUpdate() {}
   update() {}
   showModal() {}
+  awaitModalSubmit() {}
 }
 
 InteractionResponses.applyToClass(MessageComponentInteraction);

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -250,7 +250,7 @@ class InteractionResponses {
   }
 
   /**
-   * An object containing the same properties as CollectorOptions, but a few less:
+   * An object containing the same properties as {@link CollectorOptions}, but a few less:
    * @typedef {Object} AwaitModalSubmitOptions
    * @property {CollectorFilter} [filter] The filter applied to this collector
    * @property {number} time Time to wait for an interaction before rejecting

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const { isJSONEncodable } = require('@discordjs/builders');
-const { InteractionResponseType, MessageFlags, Routes } = require('discord-api-types/v10');
+const { InteractionResponseType, MessageFlags, Routes, InteractionType } = require('discord-api-types/v10');
 const { Error } = require('../../errors');
+const InteractionCollector = require('../InteractionCollector');
 const MessagePayload = require('../MessagePayload');
 
 /**
@@ -248,6 +249,38 @@ class InteractionResponses {
     this.replied = true;
   }
 
+  /**
+   * An object containing the same properties as CollectorOptions, but a few more:
+   * @typedef {Object} AwaitModalSubmitOptions
+   * @property {CollectorFilter} [filter] The filter applied to this collector
+   * @property {number} time Time to wait for an interaction before rejecting
+   */
+
+  /**
+   * Collects a single modal submit interaction that passes the filter.
+   * The Promise will reject if the time expires.
+   * @param {AwaitModalSubmitOptions} options Options to pass to the internal collector
+   * @returns {Promise<ModalSubmitInteraction>}
+   * @example
+   * // Collect a modal submit interaction
+   * const filter = (interaction) => interaction.customId === 'modal';
+   * interaction.awaitModalSubmit({ filter, time: 15_000 })
+   *   .then(interaction => console.log(`${interaction.customId} was submitted!`))
+   *   .catch(console.error);
+   */
+  awaitModalSubmit(options) {
+    if (typeof options.time !== 'number') throw new Error('INVALID_TYPE', 'time', 'number');
+    const _options = { ...options, max: 1, interactionType: InteractionType.ModalSubmit };
+    return new Promise((resolve, reject) => {
+      const collector = new InteractionCollector(this.client, _options);
+      collector.once('end', (interactions, reason) => {
+        const interaction = interactions.first();
+        if (interaction) resolve(interaction);
+        else reject(new Error('INTERACTION_COLLECTOR_ERROR', reason));
+      });
+    });
+  }
+
   static applyToClass(structure, ignore = []) {
     const props = [
       'deferReply',
@@ -259,6 +292,7 @@ class InteractionResponses {
       'deferUpdate',
       'update',
       'showModal',
+      'awaitModalSubmit',
     ];
 
     for (const prop of props) {

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -250,7 +250,7 @@ class InteractionResponses {
   }
 
   /**
-   * An object containing the same properties as CollectorOptions, but a few more:
+   * An object containing the same properties as CollectorOptions, but a few less:
    * @typedef {Object} AwaitModalSubmitOptions
    * @property {CollectorFilter} [filter] The filter applied to this collector
    * @property {number} time Time to wait for an interaction before rejecting

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -379,6 +379,7 @@ export interface InteractionResponseFields<Cached extends CacheType = CacheType>
   showModal(
     modal: JSONEncodable<APIModalInteractionResponseCallbackData> | ModalData | APIModalInteractionResponseCallbackData,
   ): Promise<void>;
+  awaitModalSubmit(options: AwaitModalSubmitOptions<ModalSubmitInteraction>): Promise<ModalSubmitInteraction<Cached>>;
 }
 
 export abstract class CommandInteraction<Cached extends CacheType = CacheType> extends Interaction<Cached> {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1746,6 +1746,7 @@ export class MessageComponentInteraction<Cached extends CacheType = CacheType> e
   public showModal(
     modal: JSONEncodable<APIModalInteractionResponseCallbackData> | ModalData | APIModalInteractionResponseCallbackData,
   ): Promise<void>;
+  public awaitModalSubmit(options: AwaitModalSubmitOptions<ModalSubmitInteraction>): Promise<ModalSubmitInteraction>;
 }
 
 export class MessageContextMenuCommandInteraction<
@@ -3585,6 +3586,18 @@ export type AwaitMessageComponentOptions<T extends MessageComponentInteraction> 
   MessageComponentCollectorOptions<T>,
   'max' | 'maxComponents' | 'maxUsers'
 >;
+
+export type ModalSubmitInteractionCollectorOptions<T extends ModalSubmitInteraction> = Omit<
+  InteractionCollectorOptions<T>,
+  'channel' | 'message' | 'guild' | 'interactionType'
+>;
+
+export type AwaitModalSubmitOptions<T extends ModalSubmitInteraction> = Omit<
+  ModalSubmitInteractionCollectorOptions<T>,
+  'max' | 'maxComponents' | 'maxUsers'
+> & {
+  time: number;
+};
 
 export interface AwaitMessagesOptions extends MessageCollectorOptions {
   errors?: string[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds the ability to `await` modal submissions via `MessageComponentInteraction#awaitModalSubmit`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)