### PR TITLE
chore: disable scope-case rule for commitlint (v13)

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -5,6 +5,7 @@
       2,
       "always",
       ["chore", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test", "types", "typings"]
-    ]
+    ],
+    "scope-case": [0]
   }
 }


### PR DESCRIPTION
Backports #7507 to version 13.