### PR TITLE
types: convert `Events` to an enum

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4216,38 +4216,38 @@ export type AutocompleteFocusedOption = Pick<CommandInteractionOption, 'name'> &
   value: string;
 };
 
-export enum Colors {
-  Default = 0x000000,
-  White = 0xffffff,
-  Aqua = 0x1abc9c,
-  Green = 0x57f287,
-  Blue = 0x3498db,
-  Yellow = 0xfee75c,
-  Purple = 0x9b59b6,
-  LuminousVividPink = 0xe91e63,
-  Fuchsia = 0xeb459e,
-  Gold = 0xf1c40f,
-  Orange = 0xe67e22,
-  Red = 0xed4245,
-  Grey = 0x95a5a6,
-  Navy = 0x34495e,
-  DarkAqua = 0x11806a,
-  DarkGreen = 0x1f8b4c,
-  DarkBlue = 0x206694,
-  DarkPurple = 0x71368a,
-  DarkVividPink = 0xad1457,
-  DarkGold = 0xc27c0e,
-  DarkOrange = 0xa84300,
-  DarkRed = 0x992d22,
-  DarkGrey = 0x979c9f,
-  DarkerGrey = 0x7f8c8d,
-  LightGrey = 0xbcc0c0,
-  DarkNavy = 0x2c3e50,
-  Blurple = 0x5865f2,
-  Greyple = 0x99aab5,
-  DarkButNotBlack = 0x2c2f33,
-  NotQuiteBlack = 0x23272a,
-}
+export declare const Colors: {
+  Default: 0x000000;
+  White: 0xffffff;
+  Aqua: 0x1abc9c;
+  Green: 0x57f287;
+  Blue: 0x3498db;
+  Yellow: 0xfee75c;
+  Purple: 0x9b59b6;
+  LuminousVividPink: 0xe91e63;
+  Fuchsia: 0xeb459e;
+  Gold: 0xf1c40f;
+  Orange: 0xe67e22;
+  Red: 0xed4245;
+  Grey: 0x95a5a6;
+  Navy: 0x34495e;
+  DarkAqua: 0x11806a;
+  DarkGreen: 0x1f8b4c;
+  DarkBlue: 0x206694;
+  DarkPurple: 0x71368a;
+  DarkVividPink: 0xad1457;
+  DarkGold: 0xc27c0e;
+  DarkOrange: 0xa84300;
+  DarkRed: 0x992d22;
+  DarkGrey: 0x979c9f;
+  DarkerGrey: 0x7f8c8d;
+  LightGrey: 0xbcc0c0;
+  DarkNavy: 0x2c3e50;
+  Blurple: 0x5865f2;
+  Greyple: 0x99aab5;
+  DarkButNotBlack: 0x2c2f33;
+  NotQuiteBlack: 0x23272a;
+};
 
 export enum Events {
   ApplicationCommandPermissionsUpdate = 'applicationCommandPermissionsUpdate',

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4216,110 +4216,110 @@ export type AutocompleteFocusedOption = Pick<CommandInteractionOption, 'name'> &
   value: string;
 };
 
-export declare const Colors: {
-  Default: 0x000000;
-  White: 0xffffff;
-  Aqua: 0x1abc9c;
-  Green: 0x57f287;
-  Blue: 0x3498db;
-  Yellow: 0xfee75c;
-  Purple: 0x9b59b6;
-  LuminousVividPink: 0xe91e63;
-  Fuchsia: 0xeb459e;
-  Gold: 0xf1c40f;
-  Orange: 0xe67e22;
-  Red: 0xed4245;
-  Grey: 0x95a5a6;
-  Navy: 0x34495e;
-  DarkAqua: 0x11806a;
-  DarkGreen: 0x1f8b4c;
-  DarkBlue: 0x206694;
-  DarkPurple: 0x71368a;
-  DarkVividPink: 0xad1457;
-  DarkGold: 0xc27c0e;
-  DarkOrange: 0xa84300;
-  DarkRed: 0x992d22;
-  DarkGrey: 0x979c9f;
-  DarkerGrey: 0x7f8c8d;
-  LightGrey: 0xbcc0c0;
-  DarkNavy: 0x2c3e50;
-  Blurple: 0x5865f2;
-  Greyple: 0x99aab5;
-  DarkButNotBlack: 0x2c2f33;
-  NotQuiteBlack: 0x23272a;
-};
+export enum Colors {
+  Default = 0x000000,
+  White = 0xffffff,
+  Aqua = 0x1abc9c,
+  Green = 0x57f287,
+  Blue = 0x3498db,
+  Yellow = 0xfee75c,
+  Purple = 0x9b59b6,
+  LuminousVividPink = 0xe91e63,
+  Fuchsia = 0xeb459e,
+  Gold = 0xf1c40f,
+  Orange = 0xe67e22,
+  Red = 0xed4245,
+  Grey = 0x95a5a6,
+  Navy = 0x34495e,
+  DarkAqua = 0x11806a,
+  DarkGreen = 0x1f8b4c,
+  DarkBlue = 0x206694,
+  DarkPurple = 0x71368a,
+  DarkVividPink = 0xad1457,
+  DarkGold = 0xc27c0e,
+  DarkOrange = 0xa84300,
+  DarkRed = 0x992d22,
+  DarkGrey = 0x979c9f,
+  DarkerGrey = 0x7f8c8d,
+  LightGrey = 0xbcc0c0,
+  DarkNavy = 0x2c3e50,
+  Blurple = 0x5865f2,
+  Greyple = 0x99aab5,
+  DarkButNotBlack = 0x2c2f33,
+  NotQuiteBlack = 0x23272a,
+}
 
