### PR TITLE
fix(WebSocketShard): emit errors directly instead of objects

### DIFF
--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -455,7 +455,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 	}
 
 	private onError(err: Error) {
-		this.emit('error', { err });
+		this.emit('error', err);
 	}
 
 	private async onClose(code: number) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR modifies `WebSocketShard#onError` to emit the received error directly instead of wrapping it in an object causing something like this:
`Uncaught Error UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "#<Object>".`

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

