### PR TITLE
types(AttachmentBuilder): remove name parameter from constructor

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1698,7 +1698,7 @@ export class Message<Cached extends boolean = boolean> extends Base {
 }
 
 export class AttachmentBuilder {
-  public constructor(attachment: BufferResolvable | Stream, name?: string, data?: RawAttachmentData);
+  public constructor(attachment: BufferResolvable | Stream, data?: RawAttachmentData);
   public attachment: BufferResolvable | Stream;
   public description: string | null;
   public name: string | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR removes `name` parameter from `AttachmentBuilder` constructor typings as it isn't actually used in the source code.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating


<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
