### PR TITLE
Command localizations don't use camelcase when creating a command with slashcommand builder

### DIFF
--- a/packages/builders/__tests__/interactions/ContextMenuCommands.test.ts
+++ b/packages/builders/__tests__/interactions/ContextMenuCommands.test.ts
@@ -112,12 +112,12 @@ describe('Context Menu Commands', () => {
 			});
 
 			test('GIVEN valid name localizations THEN valid data is stored', () => {
-				expect(getBuilder().setNameLocalization('en-US', 'foobar').name_localizations).toEqual(expectedSingleLocale);
-				expect(getBuilder().setNameLocalizations({ 'en-US': 'foobar', bg: 'test' }).name_localizations).toEqual(
+				expect(getBuilder().setNameLocalization('en-US', 'foobar').nameLocalizations).toEqual(expectedSingleLocale);
+				expect(getBuilder().setNameLocalizations({ 'en-US': 'foobar', bg: 'test' }).nameLocalizations).toEqual(
 					expectedMultipleLocales,
 				);
-				expect(getBuilder().setNameLocalizations(null).name_localizations).toBeNull();
-				expect(getBuilder().setNameLocalization('en-US', null).name_localizations).toEqual({
+				expect(getBuilder().setNameLocalizations(null).nameLocalizations).toBeNull();
+				expect(getBuilder().setNameLocalization('en-US', null).nameLocalizations).toEqual({
 					'en-US': null,
 				});
 			});

--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -460,12 +460,12 @@ describe('Slash Commands', () => {
 			});
 
 			test('GIVEN valid name localizations THEN valid data is stored', () => {
-				expect(getBuilder().setNameLocalization('en-US', 'foobar').name_localizations).toEqual(expectedSingleLocale);
-				expect(getBuilder().setNameLocalizations({ 'en-US': 'foobar', bg: 'test' }).name_localizations).toEqual(
+				expect(getBuilder().setNameLocalization('en-US', 'foobar').nameLocalizations).toEqual(expectedSingleLocale);
+				expect(getBuilder().setNameLocalizations({ 'en-US': 'foobar', bg: 'test' }).nameLocalizations).toEqual(
 					expectedMultipleLocales,
 				);
-				expect(getBuilder().setNameLocalizations(null).name_localizations).toBeNull();
-				expect(getBuilder().setNameLocalization('en-US', null).name_localizations).toEqual({
+				expect(getBuilder().setNameLocalizations(null).nameLocalizations).toBeNull();
+				expect(getBuilder().setNameLocalization('en-US', null).nameLocalizations).toEqual({
 					'en-US': null,
 				});
 			});
@@ -483,14 +483,14 @@ describe('Slash Commands', () => {
 			});
 
 			test('GIVEN valid description localizations THEN valid data is stored', () => {
-				expect(getBuilder().setDescriptionLocalization('en-US', 'foobar').description_localizations).toEqual(
+				expect(getBuilder().setDescriptionLocalization('en-US', 'foobar').descriptionLocalizations).toEqual(
 					expectedSingleLocale,
 				);
 				expect(
-					getBuilder().setDescriptionLocalizations({ 'en-US': 'foobar', bg: 'test' }).description_localizations,
+					getBuilder().setDescriptionLocalizations({ 'en-US': 'foobar', bg: 'test' }).descriptionLocalizations,
 				).toEqual(expectedMultipleLocales);
-				expect(getBuilder().setDescriptionLocalizations(null).description_localizations).toBeNull();
-				expect(getBuilder().setDescriptionLocalization('en-US', null).description_localizations).toEqual({
+				expect(getBuilder().setDescriptionLocalizations(null).descriptionLocalizations).toBeNull();
+				expect(getBuilder().setDescriptionLocalization('en-US', null).descriptionLocalizations).toEqual({
 					'en-US': null,
 				});
 			});

--- a/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
+++ b/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
@@ -24,7 +24,7 @@ export class ContextMenuCommandBuilder {
 	/**
 	 * The localized names for this command
 	 */
-	public readonly name_localizations?: LocalizationMap;
+	public readonly nameLocalizations?: LocalizationMap;
 
 	/**
 	 * The type of this context menu command
@@ -136,20 +136,20 @@ export class ContextMenuCommandBuilder {
 	 * @param localizedName - The localized description for the given locale
 	 */
 	public setNameLocalization(locale: LocaleString, localizedName: string | null) {
-		if (!this.name_localizations) {
-			Reflect.set(this, 'name_localizations', {});
+		if (!this.nameLocalizations) {
+			Reflect.set(this, 'nameLocalizations', {});
 		}
 
 		const parsedLocale = validateLocale(locale);
 
 		if (localizedName === null) {
-			this.name_localizations![parsedLocale] = null;
+			this.nameLocalizations![parsedLocale] = null;
 			return this;
 		}
 
 		validateName(localizedName);
 
-		this.name_localizations![parsedLocale] = localizedName;
+		this.nameLocalizations![parsedLocale] = localizedName;
 		return this;
 	}
 
@@ -160,11 +160,11 @@ export class ContextMenuCommandBuilder {
 	 */
 	public setNameLocalizations(localizedNames: LocalizationMap | null) {
 		if (localizedNames === null) {
-			Reflect.set(this, 'name_localizations', null);
+			Reflect.set(this, 'nameLocalizations', null);
 			return this;
 		}
 
-		Reflect.set(this, 'name_localizations', {});
+		Reflect.set(this, 'nameLocalizations', {});
 
 		for (const args of Object.entries(localizedNames))
 			this.setNameLocalization(...(args as [LocaleString, string | null]));
@@ -181,7 +181,7 @@ export class ContextMenuCommandBuilder {
 	public toJSON(): RESTPostAPIContextMenuApplicationCommandsJSONBody {
 		validateRequiredParameters(this.name, this.type);
 
-		validateLocalizationMap(this.name_localizations);
+		validateLocalizationMap(this.nameLocalizations);
 
 		return { ...this };
 	}

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -29,7 +29,7 @@ export class SlashCommandBuilder {
 	/**
 	 * The localized names for this command
 	 */
-	public readonly name_localizations?: LocalizationMap;
+	public readonly nameLocalizations?: LocalizationMap;
 
 	/**
 	 * The description of this slash command
@@ -39,7 +39,7 @@ export class SlashCommandBuilder {
 	/**
 	 * The localized descriptions for this command
 	 */
-	public readonly description_localizations?: LocalizationMap;
+	public readonly descriptionLocalizations?: LocalizationMap;
 
 	/**
 	 * The options of this slash command
@@ -80,8 +80,8 @@ export class SlashCommandBuilder {
 	public toJSON(): RESTPostAPIChatInputApplicationCommandsJSONBody {
 		validateRequiredParameters(this.name, this.description, this.options);
 
-		validateLocalizationMap(this.name_localizations);
-		validateLocalizationMap(this.description_localizations);
+		validateLocalizationMap(this.nameLocalizations);
+		validateLocalizationMap(this.descriptionLocalizations);
 
 		return {
 			...this,

--- a/packages/builders/src/interactions/slashCommands/SlashCommandSubcommands.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandSubcommands.ts
@@ -66,9 +66,9 @@ export class SlashCommandSubcommandGroupBuilder implements ToAPIApplicationComma
 		return {
 			type: ApplicationCommandOptionType.SubcommandGroup,
 			name: this.name,
-			name_localizations: this.name_localizations,
+			nameLocalizations: this.nameLocalizations,
 			description: this.description,
-			description_localizations: this.description_localizations,
+			descriptionLocalizations: this.descriptionLocalizations,
 			options: this.options.map((option) => option.toJSON()),
 		};
 	}
@@ -104,9 +104,9 @@ export class SlashCommandSubcommandBuilder implements ToAPIApplicationCommandOpt
 		return {
 			type: ApplicationCommandOptionType.Subcommand,
 			name: this.name,
-			name_localizations: this.name_localizations,
+			nameLocalizations: this.nameLocalizations,
 			description: this.description,
-			description_localizations: this.description_localizations,
+			descriptionLocalizations: this.descriptionLocalizations,
 			options: this.options.map((option) => option.toJSON()),
 		};
 	}

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionBase.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionBase.ts
@@ -27,8 +27,8 @@ export abstract class ApplicationCommandOptionBase extends SharedNameAndDescript
 		validateRequiredParameters(this.name, this.description, []);
 
 		// Validate localizations
-		validateLocalizationMap(this.name_localizations);
-		validateLocalizationMap(this.description_localizations);
+		validateLocalizationMap(this.nameLocalizations);
+		validateLocalizationMap(this.descriptionLocalizations);
 
 		// Assert that you actually passed a boolean
 		validateRequired(this.required);

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionWithChoicesAndAutocompleteMixin.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionWithChoicesAndAutocompleteMixin.ts
@@ -6,7 +6,7 @@ const stringPredicate = s.string.lengthGreaterThanOrEqual(1).lengthLessThanOrEqu
 const numberPredicate = s.number.greaterThan(Number.NEGATIVE_INFINITY).lessThan(Number.POSITIVE_INFINITY);
 const choicesPredicate = s.object({
 	name: stringPredicate,
-	name_localizations: localizationMapPredicate,
+	nameLocalizations: localizationMapPredicate,
 	value: s.union(stringPredicate, numberPredicate),
 }).array;
 const booleanPredicate = s.boolean;
@@ -37,7 +37,7 @@ export class ApplicationCommandOptionWithChoicesAndAutocompleteMixin<T extends n
 
 		validateChoicesLength(choices.length, this.choices);
 
-		for (const { name, name_localizations, value } of choices) {
+		for (const { name, nameLocalizations, value } of choices) {
 			// Validate the value
 			if (this.type === ApplicationCommandOptionType.String) {
 				stringPredicate.parse(value);
@@ -45,7 +45,7 @@ export class ApplicationCommandOptionWithChoicesAndAutocompleteMixin<T extends n
 				numberPredicate.parse(value);
 			}
 
-			this.choices!.push({ name, name_localizations, value });
+			this.choices!.push({ name, nameLocalizations, value });
 		}
 
 		return this;

--- a/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -4,11 +4,11 @@ import { validateDescription, validateLocale, validateName } from '../Assertions
 export class SharedNameAndDescription {
 	public readonly name!: string;
 
-	public readonly name_localizations?: LocalizationMap;
+	public readonly nameLocalizations?: LocalizationMap;
 
 	public readonly description!: string;
 
-	public readonly description_localizations?: LocalizationMap;
+	public readonly descriptionLocalizations?: LocalizationMap;
 
 	/**
 	 * Sets the name
@@ -45,20 +45,20 @@ export class SharedNameAndDescription {
 	 * @param localizedName - The localized description for the given locale
 	 */
 	public setNameLocalization(locale: LocaleString, localizedName: string | null) {
-		if (!this.name_localizations) {
-			Reflect.set(this, 'name_localizations', {});
+		if (!this.nameLocalizations) {
+			Reflect.set(this, 'nameLocalizations', {});
 		}
 
 		const parsedLocale = validateLocale(locale);
 
 		if (localizedName === null) {
-			this.name_localizations![parsedLocale] = null;
+			this.nameLocalizations![parsedLocale] = null;
 			return this;
 		}
 
 		validateName(localizedName);
 
-		this.name_localizations![parsedLocale] = localizedName;
+		this.nameLocalizations![parsedLocale] = localizedName;
 		return this;
 	}
 
@@ -69,11 +69,11 @@ export class SharedNameAndDescription {
 	 */
 	public setNameLocalizations(localizedNames: LocalizationMap | null) {
 		if (localizedNames === null) {
-			Reflect.set(this, 'name_localizations', null);
+			Reflect.set(this, 'nameLocalizations', null);
 			return this;
 		}
 
-		Reflect.set(this, 'name_localizations', {});
+		Reflect.set(this, 'nameLocalizations', {});
 
 		for (const args of Object.entries(localizedNames)) {
 			this.setNameLocalization(...(args as [LocaleString, string | null]));
@@ -89,20 +89,20 @@ export class SharedNameAndDescription {
 	 * @param localizedDescription - The localized description for the given locale
 	 */
 	public setDescriptionLocalization(locale: LocaleString, localizedDescription: string | null) {
-		if (!this.description_localizations) {
-			Reflect.set(this, 'description_localizations', {});
+		if (!this.descriptionLocalizations) {
+			Reflect.set(this, 'descriptionLocalizations', {});
 		}
 
 		const parsedLocale = validateLocale(locale);
 
 		if (localizedDescription === null) {
-			this.description_localizations![parsedLocale] = null;
+			this.descriptionLocalizations![parsedLocale] = null;
 			return this;
 		}
 
 		validateDescription(localizedDescription);
 
-		this.description_localizations![parsedLocale] = localizedDescription;
+		this.descriptionLocalizations![parsedLocale] = localizedDescription;
 		return this;
 	}
 
@@ -113,11 +113,11 @@ export class SharedNameAndDescription {
 	 */
 	public setDescriptionLocalizations(localizedDescriptions: LocalizationMap | null) {
 		if (localizedDescriptions === null) {
-			Reflect.set(this, 'description_localizations', null);
+			Reflect.set(this, 'descriptionLocalizations', null);
 			return this;
 		}
 
-		Reflect.set(this, 'description_localizations', {});
+		Reflect.set(this, 'descriptionLocalizations', {});
 		for (const args of Object.entries(localizedDescriptions)) {
 			this.setDescriptionLocalization(...(args as [LocaleString, string | null]));
 		}

--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -250,10 +250,10 @@ class ApplicationCommandManager extends CachedManager {
 
     return {
       name: command.name,
-      name_localizations: command.nameLocalizations ?? command.name_localizations,
+      nameLocalizations: command.nameLocalizations ?? command.nameLocalizations,
       description: command.description,
       nsfw: command.nsfw,
-      description_localizations: command.descriptionLocalizations ?? command.description_localizations,
+      descriptionLocalizations: command.descriptionLocalizations ?? command.descriptionLocalizations,
       type: command.type,
       options: command.options?.map(o => ApplicationCommand.transformOption(o)),
       default_member_permissions,

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -70,12 +70,12 @@ class ApplicationCommand extends Base {
       this.name = data.name;
     }
 
-    if ('name_localizations' in data) {
+    if ('nameLocalizations' in data) {
       /**
        * The name localizations for this command
        * @type {?Object<Locale, string>}
        */
-      this.nameLocalizations = data.name_localizations;
+      this.nameLocalizations = data.nameLocalizations;
     } else {
       this.nameLocalizations ??= null;
     }
@@ -98,12 +98,12 @@ class ApplicationCommand extends Base {
       this.description = data.description;
     }
 
-    if ('description_localizations' in data) {
+    if ('descriptionLocalizations' in data) {
       /**
        * The description localizations for this command
        * @type {?Object<Locale, string>}
        */
-      this.descriptionLocalizations = data.description_localizations;
+      this.descriptionLocalizations = data.descriptionLocalizations;
     } else {
       this.descriptionLocalizations ??= null;
     }
@@ -390,9 +390,9 @@ class ApplicationCommand extends Base {
       (command.options?.length ?? 0) !== (this.options?.length ?? 0) ||
       defaultMemberPermissions !== (this.defaultMemberPermissions?.bitfield ?? null) ||
       (typeof dmPermission !== 'undefined' && dmPermission !== this.dmPermission) ||
-      !isEqual(command.nameLocalizations ?? command.name_localizations ?? {}, this.nameLocalizations ?? {}) ||
+      !isEqual(command.nameLocalizations ?? command.nameLocalizations ?? {}, this.nameLocalizations ?? {}) ||
       !isEqual(
-        command.descriptionLocalizations ?? command.description_localizations ?? {},
+        command.descriptionLocalizations ?? command.descriptionLocalizations ?? {},
         this.descriptionLocalizations ?? {},
       )
     ) {
@@ -456,9 +456,9 @@ class ApplicationCommand extends Base {
       (option.maxValue ?? option.max_value) !== existing.maxValue ||
       (option.minLength ?? option.min_length) !== existing.minLength ||
       (option.maxLength ?? option.max_length) !== existing.maxLength ||
-      !isEqual(option.nameLocalizations ?? option.name_localizations ?? {}, existing.nameLocalizations ?? {}) ||
+      !isEqual(option.nameLocalizations ?? option.nameLocalizations ?? {}, existing.nameLocalizations ?? {}) ||
       !isEqual(
-        option.descriptionLocalizations ?? option.description_localizations ?? {},
+        option.descriptionLocalizations ?? option.descriptionLocalizations ?? {},
         existing.descriptionLocalizations ?? {},
       )
     ) {
@@ -474,7 +474,7 @@ class ApplicationCommand extends Base {
             choice.value === option.choices[index].value &&
             isEqual(
               choice.nameLocalizations ?? {},
-              option.choices[index].nameLocalizations ?? option.choices[index].name_localizations ?? {},
+              option.choices[index].nameLocalizations ?? option.choices[index].nameLocalizations ?? {},
             ),
         )
       ) {
@@ -552,17 +552,17 @@ class ApplicationCommand extends Base {
     const maxValueKey = received ? 'maxValue' : 'max_value';
     const minLengthKey = received ? 'minLength' : 'min_length';
     const maxLengthKey = received ? 'maxLength' : 'max_length';
-    const nameLocalizationsKey = received ? 'nameLocalizations' : 'name_localizations';
+    const nameLocalizationsKey = received ? 'nameLocalizations' : 'nameLocalizations';
     const nameLocalizedKey = received ? 'nameLocalized' : 'name_localized';
-    const descriptionLocalizationsKey = received ? 'descriptionLocalizations' : 'description_localizations';
+    const descriptionLocalizationsKey = received ? 'descriptionLocalizations' : 'descriptionLocalizations';
     const descriptionLocalizedKey = received ? 'descriptionLocalized' : 'description_localized';
     return {
       type: option.type,
       name: option.name,
-      [nameLocalizationsKey]: option.nameLocalizations ?? option.name_localizations,
+      [nameLocalizationsKey]: option.nameLocalizations ?? option.nameLocalizations,
       [nameLocalizedKey]: option.nameLocalized ?? option.name_localized,
       description: option.description,
-      [descriptionLocalizationsKey]: option.descriptionLocalizations ?? option.description_localizations,
+      [descriptionLocalizationsKey]: option.descriptionLocalizations ?? option.descriptionLocalizations,
       [descriptionLocalizedKey]: option.descriptionLocalized ?? option.description_localized,
       required:
         option.required ??
@@ -574,7 +574,7 @@ class ApplicationCommand extends Base {
       choices: option.choices?.map(choice => ({
         name: choice.name,
         [nameLocalizedKey]: choice.nameLocalized ?? choice.name_localized,
-        [nameLocalizationsKey]: choice.nameLocalizations ?? choice.name_localizations,
+        [nameLocalizationsKey]: choice.nameLocalizations ?? choice.nameLocalizations,
         value: choice.value,
       })),
       options: option.options?.map(o => this.transformOption(o, received)),

--- a/packages/discord.js/src/structures/ApplicationRoleConnectionMetadata.js
+++ b/packages/discord.js/src/structures/ApplicationRoleConnectionMetadata.js
@@ -15,7 +15,7 @@ class ApplicationRoleConnectionMetadata {
      * The name localizations for this metadata field
      * @type {?Object<Locale, string>}
      */
-    this.nameLocalizations = data.name_localizations ?? null;
+    this.nameLocalizations = data.nameLocalizations ?? null;
 
     /**
      * The description of this metadata field
@@ -27,7 +27,7 @@ class ApplicationRoleConnectionMetadata {
      * The description localizations for this metadata field
      * @type {?Object<Locale, string>}
      */
-    this.descriptionLocalizations = data.description_localizations ?? null;
+    this.descriptionLocalizations = data.descriptionLocalizations ?? null;
 
     /**
      * The dictionary key for this metadata field

--- a/packages/discord.js/src/structures/ClientApplication.js
+++ b/packages/discord.js/src/structures/ClientApplication.js
@@ -180,9 +180,9 @@ class ClientApplication extends Application {
         type: record.type,
         key: record.key,
         name: record.name,
-        name_localizations: record.nameLocalizations,
+        nameLocalizations: record.nameLocalizations,
         description: record.description,
-        description_localizations: record.descriptionLocalizations,
+        descriptionLocalizations: record.descriptionLocalizations,
       })),
     });
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
See #9083 

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed) - Not sure if breaking change, because technically object keys changed
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
