### PR TITLE
feat v13: add `addFollower` on GuildChannelManager

### DIFF
--- a/src/managers/GuildChannelManager.js
+++ b/src/managers/GuildChannelManager.js
@@ -230,6 +230,24 @@ class GuildChannelManager extends CachedManager {
   }
 
   /**
+   * Adds the target channel to a channel's followers.
+   * @param {NewsChannel|Snowflake} channel The channel to follow
+   * @param {TextChannelResolvable} targetChannel The channel where published announcements will be posted at
+   * @param {string} [reason] Reason for creating the webhook
+   * @returns {Promise<Snowflake>} Returns created target webhook id.
+   */
+  async addFollower(channel, targetChannel, reason) {
+    const channelId = this.resolveId(channel);
+    const targetChannelId = this.resolveId(targetChannel);
+    if (!channelId || !targetChannelId) throw new Error('GUILD_CHANNEL_RESOLVE');
+    const { webhook_id } = await this.client.api.channels[channelId].followers.post({
+      data: { webhook_channel_id: targetChannelId },
+      reason,
+    });
+    return webhook_id;
+  }
+
+  /**
    * The data for a guild channel.
    * @typedef {Object} ChannelData
    * @property {string} [name] The name of the channel

--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -9,8 +9,8 @@ const { Error } = require('../errors');
  */
 class NewsChannel extends BaseGuildTextChannel {
   /**
-   * <info>This method returns itself. To get created webhook id, use `GuildChannelManager#addFolower`</info>
    * Adds the target to this channel's followers.
+   * <info>If you need the created webhook id, use {@link GuildChannelManager#addFollower}.</info>
    * @param {TextChannelResolvable} channel The channel where the webhook should be created
    * @param {string} [reason] Reason for creating the webhook
    * @returns {Promise<NewsChannel>}

--- a/src/structures/NewsChannel.js
+++ b/src/structures/NewsChannel.js
@@ -9,6 +9,7 @@ const { Error } = require('../errors');
  */
 class NewsChannel extends BaseGuildTextChannel {
   /**
+   * <info>This method returns itself. To get created webhook id, use `GuildChannelManager#addFolower`</info>
    * Adds the target to this channel's followers.
    * @param {TextChannelResolvable} channel The channel where the webhook should be created
    * @param {string} [reason] Reason for creating the webhook

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3316,6 +3316,11 @@ export class GuildChannelManager extends CachedManager<Snowflake, GuildBasedChan
     name: string,
     options?: TextChannel | NewsChannel | VoiceChannel | Snowflake,
   ): Promise<Webhook>;
+  public addFollower(
+    channel: NewsChannel | Snowflake,
+    targetChannel: TextChannelResolvable,
+    reason?: string,
+  ): Promise<Snowflake>;
   public edit(channel: GuildChannelResolvable, data: ChannelData, reason?: string): Promise<GuildChannel>;
   public fetch(id: Snowflake, options?: BaseFetchOptions): Promise<GuildBasedChannel | null>;
   public fetch(


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
 Backports #8567
**Status and versioning classification:**
  It includes no braking changes, because `NewsChannel#addFolower` cant be changed to return webook id :( 