### PR TITLE
fix(WebSocketShard): dispatch race condition

### DIFF
--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -383,10 +383,6 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 
 		switch (payload.op) {
 			case GatewayOpcodes.Dispatch: {
-				if (this.status === WebSocketShardStatus.Ready || this.status === WebSocketShardStatus.Resuming) {
-					this.emit(WebSocketShardEvents.Dispatch, { data: payload });
-				}
-
 				if (this.status === WebSocketShardStatus.Resuming) {
 					this.replayedEvents++;
 				}
@@ -424,6 +420,8 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 					this.session.sequence = payload.s;
 					await this.strategy.updateSessionInfo(this.id, this.session);
 				}
+
+				this.emit(WebSocketShardEvents.Dispatch, { data: payload });
 
 				break;
 			}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Closes #8726

This is quite the "easy fix", by just removing the guard on dispatch events, since it was quite frankly unnecessary for a lib as low level as ws is.

Possibly related to #8558 (i.e. might improve the behavior there; otherwise that issue will need additional research)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

