### PR TITLE
fix(Collection): make error messages consistent

### DIFF
--- a/packages/collection/src/index.ts
+++ b/packages/collection/src/index.ts
@@ -41,7 +41,7 @@ export class Collection<K, V> extends Map<K, V> {
 	 */
 	public ensure(key: K, defaultValueGenerator: (key: K, collection: this) => V): V {
 		if (this.has(key)) return this.get(key)!;
-		if (typeof defaultValueGenerator !== 'function') throw new TypeError(`${defaultValueGenerator} is not a function.`);
+		if (typeof defaultValueGenerator !== 'function') throw new TypeError(`${defaultValueGenerator} is not a function`);
 		const defaultValue = defaultValueGenerator(key, this);
 		this.set(key, defaultValue);
 		return defaultValue;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This aligns the error message thrown by `Collection#ensure`, when the `defaultValueGenerator` is not a function, with the other ones thrown in the class (which are already the same as the ones thrown by the native Array).
I found this out when working on #8222 

Some examples:
https://github.com/discordjs/discord.js/blob/c7a205f7b992eea43af13a4638e2a03db7bc0d8a/packages/collection/src/index.ts#L243
https://github.com/discordjs/discord.js/blob/c7a205f7b992eea43af13a4638e2a03db7bc0d8a/packages/collection/src/index.ts#L322
https://github.com/discordjs/discord.js/blob/c7a205f7b992eea43af13a4638e2a03db7bc0d8a/packages/collection/src/index.ts#L413

**Status and versioning classification:**
This *could* be a major change, but the error message is not exactly documented, so I'll leave it up to the maintainers

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
