### PR TITLE
docs(Constants): fix SweeperKeys type

### DIFF
--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -113,7 +113,7 @@ exports.VoiceBasedChannelTypes = [ChannelType.GuildVoice, ChannelType.GuildStage
 
 /**
  * @typedef {Object} Constants Constants that can be used in an enum or object-like way.
- * @property {SweeperKey} SweeperKey The possible names of items that can be swept in sweepers
+ * @property {SweeperKey[]} SweeperKeys The possible names of items that can be swept in sweepers
  * @property {NonSystemMessageTypes} NonSystemMessageTypes The types of messages that are not deemed a system type
  * @property {TextBasedChannelTypes} TextBasedChannelTypes The types of channels that are text-based
  * @property {ThreadChannelTypes} ThreadChannelTypes The types of channels that are threads

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2972,7 +2972,7 @@ export type NonSystemMessageType =
   | MessageType.ContextMenuCommand;
 
 export const Constants: {
-  SweeperKeys: SweeperKey;
+  SweeperKeys: SweeperKey[];
   NonSystemMessageTypes: NonSystemMessageType[];
   TextBasedChannelTypes: TextBasedChannelTypes[];
   ThreadChannelTypes: ThreadChannelType[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the type for `SweeperKeys` from #8156.

**Status and versioning classification:**

- There are no code changes
- I know how to update typings and have done so
- This PR **only** includes non-code changes, like changes to documentation, README, etc.