### PR TITLE
fix: backport allow deletion of ephemeral messages to v13

### DIFF
--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -145,6 +145,8 @@ const Messages = {
 
   INTERACTION_ALREADY_REPLIED: 'The reply to this interaction has already been sent or deferred.',
   INTERACTION_NOT_REPLIED: 'The reply to this interaction has not been sent or deferred.',
+  /** @deprecated */
+  INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be deleted.',
 
   COMMAND_INTERACTION_OPTION_NOT_FOUND: name => `Required option "${name}" not found.`,
   COMMAND_INTERACTION_OPTION_TYPE: (name, type, expected) =>

--- a/src/errors/Messages.js
+++ b/src/errors/Messages.js
@@ -145,7 +145,6 @@ const Messages = {
 
   INTERACTION_ALREADY_REPLIED: 'The reply to this interaction has already been sent or deferred.',
   INTERACTION_NOT_REPLIED: 'The reply to this interaction has not been sent or deferred.',
-  INTERACTION_EPHEMERAL_REPLIED: 'Ephemeral responses cannot be deleted.',
 
   COMMAND_INTERACTION_OPTION_NOT_FOUND: name => `Required option "${name}" not found.`,
   COMMAND_INTERACTION_OPTION_TYPE: (name, type, expected) =>

--- a/src/structures/interfaces/InteractionResponses.js
+++ b/src/structures/interfaces/InteractionResponses.js
@@ -156,7 +156,6 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   async deleteReply() {
-    if (this.ephemeral) throw new Error('INTERACTION_EPHEMERAL_REPLIED');
     await this.webhook.deleteMessage('@original');
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Backport allow deletion of ephemeral messages to v13 from [this commit](https://github.com/discordjs/discord.js/commit/fc107744618857bf28c2167f204253baf690ede8)
It's my first pull request to discord.js so I don't know if I did it right

**Status and versioning classification:**
> None
