### PR TITLE
fix(PermissionOverwriteManager): mutates user

### DIFF
--- a/src/managers/PermissionOverwriteManager.js
+++ b/src/managers/PermissionOverwriteManager.js
@@ -142,8 +142,9 @@ class PermissionOverwriteManager extends CachedManager {
    *   .catch(console.error);
    */
   edit(userOrRole, options, overwriteOptions) {
-    userOrRole = this.channel.guild.roles.resolveId(userOrRole) ?? this.client.users.resolveId(userOrRole);
-    const existing = this.cache.get(userOrRole);
+    const existing = this.cache.get(
+      this.channel.guild.roles.resolveId(userOrRole) ?? this.client.users.resolveId(userOrRole),
+    );
     return this.upsert(userOrRole, options, overwriteOptions, existing);
   }
 


### PR DESCRIPTION

**Please describe the changes this PR makes and why it should be merged:**
Prevent the mutation of the user/role as it's passed into upset. 

The user passed into upset would always be of type "User" preventing the use of "GuildMember" in upset. 

It's only noticed if you have User cache disabled and only wish to use guild member cache, this fixes that limitation by passing along the original data. 

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
