### PR TITLE
refactor(builders): use arrays instead of rest parameters

### DIFF
--- a/packages/builders/__tests__/components/actionRow.test.ts
+++ b/packages/builders/__tests__/components/actionRow.test.ts
@@ -44,8 +44,8 @@ const rowWithSelectMenuData: APIActionRowComponent<APIMessageActionRowComponent>
 describe('Action Row Components', () => {
 	describe('Assertion Tests', () => {
 		test('GIVEN valid components THEN do not throw', () => {
-			expect(() => new ActionRowBuilder().addComponents(new ButtonBuilder())).not.toThrowError();
-			expect(() => new ActionRowBuilder().setComponents(new ButtonBuilder())).not.toThrowError();
+			expect(() => new ActionRowBuilder().addComponents([new ButtonBuilder()])).not.toThrowError();
+			expect(() => new ActionRowBuilder().setComponents([new ButtonBuilder()])).not.toThrowError();
 		});
 
 		test('GIVEN valid JSON input THEN valid JSON output is given', () => {
@@ -128,13 +128,13 @@ describe('Action Row Components', () => {
 				.setCustomId('1234')
 				.setMaxValues(10)
 				.setMinValues(12)
-				.setOptions(
+				.setOptions([
 					new SelectMenuOptionBuilder().setLabel('one').setValue('one'),
 					new SelectMenuOptionBuilder().setLabel('two').setValue('two'),
-				);
+				]);
 
-			expect(new ActionRowBuilder().addComponents(button).toJSON()).toEqual(rowWithButtonData);
-			expect(new ActionRowBuilder().addComponents(selectMenu).toJSON()).toEqual(rowWithSelectMenuData);
+			expect(new ActionRowBuilder().addComponents([button]).toJSON()).toEqual(rowWithButtonData);
+			expect(new ActionRowBuilder().addComponents([selectMenu]).toJSON()).toEqual(rowWithSelectMenuData);
 		});
 	});
 });

--- a/packages/builders/__tests__/components/selectMenu.test.ts
+++ b/packages/builders/__tests__/components/selectMenu.test.ts
@@ -43,29 +43,31 @@ describe('Select Menu Components', () => {
 				.setDefault(true)
 				.setEmoji({ name: 'test' })
 				.setDescription('description');
-			expect(() => selectMenu().addOptions(option)).not.toThrowError();
-			expect(() => selectMenu().setOptions(option)).not.toThrowError();
-			expect(() => selectMenu().setOptions({ label: 'test', value: 'test' })).not.toThrowError();
+			expect(() => selectMenu().addOptions([option])).not.toThrowError();
+			expect(() => selectMenu().setOptions([option])).not.toThrowError();
+			expect(() => selectMenu().setOptions([{ label: 'test', value: 'test' }])).not.toThrowError();
 			expect(() =>
-				selectMenu().addOptions({
-					label: 'test',
-					value: 'test',
-					emoji: {
-						id: '123',
-						name: 'test',
-						animated: true,
+				selectMenu().addOptions([
+					{
+						label: 'test',
+						value: 'test',
+						emoji: {
+							id: '123',
+							name: 'test',
+							animated: true,
+						},
 					},
-				}),
+				]),
 			).not.toThrowError();
 
 			const options = new Array<APISelectMenuOption>(25).fill({ label: 'test', value: 'test' });
-			expect(() => selectMenu().addOptions(...options)).not.toThrowError();
-			expect(() => selectMenu().setOptions(...options)).not.toThrowError();
+			expect(() => selectMenu().addOptions(options)).not.toThrowError();
+			expect(() => selectMenu().setOptions(options)).not.toThrowError();
 
 			expect(() =>
 				selectMenu()
-					.addOptions({ label: 'test', value: 'test' })
-					.addOptions(...new Array<APISelectMenuOption>(24).fill({ label: 'test', value: 'test' })),
+					.addOptions([{ label: 'test', value: 'test' }])
+					.addOptions(new Array<APISelectMenuOption>(24).fill({ label: 'test', value: 'test' })),
 			).not.toThrowError();
 		});
 
@@ -77,24 +79,24 @@ describe('Select Menu Components', () => {
 			expect(() => selectMenu().setDisabled(0)).toThrowError();
 			expect(() => selectMenu().setPlaceholder(longStr)).toThrowError();
 			// @ts-expect-error
-			expect(() => selectMenu().addOptions({ label: 'test' })).toThrowError();
-			expect(() => selectMenu().addOptions({ label: longStr, value: 'test' })).toThrowError();
-			expect(() => selectMenu().addOptions({ value: longStr, label: 'test' })).toThrowError();
-			expect(() => selectMenu().addOptions({ label: 'test', value: 'test', description: longStr })).toThrowError();
+			expect(() => selectMenu().addOptions([{ label: 'test' }])).toThrowError();
+			expect(() => selectMenu().addOptions([{ label: longStr, value: 'test' }])).toThrowError();
+			expect(() => selectMenu().addOptions([{ value: longStr, label: 'test' }])).toThrowError();
+			expect(() => selectMenu().addOptions([{ label: 'test', value: 'test', description: longStr }])).toThrowError();
 			// @ts-expect-error
-			expect(() => selectMenu().addOptions({ label: 'test', value: 'test', default: 100 })).toThrowError();
+			expect(() => selectMenu().addOptions([{ label: 'test', value: 'test', default: 100 }])).toThrowError();
 			// @ts-expect-error
-			expect(() => selectMenu().addOptions({ value: 'test' })).toThrowError();
+			expect(() => selectMenu().addOptions([{ value: 'test' }])).toThrowError();
 			// @ts-expect-error
-			expect(() => selectMenu().addOptions({ default: true })).toThrowError();
+			expect(() => selectMenu().addOptions([{ default: true }])).toThrowError();
 
 			const tooManyOptions = new Array<APISelectMenuOption>(26).fill({ label: 'test', value: 'test' });
-			expect(() => selectMenu().setOptions(...tooManyOptions)).toThrowError();
+			expect(() => selectMenu().setOptions(tooManyOptions)).toThrowError();
 
 			expect(() =>
 				selectMenu()
-					.addOptions({ label: 'test', value: 'test' })
-					.addOptions(...tooManyOptions),
+					.addOptions([{ label: 'test', value: 'test' }])
+					.addOptions(tooManyOptions),
 			).toThrowError();
 
 			expect(() => {
@@ -112,7 +114,7 @@ describe('Select Menu Components', () => {
 		test('GIVEN valid JSON input THEN valid JSON history is correct', () => {
 			expect(
 				new SelectMenuBuilder(selectMenuDataWithoutOptions)
-					.addOptions(new SelectMenuOptionBuilder(selectMenuOptionData))
+					.addOptions([new SelectMenuOptionBuilder(selectMenuOptionData)])
 					.toJSON(),
 			).toEqual(selectMenuData);
 			expect(new SelectMenuOptionBuilder(selectMenuOptionData).toJSON()).toEqual(selectMenuOptionData);

--- a/packages/builders/__tests__/interactions/modal.test.ts
+++ b/packages/builders/__tests__/interactions/modal.test.ts
@@ -48,15 +48,11 @@ describe('Modals', () => {
 
 	test('GIVEN valid fields THEN builder does not throw', () => {
 		expect(() =>
-			modal().setTitle('test').setCustomId('foobar').setComponents(new ActionRowBuilder()),
+			modal().setTitle('test').setCustomId('foobar').setComponents([new ActionRowBuilder()]),
 		).not.toThrowError();
 	});
 
 	test('GIVEN invalid fields THEN builder does throw', () => {
-		expect(() =>
-			// @ts-expect-error
-			modal().setTitle('test').setCustomId('foobar').setComponents([new ActionRowBuilder()]).toJSON(),
-		).toThrowError();
 		expect(() => modal().setTitle('test').setCustomId('foobar').toJSON()).toThrowError();
 		// @ts-expect-error
 		expect(() => modal().setTitle('test').setCustomId(42).toJSON()).toThrowError();
@@ -87,11 +83,11 @@ describe('Modals', () => {
 			modal()
 				.setTitle(modalData.title)
 				.setCustomId('custom id')
-				.setComponents(
-					new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(
+				.setComponents([
+					new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents([
 						new TextInputBuilder().setCustomId('custom id').setLabel('label').setStyle(TextInputStyle.Paragraph),
-					),
-				)
+					]),
+				])
 				.toJSON(),
 		).toEqual(modalData);
 	});

--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -322,7 +322,7 @@ describe('Embed', () => {
 
 		test('GIVEN an embed using Embed#addFields THEN returns valid toJSON data', () => {
 			const embed = new EmbedBuilder();
-			embed.addFields({ name: 'foo', value: 'bar' });
+			embed.addFields([{ name: 'foo', value: 'bar' }]);
 
 			expect(embed.toJSON()).toStrictEqual({
 				fields: [{ name: 'foo', value: 'bar' }],
@@ -331,7 +331,10 @@ describe('Embed', () => {
 
 		test('GIVEN an embed using Embed#spliceFields THEN returns valid toJSON data', () => {
 			const embed = new EmbedBuilder();
-			embed.addFields({ name: 'foo', value: 'bar' }, { name: 'foo', value: 'baz' });
+			embed.addFields([
+				{ name: 'foo', value: 'bar' },
+				{ name: 'foo', value: 'baz' },
+			]);
 
 			expect(embed.spliceFields(0, 1).toJSON()).toStrictEqual({
 				fields: [{ name: 'foo', value: 'baz' }],
@@ -340,7 +343,7 @@ describe('Embed', () => {
 
 		test('GIVEN an embed using Embed#spliceFields THEN returns valid toJSON data', () => {
 			const embed = new EmbedBuilder();
-			embed.addFields(...Array.from({ length: 23 }, () => ({ name: 'foo', value: 'bar' })));
+			embed.addFields(Array.from({ length: 23 }, () => ({ name: 'foo', value: 'bar' })));
 
 			expect(() =>
 				embed.spliceFields(0, 3, ...Array.from({ length: 5 }, () => ({ name: 'foo', value: 'bar' }))),
@@ -349,7 +352,7 @@ describe('Embed', () => {
 
 		test('GIVEN an embed using Embed#spliceFields that adds additional fields resulting in fields > 25 THEN throws error', () => {
 			const embed = new EmbedBuilder();
-			embed.addFields(...Array.from({ length: 23 }, () => ({ name: 'foo', value: 'bar' })));
+			embed.addFields(Array.from({ length: 23 }, () => ({ name: 'foo', value: 'bar' })));
 
 			expect(() =>
 				embed.spliceFields(0, 3, ...Array.from({ length: 8 }, () => ({ name: 'foo', value: 'bar' }))),
@@ -360,25 +363,21 @@ describe('Embed', () => {
 			const embed = new EmbedBuilder();
 
 			expect(() =>
-				embed.setFields(...Array.from({ length: 25 }, () => ({ name: 'foo', value: 'bar' }))),
+				embed.setFields(Array.from({ length: 25 }, () => ({ name: 'foo', value: 'bar' }))),
 			).not.toThrowError();
 		});
 
 		test('GIVEN an embed using Embed#setFields that sets more than 25 fields THEN throws error', () => {
 			const embed = new EmbedBuilder();
 
-			expect(() =>
-				embed.setFields(...Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' }))),
-			).toThrowError();
+			expect(() => embed.setFields(Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' })))).toThrowError();
 		});
 
 		describe('GIVEN invalid field amount THEN throws error', () => {
 			test('', () => {
 				const embed = new EmbedBuilder();
 
-				expect(() =>
-					embed.addFields(...Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' }))),
-				).toThrowError();
+				expect(() => embed.addFields(Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' })))).toThrowError();
 			});
 		});
 
@@ -386,7 +385,7 @@ describe('Embed', () => {
 			test('', () => {
 				const embed = new EmbedBuilder();
 
-				expect(() => embed.addFields({ name: '', value: 'bar' })).toThrowError();
+				expect(() => embed.addFields([{ name: '', value: 'bar' }])).toThrowError();
 			});
 		});
 
@@ -394,7 +393,7 @@ describe('Embed', () => {
 			test('', () => {
 				const embed = new EmbedBuilder();
 
-				expect(() => embed.addFields({ name: 'a'.repeat(257), value: 'bar' })).toThrowError();
+				expect(() => embed.addFields([{ name: 'a'.repeat(257), value: 'bar' }])).toThrowError();
 			});
 		});
 
@@ -402,7 +401,7 @@ describe('Embed', () => {
 			test('', () => {
 				const embed = new EmbedBuilder();
 
-				expect(() => embed.addFields({ name: '', value: 'a'.repeat(1025) })).toThrowError();
+				expect(() => embed.addFields([{ name: '', value: 'a'.repeat(1025) }])).toThrowError();
 			});
 		});
 	});

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -49,7 +49,7 @@ export class ActionRowBuilder<
 	 * @param components The components to add to this action row.
 	 * @returns
 	 */
-	public addComponents(...components: T[]) {
+	public addComponents(components: T[]) {
 		this.components.push(...components);
 		return this;
 	}
@@ -58,7 +58,7 @@ export class ActionRowBuilder<
 	 * Sets the components in this action row
 	 * @param components The components to set this row to
 	 */
-	public setComponents(...components: T[]) {
+	public setComponents(components: T[]) {
 		this.components.splice(0, this.components.length, ...components);
 		return this;
 	}

--- a/packages/builders/src/components/selectMenu/SelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/SelectMenu.ts
@@ -35,7 +35,7 @@ export class SelectMenuBuilder extends UnsafeSelectMenuBuilder {
 		return super.setDisabled(disabledValidator.parse(disabled));
 	}
 
-	public override addOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public override addOptions(options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
 		optionsLengthValidator.parse(this.options.length + options.length);
 		this.options.push(
 			...options.map((option) =>
@@ -47,7 +47,7 @@ export class SelectMenuBuilder extends UnsafeSelectMenuBuilder {
 		return this;
 	}
 
-	public override setOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public override setOptions(options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
 		optionsLengthValidator.parse(options.length);
 		this.options.splice(
 			0,

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -69,7 +69,7 @@ export class UnsafeSelectMenuBuilder extends ComponentBuilder<
 	 * @param options The options to add to this select menu
 	 * @returns
 	 */
-	public addOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public addOptions(options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
 		this.options.push(
 			...options.map((option) =>
 				option instanceof UnsafeSelectMenuOptionBuilder ? option : new UnsafeSelectMenuOptionBuilder(option),
@@ -82,7 +82,7 @@ export class UnsafeSelectMenuBuilder extends ComponentBuilder<
 	 * Sets the options on this select menu
 	 * @param options The options to set on this select menu
 	 */
-	public setOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public setOptions(options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
 		this.options.splice(
 			0,
 			this.options.length,

--- a/packages/builders/src/components/textInput/UnsafeTextInput.ts
+++ b/packages/builders/src/components/textInput/UnsafeTextInput.ts
@@ -11,7 +11,7 @@ export class UnsafeTextInputBuilder extends ComponentBuilder<
 
 	/**
 	 * Sets the custom id for this text input
-	 * @param customId The custom id of this text inputå
+	 * @param customId The custom id of this text input
 	 */
 	public setCustomId(customId: string) {
 		this.data.custom_id = customId;

--- a/packages/builders/src/interactions/modals/UnsafeModal.ts
+++ b/packages/builders/src/interactions/modals/UnsafeModal.ts
@@ -38,10 +38,10 @@ export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResp
 	 * @param components The components to add to this modal
 	 */
 	public addComponents(
-		...components: (
+		components: (
 			| ActionRowBuilder<ModalActionRowComponentBuilder>
 			| APIActionRowComponent<APIModalActionRowComponent>
-		)[]
+		)[],
 	) {
 		this.components.push(
 			...components.map((component) =>
@@ -57,7 +57,7 @@ export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResp
 	 * Sets the components in this modal
 	 * @param components The components to set this modal to
 	 */
-	public setComponents(...components: ActionRowBuilder<ModalActionRowComponentBuilder>[]) {
+	public setComponents(components: ActionRowBuilder<ModalActionRowComponentBuilder>[]) {
 		this.components.splice(0, this.components.length, ...components);
 		return this;
 	}

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -16,12 +16,12 @@ import { EmbedAuthorOptions, EmbedFooterOptions, RGBTuple, UnsafeEmbedBuilder } 
  * Represents a validated embed in a message (image/video preview, rich embed, etc.)
  */
 export class EmbedBuilder extends UnsafeEmbedBuilder {
-	public override addFields(...fields: APIEmbedField[]): this {
+	public override addFields(fields: APIEmbedField[]): this {
 		// Ensure adding these fields won't exceed the 25 field limit
 		validateFieldLength(fields.length, this.data.fields);
 
 		// Data assertions
-		return super.addFields(...embedFieldsArrayPredicate.parse(fields));
+		return super.addFields(embedFieldsArrayPredicate.parse(fields));
 	}
 
 	public override spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -44,7 +44,7 @@ export class UnsafeEmbedBuilder {
 	 *
 	 * @param fields The fields to add
 	 */
-	public addFields(...fields: APIEmbedField[]): this {
+	public addFields(fields: APIEmbedField[]): this {
 		if (this.data.fields) this.data.fields.push(...fields);
 		else this.data.fields = fields;
 		return this;
@@ -67,7 +67,7 @@ export class UnsafeEmbedBuilder {
 	 * Sets the embed's fields (max 25).
 	 * @param fields The fields to set
 	 */
-	public setFields(...fields: APIEmbedField[]) {
+	public setFields(fields: APIEmbedField[]) {
 		this.spliceFields(0, this.data.fields?.length ?? 0, ...fields);
 		return this;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Originally I had the opinion that using rest parameters allowed for a clearer UI DSL. However I've since conceded this opinion.

The main reason for this is that this design decision has resulted in a degraded UX for many users. It seems that every other message in the dev channel has to do with someone using an array instead of rest parameters. Rest paramters seem to be an unexpected input type for most.

"Why not support both rest and array parameters"

To be clear JS doesn't support this. The only way to achieve this is via a workaround, that *emulates* this behavior. This workaround involves accepting a a rest parameter 2D arrays. 

I fear that the types here are confusing since they imply you must pass in multiple 2D arrays as rest parameters, when in reality you can pass a single 1D array. This may introduce an issue in place of a resolved one. In addition, many people seem to default to array parameters anyways, so I think this workaround holds little-to-no utility.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)