### PR TITLE
docs: update docs and examples to PascalCase links

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -165,7 +165,7 @@ class Client extends BaseClient {
     this.application = null;
 
     /**
-     * Timestamp of the time the client was last `READY` at
+     * Timestamp of the time the client was last {@link Status.Ready} at
      * @type {?number}
      */
     this.readyTimestamp = null;
@@ -185,7 +185,7 @@ class Client extends BaseClient {
   }
 
   /**
-   * Time at which the client was last regarded as being in the `READY` state
+   * Time at which the client was last regarded as being in the {@link Status.Ready} state
    * (each time the client disconnects and successfully reconnects, this will be overwritten)
    * @type {?Date}
    * @readonly
@@ -195,7 +195,7 @@ class Client extends BaseClient {
   }
 
   /**
-   * How long it has been since the client last entered the `READY` state in milliseconds
+   * How long it has been since the client last entered the {@link Status.Ready} state in milliseconds
    * @type {?number}
    * @readonly
    */

--- a/packages/discord.js/src/client/actions/InviteCreate.js
+++ b/packages/discord.js/src/client/actions/InviteCreate.js
@@ -15,8 +15,8 @@ class InviteCreateAction extends Action {
 
     /**
      * Emitted when an invite is created.
-     * <info> This event only triggers if the client has `MANAGE_GUILD` permissions for the guild,
-     * or `MANAGE_CHANNELS` permissions for the channel.</info>
+     * <info> This event only triggers if the client has {@link PermissionFlagBits.ManageGuild} permissions
+     * for the guild, or `{@link PermissionFlagBits.ManageChannels}` permissions for the channel.</info>
      * @event Client#inviteCreate
      * @param {Invite} invite The invite that was created
      */

--- a/packages/discord.js/src/client/actions/InviteCreate.js
+++ b/packages/discord.js/src/client/actions/InviteCreate.js
@@ -15,8 +15,8 @@ class InviteCreateAction extends Action {
 
     /**
      * Emitted when an invite is created.
-     * <info> This event only triggers if the client has {@link PermissionFlagBits.ManageGuild} permissions
-     * for the guild, or `{@link PermissionFlagBits.ManageChannels}` permissions for the channel.</info>
+     * <info> This event only triggers if the client has {@link PermissionFlagsBits.ManageGuild} permissions
+     * for the guild, or `{@link PermissionFlagsBits.ManageChannels}` permissions for the channel.</info>
      * @event Client#inviteCreate
      * @param {Invite} invite The invite that was created
      */

--- a/packages/discord.js/src/client/actions/InviteCreate.js
+++ b/packages/discord.js/src/client/actions/InviteCreate.js
@@ -16,7 +16,7 @@ class InviteCreateAction extends Action {
     /**
      * Emitted when an invite is created.
      * <info> This event only triggers if the client has {@link PermissionFlagsBits.ManageGuild} permissions
-     * for the guild, or `{@link PermissionFlagsBits.ManageChannels}` permissions for the channel.</info>
+     * for the guild, or {@link PermissionFlagsBits.ManageChannels} permissions for the channel.</info>
      * @event Client#inviteCreate
      * @param {Invite} invite The invite that was created
      */

--- a/packages/discord.js/src/client/actions/InviteDelete.js
+++ b/packages/discord.js/src/client/actions/InviteDelete.js
@@ -17,8 +17,8 @@ class InviteDeleteAction extends Action {
 
     /**
      * Emitted when an invite is deleted.
-     * <info> This event only triggers if the client has {@link PermissionFlagBits.ManageGuild} permissions
-     * for the guild, or `{@link PermissionFlagBits.ManageChannels}` permissions for the channel.</info>
+     * <info> This event only triggers if the client has {@link PermissionFlagsBits.ManageGuild} permissions
+     * for the guild, or `{@link PermissionFlagsBits.ManageChannels}` permissions for the channel.</info>
      * @event Client#inviteDelete
      * @param {Invite} invite The invite that was deleted
      */

--- a/packages/discord.js/src/client/actions/InviteDelete.js
+++ b/packages/discord.js/src/client/actions/InviteDelete.js
@@ -17,8 +17,8 @@ class InviteDeleteAction extends Action {
 
     /**
      * Emitted when an invite is deleted.
-     * <info> This event only triggers if the client has `MANAGE_GUILD` permissions for the guild,
-     * or `MANAGE_CHANNELS` permissions for the channel.</info>
+     * <info> This event only triggers if the client has {@link PermissionFlagBits.ManageGuild} permissions
+     * for the guild, or `{@link PermissionFlagBits.ManageChannels}` permissions for the channel.</info>
      * @event Client#inviteDelete
      * @param {Invite} invite The invite that was deleted
      */

--- a/packages/discord.js/src/client/actions/ThreadMembersUpdate.js
+++ b/packages/discord.js/src/client/actions/ThreadMembersUpdate.js
@@ -31,7 +31,8 @@ class ThreadMembersUpdateAction extends Action {
       }
 
       /**
-       * Emitted whenever members are added or removed from a thread. Requires `GUILD_MEMBERS` privileged intent
+       * Emitted whenever members are added or removed from a thread. Requires
+       * {@link GatewayIntentBits.GuildMembers} privileged intent
        * @event Client#threadMembersUpdate
        * @param {Collection<Snowflake, ThreadMember>} addedMembers The members that were added
        * @param {Collection<Snowflake, ThreadMember>} removedMembers The members that were removed

--- a/packages/discord.js/src/client/actions/UserUpdate.js
+++ b/packages/discord.js/src/client/actions/UserUpdate.js
@@ -13,7 +13,8 @@ class UserUpdateAction extends Action {
     if (!oldUser.equals(newUser)) {
       /**
        * Emitted whenever a user's details (e.g. username) are changed.
-       * Triggered by the Discord gateway events USER_UPDATE, GUILD_MEMBER_UPDATE, and PRESENCE_UPDATE.
+       * Triggered by the Discord gateway events {@link Events.UserUpdate},
+       * {@link Events.GuildMemberUpdate}, and {@link Events.PresenceUpdate}.
        * @event Client#userUpdate
        * @param {User} oldUser The user before the update
        * @param {User} newUser The user after the update

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -76,18 +76,18 @@ class GuildMemberManager extends CachedManager {
    * @typedef {Object} AddGuildMemberOptions
    * @property {string} accessToken An OAuth2 access token for the user with the `guilds.join` scope granted to the
    * bot's application
-   * @property {string} [nick] The nickname to give to the member (requires {@link PermissionFlagBits.ManageNicknames})
+   * @property {string} [nick] The nickname to give to the member (requires {@link PermissionFlagsBits.ManageNicknames})
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles to add to the member
-   * (requires {@link PermissionFlagBits.ManageRoles})
-   * @property {boolean} [mute] Whether the member should be muted (requires {@link PermissionFlagBits.MuteMembers})
+   * (requires {@link PermissionFlagsBits.ManageRoles})
+   * @property {boolean} [mute] Whether the member should be muted (requires {@link PermissionFlagsBits.MuteMembers})
    * @property {boolean} [deaf] Whether the member should be deafened
-   * (requires {@link PermissionFlagBits.DeafenMembers})
+   * (requires {@link PermissionFlagsBits.DeafenMembers})
    * @property {boolean} [force] Whether to skip the cache check and call the API directly
    * @property {boolean} [fetchWhenExisting=true] Whether to fetch the user if not cached and already a member
    */
 
   /**
-   * Adds a user to the guild using OAuth2. Requires the {@link PermissionFlagBits.CreateInstantInvite} permission.
+   * Adds a user to the guild using OAuth2. Requires the {@link PermissionFlagsBits.CreateInstantInvite} permission.
    * @param {UserResolvable} user The user to add to the guild
    * @param {AddGuildMemberOptions} options Options for adding the user to the guild
    * @returns {Promise<GuildMember|null>}

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -76,17 +76,18 @@ class GuildMemberManager extends CachedManager {
    * @typedef {Object} AddGuildMemberOptions
    * @property {string} accessToken An OAuth2 access token for the user with the `guilds.join` scope granted to the
    * bot's application
-   * @property {string} [nick] The nickname to give to the member (requires `MANAGE_NICKNAMES`)
+   * @property {string} [nick] The nickname to give to the member (requires {@link PermissionFlagBits.ManageNicknames})
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles to add to the member
-   * (requires `MANAGE_ROLES`)
-   * @property {boolean} [mute] Whether the member should be muted (requires `MUTE_MEMBERS`)
-   * @property {boolean} [deaf] Whether the member should be deafened (requires `DEAFEN_MEMBERS`)
+   * (requires {@link PermissionFlagBits.ManageRoles})
+   * @property {boolean} [mute] Whether the member should be muted (requires {@link PermissionFlagBits.MuteMembers})
+   * @property {boolean} [deaf] Whether the member should be deafened
+   * (requires {@link PermissionFlagBits.DeafenMembers})
    * @property {boolean} [force] Whether to skip the cache check and call the API directly
    * @property {boolean} [fetchWhenExisting=true] Whether to fetch the user if not cached and already a member
    */
 
   /**
-   * Adds a user to the guild using OAuth2. Requires the `CREATE_INSTANT_INVITE` permission.
+   * Adds a user to the guild using OAuth2. Requires the {@link PermissionFlagBits.CreateInstantInvite} permission.
    * @param {UserResolvable} user The user to add to the guild
    * @param {AddGuildMemberOptions} options Options for adding the user to the guild
    * @returns {Promise<GuildMember|null>}

--- a/packages/discord.js/src/managers/PermissionOverwriteManager.js
+++ b/packages/discord.js/src/managers/PermissionOverwriteManager.js
@@ -115,7 +115,7 @@ class PermissionOverwriteManager extends CachedManager {
    * @example
    * // Create or Replace permission overwrites for a message author
    * message.channel.permissionOverwrites.create(message.author, {
-   *   SEND_MESSAGES: false
+   *   SendMessages: false
    * })
    *   .then(channel => console.log(channel.permissionOverwrites.cache.get(message.author.id)))
    *   .catch(console.error);
@@ -133,7 +133,7 @@ class PermissionOverwriteManager extends CachedManager {
    * @example
    * // Edit or Create permission overwrites for a message author
    * message.channel.permissionOverwrites.edit(message.author, {
-   *   SEND_MESSAGES: false
+   *   SendMessages: false
    * })
    *   .then(channel => console.log(channel.permissionOverwrites.cache.get(message.author.id)))
    *   .catch(console.error);

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -179,7 +179,7 @@ class ThreadManager extends CachedManager {
    * @typedef {Object} FetchArchivedThreadOptions
    * @property {string} [type='public'] The type of threads to fetch, either `public` or `private`
    * @property {boolean} [fetchAll=false] Whether to fetch **all** archived threads when type is `private`.
-   * Requires `MANAGE_THREADS` if true
+   * Requires {@link PermissionFlagBits.ManageThreads} if true
    * @property {DateResolvable|ThreadChannelResolvable} [before] Only return threads that were created before this Date
    * or Snowflake. <warn>Must be a {@link ThreadChannelResolvable} when type is `private` and fetchAll is `false`</warn>
    * @property {number} [limit] Maximum number of threads to return
@@ -193,7 +193,8 @@ class ThreadManager extends CachedManager {
    */
 
   /**
-   * Obtains a set of archived threads from Discord, requires `READ_MESSAGE_HISTORY` in the parent channel.
+   * Obtains a set of archived threads from Discord, requires {@link PermissionFlagBits.ReadMessageHistory}
+   * in the parent channel.
    * @param {FetchArchivedThreadOptions} [options] The options to fetch archived threads
    * @param {boolean} [cache=true] Whether to cache the new thread objects if they aren't already
    * @returns {Promise<FetchedThreads>}
@@ -231,7 +232,8 @@ class ThreadManager extends CachedManager {
   }
 
   /**
-   * Obtains the accessible active threads from Discord, requires `READ_MESSAGE_HISTORY` in the parent channel.
+   * Obtains the accessible active threads from Discord, requires {@link PermissionFlagBits.ReadMessageHistory}
+   * in the parent channel.
    * @param {boolean} [cache=true] Whether to cache the new thread objects if they aren't already
    * @returns {Promise<FetchedThreads>}
    */

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -179,7 +179,7 @@ class ThreadManager extends CachedManager {
    * @typedef {Object} FetchArchivedThreadOptions
    * @property {string} [type='public'] The type of threads to fetch, either `public` or `private`
    * @property {boolean} [fetchAll=false] Whether to fetch **all** archived threads when type is `private`.
-   * Requires {@link PermissionFlagBits.ManageThreads} if true
+   * Requires {@link PermissionFlagsBits.ManageThreads} if true
    * @property {DateResolvable|ThreadChannelResolvable} [before] Only return threads that were created before this Date
    * or Snowflake. <warn>Must be a {@link ThreadChannelResolvable} when type is `private` and fetchAll is `false`</warn>
    * @property {number} [limit] Maximum number of threads to return
@@ -193,7 +193,7 @@ class ThreadManager extends CachedManager {
    */
 
   /**
-   * Obtains a set of archived threads from Discord, requires {@link PermissionFlagBits.ReadMessageHistory}
+   * Obtains a set of archived threads from Discord, requires {@link PermissionFlagsBits.ReadMessageHistory}
    * in the parent channel.
    * @param {FetchArchivedThreadOptions} [options] The options to fetch archived threads
    * @param {boolean} [cache=true] Whether to cache the new thread objects if they aren't already
@@ -232,7 +232,7 @@ class ThreadManager extends CachedManager {
   }
 
   /**
-   * Obtains the accessible active threads from Discord, requires {@link PermissionFlagBits.ReadMessageHistory}
+   * Obtains the accessible active threads from Discord, requires {@link PermissionFlagsBits.ReadMessageHistory}
    * in the parent channel.
    * @param {boolean} [cache=true] Whether to cache the new thread objects if they aren't already
    * @returns {Promise<FetchedThreads>}

--- a/packages/discord.js/src/managers/ThreadMemberManager.js
+++ b/packages/discord.js/src/managers/ThreadMemberManager.js
@@ -122,7 +122,7 @@ class ThreadMemberManager extends CachedManager {
    */
 
   /**
-   * Fetches thread member(s) from Discord. Requires the `GUILD_MEMBERS` gateway intent.
+   * Fetches thread member(s) from Discord. Requires the {@link GatewayIntentBits.GuildMembers} gateway intent.
    * @param {ThreadMemberResolvable|FetchThreadMemberOptions|FetchThreadMembersOptions} [options]
    * Options for fetching thread member(s)
    * @returns {Promise<ThreadMember|Collection<Snowflake, ThreadMember>>}

--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -151,7 +151,7 @@ class GuildChannel extends BaseChannel {
   /**
    * Gets the overall set of permissions for a member or role in this channel, taking into account channel overwrites.
    * @param {GuildMemberResolvable|RoleResolvable} memberOrRole The member or role to obtain the overall permissions for
-   * @param {boolean} [checkAdmin=true] Whether having {@link PermissionFlagBits.Administrator}
+   * @param {boolean} [checkAdmin=true] Whether having {@link PermissionFlagsBits.Administrator}
    * will return all permissions
    * @returns {?Readonly<PermissionsBitField>}
    */
@@ -191,7 +191,7 @@ class GuildChannel extends BaseChannel {
   /**
    * Gets the overall set of permissions for a member in this channel, taking into account channel overwrites.
    * @param {GuildMember} member The member to obtain the overall permissions for
-   * @param {boolean} checkAdmin=true Whether having {@link PermissionFlagBits.Administrator}
+   * @param {boolean} checkAdmin=true Whether having {@link PermissionFlagsBits.Administrator}
    * will return all permissions
    * @returns {Readonly<PermissionsBitField>}
    * @private
@@ -223,7 +223,7 @@ class GuildChannel extends BaseChannel {
   /**
    * Gets the overall set of permissions for a role in this channel, taking into account channel overwrites.
    * @param {Role} role The role to obtain the overall permissions for
-   * @param {boolean} checkAdmin Whether having {@link PermissionFlagBits.Administrator} will return all permissions
+   * @param {boolean} checkAdmin Whether having {@link PermissionFlagsBits.Administrator} will return all permissions
    * @returns {Readonly<PermissionsBitField>}
    * @private
    */

--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -151,7 +151,8 @@ class GuildChannel extends BaseChannel {
   /**
    * Gets the overall set of permissions for a member or role in this channel, taking into account channel overwrites.
    * @param {GuildMemberResolvable|RoleResolvable} memberOrRole The member or role to obtain the overall permissions for
-   * @param {boolean} [checkAdmin=true] Whether having `ADMINISTRATOR` will return all permissions
+   * @param {boolean} [checkAdmin=true] Whether having {@link PermissionFlagBits.Administrator}
+   * will return all permissions
    * @returns {?Readonly<PermissionsBitField>}
    */
   permissionsFor(memberOrRole, checkAdmin = true) {
@@ -190,7 +191,8 @@ class GuildChannel extends BaseChannel {
   /**
    * Gets the overall set of permissions for a member in this channel, taking into account channel overwrites.
    * @param {GuildMember} member The member to obtain the overall permissions for
-   * @param {boolean} checkAdmin=true Whether having `ADMINISTRATOR` will return all permissions
+   * @param {boolean} checkAdmin=true Whether having {@link PermissionFlagBits.Administrator}
+   * will return all permissions
    * @returns {Readonly<PermissionsBitField>}
    * @private
    */
@@ -221,7 +223,7 @@ class GuildChannel extends BaseChannel {
   /**
    * Gets the overall set of permissions for a role in this channel, taking into account channel overwrites.
    * @param {Role} role The role to obtain the overall permissions for
-   * @param {boolean} checkAdmin Whether having `ADMINISTRATOR` will return all permissions
+   * @param {boolean} checkAdmin Whether having {@link PermissionFlagBits.Administrator} will return all permissions
    * @returns {Readonly<PermissionsBitField>}
    * @private
    */

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -642,7 +642,7 @@ class Message extends Base {
    * @property {Embed[]|APIEmbed[]} [embeds] Embeds to be added/edited
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * @property {MessageFlags} [flags] Which flags to set for the message.
-   * Only `MessageFlags.SuppressEmbeds` can be edited.
+   * Only {@link MessageFlags.SuppressEmbeds} can be edited.
    * @property {Attachment[]} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
    * @property {Array<JSONEncodable<AttachmentPayload>>|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files]

--- a/packages/discord.js/src/structures/PermissionOverwrites.js
+++ b/packages/discord.js/src/structures/PermissionOverwrites.js
@@ -65,7 +65,7 @@ class PermissionOverwrites extends Base {
    * @example
    * // Update permission overwrites
    * permissionOverwrites.edit({
-   *   SEND_MESSAGES: false
+   *   SendMessages: false
    * })
    *   .then(channel => console.log(channel.permissionOverwrites.get(message.author.id)))
    *   .catch(console.error);

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -223,7 +223,8 @@ class Role extends Base {
    * Returns `channel.permissionsFor(role)`. Returns permissions for a role in a guild channel,
    * taking into account permission overwrites.
    * @param {GuildChannel|Snowflake} channel The guild channel to use as context
-   * @param {boolean} [checkAdmin=true] Whether having `ADMINISTRATOR` will return all permissions
+   * @param {boolean} [checkAdmin=true] Whether having {@link PermissionFlagBits.Administrator}
+   * will return all permissions
    * @returns {Readonly<PermissionsBitField>}
    */
   permissionsIn(channel, checkAdmin = true) {

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -223,7 +223,7 @@ class Role extends Base {
    * Returns `channel.permissionsFor(role)`. Returns permissions for a role in a guild channel,
    * taking into account permission overwrites.
    * @param {GuildChannel|Snowflake} channel The guild channel to use as context
-   * @param {boolean} [checkAdmin=true] Whether having {@link PermissionFlagBits.Administrator}
+   * @param {boolean} [checkAdmin=true] Whether having {@link PermissionFlagsBits.Administrator}
    * will return all permissions
    * @returns {Readonly<PermissionsBitField>}
    */

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -75,8 +75,8 @@ class ThreadChannel extends BaseChannel {
       this.locked = data.thread_metadata.locked ?? false;
 
       /**
-       * Whether members without {@link PermissionFlagBits.ManageThreads} can invite other members without
-       * {@link PermissionFlagBits.ManageThreads}
+       * Whether members without {@link PermissionFlagsBits.ManageThreads} can invite other members without
+       * {@link PermissionFlagsBits.ManageThreads}
        * <info>Always `null` in public threads</info>
        * @type {?boolean}
        */
@@ -253,7 +253,7 @@ class ThreadChannel extends BaseChannel {
    * Gets the overall set of permissions for a member or role in this thread's parent channel, taking overwrites into
    * account.
    * @param {GuildMemberResolvable|RoleResolvable} memberOrRole The member or role to obtain the overall permissions for
-   * @param {boolean} [checkAdmin=true] Whether having {@link PermissionFlagBits.Administrator}
+   * @param {boolean} [checkAdmin=true] Whether having {@link PermissionFlagsBits.Administrator}
    * will return all permissions
    * @returns {?Readonly<PermissionsBitField>}
    */
@@ -363,8 +363,8 @@ class ThreadChannel extends BaseChannel {
   }
 
   /**
-   * Sets whether members without the {@link PermissionFlagBits.ManageThreads} permission can invite other members
-   * without the {@link PermissionFlagBits.ManageThreads} permission to this thread.
+   * Sets whether members without the {@link PermissionFlagsBits.ManageThreads} permission can invite other members
+   * without the {@link PermissionFlagsBits.ManageThreads} permission to this thread.
    * @param {boolean} [invitable=true] Whether non-moderators can invite non-moderators to this thread
    * @param {string} [reason] Reason for changing invite
    * @returns {Promise<ThreadChannel>}
@@ -377,8 +377,8 @@ class ThreadChannel extends BaseChannel {
   }
 
   /**
-   * Sets whether the thread can be **unarchived** by anyone with {@link PermissionFlagBits.SendMessages} permission.
-   * When a thread is locked only members with {@link PermissionFlagBits.ManageThreads} can unarchive it.
+   * Sets whether the thread can be **unarchived** by anyone with {@link PermissionFlagsBits.SendMessages} permission.
+   * When a thread is locked only members with {@link PermissionFlagsBits.ManageThreads} can unarchive it.
    * @param {boolean} [locked=true] Whether the thread is locked
    * @param {string} [reason] Reason for locking or unlocking the thread
    * @returns {Promise<ThreadChannel>}

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -75,7 +75,8 @@ class ThreadChannel extends BaseChannel {
       this.locked = data.thread_metadata.locked ?? false;
 
       /**
-       * Whether members without `MANAGE_THREADS` can invite other members without `MANAGE_THREADS`
+       * Whether members without {@link PermissionFlagBits.ManageThreads} can invite other members without
+       * {@link PermissionFlagBits.ManageThreads}
        * <info>Always `null` in public threads</info>
        * @type {?boolean}
        */
@@ -361,8 +362,8 @@ class ThreadChannel extends BaseChannel {
   }
 
   /**
-   * Sets whether members without the `MANAGE_THREADS` permission can invite other members without the
-   * `MANAGE_THREADS` permission to this thread.
+   * Sets whether members without the {@link PermissionFlagBits.ManageThreads} permission can invite other members
+   * without the {@link PermissionFlagBits.ManageThreads} permission to this thread.
    * @param {boolean} [invitable=true] Whether non-moderators can invite non-moderators to this thread
    * @param {string} [reason] Reason for changing invite
    * @returns {Promise<ThreadChannel>}
@@ -375,8 +376,8 @@ class ThreadChannel extends BaseChannel {
   }
 
   /**
-   * Sets whether the thread can be **unarchived** by anyone with `SEND_MESSAGES` permission.
-   * When a thread is locked only members with `MANAGE_THREADS` can unarchive it.
+   * Sets whether the thread can be **unarchived** by anyone with {@link PermissionFlagBits.SendMessages} permission.
+   * When a thread is locked only members with {@link PermissionFlagBits.ManageThreads} can unarchive it.
    * @param {boolean} [locked=true] Whether the thread is locked
    * @param {string} [reason] Reason for locking or unlocking the thread
    * @returns {Promise<ThreadChannel>}

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -253,7 +253,8 @@ class ThreadChannel extends BaseChannel {
    * Gets the overall set of permissions for a member or role in this thread's parent channel, taking overwrites into
    * account.
    * @param {GuildMemberResolvable|RoleResolvable} memberOrRole The member or role to obtain the overall permissions for
-   * @param {boolean} [checkAdmin=true] Whether having `ADMINISTRATOR` will return all permissions
+   * @param {boolean} [checkAdmin=true] Whether having {@link PermissionFlagBits.Administrator}
+   * will return all permissions
    * @returns {?Readonly<PermissionsBitField>}
    */
   permissionsFor(memberOrRole, checkAdmin) {

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -128,7 +128,7 @@ class Webhook {
    * @property {Snowflake} [threadId] The id of the thread in the channel to send to.
    * <info>For interaction webhooks, this property is ignored</info>
    * @property {MessageFlags} [flags] Which flags to set for the message.
-   * Only {@link MessageFlags.SuppressEmbeds}` can be set.
+   * Only {@link MessageFlags.SuppressEmbeds} can be set.
    */
 
   /**

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -127,7 +127,8 @@ class Webhook {
    * @property {string} [avatarURL] Avatar URL override for the message
    * @property {Snowflake} [threadId] The id of the thread in the channel to send to.
    * <info>For interaction webhooks, this property is ignored</info>
-   * @property {MessageFlags} [flags] Which flags to set for the message. Only `SUPPRESS_EMBEDS` can be set.
+   * @property {MessageFlags} [flags] Which flags to set for the message.
+   * Only {@link MessageFlags.SuppressEmbeds}` can be set.
    */
 
   /**


### PR DESCRIPTION
Updates documentation strings and examples with PascalCase enums.
This was done just using a regex searching for all-caps strings, so feel free to point out any others I might have missed.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
