### PR TITLE
refactor(Users): remove global user cache

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -105,7 +105,7 @@ class Client extends BaseClient {
       : null;
 
     /**
-     * All of the {@link User} objects that have been cached at any point, mapped by their ids
+     * The user manager of the client
      * @type {UserManager}
      */
     this.users = new UserManager(this);

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -153,12 +153,6 @@ class Client extends BaseClient {
     }
 
     /**
-     * User that the client is logged in as
-     * @type {?ClientUser}
-     */
-    this.user = null;
-
-    /**
      * The application of this bot
      * @type {?ClientApplication}
      */
@@ -169,6 +163,15 @@ class Client extends BaseClient {
      * @type {?number}
      */
     this.readyTimestamp = null;
+  }
+
+  /**
+   * User that the client is logged in as
+   * @type {?ClientUser}
+   * @readonly
+   */
+  get user() {
+    return this.users.me;
   }
 
   /**

--- a/packages/discord.js/src/client/actions/GuildMemberUpdate.js
+++ b/packages/discord.js/src/client/actions/GuildMemberUpdate.js
@@ -7,14 +7,6 @@ const Status = require('../../util/Status');
 class GuildMemberUpdateAction extends Action {
   handle(data, shard) {
     const { client } = this;
-    if (data.user.username) {
-      const user = client.users.cache.get(data.user.id);
-      if (!user) {
-        client.users._add(data.user);
-      } else if (!user._equals(data.user)) {
-        client.actions.UserUpdate.handle(data.user);
-      }
-    }
 
     const guild = client.guilds.cache.get(data.guild_id);
     if (guild) {
@@ -35,7 +27,7 @@ class GuildMemberUpdateAction extends Action {
          * @event Client#guildMemberAvailable
          * @param {GuildMember} member The member that became available
          */
-        this.client.emit(Events.GuildMemberAvailable, newMember);
+        client.emit(Events.GuildMemberAvailable, newMember);
       }
     }
   }

--- a/packages/discord.js/src/client/actions/GuildMemberUpdate.js
+++ b/packages/discord.js/src/client/actions/GuildMemberUpdate.js
@@ -19,7 +19,7 @@ class GuildMemberUpdateAction extends Action {
          * @param {GuildMember} oldMember The member before the update
          * @param {GuildMember} newMember The member after the update
          */
-        if (shard.status === Status.Ready && !member.equals(old)) client.emit(Events.GuildMemberUpdate, old, member);
+        if (shard.status === Status.Ready) client.emit(Events.GuildMemberUpdate, old, member);
       } else {
         const newMember = guild.members._add(data);
         /**

--- a/packages/discord.js/src/client/actions/GuildScheduledEventUserAdd.js
+++ b/packages/discord.js/src/client/actions/GuildScheduledEventUserAdd.js
@@ -10,7 +10,7 @@ class GuildScheduledEventUserAddAction extends Action {
 
     if (guild) {
       const guildScheduledEvent = this.getScheduledEvent(data, guild);
-      const user = this.getUser(data);
+      const user = this.getUser(data, guild);
 
       if (guildScheduledEvent && user) {
         /**

--- a/packages/discord.js/src/client/actions/GuildScheduledEventUserRemove.js
+++ b/packages/discord.js/src/client/actions/GuildScheduledEventUserRemove.js
@@ -10,7 +10,7 @@ class GuildScheduledEventUserRemoveAction extends Action {
 
     if (guild) {
       const guildScheduledEvent = this.getScheduledEvent(data, guild);
-      const user = this.getUser(data);
+      const user = this.getUser(data, guild);
 
       if (guildScheduledEvent && user) {
         /**

--- a/packages/discord.js/src/client/actions/MessageReactionRemove.js
+++ b/packages/discord.js/src/client/actions/MessageReactionRemove.js
@@ -15,12 +15,12 @@ class MessageReactionRemove extends Action {
   handle(data) {
     if (!data.emoji) return false;
 
-    const user = this.getUser(data);
-    if (!user) return false;
-
     // Verify channel
     const channel = this.getChannel(data);
     if (!channel?.isTextBased()) return false;
+
+    const user = this.getUser(data, channel.guild);
+    if (!user) return false;
 
     // Verify message
     const message = this.getMessage(data, channel);

--- a/packages/discord.js/src/client/actions/UserUpdate.js
+++ b/packages/discord.js/src/client/actions/UserUpdate.js
@@ -7,27 +7,21 @@ class UserUpdateAction extends Action {
   handle(data) {
     const client = this.client;
 
-    const newUser = data.id === client.user.id ? client.user : client.users.cache.get(data.id);
+    if (data.user.id !== client.users.me.id) return { old: null, updated: null };
+
+    const newUser = client.users.me;
     const oldUser = newUser._update(data);
 
-    if (!oldUser.equals(newUser)) {
-      /**
-       * Emitted whenever a user's details (e.g. username) are changed.
-       * Triggered by the Discord gateway events USER_UPDATE, GUILD_MEMBER_UPDATE, and PRESENCE_UPDATE.
-       * @event Client#userUpdate
-       * @param {User} oldUser The user before the update
-       * @param {User} newUser The user after the update
-       */
-      client.emit(Events.UserUpdate, oldUser, newUser);
-      return {
-        old: oldUser,
-        updated: newUser,
-      };
-    }
-
+    /**
+     * Emitted whenever the client user's details (e.g. username) are changed.
+     * @event Client#userUpdate
+     * @param {ClientUser} oldUser The user before the update
+     * @param {ClientUser} newUser The user after the update
+     */
+    client.emit(Events.UserUpdate, oldUser, newUser);
     return {
-      old: null,
-      updated: null,
+      old: oldUser,
+      updated: newUser,
     };
   }
 }

