### PR TITLE
fix(proxy-container): proper deps

### DIFF
--- a/packages/proxy-container/package.json
+++ b/packages/proxy-container/package.json
@@ -43,8 +43,8 @@
 	},
 	"homepage": "https://discord.js.org",
 	"dependencies": {
-		"@discordjs/proxy": "^0.1.0-dev",
-		"@discordjs/rest": "workspace:^",
+		"@discordjs/proxy": "^1.0.0-dev",
+		"@discordjs/rest": "^0.5.0",
 		"tslib": "^2.4.0"
 	},
 	"devDependencies": {

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -52,7 +52,7 @@
 	},
 	"homepage": "https://discord.js.org",
 	"dependencies": {
-		"@discordjs/rest": "workspace:^",
+		"@discordjs/rest": "^0.5.0",
 		"tslib": "^2.4.0",
 		"undici": "^5.4.0"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1925,8 +1925,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@discordjs/proxy-container@workspace:packages/proxy-container"
   dependencies:
-    "@discordjs/proxy": ^0.1.0-dev
-    "@discordjs/rest": "workspace:^"
+    "@discordjs/proxy": ^1.0.0-dev
+    "@discordjs/rest": ^0.5.0
     "@types/node": ^16.11.38
     "@typescript-eslint/eslint-plugin": ^5.27.0
     "@typescript-eslint/parser": ^5.27.0
@@ -1941,23 +1941,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@discordjs/proxy@npm:^0.1.0-dev":
-  version: 0.1.0-dev.1654949067-96053ba
-  resolution: "@discordjs/proxy@npm:0.1.0-dev.1654949067-96053ba"
-  dependencies:
-    "@discordjs/rest": ^0.6.0-dev
-    tslib: ^2.4.0
-    undici: ^5.4.0
-  checksum: 152c9e26b502daca7255129cc4a6c0fbf678cfd3fe5ca8b12229bacffaef33567469e000688dad6b978c04f471dfb12ece97183ecc9365ce5a86eb74220b50af
-  languageName: node
-  linkType: hard
-
-"@discordjs/proxy@workspace:packages/proxy":
+"@discordjs/proxy@^1.0.0-dev, @discordjs/proxy@workspace:packages/proxy":
   version: 0.0.0-use.local
   resolution: "@discordjs/proxy@workspace:packages/proxy"
   dependencies:
     "@discordjs/docgen": "workspace:^"
-    "@discordjs/rest": "workspace:^"
+    "@discordjs/rest": ^0.5.0
     "@discordjs/scripts": "workspace:^"
     "@favware/cliff-jumper": ^1.8.3
     "@types/node": ^16.11.39
@@ -1978,7 +1967,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@discordjs/rest@^0.6.0-dev, @discordjs/rest@workspace:^, @discordjs/rest@workspace:packages/rest":
+"@discordjs/rest@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@discordjs/rest@npm:0.5.0"
+  dependencies:
+    "@discordjs/collection": ^0.7.0
+    "@sapphire/async-queue": ^1.3.1
+    "@sapphire/snowflake": ^3.2.2
+    discord-api-types: ^0.33.3
+    tslib: ^2.4.0
+    undici: ^5.4.0
+  checksum: 36427fd77ff11285da4400e9960fccb71aafa657e43c3de4fe4772d1497f20c3d84754c844ad44d2c6f68fed45303ace790191fd811c94414312fde20d0346c2
+  languageName: node
+  linkType: hard
+
+"@discordjs/rest@workspace:^, @discordjs/rest@workspace:packages/rest":
   version: 0.0.0-use.local
   resolution: "@discordjs/rest@workspace:packages/rest"
   dependencies:
@@ -6592,7 +6595,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"discord-api-types@npm:^0.33.5":
+"discord-api-types@npm:^0.33.3, discord-api-types@npm:^0.33.5":
   version: 0.33.5
   resolution: "discord-api-types@npm:0.33.5"
   checksum: 6dcaad640c5693a69c9a4f5e444e739dde11ba835164ae6fd3dd5a1ab7b4d7f96cd022ed653eeaff2c8051ead0d998a5d502a2915cfacdde596364b82d9e3b3f


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Crawl is gonna hate me for this.

This PR:
1) bumps `@discordjs/proxy` in proxy-container. this was meant to be done right after #8000 but I guess we just didn't.
2) fixes an oversight I had yesterday with #8113 - indeed! `@discordjs/rest` should not have used the workspace protocol, I was even asked about this. I was thinking of version conflicts and things like that and completely forgot about the Docker build aspect.
3) as a result of 2, I also had to lock `@discordjs/rest` to an NPM build in `proxy` - otherwise we'd get a version miss match and the code wouldn't build.


To whoever merges this, please also dispatch the dev docker deploy workflow just to confirm everything finally works.