### PR TITLE
docs: use remarks instead of `Note` in descriptions

### DIFF
--- a/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
+++ b/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
@@ -81,8 +81,8 @@ export class ContextMenuCommandBuilder {
 	/**
 	 * Sets whether the command is enabled by default when the application is added to a guild.
 	 *
-	 * **Note**: If set to `false`, you will have to later `PUT` the permissions for this command.
-	 *
+	 * @remarks
+	 * If set to `false`, you will have to later `PUT` the permissions for this command.
 	 * @param value - Whether or not to enable this command by default
 	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
 	 * @deprecated Use {@link ContextMenuCommandBuilder.setDefaultMemberPermissions} or {@link ContextMenuCommandBuilder.setDMPermission} instead.
@@ -99,8 +99,8 @@ export class ContextMenuCommandBuilder {
 	/**
 	 * Sets the default permissions a member should have in order to run the command.
 	 *
-	 * **Note:** You can set this to `'0'` to disable the command by default.
-	 *
+	 * @remarks
+	 * You can set this to `'0'` to disable the command by default.
 	 * @param permissions - The permissions bit field to set
 	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
 	 */
@@ -174,7 +174,9 @@ export class ContextMenuCommandBuilder {
 	/**
 	 * Returns the final data that should be sent to Discord.
 	 *
-	 * **Note:** Calling this function will validate required properties based on their conditions.
+	 * @remarks
+	 * This method runs validations on the data before serializing it.
+	 * As such, it may throw an error if the data is invalid.
 	 */
 	public toJSON(): RESTPostAPIContextMenuApplicationCommandsJSONBody {
 		validateRequiredParameters(this.name, this.type);

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -67,7 +67,9 @@ export class SlashCommandBuilder {
 	/**
 	 * Returns the final data that should be sent to Discord.
 	 *
-	 * **Note:** Calling this function will validate required properties based on their conditions.
+	 * @remarks
+	 * This method runs validations on the data before serializing it.
+	 * As such, it may throw an error if the data is invalid.
 	 */
 	public toJSON(): RESTPostAPIChatInputApplicationCommandsJSONBody {
 		validateRequiredParameters(this.name, this.description, this.options);
@@ -84,8 +86,8 @@ export class SlashCommandBuilder {
 	/**
 	 * Sets whether the command is enabled by default when the application is added to a guild.
 	 *
-	 * **Note**: If set to `false`, you will have to later `PUT` the permissions for this command.
-	 *
+	 * @remarks
+	 * If set to `false`, you will have to later `PUT` the permissions for this command.
 	 * @param value - Whether or not to enable this command by default
 	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
 	 * @deprecated Use {@link (SlashCommandBuilder:class).setDefaultMemberPermissions} or {@link (SlashCommandBuilder:class).setDMPermission} instead.
@@ -102,8 +104,8 @@ export class SlashCommandBuilder {
 	/**
 	 * Sets the default permissions a member should have in order to run the command.
 	 *
-	 * **Note:** You can set this to `'0'` to disable the command by default.
-	 *
+	 * @remarks
+	 * You can set this to `'0'` to disable the command by default.
 	 * @param permissions - The permissions bit field to set
 	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Replaces "Note"s in summaries with `@remarks`

I copied the `toJSON()` note from the Component class because it seemed more complete
https://github.com/discordjs/discord.js/blob/4ffdada4f7a9f8d5bc242353e03c73d5604163a5/packages/builders/src/components/Component.ts#L25-L32

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
