### PR TITLE
chore: use cliff jumper for dev release too

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -16,6 +16,8 @@ jobs:
             folder: 'collection'
           - package: 'discord.js'
             folder: 'discord.js'
+          - package: 'docgen'
+            folder: 'docgen'
           - package: '@discordjs/proxy'
             folder: 'proxy'
           - package: '@discordjs/rest'
@@ -69,7 +71,7 @@ jobs:
       - name: Publish
         if: steps.pre-release.outputs.release == 'true'
         run: |
-          yarn workspace ${{ matrix.package }} version $(jq --raw-output '.version' packages/${{ matrix.folder }}/package.json).$(date +%s)-$(git rev-parse --short HEAD)
+          yarn workspace ${{ matrix.package }} release --preid $(date +%s)-$(git rev-parse --short HEAD)
           yarn workspace ${{ matrix.package }} npm publish --tag dev || true
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -16,8 +16,6 @@ jobs:
             folder: 'collection'
           - package: 'discord.js'
             folder: 'discord.js'
-          - package: 'docgen'
-            folder: 'docgen'
           - package: '@discordjs/proxy'
             folder: 'proxy'
           - package: '@discordjs/rest'

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -7,7 +7,7 @@
 		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
 		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"docs": "typedoc --json docs/typedoc-out.json src/index.ts && ts-docgen -i docs/typedoc-out.json -c docs/index.yml -o docs/docs.json",
-		"prepublishOnly": "yarn build && yarn lint && yarn test",
+		"prepack": "yarn build && yarn lint && yarn test",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/builders/*'",
 		"release": "cliff-jumper"
 	},

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -7,7 +7,7 @@
 		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
 		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"docs": "typedoc --json docs/typedoc-out.json src/index.ts && ts-docgen -i docs/typedoc-out.json -c docs/index.yml -o docs/docs.json",
-		"prepublishOnly": "yarn build && yarn lint && yarn test",
+		"prepack": "yarn build && yarn lint && yarn test",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/collection/*'",
 		"release": "cliff-jumper"
 	},

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -9,7 +9,7 @@
     "format": "prettier --write . && eslint src --fix",
     "docs": "docgen -i ./src/*.js ./src/**/*.js -c ./docs/index.json -r ../../ -o ./docs/docs.json",
     "docs:test": "docgen -i ./src/*.js ./src/**/*.js -c ./docs/index.json -r ../../",
-    "prepublishOnly": "yarn lint && yarn test",
+    "prepack": "yarn lint && yarn test",
     "changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/discord.js/*'",
     "release": "cliff-jumper --skip-tag --verbose"
   },

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -6,7 +6,7 @@
 		"build": "tsup",
 		"lint": "prettier --check . && eslint src --ext mjs,js,ts",
 		"format": "prettier --write . && eslint src --ext mjs,js,ts --fix",
-		"prepublishOnly": "yarn build && yarn lint && yarn test",
+		"prepack": "yarn build && yarn lint && yarn test",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/docgen/*'",
 		"release": "cliff-jumper"
 	},

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -7,7 +7,7 @@
 		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
 		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"docs": "typedoc --json docs/typedoc-out.json src/index.ts && ts-docgen -i docs/typedoc-out.json -c docs/index.yml -o docs/docs.json",
-		"prepublishOnly": "yarn build && yarn lint && yarn test",
+		"prepack": "yarn build && yarn lint && yarn test",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/proxy/*'",
 		"release": "cliff-jumper"
 	},

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -7,7 +7,7 @@
 		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
 		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"docs": "typedoc --json docs/typedoc-out.json src/index.ts && ts-docgen -i docs/typedoc-out.json -c docs/index.yml -o docs/docs.json",
-		"prepublishOnly": "yarn build && yarn lint && yarn test",
+		"prepack": "yarn build && yarn lint && yarn test",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/rest/*'",
 		"release": "cliff-jumper"
 	},

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -8,7 +8,7 @@
 		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
 		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"docs": "typedoc --json docs/typedoc-out.json src/index.ts && ts-docgen -i docs/typedoc-out.json -c docs/index.yml -o docs/docs.json",
-		"prepublishOnly": "yarn build && yarn lint && yarn test",
+		"prepack": "yarn build && yarn lint && yarn test",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/voice/*'",
 		"release": "cliff-jumper"
 	},


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
use cliff-jumper for pre-releases. 
Also changed all the `prepublishOnly` script to `prepack` [ref](https://yarnpkg.com/advanced/lifecycle-scripts)
**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
