### PR TITLE
fix(SpeakingMap): Allow docgen to detect event name

### DIFF
--- a/packages/voice/src/receive/SpeakingMap.ts
+++ b/packages/voice/src/receive/SpeakingMap.ts
@@ -1,11 +1,18 @@
+/* eslint-disable @typescript-eslint/method-signature-style, @typescript-eslint/unified-signatures */
 import { EventEmitter } from 'node:events';
 
 export interface SpeakingMap extends EventEmitter {
 	/**
-	 * Emitted when a user starts/stops speaking.
+	 * Emitted when a user starts speaking.
 	 * @event
 	 */
-	on: (event: 'start' | 'end', listener: (userId: string) => void) => this;
+	on(event: 'start', listener: (userId: string) => void): this;
+
+	/**
+	 * Emitted when a user ends speaking.
+	 * @event
+	 */
+	on(event: 'end', listener: (userId: string) => void): this;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The names of this event did not exist when parsed by the documentation generator (`'start' | 'end'`). It seems when splitting this overload out, the names are detected. This will allow the main voice documentation to load again.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
