### PR TITLE
refactor(WebSocketShard): identify throttling

### DIFF
--- a/packages/ws/__tests__/strategy/WorkerShardingStrategy.test.ts
+++ b/packages/ws/__tests__/strategy/WorkerShardingStrategy.test.ts
@@ -186,10 +186,10 @@ test('spawn, connect, send a message, session info, and destroy', async () => {
 		expect.objectContaining({ workerData: expect.objectContaining({ shardIds: [0, 1] }) }),
 	);
 
-	const payload: GatewaySendPayload = {
+	const payload = {
 		op: GatewayOpcodes.RequestGuildMembers,
 		d: { guild_id: '123', limit: 0, query: '' },
-	};
+	} satisfies GatewaySendPayload;
 	await manager.send(0, payload);
 	expect(mockSend).toHaveBeenCalledWith(0, payload);
 	expect(managerEmitSpy).toHaveBeenCalledWith(WebSocketShardEvents.Dispatch, {

--- a/packages/ws/__tests__/strategy/WorkerShardingStrategy.test.ts
+++ b/packages/ws/__tests__/strategy/WorkerShardingStrategy.test.ts
@@ -27,7 +27,7 @@ const mockConstructor = vi.fn();
 const mockSend = vi.fn();
 const mockTerminate = vi.fn();
 
-const memberChunkData: GatewayDispatchPayload = {
+const memberChunkData = {
 	op: GatewayOpcodes.Dispatch,
 	s: 123,
 	t: GatewayDispatchEvents.GuildMembersChunk,
@@ -35,13 +35,14 @@ const memberChunkData: GatewayDispatchPayload = {
 		guild_id: '123',
 		members: [],
 	},
-};
+} as unknown as GatewayDispatchPayload;
 
 const sessionInfo: SessionInfo = {
 	shardId: 0,
 	shardCount: 2,
 	sequence: 123,
 	sessionId: 'abc',
+	resumeURL: 'wss://ehehe.gg',
 };
 
 vi.mock('node:worker_threads', async () => {
@@ -107,6 +108,10 @@ vi.mock('node:worker_threads', async () => {
 						session: { ...message.session, sequence: message.session.sequence + 1 },
 					};
 					this.emit('message', session);
+					break;
+				}
+
+				case WorkerSendPayloadOp.ShardCanIdentify: {
 					break;
 				}
 			}
@@ -181,7 +186,10 @@ test('spawn, connect, send a message, session info, and destroy', async () => {
 		expect.objectContaining({ workerData: expect.objectContaining({ shardIds: [0, 1] }) }),
 	);
 
-	const payload: GatewaySendPayload = { op: GatewayOpcodes.RequestGuildMembers, d: { guild_id: '123', limit: 0 } };
+	const payload: GatewaySendPayload = {
+		op: GatewayOpcodes.RequestGuildMembers,
+		d: { guild_id: '123', limit: 0, query: '' },
+	};
 	await manager.send(0, payload);
 	expect(mockSend).toHaveBeenCalledWith(0, payload);
 	expect(managerEmitSpy).toHaveBeenCalledWith(WebSocketShardEvents.Dispatch, {

--- a/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
@@ -18,7 +18,7 @@ export interface IContextFetchingStrategy {
 	readonly options: FetchingStrategyOptions;
 	retrieveSessionInfo(shardId: number): Awaitable<SessionInfo | null>;
 	updateSessionInfo(shardId: number, sessionInfo: SessionInfo | null): Awaitable<void>;
-	waitForIdentify(shardId: number): Promise<void>;
+	waitForIdentify(): Promise<void>;
 }
 
 export async function managerToFetchingStrategyOptions(manager: WebSocketManager): Promise<FetchingStrategyOptions> {

--- a/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
@@ -18,6 +18,7 @@ export interface IContextFetchingStrategy {
 	readonly options: FetchingStrategyOptions;
 	retrieveSessionInfo(shardId: number): Awaitable<SessionInfo | null>;
 	updateSessionInfo(shardId: number, sessionInfo: SessionInfo | null): Awaitable<void>;
+	waitForIdentify(shardId: number): Promise<void>;
 }
 
 export async function managerToFetchingStrategyOptions(manager: WebSocketManager): Promise<FetchingStrategyOptions> {

--- a/packages/ws/src/strategies/context/SimpleContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/SimpleContextFetchingStrategy.ts
@@ -1,5 +1,11 @@
+import { IdentifyThrottler } from '../../utils/IdentifyThrottler.js';
 import type { SessionInfo, WebSocketManager } from '../../ws/WebSocketManager.js';
 import type { FetchingStrategyOptions, IContextFetchingStrategy } from './IContextFetchingStrategy.js';
+
+// This strategy assumes every shard is running under the same process - therefore a global identify throttler is used
+// If this is not the case, a custom strategy should be written to implement `waitForIdentify`
+
+let globalIdentifyThrottler: IdentifyThrottler;
 
 export class SimpleContextFetchingStrategy implements IContextFetchingStrategy {
 	public constructor(private readonly manager: WebSocketManager, public readonly options: FetchingStrategyOptions) {}
@@ -10,5 +16,10 @@ export class SimpleContextFetchingStrategy implements IContextFetchingStrategy {
 
 	public updateSessionInfo(shardId: number, sessionInfo: SessionInfo | null) {
 		return this.manager.options.updateSessionInfo(shardId, sessionInfo);
+	}
+
+	public async waitForIdentify(): Promise<void> {
+		globalIdentifyThrottler ??= new IdentifyThrottler(this.manager);
+		await globalIdentifyThrottler.waitForIdentify();
 	}
 }

--- a/packages/ws/src/strategies/context/WorkerContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/WorkerContextFetchingStrategy.ts
@@ -25,6 +25,12 @@ export class WorkerContextFetchingStrategy implements IContextFetchingStrategy {
 				resolve?.(payload.session);
 				this.sessionPromises.delete(payload.nonce);
 			}
+
+			if (payload.op === WorkerSendPayloadOp.ShardCanIdentify) {
+				const resolve = this.waitForIdentifyPromises.get(payload.shardId);
+				resolve?.();
+				this.waitForIdentifyPromises.delete(payload.shardId);
+			}
 		});
 	}
 

--- a/packages/ws/src/strategies/context/WorkerContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/WorkerContextFetchingStrategy.ts
@@ -27,9 +27,9 @@ export class WorkerContextFetchingStrategy implements IContextFetchingStrategy {
 			}
 
 			if (payload.op === WorkerSendPayloadOp.ShardCanIdentify) {
-				const resolve = this.waitForIdentifyPromises.get(payload.shardId);
+				const resolve = this.waitForIdentifyPromises.get(payload.nonce);
 				resolve?.();
-				this.waitForIdentifyPromises.delete(payload.shardId);
+				this.waitForIdentifyPromises.delete(payload.nonce);
 			}
 		});
 	}
@@ -56,13 +56,14 @@ export class WorkerContextFetchingStrategy implements IContextFetchingStrategy {
 		parentPort!.postMessage(payload);
 	}
 
-	public async waitForIdentify(shardId: number): Promise<void> {
+	public async waitForIdentify(): Promise<void> {
+		const nonce = Math.random();
 		const payload: WorkerRecievePayload = {
 			op: WorkerRecievePayloadOp.WaitForIdentify,
-			shardId,
+			nonce,
 		};
 		// eslint-disable-next-line no-promise-executor-return
-		const promise = new Promise<void>((resolve) => this.waitForIdentifyPromises.set(shardId, resolve));
+		const promise = new Promise<void>((resolve) => this.waitForIdentifyPromises.set(nonce, resolve));
 		parentPort!.postMessage(payload);
 		return promise;
 	}

--- a/packages/ws/src/strategies/context/WorkerContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/WorkerContextFetchingStrategy.ts
@@ -36,11 +36,11 @@ export class WorkerContextFetchingStrategy implements IContextFetchingStrategy {
 
 	public async retrieveSessionInfo(shardId: number): Promise<SessionInfo | null> {
 		const nonce = Math.random();
-		const payload: WorkerRecievePayload = {
+		const payload = {
 			op: WorkerRecievePayloadOp.RetrieveSessionInfo,
 			shardId,
 			nonce,
-		};
+		} satisfies WorkerRecievePayload;
 		// eslint-disable-next-line no-promise-executor-return
 		const promise = new Promise<SessionInfo | null>((resolve) => this.sessionPromises.set(nonce, resolve));
 		parentPort!.postMessage(payload);
@@ -48,20 +48,20 @@ export class WorkerContextFetchingStrategy implements IContextFetchingStrategy {
 	}
 
 	public updateSessionInfo(shardId: number, sessionInfo: SessionInfo | null) {
-		const payload: WorkerRecievePayload = {
+		const payload = {
 			op: WorkerRecievePayloadOp.UpdateSessionInfo,
 			shardId,
 			session: sessionInfo,
-		};
+		} satisfies WorkerRecievePayload;
 		parentPort!.postMessage(payload);
 	}
 
 	public async waitForIdentify(): Promise<void> {
 		const nonce = Math.random();
-		const payload: WorkerRecievePayload = {
+		const payload = {
 			op: WorkerRecievePayloadOp.WaitForIdentify,
 			nonce,
-		};
+		} satisfies WorkerRecievePayload;
 		// eslint-disable-next-line no-promise-executor-return
 		const promise = new Promise<void>((resolve) => this.waitForIdentifyPromises.set(nonce, resolve));
 		parentPort!.postMessage(payload);

--- a/packages/ws/src/strategies/context/WorkerContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/WorkerContextFetchingStrategy.ts
@@ -21,14 +21,12 @@ export class WorkerContextFetchingStrategy implements IContextFetchingStrategy {
 
 		parentPort!.on('message', (payload: WorkerSendPayload) => {
 			if (payload.op === WorkerSendPayloadOp.SessionInfoResponse) {
-				const resolve = this.sessionPromises.get(payload.nonce);
-				resolve?.(payload.session);
+				this.sessionPromises.get(payload.nonce)?.(payload.session);
 				this.sessionPromises.delete(payload.nonce);
 			}
 
 			if (payload.op === WorkerSendPayloadOp.ShardCanIdentify) {
-				const resolve = this.waitForIdentifyPromises.get(payload.nonce);
-				resolve?.();
+				this.waitForIdentifyPromises.get(payload.nonce)?.();
 				this.waitForIdentifyPromises.delete(payload.nonce);
 			}
 		});

--- a/packages/ws/src/strategies/sharding/SimpleShardingStrategy.ts
+++ b/packages/ws/src/strategies/sharding/SimpleShardingStrategy.ts
@@ -1,6 +1,5 @@
 import { Collection } from '@discordjs/collection';
 import type { GatewaySendPayload } from 'discord-api-types/v10';
-import { IdentifyThrottler } from '../../utils/IdentifyThrottler.js';
 import type { WebSocketManager } from '../../ws/WebSocketManager';
 import { WebSocketShard, WebSocketShardEvents, type WebSocketShardDestroyOptions } from '../../ws/WebSocketShard.js';
 import { managerToFetchingStrategyOptions } from '../context/IContextFetchingStrategy.js';
@@ -15,11 +14,8 @@ export class SimpleShardingStrategy implements IShardingStrategy {
 
 	private readonly shards = new Collection<number, WebSocketShard>();
 
-	private readonly throttler: IdentifyThrottler;
-
 	public constructor(manager: WebSocketManager) {
 		this.manager = manager;
-		this.throttler = new IdentifyThrottler(manager);
 	}
 
 	/**
@@ -46,7 +42,6 @@ export class SimpleShardingStrategy implements IShardingStrategy {
 		const promises = [];
 
 		for (const shard of this.shards.values()) {
-			await this.throttler.waitForIdentify();
 			promises.push(shard.connect());
 		}
 

--- a/packages/ws/src/strategies/sharding/WorkerShardingStrategy.ts
+++ b/packages/ws/src/strategies/sharding/WorkerShardingStrategy.ts
@@ -122,10 +122,10 @@ export class WorkerShardingStrategy implements IShardingStrategy {
 		const promises = [];
 
 		for (const [shardId, worker] of this.#workerByShardId.entries()) {
-			const payload: WorkerSendPayload = {
+			const payload = {
 				op: WorkerSendPayloadOp.Connect,
 				shardId,
-			};
+			} satisfies WorkerSendPayload;
 
 			// eslint-disable-next-line no-promise-executor-return
 			const promise = new Promise<void>((resolve) => this.connectPromises.set(shardId, resolve));
@@ -143,11 +143,11 @@ export class WorkerShardingStrategy implements IShardingStrategy {
 		const promises = [];
 
 		for (const [shardId, worker] of this.#workerByShardId.entries()) {
-			const payload: WorkerSendPayload = {
+			const payload = {
 				op: WorkerSendPayloadOp.Destroy,
 				shardId,
 				options,
-			};
+			} satisfies WorkerSendPayload;
 
 			promises.push(
 				// eslint-disable-next-line no-promise-executor-return, promise/prefer-await-to-then
@@ -171,11 +171,11 @@ export class WorkerShardingStrategy implements IShardingStrategy {
 			throw new Error(`No worker found for shard ${shardId}`);
 		}
 
-		const payload: WorkerSendPayload = {
+		const payload = {
 			op: WorkerSendPayloadOp.Send,
 			shardId,
 			payload: data,
-		};
+		} satisfies WorkerSendPayload;
 		worker.postMessage(payload);
 	}
 

--- a/packages/ws/src/strategies/sharding/worker.ts
+++ b/packages/ws/src/strategies/sharding/worker.ts
@@ -40,12 +40,12 @@ for (const shardId of data.shardIds) {
 	for (const event of Object.values(WebSocketShardEvents)) {
 		// @ts-expect-error: Event types incompatible
 		shard.on(event, (data) => {
-			const payload: WorkerRecievePayload = {
+			const payload = {
 				op: WorkerRecievePayloadOp.Event,
 				event,
 				data,
 				shardId,
-			};
+			} satisfies WorkerRecievePayload;
 			parentPort!.postMessage(payload);
 		});
 	}

--- a/packages/ws/src/strategies/sharding/worker.ts
+++ b/packages/ws/src/strategies/sharding/worker.ts
@@ -93,5 +93,9 @@ parentPort!
 			case WorkerSendPayloadOp.SessionInfoResponse: {
 				break;
 			}
+
+			case WorkerSendPayloadOp.ShardCanIdentify: {
+				break;
+			}
 		}
 	});

--- a/packages/ws/src/utils/IdentifyThrottler.ts
+++ b/packages/ws/src/utils/IdentifyThrottler.ts
@@ -1,5 +1,5 @@
 import { setTimeout as sleep } from 'node:timers/promises';
-import type { WebSocketManager } from '../ws/WebSocketManager';
+import type { WebSocketManager } from '../ws/WebSocketManager.js';
 
 export class IdentifyThrottler {
 	private identifyState = {

--- a/packages/ws/src/utils/IdentifyThrottler.ts
+++ b/packages/ws/src/utils/IdentifyThrottler.ts
@@ -19,6 +19,7 @@ export class IdentifyThrottler {
 			if (this.identifyState.remaining <= 0) {
 				const diff = this.identifyState.resetsAt - Date.now();
 				if (diff <= 5_000) {
+					// To account for the latency the IDENTIFY payload goes through, we add a bit more wait time
 					const time = diff + Math.random() * 1_500;
 					await sleep(time);
 				}

--- a/packages/ws/src/utils/IdentifyThrottler.ts
+++ b/packages/ws/src/utils/IdentifyThrottler.ts
@@ -1,7 +1,10 @@
 import { setTimeout as sleep } from 'node:timers/promises';
+import { AsyncQueue } from '@sapphire/async-queue';
 import type { WebSocketManager } from '../ws/WebSocketManager.js';
 
 export class IdentifyThrottler {
+	private readonly queue = new AsyncQueue();
+
 	private identifyState = {
 		remaining: 0,
 		resetsAt: Number.POSITIVE_INFINITY,
@@ -10,20 +13,26 @@ export class IdentifyThrottler {
 	public constructor(private readonly manager: WebSocketManager) {}
 
 	public async waitForIdentify(): Promise<void> {
-		if (this.identifyState.remaining <= 0) {
-			const diff = this.identifyState.resetsAt - Date.now();
-			if (diff <= 5_000) {
-				const time = diff + Math.random() * 1_500;
-				await sleep(time);
+		await this.queue.wait();
+
+		try {
+			if (this.identifyState.remaining <= 0) {
+				const diff = this.identifyState.resetsAt - Date.now();
+				if (diff <= 5_000) {
+					const time = diff + Math.random() * 1_500;
+					await sleep(time);
+				}
+
+				const info = await this.manager.fetchGatewayInformation();
+				this.identifyState = {
+					remaining: info.session_start_limit.max_concurrency,
+					resetsAt: Date.now() + 5_000,
+				};
 			}
 
-			const info = await this.manager.fetchGatewayInformation();
-			this.identifyState = {
-				remaining: info.session_start_limit.max_concurrency,
-				resetsAt: Date.now() + 5_000,
-			};
+			this.identifyState.remaining--;
+		} finally {
+			this.queue.shift();
 		}
-
-		this.identifyState.remaining--;
 	}
 }

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -295,6 +295,9 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			`intents: ${this.strategy.options.intents}`,
 			`compression: ${this.inflate ? 'zlib-stream' : this.useIdentifyCompress ? 'identify' : 'none'}`,
 		]);
+
+		await this.strategy.waitForIdentify(this.id);
+
 		const d: GatewayIdentifyData = {
 			token: this.strategy.options.token,
 			properties: this.strategy.options.identifyProperties,

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -296,7 +296,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			`compression: ${this.inflate ? 'zlib-stream' : this.useIdentifyCompress ? 'identify' : 'none'}`,
 		]);
 
-		await this.strategy.waitForIdentify(this.id);
+		await this.strategy.waitForIdentify();
 
 		const d: GatewayIdentifyData = {
 			token: this.strategy.options.token,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR makes `IContextFetchingStrategy` responsible for throttling identifies.

Prior to those changes, control over not spamming identify was handed to `WebSocketShard#connect`'s caller, which does NOT work correctly in the case of multiple shards reconnecting at the same time (e.g. there would be no regard to `max_concurrency`).

With this change, `/sharder` (see #8859) can now also get everything working even with cross-process sharding and such.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

