### PR TITLE
Rename Client constructor to ClientBuilder 

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -35,7 +35,7 @@ const Sweepers = require('../util/Sweepers');
  * The main hub for interacting with the Discord API, and the starting point for any bot.
  * @extends {BaseClient}
  */
-class Client extends BaseClient {
+class ClientBuilder extends BaseClient {
   /**
    * @param {ClientOptions} options Options for the client
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It renames the Client Constructor to ClientBuilder as its appropriate. 

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
