### PR TITLE
Added `setNames` & `setDescriptions` to (/) builders & context menu builder

### DIFF
--- a/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
+++ b/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
@@ -176,6 +176,20 @@ export class ContextMenuCommandBuilder {
 	}
 
 	/**
+	 * Set the name & the name localizations
+	 * 
+	 * @param locale - The locale to set the base name for
+	 * @param localizedNames - The dictionary of localized names to set
+	 */
+	public setNames(locale: LocaleString, localizedNames: LocalizationMap) {
+		if (!localizedNames[locale]) throw new Error(`No name provided for the given locale ${locale}`);
+		
+		this.setName(localizedNames[locale]);
+		this.setNameLocalizations(localizedNames);
+		return this;
+	}
+
+	/**
 	 * Returns the final data that should be sent to Discord.
 	 *
 	 * **Note:** Calling this function will validate required properties based on their conditions.

--- a/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -79,6 +79,20 @@ export class SharedNameAndDescription {
 	}
 
 	/**
+	 * Sets the name and the name localizations
+	 * 
+	 * @param locale - The locale to set the base name for
+	 * @param localizedNames - The dictionary of localized names to set
+	 */
+	public setNames(locale: LocaleString, localizedNames: LocalizationMap) {
+		if (!localizedNames[locale]) throw new Error(`No name provided for the given locale ${locale}`);
+
+		this.setName(localizedNames[locale]);
+		this.setNameLocalization(locale, localizedNames[locale]);
+		return this;
+	}
+
+	/**
 	 * Sets a description localization
 	 *
 	 * @param locale - The locale to set a description for
@@ -117,6 +131,20 @@ export class SharedNameAndDescription {
 		Object.entries(localizedDescriptions).forEach((args) =>
 			this.setDescriptionLocalization(...(args as [LocaleString, string | null])),
 		);
+		return this;
+	}
+
+	/**
+	 * Sets the description and the description localizations
+	 * 
+	 * @param locale - The locale to set the base name for
+	 * @param localizedDescriptions - The dictionary of localized descriptions to set
+	 */
+	public setDescriptions(locale: LocaleString, localizedDescriptions: LocalizationMap) {
+		if (!localizedDescriptions[locale]) throw new Error(`No description provided for the given locale ${locale}`);
+
+		this.setDescription(localizedDescriptions[locale]);
+		this.setDescriptionLocalization(locale, localizedDescriptions[locale]);
 		return this;
 	}
 }


### PR DESCRIPTION
I have created this PR to avoid the wall of code you have when you want to localize a command when registering it using builders.

**Please describe the changes this PR makes and why it should be merged:**
This PR add methods that combine the basic `setName()` & `setNameLocalizations()`, `setDescription()` & `setDescriptionLocalizations()` together.

Allowing you to make this:
```ts
new SlashCommandBuilder()
  .setNames('en-US', NamesLocalizationMap)
  .setDescriptions('en-US', DescriptionLocalizationMap)
  .setDMPermission(false)
  .addChannelOption((channel) =>
    channel
      .setNames('en-US', ChannelOptionNamesLocalizationMap)
      .setDescriptions('en-US', ChannelOptionDescriptionLocalizationMap)
      .setRequired(true)
  );
```
Instead of the actual wall of code (which becomes huge with more parameters)
```ts
new SlashCommandBuilder()
  .setName(NamesLocalizationMap['en-US'])
  .setDescription(DescriptionLocalizationMap['en-US'])
  .setNameLocalizations(NamesLocalizationMap)
  .setDescriptionLocalizations(DescriptionLocalizationMap)

  .setDMPermission(false)
  .addChannelOption((channel) =>
    channel
      .setName(ChannelOptionNamesLocalizationMap['en-US'])
      .setDescription(ChannelOptionDescriptionLocalizationMap['en-US'])
      .setNameLocalizations(ChannelOptionNamesLocalizationMap)
      .setDescriptionLocalizations(ChannelOptionDescriptionLocalizationMap)
      .setRequired(true)
  );
```

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
