### PR TITLE
fix(Presence): Do not return NaN for activity timestamp

### DIFF
--- a/packages/discord.js/src/structures/Presence.js
+++ b/packages/discord.js/src/structures/Presence.js
@@ -238,7 +238,7 @@ class Activity {
      * Creation date of the activity
      * @type {number}
      */
-    this.createdTimestamp = Date.parse(data.created_at);
+    this.createdTimestamp = data.created_at;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Activity#createdTimestamp` was always `NaN` as it was calling `Date.parse()` on something that was always a [Unix timestamp](https://discord.com/developers/docs/topics/gateway#activity-object-activity-structure).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
