### PR TITLE
refactor(Util): make single `replace` call in `cleanContent`

### DIFF
--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -474,6 +474,7 @@ function basename(path, ext) {
   const res = parse(path);
   return ext && res.ext.startsWith(ext) ? res.name : res.base.split('?')[0];
 }
+
 /**
  * The content to have all mentions replaced by the equivalent text.
  * @param {string} str The string to be converted
@@ -481,32 +482,37 @@ function basename(path, ext) {
  * @returns {string}
  */
 function cleanContent(str, channel) {
-  str = str
-    .replace(/<@!?[0-9]+>/g, input => {
-      const id = input.replace(/<|!|>|@/g, '');
-      if (channel.type === ChannelType.DM) {
-        const user = channel.client.users.cache.get(id);
-        return user ? `@${user.username}` : input;
-      }
+  return str.replaceAll(/<(@[!&]?|#)(\d{17,19})>/g, (match, type, id) => {
+    switch (type) {
+      case '@':
+      case '@!': {
+        if (channel.type === ChannelType.DM) {
+          const user = channel.client.users.cache.get(id);
+          return user ? `@${user.username}` : match;
+        }
 
-      const member = channel.guild.members.cache.get(id);
-      if (member) {
-        return `@${member.displayName}`;
-      } else {
-        const user = channel.client.users.cache.get(id);
-        return user ? `@${user.username}` : input;
+        const member = channel.guild.members.cache.get(id);
+        if (member) {
+          return `@${member.displayName}`;
+        } else {
+          const user = channel.client.users.cache.get(id);
+          return user ? `@${user.username}` : match;
+        }
       }
-    })
-    .replace(/<#[0-9]+>/g, input => {
-      const mentionedChannel = channel.client.channels.cache.get(input.replace(/<|#|>/g, ''));
-      return mentionedChannel ? `#${mentionedChannel.name}` : input;
-    })
-    .replace(/<@&[0-9]+>/g, input => {
-      if (channel.type === ChannelType.DM) return input;
-      const role = channel.guild.roles.cache.get(input.replace(/<|@|>|&/g, ''));
-      return role ? `@${role.name}` : input;
-    });
-  return str;
+      case '@&': {
+        if (channel.type === ChannelType.DM) return match;
+        const role = channel.guild.roles.cache.get(id);
+        return role ? `@${role.name}` : match;
+      }
+      case '#': {
+        const mentionedChannel = channel.client.channels.cache.get(id);
+        return mentionedChannel ? `#${mentionedChannel.name}` : match;
+      }
+      default: {
+        return match;
+      }
+    }
+  });
 }
 
 /**

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -490,7 +490,7 @@ function cleanContent(str, channel) {
         if (member) {
           return `@${member.displayName}`;
         }
-        
+
         const user = channel.client.users.cache.get(id);
         return user ? `@${user.username}` : match;
       }

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -486,18 +486,13 @@ function cleanContent(str, channel) {
     switch (type) {
       case '@':
       case '@!': {
-        if (channel.type === ChannelType.DM) {
-          const user = channel.client.users.cache.get(id);
-          return user ? `@${user.username}` : match;
-        }
-
-        const member = channel.guild.members.cache.get(id);
+        const member = channel.guild?.members.cache.get(id);
         if (member) {
           return `@${member.displayName}`;
-        } else {
-          const user = channel.client.users.cache.get(id);
-          return user ? `@${user.username}` : match;
         }
+        
+        const user = channel.client.users.cache.get(id);
+        return user ? `@${user.username}` : match;
       }
       case '@&': {
         if (channel.type === ChannelType.DM) return match;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Doing multiple `.replace` risks subsequent calls from running in the previous replaces, and this also comes with an extra performance impact where the content is scanned 3 times, and then each mention is scanned and replaced *again* to get the ID. This is a much simpler approach that uses a single call and RegExp capture groups to avoid extra processing.

The PR is https://github.com/discordjs/discord.js/labels/semver%3Amajor because it changes the matching ID in mentions from `[0-9]+` to the much stricter and safer `\d{17,19}`, which may result on different results if somebody injects arbitrary IDs outside the valid range in Discord's API.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
