### PR TITLE
fix(DataResolver): make `Buffer` from string

### DIFF
--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -116,7 +116,7 @@ class DataResolver extends null {
 
     if (typeof resource[Symbol.asyncIterator] === 'function') {
       const buffers = [];
-      for await (const data of resource) buffers.push(data);
+      for await (const data of resource) buffers.push(Buffer.from(data));
       return { data: Buffer.concat(buffers) };
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
[Buffer.concat(Array\<string>)](https://nodejs.org/docs/latest-v16.x/api/buffer.html#static-method-bufferconcatlist-totallength) is not a thing and we get an error when using a `Stream`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
