### PR TITLE
types(interactions): fix `{Slash,ContextMenu}CommandBuilder#toJSON`

### DIFF
--- a/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
+++ b/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
@@ -3,7 +3,7 @@ import type {
 	LocaleString,
 	LocalizationMap,
 	Permissions,
-	RESTPostAPIApplicationCommandsJSONBody,
+	RESTPostAPIContextMenuApplicationCommandsJSONBody,
 } from 'discord-api-types/v10';
 import { validateLocale, validateLocalizationMap } from '../slashCommands/Assertions.js';
 import {
@@ -176,7 +176,7 @@ export class ContextMenuCommandBuilder {
 	 *
 	 * **Note:** Calling this function will validate required properties based on their conditions.
 	 */
-	public toJSON(): RESTPostAPIApplicationCommandsJSONBody {
+	public toJSON(): RESTPostAPIContextMenuApplicationCommandsJSONBody {
 		validateRequiredParameters(this.name, this.type);
 
 		validateLocalizationMap(this.name_localizations);

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -2,7 +2,7 @@ import type {
 	APIApplicationCommandOption,
 	LocalizationMap,
 	Permissions,
-	RESTPostAPIApplicationCommandsJSONBody,
+	RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord-api-types/v10';
 import { mix } from 'ts-mixer';
 import {
@@ -69,7 +69,7 @@ export class SlashCommandBuilder {
 	 *
 	 * **Note:** Calling this function will validate required properties based on their conditions.
 	 */
-	public toJSON(): RESTPostAPIApplicationCommandsJSONBody {
+	public toJSON(): RESTPostAPIChatInputApplicationCommandsJSONBody {
 		validateRequiredParameters(this.name, this.description, this.options);
 
 		validateLocalizationMap(this.name_localizations);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`SlashCommandBuilder` and `ContextMenuCommandBuilder`'s `toJSON` methods returned the base interface (`RESTPostAPIApplicationCommandsJSONBody`) rather than the specific interfaces they build (`RESTPostAPIChatInputApplicationCommandsJSONBody` and `RESTPostAPIContextMenuApplicationCommandsJSONBody` respectively).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
