### PR TITLE
chore: reexport rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pnpm add discord.js
 
 ## Example usage
 
-Install all required dependencies:
+Install discord.js:
 
 ```sh-session
 npm install discord.js

--- a/README.md
+++ b/README.md
@@ -49,16 +49,15 @@ pnpm add discord.js
 Install all required dependencies:
 
 ```sh-session
-npm install discord.js @discordjs/rest
-yarn add discord.js @discordjs/rest
-pnpm add discord.js @discordjs/rest
+npm install discord.js
+yarn add discord.js
+pnpm add discord.js
 ```
 
 Register a slash command against the Discord API:
 
 ```js
-const { REST } = require('@discordjs/rest');
-const { Routes } = require('discord.js');
+const { REST, Routes } = require('discord.js');
 
 const commands = [
 	{

--- a/packages/discord.js/README.md
+++ b/packages/discord.js/README.md
@@ -45,7 +45,7 @@ pnpm add discord.js
 
 ## Example usage
 
-Install all required dependencies:
+Install discord.js:
 
 ```sh-session
 npm install discord.js

--- a/packages/discord.js/README.md
+++ b/packages/discord.js/README.md
@@ -48,16 +48,15 @@ pnpm add discord.js
 Install all required dependencies:
 
 ```sh-session
-npm install discord.js @discordjs/rest
-yarn add discord.js @discordjs/rest
-pnpm add discord.js @discordjs/rest
+npm install discord.js
+yarn add discord.js
+pnpm add discord.js
 ```
 
 Register a slash command against the Discord API:
 
 ```js
-const { REST } = require('@discordjs/rest');
-const { Routes } = require('discord.js');
+const { REST, Routes } = require('discord.js');
 
 const commands = [
   {

--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -180,9 +180,6 @@ exports.WelcomeScreen = require('./structures/WelcomeScreen');
 exports.WebSocket = require('./WebSocket');
 
 // External
-exports.DiscordAPIError = require('@discordjs/rest').DiscordAPIError;
-exports.HTTPError = require('@discordjs/rest').HTTPError;
-exports.RateLimitError = require('@discordjs/rest').RateLimitError;
-
 __exportStar(require('discord-api-types/v10'), exports);
 __exportStar(require('@discordjs/builders'), exports);
+__exportStar(require('@discordjs/rest'), exports);

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5603,4 +5603,4 @@ export type InternalDiscordGatewayAdapterCreator = (
 // External
 export * from 'discord-api-types/v10';
 export * from '@discordjs/builders';
-export { DiscordAPIError, HTTPError, RateLimitError } from '@discordjs/rest';
+export * from '@discordjs/rest';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR exports all things from `@discordjs/rest`. `@discordjs/rest` is also a part of `discord.js` like `@discordjs/builders` or `@discordjs/collection`. This will simplify the interaction with `discord.js` and will also provide types from `@discordjs/rest` for TypeScript users.

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
