### PR TITLE
docs: `TextBasedChannel` -> `TextBasedChannels` typos

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -351,7 +351,7 @@ class Message extends Base {
 
   /**
    * The channel that the message was sent in
-   * @type {TextBasedChannel}
+   * @type {TextBasedChannels}
    * @readonly
    */
   get channel() {

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -277,7 +277,7 @@ module.exports = MessagePayload;
 
 /**
  * A target for a message.
- * @typedef {TextBasedChannel|User|GuildMember|Webhook|WebhookClient|Interaction|InteractionWebhook|
+ * @typedef {TextBasedChannels|User|GuildMember|Webhook|WebhookClient|Interaction|InteractionWebhook|
  * Message|MessageManager} MessageTarget
  */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Some places incorrectly used the class `TextBasedChannel` instead of `TextBasedChannels`.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
