### PR TITLE
docs: Remove `number`s from enums

### DIFF
--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -82,7 +82,7 @@ class GuildManager extends CachedManager {
    * @property {Snowflake|number} [id] The channel's id, used to set its parent,
    * this is a placeholder and will be replaced by the API after consumption
    * @property {Snowflake|number} [parentId] The parent id for this channel
-   * @property {ChannelType|number} [type] The type of the channel
+   * @property {ChannelType.GuildText|ChannelType.GuildVoice|ChannelType.GuildCategory} [type] The type of the channel
    * @property {string} name The name of the channel
    * @property {?string} [topic] The topic of the text channel
    * @property {boolean} [nsfw] Whether the channel is NSFW

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -147,7 +147,7 @@ class GuildManager extends CachedManager {
    * @property {PartialChannelData[]} [channels=[]] The channels for this guild
    * @property {GuildDefaultMessageNotifications} [defaultMessageNotifications] The default message notifications
    * for the guild
-   * @property {GuildExplicitContentFilterLevel} [explicitContentFilter] The explicit content filter level for the guild
+   * @property {GuildExplicitContentFilter} [explicitContentFilter] The explicit content filter level for the guild
    * @property {?(BufferResolvable|Base64Resolvable)} [icon=null] The icon for the guild
    * @property {PartialRoleData[]} [roles=[]] The roles for this guild,
    * the first element of this array is used to change properties of the guild's everyone role.

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -145,7 +145,7 @@ class GuildManager extends CachedManager {
    * @property {Snowflake|number} [afkChannelId] The AFK channel's id
    * @property {number} [afkTimeout] The AFK timeout in seconds
    * @property {PartialChannelData[]} [channels=[]] The channels for this guild
-   * @property {GuildDefaultMessageNotificationLevel|number} [defaultMessageNotifications] The default message notifications
+   * @property {GuildDefaultMessageNotifications} [defaultMessageNotifications] The default message notifications
    * for the guild
    * @property {GuildExplicitContentFilterLevel} [explicitContentFilter] The explicit content filter level for the guild
    * @property {?(BufferResolvable|Base64Resolvable)} [icon=null] The icon for the guild

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -171,7 +171,7 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {GuildScheduledEventEntityType} [entityType] The scheduled entity type of the event
    * @property {string} [description] The description of the guild scheduled event
    * @property {?GuildVoiceChannelResolvable} [channel] The channel of the guild scheduled event
-   * @property {GuildScheduledEventStatus|number} [status] The status of the guild scheduled event
+   * @property {GuildScheduledEventStatus} [status] The status of the guild scheduled event
    * @property {GuildScheduledEventEntityMetadataOptions} [entityMetadata] The entity metadata of the
    * guild scheduled event
    * <warn>This can be modified only if `entityType` of the `GuildScheduledEvent` to be edited is

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -44,7 +44,7 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {DateResolvable} [scheduledEndTime] The time to end the event at
    * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External}</warn>
    * @property {GuildScheduledEventPrivacyLevel} privacyLevel The privacy level of the guild scheduled event
-   * @property {GuildScheduledEventEntityType|number} entityType The scheduled entity type of the event
+   * @property {GuildScheduledEventEntityType} entityType The scheduled entity type of the event
    * @property {string} [description] The description of the guild scheduled event
    * @property {GuildVoiceChannelResolvable} [channel] The channel of the guild scheduled event
    * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.StageInstance} or
@@ -168,7 +168,7 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {DateResolvable} [scheduledStartTime] The time to schedule the event at
    * @property {DateResolvable} [scheduledEndTime] The time to end the event at
    * @property {GuildScheduledEventPrivacyLevel} [privacyLevel] The privacy level of the guild scheduled event
-   * @property {GuildScheduledEventEntityType|number} [entityType] The scheduled entity type of the event
+   * @property {GuildScheduledEventEntityType} [entityType] The scheduled entity type of the event
    * @property {string} [description] The description of the guild scheduled event
    * @property {?GuildVoiceChannelResolvable} [channel] The channel of the guild scheduled event
    * @property {GuildScheduledEventStatus|number} [status] The status of the guild scheduled event

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -43,7 +43,7 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {DateResolvable} scheduledStartTime The time to schedule the event at
    * @property {DateResolvable} [scheduledEndTime] The time to end the event at
    * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External}</warn>
-   * @property {GuildScheduledEventPrivacyLevel|number} privacyLevel The privacy level of the guild scheduled event
+   * @property {GuildScheduledEventPrivacyLevel} privacyLevel The privacy level of the guild scheduled event
    * @property {GuildScheduledEventEntityType|number} entityType The scheduled entity type of the event
    * @property {string} [description] The description of the guild scheduled event
    * @property {GuildVoiceChannelResolvable} [channel] The channel of the guild scheduled event
