### PR TITLE
fix: add name typing in Widget

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3384,6 +3384,7 @@ export class Widget extends Base {
   private _patch(data: RawWidgetData): void;
   public fetch(): Promise<Widget>;
   public id: Snowflake;
+  public name: string;
   public instantInvite?: string;
   public channels: Collection<Snowflake, WidgetChannel>;
   public members: Collection<string, WidgetMember>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Widget` was missing the name property, as [docs](https://discord.js.org/#/docs/discord.js/main/class/Widget) says it should have one.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
