### PR TITLE
fix(InteractionCreateAction): Ensure text-based channel for caching messages

### DIFF
--- a/packages/discord.js/src/client/actions/InteractionCreate.js
+++ b/packages/discord.js/src/client/actions/InteractionCreate.js
@@ -31,7 +31,7 @@ class InteractionCreateAction extends Action {
             InteractionClass = UserContextMenuCommandInteraction;
             break;
           case ApplicationCommandType.Message:
-            if (c && c.isTextBased()) return;
+            if (c && !c.isTextBased()) return;
             InteractionClass = MessageContextMenuCommandInteraction;
             break;
           default:
@@ -43,7 +43,7 @@ class InteractionCreateAction extends Action {
         }
         break;
       case InteractionType.MessageComponent:
-        if (c && c.isTextBased()) return;
+        if (c && !c.isTextBased()) return;
 
         switch (data.data.component_type) {
           case ComponentType.Button:

--- a/packages/discord.js/src/client/actions/InteractionCreate.js
+++ b/packages/discord.js/src/client/actions/InteractionCreate.js
@@ -31,7 +31,7 @@ class InteractionCreateAction extends Action {
             InteractionClass = UserContextMenuCommandInteraction;
             break;
           case ApplicationCommandType.Message:
-            if (!c.isTextBased()) return;
+            if (c && c.isTextBased()) return;
             InteractionClass = MessageContextMenuCommandInteraction;
             break;
           default:
@@ -43,7 +43,7 @@ class InteractionCreateAction extends Action {
         }
         break;
       case InteractionType.MessageComponent:
-        if (!c.isTextBased()) return;
+        if (c && c.isTextBased()) return;
 
         switch (data.data.component_type) {
           case ComponentType.Button:

--- a/packages/discord.js/src/client/actions/InteractionCreate.js
+++ b/packages/discord.js/src/client/actions/InteractionCreate.js
@@ -16,9 +16,11 @@ class InteractionCreateAction extends Action {
     const client = this.client;
 
     // Resolve and cache partial channels for Interaction#channel getter
-    this.getChannel(data);
+    const c = this.getChannel(data);
 
+    // Do not emit this for interactions that cache messages that are non-text-based.
     let InteractionClass;
+
     switch (data.type) {
       case InteractionType.ApplicationCommand:
         switch (data.data.type) {
@@ -29,6 +31,7 @@ class InteractionCreateAction extends Action {
             InteractionClass = UserContextMenuCommandInteraction;
             break;
           case ApplicationCommandType.Message:
+            if (!c.isTextBased()) return;
             InteractionClass = MessageContextMenuCommandInteraction;
             break;
           default:
@@ -40,6 +43,8 @@ class InteractionCreateAction extends Action {
         }
         break;
       case InteractionType.MessageComponent:
+        if (!c.isTextBased()) return;
+
         switch (data.data.component_type) {
           case ComponentType.Button:
             InteractionClass = ButtonInteraction;

--- a/packages/discord.js/src/client/actions/InteractionCreate.js
+++ b/packages/discord.js/src/client/actions/InteractionCreate.js
@@ -16,7 +16,7 @@ class InteractionCreateAction extends Action {
     const client = this.client;
 
     // Resolve and cache partial channels for Interaction#channel getter
-    const c = this.getChannel(data);
+    const channel = this.getChannel(data);
 
     // Do not emit this for interactions that cache messages that are non-text-based.
     let InteractionClass;
@@ -31,7 +31,7 @@ class InteractionCreateAction extends Action {
             InteractionClass = UserContextMenuCommandInteraction;
             break;
           case ApplicationCommandType.Message:
-            if (c && !c.isTextBased()) return;
+            if (channel && !channel.isTextBased()) return;
             InteractionClass = MessageContextMenuCommandInteraction;
             break;
           default:
@@ -43,7 +43,7 @@ class InteractionCreateAction extends Action {
         }
         break;
       case InteractionType.MessageComponent:
-        if (c && !c.isTextBased()) return;
+        if (channel && !channel.isTextBased()) return;
 
         switch (data.data.component_type) {
           case ComponentType.Button:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Text-in-Voice channels are gradually rolling out. When an interaction from a component is received in such a channel, discord.js will crash as it attempts to cache the respective message as we do not provide a message cache for voice channels.

This has been resolved by verifying that the channel an interaction came from is text-based (if it is going to cache the respective message). This logic has been applied to message context menu command interactions too despite being currently unusable in text-in-voice channels, but it is better to be safe than sorry.

This pull request resolves #7749.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
