### PR TITLE
fix(codecov): use cobertura

### DIFF
--- a/packages/actions/src/uploadCoverage/action.yml
+++ b/packages/actions/src/uploadCoverage/action.yml
@@ -6,47 +6,47 @@ runs:
     - name: Upload Builders Coverage
       uses: codecov/codecov-action@v3
       with:
-        files: ./packages/builders/coverage/lcov.info
+        files: ./packages/builders/coverage/cobertura-coverage.xml
         flags: builders
 
     - name: Upload Collection Coverage
       uses: codecov/codecov-action@v3
       with:
-        files: ./packages/collection/coverage/lcov.info
+        files: ./packages/collection/coverage/cobertura-coverage.xml
         flags: collection
 
     - name: Upload Discord.js Coverage
       uses: codecov/codecov-action@v3
       with:
-        files: ./packages/discord.js/coverage/lcov.info
+        files: ./packages/discord.js/coverage/cobertura-coverage.xml
         flags: discord.js
 
     - name: Upload Proxy Coverage
       uses: codecov/codecov-action@v3
       with:
-        files: ./packages/proxy/coverage/lcov.info
+        files: ./packages/proxy/coverage/cobertura-coverage.xml
         flags: proxy
 
     - name: Upload Rest Coverage
       uses: codecov/codecov-action@v3
       with:
-        files: ./packages/rest/coverage/lcov.info
+        files: ./packages/rest/coverage/cobertura-coverage.xml
         flags: rest
 
     - name: Upload Voice Coverage
       uses: codecov/codecov-action@v3
       with:
-        files: ./packages/voice/coverage/lcov.info
+        files: ./packages/voice/coverage/cobertura-coverage.xml
         flags: voice
 
     - name: Upload Website Coverage
       uses: codecov/codecov-action@v3
       with:
-        files: ./packages/website/coverage/lcov.info
+        files: ./packages/website/coverage/cobertura-coverage.xml
         flags: website
 
     - name: Upload Utilities Coverage
       uses: codecov/codecov-action@v3
       with:
-        files: ./packages/actions/coverage/lcov.info, ./packages/docgen/coverage/lcov.info, ./packages/scripts/coverage/lcov.info
+        files: ./packages/actions/coverage/cobertura-coverage.xml, ./packages/docgen/coverage/cobertura-coverage.xml, ./packages/scripts/coverage/cobertura-coverage.xml
         flags: utilities

--- a/packages/voice/jest.config.js
+++ b/packages/voice/jest.config.js
@@ -7,5 +7,5 @@ module.exports = {
 	collectCoverage: true,
 	collectCoverageFrom: ['src/**/*.ts'],
 	coverageDirectory: 'coverage',
-	coverageReporters: ['text', 'lcov', 'clover'],
+	coverageReporters: ['text', 'lcov', 'cobertura'],
 };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
 		coverage: {
 			enabled: true,
 			all: true,
-			reporter: ['text', 'lcov', 'clover'],
+			reporter: ['text', 'lcov', 'cobertura'],
 			include: ['src'],
 			// All ts files that only contain types, due to ALL
 			exclude: ['**/*.{interface,type,d}.ts'],


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Lcov doesn't work because relative paths and collection isn't uniquely identifiable from file structure.
Cobertura actually seems to be the suggested coverage for ts / js. Checked it does have accurate branch coverage reporting and codecov recognizes the semi relative paths for collection.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
