### PR TITLE
types: fix `ApplicationCommandPermissionsUpdate` event typings

### DIFF
--- a/packages/discord.js/src/client/actions/ApplicationCommandPermissionsUpdate.js
+++ b/packages/discord.js/src/client/actions/ApplicationCommandPermissionsUpdate.js
@@ -9,7 +9,7 @@ const Events = require('../../util/Events');
  * @property {Snowflake} id The id of the command or global entity that was updated
  * @property {Snowflake} guildId The id of the guild in which permissions were updated
  * @property {Snowflake} applicationId The id of the application that owns the command or entity being updated
- * @property {ApplicationCommandPermissions} permissions The updated permissions
+ * @property {ApplicationCommandPermissions[]} permissions The updated permissions
  */
 
 class ApplicationCommandPermissionsUpdateAction extends Action {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4099,6 +4099,7 @@ export declare const Colors: {
 };
 
 export declare const Events: {
+  ApplicationCommandPermissionsUpdate: 'applicationCommandPermissionsUpdate';
   ClientReady: 'ready';
   GuildCreate: 'guildCreate';
   GuildDelete: 'guildDelete';

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3705,7 +3705,7 @@ export interface ApplicationCommandPermissionsUpdateData {
   id: Snowflake;
   guildId: Snowflake;
   applicationId: Snowflake;
-  permissions: ApplicationCommandPermissions;
+  permissions: ApplicationCommandPermissions[];
 }
 
 export interface EditApplicationCommandPermissionsMixin {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds missing `ApplicationCommandPermissionsUpdate` to `Events` in typings.
Also fixes `ApplicationCommandPermissionsUpdateData#permissions` property to be an array.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
