### PR TITLE
fix(GuildChannelManager):  typo in `flags` property name when editing

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -287,7 +287,7 @@ class GuildChannelManager extends CachedManager {
         available_tags: data.availableTags?.map(availableTag => transformGuildForumTag(availableTag)),
         default_reaction_emoji: data.defaultReactionEmoji && transformGuildDefaultReaction(data.defaultReactionEmoji),
         default_thread_rate_limit_per_user: data.defaultThreadRateLimitPerUser,
-        tags: 'flags' in data ? ChannelFlagsBitField.resolve(data.flags) : undefined,
+        fags: 'flags' in data ? ChannelFlagsBitField.resolve(data.flags) : undefined,
       },
       reason: data.reason,
     });

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -287,7 +287,7 @@ class GuildChannelManager extends CachedManager {
         available_tags: data.availableTags?.map(availableTag => transformGuildForumTag(availableTag)),
         default_reaction_emoji: data.defaultReactionEmoji && transformGuildDefaultReaction(data.defaultReactionEmoji),
         default_thread_rate_limit_per_user: data.defaultThreadRateLimitPerUser,
-        fags: 'flags' in data ? ChannelFlagsBitField.resolve(data.flags) : undefined,
+        flags: 'flags' in data ? ChannelFlagsBitField.resolve(data.flags) : undefined,
       },
       reason: data.reason,
     });

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4904,7 +4904,7 @@ export interface GuildChannelEditOptions {
   availableTags?: GuildForumTagData[];
   defaultReactionEmoji?: DefaultReactionEmoji | null;
   defaultThreadRateLimitPerUser?: number;
-  tags?: ChannelFlagsResolvable;
+  fags?: ChannelFlagsResolvable;
   reason?: string;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4904,7 +4904,7 @@ export interface GuildChannelEditOptions {
   availableTags?: GuildForumTagData[];
   defaultReactionEmoji?: DefaultReactionEmoji | null;
   defaultThreadRateLimitPerUser?: number;
-  fags?: ChannelFlagsResolvable;
+  flags?: ChannelFlagsResolvable;
   reason?: string;
 }
 


### PR DESCRIPTION
typo from #8637 