### PR TITLE
fix(discord.js): support emoji id strings in components

### DIFF
--- a/packages/discord.js/src/structures/ButtonBuilder.js
+++ b/packages/discord.js/src/structures/ButtonBuilder.js
@@ -2,7 +2,7 @@
 
 const { ButtonBuilder: BuildersButton, isJSONEncodable } = require('@discordjs/builders');
 const { toSnakeCase } = require('../util/Transformers');
-const { parseEmoji } = require('../util/Util');
+const { resolvePartialEmoji } = require('../util/Util');
 
 /**
  * Represents a button builder.
@@ -10,7 +10,7 @@ const { parseEmoji } = require('../util/Util');
  */
 class ButtonBuilder extends BuildersButton {
   constructor({ emoji, ...data } = {}) {
-    super(toSnakeCase({ ...data, emoji: emoji && typeof emoji === 'string' ? parseEmoji(emoji) : emoji }));
+    super(toSnakeCase({ ...data, emoji: emoji && typeof emoji === 'string' ? resolvePartialEmoji(emoji) : emoji }));
   }
 
   /**
@@ -20,7 +20,7 @@ class ButtonBuilder extends BuildersButton {
    */
   setEmoji(emoji) {
     if (typeof emoji === 'string') {
-      return super.setEmoji(parseEmoji(emoji));
+      return super.setEmoji(resolvePartialEmoji(emoji));
     }
     return super.setEmoji(emoji);
   }

--- a/packages/discord.js/src/structures/SelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuBuilder.js
@@ -2,7 +2,7 @@
 
 const { SelectMenuBuilder: BuildersSelectMenu, isJSONEncodable, normalizeArray } = require('@discordjs/builders');
 const { toSnakeCase } = require('../util/Transformers');
-const { parseEmoji } = require('../util/Util');
+const { resolvePartialEmoji } = require('../util/Util');
 
 /**
  * Class used to build select menu components to be sent through the API
@@ -15,7 +15,7 @@ class SelectMenuBuilder extends BuildersSelectMenu {
         ...data,
         options: options?.map(({ emoji, ...option }) => ({
           ...option,
-          emoji: emoji && typeof emoji === 'string' ? parseEmoji(emoji) : emoji,
+          emoji: emoji && typeof emoji === 'string' ? resolvePartialEmoji(emoji) : emoji,
         })),
       }),
     );
@@ -35,7 +35,7 @@ class SelectMenuBuilder extends BuildersSelectMenu {
     const { emoji, ...option } = selectMenuOption;
     return {
       ...option,
-      emoji: typeof emoji === 'string' ? parseEmoji(emoji) : emoji,
+      emoji: typeof emoji === 'string' ? resolvePartialEmoji(emoji) : emoji,
     };
   }
 

--- a/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
@@ -2,7 +2,7 @@
 
 const { SelectMenuOptionBuilder: BuildersSelectMenuOption, isJSONEncodable } = require('@discordjs/builders');
 const { toSnakeCase } = require('../util/Transformers');
-const { parseEmoji } = require('../util/Util');
+const { resolvePartialEmoji } = require('../util/Util');
 
 /**
  * Represents a select menu option builder.
@@ -13,7 +13,7 @@ class SelectMenuOptionBuilder extends BuildersSelectMenuOption {
     super(
       toSnakeCase({
         ...data,
-        emoji: emoji && typeof emoji === 'string' ? parseEmoji(emoji) : emoji,
+        emoji: emoji && typeof emoji === 'string' ? resolvePartialEmoji(emoji) : emoji,
       }),
     );
   }
@@ -24,7 +24,7 @@ class SelectMenuOptionBuilder extends BuildersSelectMenuOption {
    */
   setEmoji(emoji) {
     if (typeof emoji === 'string') {
-      return super.setEmoji(parseEmoji(emoji));
+      return super.setEmoji(resolvePartialEmoji(emoji));
     }
     return super.setEmoji(emoji);
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently passing an emoji string to `emoji` in components fails in v14 because it puts the id in `name` instead of `id`. Using `resolvePartialEmoji` instead of `parseEmoji` fixes this, doing the v13 behavior and sending the message correctly.

I thought this was already fixed but turns out it was not.

Example code that works after this change and on v13, but not on v14.0.2:

```js
message.channel.send({
    components: [{
        type: Discord.ComponentType.ActionRow,
        components: [
            {
                type: Discord.ComponentType.Button,
                style: 1,
                customId: 'test',
                label: 'test',
                emoji: '851461487498493952'
            }
        ]   
    }]
})
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
