### PR TITLE
feat(ApplicationCommand): add `min_length` and `max_length` for string option (v13)

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -512,10 +512,10 @@ class ApplicationCommand extends Base {
    * the allowed types of channels that can be selected
    * @property {number} [minValue] The minimum value for an `INTEGER` or `NUMBER` option
    * @property {number} [maxValue] The maximum value for an `INTEGER` or `NUMBER` option
-   * @property {number} [minLength] The minimum length for an `STRING` option
-   * (minimum of 0, maximum of `6000`)
-   * @property {number} [maxLength] The maximum length for an `STRING` option
-   * (minimum of 1, maximum of `6000`)
+   * @property {number} [minLength] The minimum length for a `STRING` option
+   * (minimum of `0`, maximum of `6000`)
+   * @property {number} [maxLength] The maximum length for a `STRING` option
+   * (minimum of `1`, maximum of `6000`)
    */
 
   /**

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -567,7 +567,7 @@ class ApplicationCommand extends Base {
       [minValueKey]: option.minValue ?? option.min_value,
       [maxValueKey]: option.maxValue ?? option.max_value,
       [minLengthKey]: option.minLength ?? option.min_length,
-      [maxLengthKey]: option.maxLength ?? option.max_length,      
+      [maxLengthKey]: option.maxLength ?? option.max_length,
     };
   }
 }

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -454,7 +454,9 @@ class ApplicationCommand extends Base {
       option.options?.length !== existing.options?.length ||
       (option.channelTypes ?? option.channel_types)?.length !== existing.channelTypes?.length ||
       (option.minValue ?? option.min_value) !== existing.minValue ||
-      (option.maxValue ?? option.max_value) !== existing.maxValue
+      (option.maxValue ?? option.max_value) !== existing.maxValue ||
+      (option.minLength ?? option.min_length) !== existing.minLength ||
+      (option.maxLength ?? option.max_length) !== existing.maxLength
     ) {
       return false;
     }
@@ -533,6 +535,8 @@ class ApplicationCommand extends Base {
     const channelTypesKey = received ? 'channelTypes' : 'channel_types';
     const minValueKey = received ? 'minValue' : 'min_value';
     const maxValueKey = received ? 'maxValue' : 'max_value';
+    const minLengthKey = received ? 'minLength' : 'min_length';
+    const maxLengthKey = received ? 'maxLength' : 'max_length';
     const nameLocalizationsKey = received ? 'nameLocalizations' : 'name_localizations';
     const nameLocalizedKey = received ? 'nameLocalized' : 'name_localized';
     const descriptionLocalizationsKey = received ? 'descriptionLocalizations' : 'description_localizations';
@@ -562,6 +566,8 @@ class ApplicationCommand extends Base {
           option.channel_types,
       [minValueKey]: option.minValue ?? option.min_value,
       [maxValueKey]: option.maxValue ?? option.max_value,
+      [minLengthKey]: option.minLength ?? option.min_length,
+      [maxLengthKey]: option.maxLength ?? option.max_length,      
     };
   }
 }

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -226,6 +226,10 @@ class ApplicationCommand extends Base {
    * the allowed types of channels that can be selected
    * @property {number} [minValue] The minimum value for an `INTEGER` or `NUMBER` option
    * @property {number} [maxValue] The maximum value for an `INTEGER` or `NUMBER` option
+   * @property {number} [minLength] The minimum length for a `STRING` option
+   * (maximum of `6000`)
+   * @property {number} [maxLength] The maximum length for a `STRING` option
+   * (maximum of `6000`)
    */
 
   /**
@@ -513,9 +517,9 @@ class ApplicationCommand extends Base {
    * @property {number} [minValue] The minimum value for an `INTEGER` or `NUMBER` option
    * @property {number} [maxValue] The maximum value for an `INTEGER` or `NUMBER` option
    * @property {number} [minLength] The minimum length for a `STRING` option
-   * (minimum of `0`, maximum of `6000`)
+   * (maximum of `6000`)
    * @property {number} [maxLength] The maximum length for a `STRING` option
-   * (minimum of `1`, maximum of `6000`)
+   * (maximum of `6000`)
    */
 
   /**

--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -512,6 +512,10 @@ class ApplicationCommand extends Base {
    * the allowed types of channels that can be selected
    * @property {number} [minValue] The minimum value for an `INTEGER` or `NUMBER` option
    * @property {number} [maxValue] The maximum value for an `INTEGER` or `NUMBER` option
+   * @property {number} [minLength] The minimum length for an `STRING` option
+   * (minimum of 0, maximum of `6000`)
+   * @property {number} [maxLength] The maximum length for an `STRING` option
+   * (minimum of 1, maximum of `6000`)
    */
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3872,7 +3872,7 @@ export interface ApplicationCommandChoicesData extends Omit<BaseApplicationComma
 }
 
 export interface ApplicationCommandChoicesOption extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
