### PR TITLE
docs(ApplicationCommand): add `min_length` and `max_length` to ApplicationCommandOptionData

### DIFF
--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -221,6 +221,10 @@ class ApplicationCommand extends Base {
    * {@link ApplicationCommandOptionType.Number} option
    * @property {number} [maxValue] The maximum value for an {@link ApplicationCommandOptionType.Integer} or
    * {@link ApplicationCommandOptionType.Number} option
+   * @property {number} [minLength] The minimum length for an {@link ApplicationCommandOptionType.String} option
+   * (minimum of `0`, maximum of `6000`)
+   * @property {number} [maxLength] The maximum length for an {@link ApplicationCommandOptionType.String} option
+   * (minimum of `1`, maximum of `6000`)
    */
 
   /**
@@ -512,9 +516,9 @@ class ApplicationCommand extends Base {
    * @property {number} [maxValue] The maximum value for an {@link ApplicationCommandOptionType.Integer} or
    * {@link ApplicationCommandOptionType.Number} option
    * @property {number} [minLength] The minimum length for an {@link ApplicationCommandOptionType.String} option
-   * (minimum of 0, maximum of `6000`)
+   * (minimum of `0`, maximum of `6000`)
    * @property {number} [maxLength] The maximum length for an {@link ApplicationCommandOptionType.String} option
-   * (minimum of 1, maximum of `6000`)
+   * (minimum of `1`, maximum of `6000`)
    */
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds `min_length` and `max_length` fields to ApplicationCommandOptionData.
(And then adds missing quotes, which is something that wasn't added in #8215, just a little change)

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
