### PR TITLE
types(SelectMenuBuilder): remove spread operators

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -597,10 +597,10 @@ export class ButtonBuilder extends BuilderButtonComponent {
 export class SelectMenuBuilder extends BuilderSelectMenuComponent {
   public constructor(data?: Partial<SelectMenuComponentData | APISelectMenuComponent>);
   public override addOptions(
-    ...options: (BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption)[]
+    options: (BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption)[],
   ): this;
   public override setOptions(
-    ...options: (BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption)[]
+    options: (BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption)[],
   ): this;
   public static from(other: JSONEncodable<APISelectMenuComponent> | APISelectMenuComponent): SelectMenuBuilder;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes a couple spread operators from the typings, that would cause the following errors (screenshot) in the TypeScript Compiler.

![CaptureZ](https://user-images.githubusercontent.com/40654585/164771928-e9b76f3f-84f7-47b9-94bb-506ede9aa184.PNG)


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

