### PR TITLE
fix: make ratelimit timeout require event loop to be active

### DIFF
--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -460,7 +460,7 @@ export class SequentialHandler implements IHandler {
 
 				this.#sublimitPromise?.resolve();
 				this.#sublimitPromise = null;
-				await sleep(sublimitTimeout, undefined);
+				await sleep(sublimitTimeout);
 				let resolve: () => void;
 				// eslint-disable-next-line promise/param-names, no-promise-executor-return
 				const promise = new Promise<void>((res) => (resolve = res));

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -137,7 +137,7 @@ export class SequentialHandler implements IHandler {
 	 * @param time - The amount of time to delay all requests for
 	 */
 	private async globalDelayFor(time: number): Promise<void> {
-		await sleep(time, undefined, { ref: false });
+		await sleep(time, undefined);
 		this.manager.globalDelay = null;
 	}
 
@@ -460,7 +460,7 @@ export class SequentialHandler implements IHandler {
 
 				this.#sublimitPromise?.resolve();
 				this.#sublimitPromise = null;
-				await sleep(sublimitTimeout, undefined, { ref: false });
+				await sleep(sublimitTimeout, undefined);
 				let resolve: () => void;
 				// eslint-disable-next-line promise/param-names, no-promise-executor-return
 				const promise = new Promise<void>((res) => (resolve = res));

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -137,7 +137,7 @@ export class SequentialHandler implements IHandler {
 	 * @param time - The amount of time to delay all requests for
 	 */
 	private async globalDelayFor(time: number): Promise<void> {
-		await sleep(time, undefined);
+		await sleep(time);
 		this.manager.globalDelay = null;
 	}
 


### PR DESCRIPTION
related to #8757

The ``ref`` option doesn't require the Node.js event loop to remain active when waiting for the timeout causing the program to end if there isn't an active gateway connection.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

