### PR TITLE
refact: Sticker's `tags` property

### DIFF
--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -70,10 +70,10 @@ class Sticker extends Base {
 
     if ('tags' in sticker) {
       /**
-       * An array of tags for the sticker
-       * @type {?string[]}
+       * Autocomplete/suggestions for the sticker
+       * @type {?string}
        */
-      this.tags = sticker.tags.split(', ');
+      this.tags = sticker.tags;
     } else {
       this.tags ??= null;
     }
@@ -246,8 +246,7 @@ class Sticker extends Base {
         other.format === this.format &&
         other.name === this.name &&
         other.packId === this.packId &&
-        other.tags.length === this.tags.length &&
-        other.tags.every(tag => this.tags.includes(tag)) &&
+        other.tags === this.tags &&
         other.available === this.available &&
         other.guildId === this.guildId &&
         other.sortValue === this.sortValue
@@ -257,7 +256,7 @@ class Sticker extends Base {
         other.id === this.id &&
         other.description === this.description &&
         other.name === this.name &&
-        other.tags === this.tags.join(', ')
+        other.tags === this.tags
       );
     }
   }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2276,7 +2276,7 @@ export class Sticker extends Base {
   public packId: Snowflake | null;
   public get partial(): boolean;
   public sortValue: number | null;
-  public tags: string[] | null;
+  public tags: string | null;
   public type: StickerType | null;
   public user: User | null;
   public get url(): string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
So, after working with stickers I've realized that the Sticker's `tags` property doesn't really make that much sense. As of now its type is `string[]` even though the Discord API returns `string`.

For every sticker the string value is parsed with `.split(', ')` which doesn't make sense considering that only standard stickers have `tags` as  a comma separated list of keywords. This adds overhead with no purpose as you can't edit standard stickers and guild stickers ignore the commas and use the whole string for suggestion. Further more, this makes sticker comparison slower because it's comparing arrays of strings instead of just strings (O(n*k) vs O(n)).

It's also inconsistent with the create/edit methods as they accept tags: `string` and nowhere is it mentioned why the tags are/would be an array of strings apart from the developer docs.

https://discord.com/developers/docs/resources/sticker#sticker-resource

If people want to iterate over standard sticker's `tags` (for whatever reason) they should split the string themselves, no reason to always parse the string.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
