### PR TITLE
fix(ThreadChannel): Add forum channel to parent

### DIFF
--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -245,7 +245,7 @@ class ThreadChannel extends BaseChannel {
 
   /**
    * The parent channel of this thread
-   * @type {?(NewsChannel|TextChannel)}
+   * @type {?(NewsChannel|TextChannel|ForumChannel)}
    * @readonly
    */
   get parent() {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2540,19 +2540,19 @@ export class TextChannel extends BaseGuildTextChannel {
   public type: ChannelType.GuildText;
 }
 
-export type AnyThreadChannel = PublicThreadChannel | PrivateThreadChannel;
+export type AnyThreadChannel<Forum extends boolean = boolean> = PublicThreadChannel<Forum> | PrivateThreadChannel;
 
-export interface PublicThreadChannel extends ThreadChannel {
+export interface PublicThreadChannel<Forum extends boolean = boolean> extends ThreadChannel<Forum> {
   type: ChannelType.PublicThread | ChannelType.AnnouncementThread;
 }
 
-export interface PrivateThreadChannel extends ThreadChannel {
+export interface PrivateThreadChannel extends ThreadChannel<false> {
   get createdTimestamp(): number;
   get createdAt(): Date;
   type: ChannelType.PrivateThread;
 }
 
-export class ThreadChannel extends TextBasedChannelMixin(BaseChannel, true, [
+export class ThreadChannel<Forum extends boolean = boolean> extends TextBasedChannelMixin(BaseChannel, true, [
   'fetchWebhooks',
   'createWebhook',
   'setNSFW',
@@ -2584,7 +2584,7 @@ export class ThreadChannel extends TextBasedChannelMixin(BaseChannel, true, [
   public members: ThreadMemberManager;
   public name: string;
   public ownerId: Snowflake | null;
-  public get parent(): TextChannel | NewsChannel | null;
+  public get parent(): If<Forum, ForumChannel, TextChannel | NewsChannel> | null;
   public parentId: Snowflake | null;
   public rateLimitPerUser: number | null;
   public type: ThreadChannelType;
@@ -2608,7 +2608,7 @@ export class ThreadChannel extends TextBasedChannelMixin(BaseChannel, true, [
   public setInvitable(invitable?: boolean, reason?: string): Promise<AnyThreadChannel>;
   public setLocked(locked?: boolean, reason?: string): Promise<AnyThreadChannel>;
   public setName(name: string, reason?: string): Promise<AnyThreadChannel>;
-  public setAppliedTags(appliedTags: Snowflake[], reason?: string): Promise<ThreadChannel>;
+  public setAppliedTags(appliedTags: Snowflake[], reason?: string): Promise<ThreadChannel<true>>;
   public toString(): ChannelMention;
 }
 
@@ -3673,22 +3673,24 @@ export class StageInstanceManager extends CachedManager<Snowflake, StageInstance
   public delete(channel: StageChannelResolvable): Promise<void>;
 }
 
-export class ThreadManager extends CachedManager<Snowflake, ThreadChannel, ThreadChannelResolvable> {
+export class ThreadManager<Forum extends boolean = boolean> extends CachedManager<
+  Snowflake,
+  ThreadChannel<Forum>,
+  ThreadChannelResolvable
+> {
   protected constructor(channel: TextChannel | NewsChannel | ForumChannel, iterable?: Iterable<RawThreadChannelData>);
-  public channel: TextChannel | NewsChannel | ForumChannel;
+  public channel: If<Forum, ForumChannel, TextChannel | NewsChannel>;
   public fetch(options: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<AnyThreadChannel | null>;
   public fetch(options?: FetchThreadsOptions, cacheOptions?: { cache?: boolean }): Promise<FetchedThreads>;
   public fetchArchived(options?: FetchArchivedThreadOptions, cache?: boolean): Promise<FetchedThreads>;
   public fetchActive(cache?: boolean): Promise<FetchedThreads>;
 }
 
-export class GuildTextThreadManager<AllowedThreadType> extends ThreadManager {
-  public channel: TextChannel | NewsChannel;
+export class GuildTextThreadManager<AllowedThreadType> extends ThreadManager<false> {
   public create(options: GuildTextThreadCreateOptions<AllowedThreadType>): Promise<ThreadChannel>;
 }
 
-export class GuildForumThreadManager extends ThreadManager {
-  public channel: ForumChannel;
+export class GuildForumThreadManager extends ThreadManager<true> {
   public create(options: GuildForumThreadCreateOptions): Promise<ThreadChannel>;
 }
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -139,6 +139,8 @@ import {
   ModalSubmitInteraction,
   ForumChannel,
   ChannelFlagsBitField,
+  GuildForumThreadManager,
+  GuildTextThreadManager,
 } from '.';
 import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import type { ContextMenuCommandBuilder, SlashCommandBuilder } from '@discordjs/builders';
@@ -1224,12 +1226,19 @@ expectType<Promise<number[]>>(shardClientUtil.broadcastEval(async () => 1));
 
 declare const dmChannel: DMChannel;
 declare const threadChannel: ThreadChannel;
+declare const threadChannelFromForum: ThreadChannel<true>;
+declare const threadChannelNotFromForum: ThreadChannel<false>;
 declare const newsChannel: NewsChannel;
 declare const textChannel: TextChannel;
 declare const voiceChannel: VoiceChannel;
 declare const guild: Guild;
 declare const user: User;
 declare const guildMember: GuildMember;
+
+// Test thread channels' parent inference
+expectType<TextChannel | NewsChannel | ForumChannel | null>(threadChannel.parent);
+expectType<ForumChannel | null>(threadChannelFromForum.parent);
+expectType<TextChannel | NewsChannel | null>(threadChannelNotFromForum.parent);
 
 // Test whether the structures implement send
 expectType<TextBasedChannelFields<false>['send']>(dmChannel.send);
@@ -1404,6 +1413,14 @@ declare const guildChannelManager: GuildChannelManager;
   expectType<null>(message.guildId);
   expectType<TextBasedChannel>(message.channel.messages.channel);
 }
+
+declare const guildForumThreadManager: GuildForumThreadManager;
+expectType<ForumChannel>(guildForumThreadManager.channel);
+
+declare const guildTextThreadManager: GuildTextThreadManager<
+  ChannelType.PublicThread | ChannelType.PrivateThread | ChannelType.AnnouncementThread
+>;
+expectType<TextChannel | NewsChannel>(guildTextThreadManager.channel);
 
 declare const messageManager: MessageManager;
 {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`ThreadChannel#parent` now documents and types forum channels.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
