### PR TITLE
docs: Fix a typo in the MentionableSelectMenuInteraction link

### DIFF
--- a/packages/discord.js/src/structures/BaseInteraction.js
+++ b/packages/discord.js/src/structures/BaseInteraction.js
@@ -322,7 +322,7 @@ class BaseInteraction extends Base {
   }
 
   /**
-   * Indicates whether this interaction is a {@link MenionableSelectMenuInteraction}
+   * Indicates whether this interaction is a {@link MentionableSelectMenuInteraction}
    * @returns {boolean}
    */
   isMentionableSelectMenu() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There was a typo in the link specified in https://github.com/discordjs/discord.js/blob/d3e9f2a355a1f5272d62a507eb6ecd8808904fff/packages/discord.js/src/structures/BaseInteraction.js#L325 and I've fixed it.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
