### PR TITLE
docs: fix duplicate typedefs

### DIFF
--- a/packages/discord.js/src/managers/GuildForumThreadManager.js
+++ b/packages/discord.js/src/managers/GuildForumThreadManager.js
@@ -17,7 +17,7 @@ class GuildForumThreadManager extends ThreadManager {
    */
 
   /**
-   * @typedef {BaseMessageOptions} GuildForumThreadCreateOptions
+   * @typedef {BaseMessageOptions} GuildForumThreadMessageCreateOptions
    * @property {stickers} [stickers] The stickers to send with the message
    * @property {BitFieldResolvable} [flags] The flags to send with the message
    */
@@ -25,7 +25,7 @@ class GuildForumThreadManager extends ThreadManager {
   /**
    * Options for creating a thread.
    * @typedef {StartThreadOptions} GuildForumThreadCreateOptions
-   * @property {GuildForumThreadCreateOptions|MessagePayload} message The message associated with the thread post
+   * @property {GuildForumThreadMessageCreateOptions|MessagePayload} message The message associated with the thread post
    * @property {Snowflake[]} [appliedTags] The tags to apply to the thread
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes duplicate typedefs for `GuildForumThreadCreateOptions`
**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
