### PR TITLE
fix(WebSocketShard): only cleanup the connection if a connection still exists

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -603,7 +603,9 @@ class WebSocketShard extends EventEmitter {
       );
 
       // Cleanup connection listeners
-      this._cleanupConnection();
+      if (this.connection) {
+        this._cleanupConnection();
+      }
 
       this.emitClose();
       // Setting the variable false to check for zombie connections.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes the bug introduced with #8927 where the timeout in `WebSocketShard#setWsCloseTimeout()` tries to cleanup a connection even if none exists anymore.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
