### PR TITLE
refactor(Embed): use `embedLength` function from builders

### DIFF
--- a/packages/discord.js/src/structures/Embed.js
+++ b/packages/discord.js/src/structures/Embed.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { embedLength } = require('@discordjs/builders');
 const isEqual = require('fast-deep-equal');
 
 /**
@@ -181,13 +182,7 @@ class Embed {
    * @readonly
    */
   get length() {
-    return (
-      (this.data.title?.length ?? 0) +
-      (this.data.description?.length ?? 0) +
-      (this.data.fields?.reduce((prev, curr) => prev + curr.name.length + curr.value.length, 0) ?? 0) +
-      (this.data.footer?.text.length ?? 0) +
-      (this.data.author?.name.length ?? 0)
-    );
+    return embedLength(this.data);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Uses the [`embedLength()`](https://discordjs.dev/docs/packages/builders/main/embedLength:Function) function from /builders in `Embed#length` to reduce code duplication

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
