### PR TITLE
fix(DJSError): error code validation

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -29,6 +29,14 @@ const UNRECOVERABLE_CLOSE_CODES = [
   GatewayCloseCodes.InvalidIntents,
   GatewayCloseCodes.DisallowedIntents,
 ];
+const unrecoverableErrorCodeMap = {
+  [GatewayCloseCodes.AuthenticationFailed]: ErrorCodes.TokenInvalid,
+  [GatewayCloseCodes.InvalidShard]: ErrorCodes.ShardingInvalid,
+  [GatewayCloseCodes.ShardingRequired]: ErrorCodes.ShardingRequired,
+  [GatewayCloseCodes.InvalidIntents]: ErrorCodes.InvalidIntents,
+  [GatewayCloseCodes.DisallowedIntents]: ErrorCodes.DisallowedIntents,
+};
+
 const UNRESUMABLE_CLOSE_CODES = [1000, GatewayCloseCodes.AlreadyAuthenticated, GatewayCloseCodes.InvalidSeq];
 
 /**
@@ -246,7 +254,7 @@ class WebSocketManager extends EventEmitter {
       await shard.connect();
     } catch (error) {
       if (error?.code && UNRECOVERABLE_CLOSE_CODES.includes(error.code)) {
-        throw new Error(GatewayCloseCodes[error.code]);
+        throw new Error(unrecoverableErrorCodeMap[error.code]);
         // Undefined if session is invalid, error event for regular closes
       } else if (!error || error.code) {
         this.debug('Failed to connect to the gateway, requeueing...', shard);

--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -22,13 +22,6 @@ const BeforeReadyWhitelist = [
   GatewayDispatchEvents.GuildMemberRemove,
 ];
 
-const UNRECOVERABLE_CLOSE_CODES = [
-  GatewayCloseCodes.AuthenticationFailed,
-  GatewayCloseCodes.InvalidShard,
-  GatewayCloseCodes.ShardingRequired,
-  GatewayCloseCodes.InvalidIntents,
-  GatewayCloseCodes.DisallowedIntents,
-];
 const unrecoverableErrorCodeMap = {
   [GatewayCloseCodes.AuthenticationFailed]: ErrorCodes.TokenInvalid,
   [GatewayCloseCodes.InvalidShard]: ErrorCodes.ShardingInvalid,
@@ -36,6 +29,7 @@ const unrecoverableErrorCodeMap = {
   [GatewayCloseCodes.InvalidIntents]: ErrorCodes.InvalidIntents,
   [GatewayCloseCodes.DisallowedIntents]: ErrorCodes.DisallowedIntents,
 };
+const UNRECOVERABLE_CLOSE_CODES = Object.keys(unrecoverableErrorCodeMap).map(k => Number(k));
 
 const UNRESUMABLE_CLOSE_CODES = [1000, GatewayCloseCodes.AlreadyAuthenticated, GatewayCloseCodes.InvalidSeq];
 

--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -29,7 +29,6 @@ const unrecoverableErrorCodeMap = {
   [GatewayCloseCodes.InvalidIntents]: ErrorCodes.InvalidIntents,
   [GatewayCloseCodes.DisallowedIntents]: ErrorCodes.DisallowedIntents,
 };
-const UNRECOVERABLE_CLOSE_CODES = Object.keys(unrecoverableErrorCodeMap).map(k => Number(k));
 
 const UNRESUMABLE_CLOSE_CODES = [1000, GatewayCloseCodes.AlreadyAuthenticated, GatewayCloseCodes.InvalidSeq];
 
@@ -196,7 +195,7 @@ class WebSocketManager extends EventEmitter {
       });
 
       shard.on(ShardEvents.Close, event => {
-        if (event.code === 1_000 ? this.destroyed : UNRECOVERABLE_CLOSE_CODES.includes(event.code)) {
+        if (event.code === 1_000 ? this.destroyed : event.code in unrecoverableErrorCodeMap) {
           /**
            * Emitted when a shard's WebSocket disconnects and will no longer reconnect.
            * @event Client#shardDisconnect
@@ -247,7 +246,7 @@ class WebSocketManager extends EventEmitter {
     try {
       await shard.connect();
     } catch (error) {
-      if (error?.code && UNRECOVERABLE_CLOSE_CODES.includes(error.code)) {
+      if (error?.code && error.code in unrecoverableErrorCodeMap) {
         throw new Error(unrecoverableErrorCodeMap[error.code]);
         // Undefined if session is invalid, error event for regular closes
       } else if (!error || error.code) {

--- a/packages/discord.js/src/errors/DJSError.js
+++ b/packages/discord.js/src/errors/DJSError.js
@@ -16,7 +16,7 @@ function makeDiscordjsError(Base) {
     constructor(code, ...args) {
       super(message(code, args));
       this[kCode] = code;
-      if (Error.captureStackTrace) Error.captureStackTrace(this, DiscordjsError);
+      Error.captureStackTrace?.(this, DiscordjsError);
     }
 
     get name() {

--- a/packages/discord.js/src/errors/Messages.js
+++ b/packages/discord.js/src/errors/Messages.js
@@ -159,11 +159,4 @@ const Messages = {
   [DjsErrorCodes.SweepFilterReturn]: 'The return value of the sweepFilter function was not false or a Function',
 };
 
-// Magic needed by WS
-Messages.AuthenticationFailed = Messages[DjsErrorCodes.TokenInvalid];
-Messages.InvalidShard = Messages[DjsErrorCodes.ShardingInvalid];
-Messages.ShardingRequired = Messages[DjsErrorCodes.ShardingRequired];
-Messages.InvalidIntents = Messages[DjsErrorCodes.InvalidIntents];
-Messages.DisallowedIntents = Messages[DjsErrorCodes.DisallowedIntents];
-
 module.exports = Messages;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #8148

The ws magic:tm: passes strings to the Error constructor, which then passes said string to the `message()` function, which only accepts numbers
https://github.com/discordjs/discord.js/blob/a3799f9ebb027904830457119708d550e2009200/packages/discord.js/src/client/websocket/WebSocketManager.js#L248-L249
https://github.com/discordjs/discord.js/blob/a3799f9ebb027904830457119708d550e2009200/packages/discord.js/src/errors/DJSError.js#L15-L17
https://github.com/discordjs/discord.js/blob/a3799f9ebb027904830457119708d550e2009200/packages/discord.js/src/errors/DJSError.js#L39-L40

However, the (string) error codes passed by the WS are defined
https://github.com/discordjs/discord.js/blob/a3799f9ebb027904830457119708d550e2009200/packages/discord.js/src/errors/Messages.js#L162-L167

***

To solve this, I mapped the ws error codes (because the ErrorCode keys don't always map) to djs' error codes, replacing the "ws magic" in Messages, meaning that only number error codes will be passed

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
