### PR TITLE
fix(WebSocketShard): wsCloseTimeout in wrong if

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -820,14 +820,12 @@ class WebSocketShard extends EventEmitter {
       if (this.connection.readyState === WebSocket.OPEN) {
         this.connection.close(closeCode);
         this.debug(`[WebSocket] Close: Tried closing. | WS State: ${CONNECTION_STATE[this.connection.readyState]}`);
-        if (this.connection.readyState === WebSocket.CLOSING || this.connection.readyState === WebSocket.CLOSED) {
-          this.closeEmitted = false;
-          this.debug(
-            `[WebSocket] Adding a WebSocket close timeout to ensure a correct WS reconnect.
+        this.closeEmitted = false;
+        this.debug(
+          `[WebSocket] Adding a WebSocket close timeout to ensure a correct WS reconnect.
             Timeout: ${this.manager.client.options.closeTimeout}ms`,
-          );
-          this.setWsCloseTimeout(this.manager.client.options.closeTimeout);
-        }
+        );
+        this.setWsCloseTimeout(this.manager.client.options.closeTimeout);
       } else {
         // Connection is not OPEN
         this.debug(`WS State: ${CONNECTION_STATE[this.connection.readyState]}`);

--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -278,6 +278,7 @@ class WebSocketShard extends EventEmitter {
       this.setHelloTimeout();
 
       this.connectedAt = Date.now();
+      this.setWsCloseTimeout(-1);
 
       // Adding a handshake timeout to just make sure no zombie connection appears.
       const ws = (this.connection = WebSocket.create(gateway, wsQuery, { handshakeTimeout: 30_000 }));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes issues introduced by #8956 because it added the `wsCloseTimeout` even when the Websocket was already `Closed` before. This lead to the timeout trying to close the new connection after it successfully reconnected.
Also added a clearing of the `wsCloseTimeout` before making a new connection to prevent any other obscure occurences like this.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
