### PR TITLE
fix(SequentialHandler): throw http error with proper name and more useful message

### DIFF
--- a/packages/rest/src/lib/errors/HTTPError.ts
+++ b/packages/rest/src/lib/errors/HTTPError.ts
@@ -1,3 +1,4 @@
+import { STATUS_CODES } from 'node:http';
 import type { InternalRequest } from '../RequestManager.js';
 import type { RequestBody } from './DiscordAPIError.js';
 
@@ -7,21 +8,21 @@ import type { RequestBody } from './DiscordAPIError.js';
 export class HTTPError extends Error {
 	public requestBody: RequestBody;
 
+	public override name = HTTPError.name;
+
 	/**
-	 * @param name - The name of the error
 	 * @param status - The status code of the response
 	 * @param method - The method of the request that erred
 	 * @param url - The url of the request that erred
 	 * @param bodyData - The unparsed data for the request that errored
 	 */
 	public constructor(
-		public override name: string,
 		public status: number,
 		public method: string,
 		public url: string,
 		bodyData: Pick<InternalRequest, 'body' | 'files'>,
 	) {
-		super();
+		super(STATUS_CODES[status]);
 
 		this.requestBody = { files: bodyData.files, json: bodyData.body };
 	}

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -482,7 +482,7 @@ export class SequentialHandler implements IHandler {
 			}
 
 			// We are out of retries, throw an error
-			throw new HTTPError(res.constructor.name, status, method, url, requestData);
+			throw new HTTPError(status, method, url, requestData);
 		} else {
 			// Handle possible malformed requests
 			if (status >= 400 && status < 500) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes #8615 by overwriting the error of `HTTPError` with the name of the class (as I think is how sub-classed errors should generally work) and synthesizing an error message based on the http status (as undici apparently does not expose the status text?).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

