### PR TITLE
fix(SlashCommandBuilder): import `Permissions` correctly

### DIFF
--- a/packages/builders/__tests__/interactions/ContextMenuCommands.test.ts
+++ b/packages/builders/__tests__/interactions/ContextMenuCommands.test.ts
@@ -1,3 +1,4 @@
+import { PermissionFlagsBits } from 'discord-api-types/v10';
 import { ContextMenuCommandAssertions, ContextMenuCommandBuilder } from '../../src/index';
 
 const getBuilder = () => new ContextMenuCommandBuilder();
@@ -114,6 +115,28 @@ describe('Context Menu Commands', () => {
 				expect(getBuilder().setNameLocalization('en-US', null).name_localizations).toEqual({
 					'en-US': null,
 				});
+			});
+		});
+
+		describe('permissions', () => {
+			test('GIVEN valid permission string THEN does not throw error', () => {
+				expect(() => getBuilder().setDefaultMemberPermissions('1')).not.toThrowError();
+			});
+
+			test('GIVEN valid permission bitfield THEN does not throw error', () => {
+				expect(() =>
+					getBuilder().setDefaultMemberPermissions(PermissionFlagsBits.AddReactions | PermissionFlagsBits.AttachFiles),
+				).not.toThrowError();
+			});
+
+			test('GIVEN null permissions THEN does not throw error', () => {
+				expect(() => getBuilder().setDefaultMemberPermissions(null)).not.toThrowError();
+			});
+
+			test('GIVEN invalid inputs THEN does throw error', () => {
+				expect(() => getBuilder().setDefaultMemberPermissions('1.1')).toThrowError();
+
+				expect(() => getBuilder().setDefaultMemberPermissions(1.1)).toThrowError();
 			});
 		});
 	});

--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -1,4 +1,4 @@
-import { APIApplicationCommandOptionChoice, ChannelType } from 'discord-api-types/v10';
+import { APIApplicationCommandOptionChoice, ChannelType, PermissionFlagsBits } from 'discord-api-types/v10';
 import {
 	SlashCommandAssertions,
 	SlashCommandBooleanOption,
@@ -474,6 +474,28 @@ describe('Slash Commands', () => {
 				expect(getBuilder().setDescriptionLocalization('en-US', null).description_localizations).toEqual({
 					'en-US': null,
 				});
+			});
+		});
+
+		describe('permissions', () => {
+			test('GIVEN valid permission string THEN does not throw error', () => {
+				expect(() => getBuilder().setDefaultMemberPermissions('1')).not.toThrowError();
+			});
+
+			test('GIVEN valid permission bitfield THEN does not throw error', () => {
+				expect(() =>
+					getBuilder().setDefaultMemberPermissions(PermissionFlagsBits.AddReactions | PermissionFlagsBits.AttachFiles),
+				).not.toThrowError();
+			});
+
+			test('GIVEN null permissions THEN does not throw error', () => {
+				expect(() => getBuilder().setDefaultMemberPermissions(null)).not.toThrowError();
+			});
+
+			test('GIVEN invalid inputs THEN does throw error', () => {
+				expect(() => getBuilder().setDefaultMemberPermissions('1.1')).toThrowError();
+
+				expect(() => getBuilder().setDefaultMemberPermissions(1.1)).toThrowError();
 			});
 		});
 	});

--- a/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
+++ b/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
@@ -106,7 +106,7 @@ export class ContextMenuCommandBuilder {
 	 *
 	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
 	 */
-	public setDefaultMemberPermissions(permissions: Permissions | null | undefined) {
+	public setDefaultMemberPermissions(permissions: Permissions | bigint | number | null | undefined) {
 		// Assert the value and parse it
 		const permissionValue = validateDefaultMemberPermissions(permissions);
 

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -109,7 +109,7 @@ export class SlashCommandBuilder {
 	 *
 	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
 	 */
-	public setDefaultMemberPermissions(permissions: Permissions | null | undefined) {
+	public setDefaultMemberPermissions(permissions: Permissions | bigint | number | null | undefined) {
 		// Assert the value and parse it
 		const permissionValue = validateDefaultMemberPermissions(permissions);
 

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -1,6 +1,7 @@
 import type {
 	APIApplicationCommandOption,
 	LocalizationMap,
+	Permissions,
 	RESTPostAPIApplicationCommandsJSONBody,
 } from 'discord-api-types/v10';
 import { mix } from 'ts-mixer';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes #7920 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