--- a/packages/discord.js/src/client/websocket/handlers/READY.js
+++ b/packages/discord.js/src/client/websocket/handlers/READY.js
@@ -8,8 +8,7 @@ module.exports = (client, { d: data }, shard) => {
     client.user._patch(data.user);
   } else {
     ClientUser ??= require('../../../structures/ClientUser');
-    client.user = new ClientUser(client, data.user);
-    client.users.cache.set(client.user.id, client.user);
+    client.users.me = new ClientUser(client, data.user);
   }
 
   for (const guild of data.guilds) {

--- a/packages/discord.js/src/managers/GuildBanManager.js
+++ b/packages/discord.js/src/managers/GuildBanManager.js
@@ -154,7 +154,7 @@ class GuildBanManager extends CachedManager {
       reason: options.reason,
     });
     if (user instanceof GuildMember) return user;
-    const _user = this.client.users.resolve(id);
+    const _user = this.client.users.resolve(id, this.guild);
     if (_user) {
       return this.guild.members.resolve(_user) ?? _user;
     }
@@ -176,7 +176,7 @@ class GuildBanManager extends CachedManager {
     const id = this.client.users.resolveId(user);
     if (!id) throw new Error('BAN_RESOLVE_ID');
     await this.client.rest.delete(Routes.guildBan(this.guild.id, id), { reason });
-    return this.client.users.resolve(user);
+    return this.client.users.resolve(user, this.guild);
   }
 }
 

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -394,7 +394,7 @@ class GuildMemberManager extends CachedManager {
 
     await this.client.rest.delete(Routes.guildMember(this.guild.id, id), { reason });
 
-    return this.resolve(user) ?? this.client.users.resolve(user) ?? id;
+    return this.resolve(user) ?? this.client.users.resolve(user, this.guild) ?? id;
   }
 
   /**

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -286,8 +286,9 @@ class GuildScheduledEventManager extends CachedManager {
       (coll, rawData) =>
         coll.set(rawData.user.id, {
           guildScheduledEventId: rawData.guild_scheduled_event_id,
-          user: this.client.users._add(rawData.user),
+          // Add member first so user doesn't get created twice
           member: rawData.member ? this.guild.members._add({ ...rawData.member, user: rawData.user }) : null,
+          user: this.client.users._obtain(rawData.user, this.guild),
         }),
       new Collection(),
     );

--- a/packages/discord.js/src/managers/PermissionOverwriteManager.js
+++ b/packages/discord.js/src/managers/PermissionOverwriteManager.js
@@ -92,7 +92,8 @@ class PermissionOverwriteManager extends CachedManager {
     let userOrRoleId = this.channel.guild.roles.resolveId(userOrRole) ?? this.client.users.resolveId(userOrRole);
     let { type, reason } = overwriteOptions;
     if (typeof type !== 'number') {
-      userOrRole = this.channel.guild.roles.resolve(userOrRole) ?? this.client.users.resolve(userOrRole);
+      userOrRole =
+        this.channel.guild.roles.resolve(userOrRole) ?? this.client.users.resolve(userOrRole, this.channel.guild);
       if (!userOrRole) throw new TypeError('INVALID_TYPE', 'parameter', 'User nor a Role');
       type = userOrRole instanceof Role ? OverwriteType.Role : OverwriteType.Member;
     }

--- a/packages/discord.js/src/managers/ReactionUserManager.js
+++ b/packages/discord.js/src/managers/ReactionUserManager.js
@@ -49,7 +49,7 @@ class ReactionUserManager extends CachedManager {
     );
     const users = new Collection();
     for (const rawUser of data) {
-      const user = this.client.users._add(rawUser);
+      const user = this.client.users._obtain(rawUser, this.reaction.message.guild);
       this.cache.set(user.id, user);
       users.set(user.id, user);
     }

--- a/packages/discord.js/src/managers/UserManager.js
+++ b/packages/discord.js/src/managers/UserManager.js
@@ -8,7 +8,7 @@ const ThreadMember = require('../structures/ThreadMember');
 const User = require('../structures/User');
 
 /**
- * Manages API methods for users and stores their cache.
+ * Manages API methods for users.
  * @extends {CachedManager}
  */
 class UserManager extends BaseManager {
@@ -82,7 +82,7 @@ class UserManager extends BaseManager {
     const id = this.resolveId(user);
     const data = await this.client.rest.get(Routes.user(id));
     if (user instanceof User) return user._patch(data);
-    return new User(data);
+    return new User(this.client, data);
   }
 
   /**

--- a/packages/discord.js/src/structures/ClientApplication.js
+++ b/packages/discord.js/src/structures/ClientApplication.js
@@ -2,6 +2,7 @@
 
 const { Routes } = require('discord-api-types/v10');
 const Team = require('./Team');
+const User = require('./User');
 const Application = require('./interfaces/Application');
 const ApplicationCommandManager = require('../managers/ApplicationCommandManager');
 const ApplicationFlagsBitField = require('../util/ApplicationFlagsBitField');
@@ -115,7 +116,7 @@ class ClientApplication extends Application {
     this.owner = data.team
       ? new Team(this.client, data.team)
       : data.owner
-      ? this.client.users._add(data.owner)
+      ? new User(this.client, data.owner)
       : this.owner ?? null;
   }
 

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -105,7 +105,7 @@ class CommandInteraction extends Interaction {
     if (users) {
       result.users = new Collection();
       for (const user of Object.values(users)) {
-        result.users.set(user.id, this.client.users._add(user));
+        result.users.set(user.id, this.client.users._obtain(user, this.guild));
       }
     }
 
@@ -177,7 +177,7 @@ class CommandInteraction extends Interaction {
 
     if (resolved) {
       const user = resolved.users?.[option.value];
-      if (user) result.user = this.client.users._add(user);
+      if (user) result.user = this.client.users._obtain(user, this.guild);
 
       const member = resolved.members?.[option.value];
       if (member) result.member = this.guild?.members._add({ user, ...member }) ?? member;

--- a/packages/discord.js/src/structures/DMChannel.js
+++ b/packages/discord.js/src/structures/DMChannel.js
@@ -3,6 +3,7 @@
 const { userMention } = require('@discordjs/builders');
 const { ChannelType } = require('discord-api-types/v10');
 const { Channel } = require('./Channel');
+const User = require('./User');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const MessageManager = require('../managers/MessageManager');
 const Partials = require('../util/Partials');
@@ -39,8 +40,16 @@ class DMChannel extends Channel {
       this.recipientId = recipient.id;
 
       if ('username' in recipient || this.client.options.partials.includes(Partials.Users)) {
-        this.client.users._add(recipient);
+        /**
+         * The recipient on the other end of the DM
+         * @type {?User}
+         */
+        this.recipient = this.recipient ? this.recipient._patch(recipient) : new User(this.client, recipient);
+      } else {
+        this.recipient ??= null;
       }
