### PR TITLE
fix(WebSocketShard): Zombie connection fix

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -408,6 +408,7 @@ class WebSocketShard extends EventEmitter {
      */
     this.emit(WebSocketShardEvents.Close, event);
   }
+
   /**
    * Called whenever a packet is received.
    * @param {Object} packet The received packet
@@ -593,9 +594,7 @@ class WebSocketShard extends EventEmitter {
       // Check if close event was emitted.
       if (this.closeEmitted) {
         this.debug(
-          `[WebSocket] was closed. | WS State: ${
-            CONNECTION_STATE[this.connection?.readyState ?? WebSocket.CLOSED]
-          } | Close Emitted: ${this.closeEmitted}`,
+          `[WebSocket] was closed. | WS State: ${CONNECTION_STATE[this.connection?.readyState ?? WebSocket.CLOSED]}`,
         );
         // Setting the variable false to check for zombie connections.
         this.closeEmitted = false;
@@ -607,17 +606,13 @@ class WebSocketShard extends EventEmitter {
       );
 
       // Cleanup connection listeners
-      if (this.connection) {
-        this._cleanupConnection();
-      }
+      if (this.connection) this._cleanupConnection();
 
       this.emitClose({
         code: 4009,
         reason: 'Session time out.',
         wasClean: false,
       });
-      // Setting the variable false to check for zombie connections.
-      this.closeEmitted = false;
     }, time);
   }
 


### PR DESCRIPTION
Fixes #8486, fixes #8984 and supersedes #8981 

- Fix backport #7626 missing changes
- Reverted the pull request #8956
- Removed unref of wsCloseTimeout
- ~~We are resuming the connection for zombie instead of starting a new~~ To not mess it up we didn't push this. Will create a separate pr for this.

**Please describe the changes this PR makes and why it should be merged:**

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating