### PR TITLE
feat: REST#raw

### DIFF
--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -5,4 +5,4 @@ export * from './lib/errors/RateLimitError';
 export * from './lib/RequestManager';
 export * from './lib/REST';
 export * from './lib/utils/constants';
-export { makeURLSearchParams } from './lib/utils/utils';
+export { makeURLSearchParams, parseResponse } from './lib/utils/utils';

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -13,6 +13,7 @@ import {
 import type { HashData } from './RequestManager';
 import type { IHandler } from './handlers/IHandler';
 import { DefaultRestOptions, RESTEvents } from './utils/constants';
+import { parseResponse } from './utils/utils';
 
 /**
  * Options to be passed when creating the REST instance
@@ -314,7 +315,14 @@ export class REST extends EventEmitter {
 	 * Runs a request from the api
 	 * @param options Request options
 	 */
-	public request(options: InternalRequest) {
+	public async request(options: InternalRequest) {
+		return parseResponse(await this.requestManager.queueRequest(options));
+	}
+
+	/**
+	 * Runs a request from the api, yielding the raw Response object
+	 */
+	public raw(options: InternalRequest) {
 		return this.requestManager.queueRequest(options);
 	}
 }

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -294,7 +294,7 @@ export class RequestManager extends EventEmitter {
 	 * @param request All the information needed to make a request
 	 * @returns The response from the api request
 	 */
-	public async queueRequest(request: InternalRequest): Promise<unknown> {
+	public async queueRequest(request: InternalRequest): Promise<Dispatcher.ResponseData> {
 		// Generalize the endpoint to its route data
 		const routeId = RequestManager.generateRouteData(request.fullRoute, request.method);
 		// Get the bucket hash for the generic route, or point to a global route otherwise

--- a/packages/rest/src/lib/handlers/IHandler.ts
+++ b/packages/rest/src/lib/handlers/IHandler.ts
@@ -1,3 +1,4 @@
+import type { Dispatcher } from 'undici';
 import type { RequestOptions } from '../REST';
 import type { HandlerRequestData, RouteData } from '../RequestManager';
 
@@ -7,7 +8,7 @@ export interface IHandler {
 		url: string,
 		options: RequestOptions,
 		requestData: HandlerRequestData,
-	) => Promise<unknown>;
+	) => Promise<Dispatcher.ResponseData>;
 	// eslint-disable-next-line @typescript-eslint/method-signature-style -- This is meant to be a getter returning a bool
 	get inactive(): boolean;
 	readonly id: string;

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -170,7 +170,7 @@ export class SequentialHandler implements IHandler {
 		url: string,
 		options: RequestOptions,
 		requestData: HandlerRequestData,
-	): Promise<unknown> {
+	): Promise<Dispatcher.ResponseData> {
 		let queue = this.#asyncQueue;
 		let queueType = QueueType.Standard;
 		// Separate sublimited requests when already sublimited
@@ -228,7 +228,7 @@ export class SequentialHandler implements IHandler {
 		options: RequestOptions,
 		requestData: HandlerRequestData,
 		retries = 0,
-	): Promise<unknown> {
+	): Promise<Dispatcher.ResponseData> {
 		/*
 		 * After calculations have been done, pre-emptively stop further requests
 		 * Potentially loop until this task can run if e.g. the global rate limit is hit twice
@@ -392,7 +392,7 @@ export class SequentialHandler implements IHandler {
 		}
 
 		if (status >= 200 && status < 300) {
-			return parseResponse(res);
+			return res;
 		} else if (status === 429) {
 			// A rate limit was hit - this may happen if the route isn't associated with an official bucket hash yet, or when first globally rate limited
 			const isGlobal = this.globalLimited;
@@ -474,7 +474,7 @@ export class SequentialHandler implements IHandler {
 				// throw the API error
 				throw new DiscordAPIError(data, 'code' in data ? data.code : data.error, status, method, url, requestData);
 			}
-			return null;
+			return res;
 		}
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a new `REST#raw` method, enabling users to get raw response objects and consume the body themselves, also exposing the `parseResponse` function.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