+    } else {
+      this.recipient ??= null;
     }
 
     if ('last_message_id' in data) {
@@ -69,15 +78,6 @@ class DMChannel extends Channel {
    */
   get partial() {
     return typeof this.lastMessageId === 'undefined';
-  }
-
-  /**
-   * The recipient on the other end of the DM
-   * @type {?User}
-   * @readonly
-   */
-  get recipient() {
-    return this.client.users.resolve(this.recipientId);
   }
 
   /**

--- a/packages/discord.js/src/structures/DMChannel.js
+++ b/packages/discord.js/src/structures/DMChannel.js
@@ -44,7 +44,7 @@ class DMChannel extends Channel {
          * The recipient on the other end of the DM
          * @type {?User}
          */
-        this.recipient = this.recipient ? this.recipient._patch(recipient) : new User(this.client, recipient);
+        this.recipient = this.recipient?._patch(recipient) ?? new User(this.client, recipient);
       } else {
         this.recipient ??= null;
       }

--- a/packages/discord.js/src/structures/GuildAuditLogs.js
+++ b/packages/discord.js/src/structures/GuildAuditLogs.js
@@ -3,6 +3,7 @@
 const { Collection } = require('@discordjs/collection');
 const GuildAuditLogsEntry = require('./GuildAuditLogsEntry');
 const Integration = require('./Integration');
+const User = require('./User');
 const Webhook = require('./Webhook');
 const Util = require('../util/Util');
 
@@ -29,7 +30,12 @@ const Util = require('../util/Util');
  */
 class GuildAuditLogs {
   constructor(guild, data) {
-    if (data.users) for (const user of data.users) guild.client.users._add(user);
+    this.users = new Collection();
+    if (data.users) {
+      for (const user of data.users) {
+        this.users.set(user.id, new User(guild.client, user));
+      }
+    }
     if (data.threads) for (const thread of data.threads) guild.client.channels._add(thread, guild);
     /**
      * Cached webhooks

--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -102,8 +102,8 @@ class GuildAuditLogsEntry {
      */
     this.executor = data.user_id
       ? guild.client.options.partials.includes(Partials.User)
-        ? guild.client.users._add({ id: data.user_id })
-        : guild.client.users.cache.get(data.user_id)
+        ? guild.client.users._obtain({ id: data.user_id }, guild)
+        : logs.users.get(data.user_id)
       : null;
 
     /**
@@ -212,8 +212,8 @@ class GuildAuditLogsEntry {
       // MemberDisconnect and similar types do not provide a target_id.
     } else if (targetType === Targets.User && data.target_id) {
       this.target = guild.client.options.partials.includes(Partials.User)
-        ? guild.client.users._add({ id: data.target_id })
-        : guild.client.users.cache.get(data.target_id);
+        ? guild.client.users._obtain({ id: data.target_id }, guild)
+        : logs.users.get(data.target_id);
     } else if (targetType === Targets.Guild) {
       this.target = guild.client.guilds.cache.get(data.target_id);
     } else if (targetType === Targets.Webhook) {
@@ -253,7 +253,7 @@ class GuildAuditLogsEntry {
       this.target =
         data.action_type === AuditLogEvent.MessageBulkDelete
           ? guild.channels.cache.get(data.target_id) ?? { id: data.target_id }
-          : guild.client.users.cache.get(data.target_id);
+          : logs.users.get(data.target_id);
     } else if (targetType === Targets.Integration) {
       this.target =
         logs.integrations.get(data.target_id) ??

--- a/packages/discord.js/src/structures/GuildBan.js
+++ b/packages/discord.js/src/structures/GuildBan.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Base = require('./Base');
+const User = require('./User');
 
 /**
  * Represents a ban in a guild on Discord.
@@ -25,7 +26,8 @@ class GuildBan extends Base {
        * The user this ban applies to
        * @type {User}
        */
-      this.user = this.client.users._add(data.user, true);
+      // Store / create reference directly as member is highly unlikely to exist anymore
+      this.user = this.user ? this.user._patch(data.user) : new User(this.client, data.user);
     }
 
     if ('reason' in data) {

--- a/packages/discord.js/src/structures/GuildBan.js
+++ b/packages/discord.js/src/structures/GuildBan.js
@@ -27,7 +27,7 @@ class GuildBan extends Base {
        * @type {User}
        */
       // Store / create reference directly as member is highly unlikely to exist anymore
-      this.user = this.user ? this.user._patch(data.user) : new User(this.client, data.user);
+      this.user = this.user?._patch(data.user) ?? new User(this.client, data.user);
     }
 
     if ('reason' in data) {

--- a/packages/discord.js/src/structures/GuildEmoji.js
+++ b/packages/discord.js/src/structures/GuildEmoji.js
@@ -45,7 +45,7 @@ class GuildEmoji extends BaseGuildEmoji {
   _patch(data) {
     super._patch(data);
 
-    if (data.user) this.author = this.client.users._add(data.user);
+    if (data.user) this.author = this.client.users._obtain(data.user, this.guild);
     if (data.roles) this._roles = data.roles;
   }
 

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -2,6 +2,7 @@
 
 const { PermissionFlagsBits } = require('discord-api-types/v10');
 const Base = require('./Base');
+const User = require('./User');
 const VoiceState = require('./VoiceState');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { Error } = require('../errors');
@@ -63,7 +64,7 @@ class GuildMember extends Base {
        * The user that this guild member instance represents
        * @type {?User}
        */
-      this.user = this.client.users._add(data.user, true);
+      this.user = this.user ? this.user._clone().patch(data.user) : new User(this.client, data.user);
     }
 
     if ('nick' in data) this.nickname = data.nick;

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -64,7 +64,7 @@ class GuildMember extends Base {
        * The user that this guild member instance represents
        * @type {?User}
        */
-      this.user = this.user ? this.user._clone().patch(data.user) : new User(this.client, data.user);
+      this.user = this.user?.patch(data.user) ?? new User(this.client, data.user);
     }
 
     if ('nick' in data) this.nickname = data.nick;
@@ -99,6 +99,7 @@ class GuildMember extends Base {
   _clone() {
     const clone = super._clone();
     clone._roles = this._roles.slice();
+    clone.user = this.user?._clone() ?? null;
     return clone;
   }
 

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -123,9 +123,9 @@ class GuildScheduledEvent extends Base {
        * The user that created this guild scheduled event
        * @type {?User}
        */
-      this.creator = this.client.users._add(data.creator);
+      this.creator = this.client.users._obtain(data.creator, this.guild);
     } else {
-      this.creator ??= this.client.users.resolve(this.creatorId);
+      this.creator ??= this.client.users.resolve(this.creatorId, this.guild);
     }
 
     /* eslint-disable max-len */

--- a/packages/discord.js/src/structures/GuildTemplate.js
+++ b/packages/discord.js/src/structures/GuildTemplate.js
@@ -3,6 +3,7 @@
 const { setTimeout, clearTimeout } = require('node:timers');
 const { RouteBases, Routes } = require('discord-api-types/v10');
 const Base = require('./Base');
+const User = require('./User');
 const DataResolver = require('../util/DataResolver');
 const Events = require('../util/Events');
 
@@ -69,7 +70,7 @@ class GuildTemplate extends Base {
        * The user that created this template
        * @type {User}
        */
-      this.creator = this.client.users._add(data.creator);
+      this.creator = this.creator ? this.creator._patch(data.creator) : new User(this.client, data.creator);
     }
 
     if ('created_at' in data) {

--- a/packages/discord.js/src/structures/GuildTemplate.js
+++ b/packages/discord.js/src/structures/GuildTemplate.js
@@ -70,7 +70,7 @@ class GuildTemplate extends Base {
        * The user that created this template
        * @type {User}
        */
-      this.creator = this.creator ? this.creator._patch(data.creator) : new User(this.client, data.creator);
+      this.creator = this.creator?._patch(data.creator) ?? new User(this.client, data.creator);
     }
 
     if ('created_at' in data) {

--- a/packages/discord.js/src/structures/Integration.js
+++ b/packages/discord.js/src/structures/Integration.js
@@ -87,7 +87,7 @@ class Integration extends Base {
        * The user for this integration
        * @type {?User}
        */
-      this.user = this.client.users._add(data.user);
+      this.user = this.client.users._obtain(data.user, this.guild);
     } else {
       this.user ??= null;
     }

--- a/packages/discord.js/src/structures/IntegrationApplication.js
+++ b/packages/discord.js/src/structures/IntegrationApplication.js
@@ -16,7 +16,7 @@ class IntegrationApplication extends Application {
        * The bot user for this application
        * @type {?User}
        */
-      this.bot = this.bot ? this.bot._patch(data.bot) : new User(this.user, data.bot);
+      this.bot = this.bot?._patch(data.bot) ?? new User(this.client, data.bot);
     } else {
       this.bot ??= null;
     }

--- a/packages/discord.js/src/structures/IntegrationApplication.js
+++ b/packages/discord.js/src/structures/IntegrationApplication.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const User = require('./User');
 const Application = require('./interfaces/Application');
 
 /**
@@ -15,7 +16,7 @@ class IntegrationApplication extends Application {
        * The bot user for this application
        * @type {?User}
        */
-      this.bot = this.client.users._add(data.bot);
+      this.bot = this.bot ? this.bot._patch(data.bot) : new User(this.user, data.bot);
     } else {
       this.bot ??= null;
     }

--- a/packages/discord.js/src/structures/Interaction.js
+++ b/packages/discord.js/src/structures/Interaction.js
@@ -55,7 +55,7 @@ class Interaction extends Base {
      * The user which sent this interaction
      * @type {User}
      */
-    this.user = this.client.users._add(data.user ?? data.member.user);
+    this.user = this.client.users._obtain(data.user ?? data.member.user, this.guild);
 
     /**
      * If this interaction was sent in a guild, the member which sent it

--- a/packages/discord.js/src/structures/Invite.js
+++ b/packages/discord.js/src/structures/Invite.js
@@ -124,8 +124,13 @@ class Invite extends Base {
     }
 
     if ('inviter' in data) {
-      this.client.users._add(data.inviter);
-      this.inviterId = data.inviter.id;
+      /**
+       * The user who created this invite
+       * @type {?User}
+       */
+      this.inviter = this.client.users._obtain(data.inviter, this.guild);
+    } else {
+      this.inviter ??= null;
     }
 
     if ('target_user' in data) {
@@ -133,7 +138,7 @@ class Invite extends Base {
        * The user whose stream to display for this voice channel stream invite
        * @type {?User}
        */
-      this.targetUser = this.client.users._add(data.target_user);
+      this.targetUser = this.client.users._obtain(data.target_user, this.guild);
     } else {
       this.targetUser ??= null;
     }
@@ -262,15 +267,6 @@ class Invite extends Base {
   }
 
   /**
-   * The user who created this invite
-   * @type {?User}
-   * @readonly
-   */
-  get inviter() {
-    return this.inviterId && this.client.users.resolve(this.inviterId);
-  }
-
-  /**
    * The URL to the invite
    * @type {string}
    * @readonly
@@ -308,7 +304,7 @@ class Invite extends Base {
       memberCount: false,
       uses: false,
       channel: 'channelId',
-      inviter: 'inviterId',
+      inviter: true,
       guild: 'guildId',
     });
   }

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -94,7 +94,7 @@ class Message extends Base {
        * The author of the message
        * @type {?User}
        */
-      this.author = this.client.users._add(data.author, !data.webhook_id);
+      this.author = this.client.users._obtain(data.author, this.guild);
     } else {
       this.author ??= null;
     }
@@ -342,7 +342,7 @@ class Message extends Base {
         id: data.interaction.id,
         type: data.interaction.type,
         commandName: data.interaction.name,
-        user: this.client.users._add(data.interaction.user),
+        user: this.client.users._obtain(data.interaction.user, this.guild),
       };
     } else {
       this.interaction ??= null;

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -78,7 +78,7 @@ class MessageMentions {
           if (mention.member && message.guild) {
             message.guild.members._add(Object.assign(mention.member, { user: mention }));
           }
-          const user = message.client.users._add(mention);
+          const user = message.client.users._obtain(mention, this.guild);
           this.users.set(user.id, user);
         }
       }
@@ -156,7 +156,7 @@ class MessageMentions {
      * The author of the message that this message is a reply to
      * @type {?User}
      */
-    this.repliedUser = repliedUser ? this.client.users._add(repliedUser) : null;
+    this.repliedUser = repliedUser ? this.client.users._obtain(repliedUser, this.guild) : null;
   }
 
   /**
@@ -211,7 +211,7 @@ class MessageMentions {
    * @returns {boolean}
    */
   has(data, { ignoreDirect = false, ignoreRoles = false, ignoreRepliedUser = false, ignoreEveryone = false } = {}) {
-    const user = this.client.users.resolve(data);
+    const user = this.client.users.resolve(data, this.guild);
     const role = this.guild?.roles.resolve(data);
     const channel = this.client.channels.resolve(data);
 

--- a/packages/discord.js/src/structures/PermissionOverwrites.js
+++ b/packages/discord.js/src/structures/PermissionOverwrites.js
@@ -180,7 +180,7 @@ class PermissionOverwrites extends Base {
       };
     }
 
-    const userOrRole = guild.roles.resolve(overwrite.id) ?? guild.client.users.resolve(overwrite.id);
+    const userOrRole = guild.roles.resolve(overwrite.id) ?? guild.client.users.resolve(overwrite.id, guild);
     if (!userOrRole) throw new TypeError('INVALID_TYPE', 'parameter', 'User nor a Role');
     const type = userOrRole instanceof Role ? OverwriteType.Role : OverwriteType.Member;
 

--- a/packages/discord.js/src/structures/Presence.js
+++ b/packages/discord.js/src/structures/Presence.js
@@ -2,6 +2,7 @@
 
 const Base = require('./Base');
 const { Emoji } = require('./Emoji');
+const User = require('./User');
 const ActivityFlagsBitField = require('../util/ActivityFlagsBitField');
 const Util = require('../util/Util');
 
@@ -58,7 +59,7 @@ class Presence extends Base {
    * @readonly
    */
   get user() {
-    return this.client.users.resolve(this.userId);
+    return this.member?.user ?? this._user ? new User(this.client, this._user) : null;
   }
 
   /**
@@ -103,6 +104,13 @@ class Presence extends Base {
     } else {
       this.clientStatus ??= null;
     }
+
+    /**
+     * The raw user object from the API
+     * @type {Partial<APIUser>}
+     * @private
+     */
+    this._user = this._user ? { ...this._user, ...data.user } : data.user;
 
     return this;
   }

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -3,6 +3,7 @@
 const { DiscordSnowflake } = require('@sapphire/snowflake');
 const { Routes, StickerFormatType } = require('discord-api-types/v10');
 const Base = require('./Base');
+const User = require('./User');
 
 /**
  * Represents a Sticker.
@@ -103,7 +104,7 @@ class Sticker extends Base {
        * The user that uploaded the guild sticker
        * @type {?User}
        */
-      this.user = this.client.users._add(sticker.user);
+      this.user = this.user ? this.user._patch(sticker.user) : new User(this.client, sticker.user);
     } else {
       this.user ??= null;
     }

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -104,7 +104,7 @@ class Sticker extends Base {
        * The user that uploaded the guild sticker
        * @type {?User}
        */
-      this.user = this.user ? this.user._patch(sticker.user) : new User(this.client, sticker.user);
+      this.user = this.user?._patch(sticker.user) ?? new User(this.client, sticker.user);
     } else {
       this.user ??= null;
     }

--- a/packages/discord.js/src/structures/TeamMember.js
+++ b/packages/discord.js/src/structures/TeamMember.js
@@ -42,7 +42,7 @@ class TeamMember extends Base {
        * The user for this Team Member
        * @type {User}
        */
-      this.user = this.user ? this.user._patch(data.user) : new User(this.team.client, data.user);
+      this.user = this.user?._patch(data.user) ?? new User(this.team.client, data.user);
     }
   }
 

--- a/packages/discord.js/src/structures/TeamMember.js
+++ b/packages/discord.js/src/structures/TeamMember.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Base = require('./Base');
+const User = require('./User');
 
 /**
  * Represents a Client OAuth2 Application Team Member.
@@ -41,7 +42,7 @@ class TeamMember extends Base {
        * The user for this Team Member
        * @type {User}
        */
-      this.user = this.client.users._add(data.user);
+      this.user = this.user ? this.user._patch(data.user) : new User(this.team.client, data.user);
     }
   }
 

--- a/packages/discord.js/src/structures/ThreadMember.js
+++ b/packages/discord.js/src/structures/ThreadMember.js
@@ -76,7 +76,7 @@ class ThreadMember extends Base {
    * @readonly
    */
   get user() {
-    return this.client.users.resolve(this.id);
+    return this.guildMember?.user;
   }
 
   /**

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -263,20 +263,18 @@ class User extends Base {
 
   /**
    * Fetches this user's flags.
-   * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<UserFlagsBitField>}
    */
-  fetchFlags(force = false) {
-    return this.client.users.fetchFlags(this.id, { force });
+  fetchFlags() {
+    return this.client.users.fetchFlags(this);
   }
 
   /**
    * Fetches this user.
-   * @param {boolean} [force=true] Whether to skip the cache check and request the API
    * @returns {Promise<User>}
    */
-  fetch(force = true) {
-    return this.client.users.fetch(this.id, { force });
+  fetch() {
+    return this.client.users.fetch(this);
   }
 
   /**

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -110,6 +110,8 @@ class User extends Base {
        */
       this.flags = new UserFlagsBitField(data.public_flags);
     }
+
+    return this;
   }
 
   /**

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -4,6 +4,7 @@ const { makeURLSearchParams } = require('@discordjs/rest');
 const { DiscordSnowflake } = require('@sapphire/snowflake');
 const { Routes, WebhookType } = require('discord-api-types/v10');
 const MessagePayload = require('./MessagePayload');
+const { User } = require('..');
 const { Error } = require('../errors');
 const DataResolver = require('../util/DataResolver');
 const { lazy } = require('../util/Util');
@@ -80,11 +81,15 @@ class Webhook {
     }
 
     if ('user' in data) {
-      /**
-       * The owner of the webhook
-       * @type {?(User|APIUser)}
-       */
-      this.owner = this.client.users?._add(data.user) ?? data.user;
+      if ('users' in this.client) {
+        this.owner = this.owner ? this.owner._patch(data.user) : new User(this.client, data.user);
+      } else {
+        /**
+         * The owner of the webhook
+         * @type {?(User|APIUser)}
+         */
+        this.owner = this.owner ? { ...this.owner, ...data.user } : data.user;
+      }
     } else {
       this.owner ??= null;
     }

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -4,7 +4,7 @@ const { makeURLSearchParams } = require('@discordjs/rest');
 const { DiscordSnowflake } = require('@sapphire/snowflake');
 const { Routes, WebhookType } = require('discord-api-types/v10');
 const MessagePayload = require('./MessagePayload');
-const { User } = require('..');
+const { User } = require('./User');
 const { Error } = require('../errors');
 const DataResolver = require('../util/DataResolver');
 const { lazy } = require('../util/Util');
@@ -82,7 +82,7 @@ class Webhook {
 
     if ('user' in data) {
       if ('users' in this.client) {
-        this.owner = this.owner ? this.owner._patch(data.user) : new User(this.client, data.user);
+        this.owner = this.owner?._patch(data.user) ?? new User(this.client, data.user);
       } else {
         /**
          * The owner of the webhook

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -20,7 +20,6 @@ exports.UserAgent = `DiscordBot (${Package.homepage}, ${Package.version}) Node.j
  * * `stickers`
  * * `threadMembers`
  * * `threads` - accepts the `lifetime` property, using it will sweep archived threads based on archived timestamp
- * * `users`
  * * `voiceStates`
  * @typedef {string} SweeperKey
  */
@@ -37,7 +36,6 @@ exports.SweeperKeys = [
   'stickers',
   'threadMembers',
   'threads',
-  'users',
   'voiceStates',
 ];
 

--- a/packages/discord.js/src/util/Sweepers.js
+++ b/packages/discord.js/src/util/Sweepers.js
@@ -256,23 +256,6 @@ class Sweepers {
   }
 
   /**
-   * Sweeps all users and removes the ones which are indicated by the filter.
-   * @param {Function} filter The function used to determine which users will be removed from the caches.
-   * @returns {number} Amount of users that were removed from the caches
-   */
-  sweepUsers(filter) {
-    if (typeof filter !== 'function') {
-      throw new TypeError('INVALID_TYPE', 'filter', 'function');
-    }
-
-    const users = this.client.users.cache.sweep(filter);
-
-    this.client.emit(Events.CacheSweep, `Swept ${users} users.`);
-
-    return users;
-  }
-
-  /**
    * Sweeps all guild voice states and removes the ones which are indicated by the filter.
    * @param {Function} filter The function used to determine which voice states will be removed from the caches.
    * @returns {number} Amount of voice states that were removed from the caches

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -494,12 +494,7 @@ class Util extends null {
         }
 
         const member = channel.guild.members.cache.get(id);
-        if (member) {
-          return `@${member.displayName}`;
-        } else {
-          const user = channel.guild?.members?.cache.get(id)?.user;
-          return user ? `@${user.username}` : input;
-        }
+        return member ? `@${member.displayName}` : input;
       })
       .replace(/<#[0-9]+>/g, input => {
         const mentionedChannel = channel.client.channels.cache.get(input.replace(/<|#|>/g, ''));

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -489,7 +489,7 @@ class Util extends null {
       .replace(/<@!?[0-9]+>/g, input => {
         const id = input.replace(/<|!|>|@/g, '');
         if (channel.type === ChannelType.DM) {
-          const user = channel.client.users.cache.get(id);
+          const user = channel.recipient;
           return user ? `@${user.username}` : input;
         }
 
@@ -497,7 +497,7 @@ class Util extends null {
         if (member) {
           return `@${member.displayName}`;
         } else {
-          const user = channel.client.users.cache.get(id);
+          const user = channel.guild?.members?.cache.get(id)?.user;
           return user ? `@${user.username}` : input;
         }
       })

--- a/packages/discord.js/test/random.js
+++ b/packages/discord.js/test/random.js
@@ -43,7 +43,7 @@ client.on('ready', async () => {
     console.log(`Failed to fetch all members before ready! ${err}\n${err.stack}`);
   }
 
-  console.log(`ready with ${client.users.cache.size} users`);
+  console.log(`ready`);
   console.timeEnd('magic');
 });
 
@@ -123,7 +123,6 @@ client.on('messageCreate', message => {
       m += `I am aware of ${message.guild.members.cache.size} members\n`;
       m += `I am aware of ${client.channels.cache.size} channels overall\n`;
       m += `I am aware of ${client.guilds.cache.size} guilds overall\n`;
-      m += `I am aware of ${client.users.cache.size} users overall\n`;
       message.channel
         .send(m)
         .then(msg => msg.edit('nah'))

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -775,7 +775,7 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
   public shard: ShardClientUtil | null;
   public token: If<Ready, string, string | null>;
   public get uptime(): If<Ready, number>;
-  public readonly user: If<Ready, ClientUser>;
+  public get user(): If<Ready, ClientUser>;
   public users: UserManager<Ready>;
   public voice: ClientVoiceManager;
   public ws: WebSocketManager;
@@ -3377,7 +3377,7 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
   public remove(id: Snowflake | '@me', reason?: string): Promise<Snowflake>;
 }
 
-export class UserManager<Ready extends boolean> extends BaseManager {
+export class UserManager<Ready extends boolean = boolean> extends BaseManager {
   private constructor(client: Client);
   public me: If<Ready, ClientUser>;
   private _obtain(data: Partial<APIUser>, guild: BaseGuild | null): User;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

> **Warning**
> This PR has not yet been fully tested, testing is still under way

- This PR is an attempt to satisfy the roadmap issue and will close #7474 

Most of what this PR achieves and why is outlined perfectly by that issue, differences and other notes here:
- `UserManager` extends `BaseManager` to not have a false `cache` property, but still retains `resolve(Id)`
- Members are the primary source of truth for user data
- Presences are a potential primary source of truth, but they create members anyways (and if you have the presence intent it seems highly likely you have the members intent as well)
- There's a lot of places like `Invite` where we're creating a `User` instance that can get stale quickly, is this okay? Yes, it is highly likely that the exact same thing was happening before but went unnoticed.
- `client.user` has been changed into a getter instead of removing it completely for now

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
