### PR TITLE
types(GuildFeature): allow feature strings to be passed

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -494,7 +494,7 @@ export abstract class BaseGuild extends Base {
   protected constructor(client: Client, data: RawBaseGuildData);
   public get createdAt(): Date;
   public get createdTimestamp(): number;
-  public features: GuildFeature[];
+  public features: `${GuildFeature}`[];
   public icon: string | null;
   public id: Snowflake;
   public name: string;
@@ -1339,7 +1339,7 @@ export class GuildPreview extends Base {
   public discoverySplash: string | null;
   public emojis: Collection<Snowflake, GuildPreviewEmoji>;
   public stickers: Collection<Snowflake, Sticker>;
-  public features: GuildFeature[];
+  public features: `${GuildFeature}`[];
   public icon: string | null;
   public id: Snowflake;
   public name: string;
@@ -4754,7 +4754,7 @@ export interface GuildEditData {
   preferredLocale?: Locale | null;
   premiumProgressBarEnabled?: boolean;
   description?: string | null;
-  features?: GuildFeature[];
+  features?: `${GuildFeature}`[];
   reason?: string;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the type of all the props using the GuildFeature enum to allow feature strings to be passed along and not limit that to enum properties only. This is the only situation where raw data received from Discord is passed as it is, so using the feature strings is correct and safe. This also mimics the behavior in v13

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
