### PR TITLE
refactor(ApplicationCommandManager): use `makeURLSearchParams`

### DIFF
--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Collection } = require('@discordjs/collection');
+const { makeURLSearchParams } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v10');
 const ApplicationCommandPermissionsManager = require('./ApplicationCommandPermissionsManager');
 const CachedManager = require('./CachedManager');
@@ -111,10 +112,7 @@ class ApplicationCommandManager extends CachedManager {
       headers: {
         'X-Discord-Locale': locale,
       },
-      query:
-        typeof withLocalizations === 'boolean'
-          ? new URLSearchParams({ with_localizations: withLocalizations })
-          : undefined,
+      query: makeURLSearchParams({ with_localizations: withLocalizations }),
     });
     return data.reduce((coll, command) => coll.set(command.id, this._add(command, cache, guildId)), new Collection());
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes an oversight from #7684, where the `URLSearchParams` would be built with conditionals. We use `makeURLSearchParams` everywhere else, so let's make it consistent.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
