### PR TITLE
types: Disallow some channel types from webhook creation

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -164,7 +164,7 @@ class GuildChannelManager extends CachedManager {
 
   /**
    * @typedef {ChannelWebhookCreateOptions} WebhookCreateOptions
-   * @property {GuildChannelResolvable} channel The channel to create the webhook for
+   * @property {TextChannel|NewsChannel|VoiceChannel|Snowflake} channel The channel to create the webhook for
    */
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4152,7 +4152,7 @@ export interface ChannelWebhookCreateOptions {
 }
 
 export interface WebhookCreateOptions extends ChannelWebhookCreateOptions {
-  channel: GuildChannelResolvable;
+  channel: TextChannel | NewsChannel | VoiceChannel | Snowflake;
 }
 
 export interface ClientEvents {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Webhooks cannot be created in thread channels, category channels or stage channels.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
