### PR TITLE
fix(GuildMemberManager): unable to change client's nickname

### DIFF
--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -299,11 +299,13 @@ class GuildMemberManager extends CachedManager {
     }
     data.roles &&= data.roles.map(role => (role instanceof Role ? role.id : role));
 
-    data.communication_disabled_until =
-      // eslint-disable-next-line eqeqeq
-      data.communicationDisabledUntil != null
-        ? new Date(data.communicationDisabledUntil).toISOString()
-        : data.communicationDisabledUntil;
+    if (typeof data.communicationDisabledUntil !== 'undefined') {
+      data.communication_disabled_until =
+        // eslint-disable-next-line eqeqeq
+        data.communicationDisabledUntil != null
+          ? new Date(data.communicationDisabledUntil).toISOString()
+          : data.communicationDisabledUntil;
+    }
 
     let endpoint;
     if (id === this.client.user.id) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently `data.communication_disabled_until` is always being assigned (even with undefined).
That leads to the if check never being true as `Object.keys` will always return `communication_disabled_until`, even when trying to change just the client's nickname
https://github.com/discordjs/discord.js/blob/c4653f97b1529eb0b99fccdba67c37eb4f467ff9/packages/discord.js/src/managers/GuildMemberManager.js#L310-L311

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
