### PR TITLE
fix: add static method `from` in builders

### DIFF
--- a/packages/discord.js/src/structures/ActionRowBuilder.js
+++ b/packages/discord.js/src/structures/ActionRowBuilder.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ActionRowBuilder: BuildersActionRow, ComponentBuilder } = require('@discordjs/builders');
+const { ActionRowBuilder: BuildersActionRow, ComponentBuilder, isJSONEncodable } = require('@discordjs/builders');
 const Components = require('../util/Components');
 const Transformers = require('../util/Transformers');
 
@@ -14,6 +14,19 @@ class ActionRowBuilder extends BuildersActionRow {
       ...Transformers.toSnakeCase(data),
       components: components?.map(c => (c instanceof ComponentBuilder ? c : Components.createComponentBuilder(c))),
     });
+  }
+
+  /**
+   * Creates a new ActionRowBuilder from JSON data
+   * @param {JSONEncodable<APIActionRowComponent<APIActionRowComponentTypes>>
+   * |APIActionRowComponent<APIActionRowComponentTypes>} other The other data
+   * @returns {ActionRowBuilder}
+   */
+  static from(other) {
+    if (isJSONEncodable(other)) {
+      return new this(other.toJSON());
+    }
+    return new this(other);
   }
 }
 

--- a/packages/discord.js/src/structures/ActionRowBuilder.js
+++ b/packages/discord.js/src/structures/ActionRowBuilder.js
@@ -17,7 +17,7 @@ class ActionRowBuilder extends BuildersActionRow {
   }
 
   /**
-   * Creates a new ActionRowBuilder from JSON data
+   * Creates a new action row builder from JSON data
    * @param {JSONEncodable<APIActionRowComponent<APIActionRowComponentTypes>>
    * |APIActionRowComponent<APIActionRowComponentTypes>} other The other data
    * @returns {ActionRowBuilder}

--- a/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { SelectMenuOptionBuilder: BuildersSelectMenuOption } = require('@discordjs/builders');
+const { SelectMenuOptionBuilder: BuildersSelectMenuOption, isJSONEncodable } = require('@discordjs/builders');
 const Transformers = require('../util/Transformers');
 const Util = require('../util/Util');
 
@@ -27,6 +27,18 @@ class SelectMenuOptionBuilder extends BuildersSelectMenuOption {
       return super.setEmoji(Util.parseEmoji(emoji));
     }
     return super.setEmoji(emoji);
+  }
+
+  /**
+   * Creates a new SelectMenuOptionBuilder from JSON data
+   * @param {JSONEncodable<APISelectMenuOption>|APISelectMenuOption} other The other data
+   * @returns {SelectMenuOptionBuilder}
+   */
+  static from(other) {
+    if (isJSONEncodable(other)) {
+      return new this(other.toJSON());
+    }
+    return new this(other);
   }
 }
 

--- a/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
@@ -30,7 +30,7 @@ class SelectMenuOptionBuilder extends BuildersSelectMenuOption {
   }
 
   /**
-   * Creates a new SelectMenuOptionBuilder from JSON data
+   * Creates a new select menu option builder from JSON data
    * @param {JSONEncodable<APISelectMenuOption>|APISelectMenuOption} other The other data
    * @returns {SelectMenuOptionBuilder}
    */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -601,7 +601,8 @@ export class SelectMenuBuilder extends BuilderSelectMenuComponent {
 
 export class SelectMenuOptionBuilder extends BuildersSelectMenuOption {
   public constructor(data?: SelectMenuComponentOptionData | APISelectMenuOption);
-  public setEmoji(emoji: ComponentEmojiResolvable): this;
+  public override setEmoji(emoji: ComponentEmojiResolvable): this;
+  public static from(other: JSONEncodable<APISelectMenuOption> | APISelectMenuOption): SelectMenuOptionBuilder;
 }
 
 export class ModalBuilder extends BuildersModal {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Some builders were missing `from` method. This pr adds them.
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
