### PR TITLE
fix: correctly construct a builder

### DIFF
--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -109,7 +109,7 @@ function createComponentBuilder(data) {
     case ComponentType.SelectMenu:
       return new SelectMenuBuilder(data);
     case ComponentType.TextInput:
-      return new TextInputComponent(data);
+      return new TextInputBuilder(data);
     default:
       throw new Error(`Found unknown component type: ${data.type}`);
   }
@@ -124,6 +124,7 @@ const ButtonComponent = require('../structures/ButtonComponent');
 const Component = require('../structures/Component');
 const SelectMenuBuilder = require('../structures/SelectMenuBuilder');
 const SelectMenuComponent = require('../structures/SelectMenuComponent');
+const TextInputBuilder = require('../structures/TextInputBuilder');
 const TextInputComponent = require('../structures/TextInputComponent');
 
 /**


### PR DESCRIPTION
Fixes a bug where `createComponentBuilder` was constructing a `TextInputComponent` instead of a `TextInputBuilder`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating