### PR TITLE
fix(ThreadChannel): Allow editing flags

### DIFF
--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -6,6 +6,7 @@ const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const { RangeError, ErrorCodes } = require('../errors');
 const MessageManager = require('../managers/MessageManager');
 const ThreadMemberManager = require('../managers/ThreadMemberManager');
+const ChannelFlagsBitField = require('../util/ChannelFlagsBitField');
 
 /**
  * Represents a thread channel on Discord.
@@ -324,6 +325,7 @@ class ThreadChannel extends BaseChannel {
    * @property {boolean} [locked] Whether the thread is locked
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to a thread
    * @property {Snowflake[]} [appliedTags] The tags to apply to the thread
+   * @property {ChannelFlagsResolvable} [flags] The flags to set on the channel
    * @property {string} [reason] Reason for editing the thread
    * <info>Can only be edited on {@link ChannelType.PrivateThread}</info>
    */
@@ -348,6 +350,7 @@ class ThreadChannel extends BaseChannel {
         locked: data.locked,
         invitable: this.type === ChannelType.PrivateThread ? data.invitable : undefined,
         applied_tags: data.appliedTags,
+        flags: 'flags' in data ? ChannelFlagsBitField.resolve(data.flags) : undefined,
       },
       reason: data.reason,
     });

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5658,6 +5658,7 @@ export interface ThreadEditData {
   locked?: boolean;
   invitable?: boolean;
   appliedTags?: Snowflake[];
+  flags?: ChannelFlagsResolvable;
   reason?: string;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allowing threads to edit flags which was overlooked in #8637.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
