### PR TITLE
feat: restore missing typeguards

### DIFF
--- a/packages/discord.js/src/structures/BaseInteraction.js
+++ b/packages/discord.js/src/structures/BaseInteraction.js
@@ -194,6 +194,14 @@ class BaseInteraction extends Base {
   }
 
   /**
+   * Indicates whether this interaction is an {@link AutocompleteInteraction}
+   * @returns {boolean}
+   */
+  isAutocomplete() {
+    return this.type === InteractionType.ApplicationCommandAutocomplete;
+  }
+
+  /**
    * Indicates whether this interaction is a {@link ChatInputCommandInteraction}.
    * @returns {boolean}
    */
@@ -210,6 +218,14 @@ class BaseInteraction extends Base {
       this.type === InteractionType.ApplicationCommand &&
       [ApplicationCommandType.User, ApplicationCommandType.Message].includes(this.commandType)
     );
+  }
+
+  /**
+   * Indicates whether this interaction is a {@link ModalSubmitInteraction}
+   * @returns {boolean}
+   */
+  isModalSubmit() {
+    return this.type === InteractionType.ModalSubmit;
   }
 
   /**

--- a/packages/discord.js/src/structures/BaseInteraction.js
+++ b/packages/discord.js/src/structures/BaseInteraction.js
@@ -202,6 +202,14 @@ class BaseInteraction extends Base {
   }
 
   /**
+   * Indicates whether this interaction is a {@link CommandInteraction}
+   * @returns {boolean}
+   */
+  isCommand() {
+    return this.type === InteractionType.ApplicationCommand;
+  }
+
+  /**
    * Indicates whether this interaction is a {@link ChatInputCommandInteraction}.
    * @returns {boolean}
    */
@@ -218,6 +226,14 @@ class BaseInteraction extends Base {
       this.type === InteractionType.ApplicationCommand &&
       [ApplicationCommandType.User, ApplicationCommandType.Message].includes(this.commandType)
     );
+  }
+
+  /**
+   * Indicates whether this interaction is a {@link MessageComponentInteraction}
+   * @returns {boolean}
+   */
+  isMessageComponent() {
+    return this.type === InteractionType.MessageComponent;
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1527,7 +1527,9 @@ export class BaseInteraction<Cached extends CacheType = CacheType> extends Base 
   public isButton(): this is ButtonInteraction<Cached>;
   public isAutocomplete(): this is AutocompleteInteraction<Cached>;
   public isChatInputCommand(): this is ChatInputCommandInteraction<Cached>;
+  public isCommand(): this is CommandInteraction<Cached>;
   public isContextMenuCommand(): this is ContextMenuCommandInteraction<Cached>;
+  public isMessageComponent(): this is MessageComponentInteraction<Cached>;
   public isMessageContextMenuCommand(): this is MessageContextMenuCommandInteraction<Cached>;
   public isModalSubmit(): this is ModalSubmitInteraction<Cached>;
   public isUserContextMenuCommand(): this is UserContextMenuCommandInteraction<Cached>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1525,9 +1525,11 @@ export class BaseInteraction<Cached extends CacheType = CacheType> extends Base 
   public inCachedGuild(): this is BaseInteraction<'cached'>;
   public inRawGuild(): this is BaseInteraction<'raw'>;
   public isButton(): this is ButtonInteraction<Cached>;
+  public isAutocomplete(): this is AutocompleteInteraction<Cached>;
   public isChatInputCommand(): this is ChatInputCommandInteraction<Cached>;
   public isContextMenuCommand(): this is ContextMenuCommandInteraction<Cached>;
   public isMessageContextMenuCommand(): this is MessageContextMenuCommandInteraction<Cached>;
+  public isModalSubmit(): this is ModalSubmitInteraction<Cached>;
   public isUserContextMenuCommand(): this is UserContextMenuCommandInteraction<Cached>;
   public isSelectMenu(): this is SelectMenuInteraction<Cached>;
   public isRepliable(): this is this & InteractionResponseFields<Cached>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This restores the following typeguard methods:
- `BaseInteraction#isAutocomplete()`
- `BaseInteraction#isCommand()`
- `BaseInteraction#isMessageComponent()`
- `BaseInteraction#isModalSubmit()`

While I agree with the _principle_ that helper methods should not be provided where single equality checks suffice (e.g. channel typing) that principle cannot be consistently applied to Interaction types. For that reason, I believe having a consistent and intuitive library interface should take a higher priority.

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

Closes https://github.com/discordjs/discord.js/issues/8321 if merged