### PR TITLE
types(GuildChannel): fix type of `.isText()` method

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1115,7 +1115,7 @@ export abstract class GuildChannel extends Channel {
   public setName(name: string, reason?: string): Promise<this>;
   public setParent(channel: CategoryChannelResolvable | null, options?: SetParentOptions): Promise<this>;
   public setPosition(position: number, options?: SetChannelPositionOptions): Promise<this>;
-  public isText(): this is TextChannel | NewsChannel;
+  public isText(): this is GuildTextBasedChannel;
 }
 
 export class GuildEmoji extends BaseGuildEmoji {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pr fixes type of `GuildChannel#isText()` method

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
