### PR TITLE
docs(AutocompleteInteraction): change useless log in responds example 

### DIFF
--- a/packages/discord.js/src/structures/AutocompleteInteraction.js
+++ b/packages/discord.js/src/structures/AutocompleteInteraction.js
@@ -70,7 +70,7 @@ class AutocompleteInteraction extends Interaction {
    *    value: 'option1',
    *  },
    * ])
-   *  .then(console.log)
+   *  .then(() => console.log('Successfully responded to the autocomplete interaction'))
    *  .catch(console.error);
    */
   async respond(options) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
\<AutocompleteInteraction>.respond doesn't really resolve to anything. So that console.log is pretty pointless. I am still unsure of exactly why all the methods having a then and a catch is necessary. Regardless, I have looked at other methods and changed the example to what I think would be more appropriate. 

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
