### PR TITLE
refactor(PermissionOverwriteManager): Use `OverwriteType`

### DIFF
--- a/packages/discord.js/src/managers/PermissionOverwriteManager.js
+++ b/packages/discord.js/src/managers/PermissionOverwriteManager.js
@@ -72,11 +72,11 @@ class PermissionOverwriteManager extends CachedManager {
   }
 
   /**
-   * Extra information about the overwrite
+   * Extra information about the overwrite.
    * @typedef {Object} GuildChannelOverwriteOptions
-   * @property {string} [reason] Reason for creating/editing this overwrite
-   * @property {number} [type] The type of overwrite, either `0` for a role or `1` for a member. Use this to bypass
-   * automatic resolution of type that results in an error for uncached structure
+   * @property {string} [reason] The reason for creating/editing this overwrite
+   * @property {OverwriteType} [type] The type of overwrite. Use this to bypass automatic resolution of `type`
+   * that results in an error for an uncached structure
    */
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4712,7 +4712,7 @@ export interface GuildChannelEditOptions {
 
 export interface GuildChannelOverwriteOptions {
   reason?: string;
-  type?: number;
+  type?: OverwriteType;
 }
 
 export interface GuildCreateOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Modifies `GuildChannelOverwriteOptions`'s `type` to use the `OverwriteType` enumeration.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
