### PR TITLE
fix(ApplicationCommandManager): allow passing 0n to defaultMemberPermissions

### DIFF
--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -242,9 +242,10 @@ class ApplicationCommandManager extends CachedManager {
     }
 
     if ('defaultMemberPermissions' in command) {
-      default_member_permissions = command.defaultMemberPermissions
-        ? new PermissionsBitField(command.defaultMemberPermissions).bitfield.toString()
-        : command.defaultMemberPermissions;
+      default_member_permissions =
+        command.defaultMemberPermissions !== null
+          ? new PermissionsBitField(command.defaultMemberPermissions).bitfield.toString()
+          : command.defaultMemberPermissions;
     }
 
     return {

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -365,9 +365,10 @@ class ApplicationCommand extends Base {
     }
 
     if ('defaultMemberPermissions' in command) {
-      defaultMemberPermissions = command.defaultMemberPermissions
-        ? new PermissionsBitField(command.defaultMemberPermissions).bitfield
-        : null;
+      defaultMemberPermissions =
+        command.defaultMemberPermissions !== null
+          ? new PermissionsBitField(command.defaultMemberPermissions).bitfield
+          : null;
     }
 
     // Check top level parameters


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`defaultMemberPermissions` can be `0n`, and it was being passed as a bigint to JSON.stringify(), which doesn't know how to serialize them

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
