### PR TITLE
docs: align webhook method return types with implementation

### DIFF
--- a/packages/discord.js/src/client/WebhookClient.js
+++ b/packages/discord.js/src/client/WebhookClient.js
@@ -42,12 +42,32 @@ class WebhookClient extends BaseClient {
   }
 
   // These are here only for documentation purposes - they are implemented by Webhook
-  /* eslint-disable no-empty-function */
+  /* eslint-disable no-empty-function, valid-jsdoc */
+  /**
+   * Sends a message with this webhook.
+   * @param {string|MessagePayload|WebhookMessageOptions} options The content for the reply
+   * @returns {Promise<APIMessage>}
+   */
   send() {}
-  sendSlackMessage() {}
+
+  /**
+   * Gets a message that was sent by this webhook.
+   * @param {Snowflake} message The id of the message to fetch
+   * @param {WebhookFetchMessageOptions} [options={}] The options to provide to fetch the message.
+   * @returns {Promise<APIMessage>} Returns the message sent by this webhook
+   */
   fetchMessage() {}
-  edit() {}
+
+  /**
+   * Edits a message that was sent by this webhook.
+   * @param {MessageResolvable} message The message to edit
+   * @param {string|MessagePayload|WebhookEditMessageOptions} options The options to provide
+   * @returns {Promise<APIMessage>} Returns the message edited by this webhook
+   */
   editMessage() {}
+
+  sendSlackMessage() {}
+  edit() {}
   delete() {}
   deleteMessage() {}
   get createdTimestamp() {}

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -148,7 +148,7 @@ class Webhook {
   /**
    * Sends a message with this webhook.
    * @param {string|MessagePayload|WebhookMessageOptions} options The options to provide
-   * @returns {Promise<APIMessage>}
+   * @returns {Promise<Message>}
    * @example
    * // Send a basic message
    * webhook.send('hello!')
@@ -288,7 +288,7 @@ class Webhook {
    * Gets a message that was sent by this webhook.
    * @param {Snowflake|'@original'} message The id of the message to fetch
    * @param {WebhookFetchMessageOptions} [options={}] The options to provide to fetch the message.
-   * @returns {Promise<APIMessage>} Returns the message sent by this webhook
+   * @returns {Promise<Message>} Returns the message sent by this webhook
    */
   async fetchMessage(message, { threadId } = {}) {
     if (!this.token) throw new Error(ErrorCodes.WebhookTokenUnavailable);
@@ -309,7 +309,7 @@ class Webhook {
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable|'@original'} message The message to edit
    * @param {string|MessagePayload|WebhookEditMessageOptions} options The options to provide
-   * @returns {Promise<APIMessage>} Returns the message edited by this webhook
+   * @returns {Promise<Message>} Returns the message edited by this webhook
    */
   async editMessage(message, options) {
     if (!this.token) throw new Error(ErrorCodes.WebhookTokenUnavailable);

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1575,10 +1575,10 @@ export class InteractionWebhook extends PartialWebhookMixin() {
   public token: string;
   public send(options: string | MessagePayload | InteractionReplyOptions): Promise<Message>;
   public editMessage(
-    message: MessageResolvable,
+    message: MessageResolvable | '@original',
     options: string | MessagePayload | WebhookEditMessageOptions,
   ): Promise<Message>;
-  public fetchMessage(message: string): Promise<Message>;
+  public fetchMessage(message: Snowflake | '@original'): Promise<Message>;
 }
 
 export class Invite extends Base {
@@ -2809,6 +2809,13 @@ export class Webhook extends WebhookMixin() {
     applicationId: null;
     owner: User | APIUser;
   };
+
+  public editMessage(
+    message: MessageResolvable,
+    options: string | MessagePayload | WebhookEditMessageOptions,
+  ): Promise<Message>;
+  public fetchMessage(message: Snowflake, options?: WebhookFetchMessageOptions): Promise<Message>;
+  public send(options: string | MessagePayload | Omit<WebhookMessageOptions, 'flags'>): Promise<Message>;
 }
 
 export class WebhookClient extends WebhookMixin(BaseClient) {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -23,6 +23,7 @@ import {
   APITextInputComponent,
   APIEmbed,
   ApplicationCommandType,
+  APIMessage,
 } from 'discord-api-types/v10';
 import {
   ApplicationCommand,
@@ -130,6 +131,9 @@ import {
   ThreadMemberManager,
   CollectedMessageInteraction,
   ShardEvents,
+  Webhook,
+  WebhookClient,
+  InteractionWebhook,
 } from '.';
 import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import type { ContextMenuCommandBuilder, SlashCommandBuilder } from '@discordjs/builders';
@@ -1691,3 +1695,20 @@ expectType<ChannelMention>(partialGroupDMChannel.toString());
 expectType<UserMention>(dmChannel.toString());
 expectType<UserMention>(user.toString());
 expectType<UserMention>(guildMember.toString());
+
+declare const webhook: Webhook;
+declare const webhookClient: WebhookClient;
+declare const interactionWebhook: InteractionWebhook;
+declare const snowflake: Snowflake;
+
+expectType<Promise<Message>>(webhook.send('content'));
+expectType<Promise<Message>>(webhook.editMessage(snowflake, 'content'));
+expectType<Promise<Message>>(webhook.fetchMessage(snowflake));
+
+expectType<Promise<APIMessage>>(webhookClient.send('content'));
+expectType<Promise<APIMessage>>(webhookClient.editMessage(snowflake, 'content'));
+expectType<Promise<APIMessage>>(webhookClient.fetchMessage(snowflake));
+
+expectType<Promise<Message>>(interactionWebhook.send('content'));
+expectType<Promise<Message>>(interactionWebhook.editMessage(snowflake, 'content'));
+expectType<Promise<Message>>(interactionWebhook.fetchMessage(snowflake));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This is the part that matters (from the `send()` method). The other methods have (more or less) the same implementation
https://github.com/discordjs/discord.js/blob/33ae7df000f809d1534baacb4353d81b01811c9a/packages/discord.js/src/structures/Webhook.js#L215-L216

The only instance where `this.client.channels` will not exist is on the `WebhookClient` class, given that `WebhookClient#client` is a circular reference to itself. `Webhook#client` and `InteractionWebhook#client` is the `Client`
https://github.com/discordjs/discord.js/blob/33ae7df000f809d1534baacb4353d81b01811c9a/packages/discord.js/src/client/WebhookClient.js#L28

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
