### PR TITLE
fix: Remove global flag on regular expressions

### DIFF
--- a/packages/discord.js/src/structures/GuildTemplate.js
+++ b/packages/discord.js/src/structures/GuildTemplate.js
@@ -12,11 +12,12 @@ const Events = require('../util/Events');
  */
 class GuildTemplate extends Base {
   /**
-   * Regular expression that globally matches guild template links
+   * A regular expression that globally matches guild template links.
+   * The `code` group property is present on the `exec()` result of this expression.
    * @type {RegExp}
    * @memberof GuildTemplate
    */
-  static GuildTemplatesPattern = /discord(?:app)?\.(?:com\/template|new)\/([\w-]{2,255})/gi;
+  static GuildTemplatesPattern = /discord(?:app)?\.(?:com\/template|new)\/(?<code>[\w-]{2,255})/i;
 
   constructor(client, data) {
     super(client);

--- a/packages/discord.js/src/structures/Invite.js
+++ b/packages/discord.js/src/structures/Invite.js
@@ -13,11 +13,12 @@ const { Error, ErrorCodes } = require('../errors');
  */
 class Invite extends Base {
   /**
-   * Regular expression that globally matches Discord invite links
+   * A regular expression that globally matches Discord invite links.
+   * The `code` group property is present on the `exec()` result of this expression.
    * @type {RegExp}
    * @memberof Invite
    */
-  static InvitesPattern = /discord(?:(?:app)?\.com\/invite|\.gg(?:\/invite)?)\/([\w-]{2,255})/gi;
+  static InvitesPattern = /discord(?:(?:app)?\.com\/invite|\.gg(?:\/invite)?)\/(?<code>[\w-]{2,255})/i;
 
   constructor(client, data) {
     super(client);

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Collection } = require('@discordjs/collection');
-const { FormattingPatterns } = require('discord-api-types/globals');
+const { FormattingPatterns } = require('discord-api-types/v10');
 const { flatten } = require('../util/Util');
 
 /**

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -40,6 +40,14 @@ class MessageMentions {
    */
   static ChannelsPattern = FormattingPatterns.Channel;
 
+  /**
+   * A global regular expression variant of {@link MessageMentions.ChannelsPattern}.
+   * @type {RegExp}
+   * @memberof MessageMentions
+   * @private
+   */
+  static GlobalChannelsPattern = new RegExp(this.ChannelsPattern.source, 'g');
+
   constructor(message, users, roles, everyone, crosspostedChannels, repliedUser) {
     /**
      * The client the message is from
@@ -190,10 +198,9 @@ class MessageMentions {
   get channels() {
     if (this._channels) return this._channels;
     this._channels = new Collection();
-    const globalChannelsPatern = new RegExp(this.constructor.ChannelsPattern.source, 'g');
     let matches;
 
-    while ((matches = globalChannelsPatern.exec(this._content)) !== null) {
+    while ((matches = this.constructor.GlobalChannelsPattern.exec(this._content)) !== null) {
       const channel = this.client.channels.cache.get(matches.groups.id);
       if (channel) this._channels.set(channel.id, channel);
     }

--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -33,7 +33,7 @@ class DataResolver extends null {
    * @returns {string}
    */
   static resolveCode(data, regex) {
-    return data.matchAll(regex).next().value?.[1] ?? data;
+    return regex.exec(data)?.[1] ?? data;
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1874,6 +1874,7 @@ export class MessageMentions {
   public toJSON(): unknown;
 
   public static ChannelsPattern: typeof FormattingPatterns.Channel;
+  private static GlobalChannelsPattern: RegExp;
   public static EveryonePattern: RegExp;
   public static RolesPattern: typeof FormattingPatterns.Role;
   public static UsersPattern: typeof FormattingPatterns.User;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -121,6 +121,7 @@ import {
   APIAttachment,
   APIChannel,
   ThreadAutoArchiveDuration,
+  FormattingPatterns,
 } from 'discord-api-types/v10';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -1872,10 +1873,10 @@ export class MessageMentions {
   public crosspostedChannels: Collection<Snowflake, CrosspostedChannel>;
   public toJSON(): unknown;
 
-  public static ChannelsPattern: RegExp;
+  public static ChannelsPattern: typeof FormattingPatterns.Channel;
   public static EveryonePattern: RegExp;
-  public static RolesPattern: RegExp;
-  public static UsersPattern: RegExp;
+  public static RolesPattern: typeof FormattingPatterns.Role;
+  public static UsersPattern: typeof FormattingPatterns.User;
 }
 
 export class MessagePayload {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #8175 by removing the global flag on regular expressions. Some are now imported from discord-api-types and they all used named capturing groups now.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
