### PR TITLE
docs: Correctly overwrite `setRTCRegion` method

### DIFF
--- a/packages/discord.js/src/structures/StageChannel.js
+++ b/packages/discord.js/src/structures/StageChannel.js
@@ -51,20 +51,22 @@ class StageChannel extends BaseGuildVoiceChannel {
   setTopic(topic, reason) {
     return this.edit({ topic, reason });
   }
-
-  /**
-   * Sets the RTC region of the channel.
-   * @name StageChannel#setRTCRegion
-   * @param {?string} rtcRegion The new region of the channel. Set to `null` to remove a specific region for the channel
-   * @param {string} [reason] The reason for modifying this region.
-   * @returns {Promise<StageChannel>}
-   * @example
-   * // Set the RTC region to sydney
-   * stageChannel.setRTCRegion('sydney');
-   * @example
-   * // Remove a fixed region for this channel - let Discord decide automatically
-   * stageChannel.setRTCRegion(null, 'We want to let Discord decide.');
-   */
 }
+
+/**
+ * Sets the RTC region of the channel.
+ * @method setRTCRegion
+ * @memberof StageChannel
+ * @instance
+ * @param {?string} rtcRegion The new region of the channel. Set to `null` to remove a specific region for the channel
+ * @param {string} [reason] The reason for modifying this region.
+ * @returns {Promise<StageChannel>}
+ * @example
+ * // Set the RTC region to sydney
+ * stageChannel.setRTCRegion('sydney');
+ * @example
+ * // Remove a fixed region for this channel - let Discord decide automatically
+ * stageChannel.setRTCRegion(null, 'We want to let Discord decide.');
+ */
 
 module.exports = StageChannel;

--- a/packages/discord.js/src/structures/VoiceChannel.js
+++ b/packages/discord.js/src/structures/VoiceChannel.js
@@ -149,22 +149,24 @@ class VoiceChannel extends BaseGuildVoiceChannel {
   createWebhook() {}
   setRateLimitPerUser() {}
   setNSFW() {}
-
-  /**
-   * Sets the RTC region of the channel.
-   * @name VoiceChannel#setRTCRegion
-   * @param {?string} rtcRegion The new region of the channel. Set to `null` to remove a specific region for the channel
-   * @param {string} [reason] The reason for modifying this region.
-   * @returns {Promise<VoiceChannel>}
-   * @example
-   * // Set the RTC region to sydney
-   * voiceChannel.setRTCRegion('sydney');
-   * @example
-   * // Remove a fixed region for this channel - let Discord decide automatically
-   * voiceChannel.setRTCRegion(null, 'We want to let Discord decide.');
-   */
 }
 
 TextBasedChannel.applyToClass(VoiceChannel, true, ['lastPinAt']);
+
+/**
+ * Sets the RTC region of the channel.
+ * @method setRTCRegion
+ * @memberof VoiceChannel
+ * @instance
+ * @param {?string} rtcRegion The new region of the channel. Set to `null` to remove a specific region for the channel
+ * @param {string} [reason] The reason for modifying this region.
+ * @returns {Promise<VoiceChannel>}
+ * @example
+ * // Set the RTC region to sydney
+ * voiceChannel.setRTCRegion('sydney');
+ * @example
+ * // Remove a fixed region for this channel - let Discord decide automatically
+ * voiceChannel.setRTCRegion(null, 'We want to let Discord decide.');
+ */
 
 module.exports = VoiceChannel;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The existing overwriting documentation for `setRTCRegion()` in voice channels and stage channels did not work. This pull request fixes them to correctly overwrite.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
