### PR TITLE
refactor(collection): remove default export

### DIFF
--- a/packages/collection/__tests__/collection.test.ts
+++ b/packages/collection/__tests__/collection.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import Collection from '../src';
+import { Collection } from '../src';
 
 type TestCollection = Collection<string, number>;
 

--- a/packages/collection/src/index.ts
+++ b/packages/collection/src/index.ts
@@ -776,5 +776,3 @@ export type Keep<V> = { keep: true; value: V } | { keep: false };
  * @internal
  */
 export type Comparator<K, V> = (firstValue: V, secondValue: V, firstKey: K, secondKey: K) => number;
-
-export default Collection;

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import type Collection from '@discordjs/collection';
+import type { Collection } from '@discordjs/collection';
 import type { request, Dispatcher } from 'undici';
 import { CDN } from './CDN';
 import {

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -1,6 +1,6 @@
 import { Blob } from 'node:buffer';
 import { EventEmitter } from 'node:events';
-import Collection from '@discordjs/collection';
+import { Collection } from '@discordjs/collection';
 import { DiscordSnowflake } from '@sapphire/snowflake';
 import { FormData, type RequestInit, type BodyInit, type Dispatcher, Agent } from 'undici';
 import type { RESTOptions, RestEvents, RequestOptions } from './REST';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Right now, to import Collection in TypeScript or in ESM, we have the following two choices:

```js
import { Collection } from '@discordjs/collection';
```
```js
import Collection from '@discordjs/collection';
```

However, one might be tempted to translate it as-is to CommonJS:

```js
const { Collection } = require('@discordjs/collection');
```
```js
const Collection = require('@discordjs/collection');
```

However, the latter is invalid, as it would require `export =`, which is not ESM compatible.

For the same reason, the reverse also makes the default export less intuitive and "correct" for those who switch from CJS to ESM, as the code number 4 errors. This, alongside many developers preferring named exports over default exports, makes this export a lot less popular.

It is also true that this is the only package with a default export, so it's not being consistent with the others.

If you're an ESM user who uses VSCode, I'm sure you have seen the following prompt when you try to auto-import the `Collection` class:

![Code_Sf0drCSI1U](https://user-images.githubusercontent.com/24852502/172868932-094042c9-ee2b-419f-a22b-146cf90c5441.png)

And both options are identical, but import `Collection` differently. Which one imports from default, and which one imports from named export? Furthermore, this lack of certainty also makes editors unable to auto-import on the fly without extra steps, which brings productivity down.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
