### PR TITLE
types(ThreadMemberManager): Fix return type of fetching members with no arguments

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3404,7 +3404,7 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
   public thread: AnyThreadChannel;
   public get me(): ThreadMember | null;
   public add(member: UserResolvable | '@me', reason?: string): Promise<Snowflake>;
-  public fetch(options?: ThreadMemberResolvable | FetchThreadMemberOptions): Promise<ThreadMember>;
+  public fetch(options: ThreadMemberResolvable | FetchThreadMemberOptions): Promise<ThreadMember>;
   public fetch(options?: FetchThreadMembersOptions): Promise<Collection<Snowflake, ThreadMember>>;
   public fetchMe(options?: BaseFetchOptions): Promise<ThreadMember>;
   public remove(id: Snowflake | '@me', reason?: string): Promise<Snowflake>;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -126,6 +126,7 @@ import {
   MessageContextMenuCommandInteraction,
   UserContextMenuCommandInteraction,
   AnyThreadChannel,
+  ThreadMemberManager,
 } from '.';
 import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import { UnsafeButtonBuilder, UnsafeEmbedBuilder, UnsafeSelectMenuBuilder } from '@discordjs/builders';
@@ -558,19 +559,6 @@ client.on('guildCreate', async g => {
     });
 
     channel.send({ components: [row, row2] });
-  }
-
-  if (channel.isThread()) {
-    const fetchedMember = await channel.members.fetch('12345678');
-    const fetchedMember2 = await channel.members.fetch({ member: '12345678', cache: false, force: true });
-    expectType<ThreadMember>(fetchedMember);
-    expectType<ThreadMember>(fetchedMember2);
-    const fetchedMemberCol = await channel.members.fetch({ cache: true });
-    const fetchedMemberCol2 = await channel.members.fetch();
-    expectType<Collection<Snowflake, ThreadMember>>(fetchedMemberCol);
-    expectType<Collection<Snowflake, ThreadMember>>(fetchedMemberCol2);
-    // @ts-expect-error The `force` option cannot be used alongside fetching all thread members.
-    const fetchedMemberCol3 = await channel.members.fetch({ cache: true, force: false });
   }
 
   channel.setName('foo').then(updatedChannel => {
@@ -1110,6 +1098,19 @@ declare const guildBanManager: GuildBanManager;
   guildBanManager.fetch({ cache: true, force: false });
   // @ts-expect-error
   guildBanManager.fetch({ user: '1234567890', after: '1234567890', cache: true, force: false });
+}
+
+declare const threadMemberManager: ThreadMemberManager;
+{
+  expectType<Promise<ThreadMember>>(threadMemberManager.fetch('12345678'));
+  expectType<Promise<ThreadMember>>(threadMemberManager.fetch({ member: '12345678', cache: false }));
+  expectType<Promise<ThreadMember>>(threadMemberManager.fetch({ member: '12345678', force: true }));
+  expectType<Promise<ThreadMember>>(threadMemberManager.fetch({ member: '12345678', cache: false, force: true }));
+  expectType<Promise<Collection<Snowflake, ThreadMember>>>(threadMemberManager.fetch());
+  expectType<Promise<Collection<Snowflake, ThreadMember>>>(threadMemberManager.fetch({}));
+  expectType<Promise<Collection<Snowflake, ThreadMember>>>(threadMemberManager.fetch({ cache: true }));
+  // @ts-expect-error The `force` option cannot be used alongside fetching all thread members.
+  threadMemberManager.fetch({ cache: true, force: false });
 }
 
 declare const typing: Typing;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -566,9 +566,11 @@ client.on('guildCreate', async g => {
     expectType<ThreadMember>(fetchedMember);
     expectType<ThreadMember>(fetchedMember2);
     const fetchedMemberCol = await channel.members.fetch({ cache: true });
+    const fetchedMemberCol2 = await channel.members.fetch();
     expectType<Collection<Snowflake, ThreadMember>>(fetchedMemberCol);
+    expectType<Collection<Snowflake, ThreadMember>>(fetchedMemberCol2);
     // @ts-expect-error The `force` option cannot be used alongside fetching all thread members.
-    const fetchedMemberCol2 = await channel.members.fetch({ cache: true, force: false });
+    const fetchedMemberCol3 = await channel.members.fetch({ cache: true, force: false });
   }
 
   channel.setName('foo').then(updatedChannel => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
A regression from #8021: performing `<ThreadMemberManager>.fetch()` would yield a return type of a singular thread member. This should be a collection of thread members.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
