### PR TITLE
chore: use `@link` instead of markdown link in tsdocs

### DIFF
--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -42,7 +42,7 @@ export * from './util/validation.js';
 export * from '@discordjs/util';
 
 /**
- * The [\@discordjs/builders](https://github.com/discordjs/discord.js/blob/main/packages/builders/#readme) version
+ * The {@link https://github.com/discordjs/discord.js/blob/main/packages/builders/#readme | @discordjs/builders} version
  * that you are currently using.
  */
 // This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild

--- a/packages/collection/src/index.ts
+++ b/packages/collection/src/index.ts
@@ -1,7 +1,7 @@
 export * from './collection.js';
 
 /**
- * The [\@discordjs/collection](https://github.com/discordjs/discord.js/blob/main/packages/collection/#readme) version
+ * The {@link https://github.com/discordjs/discord.js/blob/main/packages/collection/#readme | @discordjs/collection} version
  * that you are currently using.
  */
 // This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -8,7 +8,7 @@ export * from './lib/utils/constants.js';
 export { makeURLSearchParams, parseResponse } from './lib/utils/utils.js';
 
 /**
- * The [\@discordjs/rest](https://github.com/discordjs/discord.js/blob/main/packages/rest/#readme) version
+ * The {@link https://github.com/discordjs/discord.js/blob/main/packages/rest/#readme | @discordjs/rest} version
  * that you are currently using.
  */
 // This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -21,7 +21,7 @@ export {
 export { type JoinConfig, getVoiceConnection, getVoiceConnections, getGroups } from './DataStore';
 
 /**
- * The [\@discordjs/voice](https://github.com/discordjs/discord.js/blob/main/packages/voice/#readme) version
+ * The {@link https://github.com/discordjs/discord.js/blob/main/packages/voice/#readme | @discordjs/voice} version
  * that you are currently using.
  */
 // This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild

--- a/packages/ws/src/index.ts
+++ b/packages/ws/src/index.ts
@@ -13,7 +13,7 @@ export * from './ws/WebSocketManager.js';
 export * from './ws/WebSocketShard.js';
 
 /**
- * The [\@discordjs/ws](https://github.com/discordjs/discord.js/blob/main/packages/ws/#readme) version
+ * The {@link https://github.com/discordjs/discord.js/blob/main/packages/ws/#readme | @discordjs/ws} version
  * that you are currently using.
  */
 // This needs to explicitly be `string` so it is not typed as a "const string" that gets injected by esbuild


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
![image](https://user-images.githubusercontent.com/42935195/194939296-add7071f-3f18-4631-9c3b-553c1d038b33.png)

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
