### PR TITLE
chore: bump dapi-types etc. of djs v13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "discord.js",
-  "version": "13.11.0",
+  "version": "13.12.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "discord.js",
-      "version": "13.11.0",
+      "version": "13.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/builders": "^0.16.0",
-        "@discordjs/collection": "^0.7.0",
+        "@discordjs/builders": "^1.3.0",
+        "@discordjs/collection": "^1.2.0",
         "@sapphire/async-queue": "^1.5.0",
         "@types/node-fetch": "^2.6.2",
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.33.5",
+        "discord-api-types": "^0.37.15",
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.7",
         "ws": "^8.9.0"
@@ -1000,13 +1000,13 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
-      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
-      "deprecated": "no longer supported",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.3.0.tgz",
+      "integrity": "sha512-Pvca6Nw8Hp+n3N+Wp17xjygXmMvggbh5ywUsOYE2Et4xkwwVRwgzxDJiMUuYapPtnYt4w/8aKlf5khc8ipLvhg==",
       "dependencies": {
-        "@sapphire/shapeshift": "^3.5.1",
-        "discord-api-types": "^0.36.2",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/shapeshift": "^3.7.0",
+        "discord-api-types": "^0.37.12",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.1",
         "tslib": "^2.4.0"
@@ -1015,16 +1015,10 @@
         "node": ">=16.9.0"
       }
     },
-    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
-      "version": "0.36.3",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-      "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
-    },
     "node_modules/@discordjs/collection": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA==",
-      "deprecated": "no longer supported",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.2.0.tgz",
+      "integrity": "sha512-VvrrtGb7vbfPHzbhGq9qZB5o8FOB+kfazrxdt0OtxzSkoBuw9dURMkCwWizZ00+rDpiK2HmLHBZX+y6JsG9khw==",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -1670,6 +1664,14 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
+      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ==",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -2439,9 +2441,9 @@
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.6.0.tgz",
-      "integrity": "sha512-tu2WLRdo5wotHRvsCkspg3qMiP6ETC3Q1dns1Q5V6zKUki+1itq6AbhMwohF9ZcLoYqg+Y8LkgRRtVxxTQVTBQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.7.0.tgz",
+      "integrity": "sha512-A6vI1zJoxhjWo4grsxpBRBgk96SqSdjLX5WlzKp9H+bJbkM07mvwcbtbVAmUZHbi/OG3HLfiZ1rlw4BhH6tsBQ==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash.uniqwith": "^4.5.0"
@@ -4545,9 +4547,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+      "version": "0.37.15",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.15.tgz",
+      "integrity": "sha512-2SpscsamTtctJflnz1J6cPp99PLs10DNGi2rrOdjID3KhP1nwsoJHPvcLe6zwcYxZnRdA/71M85RCNOQl83u1A=="
     },
     "node_modules/dmd": {
       "version": "4.0.6",
@@ -13478,28 +13480,22 @@
       }
     },
     "@discordjs/builders": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.16.0.tgz",
-      "integrity": "sha512-9/NCiZrLivgRub2/kBc0Vm5pMBE5AUdYbdXsLu/yg9ANgvnaJ0bZKTY8yYnLbsEc/LYUP79lEIdC73qEYhWq7A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.3.0.tgz",
+      "integrity": "sha512-Pvca6Nw8Hp+n3N+Wp17xjygXmMvggbh5ywUsOYE2Et4xkwwVRwgzxDJiMUuYapPtnYt4w/8aKlf5khc8ipLvhg==",
       "requires": {
-        "@sapphire/shapeshift": "^3.5.1",
-        "discord-api-types": "^0.36.2",
+        "@discordjs/util": "^0.1.0",
+        "@sapphire/shapeshift": "^3.7.0",
+        "discord-api-types": "^0.37.12",
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.1",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "discord-api-types": {
-          "version": "0.36.3",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.36.3.tgz",
-          "integrity": "sha512-bz/NDyG0KBo/tY14vSkrwQ/n3HKPf87a0WFW/1M9+tXYK+vp5Z5EksawfCWo2zkAc6o7CClc0eff1Pjrqznlwg=="
-        }
       }
     },
     "@discordjs/collection": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
