### PR TITLE
types: change type of ApplicationCommandSubCommand.options

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3907,7 +3907,19 @@ export interface ApplicationCommandSubCommandData extends Omit<BaseApplicationCo
 
 export interface ApplicationCommandSubCommand extends Omit<BaseApplicationCommandOptionsData, 'required'> {
   type: ApplicationCommandOptionType.Subcommand;
-  options?: (ApplicationCommandChoicesOption | ApplicationCommandNonOptions | ApplicationCommandChannelOption)[];
+  options?: (    
+    | ApplicationCommandNonOptionsData
+    | ApplicationCommandChannelOptionData
+    | ApplicationCommandChoicesData
+    | ApplicationCommandAutocompleteOption
+    | ApplicationCommandNumericOptionData
+    | ApplicationCommandStringOptionData
+    | ApplicationCommandRoleOptionData
+    | ApplicationCommandUserOptionData
+    | ApplicationCommandMentionableOptionData
+    | ApplicationCommandBooleanOptionData
+    | ApplicationCommandAttachmentOption
+  )[];
 }
 
 export interface ApplicationCommandNonOptionsData extends BaseApplicationCommandOptionsData {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3908,16 +3908,16 @@ export interface ApplicationCommandSubCommandData extends Omit<BaseApplicationCo
 export interface ApplicationCommandSubCommand extends Omit<BaseApplicationCommandOptionsData, 'required'> {
   type: ApplicationCommandOptionType.Subcommand;
   options?: (    
-    | ApplicationCommandNonOptionsData
-    | ApplicationCommandChannelOptionData
-    | ApplicationCommandChoicesData
+    | ApplicationCommandNonOptions
+    | ApplicationCommandChannelOption
+    | ApplicationCommandChoicesOption
     | ApplicationCommandAutocompleteOption
-    | ApplicationCommandNumericOptionData
-    | ApplicationCommandStringOptionData
-    | ApplicationCommandRoleOptionData
-    | ApplicationCommandUserOptionData
-    | ApplicationCommandMentionableOptionData
-    | ApplicationCommandBooleanOptionData
+    | ApplicationCommandNumericOption
+    | ApplicationCommandStringOption
+    | ApplicationCommandRoleOption
+    | ApplicationCommandUserOption
+    | ApplicationCommandMentionableOption
+    | ApplicationCommandBooleanOption
     | ApplicationCommandAttachmentOption
   )[];
 }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3907,7 +3907,7 @@ export interface ApplicationCommandSubCommandData extends Omit<BaseApplicationCo
 
 export interface ApplicationCommandSubCommand extends Omit<BaseApplicationCommandOptionsData, 'required'> {
   type: ApplicationCommandOptionType.Subcommand;
-  options?: (    
+  options?: (
     | ApplicationCommandNonOptions
     | ApplicationCommandChannelOption
     | ApplicationCommandChoicesOption


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes the type of the `ApplicationCommandSubCommand.options` field  in order to match the documentation and be able to use all the properties of this type (like `minValue`, `maxValue`, etc).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
