### PR TITLE
fix(BitField): remove hasParams parameters

### DIFF
--- a/packages/discord.js/src/util/BitField.js
+++ b/packages/discord.js/src/util/BitField.js
@@ -113,9 +113,7 @@ class BitField {
    * @returns {Object}
    */
   serialize() {
-    const serialized = {};
-    for (const [flag, bit] of Object.entries(this.constructor.Flags)) serialized[flag] = this.has(bit);
-    return serialized;
+    return Object.fromEntries(Object.entries(this.constructor.Flags).map(([flag, bit]) => [flag, this.has(bit)]));
   }
 
   /**

--- a/packages/discord.js/src/util/BitField.js
+++ b/packages/discord.js/src/util/BitField.js
@@ -64,11 +64,10 @@ class BitField {
   /**
    * Gets all given bits that are missing from the bitfield.
    * @param {BitFieldResolvable} bits Bit(s) to check for
-   * @param {...*} hasParams Additional parameters for the has method, if any
    * @returns {string[]}
    */
-  missing(bits, ...hasParams) {
-    return new this.constructor(bits).remove(this).toArray(...hasParams);
+  missing(bits) {
+    return new this.constructor(bits).remove(this).toArray();
   }
 
   /**
@@ -110,24 +109,21 @@ class BitField {
   }
 
   /**
-   * Gets an object mapping field names to a {@link boolean} indicating whether the
-   * bit is available.
-   * @param {...*} hasParams Additional parameters for the has method, if any
+   * Gets an object mapping field names to a {@link boolean} indicating whether the bit is available.
    * @returns {Object}
    */
-  serialize(...hasParams) {
+  serialize() {
     const serialized = {};
-    for (const [flag, bit] of Object.entries(this.constructor.Flags)) serialized[flag] = this.has(bit, ...hasParams);
+    for (const [flag, bit] of Object.entries(this.constructor.Flags)) serialized[flag] = this.has(bit);
     return serialized;
   }
 
   /**
    * Gets an {@link Array} of bitfield names based on the bits available.
-   * @param {...*} hasParams Additional parameters for the has method, if any
    * @returns {string[]}
    */
-  toArray(...hasParams) {
-    return Object.keys(this.constructor.Flags).filter(bit => this.has(bit, ...hasParams));
+  toArray() {
+    return Object.keys(this.constructor.Flags).filter(bit => this.has(bit));
   }
 
   toJSON() {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -548,10 +548,10 @@ export class BitField<S extends string, N extends number | bigint = number> {
   public equals(bit: BitFieldResolvable<S, N>): boolean;
   public freeze(): Readonly<BitField<S, N>>;
   public has(bit: BitFieldResolvable<S, N>): boolean;
-  public missing(bits: BitFieldResolvable<S, N>, ...hasParams: readonly unknown[]): S[];
+  public missing(bits: BitFieldResolvable<S, N>): S[];
   public remove(...bits: BitFieldResolvable<S, N>[]): BitField<S, N>;
-  public serialize(...hasParams: readonly unknown[]): Record<S, boolean>;
-  public toArray(...hasParams: readonly unknown[]): S[];
+  public serialize(): Record<S, boolean>;
+  public toArray(): S[];
   public toJSON(): N extends number ? number : string;
   public valueOf(): N;
   public [Symbol.iterator](): IterableIterator<S>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`has()` never had any more parameters
https://github.com/discordjs/discord.js/blob/bf9aa1858dab2e1bca3be390ce2392b99d208dbf/packages/discord.js/src/util/BitField.js#L59-L62

Also cleaned up the `serialize()` method

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
