### PR TITLE
feat: support resume urls

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -63,14 +63,14 @@ class WebSocketShard extends EventEmitter {
      * @private
      */
     this.sessionId = null;
-    
+
     /**
      * The resume url for this shard
      * @type {?string}
      * @private
      */
     this.resumeUrl = null;
-    
+
     /**
      * The previous heartbeat ping of the shard
      * @type {number}
@@ -207,7 +207,7 @@ class WebSocketShard extends EventEmitter {
     }
 
     const gateway = this.resumeUrl || this.manager.gateway;
-    
+
     return new Promise((resolve, reject) => {
       const cleanup = () => {
         this.removeListener(WebSocketShardEvents.Close, onClose);
@@ -425,7 +425,7 @@ class WebSocketShard extends EventEmitter {
         this.emit(WebSocketShardEvents.Ready);
 
         this.sessionId = packet.d.session_id;
-        this.resumeUrl = packet.d.resume_gateway_url
+        this.resumeUrl = packet.d.resume_gateway_url;
         this.expectedGuilds = new Set(packet.d.guilds.map(d => d.id));
         this.status = Status.WaitingForGuilds;
         this.debug(`[READY] Session ${this.sessionId} | Resume url ${this.resumeUrl}.`);

--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -852,10 +852,11 @@ class WebSocketShard extends EventEmitter {
     // Step 4: Cache the old sequence (use to attempt a resume)
     if (this.sequence !== -1) this.closeSequence = this.sequence;
 
-    // Step 5: Reset the sequence and session id if requested
+    // Step 5: Reset the sequence, resume url and session id if requested
     if (reset) {
       this.sequence = -1;
       this.sessionId = null;
+      this.resumeUrl = null;
     }
 
     // Step 6: reset the rate limit data

--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -69,7 +69,7 @@ class WebSocketShard extends EventEmitter {
      * @type {?string}
      * @private
      */
-    this.resumeUrl = null;
+    this.resumeURL = null;
 
     /**
      * The previous heartbeat ping of the shard
@@ -206,7 +206,7 @@ class WebSocketShard extends EventEmitter {
       return Promise.resolve();
     }
 
-    const gateway = this.resumeUrl ?? this.manager.gateway;
+    const gateway = this.resumeURL ?? this.manager.gateway;
 
     return new Promise((resolve, reject) => {
       const cleanup = () => {
@@ -425,10 +425,10 @@ class WebSocketShard extends EventEmitter {
         this.emit(WebSocketShardEvents.Ready);
 
         this.sessionId = packet.d.session_id;
-        this.resumeUrl = packet.d.resume_gateway_url;
+        this.resumeURL = packet.d.resume_gateway_url;
         this.expectedGuilds = new Set(packet.d.guilds.map(d => d.id));
         this.status = Status.WaitingForGuilds;
-        this.debug(`[READY] Session ${this.sessionId} | Resume url ${this.resumeUrl}.`);
+        this.debug(`[READY] Session ${this.sessionId} | Resume url ${this.resumeURL}.`);
         this.lastHeartbeatAcked = true;
         this.sendHeartbeat('ReadyHeartbeat');
         break;
@@ -856,7 +856,7 @@ class WebSocketShard extends EventEmitter {
     if (reset) {
       this.sequence = -1;
       this.sessionId = null;
-      this.resumeUrl = null;
+      this.resumeURL = null;
     }
 
     // Step 6: reset the rate limit data

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2994,7 +2994,7 @@ export class WebSocketShard extends EventEmitter {
   private sequence: number;
   private closeSequence: number;
   private sessionId: string | null;
-  private resumeUrl: string | null;
+  private resumeURL: string | null;
   private lastPingTimestamp: number;
   private lastHeartbeatAcked: boolean;
   private readonly ratelimit: {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2994,6 +2994,7 @@ export class WebSocketShard extends EventEmitter {
   private sequence: number;
   private closeSequence: number;
   private sessionId: string | null;
+  private resumeUrl: string | null;
   private lastPingTimestamp: number;
   private lastHeartbeatAcked: boolean;
   private readonly ratelimit: {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resume urls was not added in v14 despite on changelogs saying it is, was only added on `@discordjs/ws`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

