### PR TITLE
types(voice): bring back typed events

### DIFF
--- a/packages/voice/__tests__/SpeakingMap.test.ts
+++ b/packages/voice/__tests__/SpeakingMap.test.ts
@@ -11,8 +11,8 @@ describe('SpeakingMap', () => {
 		const starts: string[] = [];
 		const ends: string[] = [];
 
-		speaking.on('start', (userId: string) => void starts.push(userId));
-		speaking.on('end', (userId: string) => void ends.push(userId));
+		speaking.on('start', (userId) => void starts.push(userId));
+		speaking.on('end', (userId) => void ends.push(userId));
 
 		for (let i = 0; i < 10; i++) {
 			speaking.onPacket(userId);

--- a/packages/voice/src/VoiceConnection.ts
+++ b/packages/voice/src/VoiceConnection.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/method-signature-style */
 import { EventEmitter } from 'node:events';
 import type { GatewayVoiceServerUpdateDispatchData, GatewayVoiceStateUpdateDispatchData } from 'discord-api-types/v10';
 import type { CreateVoiceConnectionOptions } from '.';
@@ -160,6 +161,32 @@ export type VoiceConnectionState =
 	| VoiceConnectionConnectingState
 	| VoiceConnectionReadyState
 	| VoiceConnectionDestroyedState;
+
+export interface VoiceConnection extends EventEmitter {
+	/**
+	 * Emitted when there is an error emitted from the voice connection
+	 * @event
+	 */
+	on(event: 'error', listener: (error: Error) => void): this;
+	/**
+	 * Emitted debugging information about the voice connection
+	 * @event
+	 */
+	on(event: 'debug', listener: (message: string) => void): this;
+	/**
+	 * Emitted when the state of the voice connection changes
+	 * @event
+	 */
+	on(event: 'stateChange', listener: (oldState: VoiceConnectionState, newState: VoiceConnectionState) => void): this;
+	/**
+	 * Emitted when the state of the voice connection changes to a specific status
+	 * @event
+	 */
+	on<T extends VoiceConnectionStatus>(
+		event: T,
+		listener: (oldState: VoiceConnectionState, newState: VoiceConnectionState & { status: T }) => void,
+	): this;
+}
 
 /**
  * A connection to the voice server of a Guild, can be used to play audio in voice channels.

--- a/packages/voice/src/audio/AudioPlayer.ts
+++ b/packages/voice/src/audio/AudioPlayer.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/prefer-ts-expect-error */
+/* eslint-disable @typescript-eslint/prefer-ts-expect-error, @typescript-eslint/method-signature-style */
 import EventEmitter from 'node:events';
 import { AudioPlayerError } from './AudioPlayerError';
 import type { AudioResource } from './AudioResource';
@@ -154,10 +154,32 @@ export type AudioPlayerState =
 export interface AudioPlayer extends EventEmitter {
 	/**
 	 * Emitted when there is an error emitted from the audio resource played by the audio player
-	 *
 	 * @event
 	 */
-	on: (event: 'error', listener: (error: AudioPlayerError) => void) => this;
+	on(event: 'error', listener: (error: AudioPlayerError) => void): this;
+	/**
+	 * Emitted debugging information about the audio player
+	 * @event
+	 */
+	on(event: 'debug', listener: (message: string) => void): this;
+	/**
+	 * Emitted when the state of the audio player changes
+	 * @event
+	 */
+	on(event: 'stateChange', listener: (oldState: AudioPlayerState, newState: AudioPlayerState) => void): this;
+	/**
+	 * Emitted when the audio player is subscribed to a voice connection
+	 * @event
+	 */
+	on(event: 'subscribe' | 'unsubscribe', listener: (subscription: PlayerSubscription) => void): this;
+	/**
+	 * Emitted when the status of state changes to a specific status
+	 * @event
+	 */
+	on<T extends AudioPlayerStatus>(
+		event: T,
+		listener: (oldState: AudioPlayerState, newState: AudioPlayerState & { status: T }) => void,
+	): this;
 }
 
 /**

--- a/packages/voice/src/networking/VoiceUDPSocket.ts
+++ b/packages/voice/src/networking/VoiceUDPSocket.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/method-signature-style */
 import { createSocket, Socket } from 'node:dgram';
 import { EventEmitter } from 'node:events';
 import { isIPv4 } from 'node:net';
@@ -49,6 +50,13 @@ const KEEP_ALIVE_LIMIT = 12;
  * The maximum value of the keep alive counter.
  */
 const MAX_COUNTER_VALUE = 2 ** 32 - 1;
+
+export interface VoiceUDPSocket extends EventEmitter {
+	on(event: 'error', listener: (error: Error) => void): this;
+	on(event: 'close', listener: () => void): this;
+	on(event: 'debug', listener: (message: string) => void): this;
+	on(event: 'message', listener: (message: Buffer) => void): this;
+}
 
 /**
  * Manages the UDP networking for a voice connection.

--- a/packages/voice/src/receive/SSRCMap.ts
+++ b/packages/voice/src/receive/SSRCMap.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/method-signature-style */
 import { EventEmitter } from 'node:events';
 
 /**
@@ -19,6 +20,12 @@ export interface VoiceUserData {
 	 * The Discord user id of the user.
 	 */
 	userId: string;
+}
+
+export interface SSRCMap extends EventEmitter {
+	on(event: 'create', listener: (newData: VoiceUserData) => void): this;
+	on(event: 'update', listener: (oldData: VoiceUserData | undefined, newData: VoiceUserData) => void): this;
+	on(event: 'delete', listener: (deletedData: VoiceUserData) => void): this;
 }
 
 /**

--- a/packages/voice/src/receive/SpeakingMap.ts
+++ b/packages/voice/src/receive/SpeakingMap.ts
@@ -1,5 +1,13 @@
 import { EventEmitter } from 'node:events';
 
+export interface SpeakingMap extends EventEmitter {
+	/**
+	 * Emitted when a user starts/stops speaking.
+	 * @event
+	 */
+	on: (event: 'start' | 'end', listener: (userId: string) => void) => this;
+}
+
 /**
  * Tracks the speaking states of users in a voice channel.
  */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
d4b41dd0815b493b599d4f4d1b6dd18cd99f91ea commits removed all typed events for compatible with `docgen` I guess. But `AudioPlayer` event types are broken. That's why I bring back all removed typed events.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->