### PR TITLE
fix(GuildAuditLogs): Cache guild scheduled events

### DIFF
--- a/packages/discord.js/src/structures/GuildAuditLogs.js
+++ b/packages/discord.js/src/structures/GuildAuditLogs.js
@@ -56,6 +56,17 @@ class GuildAuditLogs {
     }
 
     /**
+     * Cached {@link GuildScheduledEvent}s.
+     * @type {Collection<Snowflake, GuildScheduledEvent>}
+     * @private
+     */
+    this.guildScheduledEvents = data.guild_scheduled_events.reduce(
+      (guildScheduledEvents, guildScheduledEvent) =>
+        guildScheduledEvents.set(guildScheduledEvent.id, guild.scheduledEvents._add(guildScheduledEvent)),
+      new Collection(),
+    );
+
+    /**
      * The entries for this guild's audit logs
      * @type {Collection<Snowflake, GuildAuditLogsEntry>}
      */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1147,6 +1147,7 @@ export class GuildAuditLogs<T extends GuildAuditLogsResolvable = null> {
   private constructor(guild: Guild, data: RawGuildAuditLogData);
   private webhooks: Collection<Snowflake, Webhook>;
   private integrations: Collection<Snowflake | string, Integration>;
+  private guildScheduledEvents: Collection<Snowflake, GuildScheduledEvent>;
   public entries: Collection<Snowflake, GuildAuditLogsEntry<T>>;
   public static Entry: typeof GuildAuditLogsEntry;
   public toJSON(): unknown;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This is [documented](https://discord.com/developers/docs/resources/audit-log#audit-log-object-audit-log-structure), but we were not handling it.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
