### PR TITLE
fix(escapeMarkdown): fix double escaping (v13)

### DIFF
--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -199,6 +199,7 @@ class Util extends null {
         })
         .join(inlineCode ? '\\`' : '`');
     }
+    if (escape) text = Util.escapeEscape(text);
     if (inlineCode) text = Util.escapeInlineCode(text);
     if (codeBlock) text = Util.escapeCodeBlock(text);
     if (italic) text = Util.escapeItalic(text);
@@ -206,7 +207,6 @@ class Util extends null {
     if (underline) text = Util.escapeUnderline(text);
     if (strikethrough) text = Util.escapeStrikethrough(text);
     if (spoiler) text = Util.escapeSpoiler(text);
-    if (escape) text = Util.escapeEscape(text);
     if (heading) text = Util.escapeHeading(text);
     if (bulletedList) text = Util.escapeBulletedList(text);
     if (numberedList) text = Util.escapeNumberedList(text);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Backports #8798 to v13
Regressed by #8703
**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
