### PR TITLE
feat(SelectMenu): allow emojis in options and option constructors

### DIFF
--- a/packages/discord.js/src/structures/SelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuBuilder.js
@@ -5,25 +5,53 @@ const Transformers = require('../util/Transformers');
 const Util = require('../util/Util');
 
 /**
- * Represents a select menu builder.
+ * Class used to build select menu components to be sent through the API
  * @extends {BuildersSelectMenu}
  */
 class SelectMenuBuilder extends BuildersSelectMenu {
   constructor({ options, ...data } = {}) {
     super(
       Transformers.toSnakeCase({
+        ...data,
         options: options?.map(({ emoji, ...option }) => ({
           ...option,
           emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji,
         })),
-        ...data,
       }),
     );
   }
 
   /**
-   * Creates a new select menu builder from JSON data
-   * @param {JSONEncodable<APISelectMenuComponent>|APISelectMenuComponent} other The other data
+   * Adds options to this select menu
+   * @param {APISelectMenuOption[]} options The options to add to this select menu
+   * @returns {SelectMenuBuilder}
+   */
+  addOptions(...options) {
+    return super.addOptions(
+      options.map(({ emoji, ...option }) => ({
+        ...option,
+        emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji,
+      })),
+    );
+  }
+
+  /**
+   * Sets the options on this select menu
+   * @param {APISelectMenuOption[]} options The options to set on this select menu
+   * @returns {SelectMenuBuilder}
+   */
+  setOptions(...options) {
+    return super.setOptions(
+      options.map(({ emoji, ...option }) => ({
+        ...option,
+        emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji,
+      })),
+    );
+  }
+
+  /**
+   * Creates a new select menu builder from json data
+   * @param {JSONEncodable<APISelectMenuComponent> | APISelectMenuComponent} other The other data
    * @returns {SelectMenuBuilder}
    */
   static from(other) {

--- a/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { SelectMenuOptionBuilder: BuildersSelectMenuOption } = require('@discordjs/builders');
+const Transformers = require('../util/Transformers');
 const Util = require('../util/Util');
 
 /**
@@ -8,6 +9,14 @@ const Util = require('../util/Util');
  * @extends {BuildersSelectMenuOption}
  */
 class SelectMenuOptionBuilder extends BuildersSelectMenuOption {
+  constructor({ emoji, ...data } = {}) {
+    super(
+      Transformers.toSnakeCase({
+        ...data,
+        emoji: emoji && typeof emoji === 'string' ? Util.parseEmoji(emoji) : emoji,
+      }),
+    );
+  }
   /**
    * Sets the emoji to display on this option
    * @param {ComponentEmojiResolvable} emoji The emoji to display on this option

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -596,10 +596,17 @@ export class ButtonBuilder extends BuilderButtonComponent {
 
 export class SelectMenuBuilder extends BuilderSelectMenuComponent {
   public constructor(data?: Partial<SelectMenuComponentData | APISelectMenuComponent>);
+  public override addOptions(
+    ...options: (BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption)[]
+  ): this;
+  public override setOptions(
+    ...options: (BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption)[]
+  ): this;
   public static from(other: JSONEncodable<APISelectMenuComponent> | APISelectMenuComponent): SelectMenuBuilder;
 }
 
 export class SelectMenuOptionBuilder extends BuildersSelectMenuOption {
+  public constructor(data?: SelectMenuComponentOptionData | APISelectMenuOption);
   public setEmoji(emoji: ComponentEmojiResolvable): this;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Oversight from #7718 this PR adds the ability to add an emoji on a SelectMenuOptionBuilder's constructor, as well as the SelectMenuBuilder methods addOptions and setOptions

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
