### PR TITLE
fix(CommandInteractionOptionResolver): Handle autocompletion interactions

### DIFF
--- a/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
+++ b/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
@@ -60,9 +60,9 @@ class CommandInteractionOptionResolver {
     /**
      * The interaction resolved data
      * @name CommandInteractionOptionResolver#resolved
-     * @type {Readonly<CommandInteractionResolvedData>}
+     * @type {?Readonly<CommandInteractionResolvedData>}
      */
-    Object.defineProperty(this, 'resolved', { value: Object.freeze(resolved) });
+    Object.defineProperty(this, 'resolved', { value: resolved ? Object.freeze(resolved) : null });
   }
 
   /**
@@ -257,9 +257,18 @@ class CommandInteractionOptionResolver {
   }
 
   /**
+   * The full autocomplete option object.
+   * @typedef {Object} AutocompleteOption
+   * @property {string} name The name of the option
+   * @property {ApplicationCommandOptionType} type The type of the application command option
+   * @property {string|number} value The value of the option
+   * @property {boolean} focused Whether this option is currently in focus for autocomplete
+   */
+
+  /**
    * Gets the focused option.
    * @param {boolean} [getFull=false] Whether to get the full option object
-   * @returns {string|number|ApplicationCommandOptionChoice}
+   * @returns {string|number|AutocompleteOption}
    * The value of the option, or the whole option if getFull is true
    */
   getFocused(getFull = false) {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -935,7 +935,17 @@ export class AutocompleteInteraction<Cached extends CacheType = CacheType> exten
   public commandName: string;
   public commandType: ApplicationCommandType.ChatInput;
   public responded: boolean;
-  public options: Omit<CommandInteractionOptionResolver<Cached>, 'getMessage'>;
+  public options: Omit<
+    CommandInteractionOptionResolver<Cached>,
+    | 'getMessage'
+    | 'getUser'
+    | 'getAttachment'
+    | 'getBoolean'
+    | 'getChannel'
+    | 'getMember'
+    | 'getMentionable'
+    | 'getRole'
+  >;
   public inGuild(): this is AutocompleteInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is AutocompleteInteraction<'cached'>;
   public inRawGuild(): this is AutocompleteInteraction<'raw'>;
@@ -946,7 +956,7 @@ export class CommandInteractionOptionResolver<Cached extends CacheType = CacheTy
   private constructor(client: Client, options: CommandInteractionOption[], resolved: CommandInteractionResolvedData);
   public readonly client: Client;
   public readonly data: readonly CommandInteractionOption<Cached>[];
-  public readonly resolved: Readonly<CommandInteractionResolvedData<Cached>>;
+  public readonly resolved: Readonly<CommandInteractionResolvedData<Cached>> | null;
   private _group: string | null;
   private _hoistedOptions: CommandInteractionOption<Cached>[];
   private _subcommand: string | null;
@@ -1000,7 +1010,7 @@ export class CommandInteractionOptionResolver<Cached extends CacheType = CacheTy
   ): NonNullable<CommandInteractionOption<Cached>['member' | 'role' | 'user']> | null;
   public getMessage(name: string, required: true): NonNullable<CommandInteractionOption<Cached>['message']>;
   public getMessage(name: string, required?: boolean): NonNullable<CommandInteractionOption<Cached>['message']> | null;
-  public getFocused(getFull: true): ApplicationCommandOptionChoiceData;
+  public getFocused(getFull: true): AutocompleteOption;
   public getFocused(getFull?: boolean): string | number;
 }
 
@@ -4024,6 +4034,8 @@ export interface CommandInteractionResolvedData<Cached extends CacheType = Cache
   messages?: Collection<Snowflake, CacheTypeReducer<Cached, Message, APIMessage>>;
   attachments?: Collection<Snowflake, Attachment>;
 }
+
+export type AutocompleteOption = Pick<CommandInteractionOption, 'name' | 'type' | 'value' | 'focused'>;
 
 export declare const Colors: {
   Default: 0x000000;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -937,14 +937,7 @@ export class AutocompleteInteraction<Cached extends CacheType = CacheType> exten
   public responded: boolean;
   public options: Omit<
     CommandInteractionOptionResolver<Cached>,
-    | 'getMessage'
-    | 'getUser'
-    | 'getAttachment'
-    | 'getBoolean'
-    | 'getChannel'
-    | 'getMember'
-    | 'getMentionable'
-    | 'getRole'
+    'getMessage' | 'getUser' | 'getAttachment' | 'getChannel' | 'getMember' | 'getMentionable' | 'getRole'
   >;
   public inGuild(): this is AutocompleteInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is AutocompleteInteraction<'cached'>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pull request resolves #7595.

1. `ApplicationCommandOptionChoice` is not the correct return type for `CommandInteractionOptionResolver#getFocused()`. The correct type didn't seem to exist, so one was created.
2. During autocomplete interactions, `CommandInteractionOptionResolver#resolved` was `undefined`. This is now `null` and typed accordingly.
3. The `CommandInteractionOptionResolver` isn't keen on its methods returning anything for autocomplete interactions. Data was simply not sent to us. Therefore, the appropriate useless methods have been removed from the typings.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
