### PR TITLE
fix(selectMenu): allow json to be used for select menu options

### DIFF
--- a/packages/builders/__tests__/components/selectMenu.test.ts
+++ b/packages/builders/__tests__/components/selectMenu.test.ts
@@ -149,6 +149,17 @@ describe('Select Menu Components', () => {
 			}).toThrowError();
 		});
 
+		test('GIVEN valid option types THEN does not throw', () => {
+			expect(() =>
+				selectMenu().addOptions({
+					label: 'test',
+					value: 'test',
+				}),
+			).not.toThrowError();
+
+			expect(() => selectMenu().addOptions(selectMenuOption().setLabel('test').setValue('test')));
+		});
+
 		test('GIVEN valid JSON input THEN valid JSON history is correct', () => {
 			expect(
 				new SelectMenuBuilder(selectMenuDataWithoutOptions)

--- a/packages/builders/__tests__/components/selectMenu.test.ts
+++ b/packages/builders/__tests__/components/selectMenu.test.ts
@@ -157,7 +157,7 @@ describe('Select Menu Components', () => {
 				}),
 			).not.toThrowError();
 
-			expect(() => selectMenu().addOptions(selectMenuOption().setLabel('test').setValue('test')));
+			expect(() => selectMenu().addOptions(selectMenuOption().setLabel('test').setValue('test'))).not.toThrowError();
 		});
 
 		test('GIVEN valid JSON input THEN valid JSON history is correct', () => {

--- a/packages/builders/src/components/Assertions.ts
+++ b/packages/builders/src/components/Assertions.ts
@@ -35,18 +35,18 @@ export const labelValueDescriptionValidator = s.string
 	.lengthGreaterThanOrEqual(1)
 	.lengthLessThanOrEqual(100)
 	.setValidationEnabled(isValidationEnabled);
-export const optionValidator = s
-	.union(
-		s.object({
-			label: labelValueDescriptionValidator,
-			value: labelValueDescriptionValidator,
-			description: labelValueDescriptionValidator.optional,
-			emoji: emojiValidator.optional,
-			default: s.boolean.optional,
-		}),
-		s.instance(SelectMenuOptionBuilder),
-	)
+
+export const jsonOptionValidator = s
+	.object({
+		label: labelValueDescriptionValidator,
+		value: labelValueDescriptionValidator,
+		description: labelValueDescriptionValidator.optional,
+		emoji: emojiValidator.optional,
+		default: s.boolean.optional,
+	})
 	.setValidationEnabled(isValidationEnabled);
+
+export const optionValidator = s.instance(SelectMenuOptionBuilder).setValidationEnabled(isValidationEnabled);
 
 export const optionsValidator = optionValidator.array
 	.lengthGreaterThanOrEqual(0)

--- a/packages/builders/src/components/selectMenu/SelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/SelectMenu.ts
@@ -4,9 +4,9 @@ import { normalizeArray, type RestOrArray } from '../../util/normalizeArray';
 import {
 	customIdValidator,
 	disabledValidator,
+	jsonOptionValidator,
 	minMaxValidator,
 	optionsLengthValidator,
-	optionValidator,
 	placeholderValidator,
 	validateRequiredSelectMenuParameters,
 } from '../Assertions';
@@ -90,7 +90,7 @@ export class SelectMenuBuilder extends ComponentBuilder<APISelectMenuComponent> 
 			...options.map((option) =>
 				option instanceof SelectMenuOptionBuilder
 					? option
-					: new SelectMenuOptionBuilder(optionValidator.parse<APISelectMenuOption>(option)),
+					: new SelectMenuOptionBuilder(jsonOptionValidator.parse(option)),
 			),
 		);
 		return this;
@@ -110,7 +110,7 @@ export class SelectMenuBuilder extends ComponentBuilder<APISelectMenuComponent> 
 			...options.map((option) =>
 				option instanceof SelectMenuOptionBuilder
 					? option
-					: new SelectMenuOptionBuilder(optionValidator.parse<APISelectMenuOption>(option)),
+					: new SelectMenuOptionBuilder(jsonOptionValidator.parse(option)),
 			),
 		);
 		return this;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes an issue where select menu builders would say json options were invalid despite allowing json types.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating