### PR TITLE
docs(VoiceChannel): annotate that it is implementing TextBasedChannel

### DIFF
--- a/packages/discord.js/src/structures/VoiceChannel.js
+++ b/packages/discord.js/src/structures/VoiceChannel.js
@@ -8,6 +8,7 @@ const MessageManager = require('../managers/MessageManager');
 /**
  * Represents a guild voice channel on Discord.
  * @extends {BaseGuildVoiceChannel}
+ * @implements {TextBasedChannel}
  */
 class VoiceChannel extends BaseGuildVoiceChannel {
   constructor(guild, data, client) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR documents that `VoiceChannel` implements `TextBasedChannel`.
(This should have been in #6921, but I must have missed that somehow)
That way methods like `send` and friends (full list at the end of the class as stubs) appear on the documentation.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

