### PR TITLE
feat(WebSocketShard): support new resume url

### DIFF
--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -55,7 +55,7 @@
 	"homepage": "https://discord.js.org",
 	"dependencies": {
 		"@sapphire/shapeshift": "^3.5.1",
-		"discord-api-types": "^0.36.3",
+		"discord-api-types": "^0.37.2",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.1",
 		"tslib": "^2.4.0"

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -54,7 +54,7 @@
     "@discordjs/rest": "workspace:^",
     "@sapphire/snowflake": "^3.2.2",
     "@types/ws": "^8.5.3",
-    "discord-api-types": "^0.36.3",
+    "discord-api-types": "^0.37.2",
     "fast-deep-equal": "^3.1.3",
     "lodash.snakecase": "^4.1.1",
     "tslib": "^2.4.0",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -55,7 +55,7 @@
 		"@discordjs/collection": "workspace:^",
 		"@sapphire/async-queue": "^1.4.0",
 		"@sapphire/snowflake": "^3.2.2",
-		"discord-api-types": "^0.36.3",
+		"discord-api-types": "^0.37.2",
 		"file-type": "^17.1.6",
 		"tslib": "^2.4.0",
 		"undici": "^5.8.2"

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -53,7 +53,7 @@
 	"homepage": "https://discord.js.org",
 	"dependencies": {
 		"@types/ws": "^8.5.3",
-		"discord-api-types": "^0.36.3",
+		"discord-api-types": "^0.37.2",
 		"prism-media": "^1.3.4",
 		"tslib": "^2.4.0",
 		"ws": "^8.8.1"

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -57,7 +57,7 @@
 		"@sapphire/async-queue": "^1.4.0",
 		"@types/ws": "^8.5.3",
 		"@vladfrangu/async_event_emitter": "^2.0.1",
-		"discord-api-types": "^0.36.3",
+		"discord-api-types": "^0.37.2",
 		"tslib": "^2.4.0",
 		"ws": "^8.8.1"
 	},

--- a/packages/ws/src/ws/WebSocketManager.ts
+++ b/packages/ws/src/ws/WebSocketManager.ts
@@ -43,6 +43,10 @@ export interface SessionInfo {
 	 * The total number of shards at the time of this shard identifying
 	 */
 	shardCount: number;
+	/**
+	 * URL to use when resuming
+	 */
+	resumeUrl: string;
 }
 
 /**

--- a/packages/ws/src/ws/WebSocketManager.ts
+++ b/packages/ws/src/ws/WebSocketManager.ts
@@ -46,7 +46,7 @@ export interface SessionInfo {
 	/**
 	 * URL to use when resuming
 	 */
-	resumeUrl: string;
+	resumeURL: string;
 }
 
 /**

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -127,7 +127,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 
 		const session = this.session ?? (await this.strategy.retrieveSessionInfo(this.id));
 
-		const url = `${session?.resumeUrl ?? this.strategy.options.gatewayInformation.url}?${params.toString()}`;
+		const url = `${session?.resumeURL ?? this.strategy.options.gatewayInformation.url}?${params.toString()}`;
 		this.debug([`Connecting to ${url}`]);
 		const connection = new WebSocket(url, { handshakeTimeout: this.strategy.options.handshakeTimeout ?? undefined })
 			/* eslint-disable @typescript-eslint/no-misused-promises */
@@ -381,7 +381,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 							sessionId: payload.d.session_id,
 							shardId: this.id,
 							shardCount: this.strategy.options.shardCount,
-							resumeUrl: payload.d.resume_gateway_url,
+							resumeURL: payload.d.resume_gateway_url,
 						};
 
 						await this.strategy.updateSessionInfo(this.id, this.session);

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -107,8 +107,6 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			throw new Error("Tried to connect a shard that wasn't idle");
 		}
 
-		const data = this.strategy.options.gatewayInformation;
-
 		const { version, encoding, compression } = this.strategy.options;
 		const params = new URLSearchParams({ v: version, encoding });
 		if (compression) {
@@ -127,7 +125,9 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			}
 		}
 
