### PR TITLE
types(AutocompleteOption): fix and improve types

### DIFF
--- a/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
+++ b/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
@@ -258,17 +258,17 @@ class CommandInteractionOptionResolver {
 
   /**
    * The full autocomplete option object.
-   * @typedef {Object} AutocompleteOption
+   * @typedef {Object} AutocompleteFocusedOption
    * @property {string} name The name of the option
    * @property {ApplicationCommandOptionType} type The type of the application command option
-   * @property {string|number} value The value of the option
+   * @property {string} value The value of the option
    * @property {boolean} focused Whether this option is currently in focus for autocomplete
    */
 
   /**
    * Gets the focused option.
    * @param {boolean} [getFull=false] Whether to get the full option object
-   * @returns {string|number|AutocompleteOption}
+   * @returns {string|AutocompleteFocusedOption}
    * The value of the option, or the whole option if getFull is true
    */
   getFocused(getFull = false) {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1006,8 +1006,8 @@ export class CommandInteractionOptionResolver<Cached extends CacheType = CacheTy
   ): NonNullable<CommandInteractionOption<Cached>['member' | 'role' | 'user']> | null;
   public getMessage(name: string, required: true): NonNullable<CommandInteractionOption<Cached>['message']>;
   public getMessage(name: string, required?: boolean): NonNullable<CommandInteractionOption<Cached>['message']> | null;
-  public getFocused(getFull: true): AutocompleteOption;
-  public getFocused(getFull?: boolean): string | number;
+  public getFocused(getFull: true): AutocompleteFocusedOption;
+  public getFocused(getFull?: boolean): string;
 }
 
 export class ContextMenuCommandInteraction<Cached extends CacheType = CacheType> extends CommandInteraction<Cached> {
@@ -4063,7 +4063,14 @@ export interface CommandInteractionResolvedData<Cached extends CacheType = Cache
   attachments?: Collection<Snowflake, Attachment>;
 }
 
-export type AutocompleteOption = Pick<CommandInteractionOption, 'name' | 'type' | 'value' | 'focused'>;
+export type AutocompleteFocusedOption = Pick<CommandInteractionOption, 'name'> & {
+  focused: true;
+  type:
+    | ApplicationCommandOptionType.String
+    | ApplicationCommandOptionType.Integer
+    | ApplicationCommandOptionType.Number;
+  value: string;
+};
 
 export declare const Colors: {
   Default: 0x000000;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The type of AutocompleteOption#value was wrong so I went ahead and fixed that and also made the other properties more accurate (made focused not optional and type more specific).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
