### PR TITLE
chore: fix rest package file

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -50,7 +50,7 @@
 	},
 	"homepage": "https://discord.js.org",
 	"dependencies": {
-		"@discordjs/collection": "workspace:^",
+		"@discordjs/collection": "^0.6.0",
 		"@sapphire/async-queue": "^1.3.1",
 		"@sapphire/snowflake": "^3.2.1",
 		"@types/node-fetch": "^2.6.1",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Right now, the new `@discordjs/rest` 0.4.0 release can't be installed because of this error
```
npm ERR! code EUNSUPPORTEDPROTOCOL
npm ERR! Unsupported URL Type "workspace:": workspace:^
```
This PR (hopefully) fixes it
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
