### PR TITLE
feat(InteractionResponse): createdTimestamp

### DIFF
--- a/packages/discord.js/src/structures/InteractionResponse.js
+++ b/packages/discord.js/src/structures/InteractionResponse.js
@@ -23,7 +23,7 @@ class InteractionResponse {
   }
 
   /**
-   * The timestamp the interaction's response was created at
+   * The timestamp the interaction response was created at
    * @type {number}
    * @readonly
    */
@@ -32,7 +32,7 @@ class InteractionResponse {
   }
 
   /**
-   * The time the interaction's response was created at
+   * The time the interaction response was created at
    * @type {Date}
    * @readonly
    */

--- a/packages/discord.js/src/structures/InteractionResponse.js
+++ b/packages/discord.js/src/structures/InteractionResponse.js
@@ -32,7 +32,7 @@ class InteractionResponse {
   }
 
   /**
-   * The time the interaction's resposne was created at
+   * The time the interaction's response was created at
    * @type {Date}
    * @readonly
    */

--- a/packages/discord.js/src/structures/InteractionResponse.js
+++ b/packages/discord.js/src/structures/InteractionResponse.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { DiscordSnowflake } = require('@sapphire/snowflake');
 const { InteractionType } = require('discord-api-types/v10');
 const { DiscordjsError, ErrorCodes } = require('../errors');
 
@@ -19,6 +20,24 @@ class InteractionResponse {
      */
     this.id = id ?? interaction.id;
     this.client = interaction.client;
+  }
+
+  /**
+   * The timestamp the interaction's response was created at
+   * @type {number}
+   * @readonly
+   */
+  get createdTimestamp() {
+    return DiscordSnowflake.timestampFrom(this.id);
+  }
+
+  /**
+   * The time the interaction's resposne was created at
+   * @type {Date}
+   * @readonly
+   */
+  get createdAt() {
+    return new Date(this.createdTimestamp);
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -555,6 +555,8 @@ export class InteractionResponse<Cached extends boolean = boolean> {
   public interaction: Interaction<WrapBooleanCache<Cached>>;
   public client: Client;
   public id: Snowflake;
+  public get createdAt(): Date;
+  public get createdTimestamp(): number;
   public awaitMessageComponent<T extends MessageComponentType>(
     options?: AwaitMessageCollectorOptionsParams<T, Cached>,
   ): Promise<MappedInteractionTypes<Cached>[T]>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
InteractionResponses have IDs, we can just destructure it and get createdAt and createdTimestamp, (it's a getter because other such properties on other classes were getters)
Close #8916 
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:

- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
