### PR TITLE
fix(AuditLog): default changes to empty array

### DIFF
--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -116,9 +116,9 @@ class GuildAuditLogsEntry {
 
     /**
      * Specific property changes
-     * @type {?AuditLogChange[]}
+     * @type {AuditLogChange[]}
      */
-    this.changes = data.changes?.map(c => ({ key: c.key, old: c.old_value, new: c.new_value })) ?? null;
+    this.changes = data.changes?.map(c => ({ key: c.key, old: c.old_value, new: c.new_value })) ?? [];
 
     /**
      * The entry's id

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1213,7 +1213,7 @@ export class GuildAuditLogsEntry<
   public static Targets: GuildAuditLogsTargets;
   public action: TAction;
   public actionType: TActionType;
-  public changes: AuditLogChange[] | null;
+  public changes: AuditLogChange[];
   public get createdAt(): Date;
   public get createdTimestamp(): number;
   public executor: User | null;


### PR DESCRIPTION
`GuildAuditLogsEntry` assumes `this.changes` exists for most action types even though we default it to `null`. This becomes an issue when resolving to `TargetType.Unknown` where `this.changes` is accessed without optional chaining.

Defaulting to an empty array rather than null fixes the error in a way that is resilient to changes overall, e.g. should Discord decide to stop sending changes with another audit log type where we expect them.

The alternative approach is to optionally chain access to `this.changes` everywhere else and make other properties optional/nullable. If this is preferred let me know and I'll switch.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
