### PR TITLE
fix(MessagePayload): guard against `repliedUser` property

### DIFF
--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -7,7 +7,7 @@ const ActionRowBuilder = require('./ActionRowBuilder');
 const { RangeError, ErrorCodes } = require('../errors');
 const DataResolver = require('../util/DataResolver');
 const MessageFlagsBitField = require('../util/MessageFlagsBitField');
-const { basename, cloneObject, verifyString, lazy } = require('../util/Util');
+const { basename, verifyString, lazy } = require('../util/Util');
 
 const getBaseInteraction = lazy(() => require('./BaseInteraction'));
 
@@ -165,9 +165,8 @@ class MessagePayload {
         ? this.target.client.options.allowedMentions
         : this.options.allowedMentions;
 
-    if (allowedMentions) {
-      allowedMentions = cloneObject(allowedMentions);
-      allowedMentions.replied_user = allowedMentions.repliedUser;
+    if (typeof allowedMentions?.repliedUser !== 'undefined') {
+      allowedMentions = { ...allowedMentions, replied_user: allowedMentions.repliedUser };
       delete allowedMentions.repliedUser;
     }
 

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -267,16 +267,6 @@ function resolvePartialEmoji(emoji) {
 }
 
 /**
- * Shallow-copies an object with its class/prototype intact.
- * @param {Object} obj Object to clone
- * @returns {Object}
- * @private
- */
-function cloneObject(obj) {
-  return Object.assign(Object.create(obj), obj);
-}
-
-/**
  * Sets default properties on an object that aren't already specified.
  * @param {Object} def Default properties
  * @param {Object} given Object to assign defaults to
@@ -567,7 +557,6 @@ module.exports = {
   fetchRecommendedShards,
   parseEmoji,
   resolvePartialEmoji,
-  cloneObject,
   mergeDefault,
   makeError,
   makePlainError,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2628,7 +2628,6 @@ export class UserFlagsBitField extends BitField<UserFlagsString> {
 
 export function basename(path: string, ext?: string): string;
 export function cleanContent(str: string, channel: TextBasedChannel): string;
-export function cloneObject(obj: unknown): unknown;
 export function discordSort<K, V extends { rawPosition: number; id: Snowflake }>(
   collection: Collection<K, V>,
 ): Collection<K, V>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

If a user specified `allowedMentions.replied_user`, it would be erroneously replaced with `allowedMentions.repliedUser`, which may not exist. This PR fixes that by checking against `allowedMentions.repliedUser`'s existence, and does no operation (nor a clone) if it's not specified.

Also removed `cloneObject` since that was the last instance of it.

**Status and versioning classification:**

<!--
- Code changes have been tested against the Discord API, or there are no code changes
-->
- I know how to update typings and have done so, or typings don't need updating
