### PR TITLE
types: Swap message reaction and emoji identifier types

### DIFF
--- a/packages/discord.js/src/managers/BaseGuildEmojiManager.js
+++ b/packages/discord.js/src/managers/BaseGuildEmojiManager.js
@@ -50,9 +50,9 @@ class BaseGuildEmojiManager extends CachedManager {
 
   /**
    * Data that can be resolved to give an emoji identifier. This can be:
-   * * The unicode representation of an emoji
-   * * The `<a:name:id>`, `<:name:id>`, `a:name:id` or `name:id` emoji identifier string of an emoji
    * * An EmojiResolvable
+   * * The `<a:name:id>`, `<:name:id>`, `a:name:id` or `name:id` emoji identifier string of an emoji
+   * * The Unicode representation of an emoji
    * @typedef {string|EmojiResolvable} EmojiIdentifierResolvable
    */
 

--- a/packages/discord.js/src/managers/ReactionManager.js
+++ b/packages/discord.js/src/managers/ReactionManager.js
@@ -33,6 +33,7 @@ class ReactionManager extends CachedManager {
    * Data that can be resolved to a MessageReaction object. This can be:
    * * A MessageReaction
    * * A Snowflake
+   * * The Unicode representation of an emoji
    * @typedef {MessageReaction|Snowflake} MessageReactionResolvable
    */
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5040,7 +5040,12 @@ export interface EmbedField {
   inline: boolean;
 }
 
-export type EmojiIdentifierResolvable = string | EmojiResolvable;
+export type EmojiIdentifierResolvable =
+  | EmojiResolvable
+  | `${string}:${Snowflake}`
+  | `<:${string}:${Snowflake}>`
+  | `<a:${string}:${Snowflake}>`
+  | string;
 
 export type EmojiResolvable = Snowflake | GuildEmoji | ReactionEmoji;
 
@@ -5785,13 +5790,7 @@ export interface MessageEditOptions extends Omit<BaseMessageOptions, 'content'> 
   flags?: BitFieldResolvable<Extract<MessageFlagsString, 'SuppressEmbeds'>, MessageFlags.SuppressEmbeds>;
 }
 
-export type MessageReactionResolvable =
-  | MessageReaction
-  | Snowflake
-  | `${string}:${Snowflake}`
-  | `<:${string}:${Snowflake}>`
-  | `<a:${string}:${Snowflake}>`
-  | string;
+export type MessageReactionResolvable = MessageReaction | Snowflake | string;
 
 export interface MessageReference {
   channelId: Snowflake;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5042,9 +5042,8 @@ export interface EmbedField {
 
 export type EmojiIdentifierResolvable =
   | EmojiResolvable
-  | `${string}:${Snowflake}`
-  | `<:${string}:${Snowflake}>`
-  | `<a:${string}:${Snowflake}>`
+  | `${'' | 'a:'}${string}:${Snowflake}`
+  | `<${'' | 'a'}:${string}:${Snowflake}>`
   | string;
 
 export type EmojiResolvable = Snowflake | GuildEmoji | ReactionEmoji;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #8968 by somewhat swapping the types for `EmojiIdentifierResolvable` and `MessageReactionResolvable`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
