### PR TITLE
docs(APITypes): Remove duplicate type definition

### DIFF
--- a/packages/discord.js/src/util/APITypes.js
+++ b/packages/discord.js/src/util/APITypes.js
@@ -304,11 +304,6 @@
  */
 
 /**
- * @external ChannelType
- * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ChannelType}
- */
-
-/**
  * @external PermissionFlagsBits
  * @see {@link https://discord-api-types.dev/api/discord-api-types-payloads/common#PermissionFlagsBits}
  */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`ChannelType` exists in duplicated for some reason:

https://github.com/discordjs/discord.js/blob/65d1879c0ae2d8d820323d0d835b1e5e3d071e57/packages/discord.js/src/util/APITypes.js#L166-L169

https://github.com/discordjs/discord.js/blob/65d1879c0ae2d8d820323d0d835b1e5e3d071e57/packages/discord.js/src/util/APITypes.js#L306-L309

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
