### PR TITLE
Fixed bug on TypeScript with the autocomplete in the options property

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3761,7 +3761,7 @@ export interface BaseApplicationCommandOptionsData {
   description: string;
   descriptionLocalizations?: LocalizationMap;
   required?: boolean;
-  autocomplete?: never;
+  autocomplete?: boolean;
 }
 
 export interface UserApplicationCommandData extends BaseApplicationCommandData {
@@ -3828,19 +3828,19 @@ export interface ApplicationCommandAutocompleteOption extends Omit<BaseApplicati
     | ApplicationCommandOptionType.String
     | ApplicationCommandOptionType.Number
     | ApplicationCommandOptionType.Integer;
-  autocomplete: true;
+  autocomplete: boolean;
 }
 
 export interface ApplicationCommandChoicesData extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
   type: CommandOptionChoiceResolvableType;
   choices?: ApplicationCommandOptionChoiceData[];
-  autocomplete?: false;
+  autocomplete?: boolean;
 }
 
 export interface ApplicationCommandChoicesOption extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
   type: CommandOptionChoiceResolvableType;
   choices?: ApplicationCommandOptionChoiceData[];
-  autocomplete?: false;
+  autocomplete?: boolean;
 }
 
 export interface ApplicationCommandNumericOptionData extends ApplicationCommandChoicesData {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3761,7 +3761,7 @@ export interface BaseApplicationCommandOptionsData {
   description: string;
   descriptionLocalizations?: LocalizationMap;
   required?: boolean;
-  autocomplete?: boolean;
+  autocomplete?: never;
 }
 
 export interface UserApplicationCommandData extends BaseApplicationCommandData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It changes some typings for the autocomplete property inside the package of discord.js in order to be usable by typescript.
With this change typescript users are now able to use the autocomplete inside options and change it to true | false and actually work with it.

**Status and versioning classification:**
discord.js version 14.2.0

- Code changes have been tested against the Discord API, or there are no code changes-
- I know how to update typings and have done so, or typings don't need updating

