### PR TITLE
feat(Client): `guildAuditLogEntryCreate` event

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -120,7 +120,7 @@ body:
         - No Intents
         - Guilds
         - GuildMembers
-        - GuildBans
+        - GuildModeration
         - GuildEmojisAndStickers
         - GuildIntegrations
         - GuildWebhooks

--- a/packages/discord.js/src/client/actions/ActionsManager.js
+++ b/packages/discord.js/src/client/actions/ActionsManager.js
@@ -12,6 +12,7 @@ class ActionsManager {
     this.register(require('./ChannelCreate'));
     this.register(require('./ChannelDelete'));
     this.register(require('./ChannelUpdate'));
+    this.register(require('./GuildAuditLogEntryCreate'));
     this.register(require('./GuildBanAdd'));
     this.register(require('./GuildBanRemove'));
     this.register(require('./GuildChannelsPositionUpdate'));

--- a/packages/discord.js/src/client/actions/GuildAuditLogEntryCreate.js
+++ b/packages/discord.js/src/client/actions/GuildAuditLogEntryCreate.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const Action = require('./Action');
+const GuildAuditLogsEntry = require('../../structures/GuildAuditLogsEntry');
+const Events = require('../../util/Events');
+
+class GuildAuditLogEntryCreateAction extends Action {
+  handle(data) {
+    const client = this.client;
+    const guild = client.guilds.cache.get(data.guild_id);
+    let auditLogEntry;
+
+    if (guild) {
+      auditLogEntry = new GuildAuditLogsEntry(guild, data);
+
+      /**
+       * Emitted whenever a guild audit log entry is created.
+       * @event Client#guildAuditLogEntryCreate
+       * @param {GuildAuditLogsEntry} auditLogEntry The entry that was created
+       * @param {Guild} guild The guild where the entry was created
+       */
+      client.emit(Events.GuildAuditLogEntryCreate, auditLogEntry, guild);
+    }
+
+    return { auditLogEntry };
+  }
+}
+
+module.exports = GuildAuditLogEntryCreateAction;

--- a/packages/discord.js/src/client/websocket/handlers/GUILD_AUDIT_LOG_ENTRY_CREATE.js
+++ b/packages/discord.js/src/client/websocket/handlers/GUILD_AUDIT_LOG_ENTRY_CREATE.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = (client, packet) => {
+  client.actions.GuildAuditLogEntryCreate.handle(packet.d);
+};

--- a/packages/discord.js/src/client/websocket/handlers/index.js
+++ b/packages/discord.js/src/client/websocket/handlers/index.js
@@ -10,6 +10,7 @@ const handlers = Object.fromEntries([
   ['CHANNEL_DELETE', require('./CHANNEL_DELETE')],
   ['CHANNEL_PINS_UPDATE', require('./CHANNEL_PINS_UPDATE')],
   ['CHANNEL_UPDATE', require('./CHANNEL_UPDATE')],
+  ['GUILD_AUDIT_LOG_ENTRY_CREATE', require('./GUILD_AUDIT_LOG_ENTRY_CREATE')],
   ['GUILD_BAN_ADD', require('./GUILD_BAN_ADD')],
   ['GUILD_BAN_REMOVE', require('./GUILD_BAN_REMOVE')],
   ['GUILD_CREATE', require('./GUILD_CREATE')],

--- a/packages/discord.js/src/managers/GuildBanManager.js
+++ b/packages/discord.js/src/managers/GuildBanManager.js
@@ -12,7 +12,7 @@ const { GuildMember } = require('../structures/GuildMember');
 let deprecationEmittedForDeleteMessageDays = false;
 
 /**
- * Manages API methods for GuildBans and stores their cache.
+ * Manages API methods for guild bans and stores their cache.
  * @extends {CachedManager}
  */
 class GuildBanManager extends CachedManager {

--- a/packages/discord.js/src/structures/GuildAuditLogs.js
+++ b/packages/discord.js/src/structures/GuildAuditLogs.js
@@ -78,7 +78,7 @@ class GuildAuditLogs {
      */
     this.entries = new Collection();
     for (const item of data.audit_log_entries) {
-      const entry = new GuildAuditLogsEntry(this, guild, item);
+      const entry = new GuildAuditLogsEntry(guild, item, this);
       this.entries.set(entry.id, entry);
     }
   }

--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -109,7 +109,7 @@ class GuildAuditLogsEntry {
     this.actionType = GuildAuditLogsEntry.actionType(data.action_type);
 
     /**
-     * The type of action that occured.
+     * The type of action that occurred.
      * @type {AuditLogEvent}
      */
     this.action = data.action_type;
@@ -121,13 +121,19 @@ class GuildAuditLogsEntry {
     this.reason = data.reason ?? null;
 
     /**
+     * The id of the user that executed this entry
+     * @type {?Snowflake}
+     */
+    this.executorId = data.user_id;
+
+    /**
      * The user that executed this entry
      * @type {?User}
      */
     this.executor = data.user_id
       ? guild.client.options.partials.includes(Partials.User)
         ? guild.client.users._add({ id: data.user_id })
-        : guild.client.users.cache.get(data.user_id)
+        : guild.client.users.cache.get(data.user_id) ?? null
       : null;
 
     /**
@@ -240,6 +246,12 @@ class GuildAuditLogsEntry {
     }
 
     /**
+     * The id of the target of this entry
+     * @type {?Snowflake}
+     */
+    this.targetId = data.target_id;
+
+    /**
      * The target of this entry
      * @type {?AuditLogEntryTarget}
      */
@@ -254,7 +266,7 @@ class GuildAuditLogsEntry {
     } else if (targetType === Targets.User && data.target_id) {
       this.target = guild.client.options.partials.includes(Partials.User)
         ? guild.client.users._add({ id: data.target_id })
-        : guild.client.users.cache.get(data.target_id);
+        : guild.client.users.cache.get(data.target_id) ?? null;
     } else if (targetType === Targets.Guild) {
       this.target = guild.client.guilds.cache.get(data.target_id);
     } else if (targetType === Targets.Webhook) {
@@ -294,7 +306,7 @@ class GuildAuditLogsEntry {
       this.target =
         data.action_type === AuditLogEvent.MessageBulkDelete
           ? guild.channels.cache.get(data.target_id) ?? { id: data.target_id }
-          : guild.client.users.cache.get(data.target_id);
+          : guild.client.users.cache.get(data.target_id) ?? null;
     } else if (targetType === Targets.Integration) {
       this.target =
         logs?.integrations.get(data.target_id) ??

--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -94,7 +94,7 @@ class GuildAuditLogsEntry {
    */
   static Targets = Targets;
 
-  constructor(logs, guild, data) {
+  constructor(guild, data, logs) {
     /**
      * The target type of this entry
      * @type {AuditLogTargetType}
@@ -259,7 +259,7 @@ class GuildAuditLogsEntry {
       this.target = guild.client.guilds.cache.get(data.target_id);
     } else if (targetType === Targets.Webhook) {
       this.target =
-        logs.webhooks.get(data.target_id) ??
+        logs?.webhooks.get(data.target_id) ??
         new Webhook(
           guild.client,
           this.changes.reduce(
@@ -297,7 +297,7 @@ class GuildAuditLogsEntry {
           : guild.client.users.cache.get(data.target_id);
     } else if (targetType === Targets.Integration) {
       this.target =
-        logs.integrations.get(data.target_id) ??
+        logs?.integrations.get(data.target_id) ??
         new Integration(
           guild.client,
           this.changes.reduce(
@@ -363,7 +363,7 @@ class GuildAuditLogsEntry {
           ),
         );
     } else if (targetType === Targets.ApplicationCommand) {
-      this.target = logs.applicationCommands.get(data.target_id) ?? { id: data.target_id };
+      this.target = logs?.applicationCommands.get(data.target_id) ?? { id: data.target_id };
     } else if (targetType === Targets.AutoModeration) {
       this.target =
         guild.autoModerationRules.cache.get(data.target_id) ??

--- a/packages/discord.js/src/util/Events.js
+++ b/packages/discord.js/src/util/Events.js
@@ -11,6 +11,7 @@
  * @property {string} ClientReady ready
  * @property {string} Debug debug
  * @property {string} Error error
+ * @property {string} GuildAuditLogEntryCreate guildAuditLogEntryCreate
  * @property {string} GuildBanAdd guildBanAdd
  * @property {string} GuildBanRemove guildBanRemove
  * @property {string} GuildCreate guildCreate
@@ -91,6 +92,7 @@ module.exports = {
   ClientReady: 'ready',
   Debug: 'debug',
   Error: 'error',
+  GuildAuditLogEntryCreate: 'guildAuditLogEntryCreate',
   GuildBanAdd: 'guildBanAdd',
   GuildBanRemove: 'guildBanRemove',
   GuildCreate: 'guildCreate',

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5309,7 +5309,7 @@ export interface GuildAuditLogsEntryTargetField<TActionType extends GuildAuditLo
   StageInstance: StageInstance;
   Sticker: Sticker;
   GuildScheduledEvent: GuildScheduledEvent;
-  ApplicationCommand: ApplicationCommand;
+  ApplicationCommand: ApplicationCommand | { id: Snowflake };
   AutoModerationRule: AutoModerationRule;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1387,7 +1387,7 @@ export class GuildAuditLogsEntry<
     : GuildAuditLogsTargetType,
   TResolvedType = TAction extends null ? AuditLogEvent : TAction,
 > {
-  private constructor(logs: GuildAuditLogs, guild: Guild, data: RawGuildAuditLogEntryData);
+  private constructor(guild: Guild, data: RawGuildAuditLogEntryData, logs?: GuildAuditLogs);
   public static Targets: GuildAuditLogsTargets;
   public action: TResolvedType;
   public actionType: TActionType;
@@ -4689,6 +4689,7 @@ export interface ClientEvents {
   emojiDelete: [emoji: GuildEmoji];
   emojiUpdate: [oldEmoji: GuildEmoji, newEmoji: GuildEmoji];
   error: [error: Error];
+  guildAuditLogEntryCreate: [auditLogEntry: GuildAuditLogsEntry, guild: Guild];
   guildBanAdd: [ban: GuildBan];
   guildBanRemove: [ban: GuildBan];
   guildCreate: [guild: Guild];
@@ -4895,6 +4896,7 @@ export enum Events {
   AutoModerationRuleDelete = 'autoModerationRuleDelete',
   AutoModerationRuleUpdate = 'autoModerationRuleUpdate',
   ClientReady = 'ready',
+  GuildAuditLogEntryCreate = 'guildAuditLogEntryCreate',
   GuildCreate = 'guildCreate',
   GuildDelete = 'guildDelete',
   GuildUpdate = 'guildUpdate',

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1394,12 +1394,14 @@ export class GuildAuditLogsEntry<
   public changes: AuditLogChange[];
   public get createdAt(): Date;
   public get createdTimestamp(): number;
+  public executorId: Snowflake | null;
   public executor: User | null;
   public extra: TResolvedType extends keyof GuildAuditLogsEntryExtraField
     ? GuildAuditLogsEntryExtraField[TResolvedType]
     : null;
   public id: Snowflake;
   public reason: string | null;
+  public targetId: Snowflake | null;
   public target: TTargetType extends keyof GuildAuditLogsEntryTargetField<TActionType>
     ? GuildAuditLogsEntryTargetField<TActionType>[TTargetType]
     : Role | GuildEmoji | { id: Snowflake } | null;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -2138,3 +2138,8 @@ if (anySelectMenu.isStringSelectMenu()) {
 } else if (anySelectMenu.isMentionableSelectMenu()) {
   expectType<MentionableSelectMenuInteraction>(anySelectMenu);
 }
+
+client.on('guildAuditLogEntryCreate', (auditLogEntry, guild) => {
+  expectType<GuildAuditLogsEntry>(auditLogEntry);
+  expectType<Guild>(guild);
+});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Implements basic support for the `GUILD_AUDIT_LOG_ENTRY_CREATE` event

Changes:
- Add `Client#guildAuditLogEntryCreate` event
- `GuildAuditLogsEntry#targetId` and `GuildAuditLogsEntry#executorId` to address https://github.com/discordjs/discord.js/pull/9058#issuecomment-1382655421
- Moved `logs` to the last constructor parameter of `GuildAuditLogsEntry` (which is private) so as to not make it nullable (we don't received it via the gateway)

Upstream:
- discord/discord-api-docs#5849

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
