### PR TITLE
docs: Description and missing `@typedef` fixes

### DIFF
--- a/packages/discord.js/src/managers/GuildEmojiManager.js
+++ b/packages/discord.js/src/managers/GuildEmojiManager.js
@@ -27,7 +27,7 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
 
   /**
    * Options used for creating an emoji in a guild.
-   * @typedef {Object}
+   * @typedef {Object} GuildEmojiCreateOptions
    * @property {BufferResolvable|Base64Resolvable} attachment The image for the emoji
    * @property {string} name The name for the emoji
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles to limit the emoji to

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -44,7 +44,7 @@ class GuildStickerManager extends CachedManager {
 
   /**
    * Creates a new custom sticker in the guild.
-   * @param {GuildStickerCreateOptions} options Options for creating a guild sticker.
+   * @param {GuildStickerCreateOptions} options Options for creating a guild sticker
    * @returns {Promise<Sticker>} The created sticker
    * @example
    * // Create a new sticker from a URL

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -33,7 +33,7 @@ class GuildStickerManager extends CachedManager {
   }
 
   /**
-   * Options for creating a guild sticker.
+   * Options used to create a guild sticker.
    * @typedef {Object} GuildStickerCreateOptions
    * @property {BufferResolvable|Stream|JSONEncodable<AttachmentPayload>} file The file for the sticker
    * @property {string} name The name for the sticker
@@ -44,7 +44,7 @@ class GuildStickerManager extends CachedManager {
 
   /**
    * Creates a new custom sticker in the guild.
-   * @param {GuildStickerCreateOptions} options Options
+   * @param {GuildStickerCreateOptions} options Options for creating a guild sticker.
    * @returns {Promise<Sticker>} The created sticker
    * @example
    * // Create a new sticker from a URL


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Added a more suitable description instead of "Options" for `GuildStickerManager#create()`
- Added back the missing `GuildEmojiCreateOptions` type definition.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
