### PR TITLE
types: fix missing types for mentionable options

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3793,6 +3793,30 @@ export interface ApplicationCommandChannelOption extends BaseApplicationCommandO
   channelTypes?: ChannelType[];
 }
 
+export interface ApplicationCommandRoleOptionData extends BaseApplicationCommandOptionsData {
+  type: ApplicationCommandOptionType.Role;
+}
+
+export interface ApplicationCommandRoleOption extends BaseApplicationCommandOptionsData {
+  type: ApplicationCommandOptionType.Role;
+}
+
+export interface ApplicationCommandUserOptionData extends BaseApplicationCommandOptionsData {
+  type: ApplicationCommandOptionType.User;
+}
+
+export interface ApplicationCommandUserOption extends BaseApplicationCommandOptionsData {
+  type: ApplicationCommandOptionType.User;
+}
+
+export interface ApplicationCommandMentionableOptionData extends BaseApplicationCommandOptionsData {
+  type: ApplicationCommandOptionType.Mentionable;
+}
+
+export interface ApplicationCommandMentionableOption extends BaseApplicationCommandData {
+  type: ApplicationCommandOptionType.Mentionable;
+}
+
 export interface ApplicationCommandAttachmentOption extends BaseApplicationCommandOptionsData {
   type: ApplicationCommandOptionType.Attachment;
 }
@@ -3863,6 +3887,9 @@ export interface ApplicationCommandSubCommandData extends Omit<BaseApplicationCo
     | ApplicationCommandChannelOptionData
     | ApplicationCommandAutocompleteOption
     | ApplicationCommandNumericOptionData
+    | ApplicationCommandRoleOptionData
+    | ApplicationCommandUserOptionData
+    | ApplicationCommandMentionableOptionData
     | ApplicationCommandStringOptionData
   )[];
 }
@@ -3888,6 +3915,9 @@ export type ApplicationCommandOptionData =
   | ApplicationCommandAutocompleteOption
   | ApplicationCommandNumericOptionData
   | ApplicationCommandStringOptionData
+  | ApplicationCommandRoleOptionData
+  | ApplicationCommandUserOptionData
+  | ApplicationCommandMentionableOptionData
   | ApplicationCommandSubCommandData;
 
 export type ApplicationCommandOption =
@@ -3897,6 +3927,9 @@ export type ApplicationCommandOption =
   | ApplicationCommandChoicesOption
   | ApplicationCommandNumericOption
   | ApplicationCommandStringOption
+  | ApplicationCommandRoleOption
+  | ApplicationCommandUserOption
+  | ApplicationCommandMentionableOption
   | ApplicationCommandAttachmentOption
   | ApplicationCommandSubCommand;
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3813,7 +3813,7 @@ export interface ApplicationCommandMentionableOptionData extends BaseApplication
   type: ApplicationCommandOptionType.Mentionable;
 }
 
-export interface ApplicationCommandMentionableOption extends BaseApplicationCommandData {
+export interface ApplicationCommandMentionableOption extends BaseApplicationCommandOptionsData {
   type: ApplicationCommandOptionType.Mentionable;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Add `ApplicationCommandRoleOptionData` interface
- Add `ApplicationCommandRoleOption` interface
- Add `ApplicationCommandUserOptionData` interface
- Add `ApplicationCommandUserOption` interface
- Add `ApplicationCommandMentionableOptionData` interface
- Add `ApplicationCommandMentionableOption` interface
- Update `ApplicationCommandSubCommandData.options` union
- Update `ApplicationCommandOptionData` union
- Update `ApplicationCommandOption` union

Fixes #8440 

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
