### PR TITLE
feat: deprecate `ActionRow.from()`

### DIFF
--- a/packages/discord.js/src/structures/ActionRow.js
+++ b/packages/discord.js/src/structures/ActionRow.js
@@ -1,8 +1,11 @@
 'use strict';
 
+const { emitWarning } = require('node:process');
 const { isJSONEncodable } = require('@discordjs/builders');
 const Component = require('./Component');
 const { createComponent } = require('../util/Components');
+
+let deprecationEmittedForFrom = false;
 
 /**
  * Represents an action row
@@ -24,8 +27,17 @@ class ActionRow extends Component {
    * Creates a new action row builder from JSON data
    * @param {JSONEncodable<APIActionRowComponent>|APIActionRowComponent} other The other data
    * @returns {ActionRowBuilder}
+   * @deprecated Use {@link ActionRowBuilder.from()} instead
    */
   static from(other) {
+    if (!deprecationEmittedForFrom) {
+      emitWarning(
+        'The ActionRow.from() method is deprecated. Use ActionRowBuilder.from() instead.',
+        'DeprecationWarning',
+      );
+      deprecationEmittedForFrom = true;
+    }
+
     if (isJSONEncodable(other)) {
       return new this(other.toJSON());
     }

--- a/packages/discord.js/src/structures/ActionRow.js
+++ b/packages/discord.js/src/structures/ActionRow.js
@@ -1,11 +1,9 @@
 'use strict';
 
-const { emitWarning } = require('node:process');
+const { deprecate } = require('node:util');
 const { isJSONEncodable } = require('@discordjs/builders');
 const Component = require('./Component');
 const { createComponent } = require('../util/Components');
-
-let deprecationEmittedForFrom = false;
 
 /**
  * Represents an action row
@@ -27,17 +25,9 @@ class ActionRow extends Component {
    * Creates a new action row builder from JSON data
    * @param {JSONEncodable<APIActionRowComponent>|APIActionRowComponent} other The other data
    * @returns {ActionRowBuilder}
-   * @deprecated Use {@link ActionRowBuilder.from()} instead
+   * @deprecated Use {@link ActionRowBuilder.from()} instead.
    */
   static from(other) {
-    if (!deprecationEmittedForFrom) {
-      emitWarning(
-        'The ActionRow.from() method is deprecated. Use ActionRowBuilder.from() instead.',
-        'DeprecationWarning',
-      );
-      deprecationEmittedForFrom = true;
-    }
-
     if (isJSONEncodable(other)) {
       return new this(other.toJSON());
     }
@@ -52,5 +42,7 @@ class ActionRow extends Component {
     return { ...this.data, components: this.components.map(c => c.toJSON()) };
   }
 }
+
+ActionRow.from = deprecate(ActionRow.from, 'ActionRow.from() is deprecated. Use ActionRowBuilder.from() instead.');
 
 module.exports = ActionRow;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a depreciation warning for `ActionRow.from()`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
