### PR TITLE
fix: add missing update method in types

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1898,6 +1898,10 @@ export class ModalSubmitInteraction<Cached extends CacheType = CacheType> extend
   public inCachedGuild(): this is ModalSubmitInteraction<'cached'>;
   public inRawGuild(): this is ModalSubmitInteraction<'raw'>;
   public isFromMessage(): this is ModalMessageModalSubmitInteraction<Cached>;
+  public update(options: InteractionUpdateOptions & { fetchReply: true }): Promise<GuildCacheMessage<Cached>>;
+  public update(
+    options: string | MessagePayload | InteractionUpdateOptions,
+  ): Promise<InteractionResponse<BooleanCache<Cached>>>;
 }
 
 export class NewsChannel extends BaseGuildTextChannel {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR return missing `update` method in `ModalSubmitInteraction` typings
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
