### PR TITLE
types(ChannelManager): fetch cannot return null

### DIFF
--- a/packages/discord.js/src/managers/ChannelManager.js
+++ b/packages/discord.js/src/managers/ChannelManager.js
@@ -107,7 +107,7 @@ class ChannelManager extends CachedManager {
    * Obtains a channel from Discord, or the channel cache if it's already available.
    * @param {Snowflake} id The channel's id
    * @param {FetchChannelOptions} [options] Additional options for this fetch
-   * @returns {Promise<?BaseChannel>}
+   * @returns {Promise<BaseChannel>}
    * @example
    * // Fetch a channel by its id
    * client.channels.fetch('222109930545610754')

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3323,7 +3323,7 @@ export class CategoryChannelChildManager extends DataManager<Snowflake, Category
 
 export class ChannelManager extends CachedManager<Snowflake, Channel, ChannelResolvable> {
   private constructor(client: Client, iterable: Iterable<RawChannelData>);
-  public fetch(id: Snowflake, options?: FetchChannelOptions): Promise<Channel | null>;
+  public fetch(id: Snowflake, options?: FetchChannelOptions): Promise<Channel>;
 }
 
 export type FetchGuildApplicationCommandFetchOptions = Omit<FetchApplicationCommandOptions, 'guildId'>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The types for ChannelManager#fetch were wrong as no fetch operation returns null, it rejects if the channel is not found

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
