### PR TITLE
fix(User): banner and accentColor undefined, use null instead

### DIFF
--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -78,8 +78,8 @@ class User extends Base {
        * @type {?string}
        */
       this.banner = data.banner;
-    } else if (this.banner !== null) {
-      this.banner ??= undefined;
+    } else {
+      this.banner ??= null;
     }
 
     if ('accent_color' in data) {
@@ -89,8 +89,8 @@ class User extends Base {
        * @type {?number}
        */
       this.accentColor = data.accent_color;
-    } else if (this.accentColor !== null) {
-      this.accentColor ??= undefined;
+    } else {
+      this.accentColor ??= null;
     }
 
     if ('system' in data) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the `banner` and `accentColor` properties of `User`, use null instead of undefined.

I don't refer that using undefined is wrong, but I think it is a matter of aspect because if there is no data, null is used always, but only on these properties, undefined is used.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
