### PR TITLE
refactor(ClientOptions): remove `$` prefix from `ws.properties` keys

### DIFF
--- a/packages/discord.js/src/util/Options.js
+++ b/packages/discord.js/src/util/Options.js
@@ -86,9 +86,9 @@ class Options extends null {
         large_threshold: 50,
         compress: false,
         properties: {
-          $os: process.platform,
-          $browser: 'discord.js',
-          $device: 'discord.js',
+          os: process.platform,
+          browser: 'discord.js',
+          device: 'discord.js',
         },
         version: 10,
       },

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5337,9 +5337,9 @@ export interface WebSocketOptions {
 }
 
 export interface WebSocketProperties {
-  $os?: string;
-  $browser?: string;
-  $device?: string;
+  os?: string;
+  browser?: string;
+  device?: string;
 }
 
 export interface WidgetActivity {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- discord/discord-api-docs#5058
- https://github.com/discord/discord-api-docs/pull/5067

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
