### PR TITLE
feat(util): parseWebhookURL

### DIFF
--- a/packages/discord.js/src/client/WebhookClient.js
+++ b/packages/discord.js/src/client/WebhookClient.js
@@ -3,6 +3,7 @@
 const BaseClient = require('./BaseClient');
 const { Error, ErrorCodes } = require('../errors');
 const Webhook = require('../structures/Webhook');
+const { parseWebhookURL } = require('../util/Util');
 
 /**
  * The webhook client.
@@ -28,14 +29,12 @@ class WebhookClient extends BaseClient {
     let { id, token } = data;
 
     if ('url' in data) {
-      const url = data.url.match(
-        // eslint-disable-next-line no-useless-escape
-        /https?:\/\/(?:ptb\.|canary\.)?discord\.com\/api(?:\/v\d{1,2})?\/webhooks\/(\d{17,19})\/([\w-]{68})/i,
-      );
+      const parsed = parseWebhookURL(data.url);
+      if (!parsed) {
+        throw new Error(ErrorCodes.WebhookURLInvalid);
+      }
 
-      if (!url || url.length <= 1) throw new Error(ErrorCodes.WebhookURLInvalid);
-
-      [, id, token] = url;
+      ({ id, token } = parsed);
     }
 
     this.id = id;

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -528,6 +528,32 @@ function lazy(cb) {
   return () => (defaultValue ??= cb());
 }
 
+/**
+ * Represents the credentials used for a given webhook
+ * @typedef {object} WebhookCredentials
+ * @property {string} id The webhook's id
+ * @property {string} token The webhook's token
+ */
+
+/**
+ * Parses a webhook URL for the id and token
+ * @param {string} url The URL to parse
+ * @returns {?WebhookCredentials} Null if the URL is invalid, otherwise the id and the token
+ */
+function parseWebhookURL(url) {
+  const matches = url.match(
+    /https?:\/\/(?:ptb\.|canary\.)?discord\.com\/api(?:\/v\d{1,2})?\/webhooks\/(\d{17,19})\/([\w-]{68})/i,
+  );
+
+  if (!matches || matches.length <= 2) return null;
+
+  const [, id, token] = matches;
+  return {
+    id,
+    token,
+  };
+}
+
 module.exports = {
   flatten,
   escapeMarkdown,
@@ -554,6 +580,7 @@ module.exports = {
   cleanContent,
   cleanCodeBlockContent,
   lazy,
+  parseWebhookURL,
 };
 
 // Fixes Circular

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -530,7 +530,7 @@ function lazy(cb) {
 
 /**
  * Represents the credentials used for a given webhook
- * @typedef {object} WebhookCredentials
+ * @typedef {Object} WebhookCredentials
  * @property {string} id The webhook's id
  * @property {string} token The webhook's token
  */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2625,11 +2625,6 @@ export class UserFlagsBitField extends BitField<UserFlagsString> {
   public static resolve(bit?: BitFieldResolvable<UserFlagsString, number>): number;
 }
 
-export interface WebhookCredentials {
-  id: string;
-  token: string;
-}
-
 export function basename(path: string, ext?: string): string;
 export function cleanContent(str: string, channel: TextBasedChannel): string;
 export function cloneObject(obj: unknown): unknown;
@@ -2664,7 +2659,7 @@ export function setPosition<T extends Channel | Role>(
   route: string,
   reason?: string,
 ): Promise<{ id: Snowflake; position: number }[]>;
-export function parseWebhookURL(url: string): WebhookCredentials | null;
+export function parseWebhookURL(url: string): WebhookClientDataIdWithToken | null;
 
 export interface MappedComponentBuilderTypes {
   [ComponentType.Button]: ButtonBuilder;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2625,6 +2625,11 @@ export class UserFlagsBitField extends BitField<UserFlagsString> {
   public static resolve(bit?: BitFieldResolvable<UserFlagsString, number>): number;
 }
 
+export interface WebhookCredentials {
+  id: string;
+  token: string;
+}
+
 export function basename(path: string, ext?: string): string;
 export function cleanContent(str: string, channel: TextBasedChannel): string;
 export function cloneObject(obj: unknown): unknown;
@@ -2659,6 +2664,7 @@ export function setPosition<T extends Channel | Role>(
   route: string,
   reason?: string,
 ): Promise<{ id: Snowflake; position: number }[]>;
+export function parseWebhookURL(url: string): WebhookCredentials | null;
 
 export interface MappedComponentBuilderTypes {
   [ComponentType.Button]: ButtonBuilder;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR moves the URL parsing part out of the `WebhookClient` constructor and instead makes it a util

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

