### PR TITLE
feat(ApplicationCommand): add `toString()`

### DIFF
--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -399,8 +399,9 @@ class ApplicationCommand extends Base {
   }
   
   /**
-   * When concatenated with a string, if this is a chat input command,
-   * this automatically returns the command's mention instead of the ApplicationCommand object.
+   * When concatenated with a string, this automatically returns the command's mention
+   * instead of the ApplicationCommand object.
+   * <info>This only works with {@link ChatInputCommandInteraction}s.</info>
    * @returns {string}
    * @example
    * // Logs: Command: </ping:123456789012345678>

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -2,7 +2,7 @@
 
 const { chatInputApplicationCommandMention } = require('@discordjs/builders');
 const { DiscordSnowflake } = require('@sapphire/snowflake');
-const { ApplicationCommandOptionType } = require('discord-api-types/v10');
+const { ApplicationCommandOptionType, ApplicationCommandType } = require('discord-api-types/v10');
 const isEqual = require('fast-deep-equal');
 const Base = require('./Base');
 const ApplicationCommandPermissionsManager = require('../managers/ApplicationCommandPermissionsManager');

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -399,7 +399,8 @@ class ApplicationCommand extends Base {
   }
   
   /**
-   * When concatenated with a string, if this is a chat input command, this automatically returns the command's mention instead of the ApplicationCommand object.
+   * When concatenated with a string, if this is a chat input command,
+   * this automatically returns the command's mention instead of the ApplicationCommand object.
    * @returns {string}
    * @example
    * // Logs: Command: </ping:123456789012345678>

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -408,7 +408,7 @@ class ApplicationCommand extends Base {
   toString() {
     return this.type === ApplicationCommandType.ChatInput
       ? chatInputApplicationCommandMention(this.name, this.id)
-      : '[object Object]';
+      : super.toString();
   }
 
   /**

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -396,6 +396,17 @@ class ApplicationCommand extends Base {
     }
     return true;
   }
+  
+  /**
+   * When concatenated with a string, this automatically returns the command's mention instead of the ApplicationCommand object.
+   * @returns {string}
+   * @example
+   * // Logs: Command: </ping:123456789012345678>
+   * console.log(`Command: ${command}`);
+   */
+  toString() {
+    return `</${this.name}:${this.id}>`
+  }
 
   /**
    * Recursively checks that all options for an {@link ApplicationCommand} are equal to the provided options.

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { chatInputApplicationCommandMention } = require('@discordjs/builders');
 const { DiscordSnowflake } = require('@sapphire/snowflake');
 const { ApplicationCommandOptionType } = require('discord-api-types/v10');
 const isEqual = require('fast-deep-equal');
@@ -405,7 +406,7 @@ class ApplicationCommand extends Base {
    * console.log(`Command: ${command}`);
    */
   toString() {
-    return `</${this.name}:${this.id}>`
+    return chatInputApplicationCommandMention(`${this.name}`, this.id);
   }
 
   /**

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -399,7 +399,7 @@ class ApplicationCommand extends Base {
   }
   
   /**
-   * When concatenated with a string, this automatically returns the command's mention instead of the ApplicationCommand object.
+   * When concatenated with a string, if this is a chat input command, this automatically returns the command's mention instead of the ApplicationCommand object.
    * @returns {string}
    * @example
    * // Logs: Command: </ping:123456789012345678>

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -406,7 +406,7 @@ class ApplicationCommand extends Base {
    * console.log(`Command: ${command}`);
    */
   toString() {
-    return chatInputApplicationCommandMention(`${this.name}`, this.id);
+    return chatInputApplicationCommandMention(this.name, this.id);
   }
 
   /**

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -406,7 +406,9 @@ class ApplicationCommand extends Base {
    * console.log(`Command: ${command}`);
    */
   toString() {
-    return chatInputApplicationCommandMention(this.name, this.id);
+    return this.type === ApplicationCommandType.ChatInput
+      ? chatInputApplicationCommandMention(this.name, this.id)
+      : '[object Object]';
   }
 
   /**

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -401,7 +401,7 @@ class ApplicationCommand extends Base {
   /**
    * When concatenated with a string, this automatically returns the command's mention
    * instead of the ApplicationCommand object.
-   * <info>This only works with {@link ChatInputCommandInteraction}s.</info>
+   * <info>This only works with chat input application commands.</info>
    * @returns {string}
    * @example
    * // Logs: Command: </ping:123456789012345678>

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -376,7 +376,7 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
     command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData,
     enforceOptionOrder?: boolean,
   ): boolean;
-  public toString(): ChatInputApplicationCommandMention;
+  public toString(): ChatInputApplicationCommandMention | string;
   public static optionsEqual(
     existing: ApplicationCommandOption[],
     options: ApplicationCommandOption[] | ApplicationCommandOptionData[] | APIApplicationCommandOption[],

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -376,6 +376,7 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
     command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData,
     enforceOptionOrder?: boolean,
   ): boolean;
+  public toString(): ApplicationCommandMention;
   public static optionsEqual(
     existing: ApplicationCommandOption[],
     options: ApplicationCommandOption[] | ApplicationCommandOptionData[] | APIApplicationCommandOption[],
@@ -4118,6 +4119,8 @@ export type ApplicationCommandData =
   | UserApplicationCommandData
   | MessageApplicationCommandData
   | ChatInputApplicationCommandData;
+
+export type ApplicationCommandMention = `</${string}:${Snowflake}>`;
 
 export interface ApplicationCommandChannelOptionData extends BaseApplicationCommandOptionsData {
   type: CommandOptionChannelResolvableType;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -376,7 +376,7 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
     command: ApplicationCommand | ApplicationCommandData | RawApplicationCommandData,
     enforceOptionOrder?: boolean,
   ): boolean;
-  public toString(): ApplicationCommandMention;
+  public toString(): ChatInputApplicationCommandMention;
   public static optionsEqual(
     existing: ApplicationCommandOption[],
     options: ApplicationCommandOption[] | ApplicationCommandOptionData[] | APIApplicationCommandOption[],
@@ -4120,8 +4120,6 @@ export type ApplicationCommandData =
   | MessageApplicationCommandData
   | ChatInputApplicationCommandData;
 
-export type ApplicationCommandMention = `</${string}:${Snowflake}>`;
-
 export interface ApplicationCommandChannelOptionData extends BaseApplicationCommandOptionsData {
   type: CommandOptionChannelResolvableType;
   channelTypes?: ChannelType[];
@@ -4489,6 +4487,8 @@ export interface ChannelWebhookCreateOptions {
 export interface WebhookCreateOptions extends ChannelWebhookCreateOptions {
   channel: TextChannel | NewsChannel | VoiceChannel | ForumChannel | Snowflake;
 }
+
+export type ChatInputApplicationCommandMention = `</${string}:${Snowflake}>`;
 
 export interface ClientEvents {
   applicationCommandPermissionsUpdate: [data: ApplicationCommandPermissionsUpdateData];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds `ApplicationCommand#toString()` in the format of `</name:id>` mentions.  Please note that this does not currently account for subcommands: Discord still highlights the mention if only the base command name is in the mentions, however it is unclickable.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
