### PR TITLE
fix: bump @sapphire/shapeshift for TypeScript 4.8 compatibility

### DIFF
--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -54,7 +54,7 @@
 	},
 	"homepage": "https://discord.js.org",
 	"dependencies": {
-		"@sapphire/shapeshift": "^3.5.1",
+		"@sapphire/shapeshift": "^3.6.0",
 		"discord-api-types": "^0.37.4",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1785,7 +1785,7 @@ __metadata:
     "@discordjs/docgen": "workspace:^"
     "@favware/cliff-jumper": ^1.8.7
     "@microsoft/api-extractor": ^7.29.3
-    "@sapphire/shapeshift": ^3.5.1
+    "@sapphire/shapeshift": ^3.6.0
     "@types/node": ^16.11.54
     "@typescript-eslint/eslint-plugin": ^5.34.0
     "@typescript-eslint/parser": ^5.34.0
@@ -3500,13 +3500,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/shapeshift@npm:^3.5.1":
-  version: 3.5.1
-  resolution: "@sapphire/shapeshift@npm:3.5.1"
+"@sapphire/shapeshift@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@sapphire/shapeshift@npm:3.6.0"
   dependencies:
     fast-deep-equal: ^3.1.3
     lodash.uniqwith: ^4.5.0
-  checksum: caecfef844c9e43e921a5051da888fae7da8980bfd9f9bb4f7fee85931d40929ffb9b6dfae464c0dccee61e56f7698f998e4d9a54d25f35fad39a51ba1a4f391
+  checksum: 31b426424d064c516144c6eda07dfa0e44d7cbb8309dde919b923aa6ae939faac6384fa4d08db391a8da11efa3a83c18c9be1ebd053ba29403e61f5e2450b788
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

@sapphire/shapeshift was broken on TS 4.8 due to changes of how they handle `{}` as a type now.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
