### PR TITLE
chore: use `satisfies` where applicable

### DIFF
--- a/packages/brokers/src/brokers/Broker.ts
+++ b/packages/brokers/src/brokers/Broker.ts
@@ -34,7 +34,7 @@ export interface BaseBrokerOptions {
 /**
  * Default broker options
  */
-export const DefaultBrokerOptions: Required<BaseBrokerOptions> = {
+export const DefaultBrokerOptions = {
 	name: randomBytes(20).toString('hex'),
 	maxChunk: 10,
 	blockTimeout: 5_000,
@@ -43,7 +43,7 @@ export const DefaultBrokerOptions: Required<BaseBrokerOptions> = {
 		return Buffer.from(encoded.buffer, encoded.byteOffset, encoded.byteLength);
 	},
 	decode: (data): unknown => decode(data),
-};
+} as const satisfies Required<BaseBrokerOptions>;
 
 export type ToEventMap<
 	TRecord extends Record<string, any>,

--- a/packages/brokers/src/brokers/redis/RPCRedis.ts
+++ b/packages/brokers/src/brokers/redis/RPCRedis.ts
@@ -21,10 +21,10 @@ export interface RPCRedisBrokerOptions extends RedisBrokerOptions {
 /**
  * Default values used for the {@link RPCRedisBrokerOptions}
  */
-export const DefaultRPCRedisBrokerOptions: Required<Omit<RPCRedisBrokerOptions, 'redisClient'>> = {
+export const DefaultRPCRedisBrokerOptions = {
 	...DefaultBrokerOptions,
 	timeout: 5_000,
-};
+} as const satisfies Required<Omit<RPCRedisBrokerOptions, 'redisClient'>>;
 
 /**
  * RPC broker powered by Redis

--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -415,7 +415,7 @@ export const TimestampStyles = {
 	 * Relative time format, consisting of a relative duration format, e.g. 2 months ago
 	 */
 	RelativeTime: 'R',
-} as const;
+} as const satisfies Record<string, string>;
 
 /**
  * The possible values, see {@link TimestampStyles} for more information

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -1,7 +1,6 @@
 import process from 'node:process';
 import { APIVersion } from 'discord-api-types/v10';
 import { Agent } from 'undici';
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import type { RESTOptions } from '../REST.js';
 
 export const DefaultUserAgent = `DiscordBot (https://discord.js.org, [VI]{{inject}}[/VI])`;

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -1,11 +1,12 @@
 import process from 'node:process';
 import { APIVersion } from 'discord-api-types/v10';
 import { Agent } from 'undici';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import type { RESTOptions } from '../REST.js';
 
 export const DefaultUserAgent = `DiscordBot (https://discord.js.org, [VI]{{inject}}[/VI])`;
 
-export const DefaultRestOptions: Required<RESTOptions> = {
+export const DefaultRestOptions = {
 	get agent() {
 		return new Agent({
 			connect: {
@@ -28,7 +29,7 @@ export const DefaultRestOptions: Required<RESTOptions> = {
 	hashSweepInterval: 14_400_000, // 4 Hours
 	hashLifetime: 86_400_000, // 24 Hours
 	handlerSweepInterval: 3_600_000, // 1 Hour
-};
+} as const satisfies Required<RESTOptions>;
 
 /**
  * The events that the REST manager emits
@@ -42,9 +43,9 @@ export const enum RESTEvents {
 	Response = 'response',
 }
 
-export const ALLOWED_EXTENSIONS = ['webp', 'png', 'jpg', 'jpeg', 'gif'] as const;
-export const ALLOWED_STICKER_EXTENSIONS = ['png', 'json'] as const;
-export const ALLOWED_SIZES = [16, 32, 64, 128, 256, 512, 1_024, 2_048, 4_096] as const;
+export const ALLOWED_EXTENSIONS = ['webp', 'png', 'jpg', 'jpeg', 'gif'] as const satisfies readonly string[];
+export const ALLOWED_STICKER_EXTENSIONS = ['png', 'json'] as const satisfies readonly string[];
+export const ALLOWED_SIZES = [16, 32, 64, 128, 256, 512, 1_024, 2_048, 4_096] as const satisfies readonly number[];
 
 export type ImageExtension = typeof ALLOWED_EXTENSIONS[number];
 export type StickerExtension = typeof ALLOWED_STICKER_EXTENSIONS[number];

--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -2,7 +2,8 @@ import process from 'node:process';
 import { Collection } from '@discordjs/collection';
 import { lazy } from '@discordjs/util';
 import { APIVersion, GatewayOpcodes } from 'discord-api-types/v10';
-import type { OptionalWebSocketManagerOptions, SessionInfo } from '../ws/WebSocketManager.js';
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import type { SessionInfo, OptionalWebSocketManagerOptions } from '../ws/WebSocketManager.js';
 import type { SendRateLimitState } from '../ws/WebSocketShard.js';
 
 /**
@@ -26,7 +27,7 @@ const getDefaultSessionStore = lazy(() => new Collection<number, SessionInfo | n
 /**
  * Default options used by the manager
  */
-export const DefaultWebSocketManagerOptions: OptionalWebSocketManagerOptions = {
+export const DefaultWebSocketManagerOptions = {
 	shardCount: null,
 	shardIds: null,
 	largeThreshold: null,
@@ -54,7 +55,7 @@ export const DefaultWebSocketManagerOptions: OptionalWebSocketManagerOptions = {
 	handshakeTimeout: 30_000,
 	helloTimeout: 60_000,
 	readyTimeout: 15_000,
-};
+} as const satisfies OptionalWebSocketManagerOptions;
 
 export const ImportantGatewayOpcodes = new Set([
 	GatewayOpcodes.Heartbeat,

--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -2,7 +2,6 @@ import process from 'node:process';
 import { Collection } from '@discordjs/collection';
 import { lazy } from '@discordjs/util';
 import { APIVersion, GatewayOpcodes } from 'discord-api-types/v10';
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import type { SessionInfo, OptionalWebSocketManagerOptions } from '../ws/WebSocketManager.js';
 import type { SendRateLimitState } from '../ws/WebSocketShard.js';
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

We need a couple eslint-ignores because of https://github.com/typescript-eslint/typescript-eslint/issues/6077

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating