### PR TITLE
chore: remove proxy dep hack

### DIFF
--- a/packages/proxy-container/package.json
+++ b/packages/proxy-container/package.json
@@ -43,8 +43,8 @@
 	},
 	"homepage": "https://discord.js.org",
 	"dependencies": {
-		"@discordjs/proxy": "^1.2.1",
-		"@discordjs/rest": "^1.4.0",
+		"@discordjs/proxy": "workspace:^",
+		"@discordjs/rest": "workspace:^",
 		"tslib": "^2.4.1"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2231,8 +2231,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@discordjs/proxy-container@workspace:packages/proxy-container"
   dependencies:
-    "@discordjs/proxy": ^1.2.1
-    "@discordjs/rest": ^1.4.0
+    "@discordjs/proxy": "workspace:^"
+    "@discordjs/rest": "workspace:^"
     "@types/node": 16.18.4
     cross-env: ^7.0.3
     eslint: ^8.28.0
@@ -2245,7 +2245,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@discordjs/proxy@^1.2.1, @discordjs/proxy@workspace:packages/proxy":
+"@discordjs/proxy@workspace:^, @discordjs/proxy@workspace:packages/proxy":
   version: 0.0.0-use.local
   resolution: "@discordjs/proxy@workspace:packages/proxy"
   dependencies:
@@ -2270,7 +2270,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@discordjs/rest@^1.4.0, @discordjs/rest@workspace:^, @discordjs/rest@workspace:packages/rest":
+"@discordjs/rest@workspace:^, @discordjs/rest@workspace:packages/rest":
   version: 0.0.0-use.local
   resolution: "@discordjs/rest@workspace:packages/rest"
   dependencies:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This has been possible since 9922151266a8ac618f41b7583c984a8755eccf14

I have tested locally using `docker build -t discordjs/proxy:latest -f packages/proxy-container/Dockerfile .` and the image still builds.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.