### PR TITLE
fix(ThreadChannel): `reason` as second parameter

### DIFF
--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -451,7 +451,7 @@ class ThreadChannel extends Channel {
    * @returns {Promise<ThreadChannel>}
    */
   pin(reason) {
-    return this.edit({ flags: this.flags.add(ChannelFlags.FLAGS.PINNED), reason });
+    return this.edit({ flags: this.flags.add(ChannelFlags.FLAGS.PINNED) }, reason);
   }
 
   /**
@@ -460,7 +460,7 @@ class ThreadChannel extends Channel {
    * @returns {Promise<ThreadChannel>}
    */
   unpin(reason) {
-    return this.edit({ flags: this.flags.remove(ChannelFlags.FLAGS.PINNED), reason });
+    return this.edit({ flags: this.flags.remove(ChannelFlags.FLAGS.PINNED) }, reason);
   }
 
   /**
@@ -470,7 +470,7 @@ class ThreadChannel extends Channel {
    * @returns {Promise<GuildForumThreadChannel>}
    */
   setAppliedTags(appliedTags, reason) {
-    return this.edit({ appliedTags, reason });
+    return this.edit({ appliedTags }, reason);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`reason` is improperly being passed here. It is the second parameter, not the first:

https://github.com/discordjs/discord.js/blob/546ac439115f4017f01e0c02dee2ff80b789c28b/src/structures/ThreadChannel.js#L330-L341

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
