### PR TITLE
docs(Colors): provide enum descriptions

### DIFF
--- a/packages/discord.js/src/util/Colors.js
+++ b/packages/discord.js/src/util/Colors.js
@@ -2,36 +2,36 @@
 
 /**
  * @typedef {Object} Colors
- * @property {number} Default
- * @property {number} White
- * @property {number} Aqua
- * @property {number} Green
- * @property {number} Blue
- * @property {number} Yellow
- * @property {number} Purple
- * @property {number} LuminousVividPink
- * @property {number} Fuchsia
- * @property {number} Gold
- * @property {number} Orange
- * @property {number} Red
- * @property {number} Grey
- * @property {number} Navy
- * @property {number} DarkAqua
- * @property {number} DarkGreen
- * @property {number} DarkBlue
- * @property {number} DarkPurple
- * @property {number} DarkVividPink
- * @property {number} DarkGold
- * @property {number} DarkOrange
- * @property {number} DarkRed
- * @property {number} DarkGrey
- * @property {number} DarkerGrey
- * @property {number} LightGrey
- * @property {number} DarkNavy
- * @property {number} Blurple
- * @property {number} Greyple
- * @property {number} DarkButNotBlack
- * @property {number} NotQuiteBlack
+ * @property {number} Default 0x000000 | rgb(0,0,0)
+ * @property {number} White 0xFFFFFF | rgb(255,255,255)
+ * @property {number} Aqua 0x1ABC9C | rgb(26,188,156)
+ * @property {number} Green 0x57F287 | rgb(87,242,135)
+ * @property {number} Blue 0x3498DB | rgb(52,152,219)
+ * @property {number} Yellow 0xFEE75C | rgb(254,231,92)
+ * @property {number} Purple 0x9B59B6 | rgb(155,89,182)
+ * @property {number} LuminousVividPink 0xE91E63 | rgb(233,30,99)
+ * @property {number} Fuchsia 0xEB459E | rgb(235,69,158)
+ * @property {number} Gold 0xF1C40F | rgb(241,196,15)
+ * @property {number} Orange 0xE67E22 | rgb(230,126,34)
+ * @property {number} Red 0xED4245 | rgb(237,66,69)
+ * @property {number} Grey 0x95A5A6 | rgb(149,165,166)
+ * @property {number} Navy 0x34495E | rgb(52,73,94)
+ * @property {number} DarkAqua 0x11806A | rgb(17,128,106)
+ * @property {number} DarkGreen 0x1F8B4C | rgb(31,139,76)
+ * @property {number} DarkBlue 0x206694 | rgb(32,102,148)
+ * @property {number} DarkPurple 0x71368A | rgb(113,54,138)
+ * @property {number} DarkVividPink 0xAD1457 | rgb(173,20,87)
+ * @property {number} DarkGold 0xC27C0E | rgb(194,124,14)
+ * @property {number} DarkOrange 0xA84300 | rgb(168,67,0)
+ * @property {number} DarkRed 0x992D22 | rgb(153,45,34)
+ * @property {number} DarkGrey 0x979C9F | rgb(151,156,159)
+ * @property {number} DarkerGrey 0x7F8C8D | rgb(127,140,141)
+ * @property {number} LightGrey 0xBCC0C0 | rgb(188,192,192)
+ * @property {number} DarkNavy 0x2C3E50 | rgb(44,62,80)
+ * @property {number} Blurple 0x5865F2 | rgb(88,101,242)
+ * @property {number} Greyple 0x99AAb5 | rgb(153,170,181)
+ * @property {number} DarkButNotBlack 0x2C2F33 | rgb(44,47,51)
+ * @property {number} NotQuiteBlack 0x23272A | rgb(35,39,42)
  */
 
 // JSDoc for IntelliSense purposes


### PR DESCRIPTION
Adds a description field to the Colors docs so people can know what the colour is (sort of) without opening source code.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
