### PR TITLE
fix(ThreadChannel): Make `fetchStarterMessage()` work in forum posts

### DIFF
--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -301,14 +301,16 @@ class ThreadChannel extends BaseChannel {
 
   /**
    * Fetches the message that started this thread, if any.
-   * <info>This only works when the thread started from a message in the parent channel, otherwise the promise will
-   * reject. If you just need the id of that message, use {@link ThreadChannel#id} instead.</info>
+   * <info>The `Promise` will reject if the original message in a forum post is deleted
+   * or when the original message in the parent channel is deleted.
+   * If you just need the id of that message, use {@link ThreadChannel#id} instead.</info>
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<Message<true>|null>}
    */
   // eslint-disable-next-line require-await
   async fetchStarterMessage(options) {
-    return this.parent?.messages.fetch({ message: this.id, ...options }) ?? null;
+    const channel = this.parent?.type === ChannelType.GuildForum ? this : this.parent;
+    return channel?.messages.fetch({ message: this.id, ...options }) ?? null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This caused an internal error when used in a forum post. This now fetches the original message in the forum post!

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
