### PR TITLE
fix(ButtonBuilder): default constructor to empty object

### DIFF
--- a/packages/discord.js/src/structures/ButtonBuilder.js
+++ b/packages/discord.js/src/structures/ButtonBuilder.js
@@ -5,7 +5,7 @@ const Transformers = require('../util/Transformers');
 const Util = require('../util/Util');
 
 class ButtonBuilder extends BuildersButtonComponent {
-  constructor({ emoji, ...data }) {
+  constructor({ emoji, ...data } = {}) {
     super(
       Transformers.toSnakeCase({ ...data, emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji }),
     );


### PR DESCRIPTION
Fixes a error thrown by deconstructing `property 'emoji' of 'undefined'` when calling `new ButtonBuilder()` with no argument.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating