### PR TITLE
refactor: replace usage of deprecated `ChannelType`s

### DIFF
--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -234,7 +234,7 @@ describe('Slash Commands', () => {
 
 				expect(() => {
 					getBuilder().addChannelOption(
-						getChannelOption().addChannelTypes(ChannelType.GuildNews, ChannelType.GuildText),
+						getChannelOption().addChannelTypes(ChannelType.GuildAnnouncement, ChannelType.GuildText),
 					);
 				}).not.toThrowError();
 			});

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionChannelTypesMixin.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionChannelTypesMixin.ts
@@ -6,10 +6,10 @@ const allowedChannelTypes = [
 	ChannelType.GuildText,
 	ChannelType.GuildVoice,
 	ChannelType.GuildCategory,
-	ChannelType.GuildNews,
-	ChannelType.GuildNewsThread,
-	ChannelType.GuildPublicThread,
-	ChannelType.GuildPrivateThread,
+	ChannelType.GuildAnnouncement,
+	ChannelType.AnnouncementThread,
+	ChannelType.PublicThread,
+	ChannelType.PrivateThread,
 	ChannelType.GuildStageVoice,
 ] as const;
 

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -65,13 +65,13 @@ class ThreadManager extends CachedManager {
    * @typedef {StartThreadOptions} ThreadCreateOptions
    * @property {MessageResolvable} [startMessage] The message to start a thread from. <warn>If this is defined then type
    * of thread gets automatically defined and cannot be changed. The provided `type` field will be ignored</warn>
-   * @property {ChannelType.GuildNewsThread|ChannelType.GuildPublicThread|ChannelType.GuildPrivateThread} [type]
+   * @property {ChannelType.AnnouncementThread|ChannelType.PublicThread|ChannelType.PrivateThread} [type]
    * The type of thread to create.
-   * Defaults to {@link ChannelType.GuildPublicThread} if created in a {@link TextChannel}
+   * Defaults to {@link ChannelType.PublicThread} if created in a {@link TextChannel}
    * <warn>When creating threads in a {@link NewsChannel} this is ignored and is always
-   * {@link ChannelType.GuildNewsThread}</warn>
+   * {@link ChannelType.AnnouncementThread}</warn>
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to the thread
-   * <info>Can only be set when type will be {@link ChannelType.GuildPrivateThread}</info>
+   * <info>Can only be set when type will be {@link ChannelType.PrivateThread}</info>
    */
 
   /**
@@ -94,7 +94,7 @@ class ThreadManager extends CachedManager {
    *   .create({
    *      name: 'mod-talk',
    *      autoArchiveDuration: ThreadAutoArchiveDuration.OneHour,
-   *      type: ChannelType.GuildPrivateThread,
+   *      type: ChannelType.PrivateThread,
    *      reason: 'Needed a separate thread for moderation',
    *    })
    *   .then(threadChannel => console.log(threadChannel))
@@ -113,12 +113,12 @@ class ThreadManager extends CachedManager {
       throw new TypeError(ErrorCodes.InvalidType, 'type', 'ThreadChannelType or Number');
     }
     let resolvedType =
-      this.channel.type === ChannelType.GuildNews ? ChannelType.GuildNewsThread : ChannelType.GuildPublicThread;
+      this.channel.type === ChannelType.GuildAnnouncement ? ChannelType.AnnouncementThread : ChannelType.PublicThread;
     let startMessageId;
     if (startMessage) {
       startMessageId = this.channel.messages.resolveId(startMessage);
       if (!startMessageId) throw new TypeError(ErrorCodes.InvalidType, 'startMessage', 'MessageResolvable');
-    } else if (this.channel.type !== ChannelType.GuildNews) {
+    } else if (this.channel.type !== ChannelType.GuildAnnouncement) {
       resolvedType = type ?? resolvedType;
     }
 
@@ -127,7 +127,7 @@ class ThreadManager extends CachedManager {
         name,
         auto_archive_duration: autoArchiveDuration,
         type: resolvedType,
-        invitable: resolvedType === ChannelType.GuildPrivateThread ? invitable : undefined,
+        invitable: resolvedType === ChannelType.PrivateThread ? invitable : undefined,
         rate_limit_per_user: rateLimitPerUser,
       },
       reason,

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -92,7 +92,7 @@ class BaseGuildTextChannel extends GuildChannel {
   /**
    * Sets the type of this channel.
    * <info>Only conversion between {@link TextChannel} and {@link NewsChannel} is supported.</info>
-   * @param {ChannelType.GuildText|ChannelType.GuildNews} type The new channel type
+   * @param {ChannelType.GuildText|ChannelType.GuildAnnouncement} type The new channel type
    * @param {string} [reason] Reason for changing the channel's type
    * @returns {Promise<GuildChannel>}
    */

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -1277,7 +1277,7 @@ class Guild extends AnonymousGuild {
    */
   _sortedChannels(channel) {
     const category = channel.type === ChannelType.GuildCategory;
-    const channelTypes = [ChannelType.GuildText, ChannelType.GuildNews];
+    const channelTypes = [ChannelType.GuildText, ChannelType.GuildAnnouncement];
     return discordSort(
       this.channels.cache.filter(
         c =>

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -636,7 +636,7 @@ class Message extends Base {
       (this.author.id === this.client.user.id ? PermissionsBitField.DefaultBit : PermissionFlagsBits.ManageMessages);
     const { channel } = this;
     return Boolean(
-      channel?.type === ChannelType.GuildNews &&
+      channel?.type === ChannelType.GuildAnnouncement &&
         !this.flags.has(MessageFlags.Crossposted) &&
         this.type === MessageType.Default &&
         channel.viewable &&
@@ -664,7 +664,7 @@ class Message extends Base {
    * @returns {Promise<Message>}
    * @example
    * // Crosspost a message
-   * if (message.channel.type === ChannelType.GuildNews) {
+   * if (message.channel.type === ChannelType.GuildAnnouncement) {
    *   message.crosspost()
    *     .then(() => console.log('Crossposted message'))
    *     .catch(console.error);
@@ -806,7 +806,7 @@ class Message extends Base {
    */
   startThread(options = {}) {
     if (!this.channel) return Promise.reject(new Error(ErrorCodes.ChannelNotCached));
-    if (![ChannelType.GuildText, ChannelType.GuildNews].includes(this.channel.type)) {
+    if (![ChannelType.GuildText, ChannelType.GuildAnnouncement].includes(this.channel.type)) {
       return Promise.reject(new Error(ErrorCodes.MessageThreadParent));
     }
     if (this.hasThread) return Promise.reject(new Error(ErrorCodes.MessageExistingThread));

--- a/packages/discord.js/src/structures/NewsChannel.js
+++ b/packages/discord.js/src/structures/NewsChannel.js
@@ -15,7 +15,7 @@ class NewsChannel extends BaseGuildTextChannel {
    * @param {string} [reason] Reason for creating the webhook
    * @returns {Promise<NewsChannel>}
    * @example
-   * if (channel.type === ChannelType.GuildNews) {
+   * if (channel.type === ChannelType.GuildAnnouncement) {
    *   channel.addFollower('222197033908436994', 'Important announcements')
    *     .then(() => console.log('Added follower'))
    *     .catch(console.error);

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -80,7 +80,7 @@ class ThreadChannel extends BaseChannel {
        * <info>This property is always `null` in public threads.</info>
        * @type {?boolean}
        */
-      this.invitable = this.type === ChannelType.GuildPrivateThread ? data.thread_metadata.invitable ?? false : null;
+      this.invitable = this.type === ChannelType.PrivateThread ? data.thread_metadata.invitable ?? false : null;
 
       /**
        * Whether the thread is archived
@@ -114,7 +114,7 @@ class ThreadChannel extends BaseChannel {
       this.invitable ??= null;
     }
 
-    this._createdTimestamp ??= this.type === ChannelType.GuildPrivateThread ? super.createdTimestamp : null;
+    this._createdTimestamp ??= this.type === ChannelType.PrivateThread ? super.createdTimestamp : null;
 
     if ('owner_id' in data) {
       /**
@@ -301,7 +301,7 @@ class ThreadChannel extends BaseChannel {
    * @property {boolean} [locked] Whether the thread is locked
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to a thread
    * @property {string} [reason] Reason for editing the thread
-   * <info>Can only be edited on {@link ChannelType.GuildPrivateThread}</info>
+   * <info>Can only be edited on {@link ChannelType.PrivateThread}</info>
    */
 
   /**
@@ -322,7 +322,7 @@ class ThreadChannel extends BaseChannel {
         auto_archive_duration: data.autoArchiveDuration,
         rate_limit_per_user: data.rateLimitPerUser,
         locked: data.locked,
-        invitable: this.type === ChannelType.GuildPrivateThread ? data.invitable : undefined,
+        invitable: this.type === ChannelType.PrivateThread ? data.invitable : undefined,
       },
       reason: data.reason,
     });
@@ -371,7 +371,7 @@ class ThreadChannel extends BaseChannel {
    * @returns {Promise<ThreadChannel>}
    */
   setInvitable(invitable = true, reason) {
-    if (this.type !== ChannelType.GuildPrivateThread) {
+    if (this.type !== ChannelType.PrivateThread) {
       return Promise.reject(new RangeError(ErrorCodes.ThreadInvitableType, this.type));
     }
     return this.edit({ invitable, reason });
@@ -435,7 +435,7 @@ class ThreadChannel extends BaseChannel {
    */
   get editable() {
     return (
-      (this.ownerId === this.client.user.id && (this.type !== ChannelType.GuildPrivateThread || this.joined)) ||
+      (this.ownerId === this.client.user.id && (this.type !== ChannelType.PrivateThread || this.joined)) ||
       this.manageable
     );
   }
@@ -450,9 +450,7 @@ class ThreadChannel extends BaseChannel {
       !this.archived &&
       !this.joined &&
       this.permissionsFor(this.client.user)?.has(
-        this.type === ChannelType.GuildPrivateThread
-          ? PermissionFlagsBits.ManageThreads
-          : PermissionFlagsBits.ViewChannel,
+        this.type === ChannelType.PrivateThread ? PermissionFlagsBits.ManageThreads : PermissionFlagsBits.ViewChannel,
         false,
       )
     );
@@ -500,7 +498,7 @@ class ThreadChannel extends BaseChannel {
 
     return (
       !(this.archived && this.locked && !this.manageable) &&
-      (this.type !== ChannelType.GuildPrivateThread || this.joined || this.manageable) &&
+      (this.type !== ChannelType.PrivateThread || this.joined || this.manageable) &&
       permissions.has(PermissionFlagsBits.SendMessagesInThreads, false) &&
       this.guild.members.me.communicationDisabledUntilTimestamp < Date.now()
     );

--- a/packages/discord.js/src/util/Channels.js
+++ b/packages/discord.js/src/util/Channels.js
@@ -47,7 +47,7 @@ function createChannel(client, data, guild, { allowUnknownGuild, fromInteraction
           channel = new (getCategoryChannel())(guild, data, client);
           break;
         }
-        case ChannelType.GuildNews: {
+        case ChannelType.GuildAnnouncement: {
           channel = new (getNewsChannel())(guild, data, client);
           break;
         }
@@ -55,9 +55,9 @@ function createChannel(client, data, guild, { allowUnknownGuild, fromInteraction
           channel = new (getStageChannel())(guild, data, client);
           break;
         }
-        case ChannelType.GuildNewsThread:
-        case ChannelType.GuildPublicThread:
-        case ChannelType.GuildPrivateThread: {
+        case ChannelType.AnnouncementThread:
+        case ChannelType.PublicThread:
+        case ChannelType.PrivateThread: {
           channel = new (getThreadChannel())(guild, data, client, fromInteraction);
           if (!allowUnknownGuild) channel.parent?.threads.cache.set(channel.id, channel);
           break;

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -79,35 +79,31 @@ exports.NonSystemMessageTypes = [
  * The types of channels that are text-based. The available types are:
  * * {@link ChannelType.DM}
  * * {@link ChannelType.GuildText}
- * * {@link ChannelType.GuildNews}
- * * {@link ChannelType.GuildNewsThread}
- * * {@link ChannelType.GuildPublicThread}
- * * {@link ChannelType.GuildPrivateThread}
+ * * {@link ChannelType.GuildAnnouncement}
+ * * {@link ChannelType.AnnouncementThread}
+ * * {@link ChannelType.PublicThread}
+ * * {@link ChannelType.PrivateThread}
  * * {@link ChannelType.GuildVoice}
  * @typedef {ChannelType[]} TextBasedChannelTypes
  */
 exports.TextBasedChannelTypes = [
   ChannelType.DM,
   ChannelType.GuildText,
-  ChannelType.GuildNews,
-  ChannelType.GuildNewsThread,
-  ChannelType.GuildPublicThread,
-  ChannelType.GuildPrivateThread,
+  ChannelType.GuildAnnouncement,
+  ChannelType.AnnouncementThread,
+  ChannelType.PublicThread,
+  ChannelType.PrivateThread,
   ChannelType.GuildVoice,
 ];
 
 /**
  * The types of channels that are threads. The available types are:
- * * {@link ChannelType.GuildNewsThread}
- * * {@link ChannelType.GuildPublicThread}
- * * {@link ChannelType.GuildPrivateThread}
+ * * {@link ChannelType.AnnouncementThread}
+ * * {@link ChannelType.PublicThread}
+ * * {@link ChannelType.PrivateThread}
  * @typedef {ChannelType[]} ThreadChannelTypes
  */
-exports.ThreadChannelTypes = [
-  ChannelType.GuildNewsThread,
-  ChannelType.GuildPublicThread,
-  ChannelType.GuildPrivateThread,
-];
+exports.ThreadChannelTypes = [ChannelType.AnnouncementThread, ChannelType.PublicThread, ChannelType.PrivateThread];
 
 /**
  * The types of channels that are voice-based. The available types are:

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -515,7 +515,7 @@ export class BaseGuildTextChannel extends TextBasedChannelMixin(GuildChannel, tr
   ): Promise<this>;
   public setTopic(topic: string | null, reason?: string): Promise<this>;
   public setType(type: ChannelType.GuildText, reason?: string): Promise<TextChannel>;
-  public setType(type: ChannelType.GuildNews, reason?: string): Promise<NewsChannel>;
+  public setType(type: ChannelType.GuildAnnouncement, reason?: string): Promise<NewsChannel>;
 }
 
 export class BaseGuildVoiceChannel extends GuildChannel {
@@ -699,7 +699,7 @@ export class Embed {
 }
 
 export interface MappedChannelCategoryTypes {
-  [ChannelType.GuildNews]: NewsChannel;
+  [ChannelType.GuildAnnouncement]: NewsChannel;
   [ChannelType.GuildVoice]: VoiceChannel;
   [ChannelType.GuildText]: TextChannel;
   [ChannelType.GuildStageVoice]: StageChannel;
@@ -710,9 +710,9 @@ export type CategoryChannelType = Exclude<
   ChannelType,
   | ChannelType.DM
   | ChannelType.GroupDM
-  | ChannelType.GuildPublicThread
-  | ChannelType.GuildNewsThread
-  | ChannelType.GuildPrivateThread
+  | ChannelType.PublicThread
+  | ChannelType.AnnouncementThread
+  | ChannelType.PrivateThread
   | ChannelType.GuildCategory
   | ChannelType.GuildDirectory
 >;
@@ -2013,7 +2013,7 @@ export class ModalSubmitInteraction<Cached extends CacheType = CacheType> extend
 
 export class NewsChannel extends BaseGuildTextChannel {
   public threads: ThreadManager<AllowedThreadTypeForNewsChannel>;
-  public type: ChannelType.GuildNews;
+  public type: ChannelType.GuildAnnouncement;
   public addFollower(channel: TextChannelResolvable, reason?: string): Promise<NewsChannel>;
 }
 
@@ -2490,13 +2490,13 @@ export class TextChannel extends BaseGuildTextChannel {
 export type AnyThreadChannel = PublicThreadChannel | PrivateThreadChannel;
 
 export interface PublicThreadChannel extends ThreadChannel {
-  type: ChannelType.GuildPublicThread | ChannelType.GuildNewsThread;
+  type: ChannelType.PublicThread | ChannelType.AnnouncementThread;
 }
 
 export interface PrivateThreadChannel extends ThreadChannel {
   get createdTimestamp(): number;
   get createdAt(): Date;
-  type: ChannelType.GuildPrivateThread;
+  type: ChannelType.PrivateThread;
 }
 
 export class ThreadChannel extends TextBasedChannelMixin(BaseChannel, true, [
@@ -3753,9 +3753,9 @@ export interface AddGuildMemberOptions {
 
 export type AllowedPartial = User | Channel | GuildMember | Message | MessageReaction | ThreadMember;
 
-export type AllowedThreadTypeForNewsChannel = ChannelType.GuildNewsThread;
+export type AllowedThreadTypeForNewsChannel = ChannelType.AnnouncementThread;
 
-export type AllowedThreadTypeForTextChannel = ChannelType.GuildPublicThread | ChannelType.GuildPrivateThread;
+export type AllowedThreadTypeForTextChannel = ChannelType.PublicThread | ChannelType.PrivateThread;
 
 export interface BaseApplicationCommandData {
   name: string;
@@ -4804,9 +4804,9 @@ export interface GuildChannelCreateOptions extends Omit<CategoryCreateChannelOpt
     ChannelType,
     | ChannelType.DM
     | ChannelType.GroupDM
-    | ChannelType.GuildPublicThread
-    | ChannelType.GuildNewsThread
-    | ChannelType.GuildPrivateThread
+    | ChannelType.PublicThread
+    | ChannelType.AnnouncementThread
+    | ChannelType.PrivateThread
   >;
 }
 
@@ -4816,7 +4816,7 @@ export interface GuildChannelCloneOptions extends Omit<GuildChannelCreateOptions
 
 export interface GuildChannelEditOptions {
   name?: string;
-  type?: ChannelType.GuildText | ChannelType.GuildNews;
+  type?: ChannelType.GuildText | ChannelType.GuildAnnouncement;
   position?: number;
   topic?: string | null;
   nsfw?: boolean;
@@ -5554,15 +5554,12 @@ export type TextBasedChannelResolvable = Snowflake | TextBasedChannel;
 
 export type ThreadChannelResolvable = AnyThreadChannel | Snowflake;
 
-export type ThreadChannelType =
-  | ChannelType.GuildNewsThread
-  | ChannelType.GuildPublicThread
-  | ChannelType.GuildPrivateThread;
+export type ThreadChannelType = ChannelType.AnnouncementThread | ChannelType.PublicThread | ChannelType.PrivateThread;
 
 export interface ThreadCreateOptions<AllowedThreadType> extends StartThreadOptions {
   startMessage?: MessageResolvable;
   type?: AllowedThreadType;
-  invitable?: AllowedThreadType extends ChannelType.GuildPrivateThread ? boolean : never;
+  invitable?: AllowedThreadType extends ChannelType.PrivateThread ? boolean : never;
 }
 
 export interface ThreadEditData {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1041,7 +1041,7 @@ client.on('stickerUpdate', ({ client: oldClient }, { client: newClient }) => {
 client.on('threadCreate', thread => {
   expectType<Client<true>>(thread.client);
 
-  if (thread.type === ChannelType.GuildPrivateThread) {
+  if (thread.type === ChannelType.PrivateThread) {
     expectType<number>(thread.createdTimestamp);
     expectType<Date>(thread.createdAt);
   } else {
@@ -1237,7 +1237,7 @@ expectType<TextBasedChannelFields<true>['send']>(voiceChannel.send);
 expectAssignable<PartialTextBasedChannelFields>(user);
 expectAssignable<PartialTextBasedChannelFields>(guildMember);
 
-expectType<Promise<NewsChannel>>(textChannel.setType(ChannelType.GuildNews));
+expectType<Promise<NewsChannel>>(textChannel.setType(ChannelType.GuildAnnouncement));
 expectType<Promise<TextChannel>>(newsChannel.setType(ChannelType.GuildText));
 
 expectType<Message | null>(dmChannel.lastMessage);
@@ -1347,7 +1347,9 @@ declare const categoryChannelChildManager: CategoryChannelChildManager;
 {
   expectType<Promise<VoiceChannel>>(categoryChannelChildManager.create({ name: 'name', type: ChannelType.GuildVoice }));
   expectType<Promise<TextChannel>>(categoryChannelChildManager.create({ name: 'name', type: ChannelType.GuildText }));
-  expectType<Promise<NewsChannel>>(categoryChannelChildManager.create({ name: 'name', type: ChannelType.GuildNews }));
+  expectType<Promise<NewsChannel>>(
+    categoryChannelChildManager.create({ name: 'name', type: ChannelType.GuildAnnouncement }),
+  );
   expectType<Promise<StageChannel>>(
     categoryChannelChildManager.create({ name: 'name', type: ChannelType.GuildStageVoice }),
   );
@@ -1364,7 +1366,7 @@ declare const guildChannelManager: GuildChannelManager;
   expectType<Promise<VoiceChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildVoice }));
   expectType<Promise<CategoryChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildCategory }));
   expectType<Promise<TextChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildText }));
-  expectType<Promise<NewsChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildNews }));
+  expectType<Promise<NewsChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildAnnouncement }));
   expectType<Promise<StageChannel>>(guildChannelManager.create({ name: 'name', type: ChannelType.GuildStageVoice }));
 
   expectType<Promise<Collection<Snowflake, AnyChannel | null>>>(guildChannelManager.fetch());
@@ -1773,9 +1775,9 @@ declare const NonThreadGuildBasedChannel: NonThreadGuildBasedChannel;
 declare const GuildTextBasedChannel: GuildTextBasedChannel;
 
 expectType<TextBasedChannel>(TextBasedChannel);
-expectType<ChannelType.GuildText | ChannelType.DM | ChannelType.GuildNews | ChannelType.GuildVoice | ThreadChannelType>(
-  TextBasedChannelTypes,
-);
+expectType<
+  ChannelType.GuildText | ChannelType.DM | ChannelType.GuildAnnouncement | ChannelType.GuildVoice | ThreadChannelType
+>(TextBasedChannelTypes);
 expectType<StageChannel | VoiceChannel>(VoiceBasedChannel);
 expectType<GuildBasedChannel>(GuildBasedChannel);
 expectType<CategoryChannel | NewsChannel | StageChannel | TextChannel | VoiceChannel>(NonThreadGuildBasedChannel);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Replaces the usage of the deprecated news/thread `ChannelType`s 

https://github.com/discordjs/discord-api-types/commit/817884184bf295e8d550898e1e28dc674b50600f (Released in 0.37.6)
https://github.com/discordjs/discord.js/blob/d14d47b62fea9a57570f24195ca486886751c6fa/packages/discord.js/package.json#L57

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
