### PR TITLE
fix: update `messageCount`/`totalMessageSent` on message events

### DIFF
--- a/packages/discord.js/src/client/actions/MessageCreate.js
+++ b/packages/discord.js/src/client/actions/MessageCreate.js
@@ -10,6 +10,11 @@ class MessageCreateAction extends Action {
     if (channel) {
       if (!channel.isTextBased()) return {};
 
+      if (channel.isThread()) {
+        channel.messageCount++;
+        channel.totalMessageSent++;
+      }
+
       const existing = channel.messages.cache.get(data.id);
       if (existing) return { message: existing };
       const message = channel.messages._add(data);

--- a/packages/discord.js/src/client/actions/MessageDelete.js
+++ b/packages/discord.js/src/client/actions/MessageDelete.js
@@ -11,6 +11,8 @@ class MessageDeleteAction extends Action {
     if (channel) {
       if (!channel.isTextBased()) return {};
 
+      if (channel.isThread()) channel.messageCount--;
+
       message = this.getMessage(data, channel);
       if (message) {
         channel.messages.cache.delete(message.id);

--- a/packages/discord.js/src/client/actions/MessageDeleteBulk.js
+++ b/packages/discord.js/src/client/actions/MessageDeleteBulk.js
@@ -12,6 +12,8 @@ class MessageDeleteBulkAction extends Action {
     if (channel) {
       if (!channel.isTextBased()) return {};
 
+      if (channel.isThread()) channel.messageCount -= data.ids.length;
+
       const ids = data.ids;
       const messages = new Collection();
       for (const id of ids) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
> The `message_count` and `total_message_sent` fields on threads created in a forum will increment on `MESSAGE_CREATE` and will decrement on `MESSAGE_DELETE`/`MESSAGE_DELETE_BULK`. There will be no `CHANNEL_UPDATE` event through gateway notifying those fields' changes (similar to `last_message_id` changes). Clients should update those values when receiving corresponding events.

https://discord.com/developers/docs/topics/threads#forums

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
