### PR TITLE
refactor(Client): make censoring token in debug log faster

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -214,7 +214,7 @@ class Client extends BaseClient {
     if (!token || typeof token !== 'string') throw new Error(ErrorCodes.TokenInvalid);
     this.token = token = token.replace(/^(Bot|Bearer)\s*/i, '');
     this.rest.setToken(token);
-    this.emit(Events.Debug, `Provided token: ${token.replace(/(?<=\.)[^.]+/g, match => '*'.repeat(match.length))}`);
+    this.emit(Events.Debug, `Provided token: ${token.replace(/[^.]+$/g, match => '*'.repeat(match.length))}`);
 
     if (this.options.presence) {
       this.options.ws.presence = this.presence._parse(this.options.presence);

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -214,7 +214,7 @@ class Client extends BaseClient {
     if (!token || typeof token !== 'string') throw new Error(ErrorCodes.TokenInvalid);
     this.token = token = token.replace(/^(Bot|Bearer)\s*/i, '');
     this.rest.setToken(token);
-    this.emit(Events.Debug, `Provided token: ${token.replace(/(?<!^)\.+/g, match => '*'.repeat(match.length))}`);
+    this.emit(Events.Debug, `Provided token: ${token.replace(/(?<!^).+/g, match => '*'.repeat(match.length))}`);
 
     if (this.options.presence) {
       this.options.ws.presence = this.presence._parse(this.options.presence);

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -214,13 +214,7 @@ class Client extends BaseClient {
     if (!token || typeof token !== 'string') throw new Error(ErrorCodes.TokenInvalid);
     this.token = token = token.replace(/^(Bot|Bearer)\s*/i, '');
     this.rest.setToken(token);
-    this.emit(
-      Events.Debug,
-      `Provided token: ${token
-        .split('.')
-        .map((val, i) => (i > 1 ? val.replace(/./g, '*') : val))
-        .join('.')}`,
-    );
+    this.emit(Events.Debug, `Provided token: ${token.replace(/(?<!^)\.+/g, match => '*'.repeat(match.length))}`);
 
     if (this.options.presence) {
       this.options.ws.presence = this.presence._parse(this.options.presence);

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -214,7 +214,7 @@ class Client extends BaseClient {
     if (!token || typeof token !== 'string') throw new Error(ErrorCodes.TokenInvalid);
     this.token = token = token.replace(/^(Bot|Bearer)\s*/i, '');
     this.rest.setToken(token);
-    this.emit(Events.Debug, `Provided token: ${token.replace(/(?<!^).+/g, match => '*'.repeat(match.length))}`);
+    this.emit(Events.Debug, `Provided token: ${token.replace(/(?<=\.)[^.]+/g, match => '*'.repeat(match.length))}`);
 
     if (this.options.presence) {
       this.options.ws.presence = this.presence._parse(this.options.presence);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR modifies the method used to censor tokens in debug logs within `Client#login`. From benchmarking, this is about 1/3 the duration (~`0.003` -> ~`0.001`) although both are very fast, so this may be an unnecessary change.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- Typings don't need updating