### PR TITLE
fix(GuildAuditLogsEntry): replace OverwriteType with AuditLogOptionsType

### DIFF
--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -188,7 +188,7 @@ class GuildAuditLogsEntry {
       case AuditLogEvent.ChannelOverwriteCreate:
       case AuditLogEvent.ChannelOverwriteUpdate:
       case AuditLogEvent.ChannelOverwriteDelete:
-        switch (Number(data.options.type)) {
+        switch (data.options.type) {
           case AuditLogOptionsType.Role:
             this.extra = guild.roles.cache.get(data.options.id) ?? {
               id: data.options.id,

--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -188,7 +188,7 @@ class GuildAuditLogsEntry {
       case AuditLogEvent.ChannelOverwriteCreate:
       case AuditLogEvent.ChannelOverwriteUpdate:
       case AuditLogEvent.ChannelOverwriteDelete:
-        switch (data.options.type) {
+        switch (Number(data.options.type)) {
           case OverwriteType.Role:
             this.extra = guild.roles.cache.get(data.options.id) ?? {
               id: data.options.id,

--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { DiscordSnowflake } = require('@sapphire/snowflake');
-const { OverwriteType, AuditLogEvent } = require('discord-api-types/v10');
+const { AuditLogOptionsType, AuditLogEvent } = require('discord-api-types/v10');
 const { GuildScheduledEvent } = require('./GuildScheduledEvent');
 const Integration = require('./Integration');
 const Invite = require('./Invite');
@@ -189,18 +189,18 @@ class GuildAuditLogsEntry {
       case AuditLogEvent.ChannelOverwriteUpdate:
       case AuditLogEvent.ChannelOverwriteDelete:
         switch (Number(data.options.type)) {
-          case OverwriteType.Role:
+          case AuditLogOptionsType.Role:
             this.extra = guild.roles.cache.get(data.options.id) ?? {
               id: data.options.id,
               name: data.options.role_name,
-              type: OverwriteType.Role,
+              type: AuditLogOptionsType.Role,
             };
             break;
 
-          case OverwriteType.Member:
+          case AuditLogOptionsType.Member:
             this.extra = guild.members.cache.get(data.options.id) ?? {
               id: data.options.id,
-              type: OverwriteType.Member,
+              type: AuditLogOptionsType.Member,
             };
             break;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- This PR fixes a bug with GuildAuditLogsEntry.extra, since the overwrite type is a string and the wrong enum was used.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating