### PR TITLE
refactor(ThreadMemberManager): Consistent thread member fetching

### DIFF
--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -272,7 +272,7 @@ class ThreadChannel extends Channel {
     }
 
     // We cannot fetch a single thread member, as of this commit's date, Discord API responds with 405
-    const members = await this.members.fetch(cache);
+    const members = await this.members.fetch({ cache });
     return members.get(this.ownerId) ?? null;
   }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3383,8 +3383,8 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
   public thread: ThreadChannel;
   public get me(): ThreadMember | null;
   public add(member: UserResolvable | '@me', reason?: string): Promise<Snowflake>;
-  public fetch(options?: ThreadMemberFetchOptions): Promise<ThreadMember>;
-  public fetch(cache?: boolean): Promise<Collection<Snowflake, ThreadMember>>;
+  public fetch(options?: ThreadMemberResolvable | FetchThreadMemberOptions): Promise<ThreadMember>;
+  public fetch(options?: FetchThreadMembersOptions): Promise<Collection<Snowflake, ThreadMember>>;
   public fetchMe(options?: BaseFetchOptions): Promise<ThreadMember>;
   public remove(id: Snowflake | '@me', reason?: string): Promise<Snowflake>;
 }
@@ -3725,10 +3725,6 @@ export type Base64String = string;
 export interface BaseFetchOptions {
   cache?: boolean;
   force?: boolean;
-}
-
-export interface ThreadMemberFetchOptions extends BaseFetchOptions {
-  member?: UserResolvable;
 }
 
 export type BitFieldResolvable<T extends string, N extends number | bigint> =
@@ -4290,6 +4286,14 @@ export interface FetchMessagesOptions {
 export interface FetchReactionUsersOptions {
   limit?: number;
   after?: Snowflake;
+}
+
+export interface FetchThreadMemberOptions extends BaseFetchOptions {
+  member: ThreadMemberResolvable;
+}
+
+export interface FetchThreadMembersOptions {
+  cache?: boolean;
 }
 
 export interface FetchThreadsOptions {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -124,7 +124,7 @@ import {
   PartialGroupDMChannel,
   Attachment,
 } from '.';
-import { expectAssignable, expectDeprecated, expectNotAssignable, expectNotType, expectType } from 'tsd';
+import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import { UnsafeButtonBuilder, UnsafeEmbedBuilder, UnsafeSelectMenuBuilder } from '@discordjs/builders';
 
 // Test type transformation:
@@ -558,11 +558,14 @@ client.on('guildCreate', async g => {
   }
 
   if (channel.isThread()) {
-    const fetchedMember = await channel.members.fetch({ member: '12345678' });
+    const fetchedMember = await channel.members.fetch('12345678');
+    const fetchedMember2 = await channel.members.fetch({ member: '12345678', cache: false, force: true });
     expectType<ThreadMember>(fetchedMember);
-    const fetchedMemberCol = await channel.members.fetch(true);
-    expectDeprecated(await channel.members.fetch(true));
+    expectType<ThreadMember>(fetchedMember2);
+    const fetchedMemberCol = await channel.members.fetch({ cache: true });
     expectType<Collection<Snowflake, ThreadMember>>(fetchedMemberCol);
+    // @ts-expect-error The `force` option cannot be used alongside fetching all thread members.
+    const fetchedMemberCol2 = await channel.members.fetch({ cache: true, force: false });
   }
 
   channel.setName('foo').then(updatedChannel => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`ThreadMemberManager#fetch()` has been made consistent with other managers, such as `MessageManager#fetch()` and `GuildBanManager#fetch()`. This also fixes an issue (by removing it) in which passing only a boolean was ignored and was deemed always `true`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
