### PR TITLE
fix(VoiceReceiver): parsePacket correctly

### DIFF
--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -130,20 +130,9 @@ export class VoiceReceiver {
 		if (!packet) return;
 
 		// Strip RTP Header Extensions (one-byte only)
-		if (packet[0] === 0xbe && packet[1] === 0xde && packet.length > 4) {
+		if (packet[0] === 0xbe && packet[1] === 0xde) {
 			const headerExtensionLength = packet.readUInt16BE(2);
-			let offset = 4;
-			for (let i = 0; i < headerExtensionLength; i++) {
-				const byte = packet[offset]!;
-				offset++;
-				if (byte === 0) continue;
-				offset += 1 + (byte >> 4);
-			}
-			// Skip over undocumented Discord byte (if present)
-			const byte = packet.readUInt8(offset);
-			if (byte === 0x00 || byte === 0x02) offset++;
-
-			packet = packet.slice(offset);
+			packet = packet.subarray(4 + 4 * headerExtensionLength);
 		}
 
 		return packet;


### PR DESCRIPTION
close #7647

**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the way @discordjs/voice strips RTP Header Extension in opus packet. See #7647 for details.

I have encountered a bug that this bug is responsible for.

~~*I still have to test this PR to check if this PR is valid.*~~ I have checked the minimum required test using locally built package.

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
