### PR TITLE
fix: slash command name regex

### DIFF
--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -42,6 +42,8 @@ describe('Slash Commands', () => {
 	describe('Assertions tests', () => {
 		test('GIVEN valid name THEN does not throw error', () => {
 			expect(() => SlashCommandAssertions.validateName('ping')).not.toThrowError();
+			expect(() => SlashCommandAssertions.validateName('hello-world_command')).not.toThrowError();
+			expect(() => SlashCommandAssertions.validateName('aˇ㐆1٢〣²अก')).not.toThrowError();
 		});
 
 		test('GIVEN invalid name THEN throw error', () => {
@@ -51,7 +53,10 @@ describe('Slash Commands', () => {
 			expect(() => SlashCommandAssertions.validateName('')).toThrowError();
 
 			// Invalid characters used
+			expect(() => SlashCommandAssertions.validateName('ABC')).toThrowError();
 			expect(() => SlashCommandAssertions.validateName('ABC123$%^&')).toThrowError();
+			expect(() => SlashCommandAssertions.validateName('help ping')).toThrowError();
+			expect(() => SlashCommandAssertions.validateName('🦦')).toThrowError();
 
 			// Too long of a name
 			expect(() =>

--- a/packages/builders/src/interactions/slashCommands/Assertions.ts
+++ b/packages/builders/src/interactions/slashCommands/Assertions.ts
@@ -8,7 +8,7 @@ import { isValidationEnabled } from '../../util/validation';
 const namePredicate = s.string
 	.lengthGreaterThanOrEqual(1)
 	.lengthLessThanOrEqual(32)
-	.regex(/^[\P{Lu}\p{N}\p{sc=Devanagari}\p{sc=Thai}_-]+$/u)
+	.regex(/^[\p{Ll}\p{Lm}\p{Lo}\p{N}\p{sc=Devanagari}\p{sc=Thai}_-]+$/u)
 	.setValidationEnabled(isValidationEnabled);
 
 export function validateName(name: unknown): asserts name is string {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Explicitly adds the letter unicode properties to the slash command name regex, because the negated `{Lu}` resulted in the regex matching _any_ character except uppercase letters.

**Old regex:**
![image](https://user-images.githubusercontent.com/18150845/178369837-16879b5e-4be2-4c21-a6f5-44c91c3f0422.png)

**New regex:**
![image](https://user-images.githubusercontent.com/18150845/178369843-05e04ab4-05a4-4e79-9cf3-caa1317afe84.png)

![image](https://user-images.githubusercontent.com/18150845/178369900-bffae4d6-722a-479f-8558-9020de47ce5a.png)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating