### PR TITLE
fix: `endReason` not being properly set in base Collector

### DIFF
--- a/packages/discord.js/src/structures/InteractionCollector.js
+++ b/packages/discord.js/src/structures/InteractionCollector.js
@@ -197,7 +197,7 @@ class InteractionCollector extends Collector {
     if (this.options.max && this.total >= this.options.max) return 'limit';
     if (this.options.maxComponents && this.collected.size >= this.options.maxComponents) return 'componentLimit';
     if (this.options.maxUsers && this.users.size >= this.options.maxUsers) return 'userLimit';
-    return null;
+    return super.endReason;
   }
 
   /**

--- a/packages/discord.js/src/structures/MessageCollector.js
+++ b/packages/discord.js/src/structures/MessageCollector.js
@@ -103,7 +103,7 @@ class MessageCollector extends Collector {
   get endReason() {
     if (this.options.max && this.collected.size >= this.options.max) return 'limit';
     if (this.options.maxProcessed && this.received === this.options.maxProcessed) return 'processedLimit';
-    return null;
+    return super.endReason;
   }
 
   /**

--- a/packages/discord.js/src/structures/ReactionCollector.js
+++ b/packages/discord.js/src/structures/ReactionCollector.js
@@ -165,7 +165,7 @@ class ReactionCollector extends Collector {
     if (this.options.max && this.total >= this.options.max) return 'limit';
     if (this.options.maxEmojis && this.collected.size >= this.options.maxEmojis) return 'emojiLimit';
     if (this.options.maxUsers && this.users.size >= this.options.maxUsers) return 'userLimit';
-    return null;
+    return super.endReason;
   }
 
   /**

--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -78,6 +78,13 @@ class Collector extends EventEmitter {
      */
     this._idletimeout = null;
 
+    /**
+     * The reason the collector ended
+     * @type {string|null}
+     * @private
+     */
+    this._endReason = null;
+
     if (typeof this.filter !== 'function') {
       throw new TypeError('INVALID_TYPE', 'options.filter', 'function');
     }
@@ -187,6 +194,8 @@ class Collector extends EventEmitter {
       clearTimeout(this._idletimeout);
       this._idletimeout = null;
     }
+
+    this._endReason = reason;
     this.ended = true;
 
     /**
@@ -270,9 +279,10 @@ class Collector extends EventEmitter {
    * The reason this collector has ended with, or null if it hasn't ended yet
    * @type {?string}
    * @readonly
-   * @abstract
    */
-  get endReason() {}
+  get endReason() {
+    return this._endReason;
+  }
 
   /**
    * Handles incoming events from the `handleCollect` function. Returns null if the event should not

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -882,7 +882,7 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
   public readonly client: Client;
   public collected: Collection<K, V>;
   public ended: boolean;
-  public abstract get endReason(): string | null;
+  public get endReason(): string | null;
   public filter: CollectorFilter<[V, ...F]>;
   public get next(): Promise<V>;
   public options: CollectorOptions<[V, ...F]>;
@@ -1553,7 +1553,6 @@ export class InteractionCollector<T extends Interaction> extends Collector<Snowf
   public channelId: Snowflake | null;
   public messageInteractionId: Snowflake | null;
   public componentType: ComponentType | null;
-  public get endReason(): string | null;
   public guildId: Snowflake | null;
   public interactionType: InteractionType | null;
   public messageId: Snowflake | null;
@@ -1768,7 +1767,6 @@ export class MessageCollector extends Collector<Snowflake, Message, [Collection<
   private _handleGuildDeletion(guild: Guild): void;
 
   public channel: TextBasedChannel;
-  public get endReason(): string | null;
   public options: MessageCollectorOptions;
   public received: number;
 
@@ -2016,7 +2014,6 @@ export class ReactionCollector extends Collector<Snowflake | string, MessageReac
   private _handleGuildDeletion(guild: Guild): void;
   private _handleMessageDeletion(message: Message): void;
 
-  public get endReason(): string | null;
   public message: Message;
   public options: ReactionCollectorOptions;
   public total: number;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -878,6 +878,7 @@ export abstract class Collector<K, V, F extends unknown[] = []> extends EventEmi
   protected constructor(client: Client, options?: CollectorOptions<[V, ...F]>);
   private _timeout: NodeJS.Timeout | null;
   private _idletimeout: NodeJS.Timeout | null;
+  private _endReason: string | null;
 
   public readonly client: Client;
   public collected: Collection<K, V>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

https://discord.com/channels/222078108977594368/682166281826598932/967515506884091904

`Collector.endReason` wasn't being set in the `stop` function, meaning it was essentially useless. Very useful when using `for await`;

```js
import { Collector } from 'discord.js';

const collector = new Collector(...);

setTimeout(() => collector.emit('collect', { hi: 'there' }), 1);

for await (const [i] of collector) {
    collector.stop(Math.random() > 0.5 ? 'heads' : 'tails');
}

console.log('end reason is:', collector.endReason);
```

Classes that extend Collector still retain their `endReason` getters but rather than return null if no conditions are met, it will return the custom reason (if there is one, otherwise null).

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
