### PR TITLE
fix(example-readme): use yarn instead of npm for main repo

### DIFF
--- a/packages/voice/examples/radio-bot/README.md
+++ b/packages/voice/examples/radio-bot/README.md
@@ -11,8 +11,8 @@ A proof-of-concept radio bot that uses @discordjs/voice and discord.js. Streams 
 
 ```bash
 # Clone the main @discordjs/voice repo, then install dependencies and build
-$ npm install
-$ npm run build
+$ yarn --immutable
+$ yarn build
 
 # Enter this example's directory, create a config file and start!
 $ cd examples/radio-bot

--- a/packages/voice/examples/recorder/README.md
+++ b/packages/voice/examples/recorder/README.md
@@ -7,8 +7,8 @@ and save the audio to local Ogg files.
 
 ```sh-session
 # Clone the main repository, and then run:
-$ npm install
-$ npm run build
+$ yarn --immutable
+$ yarn build
 
 # Open this example and install dependencies
 $ cd examples/recorder


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Old readme in examples uses npm for the main repo, should be yarn instead

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
