### PR TITLE
docs(WebhookClient): Make constructor a union

### DIFF
--- a/packages/discord.js/src/client/WebhookClient.js
+++ b/packages/discord.js/src/client/WebhookClient.js
@@ -12,11 +12,21 @@ const { parseWebhookURL } = require('../util/Util');
  */
 class WebhookClient extends BaseClient {
   /**
-   * The data for the webhook client containing either an id and token or just a URL
-   * @typedef {Object} WebhookClientData
-   * @property {Snowflake} [id] The id of the webhook
-   * @property {string} [token] The token of the webhook
-   * @property {string} [url] The full URL for the webhook client
+   * Represents the credentials used for a webhook in the form of its id and token.
+   * @typedef {Object} WebhookClientDataIdWithToken
+   * @property {Snowflake} id The webhook's id
+   * @property {string} token The webhook's token
+   */
+
+  /**
+   * Represents the credentials used for a webhook in the form of a URL.
+   * @typedef {Object} WebhookClientDataURL
+   * @property {string} [url] The full URL for the webhook
+   */
+
+  /**
+   * Represents the credentials used for a webhook.
+   * @typedef {WebhookClientDataIdWithToken|WebhookClientDataURL} WebhookClientData
    */
 
   /**

--- a/packages/discord.js/src/client/WebhookClient.js
+++ b/packages/discord.js/src/client/WebhookClient.js
@@ -21,7 +21,7 @@ class WebhookClient extends BaseClient {
   /**
    * Represents the credentials used for a webhook in the form of a URL.
    * @typedef {Object} WebhookClientDataURL
-   * @property {string} [url] The full URL for the webhook
+   * @property {string} url The full URL for the webhook
    */
 
   /**

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -520,16 +520,9 @@ function lazy(cb) {
 }
 
 /**
- * Represents the credentials used for a given webhook
- * @typedef {Object} WebhookCredentials
- * @property {string} id The webhook's id
- * @property {string} token The webhook's token
- */
-
-/**
- * Parses a webhook URL for the id and token
+ * Parses a webhook URL for the id and token.
  * @param {string} url The URL to parse
- * @returns {?WebhookCredentials} Null if the URL is invalid, otherwise the id and the token
+ * @returns {?WebhookClientDataIdWithToken} `null` if the URL is invalid, otherwise the id and the token
  */
 function parseWebhookURL(url) {
   const matches = url.match(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`WebhookClientData` is now a union of two possible objects rather than one object containing all the properties. This reflects the typings exactly and also introduces `WebhookClientDataIdWithToken` & `WebhookClientDataURL` in the documentation which also reflects the typings exactly.

This also fixes an issue where the return type of the top-level function `parseWebhookURL()` documented the id as a `string` instead of a `Snowflake`.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
