### PR TITLE
chore: make 'Note to developers' on version constant a regular comment

### DIFF
--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -44,8 +44,7 @@ export * from '@discordjs/util';
 /**
  * The [\@discordjs/builders](https://github.com/discordjs/discord.js/blob/main/packages/builders/#readme) version
  * that you are currently using.
- *
- * Note to developers: This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
  */
+// This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
 // eslint-disable-next-line @typescript-eslint/no-inferrable-types
 export const version: string = '[VI]{{inject}}[/VI]';

--- a/packages/collection/src/index.ts
+++ b/packages/collection/src/index.ts
@@ -3,8 +3,7 @@ export * from './collection.js';
 /**
  * The [\@discordjs/collection](https://github.com/discordjs/discord.js/blob/main/packages/collection/#readme) version
  * that you are currently using.
- *
- * Note to developers: This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
  */
+// This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
 // eslint-disable-next-line @typescript-eslint/no-inferrable-types
 export const version: string = '[VI]{{inject}}[/VI]';

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -10,8 +10,7 @@ export { makeURLSearchParams, parseResponse } from './lib/utils/utils.js';
 /**
  * The [\@discordjs/rest](https://github.com/discordjs/discord.js/blob/main/packages/rest/#readme) version
  * that you are currently using.
- *
- * Note to developers: This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
  */
+// This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
 // eslint-disable-next-line @typescript-eslint/no-inferrable-types
 export const version: string = '[VI]{{inject}}[/VI]';

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -23,8 +23,7 @@ export { type JoinConfig, getVoiceConnection, getVoiceConnections, getGroups } f
 /**
  * The [\@discordjs/voice](https://github.com/discordjs/discord.js/blob/main/packages/voice/#readme) version
  * that you are currently using.
- *
- * Note to developers: This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
  */
+// This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
 // eslint-disable-next-line @typescript-eslint/no-inferrable-types
 export const version: string = '[VI]{{inject}}[/VI]';

--- a/packages/ws/src/index.ts
+++ b/packages/ws/src/index.ts
@@ -13,10 +13,9 @@ export * from './ws/WebSocketManager.js';
 export * from './ws/WebSocketShard.js';
 
 /**
- * The [\@discordjs/voice](https://github.com/discordjs/discord.js/blob/main/packages/voice/#readme) version
+ * The [\@discordjs/ws](https://github.com/discordjs/discord.js/blob/main/packages/ws/#readme) version
  * that you are currently using.
- *
- * Note to developers: This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
  */
+// This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild
 // eslint-disable-next-line @typescript-eslint/no-inferrable-types
 export const version: string = '[VI]{{inject}}[/VI]';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Removed the "Note to developers" from the documentation
- Fixed the `ws` package link

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
