### PR TITLE
refactor(Constants): Remove leftover code

### DIFF
--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -110,3 +110,12 @@ exports.ThreadChannelTypes = [
  * @typedef {ChannelType[]} VoiceBasedChannelTypes
  */
 exports.VoiceBasedChannelTypes = [ChannelType.GuildVoice, ChannelType.GuildStageVoice];
+
+/**
+ * @typedef {Object} Constants Constants that can be used in an enum or object-like way.
+ * @property {SweeperKey} SweeperKey The possible names of items that can be swept in sweepers
+ * @property {NonSystemMessageTypes} NonSystemMessageTypes The types of messages that are not deemed a system type
+ * @property {TextBasedChannelTypes} TextBasedChannelTypes The types of channels that are text-based
+ * @property {ThreadChannelTypes} ThreadChannelTypes The types of channels that are threads
+ * @property {VoiceBasedChannelTypes} VoiceBasedChannelTypes The types of channels that are voice-based
+ */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2967,10 +2967,11 @@ export type NonSystemMessageType =
   | MessageType.ContextMenuCommand;
 
 export const Constants: {
-  ThreadChannelTypes: ThreadChannelType[];
-  TextBasedChannelTypes: TextBasedChannelTypes[];
-  VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
+  SweeperKeys: SweeperKey;
   NonSystemMessageTypes: NonSystemMessageType[];
+  TextBasedChannelTypes: TextBasedChannelTypes[];
+  ThreadChannelTypes: ThreadChannelType[];
+  VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
 };
 
 export const version: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
1. We used the user agent for sending requests in the past, but since this is now handled by /rest, this was no longer doing anything.
2. There's no need to require the package.json anymore. There's also no need to export it anymore.
3. Tidied up the `Constants` type definition.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
