### PR TITLE
chore: update Git Cliff TOMLs

### DIFF
--- a/packages/builders/cliff.toml
+++ b/packages/builders/cliff.toml
@@ -26,9 +26,8 @@ body = """
 		  {% endif %}\
 			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
-				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+				\n{% raw %}  {% endraw %}- **{{ breakingChange.token }}{{ breakingChange.separator }}** {{ breakingChange.value }}\
 			{% endfor %}\
 		{% endif %}\
 	{% endfor %}

--- a/packages/collection/cliff.toml
+++ b/packages/collection/cliff.toml
@@ -26,9 +26,8 @@ body = """
 		  {% endif %}\
 			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
-				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+				\n{% raw %}  {% endraw %}- **{{ breakingChange.token }}{{ breakingChange.separator }}** {{ breakingChange.value }}\
 			{% endfor %}\
 		{% endif %}\
 	{% endfor %}

--- a/packages/discord.js/cliff.toml
+++ b/packages/discord.js/cliff.toml
@@ -26,9 +26,8 @@ body = """
 		  {% endif %}\
 			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
-				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+				\n{% raw %}  {% endraw %}- **{{ breakingChange.token }}{{ breakingChange.separator }}** {{ breakingChange.value }}\
 			{% endfor %}\
 		{% endif %}\
 	{% endfor %}

--- a/packages/proxy-container/cliff.toml
+++ b/packages/proxy-container/cliff.toml
@@ -26,9 +26,8 @@ body = """
 		  {% endif %}\
 			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
-				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+				\n{% raw %}  {% endraw %}- **{{ breakingChange.token }}{{ breakingChange.separator }}** {{ breakingChange.value }}\
 			{% endfor %}\
 		{% endif %}\
 	{% endfor %}

--- a/packages/proxy/cliff.toml
+++ b/packages/proxy/cliff.toml
@@ -26,9 +26,8 @@ body = """
 		  {% endif %}\
 			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
-				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+				\n{% raw %}  {% endraw %}- **{{ breakingChange.token }}{{ breakingChange.separator }}** {{ breakingChange.value }}\
 			{% endfor %}\
 		{% endif %}\
 	{% endfor %}

--- a/packages/rest/cliff.toml
+++ b/packages/rest/cliff.toml
@@ -26,9 +26,8 @@ body = """
 		  {% endif %}\
 			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
-				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+				\n{% raw %}  {% endraw %}- **{{ breakingChange.token }}{{ breakingChange.separator }}** {{ breakingChange.value }}\
 			{% endfor %}\
 		{% endif %}\
 	{% endfor %}

--- a/packages/voice/cliff.toml
+++ b/packages/voice/cliff.toml
@@ -26,9 +26,8 @@ body = """
 		  {% endif %}\
 			{{ commit.message | upper_first }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/discordjs/discord.js/commit/{{ commit.id }}))\
 		{% if commit.breaking %}\
-			\n\n {% raw %}  {% endraw %} ### Breaking Changes:\n \
 			{% for breakingChange in commit.footers %}\
-				{% raw %}  {% endraw %} - {{ breakingChange }}\n\
+				\n{% raw %}  {% endraw %}- **{{ breakingChange.token }}{{ breakingChange.separator }}** {{ breakingChange.value }}\
 			{% endfor %}\
 		{% endif %}\
 	{% endfor %}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Git Cliff released version 0.8.0 with a breaking change for how footers have to be parsed that affected the configs. As an added bonus the breaking changes will also show up better now in the changelogs so this is a win-win.

Note that after this change git-cliff v0.8.x is required. No changes/updates to cliff-jumper are necessary as that just calls `git cliff`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.