### PR TITLE
fix(InteractionResponses): use optional chaining on nullable property

### DIFF
--- a/packages/discord.js/src/structures/InteractionCollector.js
+++ b/packages/discord.js/src/structures/InteractionCollector.js
@@ -211,7 +211,7 @@ class InteractionCollector extends Collector {
       this.stop('messageDelete');
     }
 
-    if (message.interaction.id === this.messageInteractionId) {
+    if (message.interaction?.id === this.messageInteractionId) {
       this.stop('messageDelete');
     }
   }

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -197,7 +197,7 @@ class InteractionResponses {
     });
     this.deferred = true;
 
-    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this, this.message.interaction.id);
+    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this, this.message.interaction?.id);
   }
 
   /**
@@ -232,7 +232,7 @@ class InteractionResponses {
     });
     this.replied = true;
 
-    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this, this.message.interaction.id);
+    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this, this.message.interaction?.id);
   }
 
   /**


### PR DESCRIPTION
MessageComponents do not require an interaction to be sent - this was causing an `id of null` error.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating