### PR TITLE
refactor(GuildAuditLogsEntry): Remove `guild` from application command permission update extra

### DIFF
--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -220,7 +220,6 @@ class GuildAuditLogsEntry {
       case AuditLogEvent.ApplicationCommandPermissionUpdate:
         this.extra = {
           applicationId: data.options.application_id,
-          guild: guild.client.guilds.cache.get(data.options.guild_id) ?? { id: data.options.guild_id },
         };
         break;
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4733,7 +4733,7 @@ export interface GuildAuditLogsEntryExtraField {
   [AuditLogEvent.StageInstanceCreate]: StageChannel | { id: Snowflake };
   [AuditLogEvent.StageInstanceDelete]: StageChannel | { id: Snowflake };
   [AuditLogEvent.StageInstanceUpdate]: StageChannel | { id: Snowflake };
-  [AuditLogEvent.ApplicationCommandPermissionUpdate]: { applicationId: Snowflake; guild: Guild | { id: Snowflake } };
+  [AuditLogEvent.ApplicationCommandPermissionUpdate]: { applicationId: Snowflake };
 }
 
 export interface GuildAuditLogsEntryTargetField<TActionType extends GuildAuditLogsActionType> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When fetching an entry which is of an application command permission update, `<GuildAuditLogsEntry>.extra.guild` is always `undefined`. This is [not documented](https://discord.com/developers/docs/resources/audit-log#audit-log-entry-object-optional-audit-entry-info), so it will be removed. It was useless anyway as we are already in a guild context.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
