### PR TITLE
feat: Rename interaction methods

### DIFF
--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -205,15 +205,15 @@ class CommandInteraction extends BaseInteraction {
   /* eslint-disable no-empty-function */
   deferReply() {}
   reply() {}
-  fetchReply() {}
-  editReply() {}
-  deleteReply() {}
+  fetchResponse() {}
+  editResponse() {}
+  deleteResponse() {}
   followUp() {}
   showModal() {}
   awaitModalSubmit() {}
 }
 
-InteractionResponses.applyToClass(CommandInteraction, ['deferUpdate', 'update']);
+InteractionResponses.applyToClass(CommandInteraction, ['deferMessageUpdate', 'updateMessage']);
 
 module.exports = CommandInteraction;
 

--- a/packages/discord.js/src/structures/MessageComponentInteraction.js
+++ b/packages/discord.js/src/structures/MessageComponentInteraction.js
@@ -87,12 +87,12 @@ class MessageComponentInteraction extends BaseInteraction {
   /* eslint-disable no-empty-function */
   deferReply() {}
   reply() {}
-  fetchReply() {}
-  editReply() {}
-  deleteReply() {}
+  fetchResponse() {}
+  editResponse() {}
+  deleteResponse() {}
   followUp() {}
-  deferUpdate() {}
-  update() {}
+  deferMessageUpdate() {}
+  updateMessage() {}
   showModal() {}
   awaitModalSubmit() {}
 }

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -288,7 +288,7 @@ module.exports = MessagePayload;
 /**
  * A possible payload option.
  * @typedef {MessageCreateOptions|MessageEditOptions|WebhookCreateMessageOptions|WebhookEditMessageOptions|
- * InteractionReplyOptions|InteractionUpdateOptions} MessagePayloadOption
+ * InteractionReplyOptions|InteractionUpdateMessageOptions} MessagePayloadOption
  */
 
 /**

--- a/packages/discord.js/src/structures/ModalSubmitInteraction.js
+++ b/packages/discord.js/src/structures/ModalSubmitInteraction.js
@@ -108,12 +108,12 @@ class ModalSubmitInteraction extends BaseInteraction {
   /* eslint-disable no-empty-function */
   deferReply() {}
   reply() {}
-  fetchReply() {}
-  editReply() {}
-  deleteReply() {}
+  fetchResponse() {}
+  editResponse() {}
+  deleteResponse() {}
   followUp() {}
