### PR TITLE
docs: add `@extends` for select menu classes

### DIFF
--- a/packages/discord.js/src/structures/SelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuBuilder.js
@@ -7,6 +7,7 @@ let deprecationEmitted = false;
 
 /**
  * @deprecated Use {@link StringSelectMenuBuilder} instead.
+ * @extends {StringSelectMenuBuilder}
  */
 class SelectMenuBuilder extends StringSelectMenuBuilder {
   constructor(...params) {

--- a/packages/discord.js/src/structures/SelectMenuComponent.js
+++ b/packages/discord.js/src/structures/SelectMenuComponent.js
@@ -7,6 +7,7 @@ let deprecationEmitted = false;
 
 /**
  * @deprecated Use {@link StringSelectMenuComponent} instead.
+ * @extends {StringSelectMenuComponent}
  */
 class SelectMenuComponent extends StringSelectMenuComponent {
   constructor(...params) {

--- a/packages/discord.js/src/structures/SelectMenuInteraction.js
+++ b/packages/discord.js/src/structures/SelectMenuInteraction.js
@@ -7,6 +7,7 @@ let deprecationEmitted = false;
 
 /**
  * @deprecated Use {@link StringSelectMenuInteraction} instead.
+ * @extends {StringSelectMenuInteraction}
  */
 class SelectMenuInteraction extends StringSelectMenuInteraction {
   constructor(...params) {

--- a/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
+++ b/packages/discord.js/src/structures/SelectMenuOptionBuilder.js
@@ -7,6 +7,7 @@ let deprecationEmitted = false;
 
 /**
  * @deprecated Use {@link StringSelectMenuOptionBuilder} instead.
+ * @extends {StringSelectMenuOptionBuilder}
  */
 class SelectMenuOptionBuilder extends StringSelectMenuOptionBuilder {
   constructor(...params) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the `@extends` to the old select menu classes. Without these, the docs didn't show any methods or properties.
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
