### PR TITLE
docs(BaseGuildTextChannel): Update `setType()`'s parameter type

### DIFF
--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -90,8 +90,9 @@ class BaseGuildTextChannel extends GuildChannel {
   }
 
   /**
-   * Sets the type of this channel (only conversion between text and news is supported)
-   * @param {string} type The new channel type
+   * Sets the type of this channel.
+   * <info>Only conversion between {@link TextChannel} and {@link NewsChannel} is supported.</info>
+   * @param {ChannelType.GuildText|ChannelType.GuildNews} type The new channel type
    * @param {string} [reason] Reason for changing the channel's type
    * @returns {Promise<GuildChannel>}
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`BaseGuildTextChannel#setType()` does not take a string, but rather, `ChannelType.GuildText | ChannelType.GuildNews` (which are numbers).

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
