### PR TITLE
fix(MessageMentions): `ignoreRepliedUser` option in `has()` (v13)

### DIFF
--- a/src/structures/MessageMentions.js
+++ b/src/structures/MessageMentions.js
@@ -94,6 +94,13 @@ class MessageMentions {
     this._channels = null;
 
     /**
+     * Cached users for {@link MessageMentions#parsedUsers}
+     * @type {?Collection<Snowflake, User>}
+     * @private
+     */
+    this._parsedUsers = null;
+
+    /**
      * Crossposted channel data.
      * @typedef {Object} CrosspostedChannel
      * @property {Snowflake} channelId The mentioned channel's id
@@ -169,6 +176,23 @@ class MessageMentions {
   }
 
   /**
+   * Any user mentions that were included in the message content
+   * <info>Order as they appear first in the message content</info>
+   * @type {Collection<Snowflake, User>}
+   * @readonly
+   */
+  get parsedUsers() {
+    if (this._parsedUsers) return this._parsedUsers;
+    this._parsedUsers = new Collection();
+    let matches;
+    while ((matches = this.constructor.USERS_PATTERN.exec(this._content)) !== null) {
+      const user = this.client.users.cache.get(matches[1]);
+      if (user) this._parsedUsers.set(user.id, user);
+    }
+    return this._parsedUsers;
+  }
+
+  /**
    * Options used to check for a mention.
    * @typedef {Object} MessageMentionsHasOptions
    * @property {boolean} [ignoreDirect=false] Whether to ignore direct mentions to the item
@@ -187,16 +211,23 @@ class MessageMentions {
    */
   has(data, { ignoreDirect = false, ignoreRoles = false, ignoreRepliedUser = false, ignoreEveryone = false } = {}) {
     const user = this.client.users.resolve(data);
-    const role = this.guild?.roles.resolve(data);
-    const channel = this.client.channels.resolve(data);
 
-    if (!ignoreRepliedUser && this.users.has(this.repliedUser?.id) && this.repliedUser?.id === user?.id) return true;
+    if (!ignoreEveryone && user && this.everyone) return true;
+
+    const userWasRepliedTo = user && this.repliedUser?.id === user.id;
+
+    if (!ignoreRepliedUser && userWasRepliedTo && this.users.has(user.id)) return true;
+
     if (!ignoreDirect) {
-      if (this.users.has(user?.id)) return true;
-      if (this.roles.has(role?.id)) return true;
-      if (this.channels.has(channel?.id)) return true;
+      if (user && (!ignoreRepliedUser || this.parsedUsers.has(user.id)) && this.users.has(user.id)) return true;
+
+      const role = this.guild?.roles.resolve(data);
+      if (role && this.roles.has(role.id)) return true;
+
+      const channel = this.client.channels.resolve(data);
+      if (channel && this.channels.has(channel.id)) return true;
     }
-    if (user && !ignoreEveryone && this.everyone) return true;
+
     if (!ignoreRoles) {
       const member = this.guild?.members.resolve(data);
       if (member) {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1806,6 +1806,7 @@ export class MessageMentions {
   private _channels: Collection<Snowflake, AnyChannel> | null;
   private readonly _content: string;
   private _members: Collection<Snowflake, GuildMember> | null;
+  private _parsedUsers: Collection<Snowflake, User> | null;
 
   public readonly channels: Collection<Snowflake, AnyChannel>;
   public readonly client: Client;
@@ -1813,6 +1814,7 @@ export class MessageMentions {
   public readonly guild: Guild;
   public has(data: UserResolvable | RoleResolvable | ChannelResolvable, options?: MessageMentionsHasOptions): boolean;
   public readonly members: Collection<Snowflake, GuildMember> | null;
+  public readonly parsedUsers: Collection<Snowflake, User>;
   public repliedUser: User | null;
   public roles: Collection<Snowflake, Role>;
   public users: Collection<Snowflake, User>;


### PR DESCRIPTION
Backports #8202 