### PR TITLE
fix: remove casts when using `makeURLSearchParams()`

### DIFF
--- a/packages/core/src/api/applicationCommands.ts
+++ b/packages/core/src/api/applicationCommands.ts
@@ -29,7 +29,7 @@ export class ApplicationCommandsAPI {
 	 */
 	public async getGlobalCommands(applicationId: Snowflake, options: RESTGetAPIApplicationCommandsQuery = {}) {
 		return this.rest.get(Routes.applicationCommands(applicationId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIApplicationCommandsResult>;
 	}
 
@@ -109,7 +109,7 @@ export class ApplicationCommandsAPI {
 		data: RESTGetAPIApplicationGuildCommandsQuery = {},
 	) {
 		return this.rest.get(Routes.applicationGuildCommands(applicationId, guildId), {
-			query: makeURLSearchParams(data as Record<string, unknown>),
+			query: makeURLSearchParams(data),
 		}) as Promise<RESTGetAPIApplicationCommandsResult>;
 	}
 

--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -76,7 +76,7 @@ export class ChannelsAPI {
 		options: RESTGetAPIChannelMessageReactionUsersQuery = {},
 	) {
 		return this.rest.get(Routes.channelMessageReaction(channelId, messageId, encodeURIComponent(emoji)), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIChannelMessageReactionUsersResult>;
 	}
 
@@ -171,7 +171,7 @@ export class ChannelsAPI {
 	 */
 	public async getMessages(channelId: Snowflake, options: RESTGetAPIChannelMessagesQuery = {}) {
 		return this.rest.get(Routes.channelMessages(channelId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIChannelMessagesResult>;
 	}
 
@@ -305,7 +305,7 @@ export class ChannelsAPI {
 		options: RESTGetAPIChannelThreadsArchivedQuery = {},
 	) {
 		return this.rest.get(Routes.channelThreads(channelId, archivedStatus), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIChannelUsersThreadsArchivedResult>;
 	}
 
@@ -320,7 +320,7 @@ export class ChannelsAPI {
 		options: RESTGetAPIChannelThreadsArchivedQuery = {},
 	) {
 		return this.rest.get(Routes.channelJoinedArchivedThreads(channelId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIChannelUsersThreadsArchivedResult>;
 	}
 }

--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -144,7 +144,7 @@ export class GuildsAPI {
 	 */
 	public async getMembers(guildId: Snowflake, options: RESTGetAPIGuildMembersQuery = {}) {
 		return this.rest.get(Routes.guildMembers(guildId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIGuildMemberResult>;
 	}
 
@@ -314,7 +314,7 @@ export class GuildsAPI {
 	 */
 	public async getPruneCount(guildId: Snowflake, options: RESTGetAPIGuildPruneCountQuery = {}) {
 		return this.rest.get(Routes.guildPrune(guildId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIGuildPruneCountResult>;
 	}
 
@@ -535,7 +535,7 @@ export class GuildsAPI {
 	 */
 	public async getScheduledEvents(guildId: Snowflake, options: RESTGetAPIGuildScheduledEventsQuery = {}) {
 		return this.rest.get(Routes.guildScheduledEvents(guildId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIGuildScheduledEventsResult>;
 	}
 
@@ -566,7 +566,7 @@ export class GuildsAPI {
 		options: RESTGetAPIGuildScheduledEventQuery = {},
 	) {
 		return this.rest.get(Routes.guildScheduledEvent(guildId, eventId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIGuildScheduledEventResult>;
 	}
 
@@ -614,7 +614,7 @@ export class GuildsAPI {
 		options: RESTGetAPIGuildScheduledEventUsersQuery = {},
 	) {
 		return this.rest.get(Routes.guildScheduledEventUsers(guildId, eventId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIGuildScheduledEventUsersResult>;
 	}
 
@@ -740,7 +740,7 @@ export class GuildsAPI {
 	 */
 	public async getAuditLogs(guildId: Snowflake, options: RESTGetAPIAuditLogQuery = {}) {
 		return this.rest.get(Routes.guildAuditLog(guildId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIAuditLogResult>;
 	}
 
@@ -832,7 +832,7 @@ export class GuildsAPI {
 	 */
 	public async searchForMembers(guildId: Snowflake, options: RESTGetAPIGuildMembersSearchQuery) {
 		return this.rest.get(Routes.guildMembersSearch(guildId), {
-			query: makeURLSearchParams(options as unknown as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIGuildMembersSearchResult>;
 	}
 

--- a/packages/core/src/api/invite.ts
+++ b/packages/core/src/api/invite.ts
@@ -11,7 +11,7 @@ export class InvitesAPI {
 	 */
 	public async get(code: string, options: RESTGetAPIInviteQuery = {}) {
 		return this.rest.get(Routes.invite(code), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPIInviteResult>;
 	}
 

--- a/packages/core/src/api/user.ts
+++ b/packages/core/src/api/user.ts
@@ -42,7 +42,7 @@ export class UsersAPI {
 	 */
 	public async getGuilds(options: RESTGetAPICurrentUserGuildsQuery = {}) {
 		return this.rest.get(Routes.userGuilds(), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 		}) as Promise<RESTGetAPICurrentUserGuildsResult>;
 	}
 

--- a/packages/core/src/api/webhook.ts
+++ b/packages/core/src/api/webhook.ts
@@ -135,7 +135,7 @@ export class WebhooksAPI {
 		options: RESTPostAPIWebhookWithTokenSlackQuery = {},
 	) {
 		await this.rest.post(Routes.webhookPlatform(id, token, 'slack'), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 			body,
 			auth: false,
 		});
@@ -155,7 +155,7 @@ export class WebhooksAPI {
 		options: RESTPostAPIWebhookWithTokenGitHubQuery = {},
 	) {
 		await this.rest.post(Routes.webhookPlatform(id, token, 'github'), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 			body,
 			auth: false,
 		});
@@ -171,7 +171,7 @@ export class WebhooksAPI {
 	 */
 	public async getMessage(id: Snowflake, token: string, messageId: Snowflake, options: { thread_id?: string } = {}) {
 		return this.rest.get(Routes.webhookMessage(id, token, messageId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 			auth: false,
 		}) as Promise<RESTGetAPIChannelMessageResult>;
 	}
@@ -207,7 +207,7 @@ export class WebhooksAPI {
 	 */
 	public async deleteMessage(id: Snowflake, token: string, messageId: Snowflake, options: { thread_id?: string } = {}) {
 		await this.rest.delete(Routes.webhookMessage(id, token, messageId), {
-			query: makeURLSearchParams(options as Record<string, unknown>),
+			query: makeURLSearchParams(options),
 			auth: false,
 		});
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
These casts are no longer needed since
- #8868

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
