### PR TITLE
types: add types to `EventEmitter` static methods

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -185,8 +185,8 @@ import {
 declare module 'node:events' {
   class EventEmitter {
     // Add type overloads for client events.
-    static once<K extends keyof ClientEvents>(eventEmitter: Client, eventName: K): Promise<ClientEvents[K]>;
-    static on<K extends keyof ClientEvents>(eventEmitter: Client, eventName: K): AsyncIterator<ClientEvents[K]>;
+    public static once<K extends keyof ClientEvents>(eventEmitter: Client, eventName: K): Promise<ClientEvents[K]>;
+    public static on<K extends keyof ClientEvents>(eventEmitter: Client, eventName: K): AsyncIterator<ClientEvents[K]>;
   }
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -182,6 +182,14 @@ import {
   RawWidgetMemberData,
 } from './rawDataTypes';
 
+declare module 'node:events' {
+  class EventEmitter {
+    // Add type overloads for client events.
+    static once<K extends keyof ClientEvents>(eventEmitter: Client, eventName: K): Promise<ClientEvents[K]>;
+    static on<K extends keyof ClientEvents>(eventEmitter: Client, eventName: K): AsyncIterator<ClientEvents[K]>;
+  }
+}
+
 //#region Classes
 
 export class Activity {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously the following code:

```ts
import { once } from 'node:events';

await client.login(process.env.DISCORD_TOKEN);
const [readyClient] = await once(client, 'ready');
```

Would improperly type `readyClient` as `any`

With this PR the types are properly provided so it resolves to `Client<true>`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
