### PR TITLE
docs: update misleading `Client#guildMemberAvailable` event description

### DIFF
--- a/packages/discord.js/src/client/actions/GuildMemberUpdate.js
+++ b/packages/discord.js/src/client/actions/GuildMemberUpdate.js
@@ -31,7 +31,7 @@ class GuildMemberUpdateAction extends Action {
       } else {
         const newMember = guild.members._add(data);
         /**
-         * Emitted whenever a member becomes available in a large guild.
+         * Emitted whenever a member becomes available.
          * @event Client#guildMemberAvailable
          * @param {GuildMember} member The member that became available
          */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This event is emitted on any guild if an uncached member is updated and the client wasn't instantiated with the `GuildMember` partial
https://github.com/discordjs/discord.js/blob/d14d47b62fea9a57570f24195ca486886751c6fa/packages/discord.js/src/client/actions/GuildMemberUpdate.js#L21-L39

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
