### PR TITLE
docs(AttachmentBuilder): fix #8407

### DIFF
--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -112,5 +112,5 @@ module.exports = AttachmentBuilder;
 /**
  * @typedef {Object} AttachmentData
  * @property {name} [string] The name of the attachment
- * @property {description} [string] The description of the component
+ * @property {description} [string] The description of the attachment
  */

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -8,7 +8,7 @@ const { basename, flatten } = require('../util/Util');
 class AttachmentBuilder {
   /**
    * @param {BufferResolvable|Stream} attachment The file
-   * @param {APIAttachment} [data] Extra data
+   * @param {AttachmentData} [data] Extra data
    */
   constructor(attachment, data = {}) {
     /**

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -108,3 +108,9 @@ module.exports = AttachmentBuilder;
  * @external APIAttachment
  * @see {@link https://discord.com/developers/docs/resources/channel#attachment-object}
  */
+
+/**
+ * @typedef {Object} AttachmentData
+ * @property {name} [string] The name of the attachment
+ * @property {description} [string] The description of the component
+ */

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -111,6 +111,6 @@ module.exports = AttachmentBuilder;
 
 /**
  * @typedef {Object} AttachmentData
- * @property {name} [string] The name of the attachment
- * @property {description} [string] The description of the attachment
+ * @property {string} [name] The name of the attachment
+ * @property {string} [description] The description of the attachment
  */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Changes the type in the JSDoc for AttachmentBuilder to fix #8407

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->

- This PR **only** includes non-code changes, like changes to documentation, README, etc.