### PR TITLE
chore: Remove `--cache`

### DIFF
--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -6,8 +6,8 @@
 	"scripts": {
 		"test": "vitest run",
 		"build": "tsup",
-		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
-		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache"
+		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
+		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix"
 	},
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -5,8 +5,8 @@
 	"scripts": {
 		"test": "vitest run",
 		"build": "tsup",
-		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
-		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache",
+		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
+		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"docs": "docgen -i src/index.ts -c docs/index.json -o docs/docs.json --typescript && api-extractor run --local",
 		"prepack": "yarn build && yarn lint",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/builders/*'",

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -5,8 +5,8 @@
 	"scripts": {
 		"test": "vitest run",
 		"build": "tsup",
-		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
-		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache",
+		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
+		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"docs": "docgen -i src/index.ts -c docs/index.json -o docs/docs.json --typescript && api-extractor run --local",
 		"prepack": "yarn build && yarn lint",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/collection/*'",

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "test": "yarn docs:test && yarn test:typescript",
     "test:typescript": "tsc --noEmit && tsd",
-    "lint": "prettier --cache --check . && eslint src --cache && tslint typings/index.d.ts",
-    "format": "prettier --cache --write . && eslint src --fix --cache",
+    "lint": "prettier --check . && eslint src && tslint typings/index.d.ts",
+    "format": "prettier --write . && eslint src --fix",
     "docs": "docgen -i './src/*.js' './src/**/*.js' -c ./docs/index.json -r ../../ -o ./docs/docs.json",
     "docs:test": "docgen -i './src/*.js' './src/**/*.js' -c ./docs/index.json -r ../../",
     "prepack": "yarn lint && yarn test",

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -4,8 +4,8 @@
 	"description": "The docs.json generator for discord.js and its related projects",
 	"scripts": {
 		"build": "tsup",
-		"lint": "prettier --cache --check . && eslint src --ext mjs,js,ts --cache",
-		"format": "prettier --cache --write . && eslint src --ext mjs,js,ts --fix --cache",
+		"lint": "prettier --check . && eslint src --ext mjs,js,ts",
+		"format": "prettier --write . && eslint src --ext mjs,js,ts --fix",
 		"prepack": "yarn build && yarn lint",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/docgen/*'",
 		"release": "cliff-jumper"

--- a/packages/proxy-container/package.json
+++ b/packages/proxy-container/package.json
@@ -4,8 +4,8 @@
 	"description": "Lightweight HTTP proxy for Discord's API, brought to you as a container 📦",
 	"scripts": {
 		"build": "tsup",
-		"lint": "prettier --cache --check . && eslint src --ext mjs,js,ts --cache",
-		"format": "prettier --cache --write . && eslint src --ext mjs,js,ts --fix --cache",
+		"lint": "prettier --check . && eslint src --ext mjs,js,ts",
+		"format": "prettier --write . && eslint src --ext mjs,js,ts --fix",
 		"prepack": "yarn build && yarn lint",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/proxy-container/*'"
 	},

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -5,8 +5,8 @@
 	"scripts": {
 		"test": "vitest run",
 		"build": "tsup",
-		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
-		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache",
+		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
+		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"docs": "docgen -i src/index.ts -c docs/index.json -o docs/docs.json --typescript && api-extractor run --local",
 		"prepack": "yarn build && yarn lint",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/proxy/*'",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -5,8 +5,8 @@
 	"scripts": {
 		"test": "vitest run",
 		"build": "tsup",
-		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
-		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache",
+		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
+		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"docs": "docgen -i src/index.ts -c docs/index.json -o docs/docs.json --typescript && api-extractor run --local",
 		"prepack": "yarn build && yarn lint",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/rest/*'",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -6,8 +6,8 @@
 	"scripts": {
 		"test": "vitest run",
 		"build": "tsup",
-		"lint": "prettier --cache --check . && eslint src --ext mjs,js,ts --cache",
-		"format": "prettier --cache --write . && eslint src --ext mjs,js,ts --fix --cache"
+		"lint": "prettier --check . && eslint src --ext mjs,js,ts",
+		"format": "prettier --write . && eslint src --ext mjs,js,ts --fix"
 	},
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -5,8 +5,8 @@
 	"scripts": {
 		"build": "tsup && node scripts/postbuild.mjs",
 		"test": "jest --coverage",
-		"lint": "prettier --cache --check . && eslint src __tests__ --ext mjs,js,ts --cache",
-		"format": "prettier --cache --write . && eslint src __tests__ --ext mjs,js,ts --fix --cache",
+		"lint": "prettier --check . && eslint src __tests__ --ext mjs,js,ts",
+		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"docs": "docgen -i src/index.ts -c docs/index.json -o docs/docs.json --typescript && api-extractor run --local",
 		"prepack": "yarn build && yarn lint && yarn test",
 		"changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/voice/*'",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -12,8 +12,8 @@
 		"dev:css": "yarn generate:css --watch",
 		"dev:remix": "remix dev",
 		"generate:css": "unocss 'src/**/*.tsx' --out-file ./src/styles/unocss.css",
-		"lint": "prettier --cache --check . && eslint src --ext mjs,js,ts,tsx --cache",
-		"format": "prettier --cache --write . && eslint src --ext mjs,js,ts,tsx --fix --cache"
+		"lint": "prettier --check . && eslint src --ext mjs,js,ts,tsx",
+		"format": "prettier --write . && eslint src --ext mjs,js,ts,tsx --fix"
 	},
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Opting to remove this option as uncommonly, `yarn lint` picks up, for example, a formatting issue that `yarn format` will not resolve due to the caching.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
