### PR TITLE
fix(webhooks): revert webhook caching (and returning Message)

### DIFF
--- a/packages/discord.js/src/structures/InteractionWebhook.js
+++ b/packages/discord.js/src/structures/InteractionWebhook.js
@@ -29,10 +29,26 @@ class InteractionWebhook {
   /**
    * Sends a message with this webhook.
    * @param {string|MessagePayload|InteractionReplyOptions} options The content for the reply
-   * @returns {Promise<Message|APIMessage>}
+   * @returns {Promise<Message>}
    */
+
   send() {}
+
+  /**
+   * Gets a message that was sent by this webhook.
+   * @param {Snowflake|'@original'} message The id of the message to fetch
+   * @returns {Promise<Message>} Returns the message sent by this webhook
+   */
+
   fetchMessage() {}
+
+  /**
+   * Edits a message that was sent by this webhook.
+   * @param {MessageResolvable|'@original'} message The message to edit
+   * @param {string|MessagePayload|WebhookEditMessageOptions} options The options to provide
+   * @returns {Promise<Message>} Returns the message edited by this webhook
+   */
+
   editMessage() {}
   deleteMessage() {}
   get url() {}

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1562,6 +1562,11 @@ export class InteractionWebhook extends PartialWebhookMixin() {
   public constructor(client: Client, id: Snowflake, token: string);
   public token: string;
   public send(options: string | MessagePayload | InteractionReplyOptions): Promise<Message>;
+  public editMessage(
+    message: MessageResolvable,
+    options: string | MessagePayload | WebhookEditMessageOptions,
+  ): Promise<Message>;
+  public fetchMessage(message: string): Promise<Message>;
 }
 
 export class Invite extends Base {
@@ -2797,9 +2802,9 @@ export class WebhookClient extends WebhookMixin(BaseClient) {
   public editMessage(
     message: MessageResolvable,
     options: string | MessagePayload | WebhookEditMessageOptions,
-  ): Promise<Message>;
-  public fetchMessage(message: Snowflake, options?: WebhookFetchMessageOptions): Promise<Message>;
-  public send(options: string | MessagePayload | WebhookMessageOptions): Promise<Message>;
+  ): Promise<APIMessage>;
+  public fetchMessage(message: Snowflake, options?: WebhookFetchMessageOptions): Promise<APIMessage>;
+  public send(options: string | MessagePayload | WebhookMessageOptions): Promise<APIMessage>;
 }
 
 export class WebSocketManager extends EventEmitter {
@@ -3484,9 +3489,9 @@ export interface PartialWebhookFields {
   editMessage(
     message: MessageResolvable | '@original',
     options: string | MessagePayload | WebhookEditMessageOptions,
-  ): Promise<Message>;
-  fetchMessage(message: Snowflake | '@original', options?: WebhookFetchMessageOptions): Promise<Message>;
-  send(options: string | MessagePayload | Omit<WebhookMessageOptions, 'flags'>): Promise<Message>;
+  ): Promise<APIMessage | Message>;
+  fetchMessage(message: Snowflake | '@original', options?: WebhookFetchMessageOptions): Promise<APIMessage | Message>;
+  send(options: string | MessagePayload | Omit<WebhookMessageOptions, 'flags'>): Promise<APIMessage | Message>;
 }
 
 export interface WebhookFields extends PartialWebhookFields {
@@ -5308,7 +5313,6 @@ export type WebhookEditMessageOptions = Pick<
 >;
 
 export interface WebhookFetchMessageOptions {
-  cache?: boolean;
   threadId?: Snowflake;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
webhooks inherently can't cache messages & the way the library currently works is by attempting to cache messages if an APIMessage was returned from using `send`, `editMessage` or `fetchMessage`, but incorrectly makes the assumption that the client is the actual bot client, not a WebhookClient, so caching doesn't work in the first place. (#7917) 

in the event that the bot client already has the channel cached, it will already cache a message because of the information provided by the gateway. basically it's messy

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:


- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
