### PR TITLE
feat(GuildAuditLogs): Support `after`

### DIFF
--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -717,12 +717,9 @@ class Guild extends AnonymousGuild {
    *   .catch(console.error);
    */
   async fetchAuditLogs({ before, after, limit, user, type } = {}) {
-    const resolvedBefore = before?.id ?? before;
-    const resolvedAfter = after?.id ?? after;
-
     const query = makeURLSearchParams({
-      before: resolvedBefore,
-      after: resolvedAfter,
+      before: before?.id ?? before,
+      after: after?.id ?? after,
       limit,
       action_type: type,
     });

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5322,6 +5322,7 @@ export interface GuildAuditLogsEntryTargetField<TActionType extends GuildAuditLo
 
 export interface GuildAuditLogsFetchOptions<T extends GuildAuditLogsResolvable> {
   before?: Snowflake | GuildAuditLogsEntry;
+  after?: Snowflake | GuildAuditLogsEntry;
   limit?: number;
   user?: UserResolvable;
   type?: T;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- https://github.com/discord/discord-api-docs/pull/5821

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
