### PR TITLE
fix(Client): don't auth for webhook fetches with token

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -313,7 +313,7 @@ class Client extends BaseClient {
    *   .catch(console.error);
    */
   async fetchWebhook(id, token) {
-    const data = await this.rest.get(Routes.webhook(id, token));
+    const data = await this.rest.get(Routes.webhook(id, token), { auth: typeof token === 'undefined' });
     return new Webhook(this, { token, ...data });
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes an oversight from moving to /rest. Any request that sends its own token should be set to auth false to avoid erroneously unsetting the client token.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
