### PR TITLE
feat(AutocompleteInteraction): Add `commandGuildId`

### DIFF
--- a/packages/discord.js/src/structures/AutocompleteInteraction.js
+++ b/packages/discord.js/src/structures/AutocompleteInteraction.js
@@ -37,6 +37,12 @@ class AutocompleteInteraction extends Interaction {
     this.commandType = data.data.type;
 
     /**
+     * The id of the guild the invoked application command is registered to
+     * @type {?Snowflake}
+     */
+    this.commandGuildId = data.data.guild_id ?? null;
+
+    /**
      * Whether this interaction has already received a response
      * @type {boolean}
      */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -937,6 +937,7 @@ export class AutocompleteInteraction<Cached extends CacheType = CacheType> exten
   public commandId: Snowflake;
   public commandName: string;
   public commandType: ApplicationCommandType.ChatInput;
+  public commandGuildId: Snowflake | null;
   public responded: boolean;
   public options: Omit<
     CommandInteractionOptionResolver<Cached>,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Implements #8018 into autocomplete interactions too.

<details>
<summary>Example autocomplete interaction data payload</summary>

```JavaScript
{
  type: 1,
  options: [ { value: 'dde', type: 3, name: 'name', focused: true } ],
  name: 'travelling-spirit',
  id: '982764979583324180',
  guild_id: '982741752098222090'
}
```
</details>

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
