### PR TITLE
fix(ThreadChannel): Handle possibly `null` parent (v13)

### DIFF
--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -283,10 +283,11 @@ class ThreadChannel extends Channel {
    * <info>This only works when the thread started from a message in the parent channel, otherwise the promise will
    * reject. If you just need the id of that message, use {@link ThreadChannel#id} instead.</info>
    * @param {BaseFetchOptions} [options] Additional options for this fetch
-   * @returns {Promise<Message>}
+   * @returns {Promise<Message|null>}
    */
-  fetchStarterMessage(options) {
-    return this.parent.messages.fetch(this.id, options);
+  // eslint-disable-next-line require-await
+  async fetchStarterMessage(options) {
+    return this.parent?.messages.fetch(this.id, options) ?? null;
   }
 
   /**

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2518,7 +2518,7 @@ export class ThreadChannel extends TextBasedChannelMixin(Channel, ['fetchWebhook
     checkAdmin?: boolean,
   ): Readonly<Permissions> | null;
   public fetchOwner(options?: BaseFetchOptions): Promise<ThreadMember | null>;
-  public fetchStarterMessage(options?: BaseFetchOptions): Promise<Message>;
+  public fetchStarterMessage(options?: BaseFetchOptions): Promise<Message | null>;
   public setArchived(archived?: boolean, reason?: string): Promise<ThreadChannel>;
   public setAutoArchiveDuration(
     autoArchiveDuration: ThreadAutoArchiveDuration | 'MAX',


### PR DESCRIPTION
Backports #8466 to version 13.