### PR TITLE
docs(ApplicationCommand): fix and improve localization docs

### DIFF
--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -65,7 +65,7 @@ class ApplicationCommand extends Base {
     if ('name_localizations' in data) {
       /**
        * The name localizations for this command
-       * @type {?Object<string, string>}
+       * @type {?Object<Locale, string>}
        */
       this.nameLocalizations = data.name_localizations;
     } else {
@@ -75,7 +75,7 @@ class ApplicationCommand extends Base {
     if ('name_localized' in data) {
       /**
        * The localized name for this command
-       * @type {?Object<string, string>}
+       * @type {?string}
        */
       this.nameLocalized = data.name_localized;
     } else {
@@ -93,7 +93,7 @@ class ApplicationCommand extends Base {
     if ('description_localizations' in data) {
       /**
        * The description localizations for this command
-       * @type {?string}
+       * @type {?Object<Locale, string>}
        */
       this.descriptionLocalizations = data.description_localizations;
     } else {
@@ -169,9 +169,9 @@ class ApplicationCommand extends Base {
    * @typedef {Object} ApplicationCommandData
    * @property {string} name The name of the command, must be in all lowercase if type is
    * {@link ApplicationCommandType.ChatInput}
-   * @property {Object<string, string>} [nameLocalizations] The localizations for the command name
+   * @property {Object<Locale, string>} [nameLocalizations] The localizations for the command name
    * @property {string} description The description of the command, if type is {@link ApplicationCommandType.ChatInput}
-   * @property {Object<string, string>} [descriptionLocalizations] The localizations for the command description,
+   * @property {Object<Locale, string>} [descriptionLocalizations] The localizations for the command description,
    * if type is {@link ApplicationCommandType.ChatInput}
    * @property {ApplicationCommandType} [type=ApplicationCommandType.ChatInput] The type of the command
    * @property {ApplicationCommandOptionData[]} [options] Options for the command
@@ -188,9 +188,9 @@ class ApplicationCommand extends Base {
    * @typedef {Object} ApplicationCommandOptionData
    * @property {ApplicationCommandOptionType} type The type of the option
    * @property {string} name The name of the option
-   * @property {Object<string, string>} [nameLocalizations] The name localizations for the option
+   * @property {Object<Locale, string>} [nameLocalizations] The name localizations for the option
    * @property {string} description The description of the option
-   * @property {Object<string, string>} [descriptionLocalizations] The description localizations for the option
+   * @property {Object<Locale, string>} [descriptionLocalizations] The description localizations for the option
    * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a
    * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandOptionType.Integer} or
    * {@link ApplicationCommandOptionType.Number} option
@@ -208,13 +208,8 @@ class ApplicationCommand extends Base {
   /**
    * @typedef {Object} ApplicationCommandOptionChoiceData
    * @property {string} name The name of the choice
-   * @property {Object<string, string>} [nameLocalizations] The localized names for this choice
+   * @property {Object<Locale, string>} [nameLocalizations] The localized names for this choice
    * @property {string|number} value The value of the choice
-   */
-
-  /**
-   * @typedef {ApplicationCommandOptionChoiceData} ApplicationCommandOptionChoice
-   * @property {string} [nameLocalized] The localized name for this choice
    */
 
   /**
@@ -244,7 +239,7 @@ class ApplicationCommand extends Base {
 
   /**
    * Edits the localized names of this ApplicationCommand
-   * @param {Object<string, string>} nameLocalizations The new localized names for the command
+   * @param {Object<Locale, string>} nameLocalizations The new localized names for the command
    * @returns {Promise<ApplicationCommand>}
    * @example
    * // Edit the name localizations of this command
@@ -270,11 +265,11 @@ class ApplicationCommand extends Base {
 
   /**
    * Edits the localized descriptions of this ApplicationCommand
-   * @param {Object<string, string>} descriptionLocalizations The new localized descriptions for the command
+   * @param {Object<Locale, string>} descriptionLocalizations The new localized descriptions for the command
    * @returns {Promise<ApplicationCommand>}
    * @example
    * // Edit the description localizations of this command
-   * command.setLocalizedDescriptions({
+   * command.setDescriptionLocalizations({
    *   'en-GB': 'A test command',
    *   'pt-BR': 'Um comando de teste',
    * })
@@ -439,10 +434,10 @@ class ApplicationCommand extends Base {
    * @typedef {Object} ApplicationCommandOption
    * @property {ApplicationCommandOptionType} type The type of the option
    * @property {string} name The name of the option
-   * @property {Object<string, string>} [nameLocalizations] The localizations for the option name
+   * @property {Object<Locale, string>} [nameLocalizations] The localizations for the option name
    * @property {string} [nameLocalized] The localized name for this option
    * @property {string} description The description of the option
-   * @property {Object<string, string>} [descriptionLocalizations] The localizations for the option description
+   * @property {Object<Locale, string>} [descriptionLocalizations] The localizations for the option description
    * @property {string} [descriptionLocalized] The localized description for this option
    * @property {boolean} [required] Whether the option is required
    * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a
@@ -456,6 +451,15 @@ class ApplicationCommand extends Base {
    * {@link ApplicationCommandOptionType.Number} option
    * @property {number} [maxValue] The maximum value for an {@link ApplicationCommandOptionType.Integer} or
    * {@link ApplicationCommandOptionType.Number} option
+   */
+
+  /**
+   * A choice for an application command option.
+   * @typedef {Object} ApplicationCommandOptionChoice
+   * @property {string} name The name of the choice
+   * @property {?string} nameLocalized The localized name of the choice in the provided locale, if any
+   * @property {?Object<string, string>} [nameLocalizations] The localized names for this choice
+   * @property {string|number} value The value of the choice
    */
 
   /**

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -336,8 +336,7 @@ class Guild extends AnonymousGuild {
     if ('preferred_locale' in data) {
       /**
        * The preferred locale of the guild, defaults to `en-US`
-       * @type {string}
-       * @see {@link https://discord.com/developers/docs/reference#locales}
+       * @type {Locale}
        */
       this.preferredLocale = data.preferred_locale;
     }

--- a/packages/discord.js/src/structures/Interaction.js
+++ b/packages/discord.js/src/structures/Interaction.js
@@ -78,15 +78,50 @@ class Interaction extends Base {
       : null;
 
     /**
-     * The locale of the user who invoked this interaction
-     * @type {string}
+     * A Discord locale string, possible values are:
+     * * en-US (English, US)
+     * * en-GB (English, UK)
+     * * bg (Bulgarian)
+     * * zh-CN (Chinese, China)
+     * * zh-TW (Chinese, Taiwan)
+     * * hr (Croatian)
+     * * cs (Czech)
+     * * da (Danish)
+     * * nl (Dutch)
+     * * fi (Finnish)
+     * * fr (French)
+     * * de (German)
+     * * el (Greek)
+     * * hi (Hindi)
+     * * hu (Hungarian)
+     * * it (Italian)
+     * * ja (Japanese)
+     * * ko (Korean)
+     * * lt (Lithuanian)
+     * * no (Norwegian)
+     * * pl (Polish)
+     * * pt-BR (Portuguese, Brazilian)
+     * * ro (Romanian, Romania)
+     * * ru (Russian)
+     * * es-ES (Spanish)
+     * * sv-SE (Swedish)
+     * * th (Thai)
+     * * tr (Turkish)
+     * * uk (Ukrainian)
+     * * vi (Vietnamese)
      * @see {@link https://discord.com/developers/docs/reference#locales}
+     * @typedef {string} Locale
+     */
+
+    /**
+     * The locale of the user who invoked this interaction
+     * @type {Locale}
      */
     this.locale = data.locale;
 
     /**
      * The preferred locale from the guild this interaction was sent in
-     * @type {?string}
+     * @type {?Locale}
      */
     this.guildLocale = data.guild_locale ?? null;
   }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3595,10 +3595,6 @@ export interface ApplicationCommandOptionChoiceData {
   value: string | number;
 }
 
-export interface ApplicationCommandOptionChoice extends ApplicationCommandOptionChoiceData {
-  nameLocalized?: string;
-}
-
 export interface ApplicationCommandPermissionData {
   id: Snowflake;
   type: ApplicationCommandPermissionType;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR:

- adds a `Locale` typedef with all the possible locales to make it easier to document them in various places
- fixes the documentation of the *Localizations and *Localized properties

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
