### PR TITLE
fix(GuildChannelManager): Access `resolveId` correctly (v13)

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -403,7 +403,7 @@ class GuildChannelManager extends CachedManager {
       id: this.client.channels.resolveId(r.channel),
       position: r.position,
       lock_permissions: r.lockPermissions,
-      parent_id: typeof r.parent !== 'undefined' ? this.channels.resolveId(r.parent) : undefined,
+      parent_id: typeof r.parent !== 'undefined' ? this.resolveId(r.parent) : undefined,
     }));
 
     await this.client.api.guilds(this.guild.id).channels.patch({ data: channelPositions });


### PR DESCRIPTION
Backports #8296 to version 13.