### PR TITLE
refactor: remove @sindresorhus/is as it's now esm only

### DIFF
--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -53,7 +53,6 @@
 	"homepage": "https://discord.js.org",
 	"dependencies": {
 		"@sapphire/shapeshift": "^3.2.0",
-		"@sindresorhus/is": "^4.6.0",
 		"discord-api-types": "^0.33.5",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.1",

--- a/packages/builders/src/interactions/slashCommands/Assertions.ts
+++ b/packages/builders/src/interactions/slashCommands/Assertions.ts
@@ -1,5 +1,4 @@
 import { s } from '@sapphire/shapeshift';
-import is from '@sindresorhus/is';
 import { type APIApplicationCommandOptionChoice, Locale, LocalizationMap } from 'discord-api-types/v10';
 import type { ToAPIApplicationCommandOptions } from './SlashCommandBuilder';
 import type { SlashCommandSubcommandBuilder, SlashCommandSubcommandGroupBuilder } from './SlashCommandSubcommands';
@@ -64,28 +63,7 @@ export function validateChoicesLength(amountAdding: number, choices?: APIApplica
 export function assertReturnOfBuilder<
 	T extends ApplicationCommandOptionBase | SlashCommandSubcommandBuilder | SlashCommandSubcommandGroupBuilder,
 >(input: unknown, ExpectedInstanceOf: new () => T): asserts input is T {
-	const instanceName = ExpectedInstanceOf.name;
-
-	if (is.nullOrUndefined(input)) {
-		throw new TypeError(
-			`Expected to receive a ${instanceName} builder, got ${input === null ? 'null' : 'undefined'} instead.`,
-		);
-	}
-
-	if (is.primitive(input)) {
-		throw new TypeError(`Expected to receive a ${instanceName} builder, got a primitive (${typeof input}) instead.`);
-	}
-
-	if (!(input instanceof ExpectedInstanceOf)) {
-		const casted = input as Record<PropertyKey, unknown>;
-
-		const constructorName = is.function_(input) ? input.name : casted.constructor.name;
-		const stringTag = Reflect.get(casted, Symbol.toStringTag) as string | undefined;
-
-		const fullResultName = stringTag ? `${constructorName} [${stringTag}]` : constructorName;
-
-		throw new TypeError(`Expected to receive a ${instanceName} builder, got ${fullResultName} instead.`);
-	}
+	s.instance(ExpectedInstanceOf).parse(input);
 }
 
 export const localizationMapPredicate = s.object<LocalizationMap>(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,7 +1833,6 @@ __metadata:
     "@discordjs/scripts": "workspace:^"
     "@favware/cliff-jumper": ^1.8.3
     "@sapphire/shapeshift": ^3.2.0
-    "@sindresorhus/is": ^4.6.0
     "@types/node": ^16.11.41
     "@typescript-eslint/eslint-plugin": ^5.28.0
     "@typescript-eslint/parser": ^5.28.0
@@ -2922,7 +2921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sindresorhus/is@npm:^4.0.0, @sindresorhus/is@npm:^4.6.0":
+"@sindresorhus/is@npm:^4.0.0":
   version: 4.6.0
   resolution: "@sindresorhus/is@npm:4.6.0"
   checksum: 83839f13da2c29d55c97abc3bc2c55b250d33a0447554997a85c539e058e57b8da092da396e252b11ec24a0279a0bed1f537fa26302209327060643e327f81d2


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
this pr replaces @sindresorhus/is with shapeshift.
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:


- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
