### PR TITLE
docs(InteractionResponses): Add `showModal()` return type

### DIFF
--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -238,6 +238,7 @@ class InteractionResponses {
   /**
    * Shows a modal component
    * @param {APIModal|ModalData|Modal} modal The modal to show
+   * @returns {Promise<void>}
    */
   async showModal(modal) {
     if (this.deferred || this.replied) throw new Error(ErrorCodes.InteractionAlreadyReplied);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `@returns` of this method was not documented, so it showed up as `void` on the documentation instead of `Promise<void>`.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
