### PR TITLE
fix(Transformers): do not transform `Date` objects

### DIFF
--- a/packages/discord.js/src/util/Transformers.js
+++ b/packages/discord.js/src/util/Transformers.js
@@ -9,6 +9,7 @@ const snakeCase = require('lodash.snakecase');
  */
 function toSnakeCase(obj) {
   if (typeof obj !== 'object' || !obj) return obj;
+  if (obj instanceof Date) return obj;
   if (Array.isArray(obj)) return obj.map(toSnakeCase);
   return Object.fromEntries(Object.entries(obj).map(([key, value]) => [snakeCase(key), toSnakeCase(value)]));
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Alternative to #8458, adds a check to not convert `Date` objects into non-Date.

![image](https://user-images.githubusercontent.com/24852502/183923139-f5140809-8673-4e2f-8a7d-9c325403c237.png)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
