### PR TITLE
feat(Client): wait for ClientReady event before resolving login

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { once } = require('node:events');
 const process = require('node:process');
 const { Collection } = require('@discordjs/collection');
 const { makeURLSearchParams } = require('@discordjs/rest');
@@ -234,7 +235,7 @@ class Client extends BaseClient {
       // because some shards may not yet be ready. Waiting for ClientReady to be
       // triggered by WebsocketManager ensures Client#login() does not resolve
       // until the client is actually ready.
-      await new Promise(resolve => this.once(Events.ClientReady, resolve));
+      await once(this, Events.ClientReady);
       return this.token;
     } catch (error) {
       this.destroy();

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -230,6 +230,11 @@ class Client extends BaseClient {
 
     try {
       await this.ws.connect();
+      // The WebSocket connecting does not necessarily mean the client is ready,
+      // because some shards may not yet be ready. Waiting for ClientReady to be
+      // triggered by WebsocketManager ensures Client#login() does not resolve
+      // until the client is actually ready.
+      await new Promise(resolve => this.once(Events.ClientReady, resolve));
       return this.token;
     } catch (error) {
       this.destroy();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Calling `Client#login()` currently resolves once the WebSocket connects. This PR additionally waits for all shards to become ready before resolving the `login()` method.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
