### PR TITLE
fix for "TypeError: Object.hasOwn is not a function"

### DIFF
--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -276,7 +276,7 @@ function resolvePartialEmoji(emoji) {
 function mergeDefault(def, given) {
   if (!given) return def;
   for (const key in def) {
-    if (!Object.hasOwn(given, key) || given[key] === undefined) {
+    if (!Object.hasOwnProperty(given, key) || given[key] === undefined) {
       given[key] = def[key];
     } else if (given[key] === Object(given[key])) {
       given[key] = mergeDefault(def[key], given[key]);


### PR DESCRIPTION
change a function name (hasOwn to hasOwnProperty) in discord.js/src/util/Util.js , ligne 279 , col 16
to patch the error ```TypeError: Object.hasOwn is not a function```
