### PR TITLE
typings: remove isAutocomplete typeguard from typings

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ client.on('ready', () => {
 });
 
 client.on('interactionCreate', async (interaction) => {
-	if (!interaction.isCommand()) return;
+	if (!interaction.isChatInputCommand()) return;
 
 	if (interaction.commandName === 'ping') {
 		await interaction.reply('Pong!');

--- a/packages/discord.js/README.md
+++ b/packages/discord.js/README.md
@@ -89,7 +89,7 @@ client.on('ready', () => {
 });
 
 client.on('interactionCreate', async interaction => {
-  if (!interaction.isCommand()) return;
+  if (!interaction.isChatInputCommand()) return;
 
   if (interaction.commandName === 'ping') {
     await interaction.reply('Pong!');

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1517,7 +1517,6 @@ export class Interaction<Cached extends CacheType = CacheType> extends Base {
   public isChatInputCommand(): this is ChatInputCommandInteraction<Cached>;
   public isContextMenuCommand(): this is ContextMenuCommandInteraction<Cached>;
   public isMessageContextMenuCommand(): this is MessageContextMenuCommandInteraction<Cached>;
-  public isAutocomplete(): this is AutocompleteInteraction<Cached>;
   public isUserContextMenuCommand(): this is UserContextMenuCommandInteraction<Cached>;
   public isSelectMenu(): this is SelectMenuInteraction<Cached>;
   public isRepliable(): this is this & InteractionResponseFields<Cached>;

--- a/packages/voice/examples/recorder/src/bot.ts
+++ b/packages/voice/examples/recorder/src/bot.ts
@@ -29,7 +29,7 @@ client.on(Events.MessageCreate, async (message) => {
 const recordable = new Set<string>();
 
 client.on(Events.InteractionCreate, async (interaction: Interaction) => {
-	if (!interaction.isChatInputCommand() || !interaction.inGuild()) return;
+	if (!interaction.isCommand() || !interaction.guildId) return;
 
 	const handler = interactionHandlers.get(interaction.commandName);
 

--- a/packages/voice/examples/recorder/src/bot.ts
+++ b/packages/voice/examples/recorder/src/bot.ts
@@ -29,7 +29,7 @@ client.on(Events.MessageCreate, async (message) => {
 const recordable = new Set<string>();
 
 client.on(Events.InteractionCreate, async (interaction: Interaction) => {
-	if (!interaction.isCommand() || !interaction.guildId) return;
+	if (!interaction.isChatInputCommand() || !interaction.inGuild()) return;
 
 	const handler = interactionHandlers.get(interaction.commandName);
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`isAutocomplete` was removed but it's still present in typings. So this pr removes it from typings. Also updated readme and example to use `isChatInputCommand` instead of `isCommand`.
**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
