### PR TITLE
docs(GuildAuditLogs): Fix and reimplement type definitions

### DIFF
--- a/packages/discord.js/src/structures/GuildAuditLogs.js
+++ b/packages/discord.js/src/structures/GuildAuditLogs.js
@@ -8,25 +8,6 @@ const Webhook = require('./Webhook');
 const { flatten } = require('../util/Util');
 
 /**
- * The target type of an entry. Here are the available types:
- * * Guild
- * * Channel
- * * User
- * * Role
- * * Invite
- * * Webhook
- * * Emoji
- * * Message
- * * Integration
- * * StageInstance
- * * Sticker
- * * Thread
- * * GuildScheduledEvent
- * * ApplicationCommandPermission
- * @typedef {string} AuditLogTargetType
- */
-
-/**
  * Audit logs entries are held in this class.
  */
 class GuildAuditLogs {

--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -62,6 +62,78 @@ const Targets = {
  */
 
 /**
+ * The target type of an entry. Here are the available types:
+ * * Guild
+ * * Channel
+ * * User
+ * * Role
+ * * Invite
+ * * Webhook
+ * * Emoji
+ * * Message
+ * * Integration
+ * * StageInstance
+ * * Sticker
+ * * Thread
+ * * GuildScheduledEvent
+ * * ApplicationCommandPermission
+ * @typedef {string} AuditLogTargetType
+ */
+
+/**
+ * The action of an entry. Here are the available actions:
+ * * GuildUpdate
+ * * ChannelCreate
+ * * ChannelUpdate
+ * * ChannelDelete
+ * * ChannelOverwriteCreate
+ * * ChannelOverwriteUpdate
+ * * ChannelOverwriteDelete
+ * * MemberKick
+ * * MemberPrune
+ * * MemberBanAdd
+ * * MemberBanRemove
+ * * MemberUpdate
+ * * MemberRoleUpdate
+ * * MemberMove
+ * * MemberDisconnect
+ * * BotAdd
+ * * RoleCreate
+ * * RoleUpdate
+ * * RoleDelete
+ * * InviteCreate
+ * * InviteUpdate
+ * * InviteDelete
+ * * WebhookCreate
+ * * WebhookUpdate
+ * * WebhookDelete
+ * * EmojiCreate
+ * * EmojiUpdate
+ * * EmojiDelete
+ * * MessageDelete
+ * * MessageBulkDelete
+ * * MessagePin
+ * * MessageUnpin
+ * * IntegrationCreate
+ * * IntegrationUpdate
+ * * IntegrationDelete
+ * * StageInstanceCreate
+ * * StageInstanceUpdate
+ * * StageInstanceDelete
+ * * StickerCreate
+ * * StickerUpdate
+ * * StickerDelete
+ * * GuildScheduledEventCreate
+ * * GuildScheduledEventUpdate
+ * * GuildScheduledEventDelete
+ * * ThreadCreate
+ * * ThreadUpdate
+ * * ThreadDelete
+ * * ApplicationCommandPermissionUpdate
+ * @typedef {string} AuditLogAction
+ */
+
+/**
  * Audit logs entry.
  */
 class GuildAuditLogsEntry {
@@ -341,7 +413,7 @@ class GuildAuditLogsEntry {
 
   /**
    * Finds the target type of a guild audit log entry.
-   * @param {AuditLogAction} target The action target.
+   * @param {AuditLogEvent} target The action target
    * @returns {AuditLogTargetType}
    */
   static targetType(target) {
@@ -364,7 +436,7 @@ class GuildAuditLogsEntry {
 
   /**
    * Finds the action type from the guild audit log entry action.
-   * @param {AuditLogAction} action The action target.
+   * @param {AuditLogEvent} action The action target
    * @returns {AuditLogActionType}
    */
   static actionType(action) {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1192,7 +1192,7 @@ export class GuildAuditLogsEntry<
   TActionType extends GuildAuditLogsActionType = TAction extends keyof GuildAuditLogsTypes
     ? GuildAuditLogsTypes[TAction][1]
     : 'All',
-  TTargetType extends GuildAuditLogsTarget = TAction extends keyof GuildAuditLogsTypes
+  TTargetType extends GuildAuditLogsTargetType = TAction extends keyof GuildAuditLogsTypes
     ? GuildAuditLogsTypes[TAction][0]
     : 'Unknown',
 > {
@@ -1211,8 +1211,8 @@ export class GuildAuditLogsEntry<
     ? GuildAuditLogsEntryTargetField<TActionType>[TTargetType]
     : Role | GuildEmoji | { id: Snowflake } | null;
   public targetType: TTargetType;
-  public static actionType(action: number): GuildAuditLogsActionType;
-  public static targetType(target: number): GuildAuditLogsTarget;
+  public static actionType(action: AuditLogEvent): GuildAuditLogsActionType;
+  public static targetType(target: AuditLogEvent): GuildAuditLogsTargetType;
   public toJSON(): unknown;
 }
 
@@ -4492,10 +4492,10 @@ export interface GuildAuditLogsFetchOptions<T extends GuildAuditLogsResolvable> 
 
 export type GuildAuditLogsResolvable = AuditLogEvent | null;
 
-export type GuildAuditLogsTarget = GuildAuditLogsTypes[keyof GuildAuditLogsTypes][0] | 'All' | 'Unknown';
+export type GuildAuditLogsTargetType = GuildAuditLogsTypes[keyof GuildAuditLogsTypes][0] | 'All' | 'Unknown';
 
 export type GuildAuditLogsTargets = {
-  [key in GuildAuditLogsTarget]: GuildAuditLogsTarget;
+  [key in GuildAuditLogsTargetType]: GuildAuditLogsTargetType;
 };
 
 export type GuildBanResolvable = GuildBan | UserResolvable;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- `AuditLogAction` was missing in the documentation. This has been readded
- `GuildAuditLogsEntry.actionType()`'s parameter was incorrectly documented. This has been fixed to `AuditLogEvent`
- `GuildAuditLogsEntry.targetType()`'s parameter was incorrectly documented. This has been fixed to `AuditLogEvent`
- Renamed `GuildAuditLogsTarget` to `GuildAuditLogsTargetType` for consistency

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
