### PR TITLE
feat(WebSocketShard): resume instead of new session for zombie shards

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -569,7 +569,7 @@ class WebSocketShard extends EventEmitter {
     this.debug('Setting a HELLO timeout for 20s.');
     this.helloTimeout = setTimeout(() => {
       this.debug('Did not receive HELLO in time. Destroying and connecting again.');
-      this.destroy({ reset: true, closeCode: 4009 });
+      this.destroy({ reset: false, closeCode: 4009 });
     }, 20_000).unref();
   }
 
@@ -590,19 +590,18 @@ class WebSocketShard extends EventEmitter {
     }
     this.wsCloseTimeout = setTimeout(() => {
       this.setWsCloseTimeout(-1);
-      this.debug(`[WebSocket] Close Emitted: ${this.closeEmitted}`);
+
       // Check if close event was emitted.
       if (this.closeEmitted) {
-        this.debug(
-          `[WebSocket] was closed. | WS State: ${CONNECTION_STATE[this.connection?.readyState ?? WebSocket.CLOSED]}`,
-        );
+        this.debug(`[WebSocket] close was already emitted, assuming the connection was closed properly.`);
         // Setting the variable false to check for zombie connections.
         this.closeEmitted = false;
         return;
       }
 
       this.debug(
-        `[WebSocket] did not close properly, assuming a zombie connection.\nEmitting close and reconnecting again.`,
+        // eslint-disable-next-line max-len
+        `[WebSocket] Close Emitted: ${this.closeEmitted} | did not close properly, assuming a zombie connection.\nEmitting close and reconnecting again.`,
       );
 
       // Cleanup connection listeners
@@ -657,7 +656,7 @@ class WebSocketShard extends EventEmitter {
     Connection State: ${this.connection ? CONNECTION_STATE[this.connection.readyState] : 'No Connection??'}`,
       );
 
-      this.destroy({ reset: true, closeCode: 4009 });
+      this.destroy({ reset: false, closeCode: 4009 });
       return;
     }
 

--- a/packages/discord.js/test/shard.js
+++ b/packages/discord.js/test/shard.js
@@ -27,7 +27,7 @@ process.send(123);
 
 client.on('ready', () => {
   console.log('Ready', client.options.shards);
-  if (client.options.shards === 0) {
+  if (client.options.shards[0] === 0) {
     setTimeout(() => {
       console.log('kek dying');
       client.destroy();


### PR DESCRIPTION
todo:
- [ ] Test

**Please describe the changes this PR makes and why it should be merged:**
From the [docs](https://discord.com/developers/docs/topics/gateway#heartbeat-interval-example-heartbeat-ack)
> If a client does not receive a heartbeat ACK between its attempts at sending heartbeats, this may be due to a failed or "zombied" connection. The client should immediately terminate the connection with any close code besides 1000 or 1001, then reconnect and attempt to [Resume](https://discord.com/developers/docs/topics/gateway#resuming).

**Status and versioning classification:**
I know how to update typings and have done so, or typings don't need updating