### PR TITLE
types(AutocompleteOption): backport fix and improve types

### DIFF
--- a/src/structures/CommandInteractionOptionResolver.js
+++ b/src/structures/CommandInteractionOptionResolver.js
@@ -241,9 +241,18 @@ class CommandInteractionOptionResolver {
   }
 
   /**
+   * The full autocomplete option object.
+   * @typedef {Object} AutocompleteFocusedOption
+   * @property {string} name The name of the option
+   * @property {ApplicationCommandOptionType} type The type of the application command option
+   * @property {string} value The value of the option
+   * @property {boolean} focused Whether this option is currently in focus for autocomplete
+   */
+
+  /**
    * Gets the focused option.
    * @param {boolean} [getFull=false] Whether to get the full option object
-   * @returns {string|number|ApplicationCommandOptionChoice}
+   * @returns {string|AutocompleteFocusedOption}
    * The value of the option, or the whole option if getFull is true
    */
   getFocused(getFull = false) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -837,8 +837,8 @@ export class CommandInteractionOptionResolver<Cached extends CacheType = CacheTy
   ): NonNullable<CommandInteractionOption<Cached>['member' | 'role' | 'user']> | null;
   public getMessage(name: string, required: true): NonNullable<CommandInteractionOption<Cached>['message']>;
   public getMessage(name: string, required?: boolean): NonNullable<CommandInteractionOption<Cached>['message']> | null;
-  public getFocused(getFull: true): ApplicationCommandOptionChoiceData;
-  public getFocused(getFull?: boolean): string | number;
+  public getFocused(getFull: true): AutocompleteFocusedOption;
+  public getFocused(getFull?: boolean): string;
   public getAttachment(name: string, required: true): NonNullable<CommandInteractionOption<Cached>['attachment']>;
   public getAttachment(
     name: string,
@@ -4357,6 +4357,18 @@ export interface ConstantsClientApplicationAssetTypes {
   SMALL: 1;
   BIG: 2;
 }
+
+export type AutocompleteFocusedOption = Pick<CommandInteractionOption, 'name'> & {
+  focused: true;
+  type:
+    | 'STRING'
+    | 'INTEGER'
+    | 'NUMBER'
+    | ApplicationCommandOptionTypes.STRING
+    | ApplicationCommandOptionTypes.INTEGER
+    | ApplicationCommandOptionTypes.NUMBER;
+  value: string;
+};
 
 export interface ConstantsColors {
   DEFAULT: 0x000000;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR backports #8069 to v13. This will be breaking for TS users but the types were wrong to begin with, so it's a semver: patch

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
