### PR TITLE
fix: ok statusCode can be 200..299

### DIFF
--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -253,6 +253,21 @@ test('postEcho', async () => {
 	expect(await api.post('/postEcho', { body: { foo: 'bar' } })).toStrictEqual({ foo: 'bar' });
 });
 
+test('201 status code', async () => {
+	mockPool
+		.intercept({
+			path: genPath('/postNon200StatusCode'),
+			method: 'POST',
+		})
+		.reply((t) => ({
+			data: t.body!,
+			statusCode: 201,
+			responseOptions,
+		}));
+
+	expect(await api.post('/postNon200StatusCode', { body: { foo: 'bar' } })).toStrictEqual({ foo: 'bar' });
+});
+
 test('Old Message Delete Edge-Case: Old message', async () => {
 	mockPool
 		.intercept({

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -391,7 +391,7 @@ export class SequentialHandler implements IHandler {
 			}
 		}
 
-		if (status === 200) {
+		if (status >= 200 && status < 300) {
 			return parseResponse(res);
 		} else if (status === 429) {
 			// A rate limit was hit - this may happen if the route isn't associated with an official bucket hash yet, or when first globally rate limited


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Expands upon #7918 with a test.

Sorry I forgot <response>.ok accounted for status codes in the 2xx range.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
