### PR TITLE
fix: extract text from link tags for descriptions

### DIFF
--- a/apps/website/src/util/summary.ts
+++ b/apps/website/src/util/summary.ts
@@ -4,6 +4,7 @@ import type {
 	DocCodeSpanJSON,
 	DocPlainTextJSON,
 	DocNodeContainerJSON,
+	DocLinkTagJSON,
 } from '@discordjs/api-extractor-utils';
 
 export function tryResolveDescription(member: ApiItemJSON) {
@@ -15,11 +16,23 @@ export function tryResolveDescription(member: ApiItemJSON) {
 
 	let retVal = '';
 
-	function recurseNodes(node: DocNodeJSON) {
+	function recurseNodes(node: DocNodeJSON, emitMarkdownLinks = false) {
 		switch (node.kind) {
 			case 'CodeSpan':
 				retVal += (node as DocCodeSpanJSON).code;
 				break;
+			case 'LinkTag': {
+				const { text, urlDestination } = node as DocLinkTagJSON;
+
+				if (text && urlDestination && emitMarkdownLinks) {
+					retVal += `[${text}](${urlDestination})`;
+				} else {
+					retVal += text ?? urlDestination ?? '';
+				}
+
+				break;
+			}
+
 			case 'PlainText':
 				retVal += (node as DocPlainTextJSON).text;
 				break;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously link tag text would be omitted in descriptions.