### PR TITLE
feat(BaseInteraction): add support for `app_permissions`

### DIFF
--- a/packages/discord.js/src/structures/BaseInteraction.js
+++ b/packages/discord.js/src/structures/BaseInteraction.js
@@ -71,6 +71,12 @@ class BaseInteraction extends Base {
     this.version = data.version;
 
     /**
+     * Set of permissions the application or bot has within the channel the interaction was sent from
+     * @type {?PermissionsBitField}
+     */
+    this.appPermissions = data.app_permissions ? new PermissionsBitField(data.app_permissions).freeze() : null;
+
+    /**
      * The permissions of the member, if one exists, in the channel this interaction was executed in
      * @type {?Readonly<PermissionsBitField>}
      */

--- a/packages/discord.js/src/structures/BaseInteraction.js
+++ b/packages/discord.js/src/structures/BaseInteraction.js
@@ -72,7 +72,7 @@ class BaseInteraction extends Base {
 
     /**
      * Set of permissions the application or bot has within the channel the interaction was sent from
-     * @type {?PermissionsBitField}
+     * @type {?Readonly<PermissionsBitField>}
      */
     this.appPermissions = data.app_permissions ? new PermissionsBitField(data.app_permissions).freeze() : null;
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1518,7 +1518,7 @@ export class BaseInteraction<Cached extends CacheType = CacheType> extends Base 
   public type: InteractionType;
   public user: User;
   public version: number;
-  public appPermissions: PermissionsBitField | null;
+  public appPermissions: Readonly<PermissionsBitField> | null;
   public memberPermissions: CacheTypeReducer<Cached, Readonly<PermissionsBitField>>;
   public locale: Locale;
   public guildLocale: CacheTypeReducer<Cached, Locale>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1518,7 +1518,7 @@ export class BaseInteraction<Cached extends CacheType = CacheType> extends Base 
   public type: InteractionType;
   public user: User;
   public version: number;
-  public appPermissions: PermissionsBitField;
+  public appPermissions: PermissionsBitField | null;
   public memberPermissions: CacheTypeReducer<Cached, Readonly<PermissionsBitField>>;
   public locale: Locale;
   public guildLocale: CacheTypeReducer<Cached, Locale>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1518,6 +1518,7 @@ export class BaseInteraction<Cached extends CacheType = CacheType> extends Base 
   public type: InteractionType;
   public user: User;
   public version: number;
+  public appPermissions: PermissionsBitField;
   public memberPermissions: CacheTypeReducer<Cached, Readonly<PermissionsBitField>>;
   public locale: Locale;
   public guildLocale: CacheTypeReducer<Cached, Locale>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds support for `app_permissions` field on Interaction payloads.

- https://github.com/discord/discord-api-docs/pull/5131
- https://github.com/discordjs/discord-api-types/pull/509

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
