### PR TITLE
fix: typings

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -99,7 +99,7 @@ class GuildChannelManager extends CachedManager {
   /**
    * Options used to create a new channel in a guild.
    * @typedef {CategoryCreateChannelOptions} GuildChannelCreateOptions
-   * @property {CategoryChannelResolvable} [parent] Parent of the new channel
+   * @property {CategoryChannelResolvable|null} [parent] Parent of the new channel
    */
 
   /**

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -199,7 +199,7 @@ class GuildChannelManager extends CachedManager {
    * @property {string} [name] The name of the channel
    * @property {ChannelType} [type] The type of the channel (only conversion between text and news is supported)
    * @property {number} [position] The position of the channel
-   * @property {string} [topic] The topic of the text channel
+   * @property {string|null} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the voice channel

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -199,7 +199,7 @@ class GuildChannelManager extends CachedManager {
    * @property {string} [name] The name of the channel
    * @property {ChannelType} [type] The type of the channel (only conversion between text and news is supported)
    * @property {number} [position] The position of the channel
-   * @property {string|null} [topic] The topic of the text channel
+   * @property {?(string|null)} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the voice channel

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -99,7 +99,7 @@ class GuildChannelManager extends CachedManager {
   /**
    * Options used to create a new channel in a guild.
    * @typedef {CategoryCreateChannelOptions} GuildChannelCreateOptions
-   * @property {CategoryChannelResolvable|null} [parent] Parent of the new channel
+   * @property {?CategoryChannelResolvable} [parent] Parent of the new channel
    */
 
   /**
@@ -199,7 +199,7 @@ class GuildChannelManager extends CachedManager {
    * @property {string} [name] The name of the channel
    * @property {ChannelType} [type] The type of the channel (only conversion between text and news is supported)
    * @property {number} [position] The position of the channel
-   * @property {?(string|null)} [topic] The topic of the text channel
+   * @property {?string} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the voice channel

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -84,7 +84,7 @@ class GuildManager extends CachedManager {
    * @property {Snowflake|number} [parentId] The parent id for this channel
    * @property {ChannelType|number} [type] The type of the channel
    * @property {string} name The name of the channel
-   * @property {string|null} [topic] The topic of the text channel
+   * @property {?string} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -84,7 +84,7 @@ class GuildManager extends CachedManager {
    * @property {Snowflake|number} [parentId] The parent id for this channel
    * @property {ChannelType|number} [type] The type of the channel
    * @property {string} name The name of the channel
-   * @property {?(string|null)} [topic] The topic of the text channel
+   * @property {?string} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -84,7 +84,7 @@ class GuildManager extends CachedManager {
    * @property {Snowflake|number} [parentId] The parent id for this channel
    * @property {ChannelType|number} [type] The type of the channel
    * @property {string} name The name of the channel
-   * @property {?string} [topic] The topic of the text channel
+   * @property {?(string|null)} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -84,7 +84,7 @@ class GuildManager extends CachedManager {
    * @property {Snowflake|number} [parentId] The parent id for this channel
    * @property {ChannelType|number} [type] The type of the channel
    * @property {string} name The name of the channel
-   * @property {string} [topic] The topic of the text channel
+   * @property {string|null} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW
    * @property {number} [bitrate] The bitrate of the voice channel
    * @property {number} [userLimit] The user limit of the channel

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4836,7 +4836,7 @@ export interface PartialChannelData {
     | ChannelType.GuildStageVoice
   >;
   name: string;
-  topic?: string;
+  topic?: string | null;
   nsfw?: boolean;
   bitrate?: number;
   userLimit?: number;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3723,7 +3723,7 @@ export interface ChannelData {
   name?: string;
   type?: Pick<typeof ChannelType, 'GuildText' | 'GuildNews'>;
   position?: number;
-  topic?: string;
+  topic?: string | null;
   nsfw?: boolean;
   bitrate?: number;
   userLimit?: number;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4340,7 +4340,7 @@ export type GuildBanResolvable = GuildBan | UserResolvable;
 export type GuildChannelResolvable = Snowflake | GuildBasedChannel;
 
 export interface GuildChannelCreateOptions extends Omit<CategoryCreateChannelOptions, 'type'> {
-  parent?: CategoryChannelResolvable;
+  parent?: CategoryChannelResolvable | null;
   type?: Exclude<
     ChannelType,
     | ChannelType.DM


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Typings were wrong for channel create/edit, some properties are nullable but weren't set as such. When using Typescript this could force workarounds like // @ts-ignore which go against the point of Typescript.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating