### PR TITLE
makeContent should accept empty strings

### DIFF
--- a/packages/discord.js/src/errors/Messages.js
+++ b/packages/discord.js/src/errors/Messages.js
@@ -71,7 +71,7 @@ const Messages = {
 
   MESSAGE_BULK_DELETE_TYPE: 'The messages must be an Array, Collection, or number.',
   MESSAGE_NONCE_TYPE: 'Message nonce must be an integer or a string.',
-  MESSAGE_CONTENT_TYPE: 'Message content must be a non-empty string.',
+  MESSAGE_CONTENT_TYPE: 'Message content must be a string.',
 
   SPLIT_MAX_LEN: 'Chunk exceeds the max length and contains no split characters.',
 

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -105,7 +105,7 @@ class MessagePayload {
     if (this.options.content === null) {
       content = '';
     } else if (typeof this.options.content !== 'undefined') {
-      content = Util.verifyString(this.options.content, RangeError, 'MESSAGE_CONTENT_TYPE', false);
+      content = Util.verifyString(this.options.content, RangeError, 'MESSAGE_CONTENT_TYPE', true);
     }
 
     return content;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently if you send an embed with an empty string as the content you get a `RangeError [MESSAGE_CONTENT_TYPE]: Message content must be a non-empty string.` and are supposed to supply `null` when indicating that the message content is not needed. However the method, namely `makeContent`, that actually causes this error simply converts that null into an empty string.

It appears to be, and do correct me if I am wrong, that the method errors if an empty string is the content but then returns an empty string anyway?

To fix this I have changed the `verifyString` function to accept empty strings stopping the errors

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)