### PR TITLE
feat:Alllow forum channels in webhook update event

### DIFF
--- a/packages/discord.js/src/client/actions/WebhooksUpdate.js
+++ b/packages/discord.js/src/client/actions/WebhooksUpdate.js
@@ -10,7 +10,7 @@ class WebhooksUpdate extends Action {
     /**
      * Emitted whenever a channel has its webhooks changed.
      * @event Client#webhookUpdate
-     * @param {TextChannel|NewsChannel|VoiceChannel} channel The channel that had a webhook update
+     * @param {TextChannel|NewsChannel|VoiceChannel|ForumChannel} channel The channel that had a webhook update
      */
     if (channel) client.emit(Events.WebhooksUpdate, channel);
   }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4317,7 +4317,7 @@ export interface ClientEvents {
   typingStart: [typing: Typing];
   userUpdate: [oldUser: User | PartialUser, newUser: User];
   voiceStateUpdate: [oldState: VoiceState, newState: VoiceState];
-  webhookUpdate: [channel: TextChannel | NewsChannel | VoiceChannel];
+  webhookUpdate: [channel: TextChannel | NewsChannel | VoiceChannel | ForumChannel];
   interactionCreate: [interaction: Interaction];
   shardDisconnect: [closeEvent: CloseEvent, shardId: number];
   shardError: [error: Error, shardId: number];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I'm receiving forum channels in `Client#webhookUpdate`. Makes sense, as forum channels can have webhooks.
 
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
