### PR TITLE
fix(WebhookClient): Updated webhook url to include old url

### DIFF
--- a/packages/discord.js/src/client/WebhookClient.js
+++ b/packages/discord.js/src/client/WebhookClient.js
@@ -30,7 +30,7 @@ class WebhookClient extends BaseClient {
     if ('url' in data) {
       const url = data.url.match(
         // eslint-disable-next-line no-useless-escape
-        /https?:\/\/(?:ptb\.|canary\.)?discord\.com\/api(?:\/v\d{1,2})?\/webhooks\/(\d{17,19})\/([\w-]{68})/i,
+        /https?:\/\/(?:ptb\.|canary\.)?(?:discord|discordapp)\.com\/api(?:\/v\d{1,2})?\/webhooks\/(\d{17,19})\/([\w-]{68})/i,
       );
 
       if (!url || url.length <= 1) throw new Error('WEBHOOK_URL_INVALID');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixed the webhook url to include the old `discordapp.com` url. When copying a webhook URL directly from Discord, it still uses the old URL. This causes the URL check to fail, even though it is a valid URL.

[Quite some time ago](https://github.com/discordjs/discord.js/pull/6192#discussion_r678500673), this check was not added or removed because discord was switching to the `discord.com` URL. However, as of writing this Merge Request, discord still uses the old `discordapp.com` URL when copying a webhook URL using the client. [Someone else](https://github.com/discordjs/discord.js/pull/7527) tried to fix this, but it was mentioned it was an intentional change.

I would like for this to be added (back), because discord still uses discordapp.com when copying the url.

https://i.imgur.com/6WENtTf.mp4

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
