### PR TITLE
fix: add `@discordjs/formatters` to dependency list

### DIFF
--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@discordjs/builders": "workspace:^",
     "@discordjs/collection": "workspace:^",
+    "@discordjs/formatters": "workspace:^",
     "@discordjs/rest": "workspace:^",
     "@discordjs/util": "workspace:^",
     "@sapphire/snowflake": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8471,6 +8471,7 @@ __metadata:
     "@discordjs/builders": "workspace:^"
     "@discordjs/collection": "workspace:^"
     "@discordjs/docgen": "workspace:^"
+    "@discordjs/formatters": "workspace:^"
     "@discordjs/rest": "workspace:^"
     "@discordjs/util": "workspace:^"
     "@favware/cliff-jumper": ^1.9.0


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
https://github.com/discordjs/discord.js/blob/c76e17078602914c3e1d227a3acc98eaa99c18d4/packages/discord.js/src/index.js#L209

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
