### PR TITLE
feat(ApplicationCommandManager.js): add 'default_member_permissions' to transformCommand

### DIFF
--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -232,7 +232,7 @@ class ApplicationCommandManager extends CachedManager {
       type: command.type,
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
       default_permission: command.defaultPermission ?? command.default_permission,
-      default_member_permissions: command.default_member_permissions ?? command.defaultMemberPermissions
+      default_member_permissions: command.default_member_permissions ?? command.defaultMemberPermissions,
     };
   }
 }

--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -232,7 +232,7 @@ class ApplicationCommandManager extends CachedManager {
       type: command.type,
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
       default_permission: command.defaultPermission ?? command.default_permission,
-      default_member_permissions: command.default_member_permissions ?? command.defaultMemberPermissions,
+      default_member_permissions: command.defaultMemberPermissions ?? command.default_member_permissions,
     };
   }
 }

--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -232,6 +232,7 @@ class ApplicationCommandManager extends CachedManager {
       type: command.type,
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
       default_permission: command.defaultPermission ?? command.default_permission,
+      default_member_permissions: (command.default_member_permissions ?? command.defaultMemberPermissions) ?? null
     };
   }
 }

--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -232,7 +232,7 @@ class ApplicationCommandManager extends CachedManager {
       type: command.type,
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
       default_permission: command.defaultPermission ?? command.default_permission,
-      default_member_permissions: (command.default_member_permissions ?? command.defaultMemberPermissions) ?? null
+      default_member_permissions: command.default_member_permissions ?? command.defaultMemberPermissions
     };
   }
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds the 'default_member_permissions' property to the returned object of the static method 'transformCommand' in the 'ApplicationCommandManager.js' (line 235) to enable the possibility of setting default permissions for commands as written in the discord documentation:
https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-using-default-permissions
It should be merged to enable the functionality of setting default permissions using bitwise permission flags which can be found here:
https://discord.com/developers/docs/topics/permissions#permissions-bitwise-permission-flags

The type 'APIApplicationCommand' from 'discord-api-types/v10' needs to be updated to compensate the changes in the file '/v10/_interactions/applicationCommands.ts' in the interface 'APIApplicationCommand'

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
