### PR TITLE
docs(GuildForumThreadManager): Fix `sticker` type

### DIFF
--- a/packages/discord.js/src/managers/GuildForumThreadManager.js
+++ b/packages/discord.js/src/managers/GuildForumThreadManager.js
@@ -18,7 +18,7 @@ class GuildForumThreadManager extends ThreadManager {
 
   /**
    * @typedef {BaseMessageOptions} GuildForumThreadMessageCreateOptions
-   * @property {stickers} [stickers] The stickers to send with the message
+   * @property {StickerResolvable} [stickers] The stickers to send with the message
    * @property {BitFieldResolvable} [flags] The flags to send with the message
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`StickerResolvable` is the correct type to document here.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
