### PR TITLE
docs(MessageInteraction#commandName): updated description

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -330,7 +330,7 @@ class Message extends Base {
      * @property {Snowflake} id The interaction's id
      * @property {InteractionType} type The type of the interaction
      * @property {string} commandName The name of the interaction's application command,
-     * including subcommands and subcommand groups
+     * as well as the subcommand and subcommand group, where applicable
      * @property {User} user The user that invoked the interaction
      */
 

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -329,7 +329,8 @@ class Message extends Base {
      * @typedef {Object} MessageInteraction
      * @property {Snowflake} id The interaction's id
      * @property {InteractionType} type The type of the interaction
-     * @property {string} commandName The name of the interaction's application command, including subcommands and subcommand groups
+     * @property {string} commandName The name of the interaction's application command,
+     * including subcommands and subcommand groups
      * @property {User} user The user that invoked the interaction
      */
 

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -329,7 +329,7 @@ class Message extends Base {
      * @typedef {Object} MessageInteraction
      * @property {Snowflake} id The interaction's id
      * @property {InteractionType} type The type of the interaction
-     * @property {string} commandName The name of the interaction's application command
+     * @property {string} commandName The name of the interaction's application command, including subcommands and subcommand groups
      * @property {User} user The user that invoked the interaction
      */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Documents breaking change for `Message#interaction`.

Source Docs:

> Starting **July 18, 2022**, the `name` field for message interaction objects will now include subcommands and subcommand groups in the value (along with the existing top-level command). In the future, we recommend not relying on this message interaction field.

https://github.com/discord/discord-api-docs/blob/main/docs/Change_Log.md#add-subcommand-groups-and-subcommands-to-message-interaction-objects

Inspiration for new description:

https://github.com/discord/discord-api-docs/pull/5140/files#diff-b44c2bafd9f1fb4cd3383e25770ef07d972796aa56dedd73ba1a7853df2d62d0R117

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->

**Footnote:**

Additionally, I believe that `commandName` should be renamed to `name` to better match Discord's new intended terminology.
However, I did not include that suggestion in this PR.