### PR TITLE
fix(Embed): Reference video in video

### DIFF
--- a/packages/discord.js/src/structures/Embed.js
+++ b/packages/discord.js/src/structures/Embed.js
@@ -115,10 +115,10 @@ class Embed {
   get video() {
     if (!this.data.video) return null;
     return {
-      url: this.data.image.url,
-      proxyURL: this.data.image.proxy_url,
-      height: this.data.image.height,
-      width: this.data.image.width,
+      url: this.data.video.url,
+      proxyURL: this.data.video.proxy_url,
+      height: this.data.video.height,
+      width: this.data.video.width,
     };
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #8472 by retrieving the video data instead of the image data when accessing... video data.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
