### PR TITLE
chore: remove -types import in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ pnpm add discord.js
 Install all required dependencies:
 
 ```sh-session
-npm install discord.js @discordjs/rest discord-api-types
-yarn add discord.js @discordjs/rest discord-api-types
-pnpm add discord.js @discordjs/rest discord-api-types
+npm install discord.js @discordjs/rest
+yarn add discord.js @discordjs/rest
+pnpm add discord.js @discordjs/rest
 ```
 
 Register a slash command against the Discord API:
 
 ```js
 const { REST } = require('@discordjs/rest');
-const { Routes } = require('discord-api-types/v10');
+const { Routes } = require('discord.js');
 
 const commands = [
 	{

--- a/packages/discord.js/README.md
+++ b/packages/discord.js/README.md
@@ -45,16 +45,16 @@ pnpm add discord.js
 Install all required dependencies:
 
 ```sh-session
-npm install discord.js @discordjs/rest discord-api-types
-yarn add discord.js @discordjs/rest discord-api-types
-pnpm add discord.js @discordjs/rest discord-api-types
+npm install discord.js @discordjs/rest
+yarn add discord.js @discordjs/rest
+pnpm add discord.js @discordjs/rest
 ```
 
 Register a slash command against the Discord API:
 
 ```js
 const { REST } = require('@discordjs/rest');
-const { Routes } = require('discord-api-types/v10');
+const { Routes } = require('discord.js');
 
 const commands = [
   {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As of #7909 discord.js re-exports everything from discord-api-types, so there's no need in installing it as a redundant dependency. 

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
- Code changes have been tested against the Discord API, or there are no code changes
<!--
Please move lines that apply to you out of the comment:

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
