### PR TITLE
fix(WebSocketManager): Correct error name

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -130,7 +130,7 @@ class WebSocketManager extends EventEmitter {
    * @private
    */
   async connect() {
-    const invalidToken = new Error(ErrorCodes.AuthenticationFailed);
+    const invalidToken = new Error(ErrorCodes.TokenInvalid);
     const {
       url: gatewayURL,
       shards: recommendedShards,

--- a/packages/discord.js/src/errors/Messages.js
+++ b/packages/discord.js/src/errors/Messages.js
@@ -160,7 +160,7 @@ const Messages = {
 };
 
 // Magic needed by WS
-Messages.AuthenticationFailed = Messages[DjsErrorCodes.AuthenticationFailed];
+Messages.AuthenticationFailed = Messages[DjsErrorCodes.TokenInvalid];
 Messages.InvalidShard = Messages[DjsErrorCodes.ShardingInvalid];
 Messages.ShardingRequired = Messages[DjsErrorCodes.ShardingRequired];
 Messages.InvalidIntents = Messages[DjsErrorCodes.InvalidIntents];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`ErrorCodes.AuthenticationFailed` did not exist, causing discord.js to crash when attempting to connect to the gateway. This resolves #8137.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
