### PR TITLE
chore: fix file path

### DIFF
--- a/packages/actions/build.config.ts
+++ b/packages/actions/build.config.ts
@@ -1,3 +1,3 @@
 import { createUnbuildConfig } from '../../build.config';
 
-export default createUnbuildConfig({ minify: true });
+export default createUnbuildConfig({ minify: true, emitCJS: false });

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -10,14 +10,8 @@
 		"format": "prettier --write . && eslint src __tests__ --ext mjs,js,ts --fix",
 		"fmt": "yarn format"
 	},
-	"main": "./dist/index.cjs",
-	"module": "./dist/index.mjs",
+	"main": "./dist/index.mjs",
 	"types": "./dist/index.d.ts",
-	"exports": {
-		"import": "./dist/index.mjs",
-		"require": "./dist/index.cjs",
-		"types": "./dist/index.d.ts"
-	},
 	"directories": {
 		"lib": "src",
 		"test": "__tests__"

--- a/packages/actions/src/formatTag/action.yml
+++ b/packages/actions/src/formatTag/action.yml
@@ -11,4 +11,4 @@ outputs:
     description: 'The semver string that was extracted from this tag'
 runs:
   using: node16
-  main: ../../dist/formatTag/index.cjs
+  main: ../../dist/formatTag/index.mjs

--- a/packages/actions/src/formatTag/action.yml
+++ b/packages/actions/src/formatTag/action.yml
@@ -11,4 +11,4 @@ outputs:
     description: 'The semver string that was extracted from this tag'
 runs:
   using: node16
-  main: ../../dist/formatTag/index.js
+  main: ../../dist/formatTag/index.cjs


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`unbuild` uses `.cjs` extension which is failing docs workflows. But how it was passing earlier?
**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
