### PR TITLE
fix(typings): remove type prefix from import

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -31,7 +31,7 @@ import {
   ModalBuilder as BuildersModal,
   AnyComponentBuilder,
   ComponentBuilder,
-  type RestOrArray,
+  RestOrArray,
 } from '@discordjs/builders';
 import { Awaitable, JSONEncodable } from '@discordjs/util';
 import { Collection } from '@discordjs/collection';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This removes the accidental "type" before importing a type, which caused issues like the following:

![image](https://user-images.githubusercontent.com/29015942/202854679-63ff924a-e331-48b2-89f2-b37fdc9bda5f.png)

 
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code change (types only)
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
