### PR TITLE
Forum channel

### DIFF
--- a/packages/discord.js/src/structures/ForumChannel.js
+++ b/packages/discord.js/src/structures/ForumChannel.js
@@ -95,6 +95,15 @@ class ForumChannel extends GuildChannel {
     } else {
       this.rateLimitPerUser ??= null;
     }
+    if ('default_sort_order' in data) {
+      /**
+       * The default sort order type used to order posts in `GUILD_FORUM` channels
+       * @type {?number}
+       */
+      this.defaultSortOrder = data.default_sort_order;
+    } else {
+      this.defaultSortOrder ??= null;
+    }
 
     if ('default_auto_archive_duration' in data) {
       /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2093,6 +2093,7 @@ export class ForumChannel extends TextBasedChannelMixin(GuildChannel, true, [
   public availableTags: GuildForumTag[];
   public defaultReactionEmoji: DefaultReactionEmoji | null;
   public defaultThreadRateLimitPerUser: number | null;
+  public defaultSortOrder: number | null;
   public rateLimitPerUser: number | null;
   public defaultAutoArchiveDuration: ThreadAutoArchiveDuration | null;
   public nsfw: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The `default_sort_order` is used to order posts in `GUILD_FORUM` channels,

`default_sort_order` is an optional field in the channel that indicates how the threads in a forum channel will be sorted for users by default. Setting `default_sort_order`.

this feature discord added it from 2 days (22 September - 2022) - the link of feature https://discord.com/developers/docs/resources/channel#channel-object-channel-structure

**Status and versioning classification:**

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
