### PR TITLE
fix: re-export util

### DIFF
--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -187,3 +187,4 @@ exports.WebSocket = require('./WebSocket');
 __exportStar(require('discord-api-types/v10'), exports);
 __exportStar(require('@discordjs/builders'), exports);
 __exportStar(require('@discordjs/rest'), exports);
+__exportStar(require('@discordjs/util'), exports);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`@discordjs/util` is currently only being re-exported from the typings and the `@discordjs/builders` package. This does not allow for using named exports from /util in djs with ESM, so the answer to
https://github.com/discordjs/discord.js/pull/8591#discussion_r980146605 is yes

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
