### PR TITLE
refactor: make `GuildAuditLogsEntry.action` return an `AuditLogEvent`

### DIFF
--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -81,59 +81,6 @@ const Targets = {
  */
 
 /**
- * The action of an entry. Here are the available actions:
- * * GuildUpdate
- * * ChannelCreate
- * * ChannelUpdate
- * * ChannelDelete
- * * ChannelOverwriteCreate
- * * ChannelOverwriteUpdate
- * * ChannelOverwriteDelete
- * * MemberKick
- * * MemberPrune
- * * MemberBanAdd
- * * MemberBanRemove
- * * MemberUpdate
- * * MemberRoleUpdate
- * * MemberMove
- * * MemberDisconnect
- * * BotAdd
- * * RoleCreate
- * * RoleUpdate
- * * RoleDelete
- * * InviteCreate
- * * InviteUpdate
- * * InviteDelete
- * * WebhookCreate
- * * WebhookUpdate
- * * WebhookDelete
- * * EmojiCreate
- * * EmojiUpdate
- * * EmojiDelete
- * * MessageDelete
- * * MessageBulkDelete
- * * MessagePin
- * * MessageUnpin
- * * IntegrationCreate
- * * IntegrationUpdate
- * * IntegrationDelete
- * * StageInstanceCreate
- * * StageInstanceUpdate
- * * StageInstanceDelete
- * * StickerCreate
- * * StickerUpdate
- * * StickerDelete
- * * GuildScheduledEventCreate
- * * GuildScheduledEventUpdate
- * * GuildScheduledEventDelete
- * * ThreadCreate
- * * ThreadUpdate
- * * ThreadDelete
- * * ApplicationCommandPermissionUpdate
- * @typedef {string} AuditLogAction
- */
-
-/**
  * Audit logs entry.
  */
 class GuildAuditLogsEntry {
@@ -160,9 +107,9 @@ class GuildAuditLogsEntry {
 
     /**
      * Specific action type of this entry in its string presentation
-     * @type {AuditLogAction}
+     * @type {AuditLogEvent}
      */
-    this.action = Object.keys(AuditLogEvent).find(k => AuditLogEvent[k] === data.action_type);
+    this.action = data.action_type;
 
     /**
      * The reason of this entry


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Similarly to the switch from `string`s to `number`s in v14, this PR changes `GuildAuditLogsEntry.action` to return an `AuditLogEvent` rather than the string version of the action.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
