### PR TITLE
fix(scripts): add quotes around blob arguments

### DIFF
--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -7,8 +7,8 @@
     "test:typescript": "tsc --noEmit && tsd",
     "lint": "prettier --check . && eslint src && tslint typings/index.d.ts",
     "format": "prettier --write . && eslint src --fix",
-    "docs": "docgen -i ./src/*.js ./src/**/*.js -c ./docs/index.json -r ../../ -o ./docs/docs.json",
-    "docs:test": "docgen -i ./src/*.js ./src/**/*.js -c ./docs/index.json -r ../../",
+    "docs": "docgen -i './src/*.js' './src/**/*.js' -c ./docs/index.json -r ../../ -o ./docs/docs.json",
+    "docs:test": "docgen -i './src/*.js' './src/**/*.js' -c ./docs/index.json -r ../../",
     "prepublishOnly": "yarn lint && yarn test",
     "changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/discord.js/*'",
     "release": "cliff-jumper --skip-tag --verbose"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Apparently, Windows with Microsoft PowerShell expands the blobs, resulting on `yarn test` to fail with "The command line is too long".

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
