### PR TITLE
refactor(codeBlock): swap order of arguments

### DIFF
--- a/packages/builders/__tests__/messages/formatters.test.ts
+++ b/packages/builders/__tests__/messages/formatters.test.ts
@@ -29,8 +29,8 @@ describe('Message formatters', () => {
 			expect<'```\ndiscord.js\n```'>(codeBlock('discord.js')).toEqual('```\ndiscord.js\n```');
 		});
 
-		test('GIVEN "discord.js" with "js" as language THEN returns "```js\\ndiscord.js```"', () => {
-			expect<'```js\ndiscord.js\n```'>(codeBlock('js', 'discord.js')).toEqual('```js\ndiscord.js\n```');
+		test('GIVEN "discord.js" with "js" as language THEN returns "```js\\ndiscord.js\n```"', () => {
+			expect<'```js\ndiscord.js\n```'>(codeBlock('discord.js', 'js')).toEqual('```js\ndiscord.js\n```');
 		});
 	});
 

--- a/packages/builders/src/messages/formatters.ts
+++ b/packages/builders/src/messages/formatters.ts
@@ -17,7 +17,9 @@ export function codeBlock<C extends string>(content: C): `\`\`\`\n${C}\n\`\`\``;
  */
 export function codeBlock<C extends string, L extends string>(content: C, language: L): `\`\`\`${L}\n${C}\n\`\`\``;
 export function codeBlock(content: string, language?: string): string {
-	if (language && language.length > 18) {
+	// unicorn-rails-log is the longest named language known to be supported at the time of this commit
+	// That's why we use 17 here, because it's the length of that language
+	if (language && language.length > 17) {
 		process.emitWarning(
 			'Passing the language as the first parameter in the codeBlock method is deprecated. Please pass it as the second parameter instead.',
 			'DeprecationWarning',

--- a/packages/builders/src/messages/formatters.ts
+++ b/packages/builders/src/messages/formatters.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import type { URL } from 'url';
 import type { Snowflake } from 'discord-api-types/globals';
 
@@ -11,12 +12,21 @@ export function codeBlock<C extends string>(content: C): `\`\`\`\n${C}\n\`\`\``;
 /**
  * Wraps the content inside a codeblock with the specified language
  *
- * @param language - The language for the codeblock
  * @param content - The content to wrap
+ * @param language - The language for the codeblock
  */
-export function codeBlock<L extends string, C extends string>(language: L, content: C): `\`\`\`${L}\n${C}\n\`\`\``;
-export function codeBlock(language: string, content?: string): string {
-	return typeof content === 'undefined' ? `\`\`\`\n${language}\n\`\`\`` : `\`\`\`${language}\n${content}\n\`\`\``;
+export function codeBlock<C extends string, L extends string>(content: C, language: L): `\`\`\`${L}\n${C}\n\`\`\``;
+export function codeBlock(content: string, language?: string): string {
+	if (language && language.length > 18) {
+		process.emitWarning(
+			'Passing the language as the first parameter in the codeBlock method is deprecated. Please pass it as the second parameter instead.',
+			'DeprecationWarning',
+		);
+		const tempLanguage = language;
+		language = content;
+		content = tempLanguage;
+	}
+	return typeof language === 'undefined' ? `\`\`\`\n${content}\n\`\`\`` : `\`\`\`${language}\n${content}\n\`\`\``;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR swaps the order of the arguments in the codeBlock function. It also adds a deprecation warning if arguments are passed the old way and attempts to swap them. This isn't 100% bulletproof as there is no official list of languages so I think it's the best we can have. This was discussed in Discord too

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
