### PR TITLE
types: fix `GuildsAPI#getMembers` return type

### DIFF
--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -1,6 +1,5 @@
 import type { RawFile } from '@discordjs/rest';
 import { makeURLSearchParams, type REST } from '@discordjs/rest';
-import type { RESTGetAPIGuildMembersResult } from 'discord-api-types/v10';
 import {
 	Routes,
 	type GuildMFALevel,
@@ -16,6 +15,7 @@ import {
 	type RESTGetAPIGuildIntegrationsResult,
 	type RESTGetAPIGuildInvitesResult,
 	type RESTGetAPIGuildMemberResult,
+	type RESTGetAPIGuildMembersResult,
 	type RESTGetAPIGuildMembersQuery,
 	type RESTGetAPIGuildMembersSearchResult,
 	type RESTGetAPIGuildPreviewResult,

--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -1,5 +1,6 @@
 import type { RawFile } from '@discordjs/rest';
 import { makeURLSearchParams, type REST } from '@discordjs/rest';
+import type { RESTGetAPIGuildMembersResult } from 'discord-api-types/v10';
 import {
 	Routes,
 	type GuildMFALevel,
@@ -151,7 +152,7 @@ export class GuildsAPI {
 	public async getMembers(guildId: Snowflake, options: RESTGetAPIGuildMembersQuery = {}) {
 		return this.rest.get(Routes.guildMembers(guildId), {
 			query: makeURLSearchParams(options),
-		}) as Promise<RESTGetAPIGuildMemberResult>;
+		}) as Promise<RESTGetAPIGuildMembersResult>;
 	}
 
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes GuildsAPI#getMembers to properly return an array of guild members.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
