### PR TITLE
fix(Activity): Fix equals() not checking for differing emoji (v13)

### DIFF
--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -293,8 +293,7 @@ class Activity {
         this.url === activity.url &&
         this.state === activity.state &&
         this.details === activity.details &&
-        this.emoji?.id === activity.emoji?.id &&
-        this.emoji?.name === activity.emoji?.name)
+        (this.emoji?.id ? this.emoji.id === activity.emoji?.id : this.emoji?.name === activity.emoji?.name))
     );
   }
 

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -292,7 +292,8 @@ class Activity {
         this.type === activity.type &&
         this.url === activity.url &&
         this.state === activity.state &&
-        this.details === activity.details)
+        this.details === activity.details &&
+        this.emoji?.id === activity.emoji?.id)
     );
   }
 

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -293,7 +293,8 @@ class Activity {
         this.url === activity.url &&
         this.state === activity.state &&
         this.details === activity.details &&
-        (this.emoji?.id ? this.emoji.id === activity.emoji?.id : this.emoji?.name === activity.emoji?.name))
+        this.emoji?.id === activity.emoji?.id &&
+        this.emoji?.name === activity.emoji?.name)
     );
   }
 

--- a/src/structures/Presence.js
+++ b/src/structures/Presence.js
@@ -293,7 +293,8 @@ class Activity {
         this.url === activity.url &&
         this.state === activity.state &&
         this.details === activity.details &&
-        this.emoji?.id === activity.emoji?.id)
+        this.emoji?.id === activity.emoji?.id &&
+        this.emoji?.name === activity.emoji?.name)
     );
   }
 


### PR DESCRIPTION
This PR fixes `Activity.equals()` not checking for differing emojis, leading `presenceUpdate` to not fire if only a custom status emoji was updated.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating