### PR TITLE
feat(builders): improve embed errors and predicates

### DIFF
--- a/packages/builders/src/messages/embed/Assertions.ts
+++ b/packages/builders/src/messages/embed/Assertions.ts
@@ -33,7 +33,7 @@ export const urlPredicate = s.string.url({
 
 export const embedAuthorPredicate = s.object({
 	name: authorNamePredicate,
-	iconURL: urlPredicate,
+	iconURL: imageURLPredicate,
 	url: urlPredicate,
 });
 
@@ -49,7 +49,7 @@ export const footerTextPredicate = s.string.lengthGe(1).lengthLe(2048).nullable;
 
 export const embedFooterPredicate = s.object({
 	text: footerTextPredicate,
-	iconURL: urlPredicate,
+	iconURL: imageURLPredicate,
 });
 
 export const timestampPredicate = s.union(s.number, s.date).nullable;

--- a/packages/builders/src/messages/embed/Assertions.ts
+++ b/packages/builders/src/messages/embed/Assertions.ts
@@ -31,6 +31,12 @@ export const urlPredicate = s.string.url({
 	allowedProtocols: ['http:', 'https:'],
 }).nullish;
 
+export const embedAuthorPredicate = s.object({
+	name: authorNamePredicate,
+	iconURL: urlPredicate,
+	url: urlPredicate,
+});
+
 export const RGBPredicate = s.number.int.ge(0).le(255);
 export const colorPredicate = s.number.int
 	.ge(0)
@@ -40,6 +46,11 @@ export const colorPredicate = s.number.int
 export const descriptionPredicate = s.string.lengthGe(1).lengthLe(4096).nullable;
 
 export const footerTextPredicate = s.string.lengthGe(1).lengthLe(2048).nullable;
+
+export const embedFooterPredicate = s.object({
+	text: footerTextPredicate,
+	iconURL: urlPredicate,
+});
 
 export const timestampPredicate = s.union(s.number, s.date).nullable;
 

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -1,10 +1,10 @@
 import type { APIEmbedField } from 'discord-api-types/v10';
 import {
-	authorNamePredicate,
 	colorPredicate,
 	descriptionPredicate,
+	embedAuthorPredicate,
 	embedFieldsArrayPredicate,
-	footerTextPredicate,
+	embedFooterPredicate,
 	imageURLPredicate,
 	timestampPredicate,
 	titlePredicate,
@@ -39,9 +39,7 @@ export class EmbedBuilder extends UnsafeEmbedBuilder {
 		}
 
 		// Data assertions
-		authorNamePredicate.parse(options.name);
-		urlPredicate.parse(options.iconURL);
-		urlPredicate.parse(options.url);
+		embedAuthorPredicate.parse(options);
 
 		return super.setAuthor(options);
 	}
@@ -62,8 +60,7 @@ export class EmbedBuilder extends UnsafeEmbedBuilder {
 		}
 
 		// Data assertions
-		footerTextPredicate.parse(options.text);
-		urlPredicate.parse(options.iconURL);
+		embedFooterPredicate.parse(options);
 
 		return super.setFooter(options);
 	}


### PR DESCRIPTION
Improves the error output of some EmbedBuilder methods by using an object validator rather than validating params individually.

This provides much better output for the most common errors seen due to old v13 style code such as `<EmbedBuilder>.setAuthor("Monbrey")`, which will now throw `Expected the value to be an object, but received string instead`.

I didn't see anywhere else this needed doing but feel free to point out any spots and I'll do the same.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

