### PR TITLE
fix: destroy options during cleanup

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -367,7 +367,7 @@ class WebSocketShard extends EventEmitter {
     if (this.connection) {
       this._cleanupConnection();
       // Having this after _cleanupConnection to just clean up the connection and not listen to ws.onclose
-      this.destroy({ reset: true, emit: false, log: false });
+      this.destroy({ reset: !this.sessionId, emit: false, log: false });
     }
     this.status = Status.DISCONNECTED;
     this.emitClose(event);

--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -33,8 +33,9 @@ const process = require('node:process');
  * @property {number|number[]|string} [shards] The shard's id to run, or an array of shard ids. If not specified,
  * the client will spawn {@link ClientOptions#shardCount} shards. If set to `auto`, it will fetch the
  * recommended amount of shards from Discord and spawn that amount
- * @property {number} [closeTimeout=1] The amount of time in milliseconds to wait for the close frame to be received
- * from the WebSocket. Don't have this too high/low. Its best to have it between 2_000-6_000 ms.
+ * @property {number} [closeTimeout=5000] The amount of time in milliseconds to wait for the close frame to be received
+ * from the WebSocket.
+ * <info>Don't have this too high/low. It's best to have it between 2000-6000 ms.</info>
  * @property {number} [shardCount=1] The total amount of shards used by all processes of this bot
  * (e.g. recommended shard count, shard count of the ShardingManager)
  * @property {CacheFactory} [makeCache] Function to create a cache.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
  reset only when `sessionId` is null
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating