### PR TITLE
refactor(*): include name/reason/etc fields into options/data params

### DIFF
--- a/packages/discord.js/src/managers/CategoryChannelChildManager.js
+++ b/packages/discord.js/src/managers/CategoryChannelChildManager.js
@@ -38,6 +38,7 @@ class CategoryChannelChildManager extends DataManager {
   /**
    * Options for creating a channel using {@link CategoryChannel#createChannel}.
    * @typedef {Object} CategoryCreateChannelOptions
+   * @property {string} name The name for the new channel
    * @property {ChannelType} [type=ChannelType.GuildText] The type of the new channel.
    * @property {string} [topic] The topic for the new channel
    * @property {boolean} [nsfw] Whether the new channel is NSFW
@@ -55,12 +56,11 @@ class CategoryChannelChildManager extends DataManager {
   /**
    * Creates a new channel within this category.
    * <info>You cannot create a channel of type {@link ChannelType.GuildCategory} inside a CategoryChannel.</info>
-   * @param {string} name The name of the new channel
    * @param {CategoryCreateChannelOptions} options Options for creating the new channel
    * @returns {Promise<GuildChannel>}
    */
-  create(name, options) {
-    return this.guild.channels.create(name, {
+  create(options) {
+    return this.guild.channels.create({
       ...options,
       parent: this.channel.id,
     });

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -163,8 +163,13 @@ class GuildChannelManager extends CachedManager {
   }
 
   /**
+   * @typedef {ChannelWebhookCreateOptions} WebhookCreateOptions
+   * @property {GuildChannelResolvable} channel The channel to create the webhook for
+   */
+
+  /**
    * Creates a webhook for the channel.
-   * @param {ChannelWebhookCreateOptions} options Options for creating the webhook
+   * @param {WebhookCreateOptions} options Options for creating the webhook
    * @returns {Promise<Webhook>} Returns the created Webhook
    * @example
    * // Create a webhook for the current channel

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -104,7 +104,7 @@ class GuildChannelManager extends CachedManager {
 
   /**
    * Creates a new channel in the guild.
-   * @param {GuildChannelCreateOptions} [options] Options for creating the new channel
+   * @param {GuildChannelCreateOptions} options Options for creating the new channel
    * @returns {Promise<GuildChannel>}
    * @example
    * // Create a new text channel
@@ -164,7 +164,7 @@ class GuildChannelManager extends CachedManager {
 
   /**
    * Creates a webhook for the channel.
-   * @param {ChannelWebhookCreateOptions} [options] Options for creating the webhook
+   * @param {ChannelWebhookCreateOptions} options Options for creating the webhook
    * @returns {Promise<Webhook>} Returns the created Webhook
    * @example
    * // Create a webhook for the current channel

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -138,7 +138,7 @@ class GuildChannelManager extends CachedManager {
     rtcRegion,
     videoQualityMode,
     reason,
-  } = {}) {
+  }) {
     parent &&= this.client.channels.resolveId(parent);
     permissionOverwrites &&= permissionOverwrites.map(o => PermissionOverwrites.resolve(o, this.guild));
 

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -177,7 +177,7 @@ class GuildChannelManager extends CachedManager {
    *   .then(console.log)
    *   .catch(console.error)
    */
-  async createWebhook({ channel, name, avatar, reason } = {}) {
+  async createWebhook({ channel, name, avatar, reason }) {
     const id = this.resolveId(channel);
     if (!id) throw new TypeError('INVALID_TYPE', 'channel', 'GuildChannelResolvable');
     if (typeof avatar === 'string' && !avatar.startsWith('data:')) {

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -288,7 +288,7 @@ class GuildChannelManager extends CachedManager {
    *   .then(newChannel => console.log(`Channel's new position is ${newChannel.position}`))
    *   .catch(console.error);
    */
-  async setPosition(channel, position, { relative, reason }) {
+  async setPosition(channel, position, { relative, reason } = {}) {
     channel = this.resolve(channel);
     if (!channel) throw new TypeError('INVALID_TYPE', 'channel', 'GuildChannelResolvable');
     const updatedChannels = await Util.setPosition(

--- a/packages/discord.js/src/managers/GuildEmojiManager.js
+++ b/packages/discord.js/src/managers/GuildEmojiManager.js
@@ -36,7 +36,7 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
 
   /**
    * Creates a new custom emoji in the guild.
-   * @param {GuildEmojiCreateOptions} [options] Options for creating the emoji
+   * @param {GuildEmojiCreateOptions} options Options for creating the emoji
    * @returns {Promise<Emoji>} The created emoji
    * @example
    * // Create a new emoji from a URL

--- a/packages/discord.js/src/managers/GuildEmojiManager.js
+++ b/packages/discord.js/src/managers/GuildEmojiManager.js
@@ -118,10 +118,9 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
    * Edits an emoji.
    * @param {EmojiResolvable} emoji The Emoji resolvable to edit
    * @param {GuildEmojiEditData} data The new data for the emoji
-   * @param {string} [reason] Reason for editing this emoji
    * @returns {Promise<GuildEmoji>}
    */
-  async edit(emoji, data, reason) {
+  async edit(emoji, data) {
     const id = this.resolveId(emoji);
     if (!id) throw new TypeError('INVALID_TYPE', 'emoji', 'EmojiResolvable', true);
     const roles = data.roles?.map(r => this.guild.roles.resolveId(r));
@@ -130,7 +129,7 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
         name: data.name,
         roles,
       },
-      reason,
+      reason: data.reason,
     });
     const existing = this.cache.get(id);
     if (existing) {

--- a/packages/discord.js/src/managers/GuildEmojiManager.js
+++ b/packages/discord.js/src/managers/GuildEmojiManager.js
@@ -27,29 +27,29 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
 
   /**
    * Options used for creating an emoji in a guild.
-   * @typedef {Object} GuildEmojiCreateOptions
+   * @typedef {Object}
+   * @property {BufferResolvable|Base64Resolvable} attachment The image for the emoji
+   * @property {string} name The name for the emoji
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles to limit the emoji to
    * @property {string} [reason] The reason for creating the emoji
    */
 
   /**
    * Creates a new custom emoji in the guild.
-   * @param {BufferResolvable|Base64Resolvable} attachment The image for the emoji
-   * @param {string} name The name for the emoji
    * @param {GuildEmojiCreateOptions} [options] Options for creating the emoji
    * @returns {Promise<Emoji>} The created emoji
    * @example
    * // Create a new emoji from a URL
-   * guild.emojis.create('https://i.imgur.com/w3duR07.png', 'rip')
+   * guild.emojis.create({ attachment: 'https://i.imgur.com/w3duR07.png', name: 'rip' })
    *   .then(emoji => console.log(`Created new emoji with name ${emoji.name}!`))
    *   .catch(console.error);
    * @example
    * // Create a new emoji from a file on your computer
-   * guild.emojis.create('./memes/banana.png', 'banana')
+   * guild.emojis.create({ attachment: './memes/banana.png', name: 'banana' })
    *   .then(emoji => console.log(`Created new emoji with name ${emoji.name}!`))
    *   .catch(console.error);
    */
-  async create(attachment, name, { roles, reason } = {}) {
+  async create({ attachment, name, roles, reason }) {
     attachment = await DataResolver.resolveImage(attachment);
     if (!attachment) throw new TypeError('REQ_RESOURCE_TYPE');
 

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -141,6 +141,7 @@ class GuildManager extends CachedManager {
   /**
    * Options used to create a guild.
    * @typedef {Object} GuildCreateOptions
+   * @property {string} name The name of the guild
    * @property {Snowflake|number} [afkChannelId] The AFK channel's id
    * @property {number} [afkTimeout] The AFK timeout in seconds
    * @property {PartialChannelData[]} [channels=[]] The channels for this guild
@@ -159,25 +160,22 @@ class GuildManager extends CachedManager {
   /**
    * Creates a guild.
    * <warn>This is only available to bots in fewer than 10 guilds.</warn>
-   * @param {string} name The name of the guild
-   * @param {GuildCreateOptions} [options] Options for creating the guild
+   * @param {GuildCreateOptions} options Options for creating the guild
    * @returns {Promise<Guild>} The guild that was created
    */
-  async create(
+  async create({
     name,
-    {
-      afkChannelId,
-      afkTimeout,
-      channels = [],
-      defaultMessageNotifications,
-      explicitContentFilter,
-      icon = null,
-      roles = [],
-      systemChannelId,
-      systemChannelFlags,
-      verificationLevel,
-    } = {},
-  ) {
+    afkChannelId,
+    afkTimeout,
+    channels = [],
+    defaultMessageNotifications,
+    explicitContentFilter,
+    icon = null,
+    roles = [],
+    systemChannelId,
+    systemChannelFlags,
+    verificationLevel,
+  }) {
     icon = await DataResolver.resolveImage(icon);
 
     for (const channel of channels) {

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -279,8 +279,7 @@ class GuildMemberManager extends CachedManager {
     const id = this.client.users.resolveId(user);
     if (!id) throw new TypeError('INVALID_TYPE', 'user', 'UserResolvable');
 
-    // Clone the data object for immutability
-    const _data = { ...data };
+    const _data = data;
     if (_data.channel) {
       _data.channel = this.guild.channels.resolve(_data.channel);
       if (!(_data.channel instanceof BaseGuildVoiceChannel)) {

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -279,25 +279,24 @@ class GuildMemberManager extends CachedManager {
     const id = this.client.users.resolveId(user);
     if (!id) throw new TypeError('INVALID_TYPE', 'user', 'UserResolvable');
 
-    const _data = data;
-    if (_data.channel) {
-      _data.channel = this.guild.channels.resolve(_data.channel);
-      if (!(_data.channel instanceof BaseGuildVoiceChannel)) {
+    if (data.channel) {
+      data.channel = this.guild.channels.resolve(data.channel);
+      if (!(data.channel instanceof BaseGuildVoiceChannel)) {
         throw new Error('GUILD_VOICE_CHANNEL_RESOLVE');
       }
-      _data.channel_id = _data.channel.id;
-      _data.channel = undefined;
-    } else if (_data.channel === null) {
-      _data.channel_id = null;
-      _data.channel = undefined;
+      data.channel_id = data.channel.id;
+      data.channel = undefined;
+    } else if (data.channel === null) {
+      data.channel_id = null;
+      data.channel = undefined;
     }
-    _data.roles &&= _data.roles.map(role => (role instanceof Role ? role.id : role));
+    data.roles &&= data.roles.map(role => (role instanceof Role ? role.id : role));
 
-    _data.communication_disabled_until =
+    data.communication_disabled_until =
       // eslint-disable-next-line eqeqeq
-      _data.communicationDisabledUntil != null
-        ? new Date(_data.communicationDisabledUntil).toISOString()
-        : _data.communicationDisabledUntil;
+      data.communicationDisabledUntil != null
+        ? new Date(data.communicationDisabledUntil).toISOString()
+        : data.communicationDisabledUntil;
 
     let endpoint;
     if (id === this.client.user.id) {
@@ -307,7 +306,7 @@ class GuildMemberManager extends CachedManager {
     } else {
       endpoint = Routes.guildMember(this.guild.id, id);
     }
-    const d = await this.client.rest.patch(endpoint, { body: _data, reason });
+    const d = await this.client.rest.patch(endpoint, { body: data, reason });
 
     const clone = this.cache.get(id)?._clone();
     clone?._patch(d);

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -265,6 +265,7 @@ class GuildMemberManager extends CachedManager {
    * (if they are connected to voice), or `null` if you want to disconnect them from voice
    * @property {DateResolvable|null} [communicationDisabledUntil] The date or timestamp
    * for the member's communication to be disabled until. Provide `null` to enable communication again.
+   * @property {string} [reason] Reason for editing this user
    */
 
   /**
@@ -272,10 +273,9 @@ class GuildMemberManager extends CachedManager {
    * <info>The user must be a member of the guild</info>
    * @param {UserResolvable} user The member to edit
    * @param {GuildMemberEditData} data The data to edit the member with
-   * @param {string} [reason] Reason for editing this user
    * @returns {Promise<GuildMember>}
    */
-  async edit(user, data, reason) {
+  async edit(user, { reason, ...data }) {
     const id = this.client.users.resolveId(user);
     if (!id) throw new TypeError('INVALID_TYPE', 'user', 'UserResolvable');
 

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -179,7 +179,7 @@ class GuildMemberRoleManager extends DataManager {
    *   .catch(console.error);
    */
   set(roles, reason) {
-    return this.member.edit({ roles }, reason);
+    return this.member.edit({ roles, reason });
   }
 
   clone() {

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -35,15 +35,15 @@ class GuildStickerManager extends CachedManager {
   /**
    * Options for creating a guild sticker.
    * @typedef {Object} GuildStickerCreateOptions
+   * @property {BufferResolvable|Stream|JSONEncodable<AttachmentPayload>} file The file for the sticker
+   * @property {string} name The name for the sticker
+   * @property {string} tags The Discord name of a unicode emoji representing the sticker's expression
    * @property {?string} [description] The description for the sticker
    * @property {string} [reason] Reason for creating the sticker
    */
 
   /**
    * Creates a new custom sticker in the guild.
-   * @param {BufferResolvable|Stream|JSONEncodable<AttachmentPayload>} file The file for the sticker
-   * @param {string} name The name for the sticker
-   * @param {string} tags The Discord name of a unicode emoji representing the sticker's expression
    * @param {GuildStickerCreateOptions} [options] Options
    * @returns {Promise<Sticker>} The created sticker
    * @example
@@ -57,7 +57,7 @@ class GuildStickerManager extends CachedManager {
    *   .then(sticker => console.log(`Created new sticker with name ${sticker.name}!`))
    *   .catch(console.error);
    */
-  async create(file, name, tags, { description, reason } = {}) {
+  async create({ file, name, tags, description, reason } = {}) {
     const resolvedFile = await MessagePayload.resolveFile(file);
     if (!resolvedFile) throw new TypeError('REQ_RESOURCE_TYPE');
     file = { ...resolvedFile, key: 'file' };

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -44,7 +44,7 @@ class GuildStickerManager extends CachedManager {
 
   /**
    * Creates a new custom sticker in the guild.
-   * @param {GuildStickerCreateOptions} [options] Options
+   * @param {GuildStickerCreateOptions} options Options
    * @returns {Promise<Sticker>} The created sticker
    * @example
    * // Create a new sticker from a URL

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -101,17 +101,16 @@ class GuildStickerManager extends CachedManager {
   /**
    * Edits a sticker.
    * @param {StickerResolvable} sticker The sticker to edit
-   * @param {GuildStickerEditData} [data] The new data for the sticker
-   * @param {string} [reason] Reason for editing this sticker
+   * @param {GuildStickerEditData} [data={}] The new data for the sticker
    * @returns {Promise<Sticker>}
    */
-  async edit(sticker, data, reason) {
+  async edit(sticker, data = {}) {
     const stickerId = this.resolveId(sticker);
     if (!stickerId) throw new TypeError('INVALID_TYPE', 'sticker', 'StickerResolvable');
 
     const d = await this.client.rest.patch(Routes.guildSticker(this.guild.id, stickerId), {
       body: data,
-      reason,
+      reason: data.reason,
     });
 
     const existing = this.cache.get(stickerId);

--- a/packages/discord.js/src/managers/RoleManager.js
+++ b/packages/discord.js/src/managers/RoleManager.js
@@ -166,10 +166,15 @@ class RoleManager extends CachedManager {
   }
 
   /**
+   * Options for editing a role
+   * @typedef {RoleData} EditRoleOptions
+   * @property {string} [reason] The reason for editing this role
+   */
+
+  /**
    * Edits a role of the guild.
    * @param {RoleResolvable} role The role to edit
-   * @param {RoleData} data The new data for the role
-   * @param {string} [reason] Reason for editing this role
+   * @param {EditRoleOptions} data The new data for the role
    * @returns {Promise<Role>}
    * @example
    * // Edit a role
@@ -177,12 +182,12 @@ class RoleManager extends CachedManager {
    *   .then(updated => console.log(`Edited role name to ${updated.name}`))
    *   .catch(console.error);
    */
-  async edit(role, data, reason) {
+  async edit(role, data) {
     role = this.resolve(role);
     if (!role) throw new TypeError('INVALID_TYPE', 'role', 'RoleResolvable');
 
     if (typeof data.position === 'number') {
-      await this.setPosition(role, data.position, { reason });
+      await this.setPosition(role, data.position, { reason: data.reason });
     }
 
     let icon = data.icon;
@@ -202,7 +207,7 @@ class RoleManager extends CachedManager {
       unicode_emoji: data.unicodeEmoji,
     };
 
-    const d = await this.client.rest.patch(Routes.guildRole(this.guild.id, role.id), { body, reason });
+    const d = await this.client.rest.patch(Routes.guildRole(this.guild.id, role.id), { body, reason: data.reason });
 
     const clone = role._clone();
     clone._patch(d);

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -96,7 +96,7 @@ class BaseGuildTextChannel extends GuildChannel {
    * @returns {Promise<GuildChannel>}
    */
   setType(type, reason) {
-    return this.edit({ type }, reason);
+    return this.edit({ type, reason });
   }
 
   /**
@@ -111,7 +111,7 @@ class BaseGuildTextChannel extends GuildChannel {
    *   .catch(console.error);
    */
   setTopic(topic, reason) {
-    return this.edit({ topic }, reason);
+    return this.edit({ topic, reason });
   }
 
   /**

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -86,7 +86,7 @@ class BaseGuildTextChannel extends GuildChannel {
    * @returns {Promise<TextChannel>}
    */
   setDefaultAutoArchiveDuration(defaultAutoArchiveDuration, reason) {
-    return this.edit({ defaultAutoArchiveDuration }, reason);
+    return this.edit({ defaultAutoArchiveDuration, reason });
   }
 
   /**

--- a/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
@@ -93,7 +93,7 @@ class BaseGuildVoiceChannel extends GuildChannel {
    * channel.setRTCRegion(null, 'We want to let Discord decide.');
    */
   setRTCRegion(rtcRegion, reason) {
-    return this.edit({ rtcRegion }, reason);
+    return this.edit({ rtcRegion, reason });
   }
 
   /**

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -737,6 +737,7 @@ class Guild extends AnonymousGuild {
    * @property {boolean} [premiumProgressBarEnabled] Whether the guild's premium progress bar is enabled
    * @property {?string} [description] The discovery description of the guild
    * @property {GuildFeature[]} [features] The features of the guild
+   * @property {string} [reason] Reason for editing this guild
    */
   /* eslint-enable max-len */
 
@@ -757,7 +758,6 @@ class Guild extends AnonymousGuild {
   /**
    * Updates the guild with new information - e.g. a new name.
    * @param {GuildEditData} data The data to update the guild with
-   * @param {string} [reason] Reason for editing this guild
    * @returns {Promise<Guild>}
    * @example
    * // Set the guild name
@@ -767,7 +767,7 @@ class Guild extends AnonymousGuild {
    *   .then(updated => console.log(`New guild name ${updated}`))
    *   .catch(console.error);
    */
-  async edit(data, reason) {
+  async edit(data) {
     const _data = {};
     if (data.name) _data.name = data.name;
     if (typeof data.verificationLevel !== 'undefined') {
@@ -810,7 +810,7 @@ class Guild extends AnonymousGuild {
     }
     if (typeof data.preferredLocale !== 'undefined') _data.preferred_locale = data.preferredLocale;
     if ('premiumProgressBarEnabled' in data) _data.premium_progress_bar_enabled = data.premiumProgressBarEnabled;
-    const newData = await this.client.rest.patch(Routes.guild(this.id), { body: _data, reason });
+    const newData = await this.client.rest.patch(Routes.guild(this.id), { body: _data, reason: data.reason });
     return this.client.actions.GuildUpdate.handle(newData).updated;
   }
 
@@ -892,7 +892,7 @@ class Guild extends AnonymousGuild {
    * @returns {Promise<Guild>}
    */
   setExplicitContentFilter(explicitContentFilter, reason) {
-    return this.edit({ explicitContentFilter }, reason);
+    return this.edit({ explicitContentFilter, reason });
   }
 
   /**
@@ -902,7 +902,7 @@ class Guild extends AnonymousGuild {
    * @returns {Promise<Guild>}
    */
   setDefaultMessageNotifications(defaultMessageNotifications, reason) {
-    return this.edit({ defaultMessageNotifications }, reason);
+    return this.edit({ defaultMessageNotifications, reason });
   }
   /* eslint-enable max-len */
 
@@ -913,7 +913,7 @@ class Guild extends AnonymousGuild {
    * @returns {Promise<Guild>}
    */
   setSystemChannelFlags(systemChannelFlags, reason) {
-    return this.edit({ systemChannelFlags }, reason);
+    return this.edit({ systemChannelFlags, reason });
   }
 
   /**
@@ -928,7 +928,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setName(name, reason) {
-    return this.edit({ name }, reason);
+    return this.edit({ name, reason });
   }
 
   /**
@@ -943,7 +943,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setVerificationLevel(verificationLevel, reason) {
-    return this.edit({ verificationLevel }, reason);
+    return this.edit({ verificationLevel, reason });
   }
 
   /**
@@ -958,7 +958,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setAFKChannel(afkChannel, reason) {
-    return this.edit({ afkChannel }, reason);
+    return this.edit({ afkChannel, reason });
   }
 
   /**
@@ -973,7 +973,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setSystemChannel(systemChannel, reason) {
-    return this.edit({ systemChannel }, reason);
+    return this.edit({ systemChannel, reason });
   }
 
   /**
@@ -988,7 +988,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setAFKTimeout(afkTimeout, reason) {
-    return this.edit({ afkTimeout }, reason);
+    return this.edit({ afkTimeout, reason });
   }
 
   /**
@@ -1003,7 +1003,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setIcon(icon, reason) {
-    return this.edit({ icon }, reason);
+    return this.edit({ icon, reason });
   }
 
   /**
@@ -1019,7 +1019,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setOwner(owner, reason) {
-    return this.edit({ owner }, reason);
+    return this.edit({ owner, reason });
   }
 
   /**
@@ -1034,7 +1034,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setSplash(splash, reason) {
-    return this.edit({ splash }, reason);
+    return this.edit({ splash, reason });
   }
 
   /**
@@ -1049,7 +1049,7 @@ class Guild extends AnonymousGuild {
    *   .catch(console.error);
    */
   setDiscoverySplash(discoverySplash, reason) {
-    return this.edit({ discoverySplash }, reason);
+    return this.edit({ discoverySplash, reason });
   }
 
   /**
@@ -1063,7 +1063,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setBanner(banner, reason) {
-    return this.edit({ banner }, reason);
+    return this.edit({ banner, reason });
   }
 
   /**
@@ -1078,7 +1078,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setRulesChannel(rulesChannel, reason) {
-    return this.edit({ rulesChannel }, reason);
+    return this.edit({ rulesChannel, reason });
   }
 
   /**
@@ -1093,7 +1093,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setPublicUpdatesChannel(publicUpdatesChannel, reason) {
-    return this.edit({ publicUpdatesChannel }, reason);
+    return this.edit({ publicUpdatesChannel, reason });
   }
 
   /**
@@ -1108,7 +1108,7 @@ class Guild extends AnonymousGuild {
    *  .catch(console.error);
    */
   setPreferredLocale(preferredLocale, reason) {
-    return this.edit({ preferredLocale }, reason);
+    return this.edit({ preferredLocale, reason });
   }
 
   /**
@@ -1118,7 +1118,7 @@ class Guild extends AnonymousGuild {
    * @returns {Promise<Guild>}
    */
   setPremiumProgressBarEnabled(enabled = true, reason) {
-    return this.edit({ premiumProgressBarEnabled: enabled }, reason);
+    return this.edit({ premiumProgressBarEnabled: enabled, reason });
   }
 
   /**

--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -264,8 +264,7 @@ class GuildChannel extends Channel {
 
   /**
    * Edits the channel.
-   * @param {ChannelData} data The new data for the channel
-   * @param {string} [reason] Reason for editing this channel
+   * @param {ChannelEditData} data The new data for the channel
    * @returns {Promise<GuildChannel>}
    * @example
    * // Edit a channel
@@ -273,8 +272,8 @@ class GuildChannel extends Channel {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  edit(data, reason) {
-    return this.guild.channels.edit(this, data, reason);
+  edit(data) {
+    return this.guild.channels.edit(this, data);
   }
 
   /**
@@ -289,7 +288,7 @@ class GuildChannel extends Channel {
    *   .catch(console.error);
    */
   setName(name, reason) {
-    return this.edit({ name }, reason);
+    return this.edit({ name, reason });
   }
 
   /**
@@ -311,13 +310,11 @@ class GuildChannel extends Channel {
    *   .catch(console.error);
    */
   setParent(channel, { lockPermissions = true, reason } = {}) {
-    return this.edit(
-      {
-        parent: channel ?? null,
-        lockPermissions,
-      },
+    return this.edit({
+      parent: channel ?? null,
+      lockPermissions,
       reason,
-    );
+    });
   }
 
   /**

--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -351,7 +351,8 @@ class GuildChannel extends Channel {
    * @returns {Promise<GuildChannel>}
    */
   clone(options = {}) {
-    return this.guild.channels.create(options.name ?? this.name, {
+    return this.guild.channels.create({
+      name: options.name ?? this.name,
       permissionOverwrites: this.permissionOverwrites.cache,
       topic: this.topic,
       type: this.type,

--- a/packages/discord.js/src/structures/GuildEmoji.js
+++ b/packages/discord.js/src/structures/GuildEmoji.js
@@ -81,12 +81,12 @@ class GuildEmoji extends BaseGuildEmoji {
    * @typedef {Object} GuildEmojiEditData
    * @property {string} [name] The name of the emoji
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] Roles to restrict emoji to
+   * @property {string} [reason] Reason for editing this emoji
    */
 
   /**
    * Edits the emoji.
    * @param {GuildEmojiEditData} data The new data for the emoji
-   * @param {string} [reason] Reason for editing this emoji
    * @returns {Promise<GuildEmoji>}
    * @example
    * // Edit an emoji
@@ -94,8 +94,8 @@ class GuildEmoji extends BaseGuildEmoji {
    *   .then(e => console.log(`Edited emoji ${e}`))
    *   .catch(console.error);
    */
-  edit(data, reason) {
-    return this.guild.emojis.edit(this.id, data, reason);
+  edit(data) {
+    return this.guild.emojis.edit(this.id, data);
   }
 
   /**
@@ -105,7 +105,7 @@ class GuildEmoji extends BaseGuildEmoji {
    * @returns {Promise<GuildEmoji>}
    */
   setName(name, reason) {
-    return this.edit({ name }, reason);
+    return this.edit({ name, reason });
   }
 
   /**

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -299,11 +299,10 @@ class GuildMember extends Base {
   /**
    * Edits this member.
    * @param {GuildMemberEditData} data The data to edit the member with
-   * @param {string} [reason] Reason for editing this user
    * @returns {Promise<GuildMember>}
    */
-  edit(data, reason) {
-    return this.guild.members.edit(this, data, reason);
+  edit(data) {
+    return this.guild.members.edit(this, data);
   }
 
   /**
@@ -313,7 +312,7 @@ class GuildMember extends Base {
    * @returns {Promise<GuildMember>}
    */
   setNickname(nick, reason) {
-    return this.edit({ nick }, reason);
+    return this.edit({ nick, reason });
   }
 
   /**
@@ -369,7 +368,7 @@ class GuildMember extends Base {
    *   .catch(console.error);
    */
   disableCommunicationUntil(communicationDisabledUntil, reason) {
-    return this.edit({ communicationDisabledUntil }, reason);
+    return this.edit({ communicationDisabledUntil, reason });
   }
 
   /**

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -217,7 +217,7 @@ class Role extends Base {
    *   .catch(console.error);
    */
   edit(data, reason) {
-    return this.guild.roles.edit(this, data, reason);
+    return this.guild.roles.edit(this, { ...data, reason });
   }
 
   /**
@@ -245,7 +245,7 @@ class Role extends Base {
    *   .catch(console.error);
    */
   setName(name, reason) {
-    return this.edit({ name }, reason);
+    return this.edit({ name, reason });
   }
 
   /**
@@ -260,7 +260,7 @@ class Role extends Base {
    *   .catch(console.error);
    */
   setColor(color, reason) {
-    return this.edit({ color }, reason);
+    return this.edit({ color, reason });
   }
 
   /**
@@ -275,7 +275,7 @@ class Role extends Base {
    *   .catch(console.error);
    */
   setHoist(hoist = true, reason) {
-    return this.edit({ hoist }, reason);
+    return this.edit({ hoist, reason });
   }
 
   /**
@@ -295,7 +295,7 @@ class Role extends Base {
    *   .catch(console.error);
    */
   setPermissions(permissions, reason) {
-    return this.edit({ permissions }, reason);
+    return this.edit({ permissions, reason });
   }
 
   /**
@@ -310,7 +310,7 @@ class Role extends Base {
    *   .catch(console.error);
    */
   setMentionable(mentionable = true, reason) {
-    return this.edit({ mentionable }, reason);
+    return this.edit({ mentionable, reason });
   }
 
   /**
@@ -322,7 +322,7 @@ class Role extends Base {
    * @returns {Promise<Role>}
    */
   setIcon(icon, reason) {
-    return this.edit({ icon }, reason);
+    return this.edit({ icon, reason });
   }
 
   /**
@@ -337,7 +337,7 @@ class Role extends Base {
    *   .catch(console.error);
    */
   setUnicodeEmoji(unicodeEmoji, reason) {
-    return this.edit({ unicodeEmoji }, reason);
+    return this.edit({ unicodeEmoji, reason });
   }
 
   /**

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -207,8 +207,7 @@ class Role extends Base {
 
   /**
    * Edits the role.
-   * @param {RoleData} data The new data for the role
-   * @param {string} [reason] Reason for editing this role
+   * @param {EditRoleOptions} data The new data for the role
    * @returns {Promise<Role>}
    * @example
    * // Edit a role
@@ -216,8 +215,8 @@ class Role extends Base {
    *   .then(updated => console.log(`Edited role name to ${updated.name}`))
    *   .catch(console.error);
    */
-  edit(data, reason) {
-    return this.guild.roles.edit(this, { ...data, reason });
+  edit(data) {
+    return this.guild.roles.edit(this, data);
   }
 
   /**

--- a/packages/discord.js/src/structures/StageChannel.js
+++ b/packages/discord.js/src/structures/StageChannel.js
@@ -49,7 +49,7 @@ class StageChannel extends BaseGuildVoiceChannel {
    *   .catch(console.error);
    */
   setTopic(topic, reason) {
-    return this.edit({ topic }, reason);
+    return this.edit({ topic, reason });
   }
 
   /**

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -200,12 +200,12 @@ class Sticker extends Base {
    * @property {string} [name] The name of the sticker
    * @property {?string} [description] The description of the sticker
    * @property {string} [tags] The Discord name of a unicode emoji representing the sticker's expression
+   * @property {string} [reason] Reason for editing this sticker
    */
 
   /**
    * Edits the sticker.
    * @param {GuildStickerEditData} [data] The new data for the sticker
-   * @param {string} [reason] Reason for editing this sticker
    * @returns {Promise<Sticker>}
    * @example
    * // Update the name of a sticker
@@ -213,8 +213,8 @@ class Sticker extends Base {
    *   .then(s => console.log(`Updated the name of the sticker to ${s.name}`))
    *   .catch(console.error);
    */
-  edit(data, reason) {
-    return this.guild.stickers.edit(this, data, reason);
+  edit(data) {
+    return this.guild.stickers.edit(this, data);
   }
 
   /**

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -205,7 +205,7 @@ class Sticker extends Base {
 
   /**
    * Edits the sticker.
-   * @param {GuildStickerEditData} [data] The new data for the sticker
+   * @param {GuildStickerEditData} data The new data for the sticker
    * @returns {Promise<Sticker>}
    * @example
    * // Update the name of a sticker

--- a/packages/discord.js/src/structures/TextChannel.js
+++ b/packages/discord.js/src/structures/TextChannel.js
@@ -26,7 +26,7 @@ class TextChannel extends BaseGuildTextChannel {
    * @returns {Promise<TextChannel>}
    */
   setRateLimitPerUser(rateLimitPerUser, reason) {
-    return this.edit({ rateLimitPerUser }, reason);
+    return this.edit({ rateLimitPerUser, reason });
   }
 }
 

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -297,13 +297,13 @@ class ThreadChannel extends Channel {
    * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the thread in seconds
    * @property {boolean} [locked] Whether the thread is locked
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to a thread
+   * @property {string} [reason] Reason for editing the thread
    * <info>Can only be edited on {@link ChannelType.GuildPrivateThread}</info>
    */
 
   /**
    * Edits this thread.
    * @param {ThreadEditData} data The new data for this thread
-   * @param {string} [reason] Reason for editing this thread
    * @returns {Promise<ThreadChannel>}
    * @example
    * // Edit a thread
@@ -311,7 +311,7 @@ class ThreadChannel extends Channel {
    *   .then(editedThread => console.log(editedThread))
    *   .catch(console.error);
    */
-  async edit(data, reason) {
+  async edit(data) {
     const newData = await this.client.rest.patch(Routes.channel(this.id), {
       body: {
         name: (data.name ?? this.name).trim(),
@@ -321,7 +321,7 @@ class ThreadChannel extends Channel {
         locked: data.locked,
         invitable: this.type === ChannelType.GuildPrivateThread ? data.invitable : undefined,
       },
-      reason,
+      reason: data.reason,
     });
 
     return this.client.actions.ChannelUpdate.handle(newData).updated;
@@ -339,7 +339,7 @@ class ThreadChannel extends Channel {
    *   .catch(console.error);
    */
   setArchived(archived = true, reason) {
-    return this.edit({ archived }, reason);
+    return this.edit({ archived, reason });
   }
 
   /**
@@ -357,7 +357,7 @@ class ThreadChannel extends Channel {
    *   .catch(console.error);
    */
   setAutoArchiveDuration(autoArchiveDuration, reason) {
-    return this.edit({ autoArchiveDuration }, reason);
+    return this.edit({ autoArchiveDuration, reason });
   }
 
   /**
@@ -371,7 +371,7 @@ class ThreadChannel extends Channel {
     if (this.type !== ChannelType.GuildPrivateThread) {
       return Promise.reject(new RangeError('THREAD_INVITABLE_TYPE', this.type));
     }
-    return this.edit({ invitable }, reason);
+    return this.edit({ invitable, reason });
   }
 
   /**
@@ -387,7 +387,7 @@ class ThreadChannel extends Channel {
    *   .catch(console.error);
    */
   setLocked(locked = true, reason) {
-    return this.edit({ locked }, reason);
+    return this.edit({ locked, reason });
   }
 
   /**
@@ -402,7 +402,7 @@ class ThreadChannel extends Channel {
    *   .catch(console.error);
    */
   setName(name, reason) {
-    return this.edit({ name }, reason);
+    return this.edit({ name, reason });
   }
 
   /**
@@ -412,7 +412,7 @@ class ThreadChannel extends Channel {
    * @returns {Promise<ThreadChannel>}
    */
   setRateLimitPerUser(rateLimitPerUser, reason) {
-    return this.edit({ rateLimitPerUser }, reason);
+    return this.edit({ rateLimitPerUser, reason });
   }
 
   /**

--- a/packages/discord.js/src/structures/VoiceChannel.js
+++ b/packages/discord.js/src/structures/VoiceChannel.js
@@ -97,7 +97,7 @@ class VoiceChannel extends BaseGuildVoiceChannel {
    *   .catch(console.error);
    */
   setBitrate(bitrate, reason) {
-    return this.edit({ bitrate }, reason);
+    return this.edit({ bitrate, reason });
   }
 
   /**
@@ -112,7 +112,7 @@ class VoiceChannel extends BaseGuildVoiceChannel {
    *   .catch(console.error);
    */
   setUserLimit(userLimit, reason) {
-    return this.edit({ userLimit }, reason);
+    return this.edit({ userLimit, reason });
   }
 
   /**
@@ -122,7 +122,7 @@ class VoiceChannel extends BaseGuildVoiceChannel {
    * @returns {Promise<VoiceChannel>}
    */
   setVideoQualityMode(videoQualityMode, reason) {
-    return this.edit({ videoQualityMode }, reason);
+    return this.edit({ videoQualityMode, reason });
   }
 
   // These are here only for documentation purposes - they are implemented by TextBasedChannel

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -172,7 +172,7 @@ class VoiceState extends Base {
    * @returns {Promise<GuildMember>}
    */
   setMute(mute = true, reason) {
-    return this.guild.members.edit(this.id, { mute }, reason);
+    return this.guild.members.edit(this.id, { mute, reason });
   }
 
   /**
@@ -182,7 +182,7 @@ class VoiceState extends Base {
    * @returns {Promise<GuildMember>}
    */
   setDeaf(deaf = true, reason) {
-    return this.guild.members.edit(this.id, { deaf }, reason);
+    return this.guild.members.edit(this.id, { deaf, reason });
   }
 
   /**
@@ -202,7 +202,7 @@ class VoiceState extends Base {
    * @returns {Promise<GuildMember>}
    */
   setChannel(channel, reason) {
-    return this.guild.members.edit(this.id, { channel }, reason);
+    return this.guild.members.edit(this.id, { channel, reason });
   }
 
   /**

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -249,15 +249,15 @@ class Webhook {
    * @property {string} [name=this.name] The new name for the webhook
    * @property {?(BufferResolvable)} [avatar] The new avatar for the webhook
    * @property {GuildTextChannelResolvable} [channel] The new channel for the webhook
+   * @property {string} [reason] Reason for editing the webhook
    */
 
   /**
    * Edits this webhook.
    * @param {WebhookEditData} options Options for editing the webhook
-   * @param {string} [reason] Reason for editing the webhook
    * @returns {Promise<Webhook>}
    */
-  async edit({ name = this.name, avatar, channel }, reason) {
+  async edit({ name = this.name, avatar, channel, reason }) {
     if (avatar && !(typeof avatar === 'string' && avatar.startsWith('data:'))) {
       avatar = await DataResolver.resolveImage(avatar);
     }

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -374,7 +374,7 @@ class TextBasedChannel {
    * @returns {Promise<this>}
    */
   setRateLimitPerUser(rateLimitPerUser, reason) {
-    return this.edit({ rateLimitPerUser }, reason);
+    return this.edit({ rateLimitPerUser, reason });
   }
 
   /**
@@ -384,7 +384,7 @@ class TextBasedChannel {
    * @returns {Promise<this>}
    */
   setNSFW(nsfw = true, reason) {
-    return this.edit({ nsfw }, reason);
+    return this.edit({ nsfw, reason });
   }
 
   static applyToClass(structure, full = false, ignore = []) {

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -345,6 +345,8 @@ class TextBasedChannel {
   /**
    * Options used to create a {@link Webhook} in a {@link TextChannel} or a {@link NewsChannel}.
    * @typedef {Object} ChannelWebhookCreateOptions
+   * @property {GuildChannelResolvable} channel The channel to create the webhook for
+   * @property {string} name The name of the webhook
    * @property {?(BufferResolvable|Base64Resolvable)} [avatar] Avatar for the webhook
    * @property {string} [reason] Reason for creating the webhook
    */

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -345,7 +345,6 @@ class TextBasedChannel {
   /**
    * Options used to create a {@link Webhook} in a {@link TextChannel} or a {@link NewsChannel}.
    * @typedef {Object} ChannelWebhookCreateOptions
-   * @property {GuildChannelResolvable} channel The channel to create the webhook for
    * @property {string} name The name of the webhook
    * @property {?(BufferResolvable|Base64Resolvable)} [avatar] Avatar for the webhook
    * @property {string} [reason] Reason for creating the webhook
@@ -365,7 +364,7 @@ class TextBasedChannel {
    *   .catch(console.error)
    */
   createWebhook(options) {
-    return this.guild.channels.createWebhook(this.id, options);
+    return this.guild.channels.createWebhook({ channel: this.id, ...options });
   }
 
   /**

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -353,7 +353,6 @@ class TextBasedChannel {
 
   /**
    * Creates a webhook for the channel.
-   * @param {string} name The name of the webhook
    * @param {ChannelWebhookCreateOptions} [options] Options for creating the webhook
    * @returns {Promise<Webhook>} Returns the created Webhook
    * @example
@@ -365,8 +364,8 @@ class TextBasedChannel {
    *   .then(console.log)
    *   .catch(console.error)
    */
-  createWebhook(name, options = {}) {
-    return this.guild.channels.createWebhook(this.id, name, options);
+  createWebhook(options) {
+    return this.guild.channels.createWebhook(this.id, options);
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1120,7 +1120,7 @@ export class Guild extends AnonymousGuild {
   public createTemplate(name: string, description?: string): Promise<GuildTemplate>;
   public delete(): Promise<Guild>;
   public discoverySplashURL(options?: ImageURLOptions): string | null;
-  public edit(data: GuildEditData, reason?: string): Promise<Guild>;
+  public edit(data: GuildEditData): Promise<Guild>;
   public editWelcomeScreen(data: WelcomeScreenEditData): Promise<WelcomeScreen>;
   public equals(guild: Guild): boolean;
   public fetchAuditLogs<T extends GuildAuditLogsResolvable = null>(
@@ -1237,7 +1237,7 @@ export abstract class GuildChannel extends Channel {
   public get viewable(): boolean;
   public clone(options?: GuildChannelCloneOptions): Promise<this>;
   public delete(reason?: string): Promise<this>;
-  public edit(data: ChannelData, reason?: string): Promise<this>;
+  public edit(data: ChannelEditData): Promise<this>;
   public equals(channel: GuildChannel): boolean;
   public lockPermissions(): Promise<this>;
   public permissionsFor(memberOrRole: GuildMember | Role, checkAdmin?: boolean): Readonly<PermissionsBitField>;
@@ -1262,7 +1262,7 @@ export class GuildEmoji extends BaseGuildEmoji {
   public get roles(): GuildEmojiRoleManager;
   public get url(): string;
   public delete(reason?: string): Promise<GuildEmoji>;
-  public edit(data: GuildEmojiEditData, reason?: string): Promise<GuildEmoji>;
+  public edit(data: GuildEmojiEditData): Promise<GuildEmoji>;
   public equals(other: GuildEmoji | unknown): boolean;
   public fetchAuthor(): Promise<User>;
   public setName(name: string, reason?: string): Promise<GuildEmoji>;
@@ -1302,7 +1302,7 @@ export class GuildMember extends PartialTextBasedChannel(Base) {
   public createDM(force?: boolean): Promise<DMChannel>;
   public deleteDM(): Promise<DMChannel>;
   public displayAvatarURL(options?: ImageURLOptions): string;
-  public edit(data: GuildMemberEditData, reason?: string): Promise<GuildMember>;
+  public edit(data: GuildMemberEditData): Promise<GuildMember>;
   public isCommunicationDisabled(): this is GuildMember & {
     communicationDisabledUntilTimestamp: number;
     readonly communicationDisabledUntil: Date;
@@ -2121,7 +2121,7 @@ export class Role extends Base {
   public icon: string | null;
   public unicodeEmoji: string | null;
   public delete(reason?: string): Promise<Role>;
-  public edit(data: RoleData, reason?: string): Promise<Role>;
+  public edit(data: EditRoleOptions): Promise<Role>;
   public equals(role: Role): boolean;
   public iconURL(options?: ImageURLOptions): string | null;
   public permissionsIn(
@@ -2335,7 +2335,7 @@ export class Sticker extends Base {
   public fetch(): Promise<Sticker>;
   public fetchPack(): Promise<StickerPack | null>;
   public fetchUser(): Promise<User | null>;
-  public edit(data?: GuildStickerEditData, reason?: string): Promise<Sticker>;
+  public edit(data?: GuildStickerEditData): Promise<Sticker>;
   public delete(reason?: string): Promise<Sticker>;
   public equals(other: Sticker | unknown): boolean;
 }
@@ -2500,7 +2500,7 @@ export class ThreadChannel extends TextBasedChannelMixin(Channel, ['fetchWebhook
   public type: ThreadChannelType;
   public get unarchivable(): boolean;
   public delete(reason?: string): Promise<this>;
-  public edit(data: ThreadEditData, reason?: string): Promise<AnyThreadChannel>;
+  public edit(data: ThreadEditData): Promise<AnyThreadChannel>;
   public join(): Promise<AnyThreadChannel>;
   public leave(): Promise<AnyThreadChannel>;
   public permissionsFor(memberOrRole: GuildMember | Role, checkAdmin?: boolean): Readonly<PermissionsBitField>;
@@ -3105,10 +3105,9 @@ export class CategoryChannelChildManager extends DataManager<
   public channel: CategoryChannel;
   public get guild(): Guild;
   public create<T extends CategoryChannelType>(
-    name: string,
     options: CategoryCreateChannelOptions & { type: T },
   ): Promise<MappedChannelCategoryTypes[T]>;
-  public create(name: string, options?: CategoryCreateChannelOptions): Promise<TextChannel>;
+  public create(options: CategoryCreateChannelOptions): Promise<TextChannel>;
 }
 
 export class ChannelManager extends CachedManager<Snowflake, AnyChannel, ChannelResolvable> {
@@ -3148,16 +3147,11 @@ export class GuildChannelManager extends CachedManager<Snowflake, GuildBasedChan
   public guild: Guild;
 
   public create<T extends GuildChannelTypes>(
-    name: string,
     options: GuildChannelCreateOptions & { type: T },
   ): Promise<MappedGuildChannelTypes[T]>;
-  public create(name: string, options?: GuildChannelCreateOptions): Promise<TextChannel>;
-  public createWebhook(
-    channel: GuildChannelResolvable,
-    name: string,
-    options?: ChannelWebhookCreateOptions,
-  ): Promise<Webhook>;
-  public edit(channel: GuildChannelResolvable, data: ChannelData, reason?: string): Promise<GuildChannel>;
+  public create(options: GuildChannelCreateOptions): Promise<TextChannel>;
+  public createWebhook(options: ChannelWebhookCreateOptions): Promise<Webhook>;
+  public edit(channel: GuildChannelResolvable, data: ChannelEditData): Promise<GuildChannel>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<NonThreadGuildBasedChannel | null>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, NonThreadGuildBasedChannel>>;
   public fetchWebhooks(channel: GuildChannelResolvable): Promise<Collection<Snowflake, Webhook>>;
@@ -3183,7 +3177,7 @@ export class GuildEmojiManager extends BaseGuildEmojiManager {
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, GuildEmoji>>;
   public fetchAuthor(emoji: EmojiResolvable): Promise<User>;
   public delete(emoji: EmojiResolvable, reason?: string): Promise<void>;
-  public edit(emoji: EmojiResolvable, data: GuildEmojiEditData, reason?: string): Promise<GuildEmoji>;
+  public edit(emoji: EmojiResolvable, data: GuildEmojiEditData): Promise<GuildEmoji>;
 }
 
 export class GuildEmojiRoleManager extends DataManager<Snowflake, Role, RoleResolvable> {
@@ -3201,7 +3195,7 @@ export class GuildEmojiRoleManager extends DataManager<Snowflake, Role, RoleReso
 
 export class GuildManager extends CachedManager<Snowflake, Guild, GuildResolvable> {
   private constructor(client: Client, iterable?: Iterable<RawGuildData>);
-  public create(name: string, options?: GuildCreateOptions): Promise<Guild>;
+  public create(options: GuildCreateOptions): Promise<Guild>;
   public fetch(options: Snowflake | FetchGuildOptions): Promise<Guild>;
   public fetch(options?: FetchGuildsOptions): Promise<Collection<Snowflake, OAuth2Guild>>;
 }
@@ -3216,7 +3210,7 @@ export class GuildMemberManager extends CachedManager<Snowflake, GuildMember, Gu
   ): Promise<GuildMember | null>;
   public add(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
   public ban(user: UserResolvable, options?: BanOptions): Promise<GuildMember | User | Snowflake>;
-  public edit(user: UserResolvable, data: GuildMemberEditData, reason?: string): Promise<void>;
+  public edit(user: UserResolvable, data: GuildMemberEditData): Promise<void>;
   public fetch(
     options: UserResolvable | FetchMemberOptions | (FetchMembersOptions & { user: UserResolvable }),
   ): Promise<GuildMember>;
@@ -3279,7 +3273,7 @@ export class GuildStickerManager extends CachedManager<Snowflake, Sticker, Stick
     tags: string,
     options?: GuildStickerCreateOptions,
   ): Promise<Sticker>;
-  public edit(sticker: StickerResolvable, data?: GuildStickerEditData, reason?: string): Promise<Sticker>;
+  public edit(sticker: StickerResolvable, data?: GuildStickerEditData): Promise<Sticker>;
   public delete(sticker: StickerResolvable, reason?: string): Promise<void>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<Sticker>;
   public fetch(id?: Snowflake, options?: BaseFetchOptions): Promise<Collection<Snowflake, Sticker>>;
@@ -3378,7 +3372,7 @@ export class RoleManager extends CachedManager<Snowflake, Role, RoleResolvable> 
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<Role | null>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, Role>>;
   public create(options?: CreateRoleOptions): Promise<Role>;
-  public edit(role: RoleResolvable, options: RoleData, reason?: string): Promise<Role>;
+  public edit(role: RoleResolvable, options: EditRoleOptions): Promise<Role>;
   public delete(role: RoleResolvable, reason?: string): Promise<void>;
   public setPosition(role: RoleResolvable, position: number, options?: SetRolePositionOptions): Promise<Role>;
   public setPositions(rolePositions: readonly RolePosition[]): Promise<Guild>;
@@ -3467,7 +3461,7 @@ export interface TextBasedChannelFields extends PartialTextBasedChannelFields {
     options?: MessageChannelCollectorOptionsParams<T, true>,
   ): InteractionCollector<MappedInteractionTypes[T]>;
   createMessageCollector(options?: MessageCollectorOptions): MessageCollector;
-  createWebhook(name: string, options?: ChannelWebhookCreateOptions): Promise<Webhook>;
+  createWebhook(options: ChannelWebhookCreateOptions): Promise<Webhook>;
   fetchWebhooks(): Promise<Collection<Snowflake, Webhook>>;
   sendTyping(): Promise<void>;
   setRateLimitPerUser(rateLimitPerUser: number, reason?: string): Promise<this>;
@@ -3493,7 +3487,7 @@ export interface WebhookFields extends PartialWebhookFields {
   get createdAt(): Date;
   get createdTimestamp(): number;
   delete(reason?: string): Promise<void>;
-  edit(options: WebhookEditData, reason?: string): Promise<Webhook>;
+  edit(options: WebhookEditData): Promise<Webhook>;
   sendSlackMessage(body: unknown): Promise<boolean>;
 }
 
@@ -3807,6 +3801,7 @@ export type CacheWithLimitsOptions = {
 };
 
 export interface CategoryCreateChannelOptions {
+  name: string;
   permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
   topic?: string;
   type?: CategoryChannelType;
@@ -3843,6 +3838,10 @@ export interface ChannelData {
   videoQualityMode?: VideoQualityMode | null;
 }
 
+export interface ChannelEditData extends ChannelData {
+  reason?: string;
+}
+
 export type ChannelMention = `<#${Snowflake}>`;
 
 export interface ChannelPosition {
@@ -3856,6 +3855,8 @@ export type GuildTextChannelResolvable = TextChannel | NewsChannel | Snowflake;
 export type ChannelResolvable = AnyChannel | Snowflake;
 
 export interface ChannelWebhookCreateOptions {
+  channel: GuildChannelResolvable;
+  name: string;
   avatar?: BufferResolvable | Base64Resolvable | null;
   reason?: string;
 }
@@ -4159,6 +4160,10 @@ export interface CreateGuildScheduledEventInviteURLOptions extends CreateInviteO
 }
 
 export interface CreateRoleOptions extends RoleData {
+  reason?: string;
+}
+
+export interface EditRoleOptions extends RoleData {
   reason?: string;
 }
 
@@ -4467,9 +4472,7 @@ export interface GuildChannelCreateOptions extends Omit<CategoryCreateChannelOpt
   >;
 }
 
-export interface GuildChannelCloneOptions extends GuildChannelCreateOptions {
-  name?: string;
-}
+export interface GuildChannelCloneOptions extends GuildChannelCreateOptions {}
 
 export interface GuildChannelOverwriteOptions {
   reason?: string;
@@ -4477,6 +4480,7 @@ export interface GuildChannelOverwriteOptions {
 }
 
 export interface GuildCreateOptions {
+  name: string;
   afkChannelId?: Snowflake | number;
   afkTimeout?: number;
   channels?: PartialChannelData[];
@@ -4514,6 +4518,7 @@ export interface GuildEditData {
   premiumProgressBarEnabled?: boolean;
   description?: string | null;
   features?: GuildFeature[];
+  reason?: string;
 }
 
 export interface GuildEmojiCreateOptions {
@@ -4524,6 +4529,7 @@ export interface GuildEmojiCreateOptions {
 export interface GuildEmojiEditData {
   name?: string;
   roles?: Collection<Snowflake, Role> | RoleResolvable[];
+  reason?: string;
 }
 
 export interface GuildStickerCreateOptions {
@@ -4535,6 +4541,7 @@ export interface GuildStickerEditData {
   name?: string;
   description?: string | null;
   tags?: string;
+  reason?: string;
 }
 
 export interface GuildMemberEditData {
@@ -4544,6 +4551,7 @@ export interface GuildMemberEditData {
   deaf?: boolean;
   channel?: GuildVoiceChannelResolvable | null;
   communicationDisabledUntil?: DateResolvable | null;
+  reason?: string;
 }
 
 export type GuildMemberResolvable = GuildMember | UserResolvable;
@@ -5214,6 +5222,7 @@ export interface ThreadEditData {
   rateLimitPerUser?: number;
   locked?: boolean;
   invitable?: boolean;
+  reason?: string;
 }
 
 export type ThreadMemberResolvable = ThreadMember | UserResolvable;
@@ -5253,6 +5262,7 @@ export interface WebhookEditData {
   name?: string;
   avatar?: BufferResolvable | null;
   channel?: GuildTextChannelResolvable;
+  reason?: string;
 }
 
 export type WebhookEditMessageOptions = Pick<

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1235,7 +1235,7 @@ export abstract class GuildChannel extends Channel {
   public rawPosition: number;
   public type: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM>;
   public get viewable(): boolean;
-  public clone(options?: GuildChannelCreateOptions): Promise<this>;
+  public clone(options?: GuildChannelCloneOptions): Promise<this>;
   public delete(reason?: string): Promise<this>;
   public edit(data: ChannelEditData): Promise<this>;
   public equals(channel: GuildChannel): boolean;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3150,7 +3150,7 @@ export class GuildChannelManager extends CachedManager<Snowflake, GuildBasedChan
     options: GuildChannelCreateOptions & { type: T },
   ): Promise<MappedGuildChannelTypes[T]>;
   public create(options: GuildChannelCreateOptions): Promise<TextChannel>;
-  public createWebhook(options: ChannelWebhookCreateOptions): Promise<Webhook>;
+  public createWebhook(options: WebhookCreateOptions): Promise<Webhook>;
   public edit(channel: GuildChannelResolvable, data: ChannelEditData): Promise<GuildChannel>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<NonThreadGuildBasedChannel | null>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, NonThreadGuildBasedChannel>>;
@@ -3855,10 +3855,13 @@ export type GuildTextChannelResolvable = TextChannel | NewsChannel | Snowflake;
 export type ChannelResolvable = AnyChannel | Snowflake;
 
 export interface ChannelWebhookCreateOptions {
-  channel: GuildChannelResolvable;
   name: string;
   avatar?: BufferResolvable | Base64Resolvable | null;
   reason?: string;
+}
+
+export interface WebhookCreateOptions extends ChannelWebhookCreateOptions {
+  channel: GuildChannelResolvable;
 }
 
 export interface ClientEvents {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3168,11 +3168,7 @@ export class GuildChannelManager extends CachedManager<Snowflake, GuildBasedChan
 export class GuildEmojiManager extends BaseGuildEmojiManager {
   private constructor(guild: Guild, iterable?: Iterable<RawGuildEmojiData>);
   public guild: Guild;
-  public create(
-    attachment: BufferResolvable | Base64Resolvable,
-    name: string,
-    options?: GuildEmojiCreateOptions,
-  ): Promise<GuildEmoji>;
+  public create(options: GuildEmojiCreateOptions): Promise<GuildEmoji>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<GuildEmoji>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, GuildEmoji>>;
   public fetchAuthor(emoji: EmojiResolvable): Promise<User>;
@@ -3267,12 +3263,7 @@ export class GuildScheduledEventManager extends CachedManager<
 export class GuildStickerManager extends CachedManager<Snowflake, Sticker, StickerResolvable> {
   private constructor(guild: Guild, iterable?: Iterable<RawStickerData>);
   public guild: Guild;
-  public create(
-    file: BufferResolvable | Stream | AttachmentPayload | JSONEncodable<AttachmentBuilder>,
-    name: string,
-    tags: string,
-    options?: GuildStickerCreateOptions,
-  ): Promise<Sticker>;
+  public create(options: GuildStickerCreateOptions): Promise<Sticker>;
   public edit(sticker: StickerResolvable, data?: GuildStickerEditData): Promise<Sticker>;
   public delete(sticker: StickerResolvable, reason?: string): Promise<void>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<Sticker>;
@@ -4527,6 +4518,8 @@ export interface GuildEditData {
 }
 
 export interface GuildEmojiCreateOptions {
+  attachment: BufferResolvable | Base64Resolvable;
+  name: string;
   roles?: Collection<Snowflake, Role> | RoleResolvable[];
   reason?: string;
 }
@@ -4538,6 +4531,9 @@ export interface GuildEmojiEditData {
 }
 
 export interface GuildStickerCreateOptions {
+  file: BufferResolvable | Stream | AttachmentPayload | JSONEncodable<AttachmentBuilder>;
+  name: string;
+  tags: string;
   description?: string | null;
   reason?: string;
 }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1235,7 +1235,7 @@ export abstract class GuildChannel extends Channel {
   public rawPosition: number;
   public type: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM>;
   public get viewable(): boolean;
-  public clone(options?: GuildChannelCloneOptions): Promise<this>;
+  public clone(options?: GuildChannelCreateOptions): Promise<this>;
   public delete(reason?: string): Promise<this>;
   public edit(data: ChannelEditData): Promise<this>;
   public equals(channel: GuildChannel): boolean;
@@ -4471,8 +4471,6 @@ export interface GuildChannelCreateOptions extends Omit<CategoryCreateChannelOpt
     | ChannelType.GuildPrivateThread
   >;
 }
-
-export interface GuildChannelCloneOptions extends GuildChannelCreateOptions {}
 
 export interface GuildChannelOverwriteOptions {
   reason?: string;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4472,6 +4472,10 @@ export interface GuildChannelCreateOptions extends Omit<CategoryCreateChannelOpt
   >;
 }
 
+export interface GuildChannelCloneOptions extends Omit<GuildChannelCreateOptions, 'name'> {
+  name?: string;
+}
+
 export interface GuildChannelOverwriteOptions {
   reason?: string;
   type?: number;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1045,25 +1045,27 @@ expectType<Promise<ApplicationCommand>>(guildApplicationCommandManager.fetch('0'
 
 declare const categoryChannelChildManager: CategoryChannelChildManager;
 {
-  expectType<Promise<VoiceChannel>>(categoryChannelChildManager.create('name', { type: ChannelType.GuildVoice }));
-  expectType<Promise<TextChannel>>(categoryChannelChildManager.create('name', { type: ChannelType.GuildText }));
-  expectType<Promise<NewsChannel>>(categoryChannelChildManager.create('name', { type: ChannelType.GuildNews }));
-  expectType<Promise<StageChannel>>(categoryChannelChildManager.create('name', { type: ChannelType.GuildStageVoice }));
-  expectType<Promise<TextChannel>>(categoryChannelChildManager.create('name', {}));
-  expectType<Promise<TextChannel>>(categoryChannelChildManager.create('name'));
+  expectType<Promise<VoiceChannel>>(categoryChannelChildManager.create({ name: 'name', type: ChannelType.GuildVoice }));
+  expectType<Promise<TextChannel>>(categoryChannelChildManager.create({ name: 'name', type: ChannelType.GuildText }));
+  expectType<Promise<NewsChannel>>(categoryChannelChildManager.create({ name: 'name', type: ChannelType.GuildNews }));
+  expectType<Promise<StageChannel>>(
+    categoryChannelChildManager.create({ name: 'name', type: ChannelType.GuildStageVoice }),
+  );
+  expectType<Promise<TextChannel>>(categoryChannelChildManager.create({ name: 'name' }));
+  expectType<Promise<TextChannel>>(categoryChannelChildManager.create({ name: 'name' }));
 }
 
 declare const guildChannelManager: GuildChannelManager;
 {
   type AnyChannel = TextChannel | VoiceChannel | CategoryChannel | NewsChannel | StageChannel;
 
-  expectType<Promise<TextChannel>>(guildChannelManager.create('name'));
-  expectType<Promise<TextChannel>>(guildChannelManager.create('name', {}));
-  expectType<Promise<VoiceChannel>>(guildChannelManager.create('name', { type: ChannelType.GuildVoice }));
-  expectType<Promise<CategoryChannel>>(guildChannelManager.create('name', { type: ChannelType.GuildCategory }));
-  expectType<Promise<TextChannel>>(guildChannelManager.create('name', { type: ChannelType.GuildText }));
-  expectType<Promise<NewsChannel>>(guildChannelManager.create('name', { type: ChannelType.GuildNews }));
-  expectType<Promise<StageChannel>>(guildChannelManager.create('name', { type: ChannelType.GuildStageVoice }));
+  expectType<Promise<TextChannel>>(guildChannelManager.create({ name: 'name' }));
+  expectType<Promise<TextChannel>>(guildChannelManager.create({ name: 'name' }));
+  expectType<Promise<VoiceChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildVoice }));
+  expectType<Promise<CategoryChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildCategory }));
+  expectType<Promise<TextChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildText }));
+  expectType<Promise<NewsChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildNews }));
+  expectType<Promise<StageChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildStageVoice }));
 
   expectType<Promise<Collection<Snowflake, AnyChannel>>>(guildChannelManager.fetch());
   expectType<Promise<Collection<Snowflake, AnyChannel>>>(guildChannelManager.fetch(undefined, {}));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Another (hopefully) more complete take on #7448

# List of breaking changes for our guide folk™️:
- `Guild#edit` now takes `reason` in the `data` parameter
- `GuildChannel#edit` now takes `reason` in the `data` parameter
- `GuildEmoji#edit` now takes `reason` in the `data` parameter
- `Role#edit` now takes `reason` in the `data` parameter
- `Sticker#edit` now takes `reason` in the `data` parameter
- `ThreadChannel#edit` now takes `reason` in the `data` parameter
- `ThreadChannel#create` now takes `name` in the `options` parameter
- `GuildChannelManager#create` now takes `name` in the `options` parameter
- `GuildChannelManager#createWebhook` now takes `channel` and `name` in the `options` parameter
- `GuildChannelManager#edit` now takes `reason` as a part of `data`
- `GuildEmojiManager#edit` now takes `reason` as a part of `data`
- `GuildManager#create` now takes `name` as a part of `options`
- `GuildMemberManager#edit` now takes `reason` as a part of `data`
- `GuildMember#edit` now takes `reason` as a part of `data`
- `GuildStickerManager#edit` now takes `reason` as a part of `data`
- `RoleManager#edit` now takes `reason` as a part of `options`
- `TextBasedChannel#createWebhook` now takes `name` as a part of `options`
- `Webhook#edit` now takes `reason` as a part of `options`
- `GuildEmojiManager#create` now takes `attachment`, and `name` as a part of `options`
- `GuildStickerManager#create` now takes `file`, `name`, and `tags` as a part of `options`

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)