### PR TITLE
feat(builders): add `AttachmentBuilder` and `UnsafeAttachmentBuilder`

### DIFF
--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -3,6 +3,10 @@ export * from './messages/embed/Embed';
 export * from './messages/formatters';
 export * from './messages/embed/UnsafeEmbed';
 
+export * as AttachmentAssertions from './messages/attachment/Assertions';
+export * from './messages/attachment/Attachment';
+export * from './messages/attachment/UnsafeAttachment';
+
 export * as ComponentAssertions from './components/Assertions';
 export * from './components/ActionRow';
 export * from './components/button/Button';

--- a/packages/builders/src/messages/attachment/Assertions.ts
+++ b/packages/builders/src/messages/attachment/Assertions.ts
@@ -6,7 +6,7 @@ export const descriptionValidator = s.string;
 
 export const spoilerValidator = s.boolean;
 
-export function validateRequiredAttachmentParameters(name: string | null, description: string | null) {
+export function validateRequiredAttachmentParameters(name: string | null | undefined, description: string | null | undefined) {
 	nameValidator.parse(name);
 	descriptionValidator.parse(description);
 }

--- a/packages/builders/src/messages/attachment/Assertions.ts
+++ b/packages/builders/src/messages/attachment/Assertions.ts
@@ -6,7 +6,10 @@ export const descriptionValidator = s.string;
 
 export const spoilerValidator = s.boolean;
 
-export function validateRequiredAttachmentParameters(name: string | null | undefined, description: string | null | undefined) {
+export function validateRequiredAttachmentParameters(
+	name: string | null | undefined,
+	description: string | null | undefined,
+) {
 	nameValidator.parse(name);
 	descriptionValidator.parse(description);
 }

--- a/packages/builders/src/messages/attachment/Assertions.ts
+++ b/packages/builders/src/messages/attachment/Assertions.ts
@@ -6,10 +6,7 @@ export const descriptionValidator = s.string;
 
 export const spoilerValidator = s.boolean;
 
-export function validateRequiredAttachmentParameters(
-	name: string | null | undefined,
-	description: string | null | undefined,
-) {
+export function validateRequiredAttachmentParameters(name: string | null, description: string | null) {
 	nameValidator.parse(name);
 	descriptionValidator.parse(description);
 }

--- a/packages/builders/src/messages/attachment/Assertions.ts
+++ b/packages/builders/src/messages/attachment/Assertions.ts
@@ -6,7 +6,7 @@ export const descriptionValidator = s.string;
 
 export const spoilerValidator = s.boolean;
 
-export function validateRequiredAttachmentParameters(name: string, description: string) {
+export function validateRequiredAttachmentParameters(name: string | null, description: string | null) {
 	nameValidator.parse(name);
 	descriptionValidator.parse(description);
 }

--- a/packages/builders/src/messages/attachment/Assertions.ts
+++ b/packages/builders/src/messages/attachment/Assertions.ts
@@ -6,7 +6,10 @@ export const descriptionValidator = s.string;
 
 export const spoilerValidator = s.boolean;
 
-export function validateRequiredAttachmentParameters(name: string | null, description: string | null) {
+export function validateRequiredAttachmentParameters(
+	name: string | null | undefined,
+	description: string | null | undefined,
+) {
 	nameValidator.parse(name);
 	descriptionValidator.parse(description);
 }

--- a/packages/builders/src/messages/attachment/Assertions.ts
+++ b/packages/builders/src/messages/attachment/Assertions.ts
@@ -1,0 +1,12 @@
+import { s } from '@sapphire/shapeshift';
+
+export const nameValidator = s.string;
+
+export const descriptionValidator = s.string;
+
+export const spoilerValidator = s.boolean;
+
+export function validateRequiredAttachmentParameters(name: string, description: string) {
+	nameValidator.parse(name);
+	descriptionValidator.parse(description);
+}

--- a/packages/builders/src/messages/attachment/Attachment.ts
+++ b/packages/builders/src/messages/attachment/Attachment.ts
@@ -20,7 +20,7 @@ export class AttachmentBuilder extends UnsafeAttachmentBuilder {
 	}
 
 	public override toJSON() {
-		validateRequiredAttachmentParameters(this.data.description, this.data.name);
+		validateRequiredAttachmentParameters(this.data.description, this.data.filename ?? this.data.name);
 		return super.toJSON();
 	}
 }

--- a/packages/builders/src/messages/attachment/Attachment.ts
+++ b/packages/builders/src/messages/attachment/Attachment.ts
@@ -1,7 +1,7 @@
-import { UnsafeAttachmentBuilder } from './UnsafeAttachment';
 import { nameValidator, descriptionValidator, validateRequiredAttachmentParameters } from './Assertions';
-import type { BufferResolvable } from './UnsafeAttachment';
 import type { Stream } from 'node:stream';
+import { UnsafeAttachmentBuilder } from './UnsafeAttachment';
+import type { BufferResolvable } from './UnsafeAttachment';
 
 export class AttachmentBuilder extends UnsafeAttachmentBuilder {
 	public override setDescription(description: string) {

--- a/packages/builders/src/messages/attachment/Attachment.ts
+++ b/packages/builders/src/messages/attachment/Attachment.ts
@@ -1,5 +1,5 @@
 import type { Stream } from 'node:stream';
-import { nameValidator, descriptionValidator, validateRequiredAttachmentParameters } from './Assertions';
+import { nameValidator, descriptionValidator, spoilerValidator, validateRequiredAttachmentParameters } from './Assertions';
 import { UnsafeAttachmentBuilder } from './UnsafeAttachment';
 import type { BufferResolvable } from './UnsafeAttachment';
 
@@ -18,6 +18,11 @@ export class AttachmentBuilder extends UnsafeAttachmentBuilder {
 	public override setName(name: string) {
 		return super.setName(nameValidator.parse(name));
 	}
+
+        public override setSpoiler(spoiler: boolean) {
+                spoilerValidator.parse(spoiler);
+                return super.setSpoiler(spoiler);
+        }
 
 	public override toJSON() {
 		validateRequiredAttachmentParameters(this.data.description, this.data.filename);

--- a/packages/builders/src/messages/attachment/Attachment.ts
+++ b/packages/builders/src/messages/attachment/Attachment.ts
@@ -13,7 +13,7 @@ export class AttachmentBuilder extends UnsafeAttachmentBuilder {
 		return super.setDescription(descriptionValidator.parse(description));
 	}
 
-	public override setFile(attachment: BufferResolvable | Stream, name: string | null) {
+	public override setFile(attachment: BufferResolvable | Stream, name: string) {
 		if (name) {
 			return super.setFile(attachment, nameValidator.parse(name));
 		}

--- a/packages/builders/src/messages/attachment/Attachment.ts
+++ b/packages/builders/src/messages/attachment/Attachment.ts
@@ -1,5 +1,10 @@
 import type { Stream } from 'node:stream';
-import { nameValidator, descriptionValidator, spoilerValidator, validateRequiredAttachmentParameters } from './Assertions';
+import {
+	nameValidator,
+	descriptionValidator,
+	spoilerValidator,
+	validateRequiredAttachmentParameters,
+} from './Assertions';
 import { UnsafeAttachmentBuilder } from './UnsafeAttachment';
 import type { BufferResolvable } from './UnsafeAttachment';
 
@@ -19,10 +24,10 @@ export class AttachmentBuilder extends UnsafeAttachmentBuilder {
 		return super.setName(nameValidator.parse(name));
 	}
 
-        public override setSpoiler(spoiler: boolean) {
-                spoilerValidator.parse(spoiler);
-                return super.setSpoiler(spoiler);
-        }
+	public override setSpoiler(spoiler: boolean) {
+		spoilerValidator.parse(spoiler);
+		return super.setSpoiler(spoiler);
+	}
 
 	public override toJSON() {
 		validateRequiredAttachmentParameters(this.data.description, this.data.filename);

--- a/packages/builders/src/messages/attachment/Attachment.ts
+++ b/packages/builders/src/messages/attachment/Attachment.ts
@@ -20,7 +20,7 @@ export class AttachmentBuilder extends UnsafeAttachmentBuilder {
 	}
 
 	public override toJSON() {
-		validateRequiredAttachmentParameters(this.data.description, this.data.filename ?? this.data.name);
+		validateRequiredAttachmentParameters(this.data.description, this.data.filename);
 		return super.toJSON();
 	}
 }

--- a/packages/builders/src/messages/attachment/Attachment.ts
+++ b/packages/builders/src/messages/attachment/Attachment.ts
@@ -1,5 +1,5 @@
-import { nameValidator, descriptionValidator, validateRequiredAttachmentParameters } from './Assertions';
 import type { Stream } from 'node:stream';
+import { nameValidator, descriptionValidator, validateRequiredAttachmentParameters } from './Assertions';
 import { UnsafeAttachmentBuilder } from './UnsafeAttachment';
 import type { BufferResolvable } from './UnsafeAttachment';
 

--- a/packages/builders/src/messages/attachment/Attachment.ts
+++ b/packages/builders/src/messages/attachment/Attachment.ts
@@ -1,0 +1,26 @@
+import { UnsafeAttachmentBuilder } from './UnsafeAttachment';
+import { nameValidator, descriptionValidator, validateRequiredAttachmentParameters } from './Assertions';
+import type { BufferResolvable } from './UnsafeAttachment';
+import type { Stream } from 'node:stream';
+
+export class AttachmentBuilder extends UnsafeAttachmentBuilder {
+	public override setDescription(description: string) {
+		return super.setDescription(descriptionValidator.parse(description));
+	}
+
+	public override setFile(attachment: BufferResolvable | Stream, name: string | null) {
+		if (name) {
+			return super.setFile(attachment, nameValidator.parse(name));
+		}
+		return super.setFile(attachment, name);
+	}
+
+	public override setName(name: string) {
+		return super.setName(nameValidator.parse(name));
+	}
+
+	public override toJSON() {
+		validateRequiredAttachmentParameters(this.data.description, this.data.name);
+		return super.toJSON();
+	}
+}

--- a/packages/builders/src/messages/attachment/Attachment.ts
+++ b/packages/builders/src/messages/attachment/Attachment.ts
@@ -30,7 +30,7 @@ export class AttachmentBuilder extends UnsafeAttachmentBuilder {
 	}
 
 	public override toJSON() {
-		validateRequiredAttachmentParameters(this.data.description, this.data.filename);
+		validateRequiredAttachmentParameters(this.description, this.name);
 		return super.toJSON();
 	}
 }

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -162,12 +162,12 @@ export class UnsafeAttachmentBuilder {
 	}
 
 	/**
-     * Whether or not this attachment has been marked as a spoiler
-     * @type {boolean}
-     * @readonly
-     */
+	 * Whether or not this attachment has been marked as a spoiler
+	 * @type {boolean}
+	 * @readonly
+	 */
 	get spoiler() {
-		if(this.name) return this.name.startsWith('SPOILER_');
+		if (this.name) return this.name.startsWith('SPOILER_');
 		return false;
 	}
 

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -78,9 +78,9 @@ export class UnsafeAttachmentBuilder {
 	}
 
 	public toJSON(): APIAttachment {
-		const JSONAttachment: APIAttachment = {
+		const JSONAttachment = {
 			filename: this.name,
-			description: this.description ?? null,
+			description: this.description,
 			url: this.attachment,
 		};
 

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -12,7 +12,7 @@ export class UnsafeAttachmentBuilder {
 	public description?: string | null;
 	public ephemeral?: boolean;
 	public height?: number | null;
-	public id: Snowflake;
+	public id!: Snowflake;
 	public name: string | null;
 	public proxyURL!: string;
 	public size!: number;

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -1,42 +1,29 @@
 import type { Stream } from 'node:stream';
-import type { APIAttachment, Snowflake } from 'discord-api-types/v10';
+import type { APIAttachment } from 'discord-api-types/v10';
 
-export type BufferResolvable = typeof ArrayBuffer | string;
+export type BufferResolvable = ArrayBuffer | string;
+
 /**
  * Represents an attachment.
  */
 export class UnsafeAttachmentBuilder {
-	public readonly data: APIAttachment;
 	public attachment: BufferResolvable | Stream;
-	public contentType?: string | null;
+	public name: string;
+	public content_type?: string | null;
 	public description?: string | null;
-	public ephemeral?: boolean;
-	public height?: number | null;
-	public id!: Snowflake;
-	public name: string | null;
-	public proxyURL!: string;
-	public size!: number;
-	public url!: string;
-	public width?: number | null;
 
-	/**
-	 * @param {APIAttachment} [data] Extra data
-	 */
-	public constructor(attachment: BufferResolvable | Stream, name = null, _data: APIAttachment) {
-		this.data = { ..._data };
+	public constructor(attachment: BufferResolvable | Stream, name: string) {
 		this.attachment = attachment;
 		/**
 		 * The name of this attachment
 		 * @type {?string}
 		 */
 		this.name = name;
-		this._patch(_data);
 	}
 
 	/**
 	 * Sets the description of this attachment.
 	 * @param {string} description The description of the file
-	 * @returns {Attachment} This attachment
 	 */
 	public setDescription(description: string) {
 		this.description = description;
@@ -47,18 +34,16 @@ export class UnsafeAttachmentBuilder {
 	 * Sets the file of this attachment.
 	 * @param {BufferResolvable|Stream} attachment The file
 	 * @param {string} [name] The name of the file, if any
-	 * @returns {Attachment} This attachment
 	 */
-	public setFile(attachment: BufferResolvable | Stream, name: string | null) {
+	public setFile(attachment: BufferResolvable | Stream, name: string) {
 		this.attachment = attachment;
-		this.name ? (this.name = name) : (this.name = null);
+		this.name = name;
 		return this;
 	}
 
 	/**
 	 * Sets the name of this attachment.
 	 * @param {string} name The name of the file
-	 * @returns {Attachment} This attachment
 	 */
 	public setName(name: string) {
 		this.name = name;
@@ -68,97 +53,18 @@ export class UnsafeAttachmentBuilder {
 	/**
 	 * Sets whether this attachment is a spoiler
 	 * @param {boolean} [spoiler=true] Whether the attachment should be marked as a spoiler
-	 * @returns {Attachment} This attachment
 	 */
 	public setSpoiler(spoiler = true) {
 		if (spoiler === this.spoiler) return this;
 
 		if (!spoiler) {
-			while (this.spoiler && typeof this.name === 'string') {
+			while (this.spoiler) {
 				this.name = this.name.slice('SPOILER_'.length);
 			}
 			return this;
 		}
-		this.name ? (this.name = `SPOILER_${this.name}`) : (this.name = null);
+		this.name = `SPOILER_${this.name}`;
 		return this;
-	}
-
-	private _patch(data: APIAttachment) {
-		/**
-		 * The attachment's id
-		 * @type {Snowflake}
-		 */
-		this.id = data.id;
-
-		if ('size' in data) {
-			/**
-			 * The size of this attachment in bytes
-			 * @type {number}
-			 */
-			this.size = data.size;
-		}
-
-		if ('url' in data) {
-			/**
-			 * The URL to this attachment
-			 * @type {string}
-			 */
-			this.url = data.url;
-		}
-
-		if ('proxy_url' in data) {
-			/**
-			 * The proxy URL to this attachment
-			 * @type {string}
-			 */
-			this.proxyURL = data.proxy_url;
-		}
-
-		if ('height' in data) {
-			/**
-			 * The height of this attachment (if an image or video)
-			 * @type {?number}
-			 */
-			this.height = data.height;
-		} else {
-			this.height ??= null;
-		}
-
-		if ('width' in data) {
-			/**
-			 * The width of this attachment (if an image or video)
-			 * @type {?number}
-			 */
-			this.width = data.width;
-		} else {
-			this.width ??= null;
-		}
-
-		if ('content_type' in data) {
-			/**
-			 * The media type of this attachment
-			 * @type {?string}
-			 */
-			this.contentType = data.content_type;
-		} else {
-			this.contentType ??= null;
-		}
-
-		if ('description' in data) {
-			/**
-			 * The description (alt text) of this attachment
-			 * @type {?string}
-			 */
-			this.description = data.description;
-		} else {
-			this.description ??= null;
-		}
-
-		/**
-		 * Whether this attachment is ephemeral
-		 * @type {boolean}
-		 */
-		this.ephemeral = data.ephemeral ?? false;
 	}
 
 	/**
@@ -173,7 +79,9 @@ export class UnsafeAttachmentBuilder {
 
 	public toJSON(): APIAttachment {
 		const JSONAttachment: APIAttachment = {
-			...this.data,
+			filename: this.name,
+			description: this.description ?? null,
+			url: this.attachment,
 		};
 
 		return JSONAttachment;

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -1,5 +1,4 @@
 import type { Stream } from 'node:stream';
-import type { APIAttachment } from 'discord-api-types/v10';
 
 export type BufferResolvable = ArrayBuffer | string;
 

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -1,5 +1,5 @@
 import type { Stream } from 'node:stream';
-import { APIAttachment, Snowflake } from 'discord-api-types/v10';
+import type { APIAttachment, Snowflake } from 'discord-api-types/v10';
 
 export type BufferResolvable = typeof ArrayBuffer | string;
 /**
@@ -22,15 +22,15 @@ export class UnsafeAttachmentBuilder {
 	/**
 	 * @param {APIAttachment} [data] Extra data
 	 */
-	public constructor(attachment: BufferResolvable | Stream, name = null, data?: APIAttachment) {
-		this.data = { ...data };
+	public constructor(attachment: BufferResolvable | Stream, name = null, _data: APIAttachment) {
+		this.data = { ..._data };
 		this.attachment = attachment;
 		/**
 		 * The name of this attachment
 		 * @type {?string}
 		 */
 		this.name = name;
-		if (data) this._patch(data);
+		if (_data) this._patch(_data);
 	}
 
 	/**

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -1,0 +1,174 @@
+import type { APIAttachment, Snowflake } from 'discord-api-types/v10';
+import type { Stream } from 'node:stream';
+
+export type BufferResolvable = typeof ArrayBuffer | string;
+/**
+ * Represents an attachment.
+ */
+export class UnsafeAttachmentBuilder {
+	public readonly data: APIAttachment;
+	public attachment: BufferResolvable | Stream;
+	public contentType?: string | null;
+	public description?: string | null;
+	public ephemeral?: boolean;
+	public height?: number | null;
+	public id: Snowflake;
+	public name: string | null;
+	public proxyURL!: string;
+	public size!: number;
+	public url!: string;
+	public width?: number | null;
+
+	/**
+	 * @param {APIAttachment} [data] Extra data
+	 */
+	public constructor(attachment: BufferResolvable | Stream, name = null, _data: APIAttachment) {
+		this.data = { ..._data };
+		this.attachment = attachment;
+		/**
+		 * The name of this attachment
+		 * @type {?string}
+		 */
+		this.name = name;
+		if (_data) this._patch(_data);
+	}
+
+	/**
+	 * Sets the description of this attachment.
+	 * @param {string} description The description of the file
+	 * @returns {Attachment} This attachment
+	 */
+	public setDescription(description: string) {
+		this.description = description;
+		return this;
+	}
+
+	/**
+	 * Sets the file of this attachment.
+	 * @param {BufferResolvable|Stream} attachment The file
+	 * @param {string} [name] The name of the file, if any
+	 * @returns {Attachment} This attachment
+	 */
+	public setFile(attachment: BufferResolvable | Stream, name: string | null) {
+		this.attachment = attachment;
+		this.name ? (this.name = name) : (this.name = null);
+		return this;
+	}
+
+	/**
+	 * Sets the name of this attachment.
+	 * @param {string} name The name of the file
+	 * @returns {Attachment} This attachment
+	 */
+	public setName(name: string) {
+		this.name = name;
+		return this;
+	}
+
+	/**
+	 * Sets whether this attachment is a spoiler
+	 * @param {boolean} [spoiler=true] Whether the attachment should be marked as a spoiler
+	 * @returns {Attachment} This attachment
+	 */
+	public setSpoiler(spoiler = true) {
+		if (spoiler === this.spoiler) return this;
+
+		if (!spoiler) {
+			while (this.spoiler && typeof this.name === 'string') {
+				this.name = this.name.slice('SPOILER_'.length);
+			}
+			return this;
+		}
+		this.name = `SPOILER_${this.name}`;
+		return this;
+	}
+
+	_patch(_data: APIAttachment) {
+		/**
+		 * The attachment's id
+		 * @type {Snowflake}
+		 */
+		this.id = _data.id;
+
+		if ('size' in _data) {
+			/**
+			 * The size of this attachment in bytes
+			 * @type {number}
+			 */
+			this.size = _data.size;
+		}
+
+		if ('url' in _data) {
+			/**
+			 * The URL to this attachment
+			 * @type {string}
+			 */
+			this.url = _data.url;
+		}
+
+		if ('proxy_url' in _data) {
+			/**
+			 * The Proxy URL to this attachment
+			 * @type {string}
+			 */
+			this.proxyURL = _data.proxy_url;
+		}
+
+		if ('height' in _data) {
+			/**
+			 * The height of this attachment (if an image or video)
+			 * @type {?number}
+			 */
+			this.height = _data.height;
+		} else {
+			this.height ??= null;
+		}
+
+		if ('width' in _data) {
+			/**
+			 * The width of this attachment (if an image or video)
+			 * @type {?number}
+			 */
+			this.width = _data.width;
+		} else {
+			this.width ??= null;
+		}
+
+		if ('content_type' in _data) {
+			/**
+			 * The media type of this attachment
+			 * @type {?string}
+			 */
+			this.contentType = _data.content_type;
+		} else {
+			this.contentType ??= null;
+		}
+
+		if ('description' in _data) {
+			/**
+			 * The description (alt text) of this attachment
+			 * @type {?string}
+			 */
+			this.description = _data.description;
+		} else {
+			this.description ??= null;
+		}
+
+		/**
+		 * Whether this attachment is ephemeral
+		 * @type {boolean}
+		 */
+		this.ephemeral = _data.ephemeral ?? false;
+	}
+
+	public toJSON() {
+		return {
+			...this.data,
+		} as APIAttachment;
+	}
+}
+
+/**
+ * @external APIAttachment
+ * @see {@link https://discord.com/developers/docs/resources/channel#attachment-object}
+ */

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -108,7 +108,7 @@ export class UnsafeAttachmentBuilder {
 
 		if ('proxy_url' in data) {
 			/**
-			 * The Proxy URL to this attachment
+			 * The proxy URL to this attachment
 			 * @type {string}
 			 */
 			this.proxyURL = data.proxy_url;

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -22,7 +22,7 @@ export class UnsafeAttachmentBuilder {
 	/**
 	 * @param {APIAttachment} [data] Extra data
 	 */
-	public constructor(attachment: BufferResolvable | Stream, name = null, _data?: APIAttachment) {
+	public constructor(attachment: BufferResolvable | Stream, name = null, _data: APIAttachment) {
 		this.data = { ..._data };
 		this.attachment = attachment;
 		/**
@@ -30,7 +30,7 @@ export class UnsafeAttachmentBuilder {
 		 * @type {?string}
 		 */
 		this.name = name;
-		if (_data) this._patch(_data);
+		this._patch(_data);
 	}
 
 	/**

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -77,7 +77,7 @@ export class UnsafeAttachmentBuilder {
 		return false;
 	}
 
-	public toJSON(): APIAttachment {
+	public toJSON() {
 		const JSONAttachment = {
 			filename: this.name,
 			description: this.description,

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -1,5 +1,5 @@
-import type { APIAttachment, Snowflake } from 'discord-api-types/v10';
 import type { Stream } from 'node:stream';
+import { APIAttachment, Snowflake } from 'discord-api-types/v10';
 
 export type BufferResolvable = typeof ArrayBuffer | string;
 /**
@@ -22,15 +22,15 @@ export class UnsafeAttachmentBuilder {
 	/**
 	 * @param {APIAttachment} [data] Extra data
 	 */
-	public constructor(attachment: BufferResolvable | Stream, name = null, _data: APIAttachment) {
-		this.data = { ..._data };
+	public constructor(attachment: BufferResolvable | Stream, name = null, data?: APIAttachment) {
+		this.data = { ...data };
 		this.attachment = attachment;
 		/**
 		 * The name of this attachment
 		 * @type {?string}
 		 */
 		this.name = name;
-		if (_data) this._patch(_data);
+		if (data) this._patch(data);
 	}
 
 	/**
@@ -79,77 +79,77 @@ export class UnsafeAttachmentBuilder {
 			}
 			return this;
 		}
-		this.name = `SPOILER_${this.name}`;
+		this.name ? (this.name = `SPOILER_${this.name}`) : (this.name = null);
 		return this;
 	}
 
-	_patch(_data: APIAttachment) {
+	private _patch(data: APIAttachment) {
 		/**
 		 * The attachment's id
 		 * @type {Snowflake}
 		 */
-		this.id = _data.id;
+		this.id = data.id;
 
-		if ('size' in _data) {
+		if ('size' in data) {
 			/**
 			 * The size of this attachment in bytes
 			 * @type {number}
 			 */
-			this.size = _data.size;
+			this.size = data.size;
 		}
 
-		if ('url' in _data) {
+		if ('url' in data) {
 			/**
 			 * The URL to this attachment
 			 * @type {string}
 			 */
-			this.url = _data.url;
+			this.url = data.url;
 		}
 
-		if ('proxy_url' in _data) {
+		if ('proxy_url' in data) {
 			/**
 			 * The Proxy URL to this attachment
 			 * @type {string}
 			 */
-			this.proxyURL = _data.proxy_url;
+			this.proxyURL = data.proxy_url;
 		}
 
-		if ('height' in _data) {
+		if ('height' in data) {
 			/**
 			 * The height of this attachment (if an image or video)
 			 * @type {?number}
 			 */
-			this.height = _data.height;
+			this.height = data.height;
 		} else {
 			this.height ??= null;
 		}
 
-		if ('width' in _data) {
+		if ('width' in data) {
 			/**
 			 * The width of this attachment (if an image or video)
 			 * @type {?number}
 			 */
-			this.width = _data.width;
+			this.width = data.width;
 		} else {
 			this.width ??= null;
 		}
 
-		if ('content_type' in _data) {
+		if ('content_type' in data) {
 			/**
 			 * The media type of this attachment
 			 * @type {?string}
 			 */
-			this.contentType = _data.content_type;
+			this.contentType = data.content_type;
 		} else {
 			this.contentType ??= null;
 		}
 
-		if ('description' in _data) {
+		if ('description' in data) {
 			/**
 			 * The description (alt text) of this attachment
 			 * @type {?string}
 			 */
-			this.description = _data.description;
+			this.description = data.description;
 		} else {
 			this.description ??= null;
 		}
@@ -158,7 +158,7 @@ export class UnsafeAttachmentBuilder {
 		 * Whether this attachment is ephemeral
 		 * @type {boolean}
 		 */
-		this.ephemeral = _data.ephemeral ?? false;
+		this.ephemeral = data.ephemeral ?? false;
 	}
 
 	/**
@@ -166,15 +166,17 @@ export class UnsafeAttachmentBuilder {
 	 * @type {boolean}
 	 * @readonly
 	 */
-	get spoiler() {
+	public get spoiler() {
 		if (this.name) return this.name.startsWith('SPOILER_');
 		return false;
 	}
 
-	public toJSON() {
-		return {
+	public toJSON(): APIAttachment {
+		const JSONAttachment: APIAttachment = {
 			...this.data,
-		} as APIAttachment;
+		};
+
+		return JSONAttachment;
 	}
 }
 

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -161,6 +161,16 @@ export class UnsafeAttachmentBuilder {
 		this.ephemeral = _data.ephemeral ?? false;
 	}
 
+	/**
+     * Whether or not this attachment has been marked as a spoiler
+     * @type {boolean}
+     * @readonly
+     */
+	get spoiler() {
+		if(this.name) return this.name.startsWith('SPOILER_');
+		return false;
+	}
+
 	public toJSON() {
 		return {
 			...this.data,

--- a/packages/builders/src/messages/attachment/UnsafeAttachment.ts
+++ b/packages/builders/src/messages/attachment/UnsafeAttachment.ts
@@ -22,7 +22,7 @@ export class UnsafeAttachmentBuilder {
 	/**
 	 * @param {APIAttachment} [data] Extra data
 	 */
-	public constructor(attachment: BufferResolvable | Stream, name = null, _data: APIAttachment) {
+	public constructor(attachment: BufferResolvable | Stream, name = null, _data?: APIAttachment) {
 		this.data = { ..._data };
 		this.attachment = attachment;
 		/**

--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -124,6 +124,7 @@ exports.InviteStageInstance = require('./structures/InviteStageInstance');
 exports.InviteGuild = require('./structures/InviteGuild');
 exports.Message = require('./structures/Message').Message;
 exports.Attachment = require('./structures/Attachment');
+exports.AttachmentBuilder = require('./structures/AttachmentBuilder');
 exports.ModalBuilder = require('./structures/ModalBuilder');
 exports.MessageCollector = require('./structures/MessageCollector');
 exports.MessageComponentInteraction = require('./structures/MessageComponentInteraction');

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { isJSONEncodable } = require('@discordjs/builders');
+const AttachmentBuilder = require('./AttachmentBuilder');
 const isEqual = require('fast-deep-equal');
 const Util = require('../util/Util');
 
@@ -25,7 +26,7 @@ class Attachment {
    * @type {Snowflake}
    */
   get id() {
-    return this.data.id ?? null;
+    return this.data.id;
   }
 
   /**
@@ -33,7 +34,7 @@ class Attachment {
    * @type {?string}
    */
   get contentType() {
-    return this.data.content_type ?? this.data.contentType ?? null;
+    return this.data.content_type ?? null;
   }
 
   /**
@@ -81,7 +82,7 @@ class Attachment {
    * @type {string}
    */
   get proxyURL() {
-    return this.data.proxy_url ?? this.data.proxyURL ?? null;
+    return this.data.proxy_url ?? null;
   }
 
   /**
@@ -116,9 +117,9 @@ class Attachment {
    */
   static from(other) {
     if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
+      return new AttachmentBuilder(other.toJSON().url, other.toJSON().filename);
     }
-    return new this(other);
+    return new AttachmentBuilder(other.attachment, other.name);
   }
 
   /**

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -100,13 +100,13 @@ class Attachment {
   }
 
   /**
-	 * Whether or not this attachment has been marked as a spoiler
-	 * @type {boolean}
-	 * @readonly
-	 */
-	get spoiler() {
-		return Util.basename(this.url ?? this.name).startsWith('SPOILER_');
-	}
+   * Whether or not this attachment has been marked as a spoiler
+   * @type {boolean}
+   * @readonly
+   */
+  get spoiler() {
+    return Util.basename(this.url ?? this.name).startsWith('SPOILER_');
+  }
 
   /**
    * Creates a new attachment builder from JSON data

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const { isJSONEncodable } = require('@discordjs/builders');
-const AttachmentBuilder = require('./AttachmentBuilder');
 const isEqual = require('fast-deep-equal');
+const AttachmentBuilder = require('./AttachmentBuilder');
 const Util = require('../util/Util');
 
 /**

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { isJSONEncodable } = require('@discordjs/builders');
+const isEqual = require('fast-deep-equal');
 const Util = require('../util/Util');
 
 /**

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -77,7 +77,7 @@ class Attachment {
   }
 
   /**
-   * The Proxy URL to this attachment
+   * The proxy URL to this attachment
    * @type {string}
    */
   get proxyURL() {

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { AttachmentBuilder: BuildersAttachment } = require('@discordjs/builders');
+const Transformers = require('../util/Transformers');
+
+/**
+ * Represents an attachment builder.
+ * @extends {BuildersAttachment}
+ */
+class AttachmentBuilder extends BuildersAttachment {
+    constructor({ ...data } = {}) {
+        super(
+            ...Transformers.toSnakeCase(data),
+        );
+    }
+}
+
+module.exports = AttachmentBuilder;
+
+/**
+ * @external BuildersAttachment
+ * @see {@link https://discord.js.org/#/docs/builders/main/class/AttachmentBuilder}
+ */

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -8,11 +8,9 @@ const Transformers = require('../util/Transformers');
  * @extends {BuildersAttachment}
  */
 class AttachmentBuilder extends BuildersAttachment {
-    constructor({ ...data } = {}) {
-        super(
-            ...Transformers.toSnakeCase(data),
-        );
-    }
+  constructor({ ...data } = {}) {
+    super(...Transformers.toSnakeCase(data));
+  }
 }
 
 module.exports = AttachmentBuilder;

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -159,7 +159,7 @@ class Message extends Base {
       this.attachments = new Collection();
       if (data.attachments) {
         for (const attachment of data.attachments) {
-          this.attachments.set(attachment.id, new Attachment(attachment.url, attachment.filename, attachment));
+          this.attachments.set(attachment.id, new Attachment(attachment));
         }
       }
     } else {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1665,7 +1665,7 @@ export class Message<Cached extends boolean = boolean> extends Base {
 
   public activity: MessageActivity | null;
   public applicationId: Snowflake | null;
-  public attachments: Collection<Snowflake, Attachment>;
+  public attachments: Collection<Snowflake, AttachmentBuilder>;
   public author: User;
   public get channel(): If<Cached, GuildTextBasedChannel, TextBasedChannel>;
   public channelId: Snowflake;
@@ -1868,7 +1868,7 @@ export class MessagePayload {
     options: string | MessageOptions | WebhookMessageOptions,
     extra?: MessageOptions | WebhookMessageOptions,
   ): MessagePayload;
-  public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | Attachment): Promise<RawFile>;
+  public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | AttachmentBuilder): Promise<RawFile>;
 
   public makeContent(): string | undefined;
   public resolveBody(): this;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1,5 +1,6 @@
 import {
   ActionRowBuilder as BuilderActionRow,
+  AttachmentBuilder as BuilderAttachment,
   MessageActionRowComponentBuilder,
   blockQuote,
   bold,
@@ -37,6 +38,7 @@ import {
   APIApplicationCommand,
   APIApplicationCommandInteractionData,
   APIApplicationCommandOption,
+  APIAttachment,
   APIAuditLogChange,
   APIButtonComponent,
   APIEmbed,
@@ -1728,26 +1730,27 @@ export class Message<Cached extends boolean = boolean> extends Base {
   public inGuild(): this is Message<true> & this;
 }
 
-export class Attachment {
+export class AttachmentBuilder extends BuilderAttachment {
   public constructor(attachment: BufferResolvable | Stream, name?: string, data?: RawAttachmentData);
+}
 
-  public attachment: BufferResolvable | Stream;
-  public contentType: string | null;
-  public description: string | null;
-  public ephemeral: boolean;
-  public height: number | null;
-  public id: Snowflake;
-  public name: string | null;
-  public proxyURL: string;
-  public size: number;
+export class Attachment {
+  public constructor(data?: RawAttachmentData);
+
+  public get contentType(): string | null;
+  public get description(): string | null;
+  public get ephemeral(): boolean;
+  public get height(): number | null;
+  public get id(): Snowflake;
+  public get name(): string | null;
+  public get proxyURL(): string;
+  public get size(): number;
   public get spoiler(): boolean;
-  public url: string;
-  public width: number | null;
-  public setDescription(description: string): this;
-  public setFile(attachment: BufferResolvable | Stream, name?: string): this;
-  public setName(name: string): this;
-  public setSpoiler(spoiler?: boolean): this;
+  public get url(): string;
+  public get width(): number | null;
+  public static from(other: JSONEncodable<RawAttachmentData> | APIAttachment): AttachmentBuilder;
   public toJSON(): unknown;
+  public equals(other: Attachment | APIAttachment): boolean;
 }
 
 export class MessageCollector extends Collector<Snowflake, Message, [Collection<Snowflake, Message>]> {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3188,7 +3188,7 @@ export class GuildStickerManager extends CachedManager<Snowflake, Sticker, Stick
   private constructor(guild: Guild, iterable?: Iterable<RawStickerData>);
   public guild: Guild;
   public create(
-    file: BufferResolvable | Stream | FileOptions | Attachment,
+    file: BufferResolvable | Stream | FileOptions | AttachmentBuilder,
     name: string,
     tags: string,
     options?: GuildStickerCreateOptions,
@@ -4787,10 +4787,10 @@ export type MessageChannelComponentCollectorOptions<T extends MessageComponentIn
 >;
 
 export interface MessageEditOptions {
-  attachments?: Attachment[];
+  attachments?: AttachmentBuilder[];
   content?: string | null;
   embeds?: (JSONEncodable<APIEmbed> | APIEmbed)[] | null;
-  files?: (FileOptions | BufferResolvable | Stream | Attachment)[];
+  files?: (FileOptions | BufferResolvable | Stream | AttachmentBuilder)[];
   flags?: BitFieldResolvable<MessageFlagsString, number>;
   allowedMentions?: MessageMentionOptions;
   components?: (
@@ -4840,10 +4840,10 @@ export interface MessageOptions {
     | APIActionRowComponent<APIMessageActionRowComponent>
   )[];
   allowedMentions?: MessageMentionOptions;
-  files?: (FileOptions | BufferResolvable | Stream | Attachment)[];
+  files?: (FileOptions | BufferResolvable | Stream | AttachmentBuilder)[];
   reply?: ReplyOptions;
   stickers?: StickerResolvable[];
-  attachments?: Attachment[];
+  attachments?: AttachmentBuilder[];
   flags?: BitFieldResolvable<Extract<MessageFlagsString, 'SuppressEmbeds'>, number>;
 }
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -57,6 +57,7 @@ import {
   Interaction,
   InteractionCollector,
   Message,
+  Attachment,
   AttachmentBuilder,
   MessageCollector,
   MessageComponentInteraction,

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -57,7 +57,7 @@ import {
   Interaction,
   InteractionCollector,
   Message,
-  Attachment,
+  AttachmentBuilder,
   MessageCollector,
   MessageComponentInteraction,
   MessageReaction,
@@ -584,7 +584,7 @@ client.on('messageCreate', async message => {
   assertIsMessage(channel.send({}));
   assertIsMessage(channel.send({ embeds: [] }));
 
-  const attachment = new Attachment('file.png');
+  const attachment = new AttachmentBuilder('file.png');
   const embed = new EmbedBuilder();
   assertIsMessage(channel.send({ files: [attachment] }));
   assertIsMessage(channel.send({ embeds: [embed] }));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I opened a PR recently (which was merged) to change `MessageAttachment` to `Attachment`.

- https://github.com/discordjs/discord.js/pull/7691

All was good, but I notice that some names were changed and some builders were added to the builders package.

**So, this PR adds `AttachmentBuilder` and `UnsafeAttachmentBuilder` to the builders package.**

(If something is wrong, please let me know)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
