### PR TITLE
fix(GuildStickerManager.fetchUser): Changed guildId to guild.id

### DIFF
--- a/src/managers/GuildStickerManager.js
+++ b/src/managers/GuildStickerManager.js
@@ -170,7 +170,7 @@ class GuildStickerManager extends CachedManager {
   async fetchUser(sticker) {
     sticker = this.resolve(sticker);
     if (!sticker) throw new TypeError('INVALID_TYPE', 'sticker', 'StickerResolvable');
-    const data = await this.client.api.guilds(this.guildId).stickers(sticker.id).get();
+    const data = await this.client.api.guilds(this.guild.id).stickers(sticker.id).get();
     sticker._patch(data);
     return sticker.user;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes a typo that causes an error when `GuildStickerManager,fetchUser` is called. This PR should be merged to allow the method to be used without error.


**Status and versioning classification:**
bug-fix

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating