### PR TITLE
docs: fix regexps incorrectly being called global

### DIFF
--- a/packages/discord.js/src/structures/GuildTemplate.js
+++ b/packages/discord.js/src/structures/GuildTemplate.js
@@ -12,7 +12,7 @@ const Events = require('../util/Events');
  */
 class GuildTemplate extends Base {
   /**
-   * A regular expression that globally matches guild template links.
+   * A regular expression that matches guild template links.
    * The `code` group property is present on the `exec()` result of this expression.
    * @type {RegExp}
    * @memberof GuildTemplate

--- a/packages/discord.js/src/structures/Invite.js
+++ b/packages/discord.js/src/structures/Invite.js
@@ -13,7 +13,7 @@ const { Error, ErrorCodes } = require('../errors');
  */
 class Invite extends Base {
   /**
-   * A regular expression that globally matches Discord invite links.
+   * A regular expression that matches Discord invite links.
    * The `code` group property is present on the `exec()` result of this expression.
    * @type {RegExp}
    * @memberof Invite


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

These RegExes are not global, but the docs say they are.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
