### PR TITLE
types(builders): allow action row builders to infer generic type

### DIFF
--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -41,9 +41,9 @@ export class ActionRowBuilder<T extends AnyComponentBuilder> extends ComponentBu
 	 *
 	 * @param components - The components to add to this action row.
 	 */
-	public addComponents(...components: RestOrArray<T>) {
+	public addComponents<U extends T>(...components: RestOrArray<U>): ActionRowBuilder<U> {
 		this.components.push(...normalizeArray(components));
-		return this;
+		return this as unknown as ActionRowBuilder<U>;
 	}
 
 	/**
@@ -51,9 +51,9 @@ export class ActionRowBuilder<T extends AnyComponentBuilder> extends ComponentBu
 	 *
 	 * @param components - The components to set this row to
 	 */
-	public setComponents(...components: RestOrArray<T>) {
+	public setComponents<U extends T>(...components: RestOrArray<U>): ActionRowBuilder<U> {
 		this.components.splice(0, this.components.length, ...normalizeArray(components));
-		return this;
+		return this as unknown as ActionRowBuilder<U>;
 	}
 
 	public toJSON(): APIActionRowComponent<ReturnType<T['toJSON']>> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously doing this:

```ts
const row = new ActionRowBuilder().addComponents([new TextInputComponentBuilder()]);
```
Would yield the type `ActionRowBuilder<AnyComponentType>` for `row`
With this PR, the generic parameter is now inferred so row would yield: `ActionRowBuilder<TextInputComponent>`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
