### PR TITLE
feat(website): render `@see` blocks

### DIFF
--- a/apps/website/src/components/MethodItem.tsx
+++ b/apps/website/src/components/MethodItem.tsx
@@ -9,6 +9,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { HyperlinkedText } from './HyperlinkedText';
 import { InheritanceText } from './InheritanceText';
 import { ParameterTable } from './ParameterTable';
+import { SeeBlock } from './tsdoc/SeeBlock';
 import { TSDoc } from './tsdoc/TSDoc';
 
 export function MethodItem({ data }: { data: ApiMethodJSON | ApiMethodSignatureJSON }) {
@@ -115,6 +116,7 @@ export function MethodItem({ data }: { data: ApiMethodJSON | ApiMethodSignatureJ
 					{overloadedData.summary ?? data.summary ? <TSDoc node={overloadedData.summary ?? data.summary!} /> : null}
 					{overloadedData.remarks ? <TSDoc node={overloadedData.remarks} /> : null}
 					{overloadedData.comment ? <TSDoc node={overloadedData.comment} /> : null}
+					<SeeBlock blocks={overloadedData.seeBlocks} />
 					{overloadedData.parameters.length ? <ParameterTable data={overloadedData.parameters} /> : null}
 					{data.inheritanceData ? <InheritanceText data={data.inheritanceData} /> : null}
 				</div>

--- a/apps/website/src/components/MethodItem.tsx
+++ b/apps/website/src/components/MethodItem.tsx
@@ -116,7 +116,7 @@ export function MethodItem({ data }: { data: ApiMethodJSON | ApiMethodSignatureJ
 					{overloadedData.summary ?? data.summary ? <TSDoc node={overloadedData.summary ?? data.summary!} /> : null}
 					{overloadedData.remarks ? <TSDoc node={overloadedData.remarks} /> : null}
 					{overloadedData.comment ? <TSDoc node={overloadedData.comment} /> : null}
-					<SeeBlock blocks={overloadedData.seeBlocks} />
+					{data.seeBlocks.length ? <SeeBlock blocks={data.seeBlocks} /> : null}
 					{overloadedData.parameters.length ? <ParameterTable data={overloadedData.parameters} /> : null}
 					{data.inheritanceData ? <InheritanceText data={data.inheritanceData} /> : null}
 				</div>

--- a/apps/website/src/components/MethodItem.tsx
+++ b/apps/website/src/components/MethodItem.tsx
@@ -116,9 +116,9 @@ export function MethodItem({ data }: { data: ApiMethodJSON | ApiMethodSignatureJ
 					{overloadedData.summary ?? data.summary ? <TSDoc node={overloadedData.summary ?? data.summary!} /> : null}
 					{overloadedData.remarks ? <TSDoc node={overloadedData.remarks} /> : null}
 					{overloadedData.comment ? <TSDoc node={overloadedData.comment} /> : null}
-					{data.seeBlocks.length ? <SeeBlock blocks={data.seeBlocks} /> : null}
 					{overloadedData.parameters.length ? <ParameterTable data={overloadedData.parameters} /> : null}
 					{data.inheritanceData ? <InheritanceText data={data.inheritanceData} /> : null}
+					{data.seeBlocks.length ? <SeeBlock blocks={data.seeBlocks} /> : null}
 				</div>
 			) : null}
 		</div>

--- a/apps/website/src/components/Sections.tsx
+++ b/apps/website/src/components/Sections.tsx
@@ -92,7 +92,7 @@ export function ConstructorSection({ data }: { data: ApiConstructorJSON }) {
 						{data.remarks ? <TSDoc node={data.remarks} /> : null}
 						{data.comment ? <TSDoc node={data.comment} /> : null}
 						{data.parameters.length ? <ParameterTable data={data.parameters} /> : null}
-						<SeeBlock blocks={data.seeBlocks} />
+						{data.seeBlocks.length ? <SeeBlock blocks={data.seeBlocks} /> : null}
 					</div>
 				) : null}
 			</div>

--- a/apps/website/src/components/Sections.tsx
+++ b/apps/website/src/components/Sections.tsx
@@ -15,6 +15,7 @@ import { useMedia } from 'react-use';
 import { MethodList } from './MethodList';
 import { ParameterTable } from './ParameterTable';
 import { PropertyList } from './PropertyList';
+import { SeeBlock } from './tsdoc/SeeBlock';
 import { TSDoc } from './tsdoc/TSDoc';
 
 export function PropertiesSection({ data }: { data: ApiClassJSON['properties'] | ApiInterfaceJSON['properties'] }) {
@@ -91,6 +92,7 @@ export function ConstructorSection({ data }: { data: ApiConstructorJSON }) {
 						{data.remarks ? <TSDoc node={data.remarks} /> : null}
 						{data.comment ? <TSDoc node={data.comment} /> : null}
 						{data.parameters.length ? <ParameterTable data={data.parameters} /> : null}
+						<SeeBlock blocks={data.seeBlocks} />
 					</div>
 				) : null}
 			</div>

--- a/apps/website/src/components/tsdoc/SeeBlock.tsx
+++ b/apps/website/src/components/tsdoc/SeeBlock.tsx
@@ -3,11 +3,11 @@ import { TSDoc } from './TSDoc';
 
 export function SeeBlock({ blocks }: { blocks: DocBlockJSON[] }) {
 	return (
-		<div>
+		<div className="space-y-xs flex flex-col">
 			<h1 className="font-bold">See Also:</h1>
-			{blocks.map((seeBlock) => {
-				return <TSDoc key={seeBlock.tag.tagName} node={seeBlock} />;
-			})}
+			{blocks.map((seeBlock) => (
+				<TSDoc key={seeBlock.tag.tagName} node={seeBlock} />
+			))}
 		</div>
 	);
 }

--- a/apps/website/src/components/tsdoc/SeeBlock.tsx
+++ b/apps/website/src/components/tsdoc/SeeBlock.tsx
@@ -1,0 +1,13 @@
+import type { DocBlockJSON } from '@discordjs/api-extractor-utils';
+import { TSDoc } from './TSDoc';
+
+export function SeeBlock({ blocks }: { blocks: DocBlockJSON[] }) {
+	return (
+		<div>
+			<h1 className="font-bold">See Also:</h1>
+			{blocks.map((seeBlock) => {
+				return <TSDoc key={seeBlock.tag.tagName} node={seeBlock} />;
+			})}
+		</div>
+	);
+}

--- a/packages/api-extractor-utils/src/ApiNodeJSONEncoder.ts
+++ b/packages/api-extractor-utils/src/ApiNodeJSONEncoder.ts
@@ -52,6 +52,7 @@ export interface ApiItemJSON {
 	path: string[];
 	referenceData: ReferenceData;
 	remarks: DocNodeContainerJSON | null;
+	seeBlocks: DocBlockJSON[];
 	summary: DocNodeContainerJSON | null;
 }
 
@@ -200,6 +201,11 @@ export class ApiNodeJSONEncoder {
 			deprecated: item.tsdocComment?.deprecatedBlock
 				? (createCommentNode(item.tsdocComment.deprecatedBlock, model, version, item.parent) as DocNodeContainerJSON)
 				: null,
+			seeBlocks: item.tsdocComment?.seeBlocks
+				? item.tsdocComment.seeBlocks.map(
+						(block) => createCommentNode(block, model, version, item.parent) as DocBlockJSON,
+				  )
+				: [],
 			path,
 			containerKey: item.containerKey,
 			comment: item.tsdocComment ? createCommentNode(item.tsdocComment, model, version, item.parent) : null,

--- a/packages/api-extractor-utils/src/ApiNodeJSONEncoder.ts
+++ b/packages/api-extractor-utils/src/ApiNodeJSONEncoder.ts
@@ -201,11 +201,10 @@ export class ApiNodeJSONEncoder {
 			deprecated: item.tsdocComment?.deprecatedBlock
 				? (createCommentNode(item.tsdocComment.deprecatedBlock, model, version, item.parent) as DocNodeContainerJSON)
 				: null,
-			seeBlocks: item.tsdocComment?.seeBlocks
-				? item.tsdocComment.seeBlocks.map(
-						(block) => createCommentNode(block, model, version, item.parent) as DocBlockJSON,
-				  )
-				: [],
+			seeBlocks:
+				item.tsdocComment?.seeBlocks?.map(
+					(block) => createCommentNode(block, model, version, item.parent) as DocBlockJSON,
+				) ?? [],
 			path,
 			containerKey: item.containerKey,
 			comment: item.tsdocComment ? createCommentNode(item.tsdocComment, model, version, item.parent) : null,

--- a/packages/api-extractor-utils/src/tsdoc/RootComment.ts
+++ b/packages/api-extractor-utils/src/tsdoc/RootComment.ts
@@ -8,6 +8,7 @@ export interface DocCommentJSON extends DocNodeJSON {
 	customBlocks: DocBlockJSON[];
 	deprecated: DocNodeJSON[];
 	remarks: DocNodeJSON[];
+	seeBlocks: DocBlockJSON[];
 	summary: DocNodeJSON[];
 }
 
@@ -20,5 +21,6 @@ export function comment(comment: DocComment, model: ApiModel, version: string, p
 		deprecated:
 			comment.deprecatedBlock?.content.nodes.map((node) => createCommentNode(node, model, version, parentItem)) ?? [],
 		customBlocks: comment.customBlocks.map((_block) => block(_block, model, version, parentItem)),
+		seeBlocks: comment.seeBlocks.map((_block) => block(_block, model, version, parentItem)) ?? [],
 	};
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds support for rending TSDoc `@see` blocks.

Closes #8920
