### PR TITLE
feat: codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,9 @@ jobs:
       - name: Tests
         run: yarn test
 
+      - name: Upload Coverage
+        uses: ./packages/actions/src/uploadCoverage
+        if: github.repository_owner == 'discordjs'
+
       - name: Build
         run: yarn build --cache-dir=".turbo"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    after_n_builds: 6
+  strict_yaml_branch: main
+
+coverage:
+  range: '50...90'
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+    patch: off
+
+flag_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 2%
+        informational: true
+
+comment:
+  require_changes: true
+  after_n_builds: 6

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"scripts": {
 		"build": "turbo run build",
-		"test": "turbo run test && vitest run",
+		"test": "turbo run test",
 		"lint": "turbo run lint",
 		"format": "turbo run format",
 		"fmt": "turbo run format",

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -4,6 +4,7 @@
 	"description": "A set of actions that we use for our workflows",
 	"private": true,
 	"scripts": {
+		"test": "vitest run",
 		"build": "tsup",
 		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
 		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache"

--- a/packages/actions/src/uploadCoverage/action.yml
+++ b/packages/actions/src/uploadCoverage/action.yml
@@ -1,0 +1,52 @@
+name: 'Upload Coverage'
+description: 'Uploads code coverage reports to codecov with separate flags for separate packages'
+runs:
+  using: 'composite'
+  steps:
+    - name: Upload Builders Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./packages/builders/coverage/clover.xml
+        flags: builders
+
+    - name: Upload Collection Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./packages/collection/coverage/clover.xml
+        flags: collection
+
+    - name: Upload Discord.js Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./packages/discord.js/coverage/clover.xml
+        flags: discord.js
+
+    - name: Upload Proxy Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./packages/proxy/coverage/clover.xml
+        flags: proxy
+
+    - name: Upload Rest Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./packages/rest/coverage/clover.xml
+        flags: rest
+
+    - name: Upload Voice Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./packages/voice/coverage/clover.xml
+        flags: voice
+
+    - name: Upload Website Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./packages/website/coverage/clover.xml
+        flags: website
+
+    - name: Upload Utilities Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./packages/actions/coverage/clover.xml, ./packages/docgen/coverage/clover.xml, ./packages/scripts/coverage/clover.xml
+        flags: utilities

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -3,6 +3,7 @@
 	"version": "0.16.0-dev",
 	"description": "A set of builders that you can use when creating your bot",
 	"scripts": {
+		"test": "vitest run",
 		"build": "tsup",
 		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
 		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache",

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -3,6 +3,7 @@
 	"version": "0.8.0-dev",
 	"description": "Utility data structure used in discord.js",
 	"scripts": {
+		"test": "vitest run",
 		"build": "tsup",
 		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
 		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache",

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -3,6 +3,7 @@
 	"version": "0.12.0-dev",
 	"description": "The docs.json generator for discord.js and its related projects",
 	"scripts": {
+		"test": "vitest run",
 		"build": "tsup",
 		"lint": "prettier --cache --check . && eslint src --ext mjs,js,ts --cache",
 		"format": "prettier --cache --write . && eslint src --ext mjs,js,ts --fix --cache",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0-dev",
 	"description": "Tools for running an HTTP proxy for Discord's API",
 	"scripts": {
+		"test": "vitest run",
 		"build": "tsup",
 		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
 		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -3,6 +3,7 @@
 	"version": "0.6.0-dev",
 	"description": "The REST API for discord.js",
 	"scripts": {
+		"test": "vitest run",
 		"build": "tsup",
 		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
 		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -4,6 +4,7 @@
 	"description": "A set of scripts that we use for our workflows",
 	"private": true,
 	"scripts": {
+		"test": "vitest run",
 		"build": "tsup",
 		"lint": "prettier --cache --check . && eslint src --ext mjs,js,ts --cache",
 		"format": "prettier --cache --write . && eslint src --ext mjs,js,ts --fix --cache"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -4,6 +4,7 @@
 	"description": "A set of builders that you can use when creating your bot",
 	"private": true,
 	"scripts": {
+		"test": "vitest run",
 		"build": "yarn build:css && yarn build:remix",
 		"build:css": "yarn generate:css",
 		"build:remix": "remix build",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,12 +2,15 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		exclude: ['**/node_modules', '**/dist', '.idea', '.git', '.cache', 'packages/discord.js', 'packages/voice'],
+		exclude: ['**/node_modules', '**/dist', '.idea', '.git', '.cache'],
 		passWithNoTests: true,
 		coverage: {
 			enabled: true,
+			all: true,
 			reporter: ['text', 'lcov', 'clover'],
-			exclude: ['**/dist', '**/__tests__'],
+			include: ['src'],
+			// All ts files that only contain types, due to ALL
+			exclude: ['**/*.{interface,type,d}.ts'],
 		},
 	},
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Moves test scripts to package level so that coverage can be reported per package.
> **Warning**
> For some reason yarn won't find vitest when trying to run yarn test in a package directory, but npx does 🤷 

Adds codecov as follows:
- Project level status reports only for now, set to informational to not fail CI at the moment. If we ever do enable patch status reports, we should probably only do it at the global level.
- Per package somewhat strict on coverage droop but as a whole a little more lenient
- Package separation is done via flags, packages that don't yet have coverage are automatically skipped (action is smart)
- Codecov will only post a report on PRs affecting coverage since there will be many that don't right now
- Will always use the configuration located in the main branch for a little more security
- Only runs on the orgs repo

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
