### PR TITLE
types: Use `ThreadAutoArchiveDuration` from discord-api-types

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -794,21 +794,11 @@ class Message extends Base {
   }
 
   /**
-   * A number that is allowed to be the duration (in minutes) of inactivity after which a thread is automatically
-   * archived. This can be:
-   * * `60` (1 hour)
-   * * `1440` (1 day)
-   * * `4320` (3 days)
-   * * `10080` (7 days)
-   * @typedef {number|string} ThreadAutoArchiveDuration
-   */
-
-  /**
    * Options for starting a thread on a message.
    * @typedef {Object} StartThreadOptions
    * @property {string} name The name of the new thread
    * @property {ThreadAutoArchiveDuration} [autoArchiveDuration=this.channel.defaultAutoArchiveDuration] The amount of
-   * time (in minutes) after which the thread should automatically archive in case of no recent activity
+   * time after which the thread should automatically archive in case of no recent activity
    * @property {string} [reason] Reason for creating the thread
    * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the thread in seconds
    */

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -292,7 +292,7 @@ class ThreadChannel extends Channel {
    * @typedef {Object} ThreadEditData
    * @property {string} [name] The new name for the thread
    * @property {boolean} [archived] Whether the thread is archived
-   * @property {ThreadAutoArchiveDuration} [autoArchiveDuration] The amount of time (in minutes) after which the thread
+   * @property {ThreadAutoArchiveDuration} [autoArchiveDuration] The amount of time after which the thread
    * should automatically archive in case of no recent activity
    * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the thread in seconds
    * @property {boolean} [locked] Whether the thread is locked
@@ -344,7 +344,7 @@ class ThreadChannel extends Channel {
 
   /**
    * Sets the duration after which the thread will automatically archive in case of no recent activity.
-   * @param {ThreadAutoArchiveDuration} autoArchiveDuration The amount of time (in minutes) after which the thread
+   * @param {ThreadAutoArchiveDuration} autoArchiveDuration The amount of time after which the thread
    * should automatically archive in case of no recent activity
    * @param {string} [reason] Reason for changing the auto archive duration
    * @returns {Promise<ThreadChannel>}

--- a/packages/discord.js/src/util/APITypes.js
+++ b/packages/discord.js/src/util/APITypes.js
@@ -344,6 +344,11 @@
  */
 
 /**
+ * @external ThreadAutoArchiveDuration
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ThreadAutoArchiveDuration}
+ */
+
+/**
  * @external UserFlags
  * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/UserFlags}
  */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -120,6 +120,7 @@ import {
   MessageActivityType,
   APIAttachment,
   APIChannel,
+  ThreadAutoArchiveDuration,
 } from 'discord-api-types/v10';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -5408,8 +5409,6 @@ export type GuildTextBasedChannel = Extract<GuildBasedChannel, TextBasedChannel>
 export type TextChannelResolvable = Snowflake | TextChannel;
 
 export type TextBasedChannelResolvable = Snowflake | TextBasedChannel;
-
-export type ThreadAutoArchiveDuration = 60 | 1440 | 4320 | 10080;
 
 export type ThreadChannelResolvable = AnyThreadChannel | Snowflake;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
discord.js's `ThreadAutoArchiveDuration` was basically the same as discord-api-types's `ThreadAutoArchiveDuration`. So moving forward, it'd be great to use discord-api-types's `ThreadAutoArchiveDuration` to prefer enums.

I've also removed the "in minutes" text on some descriptions as the enum uses "OneDay", "OneHour" etc. which may cause confusion and also to discourage one from setting magic numbers.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
