### PR TITLE
fix: keep other properties in triggerMetadata

### DIFF
--- a/packages/discord.js/src/structures/AutoModerationRule.js
+++ b/packages/discord.js/src/structures/AutoModerationRule.js
@@ -184,7 +184,7 @@ class AutoModerationRule extends Base {
    * @returns {Promise<AutoModerationRule>}
    */
   setKeywordFilter(keywordFilter, reason) {
-    return this.edit({ triggerMetadata: { keywordFilter }, reason });
+    return this.edit({ triggerMetadata: { ...this.triggerMetadata, keywordFilter }, reason });
   }
 
   /**
@@ -195,7 +195,7 @@ class AutoModerationRule extends Base {
    * @returns {Promise<AutoModerationRule>}
    */
   setRegexPatterns(regexPatterns, reason) {
-    return this.edit({ triggerMetadata: { regexPatterns }, reason });
+    return this.edit({ triggerMetadata: { ...this.triggerMetadata, regexPatterns }, reason });
   }
 
   /**
@@ -205,7 +205,7 @@ class AutoModerationRule extends Base {
    * @returns {Promise<AutoModerationRule>}
    */
   setPresets(presets, reason) {
-    return this.edit({ triggerMetadata: { presets }, reason });
+    return this.edit({ triggerMetadata: { ...this.triggerMetadata, presets }, reason });
   }
 
   /**
@@ -215,7 +215,7 @@ class AutoModerationRule extends Base {
    * @returns {Promise<AutoModerationRule>}
    */
   setAllowList(allowList, reason) {
-    return this.edit({ triggerMetadata: { allowList }, reason });
+    return this.edit({ triggerMetadata: { ...this.triggerMetadata, allowList }, reason });
   }
 
   /**
@@ -225,7 +225,7 @@ class AutoModerationRule extends Base {
    * @returns {Promise<AutoModerationRule>}
    */
   setMentionTotalLimit(mentionTotalLimit, reason) {
-    return this.edit({ triggerMetadata: { mentionTotalLimit }, reason });
+    return this.edit({ triggerMetadata: { ...this.triggerMetadata, mentionTotalLimit }, reason });
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Why? Because setting each property was resetting whole triggerMetadata.

**Status and versioning classification:**

