### PR TITLE
fix(WebSocketShard): Use correct import

### DIFF
--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -15,7 +15,7 @@ import {
 	GatewayReceivePayload,
 	GatewaySendPayload,
 } from 'discord-api-types/v10';
-import { CONNECTING, OPEN, RawData, WebSocket } from 'ws';
+import { RawData, WebSocket } from 'ws';
 import type { Inflate } from 'zlib-sync';
 import type { SessionInfo } from './WebSocketManager';
 import type { IContextFetchingStrategy } from '../strategies/context/IContextFetchingStrategy';
@@ -182,7 +182,10 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			await this.strategy.updateSessionInfo(this.id, null);
 		}
 
-		if (this.connection && (this.connection.readyState === OPEN || this.connection.readyState === CONNECTING)) {
+		if (
+			this.connection &&
+			(this.connection.readyState === WebSocket.OPEN || this.connection.readyState === WebSocket.CONNECTING)
+		) {
 			this.connection.close(options.code, options.reason);
 		}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It seems `CONNECTING` and `OPEN` should be accessed via `WebSocket` here in ESM. This pull request resolves #8356.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
