### PR TITLE
docs(Channels): internally document channel creation

### DIFF
--- a/packages/discord.js/src/util/Channels.js
+++ b/packages/discord.js/src/util/Channels.js
@@ -13,9 +13,14 @@ const getVoiceChannel = lazy(() => require('../structures/VoiceChannel'));
 const getDirectoryChannel = lazy(() => require('../structures/DirectoryChannel'));
 const getPartialGroupDMChannel = lazy(() => require('../structures/PartialGroupDMChannel'));
 
-// eslint-disable-next-line valid-jsdoc
 /**
- * @private
+ * Creates a discord.js channel from data received from the API.
+ * @param {Client} client The client
+ * @param {APIChannel} data The data of the channel to create
+ * @param {Guild} [guild] The guild where this channel belongs
+ * @param {Object} [extras] Extra information to supply for creating this channel
+ * @returns {Channel} Any kind of channel.
+ * @ignore
  */
 function createChannel(client, data, guild, { allowUnknownGuild, fromInteraction } = {}) {
   let channel;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This removes `createChannel()` from the documentation (which is completely blank) and adds some internal documentation to the method instead. This method is not meant for public use.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
