### PR TITLE
fix(`SelectMenuBuilder`): properly accept `SelectMenuOptionBuilder`s

### DIFF
--- a/packages/discord.js/src/structures/SelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuBuilder.js
@@ -35,7 +35,7 @@ class SelectMenuBuilder extends BuildersSelectMenu {
     const { emoji, ...option } = selectMenuOption;
     return {
       ...option,
-      emoji: emoji && typeof emoji === 'string' ? parseEmoji(emoji) : emoji,
+      emoji: typeof emoji === 'string' ? parseEmoji(emoji) : emoji,
     };
   }
 

--- a/packages/discord.js/src/structures/SelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuBuilder.js
@@ -22,17 +22,30 @@ class SelectMenuBuilder extends BuildersSelectMenu {
   }
 
   /**
+   * Normalizes a select menu option emoji
+   * @param {SelectMenuOptionData|JSONEncodable<APISelectMenuOption>} selectMenuOption The option to normalize
+   * @returns {Array<SelectMenuOptionBuilder | APISelectMenuOption>}
+   * @private
+   */
+  static normalizeEmoji(selectMenuOption) {
+    if (isJSONEncodable(selectMenuOption)) {
+      return selectMenuOption;
+    }
+
+    const { emoji, ...option } = selectMenuOption;
+    return {
+      ...option,
+      emoji: emoji && typeof emoji === 'string' ? parseEmoji(emoji) : emoji,
+    };
+  }
+
+  /**
    * Adds options to this select menu
    * @param {RestOrArray<APISelectMenuOption>} options The options to add to this select menu
    * @returns {SelectMenuBuilder}
    */
   addOptions(...options) {
-    return super.addOptions(
-      normalizeArray(options).map(({ emoji, ...option }) => ({
-        ...option,
-        emoji: emoji && typeof emoji === 'string' ? parseEmoji(emoji) : emoji,
-      })),
-    );
+    return super.addOptions(normalizeArray(options).map(option => SelectMenuBuilder.normalizeEmoji(option)));
   }
 
   /**
@@ -41,12 +54,7 @@ class SelectMenuBuilder extends BuildersSelectMenu {
    * @returns {SelectMenuBuilder}
    */
   setOptions(...options) {
-    return super.setOptions(
-      normalizeArray(options).map(({ emoji, ...option }) => ({
-        ...option,
-        emoji: emoji && typeof emoji === 'string' ? parseEmoji(emoji) : emoji,
-      })),
-    );
+    return super.setOptions(normalizeArray(options).map(option => SelectMenuBuilder.normalizeEmoji(option)));
   }
 
   /**

--- a/packages/discord.js/src/structures/SelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuBuilder.js
@@ -24,7 +24,7 @@ class SelectMenuBuilder extends BuildersSelectMenu {
   /**
    * Normalizes a select menu option emoji
    * @param {SelectMenuOptionData|JSONEncodable<APISelectMenuOption>} selectMenuOption The option to normalize
-   * @returns {Array<SelectMenuOptionBuilder | APISelectMenuOption>}
+   * @returns {Array<SelectMenuOptionBuilder|APISelectMenuOption>}
    * @private
    */
   static normalizeEmoji(selectMenuOption) {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -615,6 +615,9 @@ export class ButtonBuilder extends BuilderButtonComponent {
 
 export class SelectMenuBuilder extends BuilderSelectMenuComponent {
   public constructor(data?: Partial<SelectMenuComponentData | APISelectMenuComponent>);
+  private static normalizeEmoji(
+    selectMenuOption: JSONEncodable<APISelectMenuOption> | SelectMenuComponentOptionData,
+  ): (APISelectMenuOption | SelectMenuOptionBuilder)[];
   public override addOptions(
     ...options: RestOrArray<BuildersSelectMenuOption | SelectMenuComponentOptionData | APISelectMenuOption>
   ): this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes issue where djs builders wouldn't properly handle select menu option builders passed into a select menu builder.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
