### PR TITLE
fix(createPackage): invalid label/path on labeler file

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -32,9 +32,9 @@ packages:proxy-container:
 packages:rest:
   - packages/rest/*
   - packages/rest/**/*
-packages/ui:
-  - packages:ui/*
-  - packages:ui/**/*
+packages:ui:
+  - packages/ui/*
+  - packages/ui/**/*
 packages:util:
   - packages/util/*
   - packages/util/**/*

--- a/packages/scripts/src/createPackage.ts
+++ b/packages/scripts/src/createPackage.ts
@@ -61,7 +61,7 @@ export async function createPackage(packageName: string, packageDescription?: st
 	await writeFile('labels.yml', stringifyYAML(labelsYAML));
 
 	const labelerYAML = parseYAML(await readFile('labeler.yml', 'utf8')) as Record<string, string[]>;
-	labelerYAML[`packages/${packageName}`] = [`packages:${packageName}/*`, `packages:${packageName}/**/*`];
+	labelerYAML[`packages:${packageName}`] = [`packages/${packageName}/*`, `packages/${packageName}/**/*`];
 
 	await writeFile('labeler.yml', stringifyYAML(labelerYAML));
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The labeler file should formatted as `label-name: [file-globs]`

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
