### PR TITLE
fix(proxyRequests): forward query parameters

### DIFF
--- a/packages/proxy/src/handlers/proxyRequests.ts
+++ b/packages/proxy/src/handlers/proxyRequests.ts
@@ -32,8 +32,9 @@ export function proxyRequests(rest: REST): RequestHandler {
 
 		// The 2nd parameter is here so the URL constructor doesn't complain about an "invalid url" when the origin is missing
 		// we don't actually care about the origin and the value passed is irrelevant
-		// eslint-disable-next-line prefer-named-capture-group, unicorn/no-unsafe-regex
-		const fullRoute = new URL(url, 'http://noop').pathname.replace(/^\/api(\/v\d+)?/, '') as RouteLike;
+		const parsedUrl = new URL(url, 'http://noop');
+		// eslint-disable-next-line unicorn/no-unsafe-regex, prefer-named-capture-group
+		const fullRoute = parsedUrl.pathname.replace(/^\/api(\/v\d+)?/, '') as RouteLike;
 
 		try {
 			const discordResponse = await rest.raw({
@@ -42,6 +43,7 @@ export function proxyRequests(rest: REST): RequestHandler {
 				// This type cast is technically incorrect, but we want Discord to throw Method Not Allowed for us
 				method: method as RequestMethod,
 				passThroughBody: true,
+				query: parsedUrl.searchParams,
 				headers: {
 					'Content-Type': req.headers['content-type']!,
 				},


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Prior to this we weren't forwarding query parameters at all.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

