### PR TITLE
refactor(ChatInputCommandInteraction): use slash command mention instead of a string representation

### DIFF
--- a/packages/builders/src/messages/formatters.ts
+++ b/packages/builders/src/messages/formatters.ts
@@ -183,6 +183,16 @@ export function roleMention<C extends Snowflake>(roleId: C): `<@&${C}>` {
 }
 
 /**
+ * Formats a chat input application command ID and name into a slash command mention
+ * 
+ * @param chatInputId - The chat input application command ID to format
+ * @param name - The chat input application command name to format
+ */
+export function chatInputMention<C extends Snowflake, N extends string>(chatInputId: C, name: N): `</${N}:${C}>` {
+	return `</${name}:${chatInputId}>`;
+}
+
+/**
  * Formats an emoji ID into a fully qualified emoji identifier
  *
  * @param emojiId - The emoji ID to format

--- a/packages/discord.js/src/structures/ChatInputCommandInteraction.js
+++ b/packages/discord.js/src/structures/ChatInputCommandInteraction.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { chatInputMention } = require('@discordjs/builders');
 const CommandInteraction = require('./CommandInteraction');
 const CommandInteractionOptionResolver = require('./CommandInteractionOptionResolver');
 
@@ -23,18 +24,14 @@ class ChatInputCommandInteraction extends CommandInteraction {
   }
 
   /**
-   * Returns a string representation of the command interaction.
-   * This can then be copied by a user and executed again in a new command while keeping the option order.
+   * When concatenated with a string, this automatically returns the command's instead of the ChatInputCommandInteraction object.
    * @returns {string}
+   * @example
+   * // Logs: Hello from </123456789012345678>!
+   * console.log(`Hello from ${interaction}!`);
    */
   toString() {
-    const properties = [
-      this.commandName,
-      this.options._group,
-      this.options._subcommand,
-      ...this.options._hoistedOptions.map(o => `${o.name}:${o.value}`),
-    ];
-    return `/${properties.filter(Boolean).join(' ')}`;
+    return chatInputMention(this.id, this.commandName);
   }
 }
 


### PR DESCRIPTION
### PR blocked

Can be merged once API docs PR is merged.
- https://github.com/discord/discord-api-docs/pull/5186

---

**Please describe the changes this PR makes and why it should be merged:**

As all the other classes (e.g. User, TextChannel, Role) follows [the documented message formatting](https://discord.com/developers/docs/reference#message-formatting-formats) for formatting in `.toString()`, the slash command interactions should too.

This PR replaces the old functionality which returns a string representation that can be pasted into the client to use a slash command, however, is client-sided only and not documented.

- Old: `<ChatInputCommandInteraction>.toString()` -> `/pet user:1234567890123456789`
- New: `<ChatInputCommandInteraction>.toString()` -> `</pet:9876543210987654321>`

Client preview:

![image](https://user-images.githubusercontent.com/55918888/185767458-108c949c-f59a-47d3-a7ca-6794431029b4.png)

This PR also adds a new method to builders, `chatInputMention()`, which implements the new functionality mentioned above.

Since this replaces the functionality of the same method, this is a breaking change and is a major for `discord.js` (only a minor for `@discordjs/builders`).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
