### PR TITLE
fix(TextBasedChannel#bulkDelete): return deleted message

### DIFF
--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -298,13 +298,13 @@ class TextBasedChannel {
       }
       if (messageIds.length === 0) return new Collection();
       if (messageIds.length === 1) {
-        await this.client.rest.delete(Routes.channelMessage(this.id, messageIds[0]));
         const message = this.client.actions.MessageDelete.getMessage(
           {
             message_id: messageIds[0],
           },
           this,
         );
+        await this.client.rest.delete(Routes.channelMessage(this.id, messageIds[0]));
         return message ? new Collection([[message.id, message]]) : new Collection();
       }
       await this.client.rest.post(Routes.channelBulkDelete(this.id), { body: { messages: messageIds } });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #7882

As it turns out, calling `delete` caused the event handler to uncache the message before the `getMessage` call, causing bulk-deleting a single message to always return an empty collection.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
