### PR TITLE
chore: add external links for dapi-types

### DIFF
--- a/packages/discord.js/src/util/APITypes.js
+++ b/packages/discord.js/src/util/APITypes.js
@@ -1,16 +1,11 @@
 /**
  * @external APIActionRowComponent
- * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ActivityType}
- */
-
-/**
- * @external APIActionRowComponent
  * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIActionRowComponent}
  */
 
 /**
  * @external APIApplication
- * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIGuild}
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIApplication}
  */
 
 /**
@@ -270,7 +265,7 @@
 
 /**
  * @external RESTJSONErrorCodes
- * @see {@link https://discord-api-types.dev/api/next/discord-api-types-rest/common/enum/RESTJSONErrorCodes}
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-rest/common/enum/RESTJSONErrorCodes}
  */
 
 /**

--- a/packages/discord.js/src/util/APITypes.js
+++ b/packages/discord.js/src/util/APITypes.js
@@ -1,0 +1,314 @@
+/**
+ * @external APIActionRowComponent
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ActivityType}
+ */
+
+/**
+ * @external APIActionRowComponent
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIActionRowComponent}
+ */
+
+/**
+ * @external APIApplication
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIGuild}
+ */
+
+/**
+ * @external APIApplicationCommand
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIApplicationCommand}
+ */
+
+/**
+ * @external ApplicationCommandType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ApplicationCommandType}
+ */
+
+/**
+ * @external ApplicationCommandOptionType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ApplicationCommandOptionType}
+ */
+
+/**
+ * @external ApplicationCommandPermissionType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ApplicationCommandPermissionType}
+ */
+
+/**
+ * @external APIApplicationCommandOption
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10#APIApplicationCommandOption}
+ */
+
+/**
+ * @external APIButtonComponent
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10#APIButtonComponent}
+ */
+
+/**
+ * @external APIChannel
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10#APIChannel}
+ */
+
+/**
+ * @external APIEmbed
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIEmbed}
+ */
+
+/**
+ * @external APIEmoji
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIEmoji}
+ */
+
+/**
+ * @external APIGuild
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIGuild}
+ */
+
+/**
+ * @external APIInteraction
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10#APIInteraction}
+ */
+
+/**
+ * @external APIInteractionDataResolvedChannel
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIInteractionDataResolvedChannel}
+ */
+
+/**
+ * @external APIInteractionDataResolvedGuildMember
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIInteractionDataResolvedGuildMember}
+ */
+
+/**
+ * @external APIInteractionGuildMember
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIInteractionGuildMember}
+ */
+
+/**
+ * @external APIMessage
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIMessage}
+ */
+
+/**
+ * @external APIMessageComponent
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10#APIMessageComponent}
+ */
+
+/**
+ * @external APIModalInteractionResponse
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIModalInteractionResponse}
+ */
+
+/**
+ * @external APIModalSubmission
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIModalSubmission}
+ */
+
+/**
+ * @external APIPresence
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIPresence}
+ */
+
+/**
+ * @external APISelectMenuComponent
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APISelectMenuComponent}
+ */
+
+/**
+ * @external APISelectMenuOption
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APISelectMenuOption}
+ */
+
+/**
+ * @external APIUser
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIUser}
+ */
+
+/**
+ * @external AuditLogEvent
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/AuditLogEvent}
+ */
+
+/**
+ * @external ButtonStyle
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ButtonStyle}
+ */
+
+/**
+ * @external ChannelType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ChannelType}
+ */
+
+/**
+ * @external ComponentType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ComponentType}
+ */
+
+/**
+ * @external GatewayCloseCodes
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayCloseCodes}
+ */
+
+/**
+ * @external GatewayDispatchEvents
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayDispatchEvents}
+ */
+
+/**
+ * @external GatewayIntentBits
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayIntentBits}
+ */
+
+/**
+ * @external GatewayOpcodes
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayOpcodes}
+ */
+
+/**
+ * @external GuildDefaultMessageNotifications
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildDefaultMessageNotifications}
+ */
+
+/**
+ * @external GuildExplicitContentFilter
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildExplicitContentFilter}
+ */
+
+/**
+ * @external GuildFeature
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildFeature}
+ */
+
+/**
+ * @external GuildMFALevel
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildMFALevel}
+ */
+
+/**
+ * @external GuildNSFWLevel
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildNSFWLevel}
+ */
+
+/**
+ * @external GuildPremiumTier
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildPremiumTier}
+ */
+
+/**
+ * @external GuildScheduledEventEntityType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildScheduledEventEntityType}
+ */
+
+/**
+ * @external GuildScheduledEventPrivacyLevel
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildScheduledEventPrivacyLevel}
+ */
+
+/**
+ * @external GuildScheduledEventStatus
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildScheduledEventStatus}
+ */
+
+/**
+ * @external GuildSystemChannelFlags
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildSystemChannelFlags}
+ */
+
+/**
+ * @external GuildVerificationLevel
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GuildVerificationLevel}
+ */
+
+/**
+ * @external IntegrationExpireBehavior
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/IntegrationExpireBehavior}
+ */
+
+/**
+ * @external InteractionType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/InteractionType}
+ */
+
+/**
+ * @external InteractionResponseType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/InteractionResponseType}
+ */
+
+/**
+ * @external InviteTargetType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/InviteTargetType}
+ */
+
+/**
+ * @external Locale
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-rest/common/enum/Locale}
+ */
+
+/**
+ * @external MessageActivityType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/MessageActivityType}
+ */
+
+/**
+ * @external MessageType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/MessageType}
+ */
+
+/**
+ * @external MessageFlags
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/MessageFlags}
+ */
+
+/**
+ * @external OAuth2Scopes
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/OAuth2Scopes}
+ */
+
+/**
+ * @external PermissionFlagsBits
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-payloads/common#PermissionFlagsBits}
+ */
+
+/**
+ * @external RESTJSONErrorCodes
+ * @see {@link https://discord-api-types.dev/api/next/discord-api-types-rest/common/enum/RESTJSONErrorCodes}
+ */
+
+/**
+ * @external StageInstancePrivacyLevel
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/StageInstancePrivacyLevel}
+ */
+
+/**
+ * @external StickerType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/StickerType}
+ */
+
+/**
+ * @external StickerFormatType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/StickerFormatType}
+ */
+
+/**
+ * @external TeamMemberMembershipState
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/TeamMemberMembershipState}
+ */
+
+/**
+ * @external TextInputStyle
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/TextInputStyle}
+ */
+
+/**
+ * @external UserFlags
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/UserFlags}
+ */
+
+/**
+ * @external VideoQualityMode
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/VideoQualityMode}
+ */
+
+/**
+ * @external WebhookType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/WebhookType}
+ */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds external links for references to dapi-types in discord.js

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
