### PR TITLE
fix(sequentialhandler): account for 2xx status

### DIFF
--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -391,7 +391,7 @@ export class SequentialHandler implements IHandler {
 			}
 		}
 
-		if (status === 200|| status === 201) {
+		if (status === 200 || status === 201) {
 			return parseResponse(res);
 		} else if (status === 429) {
 			// A rate limit was hit - this may happen if the route isn't associated with an official bucket hash yet, or when first globally rate limited

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -391,7 +391,7 @@ export class SequentialHandler implements IHandler {
 			}
 		}
 
-		if (status === 200) {
+		if (status === 200|| status === 201) {
 			return parseResponse(res);
 		} else if (status === 429) {
 			// A rate limit was hit - this may happen if the route isn't associated with an official bucket hash yet, or when first globally rate limited

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -391,7 +391,7 @@ export class SequentialHandler implements IHandler {
 			}
 		}
 
-		if (status === 200 || status === 201) {
+		if (status >= 200 && status < 300) {
 			return parseResponse(res);
 		} else if (status === 429) {
 			// A rate limit was hit - this may happen if the route isn't associated with an official bucket hash yet, or when first globally rate limited


### PR DESCRIPTION
correct an issue where SequentialHandler.runRequest verified success with a 200 http status code, but emoji creation returns a 201

**Please describe the changes this PR makes and why it should be merged:**
standard emoji upload fails right now because it returns a 201 instead of 200, this causes case fallthrough until "null" is returned for the API request.

this results in `GuildEmojiCreateAction.handle` trying to access `createdEmoji.id` while `createdEmoji` is `nul`, and crashes

```
 const already = guild.emojis.cache.has(createdEmoji.id);
                                                        ^
TypeError: Cannot read properties of null (reading 'id')
    at GuildEmojiCreateAction.handle
```

repro script:
[emoji-failure.js.txt](https://github.com/discordjs/discord.js/files/8691314/emoji-failure.js.txt)

**Status and versioning classification:**

- Code changes have been tested against the Discord API
- I know how to update typings and have done so, or typings don't need updating


