### PR TITLE
fix(ClientOptions): make ClientOptions#intents returns an IntentsBitField

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -479,7 +479,7 @@ class Client extends BaseClient {
     if (typeof options.intents === 'undefined') {
       throw new TypeError(ErrorCodes.ClientMissingIntents);
     } else {
-      options.intents = IntentsBitField.resolve(options.intents);
+      options.intents = new IntentsBitField(options.intents).freeze();
     }
     if (typeof options.shardCount !== 'number' || isNaN(options.shardCount) || options.shardCount < 1) {
       throw new TypeError(ErrorCodes.ClientInvalidOption, 'shardCount', 'a number greater than or equal to 1');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I think it's better than `ClientOptions#intents` returns an instance of IntentsBitField instead of just a number.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
-->
