### PR TITLE
fix(ApplicationCommand): fix default member permissions assignment

### DIFF
--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -246,7 +246,7 @@ class ApplicationCommandManager extends CachedManager {
       description_localizations: command.descriptionLocalizations ?? command.description_localizations,
       type: command.type,
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
-      default_member_permissions: default_member_permissions,
+      default_member_permissions: command.defaultMemberPermissions ? command.default_member_permissions,
       dm_permission: command.dmPermission ?? command.dm_permission,
     };
   }

--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -246,7 +246,7 @@ class ApplicationCommandManager extends CachedManager {
       description_localizations: command.descriptionLocalizations ?? command.description_localizations,
       type: command.type,
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
-      default_member_permissions,
+      default_member_permissions: default_member_permissions,
       dm_permission: command.dmPermission ?? command.dm_permission,
     };
   }

--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -229,13 +229,13 @@ class ApplicationCommandManager extends CachedManager {
 
     if ('default_member_permissions' in command) {
       default_member_permissions = command.default_member_permissions
-        ? new PermissionsBitField(BigInt(command.default_member_permissions)).bitfield
+        ? new PermissionsBitField(BigInt(command.default_member_permissions)).bitfield.toString()
         : command.default_member_permissions;
     }
 
     if ('defaultMemberPermissions' in command) {
       default_member_permissions = command.defaultMemberPermissions
-        ? new PermissionsBitField(command.defaultMemberPermissions).bitfield
+        ? new PermissionsBitField(command.defaultMemberPermissions).bitfield.toString()
         : command.defaultMemberPermissions;
     }
 
@@ -246,7 +246,7 @@ class ApplicationCommandManager extends CachedManager {
       description_localizations: command.descriptionLocalizations ?? command.description_localizations,
       type: command.type,
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
-      default_member_permissions: command.defaultMemberPermissions ? command.default_member_permissions,
+      default_member_permissions,
       dm_permission: command.dmPermission ?? command.dm_permission,
     };
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes default member permissions assignment when creating or editing application commands.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
