### PR TITLE
typings(Shard#reconnecting): Backport to v13 - Fix event name

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2127,7 +2127,7 @@ export interface ShardEventTypes {
   death: [child: ChildProcess];
   disconnect: [];
   ready: [];
-  reconnection: [];
+  reconnecting: [];
   error: [error: Error];
   message: [message: any];
 }


### PR DESCRIPTION
See #8118 

Targets v13 branch instead of stable