### PR TITLE
fix: Ensure returns for function type definitions

### DIFF
--- a/packages/docgen/src/interfaces/var-type.interface.ts
+++ b/packages/docgen/src/interfaces/var-type.interface.ts
@@ -1,6 +1,7 @@
 import type { Type } from './index.js';
 
 export interface VarType extends Type {
+	type?: Required<Type>;
 	description?: string;
 	nullable?: boolean;
 }

--- a/packages/docgen/src/types/var-type.ts
+++ b/packages/docgen/src/types/var-type.ts
@@ -21,7 +21,7 @@ export class DocumentedVarType extends DocumentedItem<VarType> {
 		}
 
 		const data = this.data;
-		const names = data.names?.map((name) => splitVarName(name));
+		const names = (data.names ?? data.type?.names)?.map((name) => splitVarName(name));
 
 		if (!data.description && !data.nullable) {
 			return names;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The following pages don't have anything for their return value:

- https://discord.js.org/#/docs/discord.js/main/typedef/CacheFactory
- https://discord.js.org/#/docs/discord.js/main/typedef/GlobalSweepFilter
- https://discord.js.org/#/docs/discord.js/main/typedef/CollectorFilter (page fails to load)

This pull request resolves this.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
