### PR TITLE
feat(InteractionResponses): add message parameter

### DIFF
--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -136,21 +136,22 @@ class InteractionResponses {
   }
 
   /**
-   * Edits the initial reply to this interaction.
+   * Edits a reply to this interaction.
    * @see Webhook#editMessage
    * @param {string|MessagePayload|WebhookEditMessageOptions} options The new options for the message
+   * @param {MessageResolvable|"@original"} [message="@original"] The response to edit
    * @returns {Promise<Message>}
    * @example
-   * // Edit the reply to this interaction
+   * // Edit the initial reply to this interaction
    * interaction.editReply('New content')
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async editReply(options) {
+  async editReply(options, message = '@original') {
     if (!this.deferred && !this.replied) throw new DiscordjsError(ErrorCodes.InteractionNotReplied);
-    const message = await this.webhook.editMessage('@original', options);
+    const msg = await this.webhook.editMessage(message, options);
     this.replied = true;
-    return message;
+    return msg;
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -442,6 +442,7 @@ export abstract class CommandInteraction<Cached extends CacheType = CacheType> e
   public deleteReply(): Promise<void>;
   public editReply(
     options: string | MessagePayload | WebhookEditMessageOptions,
+    message?: MessageResolvable | '@original',
   ): Promise<Message<BooleanCache<Cached>>>;
   public fetchReply(): Promise<Message<BooleanCache<Cached>>>;
   public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message<BooleanCache<Cached>>>;
@@ -1832,6 +1833,7 @@ export class MessageComponentInteraction<Cached extends CacheType = CacheType> e
   public deleteReply(): Promise<void>;
   public editReply(
     options: string | MessagePayload | WebhookEditMessageOptions,
+    message?: MessageResolvable | '@original',
   ): Promise<Message<BooleanCache<Cached>>>;
   public fetchReply(): Promise<Message<BooleanCache<Cached>>>;
   public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message<BooleanCache<Cached>>>;
@@ -2022,6 +2024,7 @@ export class ModalSubmitInteraction<Cached extends CacheType = CacheType> extend
   public deleteReply(): Promise<void>;
   public editReply(
     options: string | MessagePayload | WebhookEditMessageOptions,
+    message?: MessageResolvable | '@original',
   ): Promise<Message<BooleanCache<Cached>>>;
   public deferReply(
     options: InteractionDeferReplyOptions & { fetchReply: true },


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a parameter to `InteractionResponses#editReply()` that lets you choose which message to edit.
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
