### PR TITLE
docs(Attachment): remove constructor doc

### DIFF
--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -13,10 +13,6 @@ const Util = require('../util/Util');
  * Represents an attachment
  */
 class Attachment {
-  /**
-   * @param {APIAttachment} data Attachment data
-   * @private
-   */
   constructor({ url, filename, ...data }) {
     this.attachment = url;
     /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Despite having `@private` in the jsdoc, the constructor is still shown in the documentation (and it doesn't show it as private at all)
Removing the jsdoc removes it from the documentation completely

Example from the Message class, which also has a private constructor:
https://github.com/discordjs/discord.js/blob/7a1095b66be3c5d81185e026281e2908c10c1695/packages/discord.js/src/structures/Message.js#L33-L34
https://github.com/discordjs/discord.js/blob/7a1095b66be3c5d81185e026281e2908c10c1695/packages/discord.js/typings/index.d.ts#L1628-L1630

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
