### PR TITLE
fix: Support `reason` in `setRTCRegion` helpers (v13)

### DIFF
--- a/src/structures/BaseGuildVoiceChannel.js
+++ b/src/structures/BaseGuildVoiceChannel.js
@@ -82,17 +82,18 @@ class BaseGuildVoiceChannel extends GuildChannel {
 
   /**
    * Sets the RTC region of the channel.
-   * @param {?string} region The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {?string} rtcRegion The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {string} [reason] The reason for modifying this region.
    * @returns {Promise<BaseGuildVoiceChannel>}
    * @example
-   * // Set the RTC region to europe
-   * channel.setRTCRegion('europe');
+   * // Set the RTC region to sydney
+   * channel.setRTCRegion('sydney');
    * @example
    * // Remove a fixed region for this channel - let Discord decide automatically
-   * channel.setRTCRegion(null);
+   * channel.setRTCRegion(null, 'We want to let Discord decide.');
    */
-  setRTCRegion(region) {
-    return this.edit({ rtcRegion: region });
+  setRTCRegion(rtcRegion, reason) {
+    return this.edit({ rtcRegion }, reason);
   }
 
   /**

--- a/src/structures/StageChannel.js
+++ b/src/structures/StageChannel.js
@@ -55,14 +55,15 @@ class StageChannel extends BaseGuildVoiceChannel {
   /**
    * Sets the RTC region of the channel.
    * @name StageChannel#setRTCRegion
-   * @param {?string} region The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {?string} rtcRegion The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {string} [reason] The reason for modifying this region.
    * @returns {Promise<StageChannel>}
    * @example
-   * // Set the RTC region to europe
-   * stageChannel.setRTCRegion('europe');
+   * // Set the RTC region to sydney
+   * stageChannel.setRTCRegion('sydney');
    * @example
    * // Remove a fixed region for this channel - let Discord decide automatically
-   * stageChannel.setRTCRegion(null);
+   * stageChannel.setRTCRegion(null, 'We want to let Discord decide.');
    */
 }
 

--- a/src/structures/VoiceChannel.js
+++ b/src/structures/VoiceChannel.js
@@ -90,14 +90,15 @@ class VoiceChannel extends BaseGuildVoiceChannel {
   /**
    * Sets the RTC region of the channel.
    * @name VoiceChannel#setRTCRegion
-   * @param {?string} region The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {?string} rtcRegion The new region of the channel. Set to `null` to remove a specific region for the channel
+   * @param {string} [reason] The reason for modifying this region.
    * @returns {Promise<VoiceChannel>}
    * @example
-   * // Set the RTC region to europe
-   * voiceChannel.setRTCRegion('europe');
+   * // Set the RTC region to sydney
+   * voiceChannel.setRTCRegion('sydney');
    * @example
    * // Remove a fixed region for this channel - let Discord decide automatically
-   * voiceChannel.setRTCRegion(null);
+   * voiceChannel.setRTCRegion(null, 'We want to let Discord decide.');
    */
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -449,7 +449,7 @@ export class BaseGuildVoiceChannel extends GuildChannel {
   public bitrate: number;
   public userLimit: number;
   public createInvite(options?: CreateInviteOptions): Promise<Invite>;
-  public setRTCRegion(region: string | null): Promise<this>;
+  public setRTCRegion(rtcRegion: string | null, reason?: string): Promise<this>;
   public fetchInvites(cache?: boolean): Promise<Collection<string, Invite>>;
 }
 


### PR DESCRIPTION
Backports #7723 to version 13.