### PR TITLE
feat: allow builders to accept rest params and arrays

### DIFF
--- a/packages/builders/__tests__/components/actionRow.test.ts
+++ b/packages/builders/__tests__/components/actionRow.test.ts
@@ -44,8 +44,8 @@ const rowWithSelectMenuData: APIActionRowComponent<APIMessageActionRowComponent>
 describe('Action Row Components', () => {
 	describe('Assertion Tests', () => {
 		test('GIVEN valid components THEN do not throw', () => {
-			expect(() => new ActionRowBuilder().addComponents([new ButtonBuilder()])).not.toThrowError();
-			expect(() => new ActionRowBuilder().setComponents([new ButtonBuilder()])).not.toThrowError();
+			expect(() => new ActionRowBuilder().addComponents(new ButtonBuilder())).not.toThrowError();
+			expect(() => new ActionRowBuilder().setComponents(new ButtonBuilder())).not.toThrowError();
 		});
 
 		test('GIVEN valid JSON input THEN valid JSON output is given', () => {
@@ -128,13 +128,13 @@ describe('Action Row Components', () => {
 				.setCustomId('1234')
 				.setMaxValues(10)
 				.setMinValues(12)
-				.setOptions([
+				.setOptions(
 					new SelectMenuOptionBuilder().setLabel('one').setValue('one'),
 					new SelectMenuOptionBuilder().setLabel('two').setValue('two'),
-				]);
+				);
 
-			expect(new ActionRowBuilder().addComponents([button]).toJSON()).toEqual(rowWithButtonData);
-			expect(new ActionRowBuilder().addComponents([selectMenu]).toJSON()).toEqual(rowWithSelectMenuData);
+			expect(new ActionRowBuilder().addComponents(button).toJSON()).toEqual(rowWithButtonData);
+			expect(new ActionRowBuilder().addComponents(selectMenu).toJSON()).toEqual(rowWithSelectMenuData);
 		});
 	});
 });

--- a/packages/builders/__tests__/components/actionRow.test.ts
+++ b/packages/builders/__tests__/components/actionRow.test.ts
@@ -46,6 +46,8 @@ describe('Action Row Components', () => {
 		test('GIVEN valid components THEN do not throw', () => {
 			expect(() => new ActionRowBuilder().addComponents(new ButtonBuilder())).not.toThrowError();
 			expect(() => new ActionRowBuilder().setComponents(new ButtonBuilder())).not.toThrowError();
+			expect(() => new ActionRowBuilder().addComponents([new ButtonBuilder()])).not.toThrowError();
+			expect(() => new ActionRowBuilder().setComponents([new ButtonBuilder()])).not.toThrowError();
 		});
 
 		test('GIVEN valid JSON input THEN valid JSON output is given', () => {
@@ -131,10 +133,16 @@ describe('Action Row Components', () => {
 				.setOptions(
 					new SelectMenuOptionBuilder().setLabel('one').setValue('one'),
 					new SelectMenuOptionBuilder().setLabel('two').setValue('two'),
-				);
+				)
+				.setOptions([
+					new SelectMenuOptionBuilder().setLabel('one').setValue('one'),
+					new SelectMenuOptionBuilder().setLabel('two').setValue('two'),
+				]);
 
 			expect(new ActionRowBuilder().addComponents(button).toJSON()).toEqual(rowWithButtonData);
 			expect(new ActionRowBuilder().addComponents(selectMenu).toJSON()).toEqual(rowWithSelectMenuData);
+			expect(new ActionRowBuilder().addComponents([button]).toJSON()).toEqual(rowWithButtonData);
+			expect(new ActionRowBuilder().addComponents([selectMenu]).toJSON()).toEqual(rowWithSelectMenuData);
 		});
 	});
 });

--- a/packages/builders/__tests__/components/selectMenu.test.ts
+++ b/packages/builders/__tests__/components/selectMenu.test.ts
@@ -46,26 +46,48 @@ describe('Select Menu Components', () => {
 			expect(() => selectMenu().addOptions(option)).not.toThrowError();
 			expect(() => selectMenu().setOptions(option)).not.toThrowError();
 			expect(() => selectMenu().setOptions({ label: 'test', value: 'test' })).not.toThrowError();
+			expect(() => selectMenu().addOptions([option])).not.toThrowError();
+			expect(() => selectMenu().setOptions([option])).not.toThrowError();
+			expect(() => selectMenu().setOptions([{ label: 'test', value: 'test' }])).not.toThrowError();
 			expect(() =>
-				selectMenu().addOptions({
-					label: 'test',
-					value: 'test',
-					emoji: {
-						id: '123',
-						name: 'test',
-						animated: true,
-					},
-				}),
+				selectMenu()
+					.addOptions({
+						label: 'test',
+						value: 'test',
+						emoji: {
+							id: '123',
+							name: 'test',
+							animated: true,
+						},
+					})
+					.addOptions([
+						{
+							label: 'test',
+							value: 'test',
+							emoji: {
+								id: '123',
+								name: 'test',
+								animated: true,
+							},
+						},
+					]),
 			).not.toThrowError();
 
 			const options = new Array<APISelectMenuOption>(25).fill({ label: 'test', value: 'test' });
 			expect(() => selectMenu().addOptions(...options)).not.toThrowError();
 			expect(() => selectMenu().setOptions(...options)).not.toThrowError();
+			expect(() => selectMenu().addOptions(options)).not.toThrowError();
+			expect(() => selectMenu().setOptions(options)).not.toThrowError();
 
 			expect(() =>
 				selectMenu()
 					.addOptions({ label: 'test', value: 'test' })
 					.addOptions(...new Array<APISelectMenuOption>(24).fill({ label: 'test', value: 'test' })),
+			).not.toThrowError();
+			expect(() =>
+				selectMenu()
+					.addOptions([{ label: 'test', value: 'test' }])
+					.addOptions(new Array<APISelectMenuOption>(24).fill({ label: 'test', value: 'test' })),
 			).not.toThrowError();
 		});
 
@@ -87,14 +109,31 @@ describe('Select Menu Components', () => {
 			expect(() => selectMenu().addOptions({ value: 'test' })).toThrowError();
 			// @ts-expect-error
 			expect(() => selectMenu().addOptions({ default: true })).toThrowError();
+			// @ts-expect-error
+			expect(() => selectMenu().addOptions([{ label: 'test' }])).toThrowError();
+			expect(() => selectMenu().addOptions([{ label: longStr, value: 'test' }])).toThrowError();
+			expect(() => selectMenu().addOptions([{ value: longStr, label: 'test' }])).toThrowError();
+			expect(() => selectMenu().addOptions([{ label: 'test', value: 'test', description: longStr }])).toThrowError();
+			// @ts-expect-error
+			expect(() => selectMenu().addOptions([{ label: 'test', value: 'test', default: 100 }])).toThrowError();
+			// @ts-expect-error
+			expect(() => selectMenu().addOptions([{ value: 'test' }])).toThrowError();
+			// @ts-expect-error
+			expect(() => selectMenu().addOptions([{ default: true }])).toThrowError();
 
 			const tooManyOptions = new Array<APISelectMenuOption>(26).fill({ label: 'test', value: 'test' });
 			expect(() => selectMenu().setOptions(...tooManyOptions)).toThrowError();
+			expect(() => selectMenu().setOptions(tooManyOptions)).toThrowError();
 
 			expect(() =>
 				selectMenu()
 					.addOptions({ label: 'test', value: 'test' })
 					.addOptions(...tooManyOptions),
+			).toThrowError();
+			expect(() =>
+				selectMenu()
+					.addOptions([{ label: 'test', value: 'test' }])
+					.addOptions(tooManyOptions),
 			).toThrowError();
 
 			expect(() => {
@@ -113,6 +152,11 @@ describe('Select Menu Components', () => {
 			expect(
 				new SelectMenuBuilder(selectMenuDataWithoutOptions)
 					.addOptions(new SelectMenuOptionBuilder(selectMenuOptionData))
+					.toJSON(),
+			).toEqual(selectMenuData);
+			expect(
+				new SelectMenuBuilder(selectMenuDataWithoutOptions)
+					.addOptions([new SelectMenuOptionBuilder(selectMenuOptionData)])
 					.toJSON(),
 			).toEqual(selectMenuData);
 			expect(new SelectMenuOptionBuilder(selectMenuOptionData).toJSON()).toEqual(selectMenuOptionData);

--- a/packages/builders/__tests__/components/selectMenu.test.ts
+++ b/packages/builders/__tests__/components/selectMenu.test.ts
@@ -43,31 +43,29 @@ describe('Select Menu Components', () => {
 				.setDefault(true)
 				.setEmoji({ name: 'test' })
 				.setDescription('description');
-			expect(() => selectMenu().addOptions([option])).not.toThrowError();
-			expect(() => selectMenu().setOptions([option])).not.toThrowError();
-			expect(() => selectMenu().setOptions([{ label: 'test', value: 'test' }])).not.toThrowError();
+			expect(() => selectMenu().addOptions(option)).not.toThrowError();
+			expect(() => selectMenu().setOptions(option)).not.toThrowError();
+			expect(() => selectMenu().setOptions({ label: 'test', value: 'test' })).not.toThrowError();
 			expect(() =>
-				selectMenu().addOptions([
-					{
-						label: 'test',
-						value: 'test',
-						emoji: {
-							id: '123',
-							name: 'test',
-							animated: true,
-						},
+				selectMenu().addOptions({
+					label: 'test',
+					value: 'test',
+					emoji: {
+						id: '123',
+						name: 'test',
+						animated: true,
 					},
-				]),
+				}),
 			).not.toThrowError();
 
 			const options = new Array<APISelectMenuOption>(25).fill({ label: 'test', value: 'test' });
-			expect(() => selectMenu().addOptions(options)).not.toThrowError();
-			expect(() => selectMenu().setOptions(options)).not.toThrowError();
+			expect(() => selectMenu().addOptions(...options)).not.toThrowError();
+			expect(() => selectMenu().setOptions(...options)).not.toThrowError();
 
 			expect(() =>
 				selectMenu()
-					.addOptions([{ label: 'test', value: 'test' }])
-					.addOptions(new Array<APISelectMenuOption>(24).fill({ label: 'test', value: 'test' })),
+					.addOptions({ label: 'test', value: 'test' })
+					.addOptions(...new Array<APISelectMenuOption>(24).fill({ label: 'test', value: 'test' })),
 			).not.toThrowError();
 		});
 
@@ -79,24 +77,24 @@ describe('Select Menu Components', () => {
 			expect(() => selectMenu().setDisabled(0)).toThrowError();
 			expect(() => selectMenu().setPlaceholder(longStr)).toThrowError();
 			// @ts-expect-error
-			expect(() => selectMenu().addOptions([{ label: 'test' }])).toThrowError();
-			expect(() => selectMenu().addOptions([{ label: longStr, value: 'test' }])).toThrowError();
-			expect(() => selectMenu().addOptions([{ value: longStr, label: 'test' }])).toThrowError();
-			expect(() => selectMenu().addOptions([{ label: 'test', value: 'test', description: longStr }])).toThrowError();
+			expect(() => selectMenu().addOptions({ label: 'test' })).toThrowError();
+			expect(() => selectMenu().addOptions({ label: longStr, value: 'test' })).toThrowError();
+			expect(() => selectMenu().addOptions({ value: longStr, label: 'test' })).toThrowError();
+			expect(() => selectMenu().addOptions({ label: 'test', value: 'test', description: longStr })).toThrowError();
 			// @ts-expect-error
-			expect(() => selectMenu().addOptions([{ label: 'test', value: 'test', default: 100 }])).toThrowError();
+			expect(() => selectMenu().addOptions({ label: 'test', value: 'test', default: 100 })).toThrowError();
 			// @ts-expect-error
-			expect(() => selectMenu().addOptions([{ value: 'test' }])).toThrowError();
+			expect(() => selectMenu().addOptions({ value: 'test' })).toThrowError();
 			// @ts-expect-error
-			expect(() => selectMenu().addOptions([{ default: true }])).toThrowError();
+			expect(() => selectMenu().addOptions({ default: true })).toThrowError();
 
 			const tooManyOptions = new Array<APISelectMenuOption>(26).fill({ label: 'test', value: 'test' });
-			expect(() => selectMenu().setOptions(tooManyOptions)).toThrowError();
+			expect(() => selectMenu().setOptions(...tooManyOptions)).toThrowError();
 
 			expect(() =>
 				selectMenu()
-					.addOptions([{ label: 'test', value: 'test' }])
-					.addOptions(tooManyOptions),
+					.addOptions({ label: 'test', value: 'test' })
+					.addOptions(...tooManyOptions),
 			).toThrowError();
 
 			expect(() => {
@@ -114,7 +112,7 @@ describe('Select Menu Components', () => {
 		test('GIVEN valid JSON input THEN valid JSON history is correct', () => {
 			expect(
 				new SelectMenuBuilder(selectMenuDataWithoutOptions)
-					.addOptions([new SelectMenuOptionBuilder(selectMenuOptionData)])
+					.addOptions(new SelectMenuOptionBuilder(selectMenuOptionData))
 					.toJSON(),
 			).toEqual(selectMenuData);
 			expect(new SelectMenuOptionBuilder(selectMenuOptionData).toJSON()).toEqual(selectMenuOptionData);

--- a/packages/builders/__tests__/interactions/modal.test.ts
+++ b/packages/builders/__tests__/interactions/modal.test.ts
@@ -48,15 +48,15 @@ describe('Modals', () => {
 
 	test('GIVEN valid fields THEN builder does not throw', () => {
 		expect(() =>
-			modal().setTitle('test').setCustomId('foobar').setComponents(new ActionRowBuilder()),
+			modal()
+				.setTitle('test')
+				.setCustomId('foobar')
+				.setComponents(new ActionRowBuilder())
+				.addComponents([new ActionRowBuilder()]),
 		).not.toThrowError();
 	});
 
 	test('GIVEN invalid fields THEN builder does throw', () => {
-		expect(() =>
-			// @ts-expect-error
-			modal().setTitle('test').setCustomId('foobar').setComponents([new ActionRowBuilder()]).toJSON(),
-		).toThrowError();
 		expect(() => modal().setTitle('test').setCustomId('foobar').toJSON()).toThrowError();
 		// @ts-expect-error
 		expect(() => modal().setTitle('test').setCustomId(42).toJSON()).toThrowError();
@@ -67,6 +67,17 @@ describe('Modals', () => {
 			title: 'title',
 			custom_id: 'custom id',
 			components: [
+				{
+					type: ComponentType.ActionRow,
+					components: [
+						{
+							type: ComponentType.TextInput,
+							label: 'label',
+							style: TextInputStyle.Paragraph,
+							custom_id: 'custom id',
+						},
+					],
+				},
 				{
 					type: ComponentType.ActionRow,
 					components: [
@@ -92,6 +103,11 @@ describe('Modals', () => {
 						new TextInputBuilder().setCustomId('custom id').setLabel('label').setStyle(TextInputStyle.Paragraph),
 					),
 				)
+				.addComponents([
+					new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(
+						new TextInputBuilder().setCustomId('custom id').setLabel('label').setStyle(TextInputStyle.Paragraph),
+					),
+				])
 				.toJSON(),
 		).toEqual(modalData);
 	});

--- a/packages/builders/__tests__/interactions/modal.test.ts
+++ b/packages/builders/__tests__/interactions/modal.test.ts
@@ -48,11 +48,15 @@ describe('Modals', () => {
 
 	test('GIVEN valid fields THEN builder does not throw', () => {
 		expect(() =>
-			modal().setTitle('test').setCustomId('foobar').setComponents([new ActionRowBuilder()]),
+			modal().setTitle('test').setCustomId('foobar').setComponents(new ActionRowBuilder()),
 		).not.toThrowError();
 	});
 
 	test('GIVEN invalid fields THEN builder does throw', () => {
+		expect(() =>
+			// @ts-expect-error
+			modal().setTitle('test').setCustomId('foobar').setComponents([new ActionRowBuilder()]).toJSON(),
+		).toThrowError();
 		expect(() => modal().setTitle('test').setCustomId('foobar').toJSON()).toThrowError();
 		// @ts-expect-error
 		expect(() => modal().setTitle('test').setCustomId(42).toJSON()).toThrowError();
@@ -83,11 +87,11 @@ describe('Modals', () => {
 			modal()
 				.setTitle(modalData.title)
 				.setCustomId('custom id')
-				.setComponents([
-					new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents([
+				.setComponents(
+					new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(
 						new TextInputBuilder().setCustomId('custom id').setLabel('label').setStyle(TextInputStyle.Paragraph),
-					]),
-				])
+					),
+				)
 				.toJSON(),
 		).toEqual(modalData);
 	});

--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -323,9 +323,13 @@ describe('Embed', () => {
 		test('GIVEN an embed using Embed#addFields THEN returns valid toJSON data', () => {
 			const embed = new EmbedBuilder();
 			embed.addFields({ name: 'foo', value: 'bar' });
+			embed.addFields([{ name: 'foo', value: 'bar' }]);
 
 			expect(embed.toJSON()).toStrictEqual({
-				fields: [{ name: 'foo', value: 'bar' }],
+				fields: [
+					{ name: 'foo', value: 'bar' },
+					{ name: 'foo', value: 'bar' },
+				],
 			});
 		});
 
@@ -362,6 +366,9 @@ describe('Embed', () => {
 			expect(() =>
 				embed.setFields(...Array.from({ length: 25 }, () => ({ name: 'foo', value: 'bar' }))),
 			).not.toThrowError();
+			expect(() =>
+				embed.setFields(Array.from({ length: 25 }, () => ({ name: 'foo', value: 'bar' }))),
+			).not.toThrowError();
 		});
 
 		test('GIVEN an embed using Embed#setFields that sets more than 25 fields THEN throws error', () => {
@@ -370,6 +377,7 @@ describe('Embed', () => {
 			expect(() =>
 				embed.setFields(...Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' }))),
 			).toThrowError();
+			expect(() => embed.setFields(Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' })))).toThrowError();
 		});
 
 		describe('GIVEN invalid field amount THEN throws error', () => {

--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -322,7 +322,7 @@ describe('Embed', () => {
 
 		test('GIVEN an embed using Embed#addFields THEN returns valid toJSON data', () => {
 			const embed = new EmbedBuilder();
-			embed.addFields([{ name: 'foo', value: 'bar' }]);
+			embed.addFields({ name: 'foo', value: 'bar' });
 
 			expect(embed.toJSON()).toStrictEqual({
 				fields: [{ name: 'foo', value: 'bar' }],
@@ -331,10 +331,7 @@ describe('Embed', () => {
 
 		test('GIVEN an embed using Embed#spliceFields THEN returns valid toJSON data', () => {
 			const embed = new EmbedBuilder();
-			embed.addFields([
-				{ name: 'foo', value: 'bar' },
-				{ name: 'foo', value: 'baz' },
-			]);
+			embed.addFields({ name: 'foo', value: 'bar' }, { name: 'foo', value: 'baz' });
 
 			expect(embed.spliceFields(0, 1).toJSON()).toStrictEqual({
 				fields: [{ name: 'foo', value: 'baz' }],
@@ -343,7 +340,7 @@ describe('Embed', () => {
 
 		test('GIVEN an embed using Embed#spliceFields THEN returns valid toJSON data', () => {
 			const embed = new EmbedBuilder();
-			embed.addFields(Array.from({ length: 23 }, () => ({ name: 'foo', value: 'bar' })));
+			embed.addFields(...Array.from({ length: 23 }, () => ({ name: 'foo', value: 'bar' })));
 
 			expect(() =>
 				embed.spliceFields(0, 3, ...Array.from({ length: 5 }, () => ({ name: 'foo', value: 'bar' }))),
@@ -352,7 +349,7 @@ describe('Embed', () => {
 
 		test('GIVEN an embed using Embed#spliceFields that adds additional fields resulting in fields > 25 THEN throws error', () => {
 			const embed = new EmbedBuilder();
-			embed.addFields(Array.from({ length: 23 }, () => ({ name: 'foo', value: 'bar' })));
+			embed.addFields(...Array.from({ length: 23 }, () => ({ name: 'foo', value: 'bar' })));
 
 			expect(() =>
 				embed.spliceFields(0, 3, ...Array.from({ length: 8 }, () => ({ name: 'foo', value: 'bar' }))),
@@ -363,21 +360,25 @@ describe('Embed', () => {
 			const embed = new EmbedBuilder();
 
 			expect(() =>
-				embed.setFields(Array.from({ length: 25 }, () => ({ name: 'foo', value: 'bar' }))),
+				embed.setFields(...Array.from({ length: 25 }, () => ({ name: 'foo', value: 'bar' }))),
 			).not.toThrowError();
 		});
 
 		test('GIVEN an embed using Embed#setFields that sets more than 25 fields THEN throws error', () => {
 			const embed = new EmbedBuilder();
 
-			expect(() => embed.setFields(Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' })))).toThrowError();
+			expect(() =>
+				embed.setFields(...Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' }))),
+			).toThrowError();
 		});
 
 		describe('GIVEN invalid field amount THEN throws error', () => {
 			test('', () => {
 				const embed = new EmbedBuilder();
 
-				expect(() => embed.addFields(Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' })))).toThrowError();
+				expect(() =>
+					embed.addFields(...Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' }))),
+				).toThrowError();
 			});
 		});
 
@@ -385,7 +386,7 @@ describe('Embed', () => {
 			test('', () => {
 				const embed = new EmbedBuilder();
 
-				expect(() => embed.addFields([{ name: '', value: 'bar' }])).toThrowError();
+				expect(() => embed.addFields({ name: '', value: 'bar' })).toThrowError();
 			});
 		});
 
@@ -393,7 +394,7 @@ describe('Embed', () => {
 			test('', () => {
 				const embed = new EmbedBuilder();
 
-				expect(() => embed.addFields([{ name: 'a'.repeat(257), value: 'bar' }])).toThrowError();
+				expect(() => embed.addFields({ name: 'a'.repeat(257), value: 'bar' })).toThrowError();
 			});
 		});
 
@@ -401,7 +402,7 @@ describe('Embed', () => {
 			test('', () => {
 				const embed = new EmbedBuilder();
 
-				expect(() => embed.addFields([{ name: '', value: 'a'.repeat(1025) }])).toThrowError();
+				expect(() => embed.addFields({ name: '', value: 'a'.repeat(1025) })).toThrowError();
 			});
 		});
 	});

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -38,7 +38,7 @@ export class ActionRowBuilder<T extends AnyComponentBuilder> extends ComponentBu
 	 * @param components The components to add to this action row.
 	 * @returns
 	 */
-	public addComponents(components: T[]) {
+	public addComponents(...components: T[]) {
 		this.components.push(...components);
 		return this;
 	}
@@ -47,7 +47,7 @@ export class ActionRowBuilder<T extends AnyComponentBuilder> extends ComponentBu
 	 * Sets the components in this action row
 	 * @param components The components to set this row to
 	 */
-	public setComponents(components: T[]) {
+	public setComponents(...components: T[]) {
 		this.components.splice(0, this.components.length, ...components);
 		return this;
 	}

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -40,7 +40,7 @@ export class ActionRowBuilder<T extends AnyComponentBuilder> extends ComponentBu
 	 * @returns
 	 */
 	public addComponents(...components: RestOrArray<T>) {
-		this.components.push(...normalizeArray(...components));
+		this.components.push(...normalizeArray(components));
 		return this;
 	}
 
@@ -49,7 +49,7 @@ export class ActionRowBuilder<T extends AnyComponentBuilder> extends ComponentBu
 	 * @param components The components to set this row to
 	 */
 	public setComponents(...components: RestOrArray<T>) {
-		this.components.splice(0, this.components.length, ...normalizeArray(...components));
+		this.components.splice(0, this.components.length, ...normalizeArray(components));
 		return this;
 	}
 

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -8,6 +8,7 @@ import {
 import { ComponentBuilder } from './Component';
 import { createComponentBuilder } from './Components';
 import type { ButtonBuilder, SelectMenuBuilder, TextInputBuilder } from '..';
+import { normalizeArray, type RestOrArray } from '../util/normalizeArray';
 
 export type MessageComponentBuilder =
 	| MessageActionRowComponentBuilder
@@ -38,8 +39,8 @@ export class ActionRowBuilder<T extends AnyComponentBuilder> extends ComponentBu
 	 * @param components The components to add to this action row.
 	 * @returns
 	 */
-	public addComponents(...components: T[]) {
-		this.components.push(...components);
+	public addComponents(...components: RestOrArray<T>) {
+		this.components.push(...normalizeArray(...components));
 		return this;
 	}
 
@@ -47,8 +48,8 @@ export class ActionRowBuilder<T extends AnyComponentBuilder> extends ComponentBu
 	 * Sets the components in this action row
 	 * @param components The components to set this row to
 	 */
-	public setComponents(...components: T[]) {
-		this.components.splice(0, this.components.length, ...components);
+	public setComponents(...components: RestOrArray<T>) {
+		this.components.splice(0, this.components.length, ...normalizeArray(...components));
 		return this;
 	}
 

--- a/packages/builders/src/components/selectMenu/SelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/SelectMenu.ts
@@ -1,6 +1,7 @@
 import type { APISelectMenuComponent, APISelectMenuOption } from 'discord-api-types/v10';
 import { UnsafeSelectMenuBuilder } from './UnsafeSelectMenu';
 import { UnsafeSelectMenuOptionBuilder } from './UnsafeSelectMenuOption';
+import { normalizeArray, type RestOrArray } from '../../util/normalizeArray';
 import {
 	customIdValidator,
 	disabledValidator,
@@ -35,7 +36,8 @@ export class SelectMenuBuilder extends UnsafeSelectMenuBuilder {
 		return super.setDisabled(disabledValidator.parse(disabled));
 	}
 
-	public override addOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public override addOptions(...options: RestOrArray<UnsafeSelectMenuOptionBuilder | APISelectMenuOption>) {
+		options = normalizeArray(...options);
 		optionsLengthValidator.parse(this.options.length + options.length);
 		this.options.push(
 			...options.map((option) =>
@@ -47,7 +49,8 @@ export class SelectMenuBuilder extends UnsafeSelectMenuBuilder {
 		return this;
 	}
 
-	public override setOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public override setOptions(...options: RestOrArray<UnsafeSelectMenuOptionBuilder | APISelectMenuOption>) {
+		options = normalizeArray(...options);
 		optionsLengthValidator.parse(options.length);
 		this.options.splice(
 			0,

--- a/packages/builders/src/components/selectMenu/SelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/SelectMenu.ts
@@ -37,7 +37,7 @@ export class SelectMenuBuilder extends UnsafeSelectMenuBuilder {
 	}
 
 	public override addOptions(...options: RestOrArray<UnsafeSelectMenuOptionBuilder | APISelectMenuOption>) {
-		options = normalizeArray(...options);
+		options = normalizeArray(options);
 		optionsLengthValidator.parse(this.options.length + options.length);
 		this.options.push(
 			...options.map((option) =>
@@ -50,7 +50,7 @@ export class SelectMenuBuilder extends UnsafeSelectMenuBuilder {
 	}
 
 	public override setOptions(...options: RestOrArray<UnsafeSelectMenuOptionBuilder | APISelectMenuOption>) {
-		options = normalizeArray(...options);
+		options = normalizeArray(options);
 		optionsLengthValidator.parse(options.length);
 		this.options.splice(
 			0,

--- a/packages/builders/src/components/selectMenu/SelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/SelectMenu.ts
@@ -35,7 +35,7 @@ export class SelectMenuBuilder extends UnsafeSelectMenuBuilder {
 		return super.setDisabled(disabledValidator.parse(disabled));
 	}
 
-	public override addOptions(options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public override addOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
 		optionsLengthValidator.parse(this.options.length + options.length);
 		this.options.push(
 			...options.map((option) =>
@@ -47,7 +47,7 @@ export class SelectMenuBuilder extends UnsafeSelectMenuBuilder {
 		return this;
 	}
 
-	public override setOptions(options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public override setOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
 		optionsLengthValidator.parse(options.length);
 		this.options.splice(
 			0,

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -67,7 +67,7 @@ export class UnsafeSelectMenuBuilder extends ComponentBuilder<APISelectMenuCompo
 	 * @param options The options to add to this select menu
 	 * @returns
 	 */
-	public addOptions(options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public addOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
 		this.options.push(
 			...options.map((option) =>
 				option instanceof UnsafeSelectMenuOptionBuilder ? option : new UnsafeSelectMenuOptionBuilder(option),
@@ -80,7 +80,7 @@ export class UnsafeSelectMenuBuilder extends ComponentBuilder<APISelectMenuCompo
 	 * Sets the options on this select menu
 	 * @param options The options to set on this select menu
 	 */
-	public setOptions(options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public setOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
 		this.options.splice(
 			0,
 			this.options.length,

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -69,7 +69,7 @@ export class UnsafeSelectMenuBuilder extends ComponentBuilder<APISelectMenuCompo
 	 * @returns
 	 */
 	public addOptions(...options: RestOrArray<UnsafeSelectMenuOptionBuilder | APISelectMenuOption>) {
-		options = normalizeArray(...options);
+		options = normalizeArray(options);
 		this.options.push(
 			...options.map((option) =>
 				option instanceof UnsafeSelectMenuOptionBuilder ? option : new UnsafeSelectMenuOptionBuilder(option),
@@ -83,7 +83,7 @@ export class UnsafeSelectMenuBuilder extends ComponentBuilder<APISelectMenuCompo
 	 * @param options The options to set on this select menu
 	 */
 	public setOptions(...options: RestOrArray<UnsafeSelectMenuOptionBuilder | APISelectMenuOption>) {
-		options = normalizeArray(...options);
+		options = normalizeArray(options);
 		this.options.splice(
 			0,
 			this.options.length,

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -1,5 +1,6 @@
 import { APISelectMenuOption, ComponentType, type APISelectMenuComponent } from 'discord-api-types/v10';
 import { UnsafeSelectMenuOptionBuilder } from './UnsafeSelectMenuOption';
+import { normalizeArray, type RestOrArray } from '../../util/normalizeArray';
 import { ComponentBuilder } from '../Component';
 
 /**
@@ -67,7 +68,8 @@ export class UnsafeSelectMenuBuilder extends ComponentBuilder<APISelectMenuCompo
 	 * @param options The options to add to this select menu
 	 * @returns
 	 */
-	public addOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public addOptions(...options: RestOrArray<UnsafeSelectMenuOptionBuilder | APISelectMenuOption>) {
+		options = normalizeArray(...options);
 		this.options.push(
 			...options.map((option) =>
 				option instanceof UnsafeSelectMenuOptionBuilder ? option : new UnsafeSelectMenuOptionBuilder(option),
@@ -80,7 +82,8 @@ export class UnsafeSelectMenuBuilder extends ComponentBuilder<APISelectMenuCompo
 	 * Sets the options on this select menu
 	 * @param options The options to set on this select menu
 	 */
-	public setOptions(...options: (UnsafeSelectMenuOptionBuilder | APISelectMenuOption)[]) {
+	public setOptions(...options: RestOrArray<UnsafeSelectMenuOptionBuilder | APISelectMenuOption>) {
+		options = normalizeArray(...options);
 		this.options.splice(
 			0,
 			this.options.length,

--- a/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/UnsafeSelectMenu.ts
@@ -69,9 +69,8 @@ export class UnsafeSelectMenuBuilder extends ComponentBuilder<APISelectMenuCompo
 	 * @returns
 	 */
 	public addOptions(...options: RestOrArray<UnsafeSelectMenuOptionBuilder | APISelectMenuOption>) {
-		options = normalizeArray(options);
 		this.options.push(
-			...options.map((option) =>
+			...normalizeArray(options).map((option) =>
 				option instanceof UnsafeSelectMenuOptionBuilder ? option : new UnsafeSelectMenuOptionBuilder(option),
 			),
 		);
@@ -83,11 +82,10 @@ export class UnsafeSelectMenuBuilder extends ComponentBuilder<APISelectMenuCompo
 	 * @param options The options to set on this select menu
 	 */
 	public setOptions(...options: RestOrArray<UnsafeSelectMenuOptionBuilder | APISelectMenuOption>) {
-		options = normalizeArray(options);
 		this.options.splice(
 			0,
 			this.options.length,
-			...options.map((option) =>
+			...normalizeArray(options).map((option) =>
 				option instanceof UnsafeSelectMenuOptionBuilder ? option : new UnsafeSelectMenuOptionBuilder(option),
 			),
 		);

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -45,3 +45,4 @@ export * from './interactions/contextMenuCommands/ContextMenuCommandBuilder';
 export * from './util/jsonEncodable';
 export * from './util/equatable';
 export * from './util/componentUtil';
+export * from './util/normalizeArray';

--- a/packages/builders/src/interactions/modals/UnsafeModal.ts
+++ b/packages/builders/src/interactions/modals/UnsafeModal.ts
@@ -4,6 +4,7 @@ import type {
 	APIModalInteractionResponseCallbackData,
 } from 'discord-api-types/v10';
 import { ActionRowBuilder, createComponentBuilder, JSONEncodable, ModalActionRowComponentBuilder } from '../../index';
+import { normalizeArray, type RestOrArray } from '../../util/normalizeArray';
 
 export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResponseCallbackData> {
 	public readonly data: Partial<APIModalInteractionResponseCallbackData>;
@@ -38,11 +39,11 @@ export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResp
 	 * @param components The components to add to this modal
 	 */
 	public addComponents(
-		...components: (
-			| ActionRowBuilder<ModalActionRowComponentBuilder>
-			| APIActionRowComponent<APIModalActionRowComponent>
-		)[]
+		...components: RestOrArray<
+			ActionRowBuilder<ModalActionRowComponentBuilder> | APIActionRowComponent<APIModalActionRowComponent>
+		>
 	) {
+		components = normalizeArray(...components);
 		this.components.push(
 			...components.map((component) =>
 				component instanceof ActionRowBuilder
@@ -57,7 +58,8 @@ export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResp
 	 * Sets the components in this modal
 	 * @param components The components to set this modal to
 	 */
-	public setComponents(...components: ActionRowBuilder<ModalActionRowComponentBuilder>[]) {
+	public setComponents(...components: RestOrArray<ActionRowBuilder<ModalActionRowComponentBuilder>>) {
+		components = normalizeArray(...components);
 		this.components.splice(0, this.components.length, ...components);
 		return this;
 	}

--- a/packages/builders/src/interactions/modals/UnsafeModal.ts
+++ b/packages/builders/src/interactions/modals/UnsafeModal.ts
@@ -43,7 +43,7 @@ export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResp
 			ActionRowBuilder<ModalActionRowComponentBuilder> | APIActionRowComponent<APIModalActionRowComponent>
 		>
 	) {
-		components = normalizeArray(...components);
+		components = normalizeArray(components);
 		this.components.push(
 			...components.map((component) =>
 				component instanceof ActionRowBuilder
@@ -59,7 +59,7 @@ export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResp
 	 * @param components The components to set this modal to
 	 */
 	public setComponents(...components: RestOrArray<ActionRowBuilder<ModalActionRowComponentBuilder>>) {
-		components = normalizeArray(...components);
+		components = normalizeArray(components);
 		this.components.splice(0, this.components.length, ...components);
 		return this;
 	}

--- a/packages/builders/src/interactions/modals/UnsafeModal.ts
+++ b/packages/builders/src/interactions/modals/UnsafeModal.ts
@@ -43,9 +43,8 @@ export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResp
 			ActionRowBuilder<ModalActionRowComponentBuilder> | APIActionRowComponent<APIModalActionRowComponent>
 		>
 	) {
-		components = normalizeArray(components);
 		this.components.push(
-			...components.map((component) =>
+			...normalizeArray(components).map((component) =>
 				component instanceof ActionRowBuilder
 					? component
 					: new ActionRowBuilder<ModalActionRowComponentBuilder>(component),
@@ -59,8 +58,7 @@ export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResp
 	 * @param components The components to set this modal to
 	 */
 	public setComponents(...components: RestOrArray<ActionRowBuilder<ModalActionRowComponentBuilder>>) {
-		components = normalizeArray(components);
-		this.components.splice(0, this.components.length, ...components);
+		this.components.splice(0, this.components.length, ...normalizeArray(components));
 		return this;
 	}
 

--- a/packages/builders/src/interactions/modals/UnsafeModal.ts
+++ b/packages/builders/src/interactions/modals/UnsafeModal.ts
@@ -38,10 +38,10 @@ export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResp
 	 * @param components The components to add to this modal
 	 */
 	public addComponents(
-		components: (
+		...components: (
 			| ActionRowBuilder<ModalActionRowComponentBuilder>
 			| APIActionRowComponent<APIModalActionRowComponent>
-		)[],
+		)[]
 	) {
 		this.components.push(
 			...components.map((component) =>
@@ -57,7 +57,7 @@ export class UnsafeModalBuilder implements JSONEncodable<APIModalInteractionResp
 	 * Sets the components in this modal
 	 * @param components The components to set this modal to
 	 */
-	public setComponents(components: ActionRowBuilder<ModalActionRowComponentBuilder>[]) {
+	public setComponents(...components: ActionRowBuilder<ModalActionRowComponentBuilder>[]) {
 		this.components.splice(0, this.components.length, ...components);
 		return this;
 	}

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -12,7 +12,7 @@ import {
 	validateFieldLength,
 } from './Assertions';
 import { EmbedAuthorOptions, EmbedFooterOptions, RGBTuple, UnsafeEmbedBuilder } from './UnsafeEmbed';
-import { normalizeArray, RestOrArray } from '../../util/normalizeArray';
+import { normalizeArray, type RestOrArray } from '../../util/normalizeArray';
 
 /**
  * Represents a validated embed in a message (image/video preview, rich embed, etc.)

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -19,7 +19,7 @@ import { normalizeArray, RestOrArray } from '../../util/normalizeArray';
  */
 export class EmbedBuilder extends UnsafeEmbedBuilder {
 	public override addFields(...fields: RestOrArray<APIEmbedField>): this {
-		fields = normalizeArray(...fields);
+		fields = normalizeArray(fields);
 		// Ensure adding these fields won't exceed the 25 field limit
 		validateFieldLength(fields.length, this.data.fields);
 

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -12,12 +12,14 @@ import {
 	validateFieldLength,
 } from './Assertions';
 import { EmbedAuthorOptions, EmbedFooterOptions, RGBTuple, UnsafeEmbedBuilder } from './UnsafeEmbed';
+import { normalizeArray, RestOrArray } from '../../util/normalizeArray';
 
 /**
  * Represents a validated embed in a message (image/video preview, rich embed, etc.)
  */
 export class EmbedBuilder extends UnsafeEmbedBuilder {
-	public override addFields(...fields: APIEmbedField[]): this {
+	public override addFields(...fields: RestOrArray<APIEmbedField>): this {
+		fields = normalizeArray(...fields);
 		// Ensure adding these fields won't exceed the 25 field limit
 		validateFieldLength(fields.length, this.data.fields);
 

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -17,12 +17,12 @@ import { EmbedAuthorOptions, EmbedFooterOptions, RGBTuple, UnsafeEmbedBuilder } 
  * Represents a validated embed in a message (image/video preview, rich embed, etc.)
  */
 export class EmbedBuilder extends UnsafeEmbedBuilder {
-	public override addFields(fields: APIEmbedField[]): this {
+	public override addFields(...fields: APIEmbedField[]): this {
 		// Ensure adding these fields won't exceed the 25 field limit
 		validateFieldLength(fields.length, this.data.fields);
 
 		// Data assertions
-		return super.addFields(embedFieldsArrayPredicate.parse(fields));
+		return super.addFields(...embedFieldsArrayPredicate.parse(fields));
 	}
 
 	public override spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -70,8 +70,7 @@ export class UnsafeEmbedBuilder {
 	 * @param fields The fields to set
 	 */
 	public setFields(...fields: RestOrArray<APIEmbedField>) {
-		fields = normalizeArray(fields);
-		this.spliceFields(0, this.data.fields?.length ?? 0, ...fields);
+		this.spliceFields(0, this.data.fields?.length ?? 0, ...normalizeArray(fields));
 		return this;
 	}
 

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -46,7 +46,7 @@ export class UnsafeEmbedBuilder {
 	 * @param fields The fields to add
 	 */
 	public addFields(...fields: RestOrArray<APIEmbedField>): this {
-		fields = normalizeArray(...fields);
+		fields = normalizeArray(fields);
 		if (this.data.fields) this.data.fields.push(...fields);
 		else this.data.fields = fields;
 		return this;
@@ -70,7 +70,7 @@ export class UnsafeEmbedBuilder {
 	 * @param fields The fields to set
 	 */
 	public setFields(...fields: RestOrArray<APIEmbedField>) {
-		fields = normalizeArray(...fields);
+		fields = normalizeArray(fields);
 		this.spliceFields(0, this.data.fields?.length ?? 0, ...fields);
 		return this;
 	}

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -44,7 +44,7 @@ export class UnsafeEmbedBuilder {
 	 *
 	 * @param fields The fields to add
 	 */
-	public addFields(fields: APIEmbedField[]): this {
+	public addFields(...fields: APIEmbedField[]): this {
 		if (this.data.fields) this.data.fields.push(...fields);
 		else this.data.fields = fields;
 		return this;
@@ -67,7 +67,7 @@ export class UnsafeEmbedBuilder {
 	 * Sets the embed's fields (max 25).
 	 * @param fields The fields to set
 	 */
-	public setFields(fields: APIEmbedField[]) {
+	public setFields(...fields: APIEmbedField[]) {
 		this.spliceFields(0, this.data.fields?.length ?? 0, ...fields);
 		return this;
 	}

--- a/packages/builders/src/messages/embed/UnsafeEmbed.ts
+++ b/packages/builders/src/messages/embed/UnsafeEmbed.ts
@@ -1,4 +1,5 @@
 import type { APIEmbed, APIEmbedAuthor, APIEmbedField, APIEmbedFooter, APIEmbedImage } from 'discord-api-types/v10';
+import { normalizeArray, type RestOrArray } from '../../util/normalizeArray';
 
 export type RGBTuple = [red: number, green: number, blue: number];
 
@@ -44,7 +45,8 @@ export class UnsafeEmbedBuilder {
 	 *
 	 * @param fields The fields to add
 	 */
-	public addFields(...fields: APIEmbedField[]): this {
+	public addFields(...fields: RestOrArray<APIEmbedField>): this {
+		fields = normalizeArray(...fields);
 		if (this.data.fields) this.data.fields.push(...fields);
 		else this.data.fields = fields;
 		return this;
@@ -67,7 +69,8 @@ export class UnsafeEmbedBuilder {
 	 * Sets the embed's fields (max 25).
 	 * @param fields The fields to set
 	 */
-	public setFields(...fields: APIEmbedField[]) {
+	public setFields(...fields: RestOrArray<APIEmbedField>) {
+		fields = normalizeArray(...fields);
 		this.spliceFields(0, this.data.fields?.length ?? 0, ...fields);
 		return this;
 	}

--- a/packages/builders/src/util/normalizeArray.ts
+++ b/packages/builders/src/util/normalizeArray.ts
@@ -1,0 +1,6 @@
+export function normalizeArray<T>(...arr: T[] | T[][]): T[] {
+	if (Array.isArray(arr[0])) return [...arr[0]];
+	return [...arr] as T[];
+}
+
+export type RestOrArray<T> = T[] | T[][];

--- a/packages/builders/src/util/normalizeArray.ts
+++ b/packages/builders/src/util/normalizeArray.ts
@@ -1,6 +1,6 @@
-export function normalizeArray<T>(...arr: T[] | T[][]): T[] {
-	if (Array.isArray(arr[0])) return [...arr[0]];
-	return [...arr] as T[];
+export function normalizeArray<T>(arr: RestOrArray<T>): T[] {
+	if (Array.isArray(arr[0])) return arr[0];
+	return arr as T[];
 }
 
 export type RestOrArray<T> = T[] | T[][];

--- a/packages/builders/src/util/normalizeArray.ts
+++ b/packages/builders/src/util/normalizeArray.ts
@@ -3,4 +3,4 @@ export function normalizeArray<T>(arr: RestOrArray<T>): T[] {
 	return arr as T[];
 }
 
-export type RestOrArray<T> = T[] | T[][];
+export type RestOrArray<T> = T[] | [T[]];

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -29,6 +29,7 @@ import {
   ModalBuilder as BuildersModal,
   AnyComponentBuilder,
   ComponentBuilder,
+  type RestOrArray,
 } from '@discordjs/builders';
 import { Collection } from '@discordjs/collection';
 import { BaseImageURLOptions, ImageURLOptions, RawFile, REST, RESTOptions } from '@discordjs/rest';
@@ -599,10 +600,10 @@ export class ButtonBuilder extends BuilderButtonComponent {
 export class SelectMenuBuilder extends BuilderSelectMenuComponent {
   public constructor(data?: Partial<SelectMenuComponentData | APISelectMenuComponent>);
   public override addOptions(
-    options: (BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption)[],
+    ...options: RestOrArray<BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption>
   ): this;
   public override setOptions(
-    options: (BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption)[],
+    ...options: RestOrArray<BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption>
   ): this;
   public static from(other: JSONEncodable<APISelectMenuComponent> | APISelectMenuComponent): SelectMenuBuilder;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes all builders methods that previously only accepted arrays as input to accept both arrays and rest params. This was done by partially reverting #7759 and adding util functions to make it easy to support these two forms of input. There is no significant performance hit as this is not using Array.prototype.flat like before, it instead uses Array.isArray to check the kind of input that was provided.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
