### PR TITLE
docs(ThreadMemberManager): Require `member` in `FetchThreadMemberOptions`

### DIFF
--- a/packages/discord.js/src/managers/ThreadMemberManager.js
+++ b/packages/discord.js/src/managers/ThreadMemberManager.js
@@ -113,7 +113,7 @@ class ThreadMemberManager extends CachedManager {
 
   /**
    * @typedef {BaseFetchOptions} FetchThreadMemberOptions
-   * @property {ThreadMemberResolvable} [member] The thread member to fetch
+   * @property {ThreadMemberResolvable} member The thread member to fetch
    */
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`member` is required for `FetchThreadMemberOptions` (duh).

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
