### PR TITLE
types: Implement `GuildChannelEditOptions`

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -199,8 +199,8 @@ class GuildChannelManager extends CachedManager {
   }
 
   /**
-   * The data for a guild channel.
-   * @typedef {Object} ChannelData
+   * Options used to edit a guild channel.
+   * @typedef {Object} GuildChannelEditOptions
    * @property {string} [name] The name of the channel
    * @property {ChannelType} [type] The type of the channel (only conversion between text and news is supported)
    * @property {number} [position] The position of the channel
@@ -224,7 +224,7 @@ class GuildChannelManager extends CachedManager {
   /**
    * Edits the channel.
    * @param {GuildChannelResolvable} channel The channel to edit
-   * @param {ChannelData} data The new data for the channel
+   * @param {GuildChannelEditOptions} data Options for editing the channel
    * @returns {Promise<GuildChannel>}
    * @example
    * // Edit a channel

--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -264,7 +264,7 @@ class GuildChannel extends BaseChannel {
 
   /**
    * Edits the channel.
-   * @param {ChannelEditData} data The new data for the channel
+   * @param {GuildChannelEditOptions} data The new data for the channel
    * @returns {Promise<GuildChannel>}
    * @example
    * // Edit a channel

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1248,7 +1248,7 @@ export abstract class GuildChannel extends BaseChannel {
   public get viewable(): boolean;
   public clone(options?: GuildChannelCloneOptions): Promise<this>;
   public delete(reason?: string): Promise<this>;
-  public edit(data: ChannelEditData): Promise<this>;
+  public edit(data: GuildChannelEditOptions): Promise<this>;
   public equals(channel: GuildChannel): boolean;
   public lockPermissions(): Promise<this>;
   public permissionsFor(memberOrRole: GuildMember | Role, checkAdmin?: boolean): Readonly<PermissionsBitField>;
@@ -3329,7 +3329,7 @@ export class GuildChannelManager extends CachedManager<Snowflake, GuildBasedChan
   ): Promise<MappedGuildChannelTypes[T]>;
   public create(options: GuildChannelCreateOptions): Promise<TextChannel>;
   public createWebhook(options: WebhookCreateOptions): Promise<Webhook>;
-  public edit(channel: GuildChannelResolvable, data: ChannelEditData): Promise<GuildChannel>;
+  public edit(channel: GuildChannelResolvable, data: GuildChannelEditOptions): Promise<GuildChannel>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<NonThreadGuildBasedChannel | null>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, NonThreadGuildBasedChannel>>;
   public fetchWebhooks(channel: GuildChannelResolvable): Promise<Collection<Snowflake, Webhook>>;
@@ -4010,27 +4010,6 @@ export interface ChannelCreationOverwrites {
   id: RoleResolvable | UserResolvable;
 }
 
-export interface ChannelData {
-  name?: string;
-  type?: ChannelType.GuildText | ChannelType.GuildNews;
-  position?: number;
-  topic?: string | null;
-  nsfw?: boolean;
-  bitrate?: number;
-  userLimit?: number;
-  parent?: CategoryChannelResolvable | null;
-  rateLimitPerUser?: number;
-  lockPermissions?: boolean;
-  permissionOverwrites?: readonly OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
-  defaultAutoArchiveDuration?: ThreadAutoArchiveDuration;
-  rtcRegion?: string | null;
-  videoQualityMode?: VideoQualityMode | null;
-}
-
-export interface ChannelEditData extends ChannelData {
-  reason?: string;
-}
-
 export type ChannelMention = `<#${Snowflake}>`;
 
 export interface ChannelPosition {
@@ -4675,6 +4654,24 @@ export interface GuildChannelCreateOptions extends Omit<CategoryCreateChannelOpt
 
 export interface GuildChannelCloneOptions extends Omit<GuildChannelCreateOptions, 'name'> {
   name?: string;
+}
+
+export interface GuildChannelEditOptions {
+  name?: string;
+  type?: ChannelType.GuildText | ChannelType.GuildNews;
+  position?: number;
+  topic?: string | null;
+  nsfw?: boolean;
+  bitrate?: number;
+  userLimit?: number;
+  parent?: CategoryChannelResolvable | null;
+  rateLimitPerUser?: number;
+  lockPermissions?: boolean;
+  permissionOverwrites?: readonly OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
+  defaultAutoArchiveDuration?: ThreadAutoArchiveDuration;
+  rtcRegion?: string | null;
+  videoQualityMode?: VideoQualityMode | null;
+  reason?: string;
 }
 
 export interface GuildChannelOverwriteOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`ChannelEditData` did not exist in the documentation. It seems in the typings that `ChannelData`'s sole purpose was to be extended. So I've consolidated them into a singular, more up-to-date name called `GuildChannelEditOptions`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
