### PR TITLE
fix(MessageMentions): `ignoreRepliedUser` option in `has()`

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1859,6 +1859,7 @@ export class MessageMentions {
   private _channels: Collection<Snowflake, Channel> | null;
   private readonly _content: string;
   private _members: Collection<Snowflake, GuildMember> | null;
+  private _parsedUsers: Collection<Snowflake, User> | null;
 
   public get channels(): Collection<Snowflake, Channel>;
   public readonly client: Client;
@@ -1866,6 +1867,7 @@ export class MessageMentions {
   public readonly guild: Guild;
   public has(data: UserResolvable | RoleResolvable | ChannelResolvable, options?: MessageMentionsHasOptions): boolean;
   public get members(): Collection<Snowflake, GuildMember> | null;
+  public get parsedUsers(): Collection<Snowflake, User>;
   public repliedUser: User | null;
   public roles: Collection<Snowflake, Role>;
   public users: Collection<Snowflake, User>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #8201

- The `ignoreRepliedUser` option was not being respected when paired with `ignoreDirect: false`
- Added a `parsedUsers` getter, which parses user mentions from the message content to address the following comment:
  - https://github.com/discordjs/discord.js/pull/8202#issuecomment-1172209705
- Moved the `ignoreEveryone` condition to the top as the other options don't affect it

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
