### PR TITLE
fix: app paths

### DIFF
--- a/apps/guide/src/util/constants.ts
+++ b/apps/guide/src/util/constants.ts
@@ -1,3 +1,3 @@
 export const DESCRIPTION = 'Imagine a guide... that explores the many possibilities for your discord.js bot.';
 
-export const GITHUB_BASE_PAGES_PATH = 'https://github.com/discordjs/discord.js/tree/main/packages/guide/src/pages';
+export const GITHUB_BASE_PAGES_PATH = 'https://github.com/discordjs/discord.js/tree/main/apps/guide/src/pages';

--- a/apps/website/src/pages/docs/[...slug].tsx
+++ b/apps/website/src/pages/docs/[...slug].tsx
@@ -51,7 +51,10 @@ export const getStaticPaths: GetStaticPaths = async () => {
 					let data: any[] = [];
 					let versions: string[] = [];
 					if (process.env.NEXT_PUBLIC_LOCAL_DEV) {
-						const res = await readFile(join(cwd(), '..', packageName, 'docs', 'docs.api.json'), 'utf8');
+						const res = await readFile(
+							join(cwd(), '..', '..', 'packages', packageName, 'docs', 'docs.api.json'),
+							'utf8',
+						);
 						data = JSON.parse(res);
 					} else {
 						const response = await fetch(`https://docs.discordjs.dev/api/info?package=${packageName}`);
@@ -137,7 +140,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 	const [memberName, overloadIndex] = member?.split(':') ?? [];
 
 	try {
-		const readme = await readFile(join(cwd(), '..', packageName, 'README.md'), 'utf8');
+		const readme = await readFile(join(cwd(), '..', '..', 'packages', packageName, 'README.md'), 'utf8');
 
 		const mdxSource = await serialize(readme, {
 			mdxOptions: {
@@ -173,7 +176,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
 
 		let data;
 		if (process.env.NEXT_PUBLIC_LOCAL_DEV) {
-			const res = await readFile(join(cwd(), '..', packageName, 'docs', 'docs.api.json'), 'utf8');
+			const res = await readFile(join(cwd(), '..', '..', 'packages', packageName, 'docs', 'docs.api.json'), 'utf8');
 			data = JSON.parse(res);
 		} else {
 			const res = await fetch(`https://docs.discordjs.dev/docs/${packageName}/${branchName}.api.json`);
@@ -280,5 +283,5 @@ export default function SlugPage(props: Partial<SidebarLayoutProps & { error?: s
 }
 
 export const config = {
-	unstable_includeFiles: ['../{builders,collection,proxy,rest,util,voice,ws}/README.md'],
+	unstable_includeFiles: [`../../packages/{${PACKAGES.join(',')}}/README.md`],
 };

--- a/packages/actions/src/uploadCoverage/action.yml
+++ b/packages/actions/src/uploadCoverage/action.yml
@@ -3,6 +3,18 @@ description: 'Uploads code coverage reports to codecov with separate flags for s
 runs:
   using: 'composite'
   steps:
+    - name: Upload Guide Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./apps/guide/coverage/cobertura-coverage.xml
+        flags: guide
+
+    - name: Upload Website Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./apps/website/coverage/cobertura-coverage.xml
+        flags: website
+
     - name: Upload Builders Coverage
       uses: codecov/codecov-action@v3
       with:
@@ -56,15 +68,3 @@ runs:
       with:
         files: ./packages/actions/coverage/cobertura-coverage.xml, ./packages/scripts/coverage/cobertura-coverage.xml
         flags: utilities
-
-    - name: Upload Guide Coverage
-      uses: codecov/codecov-action@v3
-      with:
-        files: ./apps/guide/coverage/cobertura-coverage.xml
-        flags: guide
-
-    - name: Upload Website Coverage
-      uses: codecov/codecov-action@v3
-      with:
-        files: ./apps/website/coverage/cobertura-coverage.xml
-        flags: website

--- a/packages/actions/src/uploadCoverage/action.yml
+++ b/packages/actions/src/uploadCoverage/action.yml
@@ -39,12 +39,6 @@ runs:
         files: ./packages/voice/coverage/cobertura-coverage.xml
         flags: voice
 
-    - name: Upload Website Coverage
-      uses: codecov/codecov-action@v3
-      with:
-        files: ./packages/website/coverage/cobertura-coverage.xml
-        flags: website
-
     - name: Upload WS Coverage
       uses: codecov/codecov-action@v3
       with:
@@ -62,3 +56,15 @@ runs:
       with:
         files: ./packages/actions/coverage/cobertura-coverage.xml, ./packages/scripts/coverage/cobertura-coverage.xml
         flags: utilities
+
+    - name: Upload Guide Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./apps/guide/coverage/cobertura-coverage.xml
+        flags: guide
+
+    - name: Upload Website Coverage
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./apps/website/coverage/cobertura-coverage.xml
+        flags: website


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The guide and the website now live in /apps instead of /packages

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
