### PR TITLE
fix(Formatters): add newline in `codeBlock`

### DIFF
--- a/packages/builders/__tests__/messages/formatters.test.ts
+++ b/packages/builders/__tests__/messages/formatters.test.ts
@@ -24,11 +24,11 @@ import {
 describe('Message formatters', () => {
 	describe('codeBlock', () => {
 		test('GIVEN "discord.js" with no language THEN returns "```\\ndiscord.js```"', () => {
-			expect<'```\ndiscord.js```'>(codeBlock('discord.js')).toEqual('```\ndiscord.js```');
+			expect<'```\ndiscord.js\n```'>(codeBlock('discord.js')).toEqual('```\ndiscord.js\n```');
 		});
 
 		test('GIVEN "discord.js" with "js" as language THEN returns "```js\\ndiscord.js```"', () => {
-			expect<'```js\ndiscord.js```'>(codeBlock('js', 'discord.js')).toEqual('```js\ndiscord.js```');
+			expect<'```js\ndiscord.js\n```'>(codeBlock('js', 'discord.js')).toEqual('```js\ndiscord.js\n```');
 		});
 	});
 

--- a/packages/builders/src/messages/formatters.ts
+++ b/packages/builders/src/messages/formatters.ts
@@ -6,7 +6,7 @@ import type { Snowflake } from 'discord-api-types/globals';
  *
  * @param content - The content to wrap
  */
-export function codeBlock<C extends string>(content: C): `\`\`\`\n${C}\`\`\``;
+export function codeBlock<C extends string>(content: C): `\`\`\`\n${C}\n\`\`\``;
 
 /**
  * Wraps the content inside a codeblock with the specified language
@@ -14,9 +14,9 @@ export function codeBlock<C extends string>(content: C): `\`\`\`\n${C}\`\`\``;
  * @param language - The language for the codeblock
  * @param content - The content to wrap
  */
-export function codeBlock<L extends string, C extends string>(language: L, content: C): `\`\`\`${L}\n${C}\`\`\``;
+export function codeBlock<L extends string, C extends string>(language: L, content: C): `\`\`\`${L}\n${C}\n\`\`\``;
 export function codeBlock(language: string, content?: string): string {
-	return typeof content === 'undefined' ? `\`\`\`\n${language}\`\`\`` : `\`\`\`${language}\n${content}\`\`\``;
+	return typeof content === 'undefined' ? `\`\`\`\n${language}\n\`\`\`` : `\`\`\`${language}\n${content}\n\`\`\``;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds a newline at the end of the codeblock, fixes #8368.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