-  type: Exclude<CommandOptionChoiceResolvableType, ApplicationCommandOptionTypes>;
+  type: CommandOptionChoiceResolvableType;
   choices?: ApplicationCommandOptionChoiceData[];
   autocomplete?: false;
 }
@@ -3894,13 +3894,13 @@ export interface ApplicationCommandStringOptionData extends ApplicationCommandCh
 }
 
 export interface ApplicationCommandNumericOption extends ApplicationCommandChoicesOption {
-  type: Exclude<CommandOptionNumericResolvableType, ApplicationCommandOptionTypes>;
+  type: CommandOptionNumericResolvableType;
   minValue?: number;
   maxValue?: number;
 }
 
 export interface ApplicationCommandStringOption extends ApplicationCommandChoicesOption {
-  type: Exclude<ApplicationCommandOptionTypes.STRING, ApplicationCommandOptionTypes>;
+  type: ApplicationCommandOptionTypes.STRING;
   minLength?: number;
   maxLength?: number;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3885,10 +3885,24 @@ export interface ApplicationCommandNumericOptionData extends ApplicationCommandC
   max_value?: number;
 }
 
+export interface ApplicationCommandStringOptionData extends ApplicationCommandChoicesData {
+  type: ApplicationCommandOptionTypes.STRING;
+  minLength?: number;
+  min_length?: number;
+  maxLength?: number;
+  max_length?: number;
+}
+
 export interface ApplicationCommandNumericOption extends ApplicationCommandChoicesOption {
   type: Exclude<CommandOptionNumericResolvableType, ApplicationCommandOptionTypes>;
   minValue?: number;
   maxValue?: number;
+}
+
+export interface ApplicationCommandStringOption extends ApplicationCommandChoicesOption {
+  type: Exclude<ApplicationCommandOptionTypes.STRING, ApplicationCommandOptionTypes>;
+  minLength?: number;
+  maxLength?: number;
 }
 
 export interface ApplicationCommandSubGroupData extends Omit<BaseApplicationCommandOptionsData, 'required'> {
@@ -3909,6 +3923,7 @@ export interface ApplicationCommandSubCommandData extends Omit<BaseApplicationCo
     | ApplicationCommandChannelOptionData
     | ApplicationCommandAutocompleteOption
     | ApplicationCommandNumericOptionData
+    | ApplicationCommandStringOptionData
   )[];
 }
 
@@ -3932,6 +3947,7 @@ export type ApplicationCommandOptionData =
   | ApplicationCommandChoicesData
   | ApplicationCommandAutocompleteOption
   | ApplicationCommandNumericOptionData
+  | ApplicationCommandStringOptionData
   | ApplicationCommandSubCommandData;
 
 export type ApplicationCommandOption =
@@ -3940,6 +3956,7 @@ export type ApplicationCommandOption =
   | ApplicationCommandChannelOption
   | ApplicationCommandChoicesOption
   | ApplicationCommandNumericOption
+  | ApplicationCommandStringOption
   | ApplicationCommandSubCommand;
 
 export interface ApplicationCommandOptionChoiceData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Backports #8215 to v13.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
