### PR TITLE
Update incorrect erlpack install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pnpm add discord.js
 ### Optional packages
 
 - [zlib-sync](https://www.npmjs.com/package/zlib-sync) for WebSocket data compression and inflation (`npm install zlib-sync`)
-- [erlpack](https://github.com/discord/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install discord/erlpack`)
+- [erlpack](https://www.npmjs.com/package/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install erlpack`)
 - [bufferutil](https://www.npmjs.com/package/bufferutil) for a much faster WebSocket connection (`npm install bufferutil`)
 - [utf-8-validate](https://www.npmjs.com/package/utf-8-validate) in combination with `bufferutil` for much faster WebSocket processing (`npm install utf-8-validate`)
 - [@discordjs/voice](https://www.npmjs.com/package/@discordjs/voice) for interacting with the Discord Voice API (`npm install @discordjs/voice`)

--- a/packages/discord.js/README.md
+++ b/packages/discord.js/README.md
@@ -39,7 +39,7 @@ pnpm add discord.js
 ### Optional packages
 
 - [zlib-sync](https://www.npmjs.com/package/zlib-sync) for WebSocket data compression and inflation (`npm install zlib-sync`)
-- [erlpack](https://github.com/discord/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install discord/erlpack`)
+- [erlpack](https://www.npmjs.com/package/erlpack) for significantly faster WebSocket data (de)serialisation (`npm install erlpack`)
 - [bufferutil](https://www.npmjs.com/package/bufferutil) for a much faster WebSocket connection (`npm install bufferutil`)
 - [utf-8-validate](https://www.npmjs.com/package/utf-8-validate) in combination with `bufferutil` for much faster WebSocket processing (`npm install utf-8-validate`)
 - [@discordjs/voice](https://www.npmjs.com/package/@discordjs/voice) for interacting with the Discord Voice API (`npm install @discordjs/voice`)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR updates the `erlpack` installation command as it was incorrect. The hyperlink now leads to the npm page of the `erlpack` package instead of the Github Page

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.