### PR TITLE
Updated README with updated Routes location

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ pnpm add discord.js
 Install all required dependencies:
 
 ```sh-session
-npm install discord.js @discordjs/rest
-yarn add discord.js @discordjs/rest
-pnpm add discord.js @discordjs/rest
+npm install discord.js @discordjs/rest discord-api-types
+yarn add discord.js @discordjs/rest discord-api-types
+pnpm add discord.js @discordjs/rest discord-api-types
 ```
 
 Register a slash command against the Discord API:
 
 ```js
 const { REST } = require('@discordjs/rest');
-const { Routes } = require('discord.js');
+const { Routes } = require('discord-api-types');
 
 const commands = [
 	{

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Register a slash command against the Discord API:
 
 ```js
 const { REST } = require('@discordjs/rest');
-const { Routes } = require('discord-api-types');
+const { Routes } = require('discord-api-types/v10');
 
 const commands = [
 	{


### PR DESCRIPTION
Simple update to the README to update the including of the `discord-api-types` package usage in order to import `Routes`.
No tests needed.
