### PR TITLE
fix(errors): error codes

### DIFF
--- a/packages/discord.js/src/errors/DJSError.js
+++ b/packages/discord.js/src/errors/DJSError.js
@@ -3,7 +3,6 @@
 // Heavily inspired by node's `internal/errors` module
 const ErrorCodes = require('./ErrorCodes');
 const Messages = require('./Messages');
-const kCode = Symbol('code');
 
 /**
  * Extend an error of some sort into a DiscordjsError.
@@ -15,16 +14,12 @@ function makeDiscordjsError(Base) {
   return class DiscordjsError extends Base {
     constructor(code, ...args) {
       super(message(code, args));
-      this[kCode] = code;
+      this.code = code;
       Error.captureStackTrace?.(this, DiscordjsError);
     }
 
     get name() {
       return `${super.name} [${this.code}]`;
-    }
-
-    get code() {
-      return ErrorCodes[this[kCode]];
     }
   };
 }
@@ -37,9 +32,9 @@ function makeDiscordjsError(Base) {
  * @ignore
  */
 function message(code, args) {
-  if (typeof code !== 'number') throw new Error('Error code must be a valid DiscordjsErrorCodes');
+  if (!(code in ErrorCodes)) throw new Error('Error code must be a valid DiscordjsErrorCodes');
   const msg = Messages[code];
-  if (!msg) throw new Error(`An invalid error code was used: ${code}.`);
+  if (!msg) throw new Error(`No message associated with error code: ${code}.`);
   if (typeof msg === 'function') return msg(...args);
   if (!args?.length) return msg;
   args.unshift(msg);

--- a/packages/discord.js/src/errors/ErrorCodes.js
+++ b/packages/discord.js/src/errors/ErrorCodes.js
@@ -1,159 +1,152 @@
 'use strict';
 
-const { createEnum } = require('../util/Enums');
-
 /**
  * @typedef {Object} DiscordjsErrorCodes
 
- * @property {number} ClientInvalidOption
- * @property {number} ClientInvalidProvidedShards
- * @property {number} ClientMissingIntents
- * @property {number} ClientNotReady
+ * @property {'ClientInvalidOption'} ClientInvalidOption
+ * @property {'ClientInvalidProvidedShards'} ClientInvalidProvidedShards
+ * @property {'ClientMissingIntents'} ClientMissingIntents
+ * @property {'ClientNotReady'} ClientNotReady
 
- * @property {number} TokenInvalid
- * @property {number} TokenMissing
- * @property {number} ApplicationCommandPermissionsTokenMissing
+ * @property {'TokenInvalid'} TokenInvalid
+ * @property {'TokenMissing'} TokenMissing
+ * @property {'ApplicationCommandPermissionsTokenMissing'} ApplicationCommandPermissionsTokenMissing
 
- * @property {number} WSCloseRequested
- * @property {number} WSConnectionExists
- * @property {number} WSNotOpen
- * @property {number} ManagerDestroyed
+ * @property {'WSCloseRequested'} WSCloseRequested
+ * @property {'WSConnectionExists'} WSConnectionExists
+ * @property {'WSNotOpen'} WSNotOpen
+ * @property {'ManagerDestroyed'} ManagerDestroyed
 
- * @property {number} BitFieldInvalid
+ * @property {'BitFieldInvalid'} BitFieldInvalid
 
- * @property {number} ShardingInvalid
- * @property {number} ShardingRequired
- * @property {number} InvalidIntents
- * @property {number} DisallowedIntents
- * @property {number} ShardingNoShards
- * @property {number} ShardingInProcess
- * @property {number} ShardingInvalidEvalBroadcast
- * @property {number} ShardingShardNotFound
- * @property {number} ShardingAlreadySpawned
- * @property {number} ShardingProcessExists
- * @property {number} ShardingWorkerExists
- * @property {number} ShardingReadyTimeout
- * @property {number} ShardingReadyDisconnected
- * @property {number} ShardingReadyDied
- * @property {number} ShardingNoChildExists
- * @property {number} ShardingShardMiscalculation
+ * @property {'ShardingInvalid'} ShardingInvalid
+ * @property {'ShardingRequired'} ShardingRequired
+ * @property {'InvalidIntents'} InvalidIntents
+ * @property {'DisallowedIntents'} DisallowedIntents
+ * @property {'ShardingNoShards'} ShardingNoShards
+ * @property {'ShardingInProcess'} ShardingInProcess
+ * @property {'ShardingInvalidEvalBroadcast'} ShardingInvalidEvalBroadcast
+ * @property {'ShardingShardNotFound'} ShardingShardNotFound
+ * @property {'ShardingAlreadySpawned'} ShardingAlreadySpawned
+ * @property {'ShardingProcessExists'} ShardingProcessExists
+ * @property {'ShardingWorkerExists'} ShardingWorkerExists
+ * @property {'ShardingReadyTimeout'} ShardingReadyTimeout
+ * @property {'ShardingReadyDisconnected'} ShardingReadyDisconnected
+ * @property {'ShardingReadyDied'} ShardingReadyDied
+ * @property {'ShardingNoChildExists'} ShardingNoChildExists
+ * @property {'ShardingShardMiscalculation'} ShardingShardMiscalculation
 
- * @property {number} ColorRange
- * @property {number} ColorConvert
+ * @property {'ColorRange'} ColorRange
+ * @property {'ColorConvert'} ColorConvert
 
- * @property {number} InviteOptionsMissingChannel
+ * @property {'InviteOptionsMissingChannel'} InviteOptionsMissingChannel
 
- * @property {number} ButtonLabel
- * @property {number} ButtonURL
- * @property {number} ButtonCustomId
+ * @property {'ButtonLabel'} ButtonLabel
+ * @property {'ButtonURL'} ButtonURL
+ * @property {'ButtonCustomId'} ButtonCustomId
 
- * @property {number} SelectMenuCustomId
- * @property {number} SelectMenuPlaceholder
- * @property {number} SelectOptionLabel
- * @property {number} SelectOptionValue
- * @property {number} SelectOptionDescription
+ * @property {'SelectMenuCustomId'} SelectMenuCustomId
+ * @property {'SelectMenuPlaceholder'} SelectMenuPlaceholder
+ * @property {'SelectOptionLabel'} SelectOptionLabel
+ * @property {'SelectOptionValue'} SelectOptionValue
+ * @property {'SelectOptionDescription'} SelectOptionDescription
 
- * @property {number} InteractionCollectorError
+ * @property {'InteractionCollectorError'} InteractionCollectorError
 
- * @property {number} FileNotFound
+ * @property {'FileNotFound'} FileNotFound
 
- * @property {number} UserBannerNotFetched
- * @property {number} UserNoDMChannel
+ * @property {'UserBannerNotFetched'} UserBannerNotFetched
+ * @property {'UserNoDMChannel'} UserNoDMChannel
 
- * @property {number} VoiceNotStageChannel
+ * @property {'VoiceNotStageChannel'} VoiceNotStageChannel
 
- * @property {number} VoiceStateNotOwn
- * @property {number} VoiceStateInvalidType
+ * @property {'VoiceStateNotOwn'} VoiceStateNotOwn
+ * @property {'VoiceStateInvalidType'} VoiceStateInvalidType
 
- * @property {number} ReqResourceType
+ * @property {'ReqResourceType'} ReqResourceType
 
- * @property {number} ImageFormat
- * @property {number} ImageSize
+ * @property {'ImageFormat'} ImageFormat
+ * @property {'ImageSize'} ImageSize
 
- * @property {number} MessageBulkDeleteType
- * @property {number} MessageNonceType
- * @property {number} MessageContentType
+ * @property {'MessageBulkDeleteType'} MessageBulkDeleteType
+ * @property {'MessageNonceType'} MessageNonceType
+ * @property {'MessageContentType'} MessageContentType
 
- * @property {number} SplitMaxLen
+ * @property {'SplitMaxLen'} SplitMaxLen
 
- * @property {number} BanResolveId
- * @property {number} FetchBanResolveId
+ * @property {'BanResolveId'} BanResolveId
+ * @property {'FetchBanResolveId'} FetchBanResolveId
 
- * @property {number} PruneDaysType
+ * @property {'PruneDaysType'} PruneDaysType
 
- * @property {number} GuildChannelResolve
- * @property {number} GuildVoiceChannelResolve
- * @property {number} GuildChannelOrphan
- * @property {number} GuildChannelUnowned
- * @property {number} GuildOwned
- * @property {number} GuildMembersTimeout
- * @property {number} GuildUncachedMe
- * @property {number} ChannelNotCached
- * @property {number} StageChannelResolve
- * @property {number} GuildScheduledEventResolve
- * @property {number} FetchOwnerId
+ * @property {'GuildChannelResolve'} GuildChannelResolve
+ * @property {'GuildVoiceChannelResolve'} GuildVoiceChannelResolve
+ * @property {'GuildChannelOrphan'} GuildChannelOrphan
+ * @property {'GuildChannelUnowned'} GuildChannelUnowned
+ * @property {'GuildOwned'} GuildOwned
+ * @property {'GuildMembersTimeout'} GuildMembersTimeout
+ * @property {'GuildUncachedMe'} GuildUncachedMe
+ * @property {'ChannelNotCached'} ChannelNotCached
+ * @property {'StageChannelResolve'} StageChannelResolve
+ * @property {'GuildScheduledEventResolve'} GuildScheduledEventResolve
+ * @property {'FetchOwnerId'} FetchOwnerId
 
- * @property {number} InvalidType
- * @property {number} InvalidElement
+ * @property {'InvalidType'} InvalidType
+ * @property {'InvalidElement'} InvalidElement
 
- * @property {number} MessageThreadParent
- * @property {number} MessageExistingThread
- * @property {number} ThreadInvitableType
+ * @property {'MessageThreadParent'} MessageThreadParent
+ * @property {'MessageExistingThread'} MessageExistingThread
+ * @property {'ThreadInvitableType'} ThreadInvitableType
 
- * @property {number} WebhookMessage
- * @property {number} WebhookTokenUnavailable
- * @property {number} WebhookURLInvalid
- * @property {number} WebhookApplication
- * @property {number} MessageReferenceMissing
+ * @property {'WebhookMessage'} WebhookMessage
+ * @property {'WebhookTokenUnavailable'} WebhookTokenUnavailable
+ * @property {'WebhookURLInvalid'} WebhookURLInvalid
+ * @property {'WebhookApplication'} WebhookApplication
+ * @property {'MessageReferenceMissing'} MessageReferenceMissing
 
- * @property {number} EmojiType
- * @property {number} EmojiManaged
- * @property {number} MissingManageEmojisAndStickersPermission
- * @property {number} NotGuildSticker
+ * @property {'EmojiType'} EmojiType
+ * @property {'EmojiManaged'} EmojiManaged
+ * @property {'MissingManageEmojisAndStickersPermission'} MissingManageEmojisAndStickersPermission
+ * @property {'NotGuildSticker'} NotGuildSticker
 
- * @property {number} ReactionResolveUser
+ * @property {'ReactionResolveUser'} ReactionResolveUser
 
- * @property {number} VanityURL
+ * @property {'VanityURL'} VanityURL
 
- * @property {number} InviteResolveCode
+ * @property {'InviteResolveCode'} InviteResolveCode
 
- * @property {number} InviteNotFound
+ * @property {'InviteNotFound'} InviteNotFound
 
- * @property {number} DeleteGroupDMChannel
- * @property {number} FetchGroupDMChannel
+ * @property {'DeleteGroupDMChannel'} DeleteGroupDMChannel
+ * @property {'FetchGroupDMChannel'} FetchGroupDMChannel
 
- * @property {number} MemberFetchNonceLength
+ * @property {'MemberFetchNonceLength'} MemberFetchNonceLength
 
- * @property {number} GlobalCommandPermissions
- * @property {number} GuildUncachedEntityResolve
+ * @property {'GlobalCommandPermissions'} GlobalCommandPermissions
+ * @property {'GuildUncachedEntityResolve'} GuildUncachedEntityResolve
 
- * @property {number} InteractionAlreadyReplied
- * @property {number} InteractionNotReplied
- * @property {number} InteractionEphemeralReplied
+ * @property {'InteractionAlreadyReplied'} InteractionAlreadyReplied
+ * @property {'InteractionNotReplied'} InteractionNotReplied
+ * @property {'InteractionEphemeralReplied'} InteractionEphemeralReplied
 
- * @property {number} CommandInteractionOptionNotFound
- * @property {number} CommandInteractionOptionType
- * @property {number} CommandInteractionOptionEmpty
- * @property {number} CommandInteractionOptionNoSubcommand
- * @property {number} CommandInteractionOptionNoSubcommandGroup
- * @property {number} AutocompleteInteractionOptionNoFocusedOption
+ * @property {'CommandInteractionOptionNotFound'} CommandInteractionOptionNotFound
+ * @property {'CommandInteractionOptionType'} CommandInteractionOptionType
+ * @property {'CommandInteractionOptionEmpty'} CommandInteractionOptionEmpty
+ * @property {'CommandInteractionOptionNoSubcommand'} CommandInteractionOptionNoSubcommand
+ * @property {'CommandInteractionOptionNoSubcommandGroup'} CommandInteractionOptionNoSubcommandGroup
+ * @property {'AutocompleteInteractionOptionNoFocusedOption'} AutocompleteInteractionOptionNoFocusedOption
 
- * @property {number} ModalSubmitInteractionFieldNotFound
- * @property {number} ModalSubmitInteractionFieldType
+ * @property {'ModalSubmitInteractionFieldNotFound'} ModalSubmitInteractionFieldNotFound
+ * @property {'ModalSubmitInteractionFieldType'} ModalSubmitInteractionFieldType
 
- * @property {number} InvalidMissingScopes
+ * @property {'InvalidMissingScopes'} InvalidMissingScopes
 
- * @property {number} NotImplemented
+ * @property {'NotImplemented'} NotImplemented
 
- * @property {number} SweepFilterReturn
+ * @property {'SweepFilterReturn'} SweepFilterReturn
  */
 
-// JSDoc for IntelliSense purposes
-/**
- * @type {DiscordjsErrorCodes}
- * @ignore
- */
-module.exports = createEnum([
+const keys = [
   'ClientInvalidOption',
   'ClientInvalidProvidedShards',
   'ClientMissingIntents',
@@ -295,4 +288,11 @@ module.exports = createEnum([
   'NotImplemented',
 
   'SweepFilterReturn',
-]);
+];
+
+// JSDoc for IntelliSense purposes
+/**
+ * @type {DiscordjsErrorCodes}
+ * @ignore
+ */
+module.exports = Object.fromEntries(keys.map(key => [key, key]));

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3021,152 +3021,152 @@ export const version: string;
 
 //#region Errors
 export enum DiscordjsErrorCodes {
-  ClientInvalidOption,
-  ClientInvalidProvidedShards,
-  ClientMissingIntents,
-  ClientNotReady,
+  ClientInvalidOption = 'ClientInvalidOption',
+  ClientInvalidProvidedShards = 'ClientInvalidProvidedShards',
+  ClientMissingIntents = 'ClientMissingIntents',
+  ClientNotReady = 'ClientNotReady',
 
-  TokenInvalid,
-  TokenMissing,
-  ApplicationCommandPermissionsTokenMissing,
+  TokenInvalid = 'TokenInvalid',
+  TokenMissing = 'TokenMissing',
+  ApplicationCommandPermissionsTokenMissing = 'ApplicationCommandPermissionsTokenMissing',
 
-  WSCloseRequested,
-  WSConnectionExists,
-  WSNotOpen,
-  ManagerDestroyed,
+  WSCloseRequested = 'WSCloseRequested',
+  WSConnectionExists = 'WSConnectionExists',
+  WSNotOpen = 'WSNotOpen',
+  ManagerDestroyed = 'ManagerDestroyed',
 
-  BitFieldInvalid,
+  BitFieldInvalid = 'BitFieldInvalid',
 
-  ShardingInvalid,
-  ShardingRequired,
-  InvalidIntents,
-  DisallowedIntents,
-  ShardingNoShards,
-  ShardingInProcess,
-  ShardingInvalidEvalBroadcast,
-  ShardingShardNotFound,
-  ShardingAlreadySpawned,
-  ShardingProcessExists,
-  ShardingWorkerExists,
-  ShardingReadyTimeout,
-  ShardingReadyDisconnected,
-  ShardingReadyDied,
-  ShardingNoChildExists,
-  ShardingShardMiscalculation,
+  ShardingInvalid = 'ShardingInvalid',
+  ShardingRequired = 'ShardingRequired',
+  InvalidIntents = 'InvalidIntents',
+  DisallowedIntents = 'DisallowedIntents',
+  ShardingNoShards = 'ShardingNoShards',
+  ShardingInProcess = 'ShardingInProcess',
+  ShardingInvalidEvalBroadcast = 'ShardingInvalidEvalBroadcast',
+  ShardingShardNotFound = 'ShardingShardNotFound',
+  ShardingAlreadySpawned = 'ShardingAlreadySpawned',
+  ShardingProcessExists = 'ShardingProcessExists',
+  ShardingWorkerExists = 'ShardingWorkerExists',
+  ShardingReadyTimeout = 'ShardingReadyTimeout',
+  ShardingReadyDisconnected = 'ShardingReadyDisconnected',
+  ShardingReadyDied = 'ShardingReadyDied',
+  ShardingNoChildExists = 'ShardingNoChildExists',
+  ShardingShardMiscalculation = 'ShardingShardMiscalculation',
 
-  ColorRange,
-  ColorConvert,
+  ColorRange = 'ColorRange',
+  ColorConvert = 'ColorConvert',
 
-  InviteOptionsMissingChannel,
+  InviteOptionsMissingChannel = 'InviteOptionsMissingChannel',
 
-  ButtonLabel,
-  ButtonURL,
-  ButtonCustomId,
+  ButtonLabel = 'ButtonLabel',
+  ButtonURL = 'ButtonURL',
+  ButtonCustomId = 'ButtonCustomId',
 
-  SelectMenuCustomId,
-  SelectMenuPlaceholder,
-  SelectOptionLabel,
-  SelectOptionValue,
-  SelectOptionDescription,
+  SelectMenuCustomId = 'SelectMenuCustomId',
+  SelectMenuPlaceholder = 'SelectMenuPlaceholder',
+  SelectOptionLabel = 'SelectOptionLabel',
+  SelectOptionValue = 'SelectOptionValue',
+  SelectOptionDescription = 'SelectOptionDescription',
 
-  InteractionCollectorError,
+  InteractionCollectorError = 'InteractionCollectorError',
 
-  FileNotFound,
+  FileNotFound = 'FileNotFound',
 
-  UserBannerNotFetched,
-  UserNoDMChannel,
+  UserBannerNotFetched = 'UserBannerNotFetched',
+  UserNoDMChannel = 'UserNoDMChannel',
 
-  VoiceNotStageChannel,
+  VoiceNotStageChannel = 'VoiceNotStageChannel',
 
-  VoiceStateNotOwn,
-  VoiceStateInvalidType,
+  VoiceStateNotOwn = 'VoiceStateNotOwn',
+  VoiceStateInvalidType = 'VoiceStateInvalidType',
 
-  ReqResourceType,
+  ReqResourceType = 'ReqResourceType',
 
-  ImageFormat,
-  ImageSize,
+  ImageFormat = 'ImageFormat',
+  ImageSize = 'ImageSize',
 
-  MessageBulkDeleteType,
-  MessageNonceType,
-  MessageContentType,
+  MessageBulkDeleteType = 'MessageBulkDeleteType',
+  MessageNonceType = 'MessageNonceType',
+  MessageContentType = 'MessageContentType',
 
-  SplitMaxLen,
+  SplitMaxLen = 'SplitMaxLen',
 
-  BanResolveId,
-  FetchBanResolveId,
+  BanResolveId = 'BanResolveId',
+  FetchBanResolveId = 'FetchBanResolveId',
 
-  PruneDaysType,
+  PruneDaysType = 'PruneDaysType',
 
-  GuildChannelResolve,
-  GuildVoiceChannelResolve,
-  GuildChannelOrphan,
-  GuildChannelUnowned,
-  GuildOwned,
-  GuildMembersTimeout,
-  GuildUncachedMe,
-  ChannelNotCached,
-  StageChannelResolve,
-  GuildScheduledEventResolve,
-  FetchOwnerId,
+  GuildChannelResolve = 'GuildChannelResolve',
+  GuildVoiceChannelResolve = 'GuildVoiceChannelResolve',
+  GuildChannelOrphan = 'GuildChannelOrphan',
+  GuildChannelUnowned = 'GuildChannelUnowned',
+  GuildOwned = 'GuildOwned',
+  GuildMembersTimeout = 'GuildMembersTimeout',
+  GuildUncachedMe = 'GuildUncachedMe',
+  ChannelNotCached = 'ChannelNotCached',
+  StageChannelResolve = 'StageChannelResolve',
+  GuildScheduledEventResolve = 'GuildScheduledEventResolve',
+  FetchOwnerId = 'FetchOwnerId',
 
-  InvalidType,
-  InvalidElement,
+  InvalidType = 'InvalidType',
+  InvalidElement = 'InvalidElement',
 
-  MessageThreadParent,
-  MessageExistingThread,
-  ThreadInvitableType,
+  MessageThreadParent = 'MessageThreadParent',
+  MessageExistingThread = 'MessageExistingThread',
+  ThreadInvitableType = 'ThreadInvitableType',
 
-  WebhookMessage,
-  WebhookTokenUnavailable,
-  WebhookURLInvalid,
-  WebhookApplication,
-  MessageReferenceMissing,
+  WebhookMessage = 'WebhookMessage',
+  WebhookTokenUnavailable = 'WebhookTokenUnavailable',
+  WebhookURLInvalid = 'WebhookURLInvalid',
+  WebhookApplication = 'WebhookApplication',
+  MessageReferenceMissing = 'MessageReferenceMissing',
 
-  EmojiType,
-  EmojiManaged,
-  MissingManageEmojisAndStickersPermission,
-  NotGuildSticker,
+  EmojiType = 'EmojiType',
+  EmojiManaged = 'EmojiManaged',
+  MissingManageEmojisAndStickersPermission = 'MissingManageEmojisAndStickersPermission',
+  NotGuildSticker = 'NotGuildSticker',
 
-  ReactionResolveUser,
+  ReactionResolveUser = 'ReactionResolveUser',
 
-  VanityURL,
+  VanityURL = 'VanityURL',
 
-  InviteResolveCode,
+  InviteResolveCode = 'InviteResolveCode',
 
-  InviteNotFound,
+  InviteNotFound = 'InviteNotFound',
 
-  DeleteGroupDMChannel,
-  FetchGroupDMChannel,
+  DeleteGroupDMChannel = 'DeleteGroupDMChannel',
+  FetchGroupDMChannel = 'FetchGroupDMChannel',
 
-  MemberFetchNonceLength,
+  MemberFetchNonceLength = 'MemberFetchNonceLength',
 
-  GlobalCommandPermissions,
-  GuildUncachedEntityResolve,
+  GlobalCommandPermissions = 'GlobalCommandPermissions',
+  GuildUncachedEntityResolve = 'GuildUncachedEntityResolve',
 
-  InteractionAlreadyReplied,
-  InteractionNotReplied,
-  InteractionEphemeralReplied,
+  InteractionAlreadyReplied = 'InteractionAlreadyReplied',
+  InteractionNotReplied = 'InteractionNotReplied',
+  InteractionEphemeralReplied = 'InteractionEphemeralReplied',
 
-  CommandInteractionOptionNotFound,
-  CommandInteractionOptionType,
-  CommandInteractionOptionEmpty,
-  CommandInteractionOptionNoSubcommand,
-  CommandInteractionOptionNoSubcommandGroup,
-  AutocompleteInteractionOptionNoFocusedOption,
+  CommandInteractionOptionNotFound = 'CommandInteractionOptionNotFound',
+  CommandInteractionOptionType = 'CommandInteractionOptionType',
+  CommandInteractionOptionEmpty = 'CommandInteractionOptionEmpty',
+  CommandInteractionOptionNoSubcommand = 'CommandInteractionOptionNoSubcommand',
+  CommandInteractionOptionNoSubcommandGroup = 'CommandInteractionOptionNoSubcommandGroup',
+  AutocompleteInteractionOptionNoFocusedOption = 'AutocompleteInteractionOptionNoFocusedOption',
 
-  ModalSubmitInteractionFieldNotFound,
-  ModalSubmitInteractionFieldType,
+  ModalSubmitInteractionFieldNotFound = 'ModalSubmitInteractionFieldNotFound',
+  ModalSubmitInteractionFieldType = 'ModalSubmitInteractionFieldType',
 
-  InvalidMissingScopes,
+  InvalidMissingScopes = 'InvalidMissingScopes',
 
-  NotImplemented,
+  NotImplemented = 'NotImplemented',
 
-  SweepFilterReturn,
+  SweepFilterReturn = 'SweepFilterReturn',
 }
 
 export interface DiscordjsErrorFields<Name extends string> {
-  readonly name: `${Name} [${keyof typeof DiscordjsErrorCodes}]`;
-  get code(): keyof typeof DiscordjsErrorCodes;
+  readonly name: `${Name} [${DiscordjsErrorCodes}]`;
+  get code(): DiscordjsErrorCodes;
 }
 
 export function DiscordjsErrorMixin<T, N extends string>(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
You currently can't compare against `error.code` using the enum. This was an oversight from the error refactor I did a while back.

This is *technically* breaking (but will just be labeled a patch since as the enum was, no matter how you used it, it basically did nothing), but it's the best thing we can get.

In the future, we'll return back to a proper enum for the error codes.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
