### PR TITLE
docs(ThreadEditOptions): Move info tag back to `invitable`

### DIFF
--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -324,10 +324,10 @@ class ThreadChannel extends BaseChannel {
    * @property {number} [rateLimitPerUser] The rate limit per user (slowmode) for the thread in seconds
    * @property {boolean} [locked] Whether the thread is locked
    * @property {boolean} [invitable] Whether non-moderators can add other non-moderators to a thread
+   * <info>Can only be edited on {@link ChannelType.PrivateThread}</info>
    * @property {Snowflake[]} [appliedTags] The tags to apply to the thread
    * @property {ChannelFlagsResolvable} [flags] The flags to set on the channel
    * @property {string} [reason] Reason for editing the thread
-   * <info>Can only be edited on {@link ChannelType.PrivateThread}</info>
    */
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This was accidentally moved in #8026 and took a few adventures into other properties since. It's home now.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