-export declare const Events: {
-  ApplicationCommandPermissionsUpdate: 'applicationCommandPermissionsUpdate';
-  ClientReady: 'ready';
-  GuildCreate: 'guildCreate';
-  GuildDelete: 'guildDelete';
-  GuildUpdate: 'guildUpdate';
-  GuildUnavailable: 'guildUnavailable';
-  GuildMemberAdd: 'guildMemberAdd';
-  GuildMemberRemove: 'guildMemberRemove';
-  GuildMemberUpdate: 'guildMemberUpdate';
-  GuildMemberAvailable: 'guildMemberAvailable';
-  GuildMembersChunk: 'guildMembersChunk';
-  GuildIntegrationsUpdate: 'guildIntegrationsUpdate';
-  GuildRoleCreate: 'roleCreate';
-  GuildRoleDelete: 'roleDelete';
-  InviteCreate: 'inviteCreate';
-  InviteDelete: 'inviteDelete';
-  GuildRoleUpdate: 'roleUpdate';
-  GuildEmojiCreate: 'emojiCreate';
-  GuildEmojiDelete: 'emojiDelete';
-  GuildEmojiUpdate: 'emojiUpdate';
-  GuildBanAdd: 'guildBanAdd';
-  GuildBanRemove: 'guildBanRemove';
-  ChannelCreate: 'channelCreate';
-  ChannelDelete: 'channelDelete';
-  ChannelUpdate: 'channelUpdate';
-  ChannelPinsUpdate: 'channelPinsUpdate';
-  MessageCreate: 'messageCreate';
-  MessageDelete: 'messageDelete';
-  MessageUpdate: 'messageUpdate';
-  MessageBulkDelete: 'messageDeleteBulk';
-  MessageReactionAdd: 'messageReactionAdd';
-  MessageReactionRemove: 'messageReactionRemove';
-  MessageReactionRemoveAll: 'messageReactionRemoveAll';
-  MessageReactionRemoveEmoji: 'messageReactionRemoveEmoji';
-  ThreadCreate: 'threadCreate';
-  ThreadDelete: 'threadDelete';
-  ThreadUpdate: 'threadUpdate';
-  ThreadListSync: 'threadListSync';
-  ThreadMemberUpdate: 'threadMemberUpdate';
-  ThreadMembersUpdate: 'threadMembersUpdate';
-  UserUpdate: 'userUpdate';
-  PresenceUpdate: 'presenceUpdate';
-  VoiceServerUpdate: 'voiceServerUpdate';
-  VoiceStateUpdate: 'voiceStateUpdate';
-  TypingStart: 'typingStart';
-  WebhooksUpdate: 'webhookUpdate';
-  InteractionCreate: 'interactionCreate';
-  Error: 'error';
-  Warn: 'warn';
-  Debug: 'debug';
-  CacheSweep: 'cacheSweep';
-  ShardDisconnect: 'shardDisconnect';
-  ShardError: 'shardError';
-  ShardReconnecting: 'shardReconnecting';
-  ShardReady: 'shardReady';
-  ShardResume: 'shardResume';
-  Invalidated: 'invalidated';
-  Raw: 'raw';
-  StageInstanceCreate: 'stageInstanceCreate';
-  StageInstanceUpdate: 'stageInstanceUpdate';
-  StageInstanceDelete: 'stageInstanceDelete';
-  GuildStickerCreate: 'stickerCreate';
-  GuildStickerDelete: 'stickerDelete';
-  GuildStickerUpdate: 'stickerUpdate';
-  GuildScheduledEventCreate: 'guildScheduledEventCreate';
-  GuildScheduledEventUpdate: 'guildScheduledEventUpdate';
-  GuildScheduledEventDelete: 'guildScheduledEventDelete';
-  GuildScheduledEventUserAdd: 'guildScheduledEventUserAdd';
-  GuildScheduledEventUserRemove: 'guildScheduledEventUserRemove';
-};
+export enum Events {
+  ApplicationCommandPermissionsUpdate = 'applicationCommandPermissionsUpdate',
+  ClientReady = 'ready',
+  GuildCreate = 'guildCreate',
+  GuildDelete = 'guildDelete',
+  GuildUpdate = 'guildUpdate',
+  GuildUnavailable = 'guildUnavailable',
+  GuildMemberAdd = 'guildMemberAdd',
+  GuildMemberRemove = 'guildMemberRemove',
+  GuildMemberUpdate = 'guildMemberUpdate',
+  GuildMemberAvailable = 'guildMemberAvailable',
+  GuildMembersChunk = 'guildMembersChunk',
+  GuildIntegrationsUpdate = 'guildIntegrationsUpdate',
+  GuildRoleCreate = 'roleCreate',
+  GuildRoleDelete = 'roleDelete',
+  InviteCreate = 'inviteCreate',
+  InviteDelete = 'inviteDelete',
+  GuildRoleUpdate = 'roleUpdate',
+  GuildEmojiCreate = 'emojiCreate',
+  GuildEmojiDelete = 'emojiDelete',
+  GuildEmojiUpdate = 'emojiUpdate',
+  GuildBanAdd = 'guildBanAdd',
+  GuildBanRemove = 'guildBanRemove',
+  ChannelCreate = 'channelCreate',
+  ChannelDelete = 'channelDelete',
+  ChannelUpdate = 'channelUpdate',
+  ChannelPinsUpdate = 'channelPinsUpdate',
+  MessageCreate = 'messageCreate',
+  MessageDelete = 'messageDelete',
+  MessageUpdate = 'messageUpdate',
+  MessageBulkDelete = 'messageDeleteBulk',
+  MessageReactionAdd = 'messageReactionAdd',
+  MessageReactionRemove = 'messageReactionRemove',
+  MessageReactionRemoveAll = 'messageReactionRemoveAll',
+  MessageReactionRemoveEmoji = 'messageReactionRemoveEmoji',
+  ThreadCreate = 'threadCreate',
+  ThreadDelete = 'threadDelete',
+  ThreadUpdate = 'threadUpdate',
+  ThreadListSync = 'threadListSync',
+  ThreadMemberUpdate = 'threadMemberUpdate',
+  ThreadMembersUpdate = 'threadMembersUpdate',
+  UserUpdate = 'userUpdate',
+  PresenceUpdate = 'presenceUpdate',
+  VoiceServerUpdate = 'voiceServerUpdate',
+  VoiceStateUpdate = 'voiceStateUpdate',
+  TypingStart = 'typingStart',
+  WebhooksUpdate = 'webhookUpdate',
+  InteractionCreate = 'interactionCreate',
+  Error = 'error',
+  Warn = 'warn',
+  Debug = 'debug',
+  CacheSweep = 'cacheSweep',
+  ShardDisconnect = 'shardDisconnect',
+  ShardError = 'shardError',
+  ShardReconnecting = 'shardReconnecting',
+  ShardReady = 'shardReady',
+  ShardResume = 'shardResume',
+  Invalidated = 'invalidated',
+  Raw = 'raw',
+  StageInstanceCreate = 'stageInstanceCreate',
+  StageInstanceUpdate = 'stageInstanceUpdate',
+  StageInstanceDelete = 'stageInstanceDelete',
+  GuildStickerCreate = 'stickerCreate',
+  GuildStickerDelete = 'stickerDelete',
+  GuildStickerUpdate = 'stickerUpdate',
+  GuildScheduledEventCreate = 'guildScheduledEventCreate',
+  GuildScheduledEventUpdate = 'guildScheduledEventUpdate',
+  GuildScheduledEventDelete = 'guildScheduledEventDelete',
+  GuildScheduledEventUserAdd = 'guildScheduledEventUserAdd',
+  GuildScheduledEventUserRemove = 'guildScheduledEventUserRemove',
+}
 
 export enum ShardEvents {
   Close = 'close',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Changes `Events` ~~and `Colors`~~ to be an enum in the typings.

Motivation to convert `Events` to an enum stems from `ShardEvents` having similar usage: already being an enum, and `Events` is used as an enumerable object already.

~~The motivation to convert `Colors` to an enum is since it is also an enumerable object.~~

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
