### PR TITLE
refactor(channel): remove redundant channel type guards

### DIFF
--- a/packages/discord.js/src/structures/Channel.js
+++ b/packages/discord.js/src/structures/Channel.js
@@ -3,7 +3,6 @@
 const { DiscordSnowflake } = require('@sapphire/snowflake');
 const { ChannelType, Routes } = require('discord-api-types/v10');
 const Base = require('./Base');
-const { ThreadChannelTypes } = require('../util/Constants');
 let CategoryChannel;
 let DMChannel;
 let NewsChannel;
@@ -108,78 +107,6 @@ class Channel extends Base {
    */
   fetch(force = true) {
     return this.client.channels.fetch(this.id, { force });
-  }
-
-  /**
-   * Indicates whether this channel is a {@link TextChannel}.
-   * @returns {boolean}
-   */
-  isText() {
-    return this.type === ChannelType.GuildText;
-  }
-
-  /**
-   * Indicates whether this channel is a {@link DMChannel}.
-   * @returns {boolean}
-   */
-  isDM() {
-    return this.type === ChannelType.DM;
-  }
-
-  /**
-   * Indicates whether this channel is a {@link VoiceChannel}.
-   * @returns {boolean}
-   */
-  isVoice() {
-    return this.type === ChannelType.GuildVoice;
-  }
-
-  /**
-   * Indicates whether this channel is a {@link PartialGroupDMChannel}.
-   * @returns {boolean}
-   */
-  isGroupDM() {
-    return this.type === ChannelType.GroupDM;
-  }
-
-  /**
-   * Indicates whether this channel is a {@link CategoryChannel}.
-   * @returns {boolean}
-   */
-  isCategory() {
-    return this.type === ChannelType.GuildCategory;
-  }
-
-  /**
-   * Indicates whether this channel is a {@link NewsChannel}.
-   * @returns {boolean}
-   */
-  isNews() {
-    return this.type === ChannelType.GuildNews;
-  }
-
-  /**
-   * Indicates whether this channel is a {@link ThreadChannel}.
-   * @returns {boolean}
-   */
-  isThread() {
-    return ThreadChannelTypes.includes(this.type);
-  }
-
-  /**
-   * Indicates whether this channel is a {@link StageChannel}.
-   * @returns {boolean}
-   */
-  isStage() {
-    return this.type === ChannelType.GuildStageVoice;
-  }
-
-  /**
-   * Indicates whether this channel is a {@link DirectoryChannel}
-   * @returns {boolean}
-   */
-  isDirectory() {
-    return this.type === ChannelType.GuildDirectory;
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -742,15 +742,6 @@ export abstract class Channel extends Base {
   public get url(): string;
   public delete(): Promise<this>;
   public fetch(force?: boolean): Promise<this>;
-  public isText(): this is TextChannel;
-  public isDM(): this is DMChannel;
-  public isVoice(): this is VoiceChannel;
-  public isGroupDM(): this is PartialGroupDMChannel;
-  public isCategory(): this is CategoryChannel;
-  public isNews(): this is NewsChannel;
-  public isThread(): this is ThreadChannel;
-  public isStage(): this is StageChannel;
-  public isDirectory(): this is DirectoryChannel;
   public isTextBased(): this is TextBasedChannel;
   public isDMBased(): this is PartialGroupDMChannel | DMChannel | PartialDMChannel;
   public isVoiceBased(): this is VoiceBasedChannel;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -528,7 +528,7 @@ client.on('guildCreate', async g => {
   const channel = g.channels.cache.random();
   if (!channel) return;
 
-  if (channel.isText()) {
+  if (channel.type === ChannelType.GuildText) {
     const row: ActionRowData<MessageActionRowComponentData> = {
       type: ComponentType.ActionRow,
       components: [
@@ -556,7 +556,7 @@ client.on('guildCreate', async g => {
     channel.send({ components: [row, row2] });
   }
 
-  if (channel.isThread()) {
+  if (channel.type === ChannelType.GuildPublicThread) {
     const fetchedMember = await channel.members.fetch({ member: '12345678' });
     expectType<ThreadMember>(fetchedMember);
     const fetchedMemberCol = await channel.members.fetch(true);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Channels are returned as discriminated unions which means *most* of the type guards on the channel class aren't needed anymore. For example, to narrow to a voice channel you can just do the following:

```ts
if (channel.type !== ChannelType.GuildVoice) {
	return;
}

channel // Narrowed to Voice channel.
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
