### PR TITLE
fix: return only boolean for `disabled`

### DIFF
--- a/packages/discord.js/src/structures/BaseSelectMenuComponent.js
+++ b/packages/discord.js/src/structures/BaseSelectMenuComponent.js
@@ -45,11 +45,11 @@ class BaseSelectMenuComponent extends Component {
 
   /**
    * Whether this select menu is disabled
-   * @type {?boolean}
+   * @type {boolean}
    * @readonly
    */
   get disabled() {
-    return this.data.disabled ?? null;
+    return this.data.disabled ?? false;
   }
 }
 

--- a/packages/discord.js/src/structures/ButtonComponent.js
+++ b/packages/discord.js/src/structures/ButtonComponent.js
@@ -36,11 +36,11 @@ class ButtonComponent extends Component {
 
   /**
    * Whether this button is disabled
-   * @type {?boolean}
+   * @type {boolean}
    * @readonly
    */
   get disabled() {
-    return this.data.disabled ?? null;
+    return this.data.disabled ?? false;
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -678,7 +678,7 @@ export class ButtonComponent extends Component<APIButtonComponent> {
   public get style(): ButtonStyle;
   public get label(): string | null;
   public get emoji(): APIMessageComponentEmoji | null;
-  public get disabled(): boolean ;
+  public get disabled(): boolean;
   public get customId(): string | null;
   public get url(): string | null;
 }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -678,7 +678,7 @@ export class ButtonComponent extends Component<APIButtonComponent> {
   public get style(): ButtonStyle;
   public get label(): string | null;
   public get emoji(): APIMessageComponentEmoji | null;
-  public get disabled(): boolean | null;
+  public get disabled(): boolean ;
   public get customId(): string | null;
   public get url(): string | null;
 }
@@ -759,7 +759,7 @@ export class BaseSelectMenuComponent<Data extends APISelectMenuComponent> extend
   public get maxValues(): number | null;
   public get minValues(): number | null;
   public get customId(): string;
-  public get disabled(): boolean | null;
+  public get disabled(): boolean;
 }
 
 export class StringSelectMenuComponent extends BaseSelectMenuComponent<APIStringSelectComponent> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes `BaseSelectMenuComponent#disabled` and `ButtonComponent#disabled` to only return booleans.

Fixes #8964 
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
