### PR TITLE
chore: revert pre-commit hook to not change state

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn build && yarn format && git add .
+yarn build && yarn format


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR reverts point 5 from #8129, which made our pre-commit hook ` && git add .` This is a *really* bad idea, as it makes it impossible to only commit select changes without skipping hooks, and generally speaking, pre-commit [should never change state](https://github.com/pre-commit/pre-commit/issues/806#issuecomment-408278608)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