-      "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.2.0.tgz",
+      "integrity": "sha512-VvrrtGb7vbfPHzbhGq9qZB5o8FOB+kfazrxdt0OtxzSkoBuw9dURMkCwWizZ00+rDpiK2HmLHBZX+y6JsG9khw=="
     },
     "@discordjs/docgen": {
       "version": "0.11.1",
@@ -13993,6 +13989,11 @@
           }
         }
       }
+    },
+    "@discordjs/util": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.1.0.tgz",
+      "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
     },
     "@eslint/eslintrc": {
       "version": "1.3.3",
@@ -14594,9 +14595,9 @@
       "dev": true
     },
     "@sapphire/shapeshift": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.6.0.tgz",
-      "integrity": "sha512-tu2WLRdo5wotHRvsCkspg3qMiP6ETC3Q1dns1Q5V6zKUki+1itq6AbhMwohF9ZcLoYqg+Y8LkgRRtVxxTQVTBQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.7.0.tgz",
+      "integrity": "sha512-A6vI1zJoxhjWo4grsxpBRBgk96SqSdjLX5WlzKp9H+bJbkM07mvwcbtbVAmUZHbi/OG3HLfiZ1rlw4BhH6tsBQ==",
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "lodash.uniqwith": "^4.5.0"
@@ -16265,9 +16266,9 @@
       }
     },
     "discord-api-types": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+      "version": "0.37.15",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.15.tgz",
+      "integrity": "sha512-2SpscsamTtctJflnz1J6cPp99PLs10DNGi2rrOdjID3KhP1nwsoJHPvcLe6zwcYxZnRdA/71M85RCNOQl83u1A=="
     },
     "dmd": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
   },
   "homepage": "https://discord.js.org",
   "dependencies": {
-    "@discordjs/builders": "^0.16.0",
-    "@discordjs/collection": "^0.7.0",
+    "@discordjs/builders": "^1.3.0",
+    "@discordjs/collection": "^1.2.0",
     "@sapphire/async-queue": "^1.5.0",
     "@types/node-fetch": "^2.6.2",
     "@types/ws": "^8.5.3",
-    "discord-api-types": "^0.33.5",
+    "discord-api-types": "^0.37.15",
     "form-data": "^4.0.0",
     "node-fetch": "^2.6.7",
     "ws": "^8.9.0"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`discord-api-types` had been introducing some breaking changes during 4 minor releases and I encountered one of their side-effect.

<details>
<summary>The error I met (trivial)</summary>

I encountered following TS error while working on my djs v13 bot:

```
Error when loading 'C:\Dev\Personal\yuzubot\src\commands\Basic\ping.ts': src/commands/Basic/ping.ts:49:25 - error TS2379: Argument of type 'APIMessage | Message<boolean>' is not assignable to parameter of type 'Message<boolean> | APIMessage' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
  Type 'APIMessage' is not assignable to type 'Message<boolean> | APIMessage' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
    Type 'import("C:/Dev/Personal/yuzubot/node_modules/.pnpm/discord-api-types@0.33.5/node_modules/discord-api-types/payloads/v9/channel").APIMessage' is not assignable to type 'import("C:/Dev/Personal/yuzubot/node_modules/.pnpm/discord-api-types@0.37.15/node_modules/discord-api-types/payloads/v9/channel").APIMessage' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
```

</details>

This PR also bumps `@discordjs/builders` and `@discordjs/collection` to their v1 releases. (mainly in order to get rid of warnings)

I'm not sure if bumping `@discordjs/collection` from v0.7 to latest has no problem because there was v0.8.  `@discordjs/builders` is OK because its v0.16 was as same as v1.0.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
