### PR TITLE
fix(GuildChannelManager): allow unsetting rtcRegion

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -267,7 +267,7 @@ class GuildChannelManager extends CachedManager {
         nsfw: data.nsfw,
         bitrate: data.bitrate ?? channel.bitrate,
         user_limit: data.userLimit ?? channel.userLimit,
-        rtc_region: data.rtcRegion ?? channel.rtcRegion,
+        rtc_region: 'rtcRegion' in data ? data.rtcRegion : channel.rtcRegion,
         video_quality_mode: data.videoQualityMode,
         parent_id: parent,
         lock_permissions: data.lockPermissions,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes the ability of `GuildChannelManager#edit` (and indirectly `GuildChannel#edit` as well as `BaseGuildVoiceChannel#setRTCRegion`) to unset the rtc region by providing `null`.

The cause for this was that the method was using `??` to default to the current value if the provided value was missing or nullish.

(Why are we even sending the current values back? They are optional. 🤔 )

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
