### PR TITLE
feat(GuildChannelManager): allow creating channels with a default auto archive duration

### DIFF
--- a/packages/discord.js/src/managers/CategoryChannelChildManager.js
+++ b/packages/discord.js/src/managers/CategoryChannelChildManager.js
@@ -53,6 +53,8 @@ class CategoryChannelChildManager extends DataManager {
    * @property {GuildForumTagData[]} [availableTags] The tags that can be used in this channel (forum only).
    * @property {DefaultReactionEmoji} [defaultReactionEmoji]
    * The emoji to show in the add reaction button on a thread in a guild forum channel.
+   * @property {ThreadAutoArchiveDuration} [defaultAutoArchiveDuration]
+   * The default auto archive duration for all new threads in this channel
    * @property {SortOrderType} [defaultSortOrder] The default sort order mode used to order posts (forum only).
    * @property {string} [reason] Reason for creating the new channel
    */

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -141,6 +141,7 @@ class GuildChannelManager extends CachedManager {
     videoQualityMode,
     availableTags,
     defaultReactionEmoji,
+    defaultAutoArchiveDuration,
     defaultSortOrder,
     reason,
   }) {
@@ -163,6 +164,7 @@ class GuildChannelManager extends CachedManager {
         video_quality_mode: videoQualityMode,
         available_tags: availableTags?.map(availableTag => transformGuildForumTag(availableTag)),
         default_reaction_emoji: defaultReactionEmoji && transformGuildDefaultReaction(defaultReactionEmoji),
+        default_auto_archive_duration: defaultAutoArchiveDuration,
         default_sort_order: defaultSortOrder,
       },
       reason,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4252,6 +4252,7 @@ export interface CategoryCreateChannelOptions {
   videoQualityMode?: VideoQualityMode;
   availableTags?: GuildForumTagData[];
   defaultReactionEmoji?: DefaultReactionEmoji;
+  defaultAutoArchiveDuration?: ThreadAutoArchiveDuration;
   defaultSortOrder?: SortOrderType;
   reason?: string;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR allows one to create channels with a default archive duration set.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

