### PR TITLE
refactor(InteractionResponses): make `InteractionResponses.followUp()` unusable after deferring

### DIFF
--- a/packages/discord.js/src/errors/ErrorCodes.js
+++ b/packages/discord.js/src/errors/ErrorCodes.js
@@ -128,6 +128,7 @@
  * @property {'InteractionAlreadyReplied'} InteractionAlreadyReplied
  * @property {'InteractionNotReplied'} InteractionNotReplied
  * @property {'InteractionEphemeralReplied'} InteractionEphemeralReplied
+ * @property {'InteractionBeenDeferred'} InteractionBeenDeferred
 
  * @property {'CommandInteractionOptionNotFound'} CommandInteractionOptionNotFound
  * @property {'CommandInteractionOptionType'} CommandInteractionOptionType

--- a/packages/discord.js/src/errors/Messages.js
+++ b/packages/discord.js/src/errors/Messages.js
@@ -137,6 +137,7 @@ const Messages = {
   [DjsErrorCodes.InteractionAlreadyReplied]: 'The reply to this interaction has already been sent or deferred.',
   [DjsErrorCodes.InteractionNotReplied]: 'The reply to this interaction has not been sent or deferred.',
   [DjsErrorCodes.InteractionEphemeralReplied]: 'Ephemeral responses cannot be deleted.',
+  [DjsErrorCodes.InteractionBeenDeferred]: 'You cannot use followUp() after the interaction been deferred.',
 
   [DjsErrorCodes.CommandInteractionOptionNotFound]: name => `Required option "${name}" not found.`,
   [DjsErrorCodes.CommandInteractionOptionType]: (name, type, expected) =>

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -174,6 +174,7 @@ class InteractionResponses {
    * @returns {Promise<Message>}
    */
   followUp(options) {
+    if (this.deferred && !this.replied) return Promise.reject(new DiscordjsError(ErrorCodes.InteractionBeenDeferred));
     if (!this.deferred && !this.replied) return Promise.reject(new DiscordjsError(ErrorCodes.InteractionNotReplied));
     return this.webhook.send(options);
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I think it's better to make `InteractionResponses.followUp()` unusable after deferring.
*I'm not sure if I did it correctly. I wasn't sure if it was really needed to create another error code and if the error code's message is correctly written. And also I didn't touch at types or tests because firstly I think they don't need to get changed and secondly, I just don't know how to edit them.* ._.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)