### PR TITLE
docs: Remove `@private` constructor documentation

### DIFF
--- a/packages/discord.js/src/structures/Component.js
+++ b/packages/discord.js/src/structures/Component.js
@@ -6,11 +6,6 @@ const isEqual = require('fast-deep-equal');
  * Represents a component
  */
 class Component {
-  /**
-   * Creates a new component from API data
-   * @param {APIMessageComponent} data The API component data
-   * @private
-   */
   constructor(data) {
     /**
      * The API data associated with this component

--- a/packages/discord.js/src/structures/InteractionResponse.js
+++ b/packages/discord.js/src/structures/InteractionResponse.js
@@ -7,11 +7,6 @@ const { ErrorCodes } = require('../errors');
  * Represents an interaction's response
  */
 class InteractionResponse {
-  /**
-   * @param {BaseInteraction} interaction The interaction associated with this response
-   * @param {Snowflake?} id The interaction id associated with the original response
-   * @private
-   */
   constructor(interaction, id) {
     /**
      * The interaction associated with the interaction response


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Component` and `InteractionResponse` were not showing up in the sidebar in the documentation. Remove the documentation on the constructors resolves this.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
