### PR TITLE
fix(WebSocketShard): either start close timeout or emit destroyed but never both

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -840,8 +840,8 @@ class WebSocketShard extends EventEmitter {
         if (emit) {
           this._emitDestroyed();
         } else if (
-          this.connection?.readyState === WebSocket.CLOSING ||
-          this.connection?.readyState === WebSocket.CLOSED
+          this.connection.readyState === WebSocket.CLOSING ||
+          this.connection.readyState === WebSocket.CLOSED
         ) {
           this.closeEmitted = false;
           this.debug(

--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -835,21 +835,25 @@ class WebSocketShard extends EventEmitter {
           );
           this.connection.terminate();
         }
+
         // Emit the destroyed event if needed
-        if (emit) this._emitDestroyed();
+        if (emit) {
+          this._emitDestroyed();
+        } else if (
+          this.connection?.readyState === WebSocket.CLOSING ||
+          this.connection?.readyState === WebSocket.CLOSED
+        ) {
+          this.closeEmitted = false;
+          this.debug(
+            `[WebSocket] Adding a WebSocket close timeout to ensure a correct WS reconnect.
+            Timeout: ${this.manager.client.options.closeTimeout}ms`,
+          );
+          this.setWsCloseTimeout(this.manager.client.options.closeTimeout);
+        }
       }
     } else if (emit) {
       // We requested a destroy, but we had no connection. Emit destroyed
       this._emitDestroyed();
-    }
-
-    if (this.connection?.readyState === WebSocket.CLOSING || this.connection?.readyState === WebSocket.CLOSED) {
-      this.closeEmitted = false;
-      this.debug(
-        `[WebSocket] Adding a WebSocket close timeout to ensure a correct WS reconnect.
-        Timeout: ${this.manager.client.options.closeTimeout}ms`,
-      );
-      this.setWsCloseTimeout(this.manager.client.options.closeTimeout);
     }
 
     // Step 2: Null the connection object


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#7626 introduced a `WebSocketShard#wsCloseTimeout()` to listen for zombie connections and reconnect when zombie connections get detected.

This fix was going a bit too far, as the timeout was also starting if `WebSocketShard#destroy()` was emitting the `WebSocketShard#destroyed` event. In those cases we don't need to listen for zombie connections anymore, as the `WebSocketManager`will reconnect the shard anyway.

But this lead to the Websocket connection being unneccessarily destroyed after the reconnect, because the timeout happened after the new connection already got made.

This PR now only starts the `wsCloseTimeout` if the `WebSocketShard#destroy()` method doesn't emit the `WebSocketShard#destroyed` event.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
