### PR TITLE
refactor(attachment): don't return attachment builders from API

### DIFF
--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -123,6 +123,7 @@ exports.InviteStageInstance = require('./structures/InviteStageInstance');
 exports.InviteGuild = require('./structures/InviteGuild');
 exports.Message = require('./structures/Message').Message;
 exports.Attachment = require('./structures/Attachment');
+exports.AttachmentBuilder = require('./structures/AttachmentBuilder');
 exports.ModalBuilder = require('./structures/ModalBuilder');
 exports.MessageCollector = require('./structures/MessageCollector');
 exports.MessageComponentInteraction = require('./structures/MessageComponentInteraction');

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -41,7 +41,7 @@ class GuildStickerManager extends CachedManager {
 
   /**
    * Creates a new custom sticker in the guild.
-   * @param {BufferResolvable|Stream|FileOptions|JSONEncodable<AttachmentPayload>} file The file for the sticker
+   * @param {BufferResolvable|Stream|JSONEncodable<AttachmentPayload>} file The file for the sticker
    * @param {string} name The name for the sticker
    * @param {string} tags The Discord name of a unicode emoji representing the sticker's expression
    * @param {GuildStickerCreateOptions} [options] Options

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -41,7 +41,7 @@ class GuildStickerManager extends CachedManager {
 
   /**
    * Creates a new custom sticker in the guild.
-   * @param {BufferResolvable|Stream|FileOptions|Attachment} file The file for the sticker
+   * @param {BufferResolvable|Stream|FileOptions|JSONEncodable<AttachmentPayload>} file The file for the sticker
    * @param {string} name The name for the sticker
    * @param {string} tags The Discord name of a unicode emoji representing the sticker's expression
    * @param {GuildStickerCreateOptions} [options] Options

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -3,16 +3,16 @@
 const Util = require('../util/Util');
 
 /**
+ * @typedef {Object} AttachmentPayload
+ * @property {?string} name
+ * @property {Stream|BufferResolvable} attachment
+ * @property {?string} description
+ */
+
+/**
  * Represents an attachment
  */
 class Attachment {
-  /**
-   * @typedef {Object} AttachmentPayload
-   * @property {?string} name
-   * @property {Stream|BufferResolvable} attachment
-   * @property {?string} description
-   */
-
   /**
    * @param {BufferResolvable|Stream} attachment The file
    * @param {string} [name=null] The name of the file, if any

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -4,9 +4,9 @@ const Util = require('../util/Util');
 
 /**
  * @typedef {Object} AttachmentPayload
- * @property {?string} name
- * @property {Stream|BufferResolvable} attachment
- * @property {?string} description
+ * @property {?string} name The name of the attachment
+ * @property {Stream|BufferResolvable} attachment The attachment in this payload
+ * @property {?string} description The description of the attachment
  */
 
 /**
@@ -14,16 +14,16 @@ const Util = require('../util/Util');
  */
 class Attachment {
   /**
-   * @param {APIAttachment} [data] Attachment data
+   * @param {APIAttachment} data Attachment data
    * @private
    */
-  constructor(data) {
-    this.attachment = data.attachment;
+  constructor({ url, filename, ...data }) {
+    this.attachment = url;
     /**
      * The name of this attachment
-     * @type {?string}
+     * @type {string}
      */
-    this.name = data.name;
+    this.name = filename;
     if (data) this._patch(data);
   }
 
@@ -114,10 +114,6 @@ class Attachment {
     return Util.basename(this.url ?? this.name).startsWith('SPOILER_');
   }
 
-  /**
-   * Serializes this into an API-compatible payload.
-   * @returns {JSONEncodable<AttachmentPayload>}
-   */
   toJSON() {
     return Util.flatten(this);
   }

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -14,17 +14,16 @@ const Util = require('../util/Util');
  */
 class Attachment {
   /**
-   * @param {BufferResolvable|Stream} attachment The file
-   * @param {string} [name=null] The name of the file, if any
-   * @param {APIAttachment} [data] Extra data
+   * @param {APIAttachment} [data] Attachment data
+   * @private
    */
-  constructor(attachment, name = null, data) {
-    this.attachment = attachment;
+  constructor(data) {
+    this.attachment = data.attachment;
     /**
      * The name of this attachment
      * @type {?string}
      */
-    this.name = name;
+    this.name = data.name;
     if (data) this._patch(data);
   }
 

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -3,9 +3,16 @@
 const Util = require('../util/Util');
 
 /**
- * Represents an attachment.
+ * Represents an attachment
  */
 class Attachment {
+  /**
+   * @typedef {Object} AttachmentPayload
+   * @property {?string} name
+   * @property {Stream|BufferResolvable} attachment
+   * @property {?string} description
+   */
+
   /**
    * @param {BufferResolvable|Stream} attachment The file
    * @param {string} [name=null] The name of the file, if any
@@ -19,56 +26,6 @@ class Attachment {
      */
     this.name = name;
     if (data) this._patch(data);
-  }
-
-  /**
-   * Sets the description of this attachment.
-   * @param {string} description The description of the file
-   * @returns {Attachment} This attachment
-   */
-  setDescription(description) {
-    this.description = description;
-    return this;
-  }
-
-  /**
-   * Sets the file of this attachment.
-   * @param {BufferResolvable|Stream} attachment The file
-   * @param {string} [name=null] The name of the file, if any
-   * @returns {Attachment} This attachment
-   */
-  setFile(attachment, name = null) {
-    this.attachment = attachment;
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Sets the name of this attachment.
-   * @param {string} name The name of the file
-   * @returns {Attachment} This attachment
-   */
-  setName(name) {
-    this.name = name;
-    return this;
-  }
-
-  /**
-   * Sets whether this attachment is a spoiler
-   * @param {boolean} [spoiler=true] Whether the attachment should be marked as a spoiler
-   * @returns {Attachment} This attachment
-   */
-  setSpoiler(spoiler = true) {
-    if (spoiler === this.spoiler) return this;
-
-    if (!spoiler) {
-      while (this.spoiler) {
-        this.name = this.name.slice('SPOILER_'.length);
-      }
-      return this;
-    }
-    this.name = `SPOILER_${this.name}`;
-    return this;
   }
 
   _patch(data) {
@@ -158,14 +115,13 @@ class Attachment {
     return Util.basename(this.url ?? this.name).startsWith('SPOILER_');
   }
 
+  /**
+   * Serializes this into an API-compatible payload.
+   * @returns {JSONEncodable<AttachmentPayload>}
+   */
   toJSON() {
     return Util.flatten(this);
   }
 }
 
 module.exports = Attachment;
-
-/**
- * @external APIAttachment
- * @see {@link https://discord.com/developers/docs/resources/channel#attachment-object}
- */

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -14,6 +14,7 @@ class AttachmentBuilder {
   constructor(attachment, name = null, data = {}) {
     /**
      * The file associated with this attachment.
+     * @type {BufferResolvable|Stream}
      */
     this.attachment = attachment;
     /**
@@ -23,6 +24,7 @@ class AttachmentBuilder {
     this.name = name;
     /**
      * The description of the attachment
+     * @type {?string}
      */
     this.description = data.description;
   }

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -8,10 +8,9 @@ const Util = require('../util/Util');
 class AttachmentBuilder {
   /**
    * @param {BufferResolvable|Stream} attachment The file
-   * @param {string} [name=null] The name of the file, if any
    * @param {APIAttachment} [data] Extra data
    */
-  constructor(attachment, name = null, data = {}) {
+  constructor(attachment, data = {}) {
     /**
      * The file associated with this attachment.
      * @type {BufferResolvable|Stream}
@@ -21,7 +20,7 @@ class AttachmentBuilder {
      * The name of this attachment
      * @type {?string}
      */
-    this.name = name;
+    this.name = data.name;
     /**
      * The description of the attachment
      * @type {?string}
@@ -42,12 +41,10 @@ class AttachmentBuilder {
   /**
    * Sets the file of this attachment.
    * @param {BufferResolvable|Stream} attachment The file
-   * @param {string} [name=null] The name of the file, if any
    * @returns {AttachmentBuilder} This attachment
    */
-  setFile(attachment, name = null) {
+  setFile(attachment) {
     this.attachment = attachment;
-    this.name = name;
     return this;
   }
 
@@ -85,7 +82,7 @@ class AttachmentBuilder {
    * @readonly
    */
   get spoiler() {
-    return Util.basename(this.url ?? this.name).startsWith('SPOILER_');
+    return Util.basename(this.name).startsWith('SPOILER_');
   }
 
   /**

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -99,7 +99,8 @@ class AttachmentBuilder {
    * @returns {AttachmentBuilder}
    */
   static from(other) {
-    return new AttachmentBuilder(other.attachment, other.name, {
+    return new AttachmentBuilder(other.attachment, {
+      name: other.name,
       description: other.description,
     });
   }

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -85,10 +85,6 @@ class AttachmentBuilder {
     return Util.basename(this.name).startsWith('SPOILER_');
   }
 
-  /**
-   * Serializes this into an API-compatible payload.
-   * @returns {JSONEncodable<AttachmentPayload>}
-   */
   toJSON() {
     return Util.flatten(this);
   }

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const Util = require('../util/Util');
+
+/**
+ * Represents an attachment builder
+ */
+class AttachmentBuilder {
+  /**
+   * @param {BufferResolvable|Stream} attachment The file
+   * @param {string} [name=null] The name of the file, if any
+   * @param {APIAttachment} [data] Extra data
+   */
+  constructor(attachment, name = null, data = {}) {
+    /**
+     * The file associated with this attachment.
+     */
+    this.attachment = attachment;
+    /**
+     * The name of this attachment
+     * @type {?string}
+     */
+    this.name = name;
+    /**
+     * The description of the attachment
+     */
+    this.description = data.description;
+  }
+
+  /**
+   * Sets the description of this attachment.
+   * @param {string} description The description of the file
+   * @returns {AttachmentBuilder} This attachment
+   */
+  setDescription(description) {
+    this.description = description;
+    return this;
+  }
+
+  /**
+   * Sets the file of this attachment.
+   * @param {BufferResolvable|Stream} attachment The file
+   * @param {string} [name=null] The name of the file, if any
+   * @returns {AttachmentBuilder} This attachment
+   */
+  setFile(attachment, name = null) {
+    this.attachment = attachment;
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Sets the name of this attachment.
+   * @param {string} name The name of the file
+   * @returns {AttachmentBuilder} This attachment
+   */
+  setName(name) {
+    this.name = name;
+    return this;
+  }
+
+  /**
+   * Sets whether this attachment is a spoiler
+   * @param {boolean} [spoiler=true] Whether the attachment should be marked as a spoiler
+   * @returns {AttachmentBuilder} This attachment
+   */
+  setSpoiler(spoiler = true) {
+    if (spoiler === this.spoiler) return this;
+
+    if (!spoiler) {
+      while (this.spoiler) {
+        this.name = this.name.slice('SPOILER_'.length);
+      }
+      return this;
+    }
+    this.name = `SPOILER_${this.name}`;
+    return this;
+  }
+
+  /**
+   * Whether or not this attachment has been marked as a spoiler
+   * @type {boolean}
+   * @readonly
+   */
+  get spoiler() {
+    return Util.basename(this.url ?? this.name).startsWith('SPOILER_');
+  }
+
+  /**
+   * Serializes this into an API-compatible payload.
+   * @returns {JSONEncodable<AttachmentPayload>}
+   */
+  toJSON() {
+    return Util.flatten(this);
+  }
+
+  /**
+   * Makes a new builder instance from a preexisting attachment structure.
+   * @param {JSONEncodable<AttachmentPayload>} other The builder to construct a new instance from
+   * @returns {AttachmentBuilder}
+   */
+  static from(other) {
+    return new AttachmentBuilder(other.attachment, other.name, {
+      description: other.description,
+    });
+  }
+}
+
+module.exports = AttachmentBuilder;
+
+/**
+ * @external APIAttachment
+ * @see {@link https://discord.com/developers/docs/resources/channel#attachment-object}
+ */

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -133,7 +133,7 @@ class CommandInteraction extends Interaction {
     if (attachments) {
       result.attachments = new Collection();
       for (const attachment of Object.values(attachments)) {
-        const patched = new Attachment(attachment.url, attachment.filename, attachment);
+        const patched = new Attachment(attachment);
         result.attachments.set(attachment.id, patched);
       }
     }
@@ -189,7 +189,7 @@ class CommandInteraction extends Interaction {
       if (role) result.role = this.guild?.roles._add(role) ?? role;
 
       const attachment = resolved.attachments?.[option.value];
-      if (attachment) result.attachment = new Attachment(attachment.url, attachment.filename, attachment);
+      if (attachment) result.attachment = new Attachment(attachment);
     }
 
     return result;

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -644,7 +644,8 @@ class Message extends Base {
    * Only `MessageFlags.SuppressEmbeds` can be edited.
    * @property {Attachment[]} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
-   * @property {JSONEncodable<AttachmentPayload>[]|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files] Files to add to the message
+   * @property {Array<JSONEncodable<AttachmentPayload>>|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files]
+   * Files to add to the message
    * @property {ActionRow[]|ActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -642,9 +642,9 @@ class Message extends Base {
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * @property {MessageFlags} [flags] Which flags to set for the message.
    * Only `MessageFlags.SuppressEmbeds` can be edited.
-   * @property {Attachment[]} [attachments] An array of attachments to keep,
+   * @property {Attachment[]|AttachmentBuilder} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
-   * @property {FileOptions[]|BufferResolvable[]|Attachment[]} [files] Files to add to the message
+   * @property {FileOptions[]|BufferResolvable[]|Attachment[]|AttachmentBuilder} [files] Files to add to the message
    * @property {ActionRow[]|ActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -159,7 +159,7 @@ class Message extends Base {
       this.attachments = new Collection();
       if (data.attachments) {
         for (const attachment of data.attachments) {
-          this.attachments.set(attachment.id, new Attachment(attachment.url, attachment.filename, attachment));
+          this.attachments.set(attachment.id, new Attachment(attachment));
         }
       }
     } else {

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -642,9 +642,9 @@ class Message extends Base {
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * @property {MessageFlags} [flags] Which flags to set for the message.
    * Only `MessageFlags.SuppressEmbeds` can be edited.
-   * @property {Attachment[]|AttachmentBuilder[]} [attachments] An array of attachments to keep,
+   * @property {Attachment[]} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
-   * @property {FileOptions[]|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files] Files to add to the message
+   * @property {JSONEncodable<AttachmentPayload>[]|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files] Files to add to the message
    * @property {ActionRow[]|ActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -642,9 +642,9 @@ class Message extends Base {
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * @property {MessageFlags} [flags] Which flags to set for the message.
    * Only `MessageFlags.SuppressEmbeds` can be edited.
-   * @property {Attachment[]|AttachmentBuilder} [attachments] An array of attachments to keep,
+   * @property {Attachment[]|AttachmentBuilder[]} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
-   * @property {FileOptions[]|BufferResolvable[]|Attachment[]|AttachmentBuilder} [files] Files to add to the message
+   * @property {FileOptions[]|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files] Files to add to the message
    * @property {ActionRow[]|ActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -224,7 +224,7 @@ class MessagePayload {
 
   /**
    * Resolves a single file into an object sendable to the API.
-   * @param {BufferResolvable|Stream|FileOptions|JSONEncodable<AttachmentPayload>} fileLike Something that could
+   * @param {BufferResolvable|Stream|JSONEncodable<AttachmentPayload>} fileLike Something that could
    * be resolved to a file
    * @returns {Promise<RawFile>}
    */

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -224,7 +224,8 @@ class MessagePayload {
 
   /**
    * Resolves a single file into an object sendable to the API.
-   * @param {BufferResolvable|Stream|FileOptions|Attachment} fileLike Something that could be resolved to a file
+   * @param {BufferResolvable|Stream|FileOptions|JSONEncodable<AttachmentPayload>} fileLike Something that could
+   * be resolved to a file
    * @returns {Promise<RawFile>}
    */
   static async resolveFile(fileLike) {

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -132,7 +132,7 @@ class Webhook {
    * @typedef {Object} WebhookEditMessageOptions
    * @property {Embed[]|APIEmbed[]} [embeds] See {@link WebhookMessageOptions#embeds}
    * @property {string} [content] See {@link BaseMessageOptions#content}
-   * @property {FileOptions[]|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files]
+   * @property {JSONEncodable<AttachmentPayload>|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files]
    * See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
    * @property {Attachment[]} [attachments] Attachments to send with the message

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -132,7 +132,8 @@ class Webhook {
    * @typedef {Object} WebhookEditMessageOptions
    * @property {Embed[]|APIEmbed[]} [embeds] See {@link WebhookMessageOptions#embeds}
    * @property {string} [content] See {@link BaseMessageOptions#content}
-   * @property {FileOptions[]|BufferResolvable[]|Attachment[]} [files] See {@link BaseMessageOptions#files}
+   * @property {FileOptions[]|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files]
+   * See {@link BaseMessageOptions#files}
    * @property {MessageMentionOptions} [allowedMentions] See {@link BaseMessageOptions#allowedMentions}
    * @property {Attachment[]} [attachments] Attachments to send with the message
    * @property {ActionRow[]|ActionRowOptions[]} [components]

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -64,7 +64,7 @@ class TextBasedChannel {
    * @property {FileOptions[]|BufferResolvable[]|Attachment[]} [files] Files to send with the message
    * @property {ActionRow[]|ActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
-   * @property {Attachment[]} [attachments] Attachments to send in the message
+   * @property {JSONEncodable<AttachmentPayload>[]} [attachments] Attachments to send in the message
    */
 
   /**

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -64,7 +64,7 @@ class TextBasedChannel {
    * @property {FileOptions[]|BufferResolvable[]|Attachment[]} [files] Files to send with the message
    * @property {ActionRow[]|ActionRowOptions[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
-   * @property {JSONEncodable<AttachmentPayload>[]} [attachments] Attachments to send in the message
+   * @property {Array<JSONEncodable<AttachmentPayload>>} [attachments] Attachments to send in the message
    */
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1687,15 +1687,8 @@ export class Message<Cached extends boolean = boolean> extends Base {
   public inGuild(): this is Message<true> & this;
 }
 
-export interface AttachmentPayload {
-  name: string | null;
-  attachment: BufferResolvable | Stream;
-  description?: string;
-}
-
 export class AttachmentBuilder implements JSONEncodable<AttachmentPayload> {
   public constructor(attachment: BufferResolvable | Stream, name?: string, data?: RawAttachmentData);
-
   public attachment: BufferResolvable | Stream;
   public description: string | null;
   public name: string | null;
@@ -1709,8 +1702,7 @@ export class AttachmentBuilder implements JSONEncodable<AttachmentPayload> {
 }
 
 export class Attachment implements JSONEncodable<AttachmentPayload> {
-  public constructor(attachment: BufferResolvable | Stream, name?: string, data?: RawAttachmentData);
-
+  private constructor(data?: RawAttachmentData);
   public attachment: BufferResolvable | Stream;
   public contentType: string | null;
   public description: string | null;
@@ -1847,7 +1839,7 @@ export class MessagePayload {
     extra?: MessageOptions | WebhookMessageOptions,
   ): MessagePayload;
   public static resolveFile(
-    fileLike: BufferResolvable | Stream | FileOptions | JSONEncodable<AttachmentPayload>,
+    fileLike: BufferResolvable | Stream | AttachmentPayload | JSONEncodable<AttachmentPayload>,
   ): Promise<RawFile>;
 
   public makeContent(): string | undefined;
@@ -3191,7 +3183,7 @@ export class GuildStickerManager extends CachedManager<Snowflake, Sticker, Stick
   private constructor(guild: Guild, iterable?: Iterable<RawStickerData>);
   public guild: Guild;
   public create(
-    file: BufferResolvable | Stream | FileOptions | JSONEncodable<AttachmentBuilder>,
+    file: BufferResolvable | Stream | AttachmentPayload | JSONEncodable<AttachmentBuilder>,
     name: string,
     tags: string,
     options?: GuildStickerCreateOptions,
@@ -4232,7 +4224,7 @@ export interface FetchThreadsOptions {
   active?: boolean;
 }
 
-export interface FileOptions {
+export interface AttachmentPayload {
   attachment: BufferResolvable | Stream;
   name?: string;
   description?: string;
@@ -4666,7 +4658,7 @@ export interface MessageEditOptions {
   attachments?: JSONEncodable<AttachmentPayload>[];
   content?: string | null;
   embeds?: (JSONEncodable<APIEmbed> | APIEmbed)[] | null;
-  files?: (FileOptions | BufferResolvable | Stream | AttachmentBuilder)[];
+  files?: (AttachmentPayload | BufferResolvable | Stream | AttachmentBuilder)[];
   flags?: BitFieldResolvable<MessageFlagsString, number>;
   allowedMentions?: MessageMentionOptions;
   components?: (
@@ -4717,7 +4709,7 @@ export interface MessageOptions {
     | APIActionRowComponent<APIMessageActionRowComponent>
   )[];
   allowedMentions?: MessageMentionOptions;
-  files?: (FileOptions | BufferResolvable | Stream | JSONEncodable<AttachmentPayload>)[];
+  files?: (AttachmentPayload | BufferResolvable | Stream | JSONEncodable<AttachmentPayload>)[];
   reply?: ReplyOptions;
   stickers?: StickerResolvable[];
   attachments?: JSONEncodable<AttachmentPayload>[];

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1687,7 +1687,28 @@ export class Message<Cached extends boolean = boolean> extends Base {
   public inGuild(): this is Message<true> & this;
 }
 
-export class Attachment {
+export interface AttachmentPayload {
+  name: string | null;
+  attachment: BufferResolvable | Stream;
+  description?: string;
+}
+
+export class AttachmentBuilder implements JSONEncodable<AttachmentPayload> {
+  public constructor(attachment: BufferResolvable | Stream, name?: string, data?: RawAttachmentData);
+
+  public attachment: BufferResolvable | Stream;
+  public description: string | null;
+  public name: string | null;
+  public get spoiler(): boolean;
+  public setDescription(description: string): this;
+  public setFile(attachment: BufferResolvable | Stream, name?: string): this;
+  public setName(name: string): this;
+  public setSpoiler(spoiler?: boolean): this;
+  public toJSON(): AttachmentPayload;
+  public static from(other: JSONEncodable<AttachmentPayload>): AttachmentBuilder;
+}
+
+export class Attachment implements JSONEncodable<AttachmentPayload> {
   public constructor(attachment: BufferResolvable | Stream, name?: string, data?: RawAttachmentData);
 
   public attachment: BufferResolvable | Stream;
@@ -1702,11 +1723,7 @@ export class Attachment {
   public get spoiler(): boolean;
   public url: string;
   public width: number | null;
-  public setDescription(description: string): this;
-  public setFile(attachment: BufferResolvable | Stream, name?: string): this;
-  public setName(name: string): this;
-  public setSpoiler(spoiler?: boolean): this;
-  public toJSON(): unknown;
+  public toJSON(): AttachmentPayload;
 }
 
 export class MessageCollector extends Collector<Snowflake, Message, [Collection<Snowflake, Message>]> {
@@ -1829,7 +1846,9 @@ export class MessagePayload {
     options: string | MessageOptions | WebhookMessageOptions,
     extra?: MessageOptions | WebhookMessageOptions,
   ): MessagePayload;
-  public static resolveFile(fileLike: BufferResolvable | Stream | FileOptions | Attachment): Promise<RawFile>;
+  public static resolveFile(
+    fileLike: BufferResolvable | Stream | FileOptions | JSONEncodable<AttachmentPayload>,
+  ): Promise<RawFile>;
 
   public makeContent(): string | undefined;
   public resolveBody(): this;
@@ -3172,7 +3191,7 @@ export class GuildStickerManager extends CachedManager<Snowflake, Sticker, Stick
   private constructor(guild: Guild, iterable?: Iterable<RawStickerData>);
   public guild: Guild;
   public create(
-    file: BufferResolvable | Stream | FileOptions | Attachment,
+    file: BufferResolvable | Stream | FileOptions | JSONEncodable<AttachmentBuilder>,
     name: string,
     tags: string,
     options?: GuildStickerCreateOptions,
@@ -3911,7 +3930,7 @@ export interface CommandInteractionOption<Cached extends CacheType = CacheType> 
   member?: CacheTypeReducer<Cached, GuildMember, APIInteractionDataResolvedGuildMember>;
   channel?: CacheTypeReducer<Cached, GuildBasedChannel, APIInteractionDataResolvedChannel>;
   role?: CacheTypeReducer<Cached, Role, APIRole>;
-  attachment?: Attachment;
+  attachment?: AttachmentBuilder;
   message?: GuildCacheMessage<Cached>;
 }
 
@@ -3921,7 +3940,7 @@ export interface CommandInteractionResolvedData<Cached extends CacheType = Cache
   roles?: Collection<Snowflake, CacheTypeReducer<Cached, Role, APIRole>>;
   channels?: Collection<Snowflake, CacheTypeReducer<Cached, AnyChannel, APIInteractionDataResolvedChannel>>;
   messages?: Collection<Snowflake, CacheTypeReducer<Cached, Message, APIMessage>>;
-  attachments?: Collection<Snowflake, Attachment>;
+  attachments?: Collection<Snowflake, AttachmentBuilder>;
 }
 
 export declare const Colors: {
@@ -4644,10 +4663,10 @@ export type MessageChannelComponentCollectorOptions<T extends MessageComponentIn
 >;
 
 export interface MessageEditOptions {
-  attachments?: Attachment[];
+  attachments?: JSONEncodable<AttachmentPayload>[];
   content?: string | null;
   embeds?: (JSONEncodable<APIEmbed> | APIEmbed)[] | null;
-  files?: (FileOptions | BufferResolvable | Stream | Attachment)[];
+  files?: (FileOptions | BufferResolvable | Stream | AttachmentBuilder)[];
   flags?: BitFieldResolvable<MessageFlagsString, number>;
   allowedMentions?: MessageMentionOptions;
   components?: (
@@ -4698,10 +4717,10 @@ export interface MessageOptions {
     | APIActionRowComponent<APIMessageActionRowComponent>
   )[];
   allowedMentions?: MessageMentionOptions;
-  files?: (FileOptions | BufferResolvable | Stream | Attachment)[];
+  files?: (FileOptions | BufferResolvable | Stream | JSONEncodable<AttachmentPayload>)[];
   reply?: ReplyOptions;
   stickers?: StickerResolvable[];
-  attachments?: Attachment[];
+  attachments?: JSONEncodable<AttachmentPayload>[];
   flags?: BitFieldResolvable<Extract<MessageFlagsString, 'SuppressEmbeds'>, number>;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -117,6 +117,7 @@ import {
   LocalizationMap,
   LocaleString,
   MessageActivityType,
+  APIAttachment,
 } from 'discord-api-types/v10';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -1687,7 +1688,7 @@ export class Message<Cached extends boolean = boolean> extends Base {
   public inGuild(): this is Message<true> & this;
 }
 
-export class AttachmentBuilder implements JSONEncodable<AttachmentPayload> {
+export class AttachmentBuilder {
   public constructor(attachment: BufferResolvable | Stream, name?: string, data?: RawAttachmentData);
   public attachment: BufferResolvable | Stream;
   public description: string | null;
@@ -1697,12 +1698,12 @@ export class AttachmentBuilder implements JSONEncodable<AttachmentPayload> {
   public setFile(attachment: BufferResolvable | Stream, name?: string): this;
   public setName(name: string): this;
   public setSpoiler(spoiler?: boolean): this;
-  public toJSON(): AttachmentPayload;
+  public toJSON(): unknown;
   public static from(other: JSONEncodable<AttachmentPayload>): AttachmentBuilder;
 }
 
-export class Attachment implements JSONEncodable<AttachmentPayload> {
-  private constructor(data?: RawAttachmentData);
+export class Attachment {
+  private constructor(data: APIAttachment);
   public attachment: BufferResolvable | Stream;
   public contentType: string | null;
   public description: string | null;
@@ -1715,7 +1716,7 @@ export class Attachment implements JSONEncodable<AttachmentPayload> {
   public get spoiler(): boolean;
   public url: string;
   public width: number | null;
-  public toJSON(): AttachmentPayload;
+  public toJSON(): unknown;
 }
 
 export class MessageCollector extends Collector<Snowflake, Message, [Collection<Snowflake, Message>]> {
@@ -4709,10 +4710,10 @@ export interface MessageOptions {
     | APIActionRowComponent<APIMessageActionRowComponent>
   )[];
   allowedMentions?: MessageMentionOptions;
-  files?: (AttachmentPayload | BufferResolvable | Stream | JSONEncodable<AttachmentPayload>)[];
+  files?: (Attachment | AttachmentBuilder | BufferResolvable | Stream)[];
   reply?: ReplyOptions;
   stickers?: StickerResolvable[];
-  attachments?: JSONEncodable<AttachmentPayload>[];
+  attachments?: (Attachment | AttachmentBuilder)[];
   flags?: BitFieldResolvable<Extract<MessageFlagsString, 'SuppressEmbeds'>, number>;
 }
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -57,7 +57,7 @@ import {
   Interaction,
   InteractionCollector,
   Message,
-  Attachment,
+  AttachmentBuilder,
   MessageCollector,
   MessageComponentInteraction,
   MessageReaction,
@@ -615,7 +615,7 @@ client.on('messageCreate', async message => {
   assertIsMessage(channel.send({}));
   assertIsMessage(channel.send({ embeds: [] }));
 
-  const attachment = new Attachment('file.png');
+  const attachment = new AttachmentBuilder('file.png');
   const embed = new EmbedBuilder();
   assertIsMessage(channel.send({ files: [attachment] }));
   assertIsMessage(channel.send({ embeds: [embed] }));
@@ -1492,8 +1492,8 @@ expectNotAssignable<ActionRowData<MessageActionRowComponentData>>({
 
 declare const chatInputInteraction: ChatInputCommandInteraction;
 
-expectType<Attachment>(chatInputInteraction.options.getAttachment('attachment', true));
-expectType<Attachment | null>(chatInputInteraction.options.getAttachment('attachment'));
+expectType<AttachmentBuilder>(chatInputInteraction.options.getAttachment('attachment', true));
+expectType<AttachmentBuilder | null>(chatInputInteraction.options.getAttachment('attachment'));
 
 declare const modal: ModalBuilder;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR creates a seperate structure for attachments returned by the API. The builder structure has been renamed to `AttachmentBuilder`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)