### PR TITLE
fix: Correct applied tags type

### DIFF
--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -321,6 +321,7 @@ class ThreadChannel extends BaseChannel {
    * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the thread in seconds
    * @property {boolean} [locked] Whether the thread is locked
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to a thread
+   * @property {Snowflake[]} [appliedTags] The tags to apply to the thread
    * @property {string} [reason] Reason for editing the thread
    * <info>Can only be edited on {@link ChannelType.PrivateThread}</info>
    */
@@ -443,9 +444,9 @@ class ThreadChannel extends BaseChannel {
 
   /**
    * Set the applied tags for this channel (only applicable to forum threads)
-   * @param {GuildForumTag[]} appliedTags The tags to set for this channel
+   * @param {Snowflake[]} appliedTags The tags to set for this channel
    * @param {string} [reason] Reason for changing the thread's applied tags
-   * @returns {Promise<GuildForumThreadChannel>}
+   * @returns {Promise<ThreadChannel>}
    */
   setAppliedTags(appliedTags, reason) {
     return this.edit({ appliedTags, reason });

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2608,7 +2608,7 @@ export class ThreadChannel extends TextBasedChannelMixin(BaseChannel, true, [
   public setInvitable(invitable?: boolean, reason?: string): Promise<AnyThreadChannel>;
   public setLocked(locked?: boolean, reason?: string): Promise<AnyThreadChannel>;
   public setName(name: string, reason?: string): Promise<AnyThreadChannel>;
-  public setAppliedTags(appliedTags: GuildForumTag[], reason?: string): Promise<AnyThreadChannel>;
+  public setAppliedTags(appliedTags: Snowflake[], reason?: string): Promise<AnyThreadChannel>;
   public toString(): ChannelMention;
 }
 
@@ -5652,6 +5652,7 @@ export interface ThreadEditData {
   rateLimitPerUser?: number;
   locked?: boolean;
   invitable?: boolean;
+  appliedTags?: Snowflake[];
   reason?: string;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2608,7 +2608,7 @@ export class ThreadChannel extends TextBasedChannelMixin(BaseChannel, true, [
   public setInvitable(invitable?: boolean, reason?: string): Promise<AnyThreadChannel>;
   public setLocked(locked?: boolean, reason?: string): Promise<AnyThreadChannel>;
   public setName(name: string, reason?: string): Promise<AnyThreadChannel>;
-  public setAppliedTags(appliedTags: Snowflake[], reason?: string): Promise<AnyThreadChannel>;
+  public setAppliedTags(appliedTags: Snowflake[], reason?: string): Promise<ThreadChannel>;
   public toString(): ChannelMention;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This required a full object, but only the ids are necessary.

In addition:

- The return type is corrected on the helper method
- `ThreadEditData` now possesses this property
- The return type of the method in the typings no longer possibly returns a private thread

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
