### PR TITLE
fix(DataResolver): fix check for readable streams

### DIFF
--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -3,7 +3,6 @@
 const { Buffer } = require('node:buffer');
 const fs = require('node:fs/promises');
 const path = require('node:path');
-const stream = require('node:stream');
 const { fetch } = require('undici');
 const { Error: DiscordError, TypeError } = require('../errors');
 const Invite = require('../structures/Invite');
@@ -107,9 +106,10 @@ class DataResolver extends null {
    * @returns {Promise<Buffer>}
    */
   static async resolveFile(resource) {
+    if (!resource) return null;
     if (Buffer.isBuffer(resource)) return resource;
 
-    if (resource instanceof stream.Readable) {
+    if (typeof resource[Symbol.asyncIterator] === 'function') {
       const buffers = [];
       for await (const data of resource) buffers.push(data);
       return Buffer.concat(buffers);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The check for a stream is too strict and misses things that are streams.

Example: The package [archiver](npmjs.com/package/archiver) uses the [readable-stream](https://www.npmjs.com/package/readable-stream) which allows for compatibility for multiple node versions. But since the check only looks for the stream.Readable, the check fails.

I've changed the check to look for an asyncIterator, which I think is the simplest fix. If desired, it could be changed to check for a readable stream:
```js
static _isReadableStream(stream) {
  return (
    typeof stream === 'object' &&
    typeof stream.pipe === 'function' &&
    stream.readable !== false &&
    typeof stream._read === 'function' &&
    typeof stream._readableState === 'object'
  );
}
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating