### PR TITLE
fix(ShardClientUtil#_respond): construct global error

### DIFF
--- a/packages/discord.js/src/sharding/ShardClientUtil.js
+++ b/packages/discord.js/src/sharding/ShardClientUtil.js
@@ -206,7 +206,7 @@ class ShardClientUtil {
    */
   _respond(type, message) {
     this.send(message).catch(err => {
-      const error = new Error(`Error when sending ${type} response to master process: ${err.message}`);
+      const error = new globalThis.Error(`Error when sending ${type} response to master process: ${err.message}`);
       error.stack = err.stack;
       /**
        * Emitted when the client encounters an error.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently, if something goes wrong here, we don't get a proper error, because `Error` here refers to our error class. This is meant to throw a global `Error`. This is likely caused because of #8068
 https://github.com/discordjs/discord.js/blob/df42fdfc421f1190f0a2267a66efd3c921ec2348/packages/discord.js/src/sharding/ShardClientUtil.js#L208-L210

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

