### PR TITLE
fix: Remove DM channels from `Client#messageDeleteBulk`'s types

### DIFF
--- a/packages/discord.js/src/client/actions/MessageDeleteBulk.js
+++ b/packages/discord.js/src/client/actions/MessageDeleteBulk.js
@@ -33,7 +33,7 @@ class MessageDeleteBulkAction extends Action {
        * Emitted whenever messages are deleted in bulk.
        * @event Client#messageDeleteBulk
        * @param {Collection<Snowflake, Message>} messages The deleted messages, mapped by their id
-       * @param {TextBasedChannels} channel The channel that the messages were deleted in
+       * @param {GuildTextBasedChannel} channel The channel that the messages were deleted in
        */
       if (messages.size > 0) client.emit(Events.MessageBulkDelete, messages, channel);
       return { messages };

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -53,13 +53,19 @@ exports.NonSystemMessageTypes = [
 ];
 
 /**
- * The channels that are text-based.
- * * DMChannel
+ * The guild channels that are text-based.
  * * TextChannel
  * * NewsChannel
  * * ThreadChannel
  * * VoiceChannel
- * @typedef {DMChannel|TextChannel|NewsChannel|ThreadChannel|VoiceChannel} TextBasedChannels
+ * @typedef {TextChannel|NewsChannel|ThreadChannel|VoiceChannel} GuildTextBasedChannel
+ */
+
+/**
+ * The channels that are text-based.
+ * * DMChannel
+ * * GuildTextBasedChannel
+ * @typedef {DMChannel|GuildTextBasedChannel} TextBasedChannels
  */
 
 /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4123,7 +4123,7 @@ export interface ClientEvents {
     reactions: Collection<string | Snowflake, MessageReaction>,
   ];
   messageReactionRemoveEmoji: [reaction: MessageReaction | PartialMessageReaction];
-  messageDeleteBulk: [messages: Collection<Snowflake, Message | PartialMessage>, channel: TextBasedChannel];
+  messageDeleteBulk: [messages: Collection<Snowflake, Message | PartialMessage>, channel: GuildTextBasedChannel];
   messageReactionAdd: [reaction: MessageReaction | PartialMessageReaction, user: User | PartialUser];
   messageReactionRemove: [reaction: MessageReaction | PartialMessageReaction, user: User | PartialUser];
   messageUpdate: [oldMessage: Message | PartialMessage, newMessage: Message | PartialMessage];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `channel` parameter from `Client#messageDeleteBulk` was of type `TextBasedChannel`. This included DM channels, which is not possible [as documented](https://discord.com/developers/docs/resources/channel#bulk-delete-messages):

> This endpoint can only be used on guild channels

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
