### PR TITLE
feat(MessageReaction): add react method

### DIFF
--- a/packages/discord.js/src/structures/MessageReaction.js
+++ b/packages/discord.js/src/structures/MessageReaction.js
@@ -53,6 +53,14 @@ class MessageReaction {
   }
 
   /**
+   * Makes the client user react with this reaction
+   * @returns {Promise<MessageReaction>}
+   */
+  react() {
+    return this.message.react(this.emoji);
+  }
+
+  /**
    * Removes all users from this reaction.
    * @returns {Promise<MessageReaction>}
    */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1883,6 +1883,7 @@ export class MessageReaction {
   public message: Message | PartialMessage;
   public get partial(): false;
   public users: ReactionUserManager;
+  public react(): Promise<MessageReaction>;
   public remove(): Promise<MessageReaction>;
   public fetch(): Promise<MessageReaction>;
   public toJSON(): unknown;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds the MessageReaction#react method to make it easier to add an existing reaction to a message. Its purpose is to make it easier for bots to react with emojis they do not know in their cache. The name is up for debate if anyone has better ideas, this was the best I could come up with

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
