### PR TITLE
feat(rest): use Agent with higher connect timeout

### DIFF
--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -10,8 +10,8 @@ export const DefaultRestOptions: Required<RESTOptions> = {
 	get agent() {
 		return new Agent({
 			connect: {
-				timeout: 30_000
-			}
+				timeout: 30_000,
+			},
 		});
 	},
 	api: 'https://discord.com/api',

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -1,15 +1,18 @@
 import process from 'node:process';
 import { APIVersion } from 'discord-api-types/v10';
-import { getGlobalDispatcher } from 'undici';
+import { Agent } from 'undici';
 import type { RESTOptions } from '../REST.js';
-// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const Package = require('../../../package.json');
 
 export const DefaultUserAgent = `DiscordBot (${Package.homepage}, ${Package.version})`;
 
 export const DefaultRestOptions: Required<RESTOptions> = {
 	get agent() {
-		return getGlobalDispatcher();
+		return new Agent({
+			connect: {
+				timeout: 30_000
+			}
+		});
 	},
 	api: 'https://discord.com/api',
 	authPrefix: 'Bot',

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -2,6 +2,7 @@ import process from 'node:process';
 import { APIVersion } from 'discord-api-types/v10';
 import { Agent } from 'undici';
 import type { RESTOptions } from '../REST.js';
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
 const Package = require('../../../package.json');
 
 export const DefaultUserAgent = `DiscordBot (${Package.homepage}, ${Package.version})`;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #8629 
Fixes #8489 

Repeated issue:
- https://discord.com/channels/222078108977594368/999007780524535978
- https://discord.com/channels/222078108977594368/1023364907619602522

I have no way of testing this but 30 seconds seems to work for others.

The issue seems to be with misconfigured ipv6, see https://github.com/nodejs/undici/issues/1531#issuecomment-1229889136

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed) (Not really sure. Increases the time allowed to establish a connection.)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes

- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
