### PR TITLE
fix: pass in the expected query object type for application commands

### DIFF
--- a/src/managers/ApplicationCommandManager.js
+++ b/src/managers/ApplicationCommandManager.js
@@ -101,10 +101,7 @@ class ApplicationCommandManager extends CachedManager {
       headers: {
         'X-Discord-Locale': locale,
       },
-      query:
-        typeof withLocalizations === 'boolean'
-          ? new URLSearchParams({ with_localizations: withLocalizations })
-          : undefined,
+      query: typeof withLocalizations === 'boolean' ? { with_localizations: withLocalizations } : undefined,
     });
     return data.reduce((coll, command) => coll.set(command.id, this._add(command, cache, guildId)), new Collection());
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes a small bug in Application Command Managers that made the query parameter to never be passed down to the URL itself. *Yay for backporting pains*

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
