### PR TITLE
feat: allow punctuation characters in context menus

### DIFF
--- a/packages/builders/src/interactions/contextMenuCommands/Assertions.ts
+++ b/packages/builders/src/interactions/contextMenuCommands/Assertions.ts
@@ -7,7 +7,7 @@ const namePredicate = s.string
 	.lengthGreaterThanOrEqual(1)
 	.lengthLessThanOrEqual(32)
 	// eslint-disable-next-line prefer-named-capture-group, unicorn/no-unsafe-regex
-	.regex(/^( *[\p{L}\p{N}\p{sc=Devanagari}\p{sc=Thai}_-]+ *)+$/u)
+	.regex(/^( *[\p{P}\p{L}\p{N}\p{sc=Devanagari}\p{sc=Thai}]+ *)+$/u)
 	.setValidationEnabled(isValidationEnabled);
 const typePredicate = s
 	.union(s.literal(ApplicationCommandType.User), s.literal(ApplicationCommandType.Message))


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Current regex validation in the context menu builder only allows - and _  
Fixes #8781
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
