### PR TITLE
refactor: update `makeURLSearchParams` to accept readonly non-`Record`s

### DIFF
--- a/packages/rest/__tests__/utils.test.ts
+++ b/packages/rest/__tests__/utils.test.ts
@@ -58,4 +58,31 @@ describe('makeURLSearchParams', () => {
 			expect([...params.entries()]).toEqual([['foo', 'bar']]);
 		});
 	});
+
+	describe('types', () => {
+		interface TestInput {
+			foo: string;
+		}
+
+		test("GIVEN object without index signature THEN TypeScript doesn't raise a type error", () => {
+			// Previously, `makeURLSearchParams` used `Record<string, unknown>` as an input, but that meant that it
+			// couldn't accept most interfaces, since they don't have an index signature. This test is to make sure
+			// non-Records can be used without casting.
+
+			const input = { foo: 'bar' } as TestInput;
+			const params = makeURLSearchParams(input);
+
+			expect([...params.entries()]).toEqual([['foo', 'bar']]);
+		});
+
+		test("GIVEN readonly object on a non-readonly generic type THEN TypeScript doesn't raise a type error", () => {
+			// While `Readonly<T>` type was always accepted in `makeURLSearchParams`, this test is to ensure that we can
+			// use the generic type and accept `Readonly<T>` rather than only [possibly] mutable `T`.
+
+			const input = Object.freeze({ foo: 'bar' } as TestInput);
+			const params = makeURLSearchParams<TestInput>(input);
+
+			expect([...params.entries()]).toEqual([['foo', 'bar']]);
+		});
+	});
 });

--- a/packages/rest/src/lib/utils/utils.ts
+++ b/packages/rest/src/lib/utils/utils.ts
@@ -43,7 +43,7 @@ function serializeSearchParam(value: unknown): string | null {
  * @param options - The options to use
  * @returns A populated URLSearchParams instance
  */
-export function makeURLSearchParams(options?: Record<string, unknown>) {
+export function makeURLSearchParams<T extends object & {}>(options?: Readonly<T>) {
 	const params = new URLSearchParams();
 	if (!options) return params;
 

--- a/packages/rest/src/lib/utils/utils.ts
+++ b/packages/rest/src/lib/utils/utils.ts
@@ -43,7 +43,7 @@ function serializeSearchParam(value: unknown): string | null {
  * @param options - The options to use
  * @returns A populated URLSearchParams instance
  */
-export function makeURLSearchParams<T extends object & {}>(options?: Readonly<T>) {
+export function makeURLSearchParams<T extends object>(options?: Readonly<T>) {
 	const params = new URLSearchParams();
 	if (!options) return params;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I didn't realize how painful it was to use the utility until I saw #8736 using them extensively. This patch ensures that:

1. We can pass non-Records:
    ```diff
      declare options: RESTGetAPIApplicationCommandsQuery;
    - makeURLSearchParams(options as Record<string, unknown>);
    + makeURLSearchParams(options);
    ```
1. We can cast types:
    ```diff
      // Expects `RESTGetAPIApplicationCommandsQuery`:
    - makeURLSearchParams({ withLocalizations: true }); // Should be `with_localizations``, doesn't raise type error.
    + makeURLSearchParams<RESTGetAPIApplicationCommandsQuery>({ withLocalizations: true }); // Raises type error due to mismatching types.
    ```

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
