### PR TITLE
chore: fix git cliff configs

### DIFF
--- a/packages/builders/cliff.toml
+++ b/packages/builders/cliff.toml
@@ -41,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "🚀 Features"},
-    { message = "^fix", group = "🐛 Bug Fixes"},
-    { message = "^docs", group = "📝 Documentation"},
-    { message = "^perf", group = "🏃 Performance"},
-    { message = "^refactor", group = "🏠 Refactor"},
-    { message = "^typings", group = "⌨️ Typings"},
-    { message = "^types", group = "⌨️ Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^docs", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^typings", group = "Typings"},
+    { message = "^types", group = "Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
     { message = "^revert", skip = true},
-    { message = "^style", group = "🪞 Styling"},
-    { message = "^test", group = "🧪 Testing"},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
     { message = "^chore", skip = true},
     { message = "^ci", skip = true},
     { message = "^build", skip = true},
-    { body = ".*security", group = "🛡️ Security"},
+    { body = ".*security", group = "Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/builders@.*"

--- a/packages/builders/cliff.toml
+++ b/packages/builders/cliff.toml
@@ -6,32 +6,32 @@ All notable changes to this project will be documented in this file.\n
 """
 body = """
 {% if version %}\
-    # [{{ version | trim_start_matches(pat="v") }}]\
-    {% if previous %}\
-        {% if previous.version %}\
-            (https://github.com/discordjs/discord.js/compare/{{ previous.version }}...{{ version }})\
-        {% else %}
-            (https://github.com/discordjs/discord.js/tree/{{ version }})\
-        {% endif %}\
-    {% endif %} \
-    - ({{ timestamp | date(format="%Y-%m-%d") }})
+	# [{{ version | trim_start_matches(pat="v") }}]\
+	{% if previous %}\
+		{% if previous.version %}\
+			(https://github.com/discordjs/discord.js/compare/{{ previous.version }}...{{ version }})\
+		{% else %}
+			(https://github.com/discordjs/discord.js/tree/{{ version }})\
+		{% endif %}\
+	{% endif %} \
+	- ({{ timestamp | date(format="%Y-%m-%d") }})
 {% else %}\
-    # [unreleased]
+	# [unreleased]
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
-    ## {{ group | upper_first }}
-    {% for commit in commits %}
+	## {{ group | upper_first }}
+	{% for commit in commits %}
 		- {% if commit.scope %}\
 			**{{commit.scope}}:** \
 		  {% endif %}\
-            {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
+			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
 			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
 				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
 			{% endfor %}\
 		{% endif %}\
-    {% endfor %}
+	{% endfor %}
 {% endfor %}\n
 """
 trim = true
@@ -41,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^docs", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^typings", group = "Typings"},
-    { message = "^types", group = "Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
-    { message = "^revert", skip = true},
-    { message = "^style", group = "Styling"},
-    { message = "^test", group = "Testing"},
-    { message = "^chore", skip = true},
-    { message = "^ci", skip = true},
-    { message = "^build", skip = true},
-    { body = ".*security", group = "Security"},
+	{ message = "^feat", group = "Features"},
+	{ message = "^fix", group = "Bug Fixes"},
+	{ message = "^docs", group = "Documentation"},
+	{ message = "^perf", group = "Performance"},
+	{ message = "^refactor", group = "Refactor"},
+	{ message = "^typings", group = "Typings"},
+	{ message = "^types", group = "Typings"},
+	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+	{ message = "^revert", skip = true},
+	{ message = "^style", group = "Styling"},
+	{ message = "^test", group = "Testing"},
+	{ message = "^chore", skip = true},
+	{ message = "^ci", skip = true},
+	{ message = "^build", skip = true},
+	{ body = ".*security", group = "Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/builders@.*"

--- a/packages/builders/cliff.toml
+++ b/packages/builders/cliff.toml
@@ -21,13 +21,16 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ## {{ group | upper_first }}
     {% for commit in commits %}
-        - {% if commit.breaking %}\
-            [**breaking**] \
-          {% endif %}\
-            {% if commit.scope %}\
-                **{{commit.scope}}:** \
-            {% endif %}\
+		- {% if commit.scope %}\
+			**{{commit.scope}}:** \
+		  {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
+		{% if commit.breaking %}\
+			\n\n {% raw %}  {% endraw %} ### 💥 Breaking Changes:\n \
+			{% for breakingChange in commit.footers %}\
+				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+			{% endfor %}\
+		{% endif %}\
     {% endfor %}
 {% endfor %}\n
 """
@@ -38,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^docs", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^typings", group = "Typings"},
-    { message = "^types", group = "Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+    { message = "^feat", group = "🚀 Features"},
+    { message = "^fix", group = "🐛 Bug Fixes"},
+    { message = "^docs", group = "📝 Documentation"},
+    { message = "^perf", group = "🏃 Performance"},
+    { message = "^refactor", group = "🏠 Refactor"},
+    { message = "^typings", group = "⌨️ Typings"},
+    { message = "^types", group = "⌨️ Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
     { message = "^revert", skip = true},
-    { message = "^style", group = "Styling"},
-    { message = "^test", group = "Testing"},
+    { message = "^style", group = "🪞 Styling"},
+    { message = "^test", group = "🧪 Testing"},
     { message = "^chore", skip = true},
     { message = "^ci", skip = true},
     { message = "^build", skip = true},
-    { body = ".*security", group = "Security"},
+    { body = ".*security", group = "🛡️ Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/builders@.*"

--- a/packages/builders/cliff.toml
+++ b/packages/builders/cliff.toml
@@ -26,7 +26,7 @@ body = """
 		  {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### 💥 Breaking Changes:\n \
+			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
 				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
 			{% endfor %}\

--- a/packages/collection/cliff.toml
+++ b/packages/collection/cliff.toml
@@ -26,7 +26,7 @@ body = """
 		  {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### 💥 Breaking Changes:\n \
+			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
 				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
 			{% endfor %}\

--- a/packages/collection/cliff.toml
+++ b/packages/collection/cliff.toml
@@ -41,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "🚀 Features"},
-    { message = "^fix", group = "🐛 Bug Fixes"},
-    { message = "^docs", group = "📝 Documentation"},
-    { message = "^perf", group = "🏃 Performance"},
-    { message = "^refactor", group = "🏠 Refactor"},
-    { message = "^typings", group = "⌨️ Typings"},
-    { message = "^types", group = "⌨️ Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^docs", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^typings", group = "Typings"},
+    { message = "^types", group = "Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
     { message = "^revert", skip = true},
-    { message = "^style", group = "🪞 Styling"},
-    { message = "^test", group = "🧪 Testing"},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
     { message = "^chore", skip = true},
     { message = "^ci", skip = true},
     { message = "^build", skip = true},
-    { body = ".*security", group = "🛡️ Security"},
+    { body = ".*security", group = "Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/collection@.*"

--- a/packages/collection/cliff.toml
+++ b/packages/collection/cliff.toml
@@ -6,32 +6,32 @@ All notable changes to this project will be documented in this file.\n
 """
 body = """
 {% if version %}\
-    # [{{ version | trim_start_matches(pat="v") }}]\
-    {% if previous %}\
-        {% if previous.version %}\
-            (https://github.com/discordjs/discord.js/compare/{{ previous.version }}...{{ version }})\
-        {% else %}
-            (https://github.com/discordjs/discord.js/tree/{{ version }})\
-        {% endif %}\
-    {% endif %} \
-    - ({{ timestamp | date(format="%Y-%m-%d") }})
+	# [{{ version | trim_start_matches(pat="v") }}]\
+	{% if previous %}\
+		{% if previous.version %}\
+			(https://github.com/discordjs/discord.js/compare/{{ previous.version }}...{{ version }})\
+		{% else %}
+			(https://github.com/discordjs/discord.js/tree/{{ version }})\
+		{% endif %}\
+	{% endif %} \
+	- ({{ timestamp | date(format="%Y-%m-%d") }})
 {% else %}\
-    # [unreleased]
+	# [unreleased]
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
-    ## {{ group | upper_first }}
-    {% for commit in commits %}
+	## {{ group | upper_first }}
+	{% for commit in commits %}
 		- {% if commit.scope %}\
 			**{{commit.scope}}:** \
 		  {% endif %}\
-            {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
+			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
 			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
 				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
 			{% endfor %}\
 		{% endif %}\
-    {% endfor %}
+	{% endfor %}
 {% endfor %}\n
 """
 trim = true
@@ -41,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^docs", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^typings", group = "Typings"},
-    { message = "^types", group = "Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
-    { message = "^revert", skip = true},
-    { message = "^style", group = "Styling"},
-    { message = "^test", group = "Testing"},
-    { message = "^chore", skip = true},
-    { message = "^ci", skip = true},
-    { message = "^build", skip = true},
-    { body = ".*security", group = "Security"},
+	{ message = "^feat", group = "Features"},
+	{ message = "^fix", group = "Bug Fixes"},
+	{ message = "^docs", group = "Documentation"},
+	{ message = "^perf", group = "Performance"},
+	{ message = "^refactor", group = "Refactor"},
+	{ message = "^typings", group = "Typings"},
+	{ message = "^types", group = "Typings"},
+	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+	{ message = "^revert", skip = true},
+	{ message = "^style", group = "Styling"},
+	{ message = "^test", group = "Testing"},
+	{ message = "^chore", skip = true},
+	{ message = "^ci", skip = true},
+	{ message = "^build", skip = true},
+	{ body = ".*security", group = "Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/collection@.*"

--- a/packages/collection/cliff.toml
+++ b/packages/collection/cliff.toml
@@ -21,13 +21,16 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ## {{ group | upper_first }}
     {% for commit in commits %}
-        - {% if commit.breaking %}\
-            [**breaking**] \
-          {% endif %}\
-            {% if commit.scope %}\
-                **{{commit.scope}}:** \
-            {% endif %}\
+		- {% if commit.scope %}\
+			**{{commit.scope}}:** \
+		  {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
+		{% if commit.breaking %}\
+			\n\n {% raw %}  {% endraw %} ### 💥 Breaking Changes:\n \
+			{% for breakingChange in commit.footers %}\
+				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+			{% endfor %}\
+		{% endif %}\
     {% endfor %}
 {% endfor %}\n
 """
@@ -38,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^docs", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^typings", group = "Typings"},
-    { message = "^types", group = "Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+    { message = "^feat", group = "🚀 Features"},
+    { message = "^fix", group = "🐛 Bug Fixes"},
+    { message = "^docs", group = "📝 Documentation"},
+    { message = "^perf", group = "🏃 Performance"},
+    { message = "^refactor", group = "🏠 Refactor"},
+    { message = "^typings", group = "⌨️ Typings"},
+    { message = "^types", group = "⌨️ Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
     { message = "^revert", skip = true},
-    { message = "^style", group = "Styling"},
-    { message = "^test", group = "Testing"},
+    { message = "^style", group = "🪞 Styling"},
+    { message = "^test", group = "🧪 Testing"},
     { message = "^chore", skip = true},
     { message = "^ci", skip = true},
     { message = "^build", skip = true},
-    { body = ".*security", group = "Security"},
+    { body = ".*security", group = "🛡️ Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/collection@.*"

--- a/packages/discord.js/cliff.toml
+++ b/packages/discord.js/cliff.toml
@@ -26,7 +26,7 @@ body = """
 		  {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### 💥 Breaking Changes:\n \
+			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
 				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
 			{% endfor %}\

--- a/packages/discord.js/cliff.toml
+++ b/packages/discord.js/cliff.toml
@@ -21,13 +21,16 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ## {{ group | upper_first }}
     {% for commit in commits %}
-        - {% if commit.breaking %}\
-            [**breaking**] \
-          {% endif %}\
-            {% if commit.scope %}\
-                **{{commit.scope}}:** \
-            {% endif %}\
+		- {% if commit.scope %}\
+			**{{commit.scope}}:** \
+		  {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
+		{% if commit.breaking %}\
+			\n\n {% raw %}  {% endraw %} ### 💥 Breaking Changes:\n \
+			{% for breakingChange in commit.footers %}\
+				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+			{% endfor %}\
+		{% endif %}\
     {% endfor %}
 {% endfor %}\n
 """
@@ -38,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^docs", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^typings", group = "Typings"},
-    { message = "^types", group = "Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+    { message = "^feat", group = "🚀 Features"},
+    { message = "^fix", group = "🐛 Bug Fixes"},
+    { message = "^docs", group = "📝 Documentation"},
+    { message = "^perf", group = "🏃 Performance"},
+    { message = "^refactor", group = "🏠 Refactor"},
+    { message = "^typings", group = "⌨️ Typings"},
+    { message = "^types", group = "⌨️ Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
     { message = "^revert", skip = true},
-    { message = "^style", group = "Styling"},
-    { message = "^test", group = "Testing"},
+    { message = "^style", group = "🪞 Styling"},
+    { message = "^test", group = "🧪 Testing"},
     { message = "^chore", skip = true},
     { message = "^ci", skip = true},
     { message = "^build", skip = true},
-    { body = ".*security", group = "Security"},
+    { body = ".*security", group = "🛡️ Security"},
 ]
 filter_commits = true
 tag_pattern = "[0-9]*"

--- a/packages/discord.js/cliff.toml
+++ b/packages/discord.js/cliff.toml
@@ -41,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "🚀 Features"},
-    { message = "^fix", group = "🐛 Bug Fixes"},
-    { message = "^docs", group = "📝 Documentation"},
-    { message = "^perf", group = "🏃 Performance"},
-    { message = "^refactor", group = "🏠 Refactor"},
-    { message = "^typings", group = "⌨️ Typings"},
-    { message = "^types", group = "⌨️ Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^docs", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^typings", group = "Typings"},
+    { message = "^types", group = "Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
     { message = "^revert", skip = true},
-    { message = "^style", group = "🪞 Styling"},
-    { message = "^test", group = "🧪 Testing"},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
     { message = "^chore", skip = true},
     { message = "^ci", skip = true},
     { message = "^build", skip = true},
-    { body = ".*security", group = "🛡️ Security"},
+    { body = ".*security", group = "Security"},
 ]
 filter_commits = true
 tag_pattern = "[0-9]*"

--- a/packages/discord.js/cliff.toml
+++ b/packages/discord.js/cliff.toml
@@ -6,32 +6,32 @@ All notable changes to this project will be documented in this file.\n
 """
 body = """
 {% if version %}\
-    # [{{ version | trim_start_matches(pat="v") }}]\
-    {% if previous %}\
-        {% if previous.version %}\
-            (https://github.com/discordjs/discord.js/compare/{{ previous.version }}...{{ version }})\
-        {% else %}
-            (https://github.com/discordjs/discord.js/tree/{{ version }})\
-        {% endif %}\
-    {% endif %} \
-    - ({{ timestamp | date(format="%Y-%m-%d") }})
+	# [{{ version | trim_start_matches(pat="v") }}]\
+	{% if previous %}\
+		{% if previous.version %}\
+			(https://github.com/discordjs/discord.js/compare/{{ previous.version }}...{{ version }})\
+		{% else %}
+			(https://github.com/discordjs/discord.js/tree/{{ version }})\
+		{% endif %}\
+	{% endif %} \
+	- ({{ timestamp | date(format="%Y-%m-%d") }})
 {% else %}\
-    # [unreleased]
+	# [unreleased]
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
-    ## {{ group | upper_first }}
-    {% for commit in commits %}
+	## {{ group | upper_first }}
+	{% for commit in commits %}
 		- {% if commit.scope %}\
 			**{{commit.scope}}:** \
 		  {% endif %}\
-            {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
+			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
 			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
 				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
 			{% endfor %}\
 		{% endif %}\
-    {% endfor %}
+	{% endfor %}
 {% endfor %}\n
 """
 trim = true
@@ -41,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^docs", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^typings", group = "Typings"},
-    { message = "^types", group = "Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
-    { message = "^revert", skip = true},
-    { message = "^style", group = "Styling"},
-    { message = "^test", group = "Testing"},
-    { message = "^chore", skip = true},
-    { message = "^ci", skip = true},
-    { message = "^build", skip = true},
-    { body = ".*security", group = "Security"},
+	{ message = "^feat", group = "Features"},
+	{ message = "^fix", group = "Bug Fixes"},
+	{ message = "^docs", group = "Documentation"},
+	{ message = "^perf", group = "Performance"},
+	{ message = "^refactor", group = "Refactor"},
+	{ message = "^typings", group = "Typings"},
+	{ message = "^types", group = "Typings"},
+	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+	{ message = "^revert", skip = true},
+	{ message = "^style", group = "Styling"},
+	{ message = "^test", group = "Testing"},
+	{ message = "^chore", skip = true},
+	{ message = "^ci", skip = true},
+	{ message = "^build", skip = true},
+	{ body = ".*security", group = "Security"},
 ]
 filter_commits = true
 tag_pattern = "[0-9]*"

--- a/packages/rest/cliff.toml
+++ b/packages/rest/cliff.toml
@@ -41,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "🚀 Features"},
-    { message = "^fix", group = "🐛 Bug Fixes"},
-    { message = "^docs", group = "📝 Documentation"},
-    { message = "^perf", group = "🏃 Performance"},
-    { message = "^refactor", group = "🏠 Refactor"},
-    { message = "^typings", group = "⌨️ Typings"},
-    { message = "^types", group = "⌨️ Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^docs", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^typings", group = "Typings"},
+    { message = "^types", group = "Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
     { message = "^revert", skip = true},
-    { message = "^style", group = "🪞 Styling"},
-    { message = "^test", group = "🧪 Testing"},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
     { message = "^chore", skip = true},
     { message = "^ci", skip = true},
     { message = "^build", skip = true},
-    { body = ".*security", group = "🛡️ Security"},
+    { body = ".*security", group = "Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/rest@.*"

--- a/packages/rest/cliff.toml
+++ b/packages/rest/cliff.toml
@@ -21,13 +21,16 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ## {{ group | upper_first }}
     {% for commit in commits %}
-        - {% if commit.breaking %}\
-            [**breaking**] \
-          {% endif %}\
-            {% if commit.scope %}\
-                **{{commit.scope}}:** \
-            {% endif %}\
+		- {% if commit.scope %}\
+			**{{commit.scope}}:** \
+		  {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
+		{% if commit.breaking %}\
+			\n\n {% raw %}  {% endraw %} ### 💥 Breaking Changes:\n \
+			{% for breakingChange in commit.footers %}\
+				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+			{% endfor %}\
+		{% endif %}\
     {% endfor %}
 {% endfor %}\n
 """
@@ -38,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^docs", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^typings", group = "Typings"},
-    { message = "^types", group = "Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+    { message = "^feat", group = "🚀 Features"},
+    { message = "^fix", group = "🐛 Bug Fixes"},
+    { message = "^docs", group = "📝 Documentation"},
+    { message = "^perf", group = "🏃 Performance"},
+    { message = "^refactor", group = "🏠 Refactor"},
+    { message = "^typings", group = "⌨️ Typings"},
+    { message = "^types", group = "⌨️ Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
     { message = "^revert", skip = true},
-    { message = "^style", group = "Styling"},
-    { message = "^test", group = "Testing"},
+    { message = "^style", group = "🪞 Styling"},
+    { message = "^test", group = "🧪 Testing"},
     { message = "^chore", skip = true},
     { message = "^ci", skip = true},
     { message = "^build", skip = true},
-    { body = ".*security", group = "Security"},
+    { body = ".*security", group = "🛡️ Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/rest@.*"

--- a/packages/rest/cliff.toml
+++ b/packages/rest/cliff.toml
@@ -26,7 +26,7 @@ body = """
 		  {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### 💥 Breaking Changes:\n \
+			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
 				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
 			{% endfor %}\

--- a/packages/rest/cliff.toml
+++ b/packages/rest/cliff.toml
@@ -6,32 +6,32 @@ All notable changes to this project will be documented in this file.\n
 """
 body = """
 {% if version %}\
-    # [{{ version | trim_start_matches(pat="v") }}]\
-    {% if previous %}\
-        {% if previous.version %}\
-            (https://github.com/discordjs/discord.js/compare/{{ previous.version }}...{{ version }})\
-        {% else %}
-            (https://github.com/discordjs/discord.js/tree/{{ version }})\
-        {% endif %}\
-    {% endif %} \
-    - ({{ timestamp | date(format="%Y-%m-%d") }})
+	# [{{ version | trim_start_matches(pat="v") }}]\
+	{% if previous %}\
+		{% if previous.version %}\
+			(https://github.com/discordjs/discord.js/compare/{{ previous.version }}...{{ version }})\
+		{% else %}
+			(https://github.com/discordjs/discord.js/tree/{{ version }})\
+		{% endif %}\
+	{% endif %} \
+	- ({{ timestamp | date(format="%Y-%m-%d") }})
 {% else %}\
-    # [unreleased]
+	# [unreleased]
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
-    ## {{ group | upper_first }}
-    {% for commit in commits %}
+	## {{ group | upper_first }}
+	{% for commit in commits %}
 		- {% if commit.scope %}\
 			**{{commit.scope}}:** \
 		  {% endif %}\
-            {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
+			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
 			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
 				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
 			{% endfor %}\
 		{% endif %}\
-    {% endfor %}
+	{% endfor %}
 {% endfor %}\n
 """
 trim = true
@@ -41,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^docs", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^typings", group = "Typings"},
-    { message = "^types", group = "Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
-    { message = "^revert", skip = true},
-    { message = "^style", group = "Styling"},
-    { message = "^test", group = "Testing"},
-    { message = "^chore", skip = true},
-    { message = "^ci", skip = true},
-    { message = "^build", skip = true},
-    { body = ".*security", group = "Security"},
+	{ message = "^feat", group = "Features"},
+	{ message = "^fix", group = "Bug Fixes"},
+	{ message = "^docs", group = "Documentation"},
+	{ message = "^perf", group = "Performance"},
+	{ message = "^refactor", group = "Refactor"},
+	{ message = "^typings", group = "Typings"},
+	{ message = "^types", group = "Typings"},
+	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+	{ message = "^revert", skip = true},
+	{ message = "^style", group = "Styling"},
+	{ message = "^test", group = "Testing"},
+	{ message = "^chore", skip = true},
+	{ message = "^ci", skip = true},
+	{ message = "^build", skip = true},
+	{ body = ".*security", group = "Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/rest@.*"

--- a/packages/voice/cliff.toml
+++ b/packages/voice/cliff.toml
@@ -41,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "🚀 Features"},
-    { message = "^fix", group = "🐛 Bug Fixes"},
-    { message = "^docs", group = "📝 Documentation"},
-    { message = "^perf", group = "🏃 Performance"},
-    { message = "^refactor", group = "🏠 Refactor"},
-    { message = "^typings", group = "⌨️ Typings"},
-    { message = "^types", group = "⌨️ Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^docs", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^typings", group = "Typings"},
+    { message = "^types", group = "Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
     { message = "^revert", skip = true},
-    { message = "^style", group = "🪞 Styling"},
-    { message = "^test", group = "🧪 Testing"},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
     { message = "^chore", skip = true},
     { message = "^ci", skip = true},
     { message = "^build", skip = true},
-    { body = ".*security", group = "🛡️ Security"},
+    { body = ".*security", group = "Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/voice@.*"

--- a/packages/voice/cliff.toml
+++ b/packages/voice/cliff.toml
@@ -26,7 +26,7 @@ body = """
 		  {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### 💥 Breaking Changes:\n \
+			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
 				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
 			{% endfor %}\

--- a/packages/voice/cliff.toml
+++ b/packages/voice/cliff.toml
@@ -21,13 +21,16 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
     ## {{ group | upper_first }}
     {% for commit in commits %}
-        - {% if commit.breaking %}\
-            [**breaking**] \
-          {% endif %}\
-            {% if commit.scope %}\
-                **{{commit.scope}}:** \
-            {% endif %}\
+		- {% if commit.scope %}\
+			**{{commit.scope}}:** \
+		  {% endif %}\
             {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
+		{% if commit.breaking %}\
+			\n\n {% raw %}  {% endraw %} ### 💥 Breaking Changes:\n \
+			{% for breakingChange in commit.footers %}\
+				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+			{% endfor %}\
+		{% endif %}\
     {% endfor %}
 {% endfor %}\n
 """
@@ -38,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^docs", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^typings", group = "Typings"},
-    { message = "^types", group = "Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+    { message = "^feat", group = "🚀 Features"},
+    { message = "^fix", group = "🐛 Bug Fixes"},
+    { message = "^docs", group = "📝 Documentation"},
+    { message = "^perf", group = "🏃 Performance"},
+    { message = "^refactor", group = "🏠 Refactor"},
+    { message = "^typings", group = "⌨️ Typings"},
+    { message = "^types", group = "⌨️ Typings"},
+    { message = ".*deprecated", body = ".*deprecated", group = "🚨 Deprecation"},
     { message = "^revert", skip = true},
-    { message = "^style", group = "Styling"},
-    { message = "^test", group = "Testing"},
+    { message = "^style", group = "🪞 Styling"},
+    { message = "^test", group = "🧪 Testing"},
     { message = "^chore", skip = true},
     { message = "^ci", skip = true},
     { message = "^build", skip = true},
-    { body = ".*security", group = "Security"},
+    { body = ".*security", group = "🛡️ Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/voice@.*"

--- a/packages/voice/cliff.toml
+++ b/packages/voice/cliff.toml
@@ -6,32 +6,32 @@ All notable changes to this project will be documented in this file.\n
 """
 body = """
 {% if version %}\
-    # [{{ version | trim_start_matches(pat="v") }}]\
-    {% if previous %}\
-        {% if previous.version %}\
-            (https://github.com/discordjs/discord.js/compare/{{ previous.version }}...{{ version }})\
-        {% else %}
-            (https://github.com/discordjs/discord.js/tree/{{ version }})\
-        {% endif %}\
-    {% endif %} \
-    - ({{ timestamp | date(format="%Y-%m-%d") }})
+	# [{{ version | trim_start_matches(pat="v") }}]\
+	{% if previous %}\
+		{% if previous.version %}\
+			(https://github.com/discordjs/discord.js/compare/{{ previous.version }}...{{ version }})\
+		{% else %}
+			(https://github.com/discordjs/discord.js/tree/{{ version }})\
+		{% endif %}\
+	{% endif %} \
+	- ({{ timestamp | date(format="%Y-%m-%d") }})
 {% else %}\
-    # [unreleased]
+	# [unreleased]
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
-    ## {{ group | upper_first }}
-    {% for commit in commits %}
+	## {{ group | upper_first }}
+	{% for commit in commits %}
 		- {% if commit.scope %}\
 			**{{commit.scope}}:** \
 		  {% endif %}\
-            {{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
+			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
 			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
 				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
 			{% endfor %}\
 		{% endif %}\
-    {% endfor %}
+	{% endfor %}
 {% endfor %}\n
 """
 trim = true
@@ -41,21 +41,21 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 commit_parsers = [
-    { message = "^feat", group = "Features"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^docs", group = "Documentation"},
-    { message = "^perf", group = "Performance"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^typings", group = "Typings"},
-    { message = "^types", group = "Typings"},
-    { message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
-    { message = "^revert", skip = true},
-    { message = "^style", group = "Styling"},
-    { message = "^test", group = "Testing"},
-    { message = "^chore", skip = true},
-    { message = "^ci", skip = true},
-    { message = "^build", skip = true},
-    { body = ".*security", group = "Security"},
+	{ message = "^feat", group = "Features"},
+	{ message = "^fix", group = "Bug Fixes"},
+	{ message = "^docs", group = "Documentation"},
+	{ message = "^perf", group = "Performance"},
+	{ message = "^refactor", group = "Refactor"},
+	{ message = "^typings", group = "Typings"},
+	{ message = "^types", group = "Typings"},
+	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
+	{ message = "^revert", skip = true},
+	{ message = "^style", group = "Styling"},
+	{ message = "^test", group = "Testing"},
+	{ message = "^chore", skip = true},
+	{ message = "^ci", skip = true},
+	{ message = "^build", skip = true},
+	{ body = ".*security", group = "Security"},
 ]
 filter_commits = true
 tag_pattern = "@discordjs\\/voice@.*"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Little while ago I remarked to @iCrawl in DM that there was a bug in the
git cliff configs that I had to fix for Sapphire. Namely when a commit
has the following body:
```
type: message

BREAKING CHANGE: One
BREAKING CHANGE: Two
... etc
```

These breaking changes weren't being listed in the changelog because of
how Git Cliff parses the commit body and footer.

That all said, this PR fixes that issue.

~~Lastly, when making the changes for Sapphire I thought it'd be fun to~~
~~add emojis to the scopes. Some other projects do this and it really~~
~~makes their changelogs look more fun. Please do let me know if for DiscordJS~~
~~you guys do not want the emojis and I'll remove them again.~~

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.