### PR TITLE
refactor(Guild): Destructure object in guild editing

### DIFF
--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -740,24 +740,24 @@ class Guild extends AnonymousGuild {
    * @typedef {Object} GuildEditOptions
    * @property {string} [name] The name of the guild
    * @property {?GuildVerificationLevel} [verificationLevel] The verification level of the guild
+   * @property {?GuildDefaultMessageNotifications} [defaultMessageNotifications] The default message
+   * notification level of the guild
    * @property {?GuildExplicitContentFilter} [explicitContentFilter] The level of the explicit content filter
    * @property {?VoiceChannelResolvable} [afkChannel] The AFK channel of the guild
-   * @property {?TextChannelResolvable} [systemChannel] The system channel of the guild
    * @property {number} [afkTimeout] The AFK timeout of the guild
    * @property {?(BufferResolvable|Base64Resolvable)} [icon] The icon of the guild
    * @property {GuildMemberResolvable} [owner] The owner of the guild
    * @property {?(BufferResolvable|Base64Resolvable)} [splash] The invite splash image of the guild
    * @property {?(BufferResolvable|Base64Resolvable)} [discoverySplash] The discovery splash image of the guild
    * @property {?(BufferResolvable|Base64Resolvable)} [banner] The banner of the guild
-   * @property {?GuildDefaultMessageNotifications} [defaultMessageNotifications] The default message
-   * notification level of the guild
+   * @property {?TextChannelResolvable} [systemChannel] The system channel of the guild
    * @property {SystemChannelFlagsResolvable} [systemChannelFlags] The system channel flags of the guild
    * @property {?TextChannelResolvable} [rulesChannel] The rules channel of the guild
    * @property {?TextChannelResolvable} [publicUpdatesChannel] The community updates channel of the guild
    * @property {?string} [preferredLocale] The preferred locale of the guild
-   * @property {boolean} [premiumProgressBarEnabled] Whether the guild's premium progress bar is enabled
-   * @property {?string} [description] The discovery description of the guild
    * @property {GuildFeature[]} [features] The features of the guild
+   * @property {?string} [description] The discovery description of the guild
+   * @property {boolean} [premiumProgressBarEnabled] Whether the guild's premium progress bar is enabled
    * @property {string} [reason] Reason for editing this guild
    */
   /* eslint-enable max-len */
@@ -788,50 +788,57 @@ class Guild extends AnonymousGuild {
    *   .then(updated => console.log(`New guild name ${updated}`))
    *   .catch(console.error);
    */
-  async edit(options) {
-    const _data = {};
-    if (options.name) _data.name = options.name;
-    if (typeof options.verificationLevel !== 'undefined') {
-      _data.verification_level = options.verificationLevel;
-    }
-    if (typeof options.afkChannel !== 'undefined') {
-      _data.afk_channel_id = this.client.channels.resolveId(options.afkChannel);
-    }
-    if (typeof options.systemChannel !== 'undefined') {
-      _data.system_channel_id = this.client.channels.resolveId(options.systemChannel);
-    }
-    if (options.afkTimeout) _data.afk_timeout = Number(options.afkTimeout);
-    if (typeof options.icon !== 'undefined') _data.icon = await DataResolver.resolveImage(options.icon);
-    if (options.owner) _data.owner_id = this.client.users.resolveId(options.owner);
-    if (typeof options.splash !== 'undefined') _data.splash = await DataResolver.resolveImage(options.splash);
-    if (typeof options.discoverySplash !== 'undefined') {
-      _data.discovery_splash = await DataResolver.resolveImage(options.discoverySplash);
-    }
-    if (typeof options.banner !== 'undefined') _data.banner = await DataResolver.resolveImage(options.banner);
-    if (typeof options.explicitContentFilter !== 'undefined') {
-      _data.explicit_content_filter = options.explicitContentFilter;
-    }
-    if (typeof options.defaultMessageNotifications !== 'undefined') {
-      _data.default_message_notifications = options.defaultMessageNotifications;
-    }
-    if (typeof options.systemChannelFlags !== 'undefined') {
-      _data.system_channel_flags = SystemChannelFlagsBitField.resolve(options.systemChannelFlags);
-    }
-    if (typeof options.rulesChannel !== 'undefined') {
-      _data.rules_channel_id = this.client.channels.resolveId(options.rulesChannel);
-    }
-    if (typeof options.publicUpdatesChannel !== 'undefined') {
-      _data.public_updates_channel_id = this.client.channels.resolveId(options.publicUpdatesChannel);
-    }
-    if (typeof options.features !== 'undefined') {
-      _data.features = options.features;
-    }
-    if (typeof options.description !== 'undefined') {
-      _data.description = options.description;
-    }
-    if (typeof options.preferredLocale !== 'undefined') _data.preferred_locale = options.preferredLocale;
-    if ('premiumProgressBarEnabled' in options) _data.premium_progress_bar_enabled = options.premiumProgressBarEnabled;
-    const newData = await this.client.rest.patch(Routes.guild(this.id), { body: _data, reason: options.reason });
+  async edit({
+    name,
+    verificationLevel,
+    defaultMessageNotifications,
+    explicitContentFilter,
+    afkChannel,
+    afkTimeout,
+    icon,
+    owner,
+    splash,
+    discoverySplash,
+    banner,
+    systemChannel,
+    systemChannelFlags,
+    rulesChannel,
+    publicUpdatesChannel,
+    preferredLocale,
+    features,
+    description,
+    premiumProgressBarEnabled,
+    reason,
+  }) {
+    const {
+      client: { channels, users },
+    } = this;
+
+    const newData = await this.client.rest.patch(Routes.guild(this.id), {
+      body: {
+        name,
+        verification_level: verificationLevel,
+        default_message_notifications: defaultMessageNotifications,
+        explicit_content_filter: explicitContentFilter,
+        afk_channel_id: afkChannel && channels.resolveId(afkChannel),
+        afk_timeout: afkTimeout,
+        icon: icon && (await DataResolver.resolveImage(icon)),
+        owner_id: owner && users.resolveId(owner),
+        splash: splash && (await DataResolver.resolveImage(splash)),
+        discovery_splash: discoverySplash && (await DataResolver.resolveImage(discoverySplash)),
+        banner: banner && (await DataResolver.resolveImage(banner)),
+        system_channel_id: systemChannel && channels.resolveId(systemChannel),
+        system_channel_flags: systemChannelFlags && SystemChannelFlagsBitField.resolve(systemChannelFlags),
+        rules_channel_id: rulesChannel && channels.resolveId(rulesChannel),
+        public_updates_channel_id: publicUpdatesChannel && channels.resolveId(publicUpdatesChannel),
+        preferred_locale: preferredLocale,
+        features,
+        description,
+        premium_progress_bar_enabled: premiumProgressBarEnabled,
+      },
+      reason,
+    });
+
     return this.client.actions.GuildUpdate.handle(newData).updated;
   }
 

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -760,7 +760,6 @@ class Guild extends AnonymousGuild {
    * @property {boolean} [premiumProgressBarEnabled] Whether the guild's premium progress bar is enabled
    * @property {string} [reason] Reason for editing this guild
    */
-  /* eslint-enable max-len */
 
   /**
    * Data that can be resolved to a Text Channel object. This can be:
@@ -912,7 +911,6 @@ class Guild extends AnonymousGuild {
     return new WelcomeScreen(this, patchData);
   }
 
-  /* eslint-disable max-len */
   /**
    * Edits the level of the explicit content filter.
    * @param {?GuildExplicitContentFilter} explicitContentFilter The new level of the explicit content filter
@@ -925,14 +923,14 @@ class Guild extends AnonymousGuild {
 
   /**
    * Edits the setting of the default message notifications of the guild.
-   * @param {?GuildDefaultMessageNotifications} defaultMessageNotifications The new default message notification level of the guild
+   * @param {?GuildDefaultMessageNotifications} defaultMessageNotifications
+   * The new default message notification level of the guild
    * @param {string} [reason] Reason for changing the setting of the default message notifications
    * @returns {Promise<Guild>}
    */
   setDefaultMessageNotifications(defaultMessageNotifications, reason) {
     return this.edit({ defaultMessageNotifications, reason });
   }
-  /* eslint-enable max-len */
 
   /**
    * Edits the flags of the default message notifications of the guild.

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -788,7 +788,6 @@ class Guild extends AnonymousGuild {
    *   .catch(console.error);
    */
   async edit({
-    name,
     verificationLevel,
     defaultMessageNotifications,
     explicitContentFilter,
@@ -804,14 +803,12 @@ class Guild extends AnonymousGuild {
     rulesChannel,
     publicUpdatesChannel,
     preferredLocale,
-    features,
-    description,
     premiumProgressBarEnabled,
-    reason,
+    ...options
   }) {
     const data = await this.client.rest.patch(Routes.guild(this.id), {
       body: {
-        name,
+        ...options,
         verification_level: verificationLevel,
         default_message_notifications: defaultMessageNotifications,
         explicit_content_filter: explicitContentFilter,
@@ -830,11 +827,9 @@ class Guild extends AnonymousGuild {
         rules_channel_id: rulesChannel && this.client.channels.resolveId(rulesChannel),
         public_updates_channel_id: publicUpdatesChannel && this.client.channels.resolveId(publicUpdatesChannel),
         preferred_locale: preferredLocale,
-        features,
-        description,
         premium_progress_bar_enabled: premiumProgressBarEnabled,
       },
-      reason,
+      reason: options.reason,
     });
 
     return this.client.actions.GuildUpdate.handle(data).updated;

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -809,28 +809,26 @@ class Guild extends AnonymousGuild {
     premiumProgressBarEnabled,
     reason,
   }) {
-    const {
-      client: { actions, channels, rest, users },
-      id,
-    } = this;
-
-    const newData = await rest.patch(Routes.guild(id), {
+    const data = await this.client.rest.patch(Routes.guild(this.id), {
       body: {
         name,
         verification_level: verificationLevel,
         default_message_notifications: defaultMessageNotifications,
         explicit_content_filter: explicitContentFilter,
-        afk_channel_id: afkChannel && channels.resolveId(afkChannel),
+        afk_channel_id: afkChannel && this.client.channels.resolveId(afkChannel),
         afk_timeout: afkTimeout,
         icon: icon && (await DataResolver.resolveImage(icon)),
-        owner_id: owner && users.resolveId(owner),
+        owner_id: owner && this.client.users.resolveId(owner),
         splash: splash && (await DataResolver.resolveImage(splash)),
         discovery_splash: discoverySplash && (await DataResolver.resolveImage(discoverySplash)),
         banner: banner && (await DataResolver.resolveImage(banner)),
-        system_channel_id: systemChannel && channels.resolveId(systemChannel),
-        system_channel_flags: systemChannelFlags && SystemChannelFlagsBitField.resolve(systemChannelFlags),
-        rules_channel_id: rulesChannel && channels.resolveId(rulesChannel),
-        public_updates_channel_id: publicUpdatesChannel && channels.resolveId(publicUpdatesChannel),
+        system_channel_id: systemChannel && this.client.channels.resolveId(systemChannel),
+        system_channel_flags:
+          typeof systemChannelFlags === 'undefined'
+            ? undefined
+            : SystemChannelFlagsBitField.resolve(systemChannelFlags),
+        rules_channel_id: rulesChannel && this.client.channels.resolveId(rulesChannel),
+        public_updates_channel_id: publicUpdatesChannel && this.client.channels.resolveId(publicUpdatesChannel),
         preferred_locale: preferredLocale,
         features,
         description,
@@ -839,7 +837,7 @@ class Guild extends AnonymousGuild {
       reason,
     });
 
-    return actions.GuildUpdate.handle(newData).updated;
+    return this.client.actions.GuildUpdate.handle(data).updated;
   }
 
   /**

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -810,10 +810,11 @@ class Guild extends AnonymousGuild {
     reason,
   }) {
     const {
-      client: { channels, users },
+      client: { actions, channels, rest, users },
+      id,
     } = this;
 
-    const newData = await this.client.rest.patch(Routes.guild(this.id), {
+    const newData = await rest.patch(Routes.guild(id), {
       body: {
         name,
         verification_level: verificationLevel,
@@ -838,7 +839,7 @@ class Guild extends AnonymousGuild {
       reason,
     });
 
-    return this.client.actions.GuildUpdate.handle(newData).updated;
+    return actions.GuildUpdate.handle(newData).updated;
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5423,23 +5423,23 @@ export interface GuildWidgetSettings {
 export interface GuildEditOptions {
   name?: string;
   verificationLevel?: GuildVerificationLevel | null;
-  explicitContentFilter?: GuildExplicitContentFilter | null;
   defaultMessageNotifications?: GuildDefaultMessageNotifications | null;
-  afkChannel?: VoiceChannelResolvable | null;
-  systemChannel?: TextChannelResolvable | null;
-  systemChannelFlags?: SystemChannelFlagsResolvable;
+  explicitContentFilter?: GuildExplicitContentFilter | null;
   afkTimeout?: number;
+  afkChannel?: VoiceChannelResolvable | null;
   icon?: BufferResolvable | Base64Resolvable | null;
   owner?: GuildMemberResolvable;
   splash?: BufferResolvable | Base64Resolvable | null;
   discoverySplash?: BufferResolvable | Base64Resolvable | null;
   banner?: BufferResolvable | Base64Resolvable | null;
+  systemChannel?: TextChannelResolvable | null;
+  systemChannelFlags?: SystemChannelFlagsResolvable;
   rulesChannel?: TextChannelResolvable | null;
   publicUpdatesChannel?: TextChannelResolvable | null;
   preferredLocale?: Locale | null;
-  premiumProgressBarEnabled?: boolean;
-  description?: string | null;
   features?: `${GuildFeature}`[];
+  description?: string | null;
+  premiumProgressBarEnabled?: boolean;
   reason?: string;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This style of code isn't consistent with other parts of the library. I think destructuring the object here looks pretty neat and seems to result in code that's easier to look at. Personally, every time I've come across this, I think about doing this but end up not bothering. But now's the time, apparently!

I also reordered the parameters as they are in Discord's documentation.

There was also a pretty suspicious max-len rule modification here which I removed. It must have served an ideal purpose in the past, but presently, it doesn't seem to do much at all.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
