### PR TITLE
fix(WebSocketShard): clear listeners on reconnect

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -602,6 +602,9 @@ class WebSocketShard extends EventEmitter {
         `[WebSocket] did not close properly, assuming a zombie connection.\nEmitting close and reconnecting again.`,
       );
 
+      // Cleanup connection listeners
+      this._cleanupConnection();
+
       this.emitClose();
       // Setting the variable false to check for zombie connections.
       this.closeEmitted = false;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR should solve resolve #8486 and maybe even resolve #8592

When a WebSocketShard doesn't receive a heartbeat in time it tries to close the Websocket. If the close event of the socket doesn't emit in time either it assumes a zombie connection and emits its own close event, but the old connection still has the onClose and other event listeners attached. So if the old Websocket finally emits the close event the WebSocketShard receives that event and assumes it's from the new (re-)connection and closes again.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating


<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
