### PR TITLE
Specify time unit in `awaitModalSubmit`

### DIFF
--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -255,7 +255,7 @@ class InteractionResponses {
    * An object containing the same properties as {@link CollectorOptions}, but a few less:
    * @typedef {Object} AwaitModalSubmitOptions
    * @property {CollectorFilter} [filter] The filter applied to this collector
-   * @property {number} time Time to wait for an interaction before rejecting
+   * @property {number} time Time in milliseconds to wait for an interaction before rejecting
    */
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I couldn't find this documented anywhere. Had to scroll through a couple dozen messages in Discord to find how people were using it. "Time" can mean anything.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
^^ At least I think comments are documentation

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
