### PR TITLE
types: Allow choice's value type to be strictly inferred

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3868,19 +3868,21 @@ export interface ApplicationCommandAutocompleteStringOptionData
   autocomplete: true;
 }
 
-export interface ApplicationCommandChoicesData extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
+export interface ApplicationCommandChoicesData<Type extends string | number = string | number>
+  extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
   type: CommandOptionChoiceResolvableType;
-  choices?: ApplicationCommandOptionChoiceData[];
+  choices?: ApplicationCommandOptionChoiceData<Type>[];
   autocomplete?: false;
 }
 
-export interface ApplicationCommandChoicesOption extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
+export interface ApplicationCommandChoicesOption<Type extends string | number = string | number>
+  extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
   type: CommandOptionChoiceResolvableType;
-  choices?: ApplicationCommandOptionChoiceData[];
+  choices?: ApplicationCommandOptionChoiceData<Type>[];
   autocomplete?: false;
 }
 
-export interface ApplicationCommandNumericOptionData extends ApplicationCommandChoicesData {
+export interface ApplicationCommandNumericOptionData extends ApplicationCommandChoicesData<number> {
   type: CommandOptionNumericResolvableType;
   minValue?: number;
   min_value?: number;
@@ -3888,7 +3890,7 @@ export interface ApplicationCommandNumericOptionData extends ApplicationCommandC
   max_value?: number;
 }
 
-export interface ApplicationCommandStringOptionData extends ApplicationCommandChoicesData {
+export interface ApplicationCommandStringOptionData extends ApplicationCommandChoicesData<string> {
   type: ApplicationCommandOptionType.String;
   minLength?: number;
   min_length?: number;
@@ -3900,13 +3902,13 @@ export interface ApplicationCommandBooleanOptionData extends BaseApplicationComm
   type: ApplicationCommandOptionType.Boolean;
 }
 
-export interface ApplicationCommandNumericOption extends ApplicationCommandChoicesOption {
+export interface ApplicationCommandNumericOption extends ApplicationCommandChoicesOption<number> {
   type: CommandOptionNumericResolvableType;
   minValue?: number;
   maxValue?: number;
 }
 
-export interface ApplicationCommandStringOption extends ApplicationCommandChoicesOption {
+export interface ApplicationCommandStringOption extends ApplicationCommandChoicesOption<string> {
   type: ApplicationCommandOptionType.String;
   minLength?: number;
   maxLength?: number;
@@ -3948,7 +3950,6 @@ export type ApplicationCommandOptionData =
   | ApplicationCommandSubGroupData
   | ApplicationCommandNonOptionsData
   | ApplicationCommandChannelOptionData
-  | ApplicationCommandChoicesData
   | ApplicationCommandAutocompleteNumericOptionData
   | ApplicationCommandAutocompleteStringOptionData
   | ApplicationCommandNumericOptionData
@@ -3965,7 +3966,6 @@ export type ApplicationCommandOption =
   | ApplicationCommandAutocompleteStringOption
   | ApplicationCommandNonOptions
   | ApplicationCommandChannelOption
-  | ApplicationCommandChoicesOption
   | ApplicationCommandNumericOption
   | ApplicationCommandStringOption
   | ApplicationCommandRoleOption
@@ -3975,10 +3975,10 @@ export type ApplicationCommandOption =
   | ApplicationCommandAttachmentOption
   | ApplicationCommandSubCommand;
 
-export interface ApplicationCommandOptionChoiceData {
+export interface ApplicationCommandOptionChoiceData<Value extends string | number = string | number> {
   name: string;
   nameLocalizations?: LocalizationMap;
-  value: string | number;
+  value: Value;
 }
 
 export interface ApplicationCommandPermissions {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1100,6 +1100,7 @@ expectAssignable<'death'>(ShardEvents.Death);
 expectAssignable<1>(Status.Connecting);
 
 declare const applicationCommandData: ApplicationCommandData;
+declare const applicationCommandOptionData: ApplicationCommandOptionData;
 declare const applicationCommandResolvable: ApplicationCommandResolvable;
 declare const applicationCommandManager: ApplicationCommandManager;
 {
@@ -1119,6 +1120,24 @@ declare const applicationCommandManager: ApplicationCommandManager;
   expectType<Promise<Collection<Snowflake, ApplicationCommand>>>(
     applicationCommandManager.set([applicationCommandData], '0'),
   );
+
+  // Test inference of choice values.
+  if ('choices' in applicationCommandOptionData) {
+    if (applicationCommandOptionData.type === ApplicationCommandOptionType.String) {
+      expectType<string>(applicationCommandOptionData.choices[0]!.value);
+      expectNotType<number>(applicationCommandOptionData.choices[0]!.value);
+    }
+
+    if (applicationCommandOptionData.type === ApplicationCommandOptionType.Integer) {
+      expectType<number>(applicationCommandOptionData.choices[0]!.value);
+      expectNotType<string>(applicationCommandOptionData.choices[0]!.value);
+    }
+
+    if (applicationCommandOptionData.type === ApplicationCommandOptionType.Number) {
+      expectType<number>(applicationCommandOptionData.choices[0]!.value);
+      expectNotType<string>(applicationCommandOptionData.choices[0]!.value);
+    }
+  }
 }
 
 declare const applicationNonChoiceOptionData: ApplicationCommandOptionData & {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The following code will not yield an error despite the type of the option being known:

```TypeScript
import { ApplicationCommandOptionType, ApplicationCommandType, Guild } from "discord.js"

declare const guild: Guild;

guild.commands.create({
  name: "test",
  description: "test",
  type: ApplicationCommandType.ChatInput,
  options: [
    {
      type: ApplicationCommandOptionType.String,
      name: "test",
      description: "test",
      choices: [
        {
          name: "test",
          value: 0 // No error!
        },
      ],
      required: true
    }
  ]
});
```

This pull request strengthens the types around here and resolves #8528.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
