### PR TITLE
Add APIRole as a valid RoleResolvable type

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -5774,7 +5774,7 @@ export interface RolePosition {
   position: number;
 }
 
-export type RoleResolvable = Role | Snowflake;
+export type RoleResolvable = Role | Snowflake | APIRole;
 
 export interface RoleTagData {
   botId?: Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`interface.options.getRole` return type is `Role | APIRole | Null`.  `APIRole` isn't include in `RoleResolvable` (which is defined as `Role |  Snowflake`) so when trying to implement a function like this:
```ts
async execute(interaction: CommandInteraction) {
        await interaction.deferReply({ ephemeral: true });

        const mutedRole = interaction.options.getRole("muted")!;

        const botHighestRole = interaction.guild!.me!.roles.highest;
        const canBotManageRole =
                botHighestRole.comparePositionTo(mutedRole) > 0;
        // ...
}
```

you get this type error in typescript:

```
Argument of type 'Role | APIRole' is not assignable to parameter of type 'RoleResolvable'.
  Type 'APIRole' is not assignable to type 'RoleResolvable'.
    Type 'APIRole' is missing the following properties from type 'Role': createdAt, createdTimestamp, deleted, editable, and 21 more.
```

The missing properties of `APIRole` aren't needed to resolve the role, what you only need is the id/Snowflake of the role which is present. There shouldn't be an error here so we should accept `APIRole` as a valid `RoleResolvable` type.



**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
