### PR TITLE
docs(PermissionsBitField): Fix `@name` of bitfield

### DIFF
--- a/packages/discord.js/src/util/PermissionsBitField.js
+++ b/packages/discord.js/src/util/PermissionsBitField.js
@@ -50,7 +50,7 @@ class PermissionsBitField extends BitField {
   /**
    * Bitfield of the packed bits
    * @type {bigint}
-   * @name Permissions#bitfield
+   * @name PermissionsBitField#bitfield
    */
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The class is called `PermissionsBitField`, not `Permissions`. This was causing the following message to appear:

```xl
"bitfield" (member of "Permissions", packages/discord.js/src/util/PermissionsBitField.js:50) has no accessible parent.
```

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
