### PR TITLE
types(ApplicationCommandOption): add `ApplicationCommandBooleanOption`

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3738,6 +3738,7 @@ export type CommandOptionChannelResolvableType = ApplicationCommandOptionType.Ch
 
 export type CommandOptionChoiceResolvableType =
   | ApplicationCommandOptionType.String
+  | ApplicationCommandOptionType.Boolean
   | CommandOptionNumericResolvableType;
 
 export type CommandOptionNumericResolvableType =
@@ -3833,6 +3834,10 @@ export interface ApplicationCommandStringOptionData extends ApplicationCommandCh
   max_length?: number;
 }
 
+export interface ApplicationCommandBooleanOptionData extends ApplicationCommandChoicesData {
+  type: ApplicationCommandOptionType.Boolean;
+}
+
 export interface ApplicationCommandNumericOption extends ApplicationCommandChoicesOption {
   type: CommandOptionNumericResolvableType;
   minValue?: number;
@@ -3843,6 +3848,10 @@ export interface ApplicationCommandStringOption extends ApplicationCommandChoice
   type: ApplicationCommandOptionType.String;
   minLength?: number;
   maxLength?: number;
+}
+
+export interface ApplicationCommandBooleanOption extends ApplicationCommandChoicesOption {
+  type: ApplicationCommandOptionType.Boolean;
 }
 
 export interface ApplicationCommandSubGroupData extends Omit<BaseApplicationCommandOptionsData, 'required'> {
@@ -3864,6 +3873,7 @@ export interface ApplicationCommandSubCommandData extends Omit<BaseApplicationCo
     | ApplicationCommandAutocompleteOption
     | ApplicationCommandNumericOptionData
     | ApplicationCommandStringOptionData
+    | ApplicationCommandBooleanOption
   )[];
 }
 
@@ -3888,6 +3898,7 @@ export type ApplicationCommandOptionData =
   | ApplicationCommandAutocompleteOption
   | ApplicationCommandNumericOptionData
   | ApplicationCommandStringOptionData
+  | ApplicationCommandBooleanOptionData
   | ApplicationCommandSubCommandData;
 
 export type ApplicationCommandOption =
@@ -3897,6 +3908,7 @@ export type ApplicationCommandOption =
   | ApplicationCommandChoicesOption
   | ApplicationCommandNumericOption
   | ApplicationCommandStringOption
+  | ApplicationCommandBooleanOption
   | ApplicationCommandAttachmentOption
   | ApplicationCommandSubCommand;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add `ApplicationCommandOptionType.Boolean` to `CommandOptionChoiceResolvableType` union
Add interface `ApplicationCommandBooleanOptionData`
Add interface `ApplicationCommandBooleanOption`
Add `ApplicationCommandBooleanOption` to `ApplicationCommandSubCommandData.options` union
Add `ApplicationCommandBooleanOptionData` to `ApplicationCommandOptionData` union
Add `ApplicationCommandBooleanOption` to `ApplicationCommandOption` union

Fixes #8433 

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
