### PR TITLE
build: switch to `esbuild-plugin-version-injector` for injecting version strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"@favware/cliff-jumper": "^1.8.8",
 		"@favware/npm-deprecate": "^1.0.5",
 		"conventional-changelog-cli": "^2.2.2",
+		"esbuild-plugin-version-injector": "^1.0.0",
 		"husky": "^8.0.1",
 		"is-ci": "^3.0.1",
 		"lint-staged": "^13.0.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"@favware/cliff-jumper": "^1.8.8",
 		"@favware/npm-deprecate": "^1.0.5",
 		"conventional-changelog-cli": "^2.2.2",
-		"esbuild-plugin-version-injector": "^1.0.0",
 		"husky": "^8.0.1",
 		"is-ci": "^3.0.1",
 		"lint-staged": "^13.0.3",

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -68,6 +68,7 @@
 		"@vitest/coverage-c8": "^0.24.0",
 		"cross-env": "^7.0.3",
 		"downlevel-dts": "^0.10.1",
+		"esbuild-plugin-version-injector": "^1.0.0",
 		"eslint": "^8.24.0",
 		"eslint-config-neon": "^0.1.35",
 		"prettier": "^2.7.1",

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -40,3 +40,12 @@ export * from './util/componentUtil.js';
 export * from './util/normalizeArray.js';
 export * from './util/validation.js';
 export * from '@discordjs/util';
+
+/**
+ * The [\@discordjs/builders](https://github.com/discordjs/discord.js/blob/main/packages/builders/#readme) version
+ * that you are currently using.
+ *
+ * Note to developers: This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
+ */
+// eslint-disable-next-line @typescript-eslint/no-inferrable-types
+export const version: string = '[VI]{{inject}}[/VI]';

--- a/packages/builders/tsup.config.js
+++ b/packages/builders/tsup.config.js
@@ -1,3 +1,6 @@
+import { esbuildPluginVersionInjector } from 'esbuild-plugin-version-injector';
 import { createTsupConfig } from '../../tsup.config.js';
 
-export default createTsupConfig();
+export default createTsupConfig({
+	esbuildPlugins: [esbuildPluginVersionInjector()],
+});

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -56,6 +56,7 @@
 		"@vitest/coverage-c8": "^0.24.0",
 		"cross-env": "^7.0.3",
 		"downlevel-dts": "^0.10.1",
+		"esbuild-plugin-version-injector": "^1.0.0",
 		"eslint": "^8.24.0",
 		"eslint-config-neon": "^0.1.35",
 		"prettier": "^2.7.1",

--- a/packages/collection/src/index.ts
+++ b/packages/collection/src/index.ts
@@ -1,1 +1,10 @@
 export * from './collection.js';
+
+/**
+ * The [\@discordjs/collection](https://github.com/discordjs/discord.js/blob/main/packages/collection/#readme) version
+ * that you are currently using.
+ *
+ * Note to developers: This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
+ */
+// eslint-disable-next-line @typescript-eslint/no-inferrable-types
+export const version: string = '[VI]{{inject}}[/VI]';

--- a/packages/collection/tsup.config.js
+++ b/packages/collection/tsup.config.js
@@ -1,3 +1,6 @@
+import { esbuildPluginVersionInjector } from 'esbuild-plugin-version-injector';
 import { createTsupConfig } from '../../tsup.config.js';
 
-export default createTsupConfig();
+export default createTsupConfig({
+	esbuildPlugins: [esbuildPluginVersionInjector()],
+});

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -68,7 +68,6 @@
 		"@vitest/coverage-c8": "^0.24.0",
 		"cross-env": "^7.0.3",
 		"downlevel-dts": "^0.10.1",
-		"esbuild-plugin-version-injector": "^1.0.0",
 		"eslint": "^8.24.0",
 		"eslint-config-neon": "^0.1.35",
 		"prettier": "^2.7.1",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -68,6 +68,7 @@
 		"@vitest/coverage-c8": "^0.24.0",
 		"cross-env": "^7.0.3",
 		"downlevel-dts": "^0.10.1",
+		"esbuild-plugin-version-injector": "^1.0.0",
 		"eslint": "^8.24.0",
 		"eslint-config-neon": "^0.1.35",
 		"prettier": "^2.7.1",

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -6,3 +6,12 @@ export * from './lib/RequestManager.js';
 export * from './lib/REST.js';
 export * from './lib/utils/constants.js';
 export { makeURLSearchParams, parseResponse } from './lib/utils/utils.js';
+
+/**
+ * The [\@discordjs/rest](https://github.com/discordjs/discord.js/blob/main/packages/rest/#readme) version
+ * that you are currently using.
+ *
+ * Note to developers: This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
+ */
+// eslint-disable-next-line @typescript-eslint/no-inferrable-types
+export const version: string = '[VI]{{inject}}[/VI]';

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -2,10 +2,8 @@ import process from 'node:process';
 import { APIVersion } from 'discord-api-types/v10';
 import { Agent } from 'undici';
 import type { RESTOptions } from '../REST.js';
-// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
-const Package = require('../../../package.json');
 
-export const DefaultUserAgent = `DiscordBot (${Package.homepage}, ${Package.version})`;
+export const DefaultUserAgent = `DiscordBot (https://discord.js.org, [VI]{{inject}}[/VI])`;
 
 export const DefaultRestOptions: Required<RESTOptions> = {
 	get agent() {

--- a/packages/rest/tsup.config.js
+++ b/packages/rest/tsup.config.js
@@ -1,3 +1,6 @@
+import { esbuildPluginVersionInjector } from 'esbuild-plugin-version-injector';
 import { createTsupConfig } from '../../tsup.config.js';
 
-export default createTsupConfig();
+export default createTsupConfig({
+	esbuildPlugins: [esbuildPluginVersionInjector()],
+});

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -68,6 +68,7 @@
 		"@types/node": "^16.11.64",
 		"cross-env": "^7.0.3",
 		"downlevel-dts": "^0.10.1",
+		"esbuild-plugin-version-injector": "^1.0.0",
 		"eslint": "^8.24.0",
 		"eslint-config-neon": "^0.1.35",
 		"jest": "^29.1.2",

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -19,3 +19,12 @@ export {
 } from './VoiceConnection';
 
 export { type JoinConfig, getVoiceConnection, getVoiceConnections, getGroups } from './DataStore';
+
+/**
+ * The [\@discordjs/voice](https://github.com/discordjs/discord.js/blob/main/packages/voice/#readme) version
+ * that you are currently using.
+ *
+ * Note to developers: This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
+ */
+// eslint-disable-next-line @typescript-eslint/no-inferrable-types
+export const version: string = '[VI]{{inject}}[/VI]';

--- a/packages/voice/src/util/generateDependencyReport.ts
+++ b/packages/voice/src/util/generateDependencyReport.ts
@@ -33,10 +33,11 @@ function findPackageJSON(
  */
 function version(name: string): string {
 	try {
-		const pkg =
-			name === '@discordjs/voice'
-				? require('../../package.json')
-				: findPackageJSON(dirname(require.resolve(name)), name, 3);
+		if (name === '@discordjs/voice') {
+			return '[VI]{{inject}}[/VI]';
+		}
+
+		const pkg = findPackageJSON(dirname(require.resolve(name)), name, 3);
 		return pkg?.version ?? 'not found';
 	} catch {
 		return 'not found';

--- a/packages/voice/tsup.config.js
+++ b/packages/voice/tsup.config.js
@@ -1,3 +1,6 @@
+import { esbuildPluginVersionInjector } from 'esbuild-plugin-version-injector';
 import { createTsupConfig } from '../../tsup.config.js';
 
-export default createTsupConfig();
+export default createTsupConfig({
+	esbuildPlugins: [esbuildPluginVersionInjector()],
+});

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -69,6 +69,7 @@
 		"@vitest/coverage-c8": "^0.24.0",
 		"cross-env": "^7.0.3",
 		"downlevel-dts": "^0.10.1",
+		"esbuild-plugin-version-injector": "^1.0.0",
 		"eslint": "^8.24.0",
 		"eslint-config-neon": "^0.1.35",
 		"mock-socket": "^9.1.5",

--- a/packages/ws/src/index.ts
+++ b/packages/ws/src/index.ts
@@ -11,3 +11,12 @@ export * from './utils/IdentifyThrottler.js';
 
 export * from './ws/WebSocketManager.js';
 export * from './ws/WebSocketShard.js';
+
+/**
+ * The [\@discordjs/voice](https://github.com/discordjs/discord.js/blob/main/packages/voice/#readme) version
+ * that you are currently using.
+ *
+ * Note to developers: This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
+ */
+// eslint-disable-next-line @typescript-eslint/no-inferrable-types
+export const version: string = '[VI]{{inject}}[/VI]';

--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -2,7 +2,6 @@ import process from 'node:process';
 import { Collection } from '@discordjs/collection';
 import { lazy } from '@discordjs/util';
 import { APIVersion, GatewayOpcodes } from 'discord-api-types/v10';
-import { version } from '../../package.json';
 import type { OptionalWebSocketManagerOptions, SessionInfo } from '../ws/WebSocketManager.js';
 
 /**
@@ -19,7 +18,7 @@ export enum CompressionMethod {
 	ZlibStream = 'zlib-stream',
 }
 
-export const DefaultDeviceProperty = `@discordjs/ws ${version}`;
+export const DefaultDeviceProperty = `@discordjs/ws [VI]{{inject}}[/VI]`;
 
 const getDefaultSessionStore = lazy(() => new Collection<number, SessionInfo | null>());
 

--- a/packages/ws/tsup.config.js
+++ b/packages/ws/tsup.config.js
@@ -1,3 +1,4 @@
+import { esbuildPluginVersionInjector } from 'esbuild-plugin-version-injector';
 import { createTsupConfig } from '../../tsup.config.js';
 
 export default createTsupConfig({
@@ -6,4 +7,5 @@ export default createTsupConfig({
 		worker: 'src/strategies/sharding/worker.ts',
 	},
 	external: ['zlib-sync'],
+	esbuildPlugins: [esbuildPluginVersionInjector()],
 });

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -15,6 +15,7 @@ export function createTsupConfig({
 	keepNames = true,
 	dts = true,
 	sourcemap = true,
+	esbuildPlugins = []
 } = {}) {
 	return defineConfig({
 		entry,
@@ -31,5 +32,6 @@ export function createTsupConfig({
 		keepNames,
 		dts,
 		sourcemap,
+		esbuildPlugins
 	});
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,6 +2210,7 @@ __metadata:
     cross-env: ^7.0.3
     discord-api-types: ^0.37.12
     downlevel-dts: ^0.10.1
+    esbuild-plugin-version-injector: ^1.0.0
     eslint: ^8.24.0
     eslint-config-neon: ^0.1.35
     file-type: ^18.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2029,6 +2029,7 @@ __metadata:
     cross-env: ^7.0.3
     discord-api-types: ^0.37.12
     downlevel-dts: ^0.10.1
+    esbuild-plugin-version-injector: ^1.0.0
     eslint: ^8.24.0
     eslint-config-neon: ^0.1.35
     fast-deep-equal: ^3.1.3
@@ -2051,6 +2052,7 @@ __metadata:
     "@vitest/coverage-c8": ^0.24.0
     cross-env: ^7.0.3
     downlevel-dts: ^0.10.1
+    esbuild-plugin-version-injector: ^1.0.0
     eslint: ^8.24.0
     eslint-config-neon: ^0.1.35
     prettier: ^2.7.1
@@ -2069,6 +2071,7 @@ __metadata:
     "@favware/cliff-jumper": ^1.8.8
     "@favware/npm-deprecate": ^1.0.5
     conventional-changelog-cli: ^2.2.2
+    esbuild-plugin-version-injector: ^1.0.0
     husky: ^8.0.1
     is-ci: ^3.0.1
     lint-staged: ^13.0.3
@@ -2207,6 +2210,7 @@ __metadata:
     cross-env: ^7.0.3
     discord-api-types: ^0.37.12
     downlevel-dts: ^0.10.1
+    esbuild-plugin-version-injector: ^1.0.0
     eslint: ^8.24.0
     eslint-config-neon: ^0.1.35
     file-type: ^18.0.0
@@ -2308,6 +2312,7 @@ __metadata:
     cross-env: ^7.0.3
     discord-api-types: ^0.37.12
     downlevel-dts: ^0.10.1
+    esbuild-plugin-version-injector: ^1.0.0
     eslint: ^8.24.0
     eslint-config-neon: ^0.1.35
     jest: ^29.1.2
@@ -2395,6 +2400,7 @@ __metadata:
     cross-env: ^7.0.3
     discord-api-types: ^0.37.12
     downlevel-dts: ^0.10.1
+    esbuild-plugin-version-injector: ^1.0.0
     eslint: ^8.24.0
     eslint-config-neon: ^0.1.35
     mock-socket: ^9.1.5
@@ -8651,6 +8657,15 @@ __metadata:
   version: 0.15.10
   resolution: "esbuild-openbsd-64@npm:0.15.10"
   conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"esbuild-plugin-version-injector@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "esbuild-plugin-version-injector@npm:1.0.0"
+  dependencies:
+    "@sapphire/result": ^2.5.0
+  checksum: 2a6eb3f2b3d3d24c6ca8af28925ad8e6f6d0a75f41cdb089bd76c7a74fbd6948d8f64563aa58bd65751054a28be0cfc081a0f56102a1952a5ba4ac541c2ff336
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2210,7 +2210,6 @@ __metadata:
     cross-env: ^7.0.3
     discord-api-types: ^0.37.12
     downlevel-dts: ^0.10.1
-    esbuild-plugin-version-injector: ^1.0.0
     eslint: ^8.24.0
     eslint-config-neon: ^0.1.35
     file-type: ^18.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2071,7 +2071,6 @@ __metadata:
     "@favware/cliff-jumper": ^1.8.8
     "@favware/npm-deprecate": ^1.0.5
     conventional-changelog-cli: ^2.2.2
-    esbuild-plugin-version-injector: ^1.0.0
     husky: ^8.0.1
     is-ci: ^3.0.1
     lint-staged: ^13.0.3


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Voice, Rest and WS were relying on package.json imports which were path specific and as shown in #8720 that is prone to errors. Not to mention that it also has downsides of either at runtime requiring a package.json file (voice) or having it inlined in the JS file (ws) by tsup, these are not ideal solutions.

The alternative: use an esbuild plugin to inject the version at build time so it's a constant string for end-users.

While adding it to the 3 packages mentioned above I figured might as well also add `version` exports to /collection and /builders, in case anyone is interested in having that information in their bots.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (**constants** added)