### PR TITLE
fix(ModalSubmitInteraction): add `isFromMessage()` missing method

### DIFF
--- a/src/structures/ModalSubmitInteraction.js
+++ b/src/structures/ModalSubmitInteraction.js
@@ -94,6 +94,14 @@ class ModalSubmitInteraction extends Interaction {
     }));
   }
 
+  /**
+   * Whether this is from a {@link MessageComponentInteraction}.
+   * @returns {boolean}
+   */
+  isFromMessage() {
+    return Boolean(this.message);
+  }
+
   // These are here only for documentation purposes - they are implemented by InteractionResponses
   /* eslint-disable no-empty-function */
   deferReply() {}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds `isFromMessage()` method to ModalSubmitInteraction.
The typings have the method but it really doesn't exist.

When the v14 Modals PR was backported to v13, this method was missing.

(I don't know if this has much importance, but I open this PR to avoid the method error)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
