### PR TITLE
docs: Add `MessageActivityType` (v13)

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -10,7 +10,12 @@ const Util = require('../util/Util');
  * Activity sent in a message.
  * @typedef {Object} MessageActivity
  * @property {string} [partyId] Id of the party represented in activity
- * @property {number} [type] Type of activity sent
+ * @property {MessageActivityType} type Type of activity sent
+ */
+
+/**
+ * @external MessageActivityType
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v9/enum/MessageActivityType}
  */
 
 /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -52,6 +52,7 @@ import {
   APIUser,
   GatewayVoiceServerUpdateDispatchData,
   GatewayVoiceStateUpdateDispatchData,
+  MessageActivityType,
   RESTPostAPIApplicationCommandsJSONBody,
   Snowflake,
   LocalizationMap,
@@ -5301,7 +5302,7 @@ export interface MessageActionRowOptions<
 
 export interface MessageActivity {
   partyId: string;
-  type: number;
+  type: MessageActivityType;
 }
 
 export interface BaseButtonOptions extends BaseMessageComponentOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Instead of just boring `number`, I added Documentation for `MessageActivity` (same as v14-dev)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
