### PR TITLE
fix(Client): omit private properties from toJSON

### DIFF
--- a/packages/discord.js/src/client/BaseClient.js
+++ b/packages/discord.js/src/client/BaseClient.js
@@ -63,7 +63,7 @@ class BaseClient extends EventEmitter {
   }
 
   toJSON(...props) {
-    return flatten(this, { domain: false }, ...props);
+    return flatten(this, ...props);
   }
 }
 

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -454,7 +454,8 @@ class Client extends BaseClient {
 
   toJSON() {
     return super.toJSON({
-      readyAt: false,
+      actions: false,
+      presence: false,
     });
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes `Client#toJSON` (and `BaseClient#toJSON`) to
- Remove references to properties that are either no longer on the class or won't get included in the resulting json anyway
- Are private (and cause an error due to indefinitely recursing) and shouldn't be included in the resulting json

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
