### PR TITLE
types(Message#activity): make `partyId` optional and use enum for `type`

### DIFF
--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -197,6 +197,7 @@ exports.InteractionType = require('discord-api-types/v10').InteractionType;
 exports.InteractionResponseType = require('discord-api-types/v10').InteractionResponseType;
 exports.InviteTargetType = require('discord-api-types/v10').InviteTargetType;
 exports.Locale = require('discord-api-types/v10').Locale;
+exports.MessageActivityType = require('discord-api-types/v10').MessageActivityType;
 exports.MessageType = require('discord-api-types/v10').MessageType;
 exports.MessageFlags = require('discord-api-types/v10').MessageFlags;
 exports.OAuth2Scopes = require('discord-api-types/v10').OAuth2Scopes;

--- a/packages/discord.js/src/structures/Presence.js
+++ b/packages/discord.js/src/structures/Presence.js
@@ -9,7 +9,7 @@ const Util = require('../util/Util');
  * Activity sent in a message.
  * @typedef {Object} MessageActivity
  * @property {string} [partyId] Id of the party represented in activity
- * @property {number} [type] Type of activity sent
+ * @property {MessageActivityType} type Type of activity sent
  */
 
 /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -116,6 +116,7 @@ import {
   VideoQualityMode,
   LocalizationMap,
   LocaleString,
+  MessageActivityType,
 } from 'discord-api-types/v10';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -4746,8 +4747,8 @@ export type ActionRowComponentOptions = ButtonComponentData | SelectMenuComponen
 export type MessageActionRowComponentResolvable = MessageActionRowComponent | ActionRowComponentOptions;
 
 export interface MessageActivity {
-  partyId: string;
-  type: number;
+  partyId?: string;
+  type: MessageActivityType;
 }
 
 export interface BaseButtonComponentData extends BaseComponentData {
@@ -5420,6 +5421,7 @@ export {
   ThreadMemberFlags,
   UserFlags,
   WebhookType,
+  MessageActivityType,
 } from 'discord-api-types/v10';
 export * from '@discordjs/builders';
 export { DiscordAPIError, HTTPError, RateLimitError } from '@discordjs/rest';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
https://discord.com/developers/docs/resources/channel#message-object-message-activity-structure

- `partyId` is optional and `type` is required
- changed the type of `type` to `MessageActivityType`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
