### PR TITLE
refactor: deprecate `$` prefix from `ws.properties` keys

### DIFF
--- a/src/util/Options.js
+++ b/src/util/Options.js
@@ -157,9 +157,9 @@ class Options extends null {
         large_threshold: 50,
         compress: false,
         properties: {
-          $os: process.platform,
-          $browser: 'discord.js',
-          $device: 'discord.js',
+          os: process.platform,
+          browser: 'discord.js',
+          device: 'discord.js',
         },
         version: 9,
       },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6016,9 +6016,9 @@ export interface WebSocketOptions {
 }
 
 export interface WebSocketProperties {
-  $os?: string;
-  $browser?: string;
-  $device?: string;
+  os?: string;
+  browser?: string;
+  device?: string;
 }
 
 export interface WidgetActivity {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6016,6 +6016,9 @@ export interface WebSocketOptions {
 }
 
 export interface WebSocketProperties {
+  $os?: string;
+  $browser?: string;
+  $device?: string;
   os?: string;
   browser?: string;
   device?: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6019,11 +6019,11 @@ export interface WebSocketProperties {
   os?: string;
   browser?: string;
   device?: string;
-  /** @deprecated Use `os` instead */
+  /** @deprecated Use {@link os} instead. */
   $os?: string;
-  /** @deprecated Use `browser` instead */
+  /** @deprecated Use {@link browser} instead. */
   $browser?: string;
-  /** @deprecated Use `device` instead */
+  /** @deprecated Use {@link device} instead. */
   $device?: string;
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6016,12 +6016,15 @@ export interface WebSocketOptions {
 }
 
 export interface WebSocketProperties {
-  $os?: string;
-  $browser?: string;
-  $device?: string;
   os?: string;
   browser?: string;
   device?: string;
+  /** @deprecated Use `os` instead */
+  $os?: string;
+  /** @deprecated Use `browser` instead */
+  $browser?: string;
+  /** @deprecated Use `device` instead */
+  $device?: string;
 }
 
 export interface WidgetActivity {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- https://github.com/discordjs/discord.js/pull/8094#issuecomment-1155549091
- https://github.com/discord/discord-api-docs/pull/5067

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
