### PR TITLE
fix: Remove trailing invites on channel deletion

### DIFF
--- a/packages/discord.js/src/managers/ChannelManager.js
+++ b/packages/discord.js/src/managers/ChannelManager.js
@@ -61,6 +61,11 @@ class ChannelManager extends CachedManager {
   _remove(id) {
     const channel = this.cache.get(id);
     channel?.guild?.channels.cache.delete(id);
+
+    for (const [code, invite] of channel?.guild?.invites.cache ?? []) {
+      if (invite.channelId === id) channel.guild.invites.cache.delete(code);
+    }
+
     channel?.parent?.threads?.cache.delete(id);
     this.cache.delete(id);
   }

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -429,6 +429,7 @@ class GuildChannelManager extends CachedManager {
     const id = this.resolveId(channel);
     if (!id) throw new TypeError('INVALID_TYPE', 'channel', 'GuildChannelResolvable');
     await this.client.rest.delete(Routes.channel(id), { reason });
+    this.client.actions.ChannelDelete.handle({ id });
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Upon channel deletion, their respective invites are not deleted. These will linger around until manually removed, which is not ideal. This pull request should address that issue by removing them from the cache upon deletion & resolves #7930.

The channel delete handler was called in `GuildChannelManager#delete()` to handle a race limit where the cache would not be updated in time when `await`ed.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
