### PR TITLE
fix(WebSocketShard): send ratelimit handling

### DIFF
--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -3,6 +3,7 @@ import { Collection } from '@discordjs/collection';
 import { lazy } from '@discordjs/util';
 import { APIVersion, GatewayOpcodes } from 'discord-api-types/v10';
 import type { OptionalWebSocketManagerOptions, SessionInfo } from '../ws/WebSocketManager.js';
+import type { SendRateLimitState } from '../ws/WebSocketShard.js';
 
 /**
  * Valid encoding types
@@ -60,3 +61,10 @@ export const ImportantGatewayOpcodes = new Set([
 	GatewayOpcodes.Identify,
 	GatewayOpcodes.Resume,
 ]);
+
+export function getInitialSendRateLimitState(): SendRateLimitState {
+	return {
+		remaining: 120,
+		resetAt: Date.now() + 60_000,
+	};
+}

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -274,10 +274,10 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 					this.debug(['Connection closed while waiting for the send rate limit to reset, re-queueing payload']);
 					this.sendQueue.shift();
 					return this.send(payload);
-				} else {
-					// This is so the listener is removed
-					controller.abort();
 				}
+
+				// This is so the listener from the `once` call is removed
+				controller.abort();
 			}
 
 			this.sendRateLimitState = getInitialSendRateLimitState();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Closes #8558

Refer to https://github.com/discordjs/discord.js/issues/8558#issuecomment-1332187881 for an explanation of the actual underlying problem.

Also related: #8399, #8405, #8479, #8731

All in all, this PR:
1) fixes a bad condition with the ratelimit `resetAt` check
2) accounts for some edge cases related to a connection being destroyed while a payload is being sent out
3) adds some more debug logs that were much needed for fixing this issue
4) adds a new `close` event that's needed for some of the new internal behavior - **making this as semver minor PR**

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