-  deferUpdate() {}
-  update() {}
+  deferMessageUpdate() {}
+  updateMessage() {}
 }
 
 InteractionResponses.applyToClass(ModalSubmitInteraction, 'showModal');

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -28,7 +28,7 @@ class InteractionResponses {
 
   /**
    * Options for deferring and updating the reply to a {@link MessageComponentInteraction}.
-   * @typedef {Object} InteractionDeferUpdateOptions
+   * @typedef {Object} InteractionDeferMessageUpdateOptions
    * @property {boolean} [fetchResponse] Whether to fetch the reply
    */
 
@@ -44,7 +44,7 @@ class InteractionResponses {
 
   /**
    * Options for updating the message received from a {@link MessageComponentInteraction}.
-   * @typedef {MessageEditOptions} InteractionUpdateOptions
+   * @typedef {MessageEditOptions} InteractionUpdateMessageOptions
    * @property {boolean} [fetchResponse] Whether to fetch the reply
    */
 
@@ -137,14 +137,14 @@ class InteractionResponses {
   }
 
   /**
-   * @typedef {WebhookEditMessageOptions} InteractionEditReplyOptions
+   * @typedef {WebhookEditMessageOptions} InteractionEditResponseOptions
    * @property {MessageResolvable|'@original'} [message='@original'] The response to edit
    */
 
   /**
    * Edits a reply to this interaction.
    * @see Webhook#editMessage
-   * @param {string|MessagePayload|InteractionEditReplyOptions} options The new options for the message
+   * @param {string|MessagePayload|InteractionEditResponseOptions} options The new options for the message
    * @returns {Promise<Message>}
    * @example
    * // Edit the initial reply to this interaction
@@ -186,7 +186,7 @@ class InteractionResponses {
 
   /**
    * Defers an update to the message to which the component was attached.
-   * @param {InteractionDeferUpdateOptions} [options] Options for deferring the update to this interaction
+   * @param {InteractionDeferMessageUpdateOptions} [options] Options for deferring the update to this interaction
    * @returns {Promise<Message|InteractionResponse>}
    * @example
    * // Defer updating and reset the component's loading state
@@ -209,7 +209,7 @@ class InteractionResponses {
 
   /**
    * Updates the original message of the component on which the interaction was received on.
-   * @param {string|MessagePayload|InteractionUpdateOptions} options The options for the updated message
+   * @param {string|MessagePayload|InteractionUpdateMessageOptions} options The options for the updated message
    * @returns {Promise<Message|void>}
    * @example
    * // Remove the components from the message

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -23,13 +23,13 @@ class InteractionResponses {
    * Options for deferring the reply to an {@link BaseInteraction}.
    * @typedef {Object} InteractionDeferReplyOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
-   * @property {boolean} [fetchReply] Whether to fetch the reply
+   * @property {boolean} [fetchResponse] Whether to fetch the reply
    */
 
   /**
    * Options for deferring and updating the reply to a {@link MessageComponentInteraction}.
    * @typedef {Object} InteractionDeferUpdateOptions
-   * @property {boolean} [fetchReply] Whether to fetch the reply
+   * @property {boolean} [fetchResponse] Whether to fetch the reply
    */
 
   /**
@@ -37,7 +37,7 @@ class InteractionResponses {
    * @typedef {BaseMessageOptions} InteractionReplyOptions
    * @property {boolean} [tts=false] Whether the message should be spoken aloud
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
-   * @property {boolean} [fetchReply] Whether to fetch the reply
+   * @property {boolean} [fetchResponse] Whether to fetch the reply
    * @property {MessageFlags} [flags] Which flags to set for the message.
    * <info>Only `MessageFlags.SuppressEmbeds` and `MessageFlags.Ephemeral` can be set.</info>
    */
@@ -45,7 +45,7 @@ class InteractionResponses {
   /**
    * Options for updating the message received from a {@link MessageComponentInteraction}.
    * @typedef {MessageEditOptions} InteractionUpdateOptions
-   * @property {boolean} [fetchReply] Whether to fetch the reply
+   * @property {boolean} [fetchResponse] Whether to fetch the reply
    */
 
   /**
@@ -77,17 +77,17 @@ class InteractionResponses {
     });
     this.deferred = true;
 
-    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this);
+    return options.fetchResponse ? this.fetchResponse() : new InteractionResponse(this);
   }
 
   /**
    * Creates a reply to this interaction.
-   * <info>Use the `fetchReply` option to get the bot's reply message.</info>
+   * <info>Use the `fetchResponse` option to get the bot's reply message.</info>
    * @param {string|MessagePayload|InteractionReplyOptions} options The options for the reply
    * @returns {Promise<Message|InteractionResponse>}
    * @example
    * // Reply to the interaction and fetch the response
-   * interaction.reply({ content: 'Pong!', fetchReply: true })
+   * interaction.reply({ content: 'Pong!', fetchResponse: true })
    *   .then((message) => console.log(`Reply sent with content ${message.content}`))
    *   .catch(console.error);
    * @example
@@ -118,7 +118,7 @@ class InteractionResponses {
     });
     this.replied = true;
 
-    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this);
+    return options.fetchResponse ? this.fetchResponse() : new InteractionResponse(this);
   }
 
   /**
@@ -128,11 +128,11 @@ class InteractionResponses {
    * @returns {Promise<Message>}
    * @example
    * // Fetch the initial reply to this interaction
-   * interaction.fetchReply()
+   * interaction.fetchResponse()
    *   .then(reply => console.log(`Replied with ${reply.content}`))
    *   .catch(console.error);
    */
-  fetchReply(message = '@original') {
+  fetchResponse(message = '@original') {
     return this.webhook.fetchMessage(message);
   }
 
@@ -148,11 +148,11 @@ class InteractionResponses {
    * @returns {Promise<Message>}
    * @example
    * // Edit the initial reply to this interaction
-   * interaction.editReply('New content')
+   * interaction.editResponse('New content')
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async editReply(options) {
+  async editResponse(options) {
     if (!this.deferred && !this.replied) throw new DiscordjsError(ErrorCodes.InteractionNotReplied);
     const msg = await this.webhook.editMessage(options.message ?? '@original', options);
     this.replied = true;
@@ -166,11 +166,11 @@ class InteractionResponses {
    * @returns {Promise<void>}
    * @example
    * // Delete the initial reply to this interaction
-   * interaction.deleteReply()
+   * interaction.deleteResponse()
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async deleteReply(message = '@original') {
+  async deleteResponse(message = '@original') {
     await this.webhook.deleteMessage(message);
   }
 
@@ -190,11 +190,11 @@ class InteractionResponses {
    * @returns {Promise<Message|InteractionResponse>}
    * @example
    * // Defer updating and reset the component's loading state
-   * interaction.deferUpdate()
+   * interaction.deferMessageUpdate()
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async deferUpdate(options = {}) {
+  async deferMessageUpdate(options = {}) {
     if (this.deferred || this.replied) throw new DiscordjsError(ErrorCodes.InteractionAlreadyReplied);
     await this.client.rest.post(Routes.interactionCallback(this.id, this.token), {
       body: {
@@ -204,7 +204,7 @@ class InteractionResponses {
     });
     this.deferred = true;
 
-    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this, this.message?.interaction?.id);
+    return options.fetchResponse ? this.fetchResponse() : new InteractionResponse(this, this.message?.interaction?.id);
   }
 
   /**
@@ -213,14 +213,14 @@ class InteractionResponses {
    * @returns {Promise<Message|void>}
    * @example
    * // Remove the components from the message
-   * interaction.update({
+   * interaction.updateMessage({
    *   content: "A component interaction was received",
    *   components: []
    * })
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async update(options) {
+  async updateMessage(options) {
     if (this.deferred || this.replied) throw new DiscordjsError(ErrorCodes.InteractionAlreadyReplied);
 
     let messagePayload;
@@ -239,7 +239,7 @@ class InteractionResponses {
     });
     this.replied = true;
 
-    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this, this.message.interaction?.id);
+    return options.fetchResponse ? this.fetchResponse() : new InteractionResponse(this, this.message.interaction?.id);
   }
 
   /**
@@ -294,12 +294,12 @@ class InteractionResponses {
     const props = [
       'deferReply',
       'reply',
-      'fetchReply',
-      'editReply',
-      'deleteReply',
+      'fetchResponse',
+      'editResponse',
+      'deleteResponse',
       'followUp',
-      'deferUpdate',
-      'update',
+      'deferMessageUpdate',
+      'updateMessage',
       'showModal',
       'awaitModalSubmit',
     ];

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -457,16 +457,16 @@ export abstract class CommandInteraction<Cached extends CacheType = CacheType> e
   public inCachedGuild(): this is CommandInteraction<'cached'>;
   public inRawGuild(): this is CommandInteraction<'raw'>;
   public deferReply(
-    options: InteractionDeferReplyOptions & { fetchReply: true },
+    options: InteractionDeferReplyOptions & { fetchResponse: true },
   ): Promise<Message<BooleanCache<Cached>>>;
   public deferReply(options?: InteractionDeferReplyOptions): Promise<InteractionResponse<BooleanCache<Cached>>>;
-  public deleteReply(message?: MessageResolvable | '@original'): Promise<void>;
-  public editReply(
-    options: string | MessagePayload | InteractionEditReplyOptions,
+  public deleteResponse(message?: MessageResolvable | '@original'): Promise<void>;
+  public editResponse(
+    options: string | MessagePayload | InteractionEditResponseOptions,
   ): Promise<Message<BooleanCache<Cached>>>;
-  public fetchReply(message?: Snowflake | '@original'): Promise<Message<BooleanCache<Cached>>>;
+  public fetchResponse(message?: Snowflake | '@original'): Promise<Message<BooleanCache<Cached>>>;
   public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message<BooleanCache<Cached>>>;
-  public reply(options: InteractionReplyOptions & { fetchReply: true }): Promise<Message<BooleanCache<Cached>>>;
+  public reply(options: InteractionReplyOptions & { fetchResponse: true }): Promise<Message<BooleanCache<Cached>>>;
   public reply(
     options: string | MessagePayload | InteractionReplyOptions,
   ): Promise<InteractionResponse<BooleanCache<Cached>>>;
@@ -1905,26 +1905,30 @@ export class MessageComponentInteraction<Cached extends CacheType = CacheType> e
   public inCachedGuild(): this is MessageComponentInteraction<'cached'>;
   public inRawGuild(): this is MessageComponentInteraction<'raw'>;
   public deferReply(
-    options: InteractionDeferReplyOptions & { fetchReply: true },
+    options: InteractionDeferReplyOptions & { fetchResponse: true },
   ): Promise<Message<BooleanCache<Cached>>>;
   public deferReply(options?: InteractionDeferReplyOptions): Promise<InteractionResponse<BooleanCache<Cached>>>;
-  public deferUpdate(
-    options: InteractionDeferUpdateOptions & { fetchReply: true },
+  public deferMessageUpdate(
+    options: InteractionDeferMessageUpdateOptions & { fetchResponse: true },
   ): Promise<Message<BooleanCache<Cached>>>;
-  public deferUpdate(options?: InteractionDeferUpdateOptions): Promise<InteractionResponse<BooleanCache<Cached>>>;
-  public deleteReply(message?: MessageResolvable | '@original'): Promise<void>;
-  public editReply(
-    options: string | MessagePayload | InteractionEditReplyOptions,
+  public deferMessageUpdate(
+    options?: InteractionDeferMessageUpdateOptions,
+  ): Promise<InteractionResponse<BooleanCache<Cached>>>;
+  public deleteResponse(message?: MessageResolvable | '@original'): Promise<void>;
+  public editResponse(
+    options: string | MessagePayload | InteractionEditResponseOptions,
   ): Promise<Message<BooleanCache<Cached>>>;
-  public fetchReply(message?: Snowflake | '@original'): Promise<Message<BooleanCache<Cached>>>;
+  public fetchResponse(message?: Snowflake | '@original'): Promise<Message<BooleanCache<Cached>>>;
   public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message<BooleanCache<Cached>>>;
-  public reply(options: InteractionReplyOptions & { fetchReply: true }): Promise<Message<BooleanCache<Cached>>>;
+  public reply(options: InteractionReplyOptions & { fetchResponse: true }): Promise<Message<BooleanCache<Cached>>>;
   public reply(
     options: string | MessagePayload | InteractionReplyOptions,
   ): Promise<InteractionResponse<BooleanCache<Cached>>>;
-  public update(options: InteractionUpdateOptions & { fetchReply: true }): Promise<Message<BooleanCache<Cached>>>;
-  public update(
-    options: string | MessagePayload | InteractionUpdateOptions,
+  public updateMessage(
+    options: InteractionUpdateMessageOptions & { fetchResponse: true },
+  ): Promise<Message<BooleanCache<Cached>>>;
+  public updateMessage(
+    options: string | MessagePayload | InteractionUpdateMessageOptions,
   ): Promise<InteractionResponse<BooleanCache<Cached>>>;
   public showModal(
     modal:
@@ -1994,7 +1998,7 @@ export type MessagePayloadOption =
   | WebhookCreateMessageOptions
   | WebhookEditMessageOptions
   | InteractionReplyOptions
-  | InteractionUpdateOptions;
+  | InteractionUpdateMessageOptions;
 
 export class MessagePayload {
   public constructor(target: MessageTarget, options: MessagePayloadOption);
@@ -2078,9 +2082,9 @@ export interface ModalMessageModalSubmitInteraction<Cached extends CacheType = C
   extends ModalSubmitInteraction<Cached> {
   message: Message<BooleanCache<Cached>>;
   channelId: Snowflake;
-  update(options: InteractionUpdateOptions & { fetchReply: true }): Promise<Message>;
-  update(
-    options: string | MessagePayload | InteractionUpdateOptions,
+  updateMessage(options: InteractionUpdateMessageOptions & { fetchResponse: true }): Promise<Message>;
+  updateMessage(
+    options: string | MessagePayload | InteractionUpdateMessageOptions,
   ): Promise<InteractionResponse<BooleanCache<Cached>>>;
   inGuild(): this is ModalMessageModalSubmitInteraction<'raw' | 'cached'>;
   inCachedGuild(): this is ModalMessageModalSubmitInteraction<'cached'>;
@@ -2098,24 +2102,26 @@ export class ModalSubmitInteraction<Cached extends CacheType = CacheType> extend
   public message: Message<BooleanCache<Cached>> | null;
   public replied: boolean;
   public readonly webhook: InteractionWebhook;
-  public reply(options: InteractionReplyOptions & { fetchReply: true }): Promise<Message<BooleanCache<Cached>>>;
+  public reply(options: InteractionReplyOptions & { fetchResponse: true }): Promise<Message<BooleanCache<Cached>>>;
   public reply(
     options: string | MessagePayload | InteractionReplyOptions,
   ): Promise<InteractionResponse<BooleanCache<Cached>>>;
-  public deleteReply(message?: MessageResolvable | '@original'): Promise<void>;
-  public editReply(
-    options: string | MessagePayload | InteractionEditReplyOptions,
+  public deleteResponse(message?: MessageResolvable | '@original'): Promise<void>;
+  public editResponse(
+    options: string | MessagePayload | InteractionEditResponseOptions,
   ): Promise<Message<BooleanCache<Cached>>>;
   public deferReply(
-    options: InteractionDeferReplyOptions & { fetchReply: true },
+    options: InteractionDeferReplyOptions & { fetchResponse: true },
   ): Promise<Message<BooleanCache<Cached>>>;
   public deferReply(options?: InteractionDeferReplyOptions): Promise<InteractionResponse<BooleanCache<Cached>>>;
-  public fetchReply(message?: Snowflake | '@original'): Promise<Message<BooleanCache<Cached>>>;
+  public fetchResponse(message?: Snowflake | '@original'): Promise<Message<BooleanCache<Cached>>>;
   public followUp(options: string | MessagePayload | InteractionReplyOptions): Promise<Message<BooleanCache<Cached>>>;
-  public deferUpdate(
-    options: InteractionDeferUpdateOptions & { fetchReply: true },
+  public deferMessageUpdate(
+    options: InteractionDeferMessageUpdateOptions & { fetchResponse: true },
   ): Promise<Message<BooleanCache<Cached>>>;
-  public deferUpdate(options?: InteractionDeferUpdateOptions): Promise<InteractionResponse<BooleanCache<Cached>>>;
+  public deferMessageUpdate(
+    options?: InteractionDeferMessageUpdateOptions,
+  ): Promise<InteractionResponse<BooleanCache<Cached>>>;
   public inGuild(): this is ModalSubmitInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is ModalSubmitInteraction<'cached'>;
   public inRawGuild(): this is ModalSubmitInteraction<'raw'>;
@@ -5353,23 +5359,23 @@ export interface InteractionCollectorOptions<T extends CollectedInteraction, Cac
 
 export interface InteractionDeferReplyOptions {
   ephemeral?: boolean;
-  fetchReply?: boolean;
+  fetchResponse?: boolean;
 }
 
-export type InteractionDeferUpdateOptions = Omit<InteractionDeferReplyOptions, 'ephemeral'>;
+export type InteractionDeferMessageUpdateOptions = Omit<InteractionDeferReplyOptions, 'ephemeral'>;
 
 export interface InteractionReplyOptions extends BaseMessageOptions {
   tts?: boolean;
   ephemeral?: boolean;
-  fetchReply?: boolean;
+  fetchResponse?: boolean;
   flags?: BitFieldResolvable<
     Extract<MessageFlagsString, 'Ephemeral' | 'SuppressEmbeds'>,
     MessageFlags.Ephemeral | MessageFlags.SuppressEmbeds
   >;
 }
 
-export interface InteractionUpdateOptions extends MessageEditOptions {
-  fetchReply?: boolean;
+export interface InteractionUpdateMessageOptions extends MessageEditOptions {
+  fetchResponse?: boolean;
 }
 
 export interface InviteGenerationOptions {
@@ -5978,7 +5984,7 @@ export interface WebhookEditMessageOptions extends Omit<MessageEditOptions, 'fla
   threadId?: Snowflake;
 }
 
-export interface InteractionEditReplyOptions extends WebhookEditMessageOptions {
+export interface InteractionEditResponseOptions extends WebhookEditMessageOptions {
   message?: MessageResolvable | '@original';
 }
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -336,7 +336,7 @@ client.on('messageCreate', async message => {
     expectAssignable<Message<true>>(message);
     const component = await message.awaitMessageComponent({ componentType: ComponentType.Button });
     expectType<ButtonInteraction<'cached'>>(component);
-    expectType<Message<true>>(await component.reply({ fetchReply: true }));
+    expectType<Message<true>>(await component.reply({ fetchResponse: true }));
 
     const buttonCollector = message.createMessageComponentCollector({ componentType: ComponentType.Button });
     expectType<InteractionCollector<ButtonInteraction<'cached'>>>(buttonCollector);
@@ -1523,36 +1523,36 @@ client.on('interactionCreate', async interaction => {
       expectType<MessageActionRowComponent>(interaction.component);
       expectType<Message<true>>(interaction.message);
       expectType<Guild>(interaction.guild);
-      expectType<Promise<Message<true>>>(interaction.reply({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message<true>>>(interaction.deferReply({ fetchReply: true }));
-      expectType<Promise<Message<true>>>(interaction.editReply({ content: 'a' }));
-      expectType<Promise<Message<true>>>(interaction.fetchReply());
-      expectType<Promise<Message<true>>>(interaction.update({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message<true>>>(interaction.deferUpdate({ fetchReply: true }));
+      expectType<Promise<Message<true>>>(interaction.reply({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message<true>>>(interaction.deferReply({ fetchResponse: true }));
+      expectType<Promise<Message<true>>>(interaction.editResponse({ content: 'a' }));
+      expectType<Promise<Message<true>>>(interaction.fetchResponse());
+      expectType<Promise<Message<true>>>(interaction.updateMessage({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message<true>>>(interaction.deferMessageUpdate({ fetchResponse: true }));
       expectType<Promise<Message<true>>>(interaction.followUp({ content: 'a' }));
     } else if (interaction.inRawGuild()) {
       expectAssignable<MessageComponentInteraction>(interaction);
       expectType<APIButtonComponent | APISelectMenuComponent>(interaction.component);
       expectType<Message<false>>(interaction.message);
       expectType<null>(interaction.guild);
-      expectType<Promise<Message<false>>>(interaction.reply({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message<false>>>(interaction.deferReply({ fetchReply: true }));
-      expectType<Promise<Message<false>>>(interaction.editReply({ content: 'a' }));
-      expectType<Promise<Message<false>>>(interaction.fetchReply());
-      expectType<Promise<Message<false>>>(interaction.update({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message<false>>>(interaction.deferUpdate({ fetchReply: true }));
+      expectType<Promise<Message<false>>>(interaction.reply({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message<false>>>(interaction.deferReply({ fetchResponse: true }));
+      expectType<Promise<Message<false>>>(interaction.editResponse({ content: 'a' }));
+      expectType<Promise<Message<false>>>(interaction.fetchResponse());
+      expectType<Promise<Message<false>>>(interaction.updateMessage({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message<false>>>(interaction.deferMessageUpdate({ fetchResponse: true }));
       expectType<Promise<Message<false>>>(interaction.followUp({ content: 'a' }));
     } else if (interaction.inGuild()) {
       expectAssignable<MessageComponentInteraction>(interaction);
       expectType<MessageActionRowComponent | APIButtonComponent | APISelectMenuComponent>(interaction.component);
       expectType<Message>(interaction.message);
       expectType<Guild | null>(interaction.guild);
-      expectType<Promise<Message>>(interaction.reply({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message>>(interaction.deferReply({ fetchReply: true }));
-      expectType<Promise<Message>>(interaction.editReply({ content: 'a' }));
-      expectType<Promise<Message>>(interaction.fetchReply());
-      expectType<Promise<Message>>(interaction.update({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message>>(interaction.deferUpdate({ fetchReply: true }));
+      expectType<Promise<Message>>(interaction.reply({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message>>(interaction.deferReply({ fetchResponse: true }));
+      expectType<Promise<Message>>(interaction.editResponse({ content: 'a' }));
+      expectType<Promise<Message>>(interaction.fetchResponse());
+      expectType<Promise<Message>>(interaction.updateMessage({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message>>(interaction.deferMessageUpdate({ fetchResponse: true }));
       expectType<Promise<Message>>(interaction.followUp({ content: 'a' }));
     }
   }
@@ -1584,26 +1584,26 @@ client.on('interactionCreate', async interaction => {
       expectAssignable<ContextMenuCommandInteraction>(interaction);
       expectAssignable<Guild>(interaction.guild);
       expectAssignable<CommandInteraction<'cached'>>(interaction);
-      expectType<Promise<Message<true>>>(interaction.reply({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message<true>>>(interaction.deferReply({ fetchReply: true }));
-      expectType<Promise<Message<true>>>(interaction.editReply({ content: 'a' }));
-      expectType<Promise<Message<true>>>(interaction.fetchReply());
+      expectType<Promise<Message<true>>>(interaction.reply({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message<true>>>(interaction.deferReply({ fetchResponse: true }));
+      expectType<Promise<Message<true>>>(interaction.editResponse({ content: 'a' }));
+      expectType<Promise<Message<true>>>(interaction.fetchResponse());
       expectType<Promise<Message<true>>>(interaction.followUp({ content: 'a' }));
     } else if (interaction.inRawGuild()) {
       expectAssignable<ContextMenuCommandInteraction>(interaction);
       expectType<null>(interaction.guild);
-      expectType<Promise<Message<false>>>(interaction.reply({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message<false>>>(interaction.deferReply({ fetchReply: true }));
-      expectType<Promise<Message<false>>>(interaction.editReply({ content: 'a' }));
-      expectType<Promise<Message<false>>>(interaction.fetchReply());
+      expectType<Promise<Message<false>>>(interaction.reply({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message<false>>>(interaction.deferReply({ fetchResponse: true }));
+      expectType<Promise<Message<false>>>(interaction.editResponse({ content: 'a' }));
+      expectType<Promise<Message<false>>>(interaction.fetchResponse());
       expectType<Promise<Message<false>>>(interaction.followUp({ content: 'a' }));
     } else if (interaction.inGuild()) {
       expectAssignable<ContextMenuCommandInteraction>(interaction);
       expectType<Guild | null>(interaction.guild);
-      expectType<Promise<Message>>(interaction.reply({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message>>(interaction.deferReply({ fetchReply: true }));
-      expectType<Promise<Message>>(interaction.editReply({ content: 'a' }));
-      expectType<Promise<Message>>(interaction.fetchReply());
+      expectType<Promise<Message>>(interaction.reply({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message>>(interaction.deferReply({ fetchResponse: true }));
+      expectType<Promise<Message>>(interaction.editResponse({ content: 'a' }));
+      expectType<Promise<Message>>(interaction.fetchResponse());
       expectType<Promise<Message>>(interaction.followUp({ content: 'a' }));
     }
   }
@@ -1631,19 +1631,19 @@ client.on('interactionCreate', async interaction => {
       expectType<ButtonComponent>(interaction.component);
       expectType<Message<true>>(interaction.message);
       expectType<Guild>(interaction.guild);
-      expectType<Promise<Message<true>>>(interaction.reply({ fetchReply: true }));
+      expectType<Promise<Message<true>>>(interaction.reply({ fetchResponse: true }));
     } else if (interaction.inRawGuild()) {
       expectAssignable<ButtonInteraction>(interaction);
       expectType<APIButtonComponent>(interaction.component);
       expectType<Message<false>>(interaction.message);
       expectType<null>(interaction.guild);
-      expectType<Promise<Message<false>>>(interaction.reply({ fetchReply: true }));
+      expectType<Promise<Message<false>>>(interaction.reply({ fetchResponse: true }));
     } else if (interaction.inGuild()) {
       expectAssignable<ButtonInteraction>(interaction);
       expectType<ButtonComponent | APIButtonComponent>(interaction.component);
       expectType<Message>(interaction.message);
       expectAssignable<Guild | null>(interaction.guild);
-      expectType<Promise<Message>>(interaction.reply({ fetchReply: true }));
+      expectType<Promise<Message>>(interaction.reply({ fetchResponse: true }));
     }
   }
 
@@ -1659,19 +1659,19 @@ client.on('interactionCreate', async interaction => {
       expectType<SelectMenuComponent>(interaction.component);
       expectType<Message<true>>(interaction.message);
       expectType<Guild>(interaction.guild);
-      expectType<Promise<Message<true>>>(interaction.reply({ fetchReply: true }));
+      expectType<Promise<Message<true>>>(interaction.reply({ fetchResponse: true }));
     } else if (interaction.inRawGuild()) {
       expectAssignable<StringSelectMenuInteraction>(interaction);
       expectType<APIStringSelectComponent>(interaction.component);
       expectType<Message<false>>(interaction.message);
       expectType<null>(interaction.guild);
-      expectType<Promise<Message<false>>>(interaction.reply({ fetchReply: true }));
+      expectType<Promise<Message<false>>>(interaction.reply({ fetchResponse: true }));
     } else if (interaction.inGuild()) {
       expectAssignable<StringSelectMenuInteraction>(interaction);
       expectType<SelectMenuComponent | APIStringSelectComponent>(interaction.component);
       expectType<Message>(interaction.message);
       expectType<Guild | null>(interaction.guild);
-      expectType<Promise<Message>>(interaction.reply({ fetchReply: true }));
+      expectType<Promise<Message>>(interaction.reply({ fetchResponse: true }));
     }
   }
 
@@ -1682,13 +1682,13 @@ client.on('interactionCreate', async interaction => {
     if (interaction.inRawGuild()) {
       expectNotAssignable<Interaction<'cached'>>(interaction);
       expectAssignable<ChatInputCommandInteraction>(interaction);
-      expectType<Promise<Message<false>>>(interaction.reply({ fetchReply: true }));
+      expectType<Promise<Message<false>>>(interaction.reply({ fetchResponse: true }));
       expectType<APIInteractionDataResolvedGuildMember | null>(interaction.options.getMember('test'));
 
       expectType<APIInteractionDataResolvedChannel>(interaction.options.getChannel('test', true));
       expectType<APIRole>(interaction.options.getRole('test', true));
     } else if (interaction.inCachedGuild()) {
-      const msg = await interaction.reply({ fetchReply: true });
+      const msg = await interaction.reply({ fetchResponse: true });
       const btn = await msg.awaitMessageComponent({ componentType: ComponentType.Button });
 
       expectType<Message<true>>(msg);
@@ -1696,7 +1696,7 @@ client.on('interactionCreate', async interaction => {
 
       expectType<GuildMember | null>(interaction.options.getMember('test'));
       expectAssignable<ChatInputCommandInteraction>(interaction);
-      expectType<Promise<Message<true>>>(interaction.reply({ fetchReply: true }));
+      expectType<Promise<Message<true>>>(interaction.reply({ fetchResponse: true }));
 
       expectType<GuildBasedChannel>(interaction.options.getChannel('test', true));
       expectType<Role>(interaction.options.getRole('test', true));
@@ -1704,7 +1704,7 @@ client.on('interactionCreate', async interaction => {
       // @ts-expect-error
       consumeCachedCommand(interaction);
       expectType<ChatInputCommandInteraction>(interaction);
-      expectType<Promise<Message>>(interaction.reply({ fetchReply: true }));
+      expectType<Promise<Message>>(interaction.reply({ fetchResponse: true }));
       expectType<APIInteractionDataResolvedGuildMember | GuildMember | null>(interaction.options.getMember('test'));
 
       expectType<GuildBasedChannel | APIInteractionDataResolvedChannel>(interaction.options.getChannel('test', true));
@@ -1755,29 +1755,29 @@ client.on('interactionCreate', async interaction => {
     if (interaction.inCachedGuild()) {
       expectAssignable<ModalSubmitInteraction>(interaction);
       expectType<Guild>(interaction.guild);
-      expectType<Promise<Message<true>>>(interaction.reply({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message<true>>>(interaction.deferReply({ fetchReply: true }));
-      expectType<Promise<Message<true>>>(interaction.editReply({ content: 'a' }));
-      expectType<Promise<Message<true>>>(interaction.fetchReply());
-      expectType<Promise<Message<true>>>(interaction.deferUpdate({ fetchReply: true }));
+      expectType<Promise<Message<true>>>(interaction.reply({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message<true>>>(interaction.deferReply({ fetchResponse: true }));
+      expectType<Promise<Message<true>>>(interaction.editResponse({ content: 'a' }));
+      expectType<Promise<Message<true>>>(interaction.fetchResponse());
+      expectType<Promise<Message<true>>>(interaction.deferMessageUpdate({ fetchResponse: true }));
       expectType<Promise<Message<true>>>(interaction.followUp({ content: 'a' }));
     } else if (interaction.inRawGuild()) {
       expectAssignable<ModalSubmitInteraction>(interaction);
       expectType<null>(interaction.guild);
-      expectType<Promise<Message<false>>>(interaction.reply({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message<false>>>(interaction.deferReply({ fetchReply: true }));
-      expectType<Promise<Message<false>>>(interaction.editReply({ content: 'a' }));
-      expectType<Promise<Message<false>>>(interaction.fetchReply());
-      expectType<Promise<Message<false>>>(interaction.deferUpdate({ fetchReply: true }));
+      expectType<Promise<Message<false>>>(interaction.reply({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message<false>>>(interaction.deferReply({ fetchResponse: true }));
+      expectType<Promise<Message<false>>>(interaction.editResponse({ content: 'a' }));
+      expectType<Promise<Message<false>>>(interaction.fetchResponse());
+      expectType<Promise<Message<false>>>(interaction.deferMessageUpdate({ fetchResponse: true }));
       expectType<Promise<Message<false>>>(interaction.followUp({ content: 'a' }));
     } else if (interaction.inGuild()) {
       expectAssignable<ModalSubmitInteraction>(interaction);
       expectType<Guild | null>(interaction.guild);
-      expectType<Promise<Message>>(interaction.reply({ content: 'a', fetchReply: true }));
-      expectType<Promise<Message>>(interaction.deferReply({ fetchReply: true }));
-      expectType<Promise<Message>>(interaction.editReply({ content: 'a' }));
-      expectType<Promise<Message>>(interaction.fetchReply());
-      expectType<Promise<Message>>(interaction.deferUpdate({ fetchReply: true }));
+      expectType<Promise<Message>>(interaction.reply({ content: 'a', fetchResponse: true }));
+      expectType<Promise<Message>>(interaction.deferReply({ fetchResponse: true }));
+      expectType<Promise<Message>>(interaction.editResponse({ content: 'a' }));
+      expectType<Promise<Message>>(interaction.fetchResponse());
+      expectType<Promise<Message>>(interaction.deferMessageUpdate({ fetchResponse: true }));
       expectType<Promise<Message>>(interaction.followUp({ content: 'a' }));
     }
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR renames some interaction methods to not be confused.

| Method                                      | Description                                                                                                                                                   |
|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `.reply()`                                  | It is ok                                                                                                                                                      |
| `.deferReply()`                             | It is ok                                                                                                                                                      |
| `.fetchReply()` -> `.fetchResponse()`       | With this method we can fetch not only interaction replies. If we do `.update()` or `.deferUpdate()` and then `.fetchReply()`, we will get the target message |
| `.editReply()` -> `.editResponse()`         | The same with `.fetchReply()`                                                                                                                                 |
| `.deleteReply()` -> `.deleteResponse()`     | The same with `.fetchReply()`                                                                                                                                 |
| `.followUp()`                               | It is ok                                                                                                                                                      |
| `.update()` -> `.updateMessage()`           | When we call that method it looks like we update the interaction (`interaction.update()`), not the target message                                             |
| `.deferUpdate()` -> `.deferMessageUpdate()` | For consistency with `.update()`                                                                                                                              |

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
