### PR TITLE
revert: add types to `EventEmitter` static methods

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -190,17 +190,6 @@ import {
   RawWidgetMemberData,
 } from './rawDataTypes';
 
-declare module 'node:events' {
-  class EventEmitter {
-    // Add type overloads for client events.
-    public static once<K extends keyof ClientEvents>(eventEmitter: Client, eventName: K): Promise<ClientEvents[K]>;
-    public static on<K extends keyof ClientEvents>(
-      eventEmitter: Client,
-      eventName: K,
-    ): AsyncIterableIterator<ClientEvents[K]>;
-  }
-}
-
 //#region Classes
 
 export class Activity {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #8634 
Reverts #7986

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
