### PR TITLE
fix(MessageManager): Allow caching option of an unspecified limit

### DIFF
--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -84,7 +84,7 @@ class MessageManager extends CachedManager {
    *   .then(messages => console.log(`${messages.filter(m => m.author.id === '84484653687267328').size} messages`))
    *   .catch(console.error);
    */
-  fetch(options = {}) {
+  fetch(options) {
     if (!options) return this._fetchMany();
     const { message, cache, force } = options;
     const resolvedMessage = this.resolveId(message ?? options);

--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -35,40 +35,79 @@ class MessageManager extends CachedManager {
   }
 
   /**
-   * The parameters to pass in when requesting previous messages from a channel. `around`, `before` and
-   * `after` are mutually exclusive. All the parameters are optional.
-   * @typedef {Object} ChannelLogsQueryOptions
-   * @property {number} [limit] Number of messages to acquire
-   * @property {Snowflake} [before] The message's id to get the messages that were posted before it
-   * @property {Snowflake} [after] The message's id to get the messages that were posted after it
-   * @property {Snowflake} [around] The message's id to get the messages that were posted around it
+   * Data that can be resolved to a Message object. This can be:
+   * * A Message
+   * * A Snowflake
+   * @typedef {Message|Snowflake} MessageResolvable
    */
 
   /**
-   * Gets a message, or messages, from this channel.
+   * Options used to fetch a message.
+   * @typedef {BaseFetchOptions} FetchMessageOptions
+   * @property {MessageResolvable} [message] The message to fetch
+   */
+
+  /**
+   * Options used to fetch multiple messages.
+   * @typedef {Object} FetchMessagesOptions
+   * @property {number} [limit] The maximum number of messages to return
+   * @property {Snowflake} [before] Consider only messages before this id
+   * @property {Snowflake} [after] Consider only messages after this id
+   * @property {Snowflake} [around] Consider only messages around this id
+   * @property {boolean} [cache] Whether to cache the fetched messages
+   */
+
+  /**
+   * Fetches message(s) from a channel.
    * <info>The returned Collection does not contain reaction users of the messages if they were not cached.
    * Those need to be fetched separately in such a case.</info>
-   * @param {Snowflake|ChannelLogsQueryOptions} [message] The id of the message to fetch, or query parameters.
-   * @param {BaseFetchOptions} [options] Additional options for this fetch
+   * @param {MessageResolvable|FetchMessageOptions|FetchMessagesOptions} [options] Options for fetching message(s)
    * @returns {Promise<Message|Collection<Snowflake, Message>>}
    * @example
-   * // Get message
+   * // Fetch a message
    * channel.messages.fetch('99539446449315840')
    *   .then(message => console.log(message.content))
    *   .catch(console.error);
    * @example
-   * // Get messages
-   * channel.messages.fetch({ limit: 10 })
+   * // Fetch a maximum of 10 messages without caching
+   * channel.messages.fetch({ limit: 10, cache: false })
    *   .then(messages => console.log(`Received ${messages.size} messages`))
    *   .catch(console.error);
    * @example
-   * // Get messages and filter by user id
+   * // Fetch a maximum of 10 messages without caching around a message id
+   * channel.messages.fetch({ limit: 10, cache: false, around: '99539446449315840' })
+   *   .then(messages => console.log(`Received ${messages.size} messages`))
+   *   .catch(console.error);
+   * @example
+   * // Fetch messages and filter by a user id
    * channel.messages.fetch()
    *   .then(messages => console.log(`${messages.filter(m => m.author.id === '84484653687267328').size} messages`))
    *   .catch(console.error);
    */
-  fetch(message, { cache = true, force = false } = {}) {
-    return typeof message === 'string' ? this._fetchId(message, cache, force) : this._fetchMany(message, cache);
+  fetch(options = {}) {
+    if (!options) return this._fetchMany();
+    const { message, cache, force } = options;
+    const resolvedMessage = this.resolveId(message ?? options);
+    if (resolvedMessage) return this._fetchSingle({ message: resolvedMessage, cache, force });
+    return this._fetchMany(options);
+  }
+
+  async _fetchSingle({ message, cache, force = false }) {
+    if (!force) {
+      const existing = this.cache.get(message);
+      if (existing && !existing.partial) return existing;
+    }
+
+    const data = await this.client.rest.get(Routes.channelMessage(this.channel.id, message));
+    return this._add(data, cache);
+  }
+
+  async _fetchMany(options = {}) {
+    const data = await this.client.rest.get(Routes.channelMessages(this.channel.id), {
+      query: makeURLSearchParams(options),
+    });
+
+    return data.reduce((_data, message) => _data.set(message.id, this._add(message, options.cache)), new Collection());
   }
 
   /**
@@ -89,13 +128,6 @@ class MessageManager extends CachedManager {
     for (const message of data) messages.set(message.id, this._add(message, cache));
     return messages;
   }
-
-  /**
-   * Data that can be resolved to a Message object. This can be:
-   * * A Message
-   * * A Snowflake
-   * @typedef {Message|Snowflake} MessageResolvable
-   */
 
   /**
    * Resolves a {@link MessageResolvable} to a {@link Message} object.
@@ -211,25 +243,6 @@ class MessageManager extends CachedManager {
     if (!message) throw new TypeError('INVALID_TYPE', 'message', 'MessageResolvable');
 
     await this.client.rest.delete(Routes.channelMessage(this.channel.id, message));
-  }
-
-  async _fetchId(messageId, cache, force) {
-    if (!force) {
-      const existing = this.cache.get(messageId);
-      if (existing && !existing.partial) return existing;
-    }
-
-    const data = await this.client.rest.get(Routes.channelMessage(this.channel.id, messageId));
-    return this._add(data, cache);
-  }
-
-  async _fetchMany(options = {}, cache) {
-    const data = await this.client.rest.get(Routes.channelMessages(this.channel.id), {
-      query: makeURLSearchParams(options),
-    });
-    const messages = new Collection();
-    for (const message of data) messages.set(message.id, this._add(message, cache));
-    return messages;
   }
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3214,11 +3214,8 @@ export class MessageManager extends CachedManager<Snowflake, Message, MessageRes
   public crosspost(message: MessageResolvable): Promise<Message>;
   public delete(message: MessageResolvable): Promise<void>;
   public edit(message: MessageResolvable, options: string | MessagePayload | MessageEditOptions): Promise<Message>;
-  public fetch(message: Snowflake, options?: BaseFetchOptions): Promise<Message>;
-  public fetch(
-    options?: ChannelLogsQueryOptions,
-    cacheOptions?: BaseFetchOptions,
-  ): Promise<Collection<Snowflake, Message>>;
+  public fetch(options: MessageResolvable | FetchMessageOptions): Promise<Message>;
+  public fetch(options?: FetchMessagesOptions): Promise<Collection<Snowflake, Message>>;
   public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message>>;
   public react(message: MessageResolvable, emoji: EmojiIdentifierResolvable): Promise<void>;
   public pin(message: MessageResolvable, reason?: string): Promise<void>;
@@ -3741,13 +3738,6 @@ export interface ChannelData {
   defaultAutoArchiveDuration?: ThreadAutoArchiveDuration | 'MAX';
   rtcRegion?: string | null;
   videoQualityMode?: VideoQualityMode | null;
-}
-
-export interface ChannelLogsQueryOptions {
-  limit?: number;
-  before?: Snowflake;
-  after?: Snowflake;
-  around?: Snowflake;
 }
 
 export type ChannelMention = `<#${Snowflake}>`;
@@ -4329,6 +4319,18 @@ export interface FetchMembersOptions {
   time?: number;
   nonce?: string;
   force?: boolean;
+}
+
+export interface FetchMessageOptions extends BaseFetchOptions {
+  message: MessageResolvable;
+}
+
+export interface FetchMessagesOptions {
+  limit?: number;
+  before?: Snowflake;
+  after?: Snowflake;
+  around?: Snowflake;
+  cache?: boolean;
 }
 
 export interface FetchReactionUsersOptions {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -119,6 +119,7 @@ import {
   MessageActionRowComponentBuilder,
   GuildBanManager,
   GuildBan,
+  MessageManager,
 } from '.';
 import { expectAssignable, expectDeprecated, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import { UnsafeButtonBuilder, UnsafeEmbedBuilder, UnsafeSelectMenuBuilder } from '@discordjs/builders';
@@ -1017,6 +1018,22 @@ declare const guildChannelManager: GuildChannelManager;
   expectType<Promise<Collection<Snowflake, AnyChannel>>>(guildChannelManager.fetch());
   expectType<Promise<Collection<Snowflake, AnyChannel>>>(guildChannelManager.fetch(undefined, {}));
   expectType<Promise<AnyChannel | null>>(guildChannelManager.fetch('0'));
+}
+
+declare const messageManager: MessageManager;
+{
+  expectType<Promise<Message>>(messageManager.fetch('1234567890'));
+  expectType<Promise<Message>>(messageManager.fetch({ message: '1234567890' }));
+  expectType<Promise<Message>>(messageManager.fetch({ message: '1234567890', cache: true, force: false }));
+  expectType<Promise<Collection<Snowflake, Message>>>(messageManager.fetch());
+  expectType<Promise<Collection<Snowflake, Message>>>(messageManager.fetch({}));
+  expectType<Promise<Collection<Snowflake, Message>>>(
+    messageManager.fetch({ limit: 100, before: '1234567890', cache: false }),
+  );
+  // @ts-expect-error
+  messageManager.fetch({ cache: true, force: false });
+  // @ts-expect-error
+  messageManager.fetch({ message: '1234567890', after: '1234567890', cache: true, force: false });
 }
 
 declare const roleManager: RoleManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pull request resolves #7093. This implementation is actually the same as #7734, so this should feel familiar and consistent.

I have also renamed `ChannelLogsQueryOptions` to `FetchMessagesOptions` to better reflect this type definition and for consistency amongst other type definitions.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
