### PR TITLE
fix: support `discordapp.com` webhook URLs

### DIFF
--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -585,7 +585,7 @@ function cleanCodeBlockContent(text) {
  */
 function parseWebhookURL(url) {
   const matches = url.match(
-    /https?:\/\/(?:ptb\.|canary\.)?discord\.com\/api(?:\/v\d{1,2})?\/webhooks\/(\d{17,19})\/([\w-]{68})/i,
+    /https?:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api(?:\/v\d{1,2})?\/webhooks\/(\d{17,19})\/([\w-]{68})/i,
   );
 
   if (!matches || matches.length <= 2) return null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Webhook URLs copied from Discord are no longer considered valid.  They are in the format `https://discordapp.com/api/webhooks/{ID}/{TOKEN}` now it seems.

This updates the regex to support such URLs and continue to parse it successfully.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