-		const url = `${data.url}?${params.toString()}`;
+		const session = this.session ?? (await this.strategy.retrieveSessionInfo(this.id));
+
+		const url = `${session?.resumeUrl ?? this.strategy.options.gatewayInformation.url}?${params.toString()}`;
 		this.debug([`Connecting to ${url}`]);
 		const connection = new WebSocket(url, { handshakeTimeout: this.strategy.options.handshakeTimeout ?? undefined })
 			/* eslint-disable @typescript-eslint/no-misused-promises */
@@ -143,7 +143,6 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 
 		await this.waitForEvent(WebSocketShardEvents.Hello, this.strategy.options.helloTimeout);
 
-		const session = this.session ?? (await this.strategy.retrieveSessionInfo(this.id));
 		if (session?.shardCount === this.strategy.options.shardCount) {
 			this.session = session;
 			await this.resume(session);
@@ -382,6 +381,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 							sessionId: payload.d.session_id,
 							shardId: this.id,
 							shardCount: this.strategy.options.shardCount,
+							resumeUrl: payload.d.resume_gateway_url,
 						};
 
 						await this.strategy.updateSessionInfo(this.id, this.session);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1819,7 +1819,7 @@ __metadata:
     "@sapphire/shapeshift": ^3.5.1
     "@types/node": ^16.11.47
     c8: ^7.12.0
-    discord-api-types: ^0.36.3
+    discord-api-types: ^0.37.2
     downlevel-dts: ^0.10.0
     eslint: ^8.21.0
     fast-deep-equal: ^3.1.3
@@ -1951,7 +1951,7 @@ __metadata:
     "@sapphire/snowflake": ^3.2.2
     "@types/node": ^16.11.47
     c8: ^7.12.0
-    discord-api-types: ^0.36.3
+    discord-api-types: ^0.37.2
     downlevel-dts: ^0.10.0
     eslint: ^8.21.0
     file-type: ^17.1.6
@@ -1996,7 +1996,7 @@ __metadata:
     "@types/jest": ^28.1.6
     "@types/node": ^16.11.47
     "@types/ws": ^8.5.3
-    discord-api-types: ^0.36.3
+    discord-api-types: ^0.37.2
     downlevel-dts: ^0.10.0
     eslint: ^8.21.0
     jest: ^28.1.3
@@ -2076,7 +2076,7 @@ __metadata:
     "@types/ws": ^8.5.3
     "@vladfrangu/async_event_emitter": ^2.0.1
     c8: ^7.12.0
-    discord-api-types: ^0.36.3
+    discord-api-types: ^0.37.2
     eslint: ^8.21.0
     mock-socket: ^9.1.5
     prettier: ^2.7.1
@@ -6581,10 +6581,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"discord-api-types@npm:^0.36.3":
-  version: 0.36.3
-  resolution: "discord-api-types@npm:0.36.3"
-  checksum: 3089c0fb37425dc5df03c76d82988d43fcc272699b06a02fc830d0a3bef550009aaebdf6d646529e8a7ccea76ae3f43b099d736ea5ef37a0be143142ab49871d
+"discord-api-types@npm:^0.37.2":
+  version: 0.37.2
+  resolution: "discord-api-types@npm:0.37.2"
+  checksum: cf89c232a70c8f77653fdfa7fc34e109f51ba2650f98d54d456aefdb0a90872e2189292dfcf7572a9ece1d16652c6993df64f75199eaee3715f28e592dbf6c25
   languageName: node
   linkType: hard
 
@@ -6600,7 +6600,7 @@ __metadata:
     "@sapphire/snowflake": ^3.2.2
     "@types/node": ^16.11.47
     "@types/ws": ^8.5.3
-    discord-api-types: ^0.36.3
+    discord-api-types: ^0.37.2
     dtslint: ^4.2.1
     eslint: ^8.21.0
     fast-deep-equal: ^3.1.3


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
See https://github.com/discord/discord-api-docs/pull/5282

Closes #8461

Also bumps `discord-api-types` across the repo since.. I needed it.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

