### PR TITLE
types(GuildScheduledEvent#scheduledStartAt): should be nullish

### DIFF
--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -192,12 +192,13 @@ class GuildScheduledEvent extends Base {
   }
 
   /**
-   * The time the guild scheduled event will start at
-   * @type {Date}
+   * The time the guild scheduled event will start at,
+   * or `null` if the event does not have a scheduled time to start
+   * @type {?Date}
    * @readonly
    */
   get scheduledStartAt() {
-    return new Date(this.scheduledStartTimestamp);
+    return this.scheduledStartTimestamp && new Date(this.scheduledStartTimestamp);
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1367,7 +1367,7 @@ export class GuildScheduledEvent<S extends GuildScheduledEventStatus = GuildSche
   public creator: User | null;
   public get createdTimestamp(): number;
   public get createdAt(): Date;
-  public get scheduledStartAt(): Date;
+  public get scheduledStartAt(): Date | null;
   public get scheduledEndAt(): Date | null;
   public get channel(): VoiceChannel | StageChannel | null;
   public get guild(): Guild | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`GuildScheduledEvent#scheduledEndTimestamp` can be nullish and was properly set as nullish for `GuildScheduledEvent#scheduledEndAt`

`GuildScheduledEvent#scheduledStartTimestamp` can be nullish but was not properly set as nullish for `GuildScheduledEvent#scheduledStartAt`

This PR brings nullish parity for `scheduledStartAt` so that when `GuildScheduledEvent#scheduledStartTimestamp` is `null`, `GuildScheduledEvent#scheduledStartAt` is not `new Date(null)`

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
