### PR TITLE
types(webhook): avatar can be null

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2811,7 +2811,7 @@ export class VoiceState extends Base {
 
 export class Webhook extends WebhookMixin() {
   private constructor(client: Client, data?: RawWebhookData);
-  public avatar: string;
+  public avatar: string | null;
   public avatarURL(options?: ImageURLOptions): string | null;
   public channelId: Snowflake;
   public readonly client: Client;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Webhook#avatar` can be null if the webhook hasn't any avatar. The documentation is correct, and `Webhook#avatarURL()` handles it correctly, but types were missing the `null` type.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.