### PR TITLE
refactor: use consistent naming for options

### DIFF
--- a/packages/discord.js/src/client/WebhookClient.js
+++ b/packages/discord.js/src/client/WebhookClient.js
@@ -68,7 +68,7 @@ class WebhookClient extends BaseClient {
   /* eslint-disable no-empty-function, valid-jsdoc */
   /**
    * Sends a message with this webhook.
-   * @param {string|MessagePayload|WebhookCreateMessageOptions} options The content for the reply
+   * @param {string|MessagePayload|WebhookMessageCreateOptions} options The content for the reply
    * @returns {Promise<APIMessage>}
    */
   send() {}
@@ -84,7 +84,7 @@ class WebhookClient extends BaseClient {
   /**
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable} message The message to edit
-   * @param {string|MessagePayload|WebhookEditMessageOptions} options The options to provide
+   * @param {string|MessagePayload|WebhookMessageEditOptions} options The options to provide
    * @returns {Promise<APIMessage>} Returns the message edited by this webhook
    */
   editMessage() {}

--- a/packages/discord.js/src/managers/ApplicationCommandPermissionsManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandPermissionsManager.js
@@ -112,14 +112,14 @@ class ApplicationCommandPermissionsManager extends BaseManager {
    * Options used to set permissions for one or more Application Commands in a guild
    * <warn>Omitting the `command` parameter edits the guild wide permissions
    * when the manager's `commandId` is `null`</warn>
-   * @typedef {BaseApplicationCommandPermissionsOptions} EditApplicationCommandPermissionsOptions
+   * @typedef {BaseApplicationCommandPermissionsOptions} ApplicationCommandPermissionsEditOptions
    * @property {ApplicationCommandPermissions[]} permissions The new permissions for the guild or overwrite
    * @property {string} token The bearer token to use that authorizes the permission edit
    */
 
   /**
    * Sets the permissions for the guild or a command overwrite.
-   * @param {EditApplicationCommandPermissionsOptions} options Options used to set permissions
+   * @param {ApplicationCommandPermissionsEditOptions} options Options used to set permissions
    * @returns {Promise<ApplicationCommandPermissions[]|Collection<Snowflake, ApplicationCommandPermissions[]>>}
    * @example
    * // Set a permission overwrite for a command
@@ -179,7 +179,7 @@ class ApplicationCommandPermissionsManager extends BaseManager {
 
   /**
    * Add permissions to a command.
-   * @param {EditApplicationCommandPermissionsOptions} options Options used to add permissions
+   * @param {ApplicationCommandPermissionsEditOptions} options Options used to add permissions
    * @returns {Promise<ApplicationCommandPermissions[]>}
    * @example
    * // Add a rule to block a role from using a command

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -258,7 +258,7 @@ class GuildChannelManager extends CachedManager {
   /**
    * Edits the channel.
    * @param {GuildChannelResolvable} channel The channel to edit
-   * @param {GuildChannelEditOptions} data Options for editing the channel
+   * @param {GuildChannelEditOptions} options Options for editing the channel
    * @returns {Promise<GuildChannel>}
    * @example
    * // Edit a channel
@@ -266,19 +266,19 @@ class GuildChannelManager extends CachedManager {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async edit(channel, data) {
+  async edit(channel, options) {
     channel = this.resolve(channel);
     if (!channel) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'channel', 'GuildChannelResolvable');
 
-    const parent = data.parent && this.client.channels.resolveId(data.parent);
+    const parent = options.parent && this.client.channels.resolveId(options.parent);
 
-    if (typeof data.position !== 'undefined') {
-      await this.setPosition(channel, data.position, { position: data.position, reason: data.reason });
+    if (typeof options.position !== 'undefined') {
+      await this.setPosition(channel, options.position, { position: options.position, reason: options.reason });
     }
 
-    let permission_overwrites = data.permissionOverwrites?.map(o => PermissionOverwrites.resolve(o, this.guild));
+    let permission_overwrites = options.permissionOverwrites?.map(o => PermissionOverwrites.resolve(o, this.guild));
 
-    if (data.lockPermissions) {
+    if (options.lockPermissions) {
       if (parent) {
         const newParent = this.guild.channels.resolve(parent);
         if (newParent?.type === ChannelType.GuildCategory) {
@@ -295,26 +295,27 @@ class GuildChannelManager extends CachedManager {
 
     const newData = await this.client.rest.patch(Routes.channel(channel.id), {
       body: {
-        name: (data.name ?? channel.name).trim(),
-        type: data.type,
-        topic: data.topic,
-        nsfw: data.nsfw,
-        bitrate: data.bitrate ?? channel.bitrate,
-        user_limit: data.userLimit ?? channel.userLimit,
-        rtc_region: 'rtcRegion' in data ? data.rtcRegion : channel.rtcRegion,
-        video_quality_mode: data.videoQualityMode,
+        name: (options.name ?? channel.name).trim(),
+        type: options.type,
+        topic: options.topic,
+        nsfw: options.nsfw,
+        bitrate: options.bitrate ?? channel.bitrate,
+        user_limit: options.userLimit ?? channel.userLimit,
+        rtc_region: 'rtcRegion' in options ? options.rtcRegion : channel.rtcRegion,
+        video_quality_mode: options.videoQualityMode,
         parent_id: parent,
-        lock_permissions: data.lockPermissions,
-        rate_limit_per_user: data.rateLimitPerUser,
-        default_auto_archive_duration: data.defaultAutoArchiveDuration,
+        lock_permissions: options.lockPermissions,
+        rate_limit_per_user: options.rateLimitPerUser,
+        default_auto_archive_duration: options.defaultAutoArchiveDuration,
         permission_overwrites,
-        available_tags: data.availableTags?.map(availableTag => transformGuildForumTag(availableTag)),
-        default_reaction_emoji: data.defaultReactionEmoji && transformGuildDefaultReaction(data.defaultReactionEmoji),
-        default_thread_rate_limit_per_user: data.defaultThreadRateLimitPerUser,
-        flags: 'flags' in data ? ChannelFlagsBitField.resolve(data.flags) : undefined,
-        default_sort_order: data.defaultSortOrder,
+        available_tags: options.availableTags?.map(availableTag => transformGuildForumTag(availableTag)),
+        default_reaction_emoji:
+          options.defaultReactionEmoji && transformGuildDefaultReaction(options.defaultReactionEmoji),
+        default_thread_rate_limit_per_user: options.defaultThreadRateLimitPerUser,
+        flags: 'flags' in options ? ChannelFlagsBitField.resolve(options.flags) : undefined,
+        default_sort_order: options.defaultSortOrder,
       },
-      reason: data.reason,
+      reason: options.reason,
     });
 
     return this.client.actions.ChannelUpdate.handle(newData).updated;

--- a/packages/discord.js/src/managers/GuildEmojiManager.js
+++ b/packages/discord.js/src/managers/GuildEmojiManager.js
@@ -124,19 +124,19 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
   /**
    * Edits an emoji.
    * @param {EmojiResolvable} emoji The Emoji resolvable to edit
-   * @param {GuildEmojiEditData} data The new data for the emoji
+   * @param {GuildEmojiEditOptions} options The options to provide
    * @returns {Promise<GuildEmoji>}
    */
-  async edit(emoji, data) {
+  async edit(emoji, options) {
     const id = this.resolveId(emoji);
     if (!id) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'emoji', 'EmojiResolvable', true);
-    const roles = data.roles?.map(r => this.guild.roles.resolveId(r));
+    const roles = options.roles?.map(r => this.guild.roles.resolveId(r));
     const newData = await this.client.rest.patch(Routes.guildEmoji(this.guild.id, id), {
       body: {
-        name: data.name,
+        name: options.name,
         roles,
       },
-      reason: data.reason,
+      reason: options.reason,
     });
     const existing = this.cache.get(id);
     if (existing) {

--- a/packages/discord.js/src/managers/GuildInviteManager.js
+++ b/packages/discord.js/src/managers/GuildInviteManager.js
@@ -167,7 +167,7 @@ class GuildInviteManager extends CachedManager {
   /**
    * Create an invite to the guild from the provided channel.
    * @param {GuildInvitableChannelResolvable} channel The options for creating the invite from a channel.
-   * @param {CreateInviteOptions} [options={}] The options for creating the invite from a channel.
+   * @param {InviteCreateOptions} [options={}] The options for creating the invite from a channel.
    * @returns {Promise<Invite>}
    * @example
    * // Create an invite to a selected channel

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -270,7 +270,7 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * The data for editing a guild member.
-   * @typedef {Object} GuildMemberEditData
+   * @typedef {Object} GuildMemberEditOptions
    * @property {?string} [nick] The nickname to set for the member
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles or role ids to apply
    * @property {boolean} [mute] Whether or not the member should be muted
@@ -286,43 +286,43 @@ class GuildMemberManager extends CachedManager {
    * Edits a member of the guild.
    * <info>The user must be a member of the guild</info>
    * @param {UserResolvable} user The member to edit
-   * @param {GuildMemberEditData} data The data to edit the member with
+   * @param {GuildMemberEditOptions} options The options to provide
    * @returns {Promise<GuildMember>}
    */
-  async edit(user, { reason, ...data }) {
+  async edit(user, { reason, ...options }) {
     const id = this.client.users.resolveId(user);
     if (!id) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'user', 'UserResolvable');
 
-    if (data.channel) {
-      data.channel = this.guild.channels.resolve(data.channel);
-      if (!(data.channel instanceof BaseGuildVoiceChannel)) {
+    if (options.channel) {
+      options.channel = this.guild.channels.resolve(options.channel);
+      if (!(options.channel instanceof BaseGuildVoiceChannel)) {
         throw new DiscordjsError(ErrorCodes.GuildVoiceChannelResolve);
       }
-      data.channel_id = data.channel.id;
-      data.channel = undefined;
-    } else if (data.channel === null) {
-      data.channel_id = null;
-      data.channel = undefined;
+      options.channel_id = options.channel.id;
+      options.channel = undefined;
+    } else if (options.channel === null) {
+      options.channel_id = null;
+      options.channel = undefined;
     }
-    data.roles &&= data.roles.map(role => (role instanceof Role ? role.id : role));
+    options.roles &&= options.roles.map(role => (role instanceof Role ? role.id : role));
 
-    if (typeof data.communicationDisabledUntil !== 'undefined') {
-      data.communication_disabled_until =
+    if (typeof options.communicationDisabledUntil !== 'undefined') {
+      options.communication_disabled_until =
         // eslint-disable-next-line eqeqeq
-        data.communicationDisabledUntil != null
-          ? new Date(data.communicationDisabledUntil).toISOString()
-          : data.communicationDisabledUntil;
+        options.communicationDisabledUntil != null
+          ? new Date(options.communicationDisabledUntil).toISOString()
+          : options.communicationDisabledUntil;
     }
 
     let endpoint;
     if (id === this.client.user.id) {
-      const keys = Object.keys(data);
+      const keys = Object.keys(options);
       if (keys.length === 1 && keys[0] === 'nick') endpoint = Routes.guildMember(this.guild.id);
       else endpoint = Routes.guildMember(this.guild.id, id);
     } else {
       endpoint = Routes.guildMember(this.guild.id, id);
     }
-    const d = await this.client.rest.patch(endpoint, { body: data, reason });
+    const d = await this.client.rest.patch(endpoint, { body: options, reason });
 
     const clone = this.cache.get(id)?._clone();
     clone?._patch(d);

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -101,16 +101,16 @@ class GuildStickerManager extends CachedManager {
   /**
    * Edits a sticker.
    * @param {StickerResolvable} sticker The sticker to edit
-   * @param {GuildStickerEditOptions} [data={}] The new data for the sticker
+   * @param {GuildStickerEditOptions} [options={}] The new data for the sticker
    * @returns {Promise<Sticker>}
    */
-  async edit(sticker, data = {}) {
+  async edit(sticker, options = {}) {
     const stickerId = this.resolveId(sticker);
     if (!stickerId) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'sticker', 'StickerResolvable');
 
     const d = await this.client.rest.patch(Routes.guildSticker(this.guild.id, stickerId), {
-      body: data,
-      reason: data.reason,
+      body: options,
+      reason: options.reason,
     });
 
     const existing = this.cache.get(stickerId);

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -101,7 +101,7 @@ class GuildStickerManager extends CachedManager {
   /**
    * Edits a sticker.
    * @param {StickerResolvable} sticker The sticker to edit
-   * @param {GuildStickerEditData} [data={}] The new data for the sticker
+   * @param {GuildStickerEditOptions} [data={}] The new data for the sticker
    * @returns {Promise<Sticker>}
    */
   async edit(sticker, data = {}) {

--- a/packages/discord.js/src/managers/RoleManager.js
+++ b/packages/discord.js/src/managers/RoleManager.js
@@ -100,7 +100,7 @@ class RoleManager extends CachedManager {
 
   /**
    * Options used to create a new role.
-   * @typedef {Object} CreateRoleOptions
+   * @typedef {Object} RoleCreateOptions
    * @property {string} [name] The name of the new role
    * @property {ColorResolvable} [color] The data to create the role with
    * @property {boolean} [hoist] Whether or not the new role should be hoisted
@@ -117,7 +117,7 @@ class RoleManager extends CachedManager {
   /**
    * Creates a new role in the guild with given information.
    * <warn>The position will silently reset to 1 if an invalid one is provided, or none.</warn>
-   * @param {CreateRoleOptions} [options] Options for creating the new role
+   * @param {RoleCreateOptions} [options] Options for creating the new role
    * @returns {Promise<Role>}
    * @example
    * // Create a new role
@@ -166,14 +166,14 @@ class RoleManager extends CachedManager {
 
   /**
    * Options for editing a role
-   * @typedef {RoleData} EditRoleOptions
+   * @typedef {RoleData} RoleEditOptions
    * @property {string} [reason] The reason for editing this role
    */
 
   /**
    * Edits a role of the guild.
    * @param {RoleResolvable} role The role to edit
-   * @param {EditRoleOptions} data The new data for the role
+   * @param {RoleEditOptions} options The options to provide
    * @returns {Promise<Role>}
    * @example
    * // Edit a role
@@ -181,15 +181,15 @@ class RoleManager extends CachedManager {
    *   .then(updated => console.log(`Edited role name to ${updated.name}`))
    *   .catch(console.error);
    */
-  async edit(role, data) {
+  async edit(role, options) {
     role = this.resolve(role);
     if (!role) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'role', 'RoleResolvable');
 
-    if (typeof data.position === 'number') {
-      await this.setPosition(role, data.position, { reason: data.reason });
+    if (typeof options.position === 'number') {
+      await this.setPosition(role, options.position, { reason: options.reason });
     }
 
-    let icon = data.icon;
+    let icon = options.icon;
     if (icon) {
       const guildEmojiURL = this.guild.emojis.resolve(icon)?.url;
       icon = guildEmojiURL ? await DataResolver.resolveImage(guildEmojiURL) : await DataResolver.resolveImage(icon);
@@ -197,16 +197,17 @@ class RoleManager extends CachedManager {
     }
 
     const body = {
-      name: data.name,
-      color: typeof data.color === 'undefined' ? undefined : resolveColor(data.color),
-      hoist: data.hoist,
-      permissions: typeof data.permissions === 'undefined' ? undefined : new PermissionsBitField(data.permissions),
-      mentionable: data.mentionable,
+      name: options.name,
+      color: typeof options.color === 'undefined' ? undefined : resolveColor(options.color),
+      hoist: options.hoist,
+      permissions:
+        typeof options.permissions === 'undefined' ? undefined : new PermissionsBitField(options.permissions),
+      mentionable: options.mentionable,
       icon,
-      unicode_emoji: data.unicodeEmoji,
+      unicode_emoji: options.unicodeEmoji,
     };
 
-    const d = await this.client.rest.patch(Routes.guildRole(this.guild.id, role.id), { body, reason: data.reason });
+    const d = await this.client.rest.patch(Routes.guildRole(this.guild.id, role.id), { body, reason: options.reason });
 
     const clone = role._clone();
     clone._patch(d);

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -125,7 +125,7 @@ class BaseGuildTextChannel extends GuildChannel {
 
   /**
    * Options used to create an invite to a guild channel.
-   * @typedef {Object} CreateInviteOptions
+   * @typedef {Object} InviteCreateOptions
    * @property {boolean} [temporary] Whether members that joined via the invite should be automatically
    * kicked after 24 hours if they have not yet received a role
    * @property {number} [maxAge] How long the invite should last (in seconds, 0 for forever)
@@ -142,7 +142,7 @@ class BaseGuildTextChannel extends GuildChannel {
 
   /**
    * Creates an invite to this guild channel.
-   * @param {CreateInviteOptions} [options={}] The options for creating the invite
+   * @param {InviteCreateOptions} [options={}] The options for creating the invite
    * @returns {Promise<Invite>}
    * @example
    * // Create an invite to a channel

--- a/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
@@ -98,7 +98,7 @@ class BaseGuildVoiceChannel extends GuildChannel {
 
   /**
    * Creates an invite to this guild channel.
-   * @param {CreateInviteOptions} [options={}] The options for creating the invite
+   * @param {InviteCreateOptions} [options={}] The options for creating the invite
    * @returns {Promise<Invite>}
    * @example
    * // Create an invite to a channel

--- a/packages/discord.js/src/structures/ClientUser.js
+++ b/packages/discord.js/src/structures/ClientUser.js
@@ -44,19 +44,19 @@ class ClientUser extends User {
 
   /**
    * Data used to edit the logged in client
-   * @typedef {Object} ClientUserEditData
+   * @typedef {Object} ClientUserEditOptions
    * @property {string} [username] The new username
    * @property {?(BufferResolvable|Base64Resolvable)} [avatar] The new avatar
    */
 
   /**
    * Edits the logged in client.
-   * @param {ClientUserEditData} data The new data
+   * @param {ClientUserEditOptions} options The options to provide
    * @returns {Promise<ClientUser>}
    */
-  async edit(data) {
-    if (typeof data.avatar !== 'undefined') data.avatar = await DataResolver.resolveImage(data.avatar);
-    const newData = await this.client.rest.patch(Routes.user(), { body: data });
+  async edit(options) {
+    if (typeof options.avatar !== 'undefined') options.avatar = await DataResolver.resolveImage(options.avatar);
+    const newData = await this.client.rest.patch(Routes.user(), { body: options });
     this.client.token = newData.token;
     this.client.rest.setToken(newData.token);
     const { updated } = this.client.actions.UserUpdate.handle(newData);

--- a/packages/discord.js/src/structures/ForumChannel.js
+++ b/packages/discord.js/src/structures/ForumChannel.js
@@ -168,7 +168,7 @@ class ForumChannel extends GuildChannel {
 
   /**
    * Creates an invite to this guild channel.
-   * @param {CreateInviteOptions} [options={}] The options for creating the invite
+   * @param {InviteCreateOptions} [options={}] The options for creating the invite
    * @returns {Promise<Invite>}
    * @example
    * // Create an invite to a channel

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -737,7 +737,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * The data for editing a guild.
-   * @typedef {Object} GuildEditData
+   * @typedef {Object} GuildEditOptions
    * @property {string} [name] The name of the guild
    * @property {?GuildVerificationLevel} [verificationLevel] The verification level of the guild
    * @property {?GuildExplicitContentFilter} [explicitContentFilter] The level of the explicit content filter
@@ -778,7 +778,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Updates the guild with new information - e.g. a new name.
-   * @param {GuildEditData} data The data to update the guild with
+   * @param {GuildEditOptions} options The options to provide
    * @returns {Promise<Guild>}
    * @example
    * // Set the guild name
@@ -788,50 +788,50 @@ class Guild extends AnonymousGuild {
    *   .then(updated => console.log(`New guild name ${updated}`))
    *   .catch(console.error);
    */
-  async edit(data) {
+  async edit(options) {
     const _data = {};
-    if (data.name) _data.name = data.name;
-    if (typeof data.verificationLevel !== 'undefined') {
-      _data.verification_level = data.verificationLevel;
+    if (options.name) _data.name = options.name;
+    if (typeof options.verificationLevel !== 'undefined') {
+      _data.verification_level = options.verificationLevel;
     }
-    if (typeof data.afkChannel !== 'undefined') {
-      _data.afk_channel_id = this.client.channels.resolveId(data.afkChannel);
+    if (typeof options.afkChannel !== 'undefined') {
+      _data.afk_channel_id = this.client.channels.resolveId(options.afkChannel);
     }
-    if (typeof data.systemChannel !== 'undefined') {
-      _data.system_channel_id = this.client.channels.resolveId(data.systemChannel);
+    if (typeof options.systemChannel !== 'undefined') {
+      _data.system_channel_id = this.client.channels.resolveId(options.systemChannel);
     }
-    if (data.afkTimeout) _data.afk_timeout = Number(data.afkTimeout);
-    if (typeof data.icon !== 'undefined') _data.icon = await DataResolver.resolveImage(data.icon);
-    if (data.owner) _data.owner_id = this.client.users.resolveId(data.owner);
-    if (typeof data.splash !== 'undefined') _data.splash = await DataResolver.resolveImage(data.splash);
-    if (typeof data.discoverySplash !== 'undefined') {
-      _data.discovery_splash = await DataResolver.resolveImage(data.discoverySplash);
+    if (options.afkTimeout) _data.afk_timeout = Number(options.afkTimeout);
+    if (typeof options.icon !== 'undefined') _data.icon = await DataResolver.resolveImage(options.icon);
+    if (options.owner) _data.owner_id = this.client.users.resolveId(options.owner);
+    if (typeof options.splash !== 'undefined') _data.splash = await DataResolver.resolveImage(options.splash);
+    if (typeof options.discoverySplash !== 'undefined') {
+      _data.discovery_splash = await DataResolver.resolveImage(options.discoverySplash);
     }
-    if (typeof data.banner !== 'undefined') _data.banner = await DataResolver.resolveImage(data.banner);
-    if (typeof data.explicitContentFilter !== 'undefined') {
-      _data.explicit_content_filter = data.explicitContentFilter;
+    if (typeof options.banner !== 'undefined') _data.banner = await DataResolver.resolveImage(options.banner);
+    if (typeof options.explicitContentFilter !== 'undefined') {
+      _data.explicit_content_filter = options.explicitContentFilter;
     }
-    if (typeof data.defaultMessageNotifications !== 'undefined') {
-      _data.default_message_notifications = data.defaultMessageNotifications;
+    if (typeof options.defaultMessageNotifications !== 'undefined') {
+      _data.default_message_notifications = options.defaultMessageNotifications;
     }
-    if (typeof data.systemChannelFlags !== 'undefined') {
-      _data.system_channel_flags = SystemChannelFlagsBitField.resolve(data.systemChannelFlags);
+    if (typeof options.systemChannelFlags !== 'undefined') {
+      _data.system_channel_flags = SystemChannelFlagsBitField.resolve(options.systemChannelFlags);
     }
-    if (typeof data.rulesChannel !== 'undefined') {
-      _data.rules_channel_id = this.client.channels.resolveId(data.rulesChannel);
+    if (typeof options.rulesChannel !== 'undefined') {
+      _data.rules_channel_id = this.client.channels.resolveId(options.rulesChannel);
     }
-    if (typeof data.publicUpdatesChannel !== 'undefined') {
-      _data.public_updates_channel_id = this.client.channels.resolveId(data.publicUpdatesChannel);
+    if (typeof options.publicUpdatesChannel !== 'undefined') {
+      _data.public_updates_channel_id = this.client.channels.resolveId(options.publicUpdatesChannel);
     }
-    if (typeof data.features !== 'undefined') {
-      _data.features = data.features;
+    if (typeof options.features !== 'undefined') {
+      _data.features = options.features;
     }
-    if (typeof data.description !== 'undefined') {
-      _data.description = data.description;
+    if (typeof options.description !== 'undefined') {
+      _data.description = options.description;
     }
-    if (typeof data.preferredLocale !== 'undefined') _data.preferred_locale = data.preferredLocale;
-    if ('premiumProgressBarEnabled' in data) _data.premium_progress_bar_enabled = data.premiumProgressBarEnabled;
-    const newData = await this.client.rest.patch(Routes.guild(this.id), { body: _data, reason: data.reason });
+    if (typeof options.preferredLocale !== 'undefined') _data.preferred_locale = options.preferredLocale;
+    if ('premiumProgressBarEnabled' in options) _data.premium_progress_bar_enabled = options.premiumProgressBarEnabled;
+    const newData = await this.client.rest.patch(Routes.guild(this.id), { body: _data, reason: options.reason });
     return this.client.actions.GuildUpdate.handle(newData).updated;
   }
 
@@ -845,7 +845,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Welcome screen edit data
-   * @typedef {Object} WelcomeScreenEditData
+   * @typedef {Object} WelcomeScreenEditOptions
    * @property {boolean} [enabled] Whether the welcome screen is enabled
    * @property {string} [description] The description for the welcome screen
    * @property {WelcomeChannelData[]} [welcomeChannels] The welcome channel data for the welcome screen
@@ -861,7 +861,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Data that can be resolved to a GuildVoiceChannel object. This can be:
-   * * A VoiceChannel
+   * * A VoiceChannelprovide
    * * A StageChannel
    * * A Snowflake
    * @typedef {VoiceChannel|StageChannel|Snowflake} GuildVoiceChannelResolvable
@@ -869,7 +869,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Updates the guild's welcome screen
-   * @param {WelcomeScreenEditData} data Data to edit the welcome screen with
+   * @param {WelcomeScreenEditOptions} options The options to provide
    * @returns {Promise<WelcomeScreen>}
    * @example
    * guild.editWelcomeScreen({
@@ -883,8 +883,8 @@ class Guild extends AnonymousGuild {
    *   ],
    * })
    */
-  async editWelcomeScreen(data) {
-    const { enabled, description, welcomeChannels } = data;
+  async editWelcomeScreen(options) {
+    const { enabled, description, welcomeChannels } = options;
     const welcome_channels = welcomeChannels?.map(welcomeChannelData => {
       const emoji = this.emojis.resolve(welcomeChannelData.emoji);
       return {

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -861,7 +861,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Data that can be resolved to a GuildVoiceChannel object. This can be:
-   * * A VoiceChannelprovide
+   * * A VoiceChannel
    * * A StageChannel
    * * A Snowflake
    * @typedef {VoiceChannel|StageChannel|Snowflake} GuildVoiceChannelResolvable

--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -268,7 +268,7 @@ class GuildChannel extends BaseChannel {
 
   /**
    * Edits the channel.
-   * @param {GuildChannelEditOptions} data The new data for the channel
+   * @param {GuildChannelEditOptions} options The options to provide
    * @returns {Promise<GuildChannel>}
    * @example
    * // Edit a channel
@@ -276,8 +276,8 @@ class GuildChannel extends BaseChannel {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  edit(data) {
-    return this.guild.channels.edit(this, data);
+  edit(options) {
+    return this.guild.channels.edit(this, options);
   }
 
   /**

--- a/packages/discord.js/src/structures/GuildEmoji.js
+++ b/packages/discord.js/src/structures/GuildEmoji.js
@@ -78,7 +78,7 @@ class GuildEmoji extends BaseGuildEmoji {
 
   /**
    * Data for editing an emoji.
-   * @typedef {Object} GuildEmojiEditData
+   * @typedef {Object} GuildEmojiEditOptions
    * @property {string} [name] The name of the emoji
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] Roles to restrict emoji to
    * @property {string} [reason] Reason for editing this emoji
@@ -86,7 +86,7 @@ class GuildEmoji extends BaseGuildEmoji {
 
   /**
    * Edits the emoji.
-   * @param {GuildEmojiEditData} data The new data for the emoji
+   * @param {GuildEmojiEditOptions} options The options to provide
    * @returns {Promise<GuildEmoji>}
    * @example
    * // Edit an emoji
@@ -94,8 +94,8 @@ class GuildEmoji extends BaseGuildEmoji {
    *   .then(e => console.log(`Edited emoji ${e}`))
    *   .catch(console.error);
    */
-  edit(data) {
-    return this.guild.emojis.edit(this.id, data);
+  edit(options) {
+    return this.guild.emojis.edit(this.id, options);
   }
 
   /**

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -307,11 +307,11 @@ class GuildMember extends Base {
 
   /**
    * Edits this member.
-   * @param {GuildMemberEditData} data The data to edit the member with
+   * @param {GuildMemberEditOptions} options The options to provide
    * @returns {Promise<GuildMember>}
    */
-  edit(data) {
-    return this.guild.members.edit(this, data);
+  edit(options) {
+    return this.guild.members.edit(this, options);
   }
 
   /**

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -240,7 +240,7 @@ class GuildScheduledEvent extends Base {
 
   /**
    * Options used to create an invite URL to a {@link GuildScheduledEvent}
-   * @typedef {CreateInviteOptions} CreateGuildScheduledEventInviteURLOptions
+   * @typedef {InviteCreateOptions} GuildScheduledEventInviteURLCreateOptions
    * @property {GuildInvitableChannelResolvable} [channel] The channel to create the invite in.
    * <warn>This is required when the `entityType` of `GuildScheduledEvent` is
    * {@link GuildScheduledEventEntityType.External}, gets ignored otherwise</warn>
@@ -248,7 +248,7 @@ class GuildScheduledEvent extends Base {
 
   /**
    * Creates an invite URL to this guild scheduled event.
-   * @param {CreateGuildScheduledEventInviteURLOptions} [options] The options to create the invite
+   * @param {GuildScheduledEventInviteURLCreateOptions} [options] The options to create the invite
    * @returns {Promise<string>}
    */
   async createInviteURL(options) {

--- a/packages/discord.js/src/structures/GuildTemplate.js
+++ b/packages/discord.js/src/structures/GuildTemplate.js
@@ -155,14 +155,14 @@ class GuildTemplate extends Base {
 
   /**
    * Options used to edit a guild template.
-   * @typedef {Object} EditGuildTemplateOptions
+   * @typedef {Object} GuildTemplateEditOptions
    * @property {string} [name] The name of this template
    * @property {string} [description] The description of this template
    */
 
   /**
    * Updates the metadata of this template.
-   * @param {EditGuildTemplateOptions} [options] Options for editing the template
+   * @param {GuildTemplateEditOptions} [options] Options for editing the template
    * @returns {Promise<GuildTemplate>}
    */
   async edit({ name, description } = {}) {

--- a/packages/discord.js/src/structures/InteractionWebhook.js
+++ b/packages/discord.js/src/structures/InteractionWebhook.js
@@ -45,7 +45,7 @@ class InteractionWebhook {
   /**
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable|'@original'} message The message to edit
-   * @param {string|MessagePayload|WebhookEditMessageOptions} options The options to provide
+   * @param {string|MessagePayload|WebhookMessageEditOptions} options The options to provide
    * @returns {Promise<Message>} Returns the message edited by this webhook
    */
 

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -287,7 +287,7 @@ module.exports = MessagePayload;
 
 /**
  * A possible payload option.
- * @typedef {MessageCreateOptions|MessageEditOptions|WebhookCreateMessageOptions|WebhookEditMessageOptions|
+ * @typedef {MessageCreateOptions|MessageEditOptions|WebhookMessageCreateOptions|WebhookMessageEditOptions|
  * InteractionReplyOptions|InteractionUpdateOptions} MessagePayloadOption
  */
 

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -207,7 +207,7 @@ class Role extends Base {
 
   /**
    * Edits the role.
-   * @param {EditRoleOptions} data The new data for the role
+   * @param {RoleEditOptions} options The options to provide
    * @returns {Promise<Role>}
    * @example
    * // Edit a role
@@ -215,8 +215,8 @@ class Role extends Base {
    *   .then(updated => console.log(`Edited role name to ${updated.name}`))
    *   .catch(console.error);
    */
-  edit(data) {
-    return this.guild.roles.edit(this, data);
+  edit(options) {
+    return this.guild.roles.edit(this, options);
   }
 
   /**

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -197,7 +197,7 @@ class Sticker extends Base {
 
   /**
    * Data for editing a sticker.
-   * @typedef {Object} GuildStickerEditData
+   * @typedef {Object} GuildStickerEditOptions
    * @property {string} [name] The name of the sticker
    * @property {?string} [description] The description of the sticker
    * @property {string} [tags] The Discord name of a unicode emoji representing the sticker's expression
@@ -206,7 +206,7 @@ class Sticker extends Base {
 
   /**
    * Edits the sticker.
-   * @param {GuildStickerEditData} data The new data for the sticker
+   * @param {GuildStickerEditOptions} options The options to provide
    * @returns {Promise<Sticker>}
    * @example
    * // Update the name of a sticker
@@ -214,8 +214,8 @@ class Sticker extends Base {
    *   .then(s => console.log(`Updated the name of the sticker to ${s.name}`))
    *   .catch(console.error);
    */
-  edit(data) {
-    return this.guild.stickers.edit(this, data);
+  edit(options) {
+    return this.guild.stickers.edit(this, options);
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -316,7 +316,7 @@ class ThreadChannel extends BaseChannel {
 
   /**
    * The options used to edit a thread channel
-   * @typedef {Object} ThreadEditData
+   * @typedef {Object} ThreadEditOptions
    * @property {string} [name] The new name for the thread
    * @property {boolean} [archived] Whether the thread is archived
    * @property {ThreadAutoArchiveDuration} [autoArchiveDuration] The amount of time after which the thread
@@ -332,7 +332,7 @@ class ThreadChannel extends BaseChannel {
 
   /**
    * Edits this thread.
-   * @param {ThreadEditData} data The new data for this thread
+   * @param {ThreadEditOptions} options The options to provide
    * @returns {Promise<ThreadChannel>}
    * @example
    * // Edit a thread
@@ -340,19 +340,19 @@ class ThreadChannel extends BaseChannel {
    *   .then(editedThread => console.log(editedThread))
    *   .catch(console.error);
    */
-  async edit(data) {
+  async edit(options) {
     const newData = await this.client.rest.patch(Routes.channel(this.id), {
       body: {
-        name: (data.name ?? this.name).trim(),
-        archived: data.archived,
-        auto_archive_duration: data.autoArchiveDuration,
-        rate_limit_per_user: data.rateLimitPerUser,
-        locked: data.locked,
-        invitable: this.type === ChannelType.PrivateThread ? data.invitable : undefined,
-        applied_tags: data.appliedTags,
-        flags: 'flags' in data ? ChannelFlagsBitField.resolve(data.flags) : undefined,
+        name: (options.name ?? this.name).trim(),
+        archived: options.archived,
+        auto_archive_duration: options.autoArchiveDuration,
+        rate_limit_per_user: options.rateLimitPerUser,
+        locked: options.locked,
+        invitable: this.type === ChannelType.PrivateThread ? options.invitable : undefined,
+        applied_tags: options.appliedTags,
+        flags: 'flags' in options ? ChannelFlagsBitField.resolve(options.flags) : undefined,
       },
-      reason: data.reason,
+      reason: options.reason,
     });
 
     return this.client.actions.ChannelUpdate.handle(newData).updated;

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -208,7 +208,7 @@ class VoiceState extends Base {
 
   /**
    * Data to edit the logged in user's own voice state with, when in a stage channel
-   * @typedef {Object} VoiceStateEditData
+   * @typedef {Object} VoiceStateEditOptions
    * @property {boolean} [requestToSpeak] Whether or not the client is requesting to become a speaker.
    * <info>Only available to the logged in user's own voice state.</info>
    * @property {boolean} [suppressed] Whether or not the user should be suppressed.
@@ -216,35 +216,35 @@ class VoiceState extends Base {
 
   /**
    * Edits this voice state. Currently only available when in a stage channel
-   * @param {VoiceStateEditData} data The data to edit the voice state with
+   * @param {VoiceStateEditOptions} options The options to provide
    * @returns {Promise<VoiceState>}
    */
-  async edit(data) {
+  async edit(options) {
     if (this.channel?.type !== ChannelType.GuildStageVoice) throw new DiscordjsError(ErrorCodes.VoiceNotStageChannel);
 
     const target = this.client.user.id === this.id ? '@me' : this.id;
 
-    if (target !== '@me' && typeof data.requestToSpeak !== 'undefined') {
+    if (target !== '@me' && typeof options.requestToSpeak !== 'undefined') {
       throw new DiscordjsError(ErrorCodes.VoiceStateNotOwn);
     }
 
-    if (!['boolean', 'undefined'].includes(typeof data.requestToSpeak)) {
+    if (!['boolean', 'undefined'].includes(typeof options.requestToSpeak)) {
       throw new DiscordjsTypeError(ErrorCodes.VoiceStateInvalidType, 'requestToSpeak');
     }
 
-    if (!['boolean', 'undefined'].includes(typeof data.suppressed)) {
+    if (!['boolean', 'undefined'].includes(typeof options.suppressed)) {
       throw new DiscordjsTypeError(ErrorCodes.VoiceStateInvalidType, 'suppressed');
     }
 
     await this.client.rest.patch(Routes.guildVoiceState(this.guild.id, target), {
       body: {
         channel_id: this.channelId,
-        request_to_speak_timestamp: data.requestToSpeak
+        request_to_speak_timestamp: options.requestToSpeak
           ? new Date().toISOString()
-          : data.requestToSpeak === false
+          : options.requestToSpeak === false
           ? null
           : undefined,
-        suppress: data.suppressed,
+        suppress: options.suppressed,
       },
     });
     return this;

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -126,7 +126,7 @@ class Webhook {
 
   /**
    * Options that can be passed into send.
-   * @typedef {BaseMessageOptions} WebhookCreateMessageOptions
+   * @typedef {BaseMessageOptions} WebhookMessageCreateOptions
    * @property {boolean} [tts=false] Whether the message should be spoken aloud
    * @property {MessageFlags} [flags] Which flags to set for the message.
    * <info>Only the {@link MessageFlags.SuppressEmbeds} flag can be set.</info>
@@ -139,7 +139,7 @@ class Webhook {
 
   /**
    * Options that can be passed into editMessage.
-   * @typedef {BaseMessageOptions} WebhookEditMessageOptions
+   * @typedef {BaseMessageOptions} WebhookMessageEditOptions
    * @property {Attachment[]} [attachments] Attachments to send with the message
    * @property {Snowflake} [threadId] The id of the thread this message belongs to
    * <info>For interaction webhooks, this property is ignored</info>
@@ -156,7 +156,7 @@ class Webhook {
 
   /**
    * Sends a message with this webhook.
-   * @param {string|MessagePayload|WebhookCreateMessageOptions} options The options to provide
+   * @param {string|MessagePayload|WebhookMessageCreateOptions} options The options to provide
    * @returns {Promise<Message>}
    * @example
    * // Send a basic message
@@ -261,7 +261,7 @@ class Webhook {
 
   /**
    * Options used to edit a {@link Webhook}.
-   * @typedef {Object} WebhookEditData
+   * @typedef {Object} WebhookEditOptions
    * @property {string} [name=this.name] The new name for the webhook
    * @property {?(BufferResolvable)} [avatar] The new avatar for the webhook
    * @property {GuildTextChannelResolvable} [channel] The new channel for the webhook
@@ -270,7 +270,7 @@ class Webhook {
 
   /**
    * Edits this webhook.
-   * @param {WebhookEditData} options Options for editing the webhook
+   * @param {WebhookEditOptions} options Options for editing the webhook
    * @returns {Promise<Webhook>}
    */
   async edit({ name = this.name, avatar, channel, reason }) {
@@ -322,7 +322,7 @@ class Webhook {
   /**
    * Edits a message that was sent by this webhook.
    * @param {MessageResolvable|'@original'} message The message to edit
-   * @param {string|MessagePayload|WebhookEditMessageOptions} options The options to provide
+   * @param {string|MessagePayload|WebhookMessageEditOptions} options The options to provide
    * @returns {Promise<Message>} Returns the message edited by this webhook
    */
   async editMessage(message, options) {

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -138,7 +138,7 @@ class InteractionResponses {
 
   /**
    * Options that can be passed into {@link InteractionResponses#editReply}.
-   * @typedef {WebhookEditMessageOptions} InteractionEditReplyOptions
+   * @typedef {WebhookMessageEditOptions} InteractionEditReplyOptions
    * @property {MessageResolvable|'@original'} [message='@original'] The response to edit
    */
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1266,7 +1266,7 @@ export class Guild extends AnonymousGuild {
   public delete(): Promise<Guild>;
   public discoverySplashURL(options?: ImageURLOptions): string | null;
   public edit(options: GuildEditOptions): Promise<Guild>;
-  public editWelcomeScreen(data: WelcomeScreenEditOptions): Promise<WelcomeScreen>;
+  public editWelcomeScreen(options: WelcomeScreenEditOptions): Promise<WelcomeScreen>;
   public equals(guild: Guild): boolean;
   public fetchAuditLogs<T extends GuildAuditLogsResolvable = null>(
     options?: GuildAuditLogsFetchOptions<T>,
@@ -1388,7 +1388,7 @@ export abstract class GuildChannel extends BaseChannel {
   public get viewable(): boolean;
   public clone(options?: GuildChannelCloneOptions): Promise<this>;
   public delete(reason?: string): Promise<this>;
-  public edit(data: GuildChannelEditOptions): Promise<this>;
+  public edit(options: GuildChannelEditOptions): Promise<this>;
   public equals(channel: GuildChannel): boolean;
   public lockPermissions(): Promise<this>;
   public permissionsFor(memberOrRole: GuildMember | Role, checkAdmin?: boolean): Readonly<PermissionsBitField>;
@@ -2704,7 +2704,7 @@ export class Sticker extends Base {
   public fetch(): Promise<Sticker>;
   public fetchPack(): Promise<StickerPack | null>;
   public fetchUser(): Promise<User | null>;
-  public edit(data?: GuildStickerEditOptions): Promise<Sticker>;
+  public edit(options?: GuildStickerEditOptions): Promise<Sticker>;
   public delete(reason?: string): Promise<Sticker>;
   public equals(other: Sticker | unknown): boolean;
 }
@@ -3163,7 +3163,7 @@ export class VoiceState extends Base {
   public setChannel(channel: GuildVoiceChannelResolvable | null, reason?: string): Promise<GuildMember>;
   public setRequestToSpeak(request?: boolean): Promise<this>;
   public setSuppressed(suppressed?: boolean): Promise<this>;
-  public edit(data: VoiceStateEditOptions): Promise<this>;
+  public edit(options: VoiceStateEditOptions): Promise<this>;
 }
 
 export class Webhook extends WebhookMixin() {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -597,7 +597,7 @@ export class BaseGuildTextChannel extends TextBasedChannelMixin(GuildChannel, tr
   public nsfw: boolean;
   public threads: GuildTextThreadManager<AllowedThreadTypeForTextChannel | AllowedThreadTypeForNewsChannel>;
   public topic: string | null;
-  public createInvite(options?: CreateInviteOptions): Promise<Invite>;
+  public createInvite(options?: InviteCreateOptions): Promise<Invite>;
   public fetchInvites(cache?: boolean): Promise<Collection<string, Invite>>;
   public setDefaultAutoArchiveDuration(
     defaultAutoArchiveDuration: ThreadAutoArchiveDuration,
@@ -616,7 +616,7 @@ export class BaseGuildVoiceChannel extends GuildChannel {
   public rtcRegion: string | null;
   public bitrate: number;
   public userLimit: number;
-  public createInvite(options?: CreateInviteOptions): Promise<Invite>;
+  public createInvite(options?: InviteCreateOptions): Promise<Invite>;
   public setRTCRegion(rtcRegion: string | null, reason?: string): Promise<this>;
   public fetchInvites(cache?: boolean): Promise<Collection<string, Invite>>;
 }
@@ -977,7 +977,7 @@ export class ClientUser extends User {
   public mfaEnabled: boolean;
   public get presence(): ClientPresence;
   public verified: boolean;
-  public edit(data: ClientUserEditData): Promise<this>;
+  public edit(options: ClientUserEditOptions): Promise<this>;
   public setActivity(options?: ActivityOptions): ClientPresence;
   public setActivity(name: string, options?: ActivityOptions): ClientPresence;
   public setAFK(afk?: boolean, shardId?: number | number[]): ClientPresence;
@@ -1265,8 +1265,8 @@ export class Guild extends AnonymousGuild {
   public createTemplate(name: string, description?: string): Promise<GuildTemplate>;
   public delete(): Promise<Guild>;
   public discoverySplashURL(options?: ImageURLOptions): string | null;
-  public edit(data: GuildEditData): Promise<Guild>;
-  public editWelcomeScreen(data: WelcomeScreenEditData): Promise<WelcomeScreen>;
+  public edit(options: GuildEditOptions): Promise<Guild>;
+  public editWelcomeScreen(data: WelcomeScreenEditOptions): Promise<WelcomeScreen>;
   public equals(guild: Guild): boolean;
   public fetchAuditLogs<T extends GuildAuditLogsResolvable = null>(
     options?: GuildAuditLogsFetchOptions<T>,
@@ -1413,7 +1413,7 @@ export class GuildEmoji extends BaseGuildEmoji {
   public get roles(): GuildEmojiRoleManager;
   public get url(): string;
   public delete(reason?: string): Promise<GuildEmoji>;
-  public edit(data: GuildEmojiEditData): Promise<GuildEmoji>;
+  public edit(options: GuildEmojiEditOptions): Promise<GuildEmoji>;
   public equals(other: GuildEmoji | unknown): boolean;
   public fetchAuthor(): Promise<User>;
   public setName(name: string, reason?: string): Promise<GuildEmoji>;
@@ -1454,7 +1454,7 @@ export class GuildMember extends PartialTextBasedChannel(Base) {
   public createDM(force?: boolean): Promise<DMChannel>;
   public deleteDM(): Promise<DMChannel>;
   public displayAvatarURL(options?: ImageURLOptions): string;
-  public edit(data: GuildMemberEditData): Promise<GuildMember>;
+  public edit(options: GuildMemberEditOptions): Promise<GuildMember>;
   public isCommunicationDisabled(): this is GuildMember & {
     communicationDisabledUntilTimestamp: number;
     readonly communicationDisabledUntil: Date;
@@ -1516,7 +1516,7 @@ export class GuildScheduledEvent<S extends GuildScheduledEventStatus = GuildSche
   public get url(): string;
   public image: string | null;
   public coverImageURL(options?: Readonly<BaseImageURLOptions>): string | null;
-  public createInviteURL(options?: CreateGuildScheduledEventInviteURLOptions): Promise<string>;
+  public createInviteURL(options?: GuildScheduledEventInviteURLCreateOptions): Promise<string>;
   public edit<T extends GuildScheduledEventSetStatusArg<S>>(
     options: GuildScheduledEventEditOptions<S, T>,
   ): Promise<GuildScheduledEvent<T>>;
@@ -1559,7 +1559,7 @@ export class GuildTemplate extends Base {
   public unSynced: boolean | null;
   public createGuild(name: string, icon?: BufferResolvable | Base64Resolvable): Promise<Guild>;
   public delete(): Promise<GuildTemplate>;
-  public edit(options?: EditGuildTemplateOptions): Promise<GuildTemplate>;
+  public edit(options?: GuildTemplateEditOptions): Promise<GuildTemplate>;
   public sync(): Promise<GuildTemplate>;
   public static GuildTemplatesPattern: RegExp;
 }
@@ -1730,7 +1730,7 @@ export class InteractionWebhook extends PartialWebhookMixin() {
   public send(options: string | MessagePayload | InteractionReplyOptions): Promise<Message>;
   public editMessage(
     message: MessageResolvable | '@original',
-    options: string | MessagePayload | WebhookEditMessageOptions,
+    options: string | MessagePayload | WebhookMessageEditOptions,
   ): Promise<Message>;
   public fetchMessage(message: Snowflake | '@original'): Promise<Message>;
 }
@@ -2056,8 +2056,8 @@ export class MessageMentions<InGuild extends boolean = boolean> {
 export type MessagePayloadOption =
   | MessageCreateOptions
   | MessageEditOptions
-  | WebhookCreateMessageOptions
-  | WebhookEditMessageOptions
+  | WebhookMessageCreateOptions
+  | WebhookMessageEditOptions
   | InteractionReplyOptions
   | InteractionUpdateOptions;
 
@@ -2254,7 +2254,7 @@ export class ForumChannel extends TextBasedChannelMixin(GuildChannel, true, [
   public setAvailableTags(tags: GuildForumTagData[], reason?: string): Promise<this>;
   public setDefaultReactionEmoji(emojiId: DefaultReactionEmoji | null, reason?: string): Promise<this>;
   public setDefaultThreadRateLimitPerUser(rateLimit: number, reason?: string): Promise<this>;
-  public createInvite(options?: CreateInviteOptions): Promise<Invite>;
+  public createInvite(options?: InviteCreateOptions): Promise<Invite>;
   public fetchInvites(cache?: boolean): Promise<Collection<string, Invite>>;
   public setDefaultAutoArchiveDuration(
     defaultAutoArchiveDuration: ThreadAutoArchiveDuration,
@@ -2382,7 +2382,7 @@ export class Role extends Base {
   public icon: string | null;
   public unicodeEmoji: string | null;
   public delete(reason?: string): Promise<Role>;
-  public edit(data: EditRoleOptions): Promise<Role>;
+  public edit(options: RoleEditOptions): Promise<Role>;
   public equals(role: Role): boolean;
   public iconURL(options?: ImageURLOptions): string | null;
   public permissionsIn(
@@ -2704,7 +2704,7 @@ export class Sticker extends Base {
   public fetch(): Promise<Sticker>;
   public fetchPack(): Promise<StickerPack | null>;
   public fetchUser(): Promise<User | null>;
-  public edit(data?: GuildStickerEditData): Promise<Sticker>;
+  public edit(data?: GuildStickerEditOptions): Promise<Sticker>;
   public delete(reason?: string): Promise<Sticker>;
   public equals(other: Sticker | unknown): boolean;
 }
@@ -2882,7 +2882,7 @@ export class ThreadChannel<Forum extends boolean = boolean> extends TextBasedCha
   public type: ThreadChannelType;
   public get unarchivable(): boolean;
   public delete(reason?: string): Promise<this>;
-  public edit(data: ThreadEditData): Promise<AnyThreadChannel>;
+  public edit(options: ThreadEditOptions): Promise<AnyThreadChannel>;
   public join(): Promise<AnyThreadChannel>;
   public leave(): Promise<AnyThreadChannel>;
   public permissionsFor(memberOrRole: GuildMember | Role, checkAdmin?: boolean): Readonly<PermissionsBitField>;
@@ -3053,12 +3053,12 @@ export interface MappedComponentTypes {
   [ComponentType.TextInput]: TextInputComponent;
 }
 
-export interface CreateChannelOptions {
+export interface ChannelCreateOptions {
   allowFromUnknownGuild?: boolean;
   fromInteraction?: boolean;
 }
 
-export function createChannel(client: Client<true>, data: APIChannel, options?: CreateChannelOptions): Channel;
+export function createChannel(client: Client<true>, data: APIChannel, options?: ChannelCreateOptions): Channel;
 
 export function createComponent<T extends keyof MappedComponentTypes>(
   data: APIMessageComponent & { type: T },
@@ -3163,7 +3163,7 @@ export class VoiceState extends Base {
   public setChannel(channel: GuildVoiceChannelResolvable | null, reason?: string): Promise<GuildMember>;
   public setRequestToSpeak(request?: boolean): Promise<this>;
   public setSuppressed(suppressed?: boolean): Promise<this>;
-  public edit(data: VoiceStateEditData): Promise<this>;
+  public edit(data: VoiceStateEditOptions): Promise<this>;
 }
 
 export class Webhook extends WebhookMixin() {
@@ -3206,10 +3206,10 @@ export class Webhook extends WebhookMixin() {
 
   public editMessage(
     message: MessageResolvable,
-    options: string | MessagePayload | WebhookEditMessageOptions,
+    options: string | MessagePayload | WebhookMessageEditOptions,
   ): Promise<Message>;
   public fetchMessage(message: Snowflake, options?: WebhookFetchMessageOptions): Promise<Message>;
-  public send(options: string | MessagePayload | WebhookCreateMessageOptions): Promise<Message>;
+  public send(options: string | MessagePayload | WebhookMessageCreateOptions): Promise<Message>;
 }
 
 export class WebhookClient extends WebhookMixin(BaseClient) {
@@ -3219,10 +3219,10 @@ export class WebhookClient extends WebhookMixin(BaseClient) {
   public token: string;
   public editMessage(
     message: MessageResolvable,
-    options: string | MessagePayload | WebhookEditMessageOptions,
+    options: string | MessagePayload | WebhookMessageEditOptions,
   ): Promise<APIMessage>;
   public fetchMessage(message: Snowflake, options?: WebhookFetchMessageOptions): Promise<APIMessage>;
-  public send(options: string | MessagePayload | WebhookCreateMessageOptions): Promise<APIMessage>;
+  public send(options: string | MessagePayload | WebhookMessageCreateOptions): Promise<APIMessage>;
 }
 
 export class WebSocketManager extends EventEmitter {
@@ -3786,7 +3786,7 @@ export class GuildEmojiManager extends BaseGuildEmojiManager {
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, GuildEmoji>>;
   public fetchAuthor(emoji: EmojiResolvable): Promise<User>;
   public delete(emoji: EmojiResolvable, reason?: string): Promise<void>;
-  public edit(emoji: EmojiResolvable, data: GuildEmojiEditData): Promise<GuildEmoji>;
+  public edit(emoji: EmojiResolvable, options: GuildEmojiEditOptions): Promise<GuildEmoji>;
 }
 
 export class GuildEmojiRoleManager extends DataManager<Snowflake, Role, RoleResolvable> {
@@ -3825,7 +3825,7 @@ export class GuildMemberManager extends CachedManager<Snowflake, GuildMember, Gu
   ): Promise<GuildMember | null>;
   public add(user: UserResolvable, options: AddGuildMemberOptions): Promise<GuildMember>;
   public ban(user: UserResolvable, options?: BanOptions): Promise<GuildMember | User | Snowflake>;
-  public edit(user: UserResolvable, data: GuildMemberEditData): Promise<GuildMember>;
+  public edit(user: UserResolvable, options: GuildMemberEditOptions): Promise<GuildMember>;
   public fetch(
     options: UserResolvable | FetchMemberOptions | (FetchMembersOptions & { user: UserResolvable }),
   ): Promise<GuildMember>;
@@ -3853,7 +3853,7 @@ export class GuildBanManager extends CachedManager<Snowflake, GuildBan, GuildBan
 export class GuildInviteManager extends DataManager<string, Invite, InviteResolvable> {
   private constructor(guild: Guild, iterable?: Iterable<RawInviteData>);
   public guild: Guild;
-  public create(channel: GuildInvitableChannelResolvable, options?: CreateInviteOptions): Promise<Invite>;
+  public create(channel: GuildInvitableChannelResolvable, options?: InviteCreateOptions): Promise<Invite>;
   public fetch(options: InviteResolvable | FetchInviteOptions): Promise<Invite>;
   public fetch(options?: FetchInvitesOptions): Promise<Collection<string, Invite>>;
   public delete(invite: InviteResolvable, reason?: string): Promise<Invite>;
@@ -3886,7 +3886,7 @@ export class GuildStickerManager extends CachedManager<Snowflake, Sticker, Stick
   private constructor(guild: Guild, iterable?: Iterable<RawStickerData>);
   public guild: Guild;
   public create(options: GuildStickerCreateOptions): Promise<Sticker>;
-  public edit(sticker: StickerResolvable, data?: GuildStickerEditData): Promise<Sticker>;
+  public edit(sticker: StickerResolvable, data?: GuildStickerEditOptions): Promise<Sticker>;
   public delete(sticker: StickerResolvable, reason?: string): Promise<void>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<Sticker>;
   public fetch(id?: Snowflake, options?: BaseFetchOptions): Promise<Collection<Snowflake, Sticker>>;
@@ -3991,8 +3991,8 @@ export class RoleManager extends CachedManager<Snowflake, Role, RoleResolvable> 
   public botRoleFor(user: UserResolvable): Role | null;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<Role | null>;
   public fetch(id?: undefined, options?: BaseFetchOptions): Promise<Collection<Snowflake, Role>>;
-  public create(options?: CreateRoleOptions): Promise<Role>;
-  public edit(role: RoleResolvable, options: EditRoleOptions): Promise<Role>;
+  public create(options?: RoleCreateOptions): Promise<Role>;
+  public edit(role: RoleResolvable, options: RoleEditOptions): Promise<Role>;
   public delete(role: RoleResolvable, reason?: string): Promise<void>;
   public setPosition(role: RoleResolvable, position: number, options?: SetRolePositionOptions): Promise<Role>;
   public setPositions(rolePositions: readonly RolePosition[]): Promise<Guild>;
@@ -4117,11 +4117,11 @@ export interface PartialWebhookFields {
   deleteMessage(message: MessageResolvable | APIMessage | '@original', threadId?: Snowflake): Promise<void>;
   editMessage(
     message: MessageResolvable | '@original',
-    options: string | MessagePayload | WebhookEditMessageOptions,
+    options: string | MessagePayload | WebhookMessageEditOptions,
   ): Promise<APIMessage | Message>;
   fetchMessage(message: Snowflake | '@original', options?: WebhookFetchMessageOptions): Promise<APIMessage | Message>;
   send(
-    options: string | MessagePayload | InteractionReplyOptions | WebhookCreateMessageOptions,
+    options: string | MessagePayload | InteractionReplyOptions | WebhookMessageCreateOptions,
   ): Promise<APIMessage | Message>;
 }
 
@@ -4129,7 +4129,7 @@ export interface WebhookFields extends PartialWebhookFields {
   get createdAt(): Date;
   get createdTimestamp(): number;
   delete(reason?: string): Promise<void>;
-  edit(options: WebhookEditData): Promise<Webhook>;
+  edit(options: WebhookEditOptions): Promise<Webhook>;
   sendSlackMessage(body: unknown): Promise<boolean>;
 }
 
@@ -4734,7 +4734,7 @@ export interface ClientPresenceStatusData {
   desktop?: ClientPresenceStatus;
 }
 
-export interface ClientUserEditData {
+export interface ClientUserEditOptions {
   username?: string;
   avatar?: BufferResolvable | Base64Resolvable | null;
 }
@@ -4940,15 +4940,15 @@ export enum Status {
   Resuming = 8,
 }
 
-export interface CreateGuildScheduledEventInviteURLOptions extends CreateInviteOptions {
+export interface GuildScheduledEventInviteURLCreateOptions extends InviteCreateOptions {
   channel?: GuildInvitableChannelResolvable;
 }
 
-export interface CreateRoleOptions extends RoleData {
+export interface RoleCreateOptions extends RoleData {
   reason?: string;
 }
 
-export interface EditRoleOptions extends RoleData {
+export interface RoleEditOptions extends RoleData {
   reason?: string;
 }
 
@@ -4967,7 +4967,7 @@ export interface CrosspostedChannel {
 
 export type DateResolvable = Date | number | string;
 
-export interface EditGuildTemplateOptions {
+export interface GuildTemplateEditOptions {
   name?: string;
   description?: string;
 }
@@ -5357,7 +5357,7 @@ export interface GuildWidgetSettings {
   channel: TextChannel | NewsChannel | VoiceBasedChannel | ForumChannel | null;
 }
 
-export interface GuildEditData {
+export interface GuildEditOptions {
   name?: string;
   verificationLevel?: GuildVerificationLevel | null;
   explicitContentFilter?: GuildExplicitContentFilter | null;
@@ -5387,7 +5387,7 @@ export interface GuildEmojiCreateOptions {
   reason?: string;
 }
 
-export interface GuildEmojiEditData {
+export interface GuildEmojiEditOptions {
   name?: string;
   roles?: Collection<Snowflake, Role> | RoleResolvable[];
   reason?: string;
@@ -5401,14 +5401,14 @@ export interface GuildStickerCreateOptions {
   reason?: string;
 }
 
-export interface GuildStickerEditData {
+export interface GuildStickerEditOptions {
   name?: string;
   description?: string | null;
   tags?: string;
   reason?: string;
 }
 
-export interface GuildMemberEditData {
+export interface GuildMemberEditOptions {
   nick?: string | null;
   roles?: Collection<Snowflake, Role> | readonly RoleResolvable[];
   mute?: boolean;
@@ -5568,7 +5568,7 @@ export interface InviteGenerationOptions {
 
 export type GuildInvitableChannelResolvable = TextChannel | VoiceChannel | NewsChannel | StageChannel | Snowflake;
 
-export interface CreateInviteOptions {
+export interface InviteCreateOptions {
   temporary?: boolean;
   maxAge?: number;
   maxUses?: number;
@@ -6110,7 +6110,7 @@ export interface GuildForumThreadCreateOptions extends StartThreadOptions {
   appliedTags?: Snowflake[];
 }
 
-export interface ThreadEditData {
+export interface ThreadEditOptions {
   name?: string;
   archived?: boolean;
   autoArchiveDuration?: ThreadAutoArchiveDuration;
@@ -6137,7 +6137,7 @@ export type VoiceBasedChannelTypes = VoiceBasedChannel['type'];
 
 export type VoiceChannelResolvable = Snowflake | VoiceChannel;
 
-export interface VoiceStateEditData {
+export interface VoiceStateEditOptions {
   requestToSpeak?: boolean;
   suppressed?: boolean;
 }
@@ -6155,18 +6155,18 @@ export interface WebhookClientDataURL {
 
 export type WebhookClientOptions = Pick<ClientOptions, 'allowedMentions' | 'rest'>;
 
-export interface WebhookEditData {
+export interface WebhookEditOptions {
   name?: string;
   avatar?: BufferResolvable | null;
   channel?: GuildTextChannelResolvable;
   reason?: string;
 }
 
-export interface WebhookEditMessageOptions extends Omit<MessageEditOptions, 'flags'> {
+export interface WebhookMessageEditOptions extends Omit<MessageEditOptions, 'flags'> {
   threadId?: Snowflake;
 }
 
-export interface InteractionEditReplyOptions extends WebhookEditMessageOptions {
+export interface InteractionEditReplyOptions extends WebhookMessageEditOptions {
   message?: MessageResolvable | '@original';
 }
 
@@ -6174,7 +6174,7 @@ export interface WebhookFetchMessageOptions {
   threadId?: Snowflake;
 }
 
-export interface WebhookCreateMessageOptions extends Omit<MessageCreateOptions, 'nonce' | 'reply' | 'stickers'> {
+export interface WebhookMessageCreateOptions extends Omit<MessageCreateOptions, 'nonce' | 'reply' | 'stickers'> {
   username?: string;
   avatarURL?: string;
   threadId?: Snowflake;
@@ -6210,7 +6210,7 @@ export interface WelcomeChannelData {
   emoji?: EmojiIdentifierResolvable;
 }
 
-export interface WelcomeScreenEditData {
+export interface WelcomeScreenEditOptions {
   enabled?: boolean;
   description?: string;
   welcomeChannels?: WelcomeChannelData[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR refactors the `XOptions`/`XData` interfaces to all follow the same format

Create options format: `StructureCreateOptions`
Edit options format: `StructureEditOptions`
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
