### PR TITLE
feat(REST): enable setting default authPrefix

### DIFF
--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -30,6 +30,12 @@ export interface RESTOptions {
 	 */
 	api: string;
 	/**
+	 * The authorization prefix to use for requests, useful if you want to use
+	 * bearer tokens
+	 * @default 'Bot'
+	 */
+	authPrefix: 'Bot' | 'Bearer';
+	/**
 	 * The cdn path
 	 * @default 'https://cdn.discordapp.com'
 	 */

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -351,7 +351,7 @@ export class RequestManager extends EventEmitter {
 				throw new Error('Expected token to be set for this request, but none was present');
 			}
 
-			headers.Authorization = `${request.authPrefix ?? 'Bot'} ${this.#token}`;
+			headers.Authorization = `${request.authPrefix ?? this.options.authPrefix} ${this.#token}`;
 		}
 
 		// If a reason was set, set it's appropriate header

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -9,6 +9,7 @@ export const DefaultUserAgent = `DiscordBot (${Package.homepage}, ${Package.vers
 export const DefaultRestOptions: Required<RESTOptions> = {
 	agent: {},
 	api: 'https://discord.com/api',
+	authPrefix: 'Bot',
 	cdn: 'https://cdn.discordapp.com',
 	headers: {},
 	invalidRequestWarningInterval: 0,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR closes #7823 by adding an `authPrefix` option to `RESTOptions`, with a default value of `Bot`. 

Previously, a user wanting to use `REST` with `Bearer` tokens had to set the `authPrefix` option on every request. With this change, users only need to initialize `REST` with `authPrefix: 'Bearer'`.

```diff
-const api = new REST({version: '10'}).setToken(token)
+const api = new REST({version: '10', authPrefix: 'Bearer'}).setToken(token)

-const me = await api.get(Routes.user(), {authPrefix: 'Bearer'})
+const me = await api.get(Routes.user())
```

`options.authPrefix` is used when setting `headers.Authorization` if `request.authPrefix` is not defined. If `options.authPrefix` isn't set, there is no change in behavior from how the library worked previously.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)