### PR TITLE
docs: Specify `ActionRowBuilder` for `components`

### DIFF
--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -61,7 +61,7 @@ class TextBasedChannel {
    * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
    * @property {Array<JSONEncodable<AttachmentPayload>>|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files]
    * The files to send with the message.
-   * @property {ActionRow[]|ActionRowOptions[]} [components]
+   * @property {ActionRow[]|ActionRowBuilder[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This pull request resolves #8833 - `ActionRowOptions[]` was not the correct type here, whatever it was. It should (obviously) accept `ActionRowBuilder[]`.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
