### PR TITLE
fix(WebSocketShard): keep an error handler on connections

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -859,7 +859,8 @@ class WebSocketShard extends EventEmitter {
    * @private
    */
   _cleanupConnection() {
-    this.connection.onopen = this.connection.onclose = this.connection.onerror = this.connection.onmessage = null;
+    this.connection.onopen = this.connection.onclose = this.connection.onmessage = null;
+    this.connection.onerror = () => null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR (hopefully) fixes an uncaught exception happening when closing a WebSocket connection before it established a connection by attaching a noop error handler.

The connection was being destroyed by either the hello timeout or an attempt to send a packet without an open connection.
The then called method, `destroy`, removed the  error handler a statement before closing the connection, here:
https://github.com/discordjs/discord.js/blob/a3799f9ebb027904830457119708d550e2009200/packages/discord.js/src/client/websocket/WebSocketShard.js#L804-L807

I'm not sure if there is a reason to remove the listeners, maybe this issue could also be addressed by not calling `_cleanupConnection` there.
(The error is emitted next tick, moving that line below would not solve this issue. (See below))

<details>
<summary>For the interested: The ws code path emitting this error</summary>

`close` will abort the still ongoing handshake
https://github.com/websockets/ws/blob/3b6af82be91713fcc21cb2e56c500977fcb63f45/lib/websocket.js#L283-L286

`abortHandshake` creates the error and emits it next tick...
https://github.com/websockets/ws/blob/3b6af82be91713fcc21cb2e56c500977fcb63f45/lib/websocket.js#L1054

...in the self-descriptive `emitErrorAndClose` function
https://github.com/websockets/ws/blob/3b6af82be91713fcc21cb2e56c500977fcb63f45/lib/websocket.js#L991-L995

</details>

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
