### PR TITLE
fix(WebSocketShard): always reconnect on disconnected with 1000

### DIFF
--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -462,15 +462,11 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 		switch (code) {
 			case CloseCodes.Normal: {
 				this.debug([`Disconnected normally from code ${code}`]);
-				if (this.status === WebSocketShardStatus.Ready) {
-					return this.destroy({
-						code,
-						reason: 'Got disconnected by Discord',
-						recover: WebSocketShardDestroyRecovery.Reconnect,
-					});
-				}
-
-				break;
+				return this.destroy({
+					code,
+					reason: 'Got disconnected by Discord',
+					recover: WebSocketShardDestroyRecovery.Reconnect,
+				});
 			}
 
 			case CloseCodes.Resuming: {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

If the connection closes with a 1000 code before the shard is ready, the shard would end up in a state where it wouldn't attempt to reconnect any further.

This PR fixes this by simply always reconnecting when the connection was closed with a 1000 code.

---

The other case that came up internally, 1006 close codes, are already appropriately handled by the `default` case.
I could implement a custom one to change the debug message if that is wanted.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