@@ -167,7 +167,7 @@ class GuildScheduledEventManager extends CachedManager {
    * @property {string} [name] The name of the guild scheduled event
    * @property {DateResolvable} [scheduledStartTime] The time to schedule the event at
    * @property {DateResolvable} [scheduledEndTime] The time to end the event at
-   * @property {GuildScheduledEventPrivacyLevel|number} [privacyLevel] The privacy level of the guild scheduled event
+   * @property {GuildScheduledEventPrivacyLevel} [privacyLevel] The privacy level of the guild scheduled event
    * @property {GuildScheduledEventEntityType|number} [entityType] The scheduled entity type of the event
    * @property {string} [description] The description of the guild scheduled event
    * @property {?GuildVoiceChannelResolvable} [channel] The channel of the guild scheduled event

--- a/packages/discord.js/src/managers/StageInstanceManager.js
+++ b/packages/discord.js/src/managers/StageInstanceManager.js
@@ -30,7 +30,7 @@ class StageInstanceManager extends CachedManager {
    * Options used to create a stage instance.
    * @typedef {Object} StageInstanceCreateOptions
    * @property {string} topic The topic of the stage instance
-   * @property {StageInstancePrivacyLevel|number} [privacyLevel] The privacy level of the stage instance
+   * @property {StageInstancePrivacyLevel} [privacyLevel] The privacy level of the stage instance
    * @property {boolean} [sendStartNotification] Whether to notify `@everyone` that the stage instance has started
    */
 
@@ -101,7 +101,7 @@ class StageInstanceManager extends CachedManager {
    * Options used to edit an existing stage instance.
    * @typedef {Object} StageInstanceEditOptions
    * @property {string} [topic] The new topic of the stage instance
-   * @property {StageInstancePrivacyLevel|number} [privacyLevel] The new privacy level of the stage instance
+   * @property {StageInstancePrivacyLevel} [privacyLevel] The new privacy level of the stage instance
    */
 
   /**

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -65,7 +65,8 @@ class ThreadManager extends CachedManager {
    * @typedef {StartThreadOptions} ThreadCreateOptions
    * @property {MessageResolvable} [startMessage] The message to start a thread from. <warn>If this is defined then type
    * of thread gets automatically defined and cannot be changed. The provided `type` field will be ignored</warn>
-   * @property {ThreadChannelTypes|number} [type] The type of thread to create.
+   * @property {ChannelType.GuildNewsThread|ChannelType.GuildPublicThread|ChannelType.GuildPrivateThread} [type]
+   * The type of thread to create.
    * Defaults to {@link ChannelType.GuildPublicThread} if created in a {@link TextChannel}
    * <warn>When creating threads in a {@link NewsChannel} this is ignored and is always
    * {@link ChannelType.GuildNewsThread}</warn>

--- a/packages/discord.js/src/structures/ClientUser.js
+++ b/packages/discord.js/src/structures/ClientUser.js
@@ -97,7 +97,7 @@ class ClientUser extends User {
    * Options for setting activities
    * @typedef {Object} ActivitiesOptions
    * @property {string} [name] Name of the activity
-   * @property {ActivityType|number} [type] Type of the activity
+   * @property {ActivityType} [type] Type of the activity
    * @property {string} [url] Twitch / YouTube stream URL
    */
 
@@ -149,7 +149,7 @@ class ClientUser extends User {
    * @typedef {Object} ActivityOptions
    * @property {string} [name] Name of the activity
    * @property {string} [url] Twitch / YouTube stream URL
-   * @property {ActivityType|number} [type] Type of the activity
+   * @property {ActivityType} [type] Type of the activity
    * @property {number|number[]} [shardId] Shard Id(s) to have the activity set on
    */
 

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -728,7 +728,7 @@ class Guild extends AnonymousGuild {
    * @property {?(BufferResolvable|Base64Resolvable)} [splash] The invite splash image of the guild
    * @property {?(BufferResolvable|Base64Resolvable)} [discoverySplash] The discovery splash image of the guild
    * @property {?(BufferResolvable|Base64Resolvable)} [banner] The banner of the guild
-   * @property {?(GuildDefaultMessageNotificationLevel|number)} [defaultMessageNotifications] The default message
+   * @property {?GuildDefaultMessageNotifications} [defaultMessageNotifications] The default message
    * notification level of the guild
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The system channel flags of the guild
    * @property {?TextChannelResolvable} [rulesChannel] The rules channel of the guild
@@ -897,7 +897,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Edits the setting of the default message notifications of the guild.
-   * @param {?(GuildDefaultMessageNotificationLevel|number)} defaultMessageNotifications The new default message notification level of the guild
+   * @param {?GuildDefaultMessageNotifications} defaultMessageNotifications The new default message notification level of the guild
    * @param {string} [reason] Reason for changing the setting of the default message notifications
    * @returns {Promise<Guild>}
    */

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -718,8 +718,8 @@ class Guild extends AnonymousGuild {
    * The data for editing a guild.
    * @typedef {Object} GuildEditData
    * @property {string} [name] The name of the guild
-   * @property {?(GuildExplicitContentFilterLevel|number)} [explicitContentFilter] The level of the explicit content filter
    * @property {?GuildVerificationLevel} [verificationLevel] The verification level of the guild
+   * @property {?GuildExplicitContentFilter} [explicitContentFilter] The level of the explicit content filter
    * @property {?VoiceChannelResolvable} [afkChannel] The AFK channel of the guild
    * @property {?TextChannelResolvable} [systemChannel] The system channel of the guild
    * @property {number} [afkTimeout] The AFK timeout of the guild
@@ -887,7 +887,7 @@ class Guild extends AnonymousGuild {
   /* eslint-disable max-len */
   /**
    * Edits the level of the explicit content filter.
-   * @param {?(GuildExplicitContentFilterLevel|number)} explicitContentFilter The new level of the explicit content filter
+   * @param {?GuildExplicitContentFilter} explicitContentFilter The new level of the explicit content filter
    * @param {string} [reason] Reason for changing the level of the guild's explicit content filter
    * @returns {Promise<Guild>}
    */

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -718,8 +718,8 @@ class Guild extends AnonymousGuild {
    * The data for editing a guild.
    * @typedef {Object} GuildEditData
    * @property {string} [name] The name of the guild
-   * @property {?(GuildVerificationLevel|number)} [verificationLevel] The verification level of the guild
    * @property {?(GuildExplicitContentFilterLevel|number)} [explicitContentFilter] The level of the explicit content filter
+   * @property {?GuildVerificationLevel} [verificationLevel] The verification level of the guild
    * @property {?VoiceChannelResolvable} [afkChannel] The AFK channel of the guild
    * @property {?TextChannelResolvable} [systemChannel] The system channel of the guild
    * @property {number} [afkTimeout] The AFK timeout of the guild

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -354,7 +354,7 @@ class GuildScheduledEvent extends Base {
    * Sets the new status of the guild scheduled event.
    * <info>If you're working with TypeScript, use this method in conjunction with status type-guards
    * like {@link GuildScheduledEvent#isScheduled} to get only valid status as suggestion</info>
-   * @param {GuildScheduledEventStatus|number} status The status of the guild scheduled event
+   * @param {GuildScheduledEventStatus} status The status of the guild scheduled event
    * @param {string} [reason] The reason for changing the status
    * @returns {Promise<GuildScheduledEvent>}
    * @example

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -82,7 +82,7 @@ exports.NonSystemMessageTypes = [
  * * {@link ChannelType.GuildPublicThread}
  * * {@link ChannelType.GuildPrivateThread}
  * * {@link ChannelType.GuildVoice}
- * @typedef {ChannelType} TextBasedChannelTypes
+ * @typedef {ChannelType[]} TextBasedChannelTypes
  */
 exports.TextBasedChannelTypes = [
   ChannelType.DM,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4651,7 +4651,7 @@ export interface GuildScheduledEventEditOptions<
   T extends GuildScheduledEventSetStatusArg<S>,
 > extends Omit<Partial<GuildScheduledEventCreateOptions>, 'channel'> {
   channel?: GuildVoiceChannelResolvable | null;
-  status?: T | number;
+  status?: T;
 }
 
 export interface GuildScheduledEventEntityMetadata {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5006,7 +5006,7 @@ export type PresenceResolvable = Presence | UserResolvable | Snowflake;
 export interface PartialChannelData {
   id?: Snowflake | number;
   parentId?: Snowflake | number;
-  type?: ChannelType.GuildText | ChannelType.GuildVoice | ChannelType.GuildCategory
+  type?: ChannelType.GuildText | ChannelType.GuildVoice | ChannelType.GuildCategory;
   name: string;
   topic?: string | null;
   nsfw?: boolean;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5006,16 +5006,7 @@ export type PresenceResolvable = Presence | UserResolvable | Snowflake;
 export interface PartialChannelData {
   id?: Snowflake | number;
   parentId?: Snowflake | number;
-  type?: Exclude<
-    ChannelType,
-    | ChannelType.DM
-    | ChannelType.GroupDM
-    | ChannelType.GuildNews
-    | ChannelType.GuildNewsThread
-    | ChannelType.GuildPublicThread
-    | ChannelType.GuildPrivateThread
-    | ChannelType.GuildStageVoice
-  >;
+  type?: ChannelType.GuildText | ChannelType.GuildVoice | ChannelType.GuildCategory
   name: string;
   topic?: string | null;
   nsfw?: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Many enums still were in union with `number`. This has been removed
- Typings for creating channels whilst creating a guild were fixed to not include directory channels or forum channels. The documentation reflects this
- `GuildDefaultMessageNotificationLevel` did not exist. This has been corrected to `GuildDefaultMessageNotifications`
- `GuildExplicitContentFilterLevel` did not exist. This has been corrected to `GuildExplicitContentFilter`
- `ThreadChannelTypes|number` wasn't the correct type to show in the documentation. This is now a union of possible types
- `TextBasedChannelTypes` was not documented as an array

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
