### PR TITLE
types(Shard#reconnecting): fix event name

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2175,7 +2175,7 @@ export interface ShardEventTypes {
   death: [child: ChildProcess];
   disconnect: [];
   ready: [];
-  reconnection: [];
+  reconnecting: [];
   error: [error: Error];
   message: [message: any];
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes the typing for the event name `Shard#reconnecting` it should be merged to avoid confusing users that use TS and other features like Intellisense that rely on these typings.

**Status and versioning classification:**
Bug-fix

- Code changes have been tested against the Discord API, or there are **no code changes**
- **I know how to update typings** and have done so, or typings don't need updating