### PR TITLE
Make SlashCommandBuilder & ContextMenuBuilder return camelCase instead of snake_case

### DIFF
--- a/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
+++ b/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
@@ -24,7 +24,7 @@ export class ContextMenuCommandBuilder {
 	/**
 	 * The localized names for this command
 	 */
-	public readonly name_localizations?: LocalizationMap;
+	public readonly nameLocalizations?: LocalizationMap;
 
 	/**
 	 * The type of this context menu command
@@ -91,7 +91,7 @@ export class ContextMenuCommandBuilder {
 		// Assert the value matches the conditions
 		validateDefaultPermission(value);
 
-		Reflect.set(this, 'default_permission', value);
+		Reflect.set(this, 'defaultPermission', value);
 
 		return this;
 	}
@@ -108,7 +108,7 @@ export class ContextMenuCommandBuilder {
 		// Assert the value and parse it
 		const permissionValue = validateDefaultMemberPermissions(permissions);
 
-		Reflect.set(this, 'default_member_permissions', permissionValue);
+		Reflect.set(this, 'defaultMemberPermissions', permissionValue);
 
 		return this;
 	}
@@ -124,7 +124,7 @@ export class ContextMenuCommandBuilder {
 		// Assert the value matches the conditions
 		validateDMPermission(enabled);
 
-		Reflect.set(this, 'dm_permission', enabled);
+		Reflect.set(this, 'dmPermission', enabled);
 
 		return this;
 	}
@@ -136,20 +136,20 @@ export class ContextMenuCommandBuilder {
 	 * @param localizedName - The localized description for the given locale
 	 */
 	public setNameLocalization(locale: LocaleString, localizedName: string | null) {
-		if (!this.name_localizations) {
-			Reflect.set(this, 'name_localizations', {});
+		if (!this.nameLocalizations) {
+			Reflect.set(this, 'nameLocalizations', {});
 		}
 
 		const parsedLocale = validateLocale(locale);
 
 		if (localizedName === null) {
-			this.name_localizations![parsedLocale] = null;
+			this.nameLocalizations![parsedLocale] = null;
 			return this;
 		}
 
 		validateName(localizedName);
 
-		this.name_localizations![parsedLocale] = localizedName;
+		this.nameLocalizations![parsedLocale] = localizedName;
 		return this;
 	}
 
@@ -160,11 +160,11 @@ export class ContextMenuCommandBuilder {
 	 */
 	public setNameLocalizations(localizedNames: LocalizationMap | null) {
 		if (localizedNames === null) {
-			Reflect.set(this, 'name_localizations', null);
+			Reflect.set(this, 'nameLocalizations', null);
 			return this;
 		}
 
-		Reflect.set(this, 'name_localizations', {});
+		Reflect.set(this, 'nameLocalizations', {});
 
 		for (const args of Object.entries(localizedNames))
 			this.setNameLocalization(...(args as [LocaleString, string | null]));
@@ -181,7 +181,7 @@ export class ContextMenuCommandBuilder {
 	public toJSON(): RESTPostAPIContextMenuApplicationCommandsJSONBody {
 		validateRequiredParameters(this.name, this.type);
 
-		validateLocalizationMap(this.name_localizations);
+		validateLocalizationMap(this.nameLocalizations);
 
 		return { ...this };
 	}

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -29,7 +29,7 @@ export class SlashCommandBuilder {
 	/**
 	 * The localized names for this command
 	 */
-	public readonly name_localizations?: LocalizationMap;
+	public readonly nameLocalizations?: LocalizationMap;
 
 	/**
 	 * The description of this slash command
@@ -39,7 +39,7 @@ export class SlashCommandBuilder {
 	/**
 	 * The localized descriptions for this command
 	 */
-	public readonly description_localizations?: LocalizationMap;
+	public readonly descriptionLocalizations?: LocalizationMap;
 
 	/**
 	 * The options of this slash command
@@ -52,18 +52,18 @@ export class SlashCommandBuilder {
 	 * @deprecated This property is deprecated and will be removed in the future.
 	 * You should use {@link (SlashCommandBuilder:class).setDefaultMemberPermissions} or {@link (SlashCommandBuilder:class).setDMPermission} instead.
 	 */
-	public readonly default_permission: boolean | undefined = undefined;
+	public readonly defaultPermission: boolean | undefined = undefined;
 
 	/**
 	 * Set of permissions represented as a bit set for the command
 	 */
-	public readonly default_member_permissions: Permissions | null | undefined = undefined;
+	public readonly defaultMemberPermissions: Permissions | null | undefined = undefined;
 
 	/**
 	 * Indicates whether the command is available in DMs with the application, only for globally-scoped commands.
 	 * By default, commands are visible.
 	 */
-	public readonly dm_permission: boolean | undefined = undefined;
+	public readonly dmPermission: boolean | undefined = undefined;
 
 	/**
 	 * Whether this command is NSFW
@@ -80,8 +80,8 @@ export class SlashCommandBuilder {
 	public toJSON(): RESTPostAPIChatInputApplicationCommandsJSONBody {
 		validateRequiredParameters(this.name, this.description, this.options);
 
-		validateLocalizationMap(this.name_localizations);
-		validateLocalizationMap(this.description_localizations);
+		validateLocalizationMap(this.nameLocalizations);
+		validateLocalizationMap(this.descriptionLocalizations);
 
 		return {
 			...this,
@@ -102,7 +102,7 @@ export class SlashCommandBuilder {
 		// Assert the value matches the conditions
 		validateDefaultPermission(value);
 
-		Reflect.set(this, 'default_permission', value);
+		Reflect.set(this, 'defaultPermission', value);
 
 		return this;
 	}
@@ -119,7 +119,7 @@ export class SlashCommandBuilder {
 		// Assert the value and parse it
 		const permissionValue = validateDefaultMemberPermissions(permissions);
 
-		Reflect.set(this, 'default_member_permissions', permissionValue);
+		Reflect.set(this, 'defaultMemberPermissions', permissionValue);
 
 		return this;
 	}
@@ -135,7 +135,7 @@ export class SlashCommandBuilder {
 		// Assert the value matches the conditions
 		validateDMPermission(enabled);
 
-		Reflect.set(this, 'dm_permission', enabled);
+		Reflect.set(this, 'dmPermission', enabled);
 
 		return this;
 	}

--- a/packages/builders/src/interactions/slashCommands/SlashCommandSubcommands.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandSubcommands.ts
@@ -66,9 +66,9 @@ export class SlashCommandSubcommandGroupBuilder implements ToAPIApplicationComma
 		return {
 			type: ApplicationCommandOptionType.SubcommandGroup,
 			name: this.name,
-			name_localizations: this.name_localizations,
+			nameLocalizations: this.nameLocalizations,
 			description: this.description,
-			description_localizations: this.description_localizations,
+			descriptionLocalizations: this.descriptionLocalizations,
 			options: this.options.map((option) => option.toJSON()),
 		};
 	}
@@ -104,9 +104,9 @@ export class SlashCommandSubcommandBuilder implements ToAPIApplicationCommandOpt
 		return {
 			type: ApplicationCommandOptionType.Subcommand,
 			name: this.name,
-			name_localizations: this.name_localizations,
+			nameLocalizations: this.nameLocalizations,
 			description: this.description,
-			description_localizations: this.description_localizations,
+			descriptionLocalizations: this.descriptionLocalizations,
 			options: this.options.map((option) => option.toJSON()),
 		};
 	}

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandNumericOptionMinMaxValueMixin.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandNumericOptionMinMaxValueMixin.ts
@@ -1,7 +1,7 @@
 export abstract class ApplicationCommandNumericOptionMinMaxValueMixin {
-	public readonly max_value?: number;
+	public readonly maxValue?: number;
 
-	public readonly min_value?: number;
+	public readonly minValuevalue?: number;
 
 	/**
 	 * Sets the maximum number value of this option

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionBase.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionBase.ts
@@ -27,8 +27,8 @@ export abstract class ApplicationCommandOptionBase extends SharedNameAndDescript
 		validateRequiredParameters(this.name, this.description, []);
 
 		// Validate localizations
-		validateLocalizationMap(this.name_localizations);
-		validateLocalizationMap(this.description_localizations);
+		validateLocalizationMap(this.nameLocalizations);
+		validateLocalizationMap(this.descriptionLocalizations);
 
 		// Assert that you actually passed a boolean
 		validateRequired(this.required);

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionChannelTypesMixin.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionChannelTypesMixin.ts
@@ -19,7 +19,7 @@ export type ApplicationCommandOptionAllowedChannelTypes = (typeof allowedChannel
 const channelTypesPredicate = s.array(s.union(...allowedChannelTypes.map((type) => s.literal(type))));
 
 export class ApplicationCommandOptionChannelTypesMixin {
-	public readonly channel_types?: ApplicationCommandOptionAllowedChannelTypes[];
+	public readonly channelTypes?: ApplicationCommandOptionAllowedChannelTypes[];
 
 	/**
 	 * Adds channel types to this option
@@ -27,11 +27,11 @@ export class ApplicationCommandOptionChannelTypesMixin {
 	 * @param channelTypes - The channel types to add
 	 */
 	public addChannelTypes(...channelTypes: ApplicationCommandOptionAllowedChannelTypes[]) {
-		if (this.channel_types === undefined) {
-			Reflect.set(this, 'channel_types', []);
+		if (this.channelTypes === undefined) {
+			Reflect.set(this, 'channelTypes', []);
 		}
 
-		this.channel_types!.push(...channelTypesPredicate.parse(channelTypes));
+		this.channelTypes!.push(...channelTypesPredicate.parse(channelTypes));
 
 		return this;
 	}

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionWithChoicesAndAutocompleteMixin.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionWithChoicesAndAutocompleteMixin.ts
@@ -6,7 +6,7 @@ const stringPredicate = s.string.lengthGreaterThanOrEqual(1).lengthLessThanOrEqu
 const numberPredicate = s.number.greaterThan(Number.NEGATIVE_INFINITY).lessThan(Number.POSITIVE_INFINITY);
 const choicesPredicate = s.object({
 	name: stringPredicate,
-	name_localizations: localizationMapPredicate,
+	nameLocalizations: localizationMapPredicate,
 	value: s.union(stringPredicate, numberPredicate),
 }).array;
 const booleanPredicate = s.boolean;
@@ -37,7 +37,7 @@ export class ApplicationCommandOptionWithChoicesAndAutocompleteMixin<T extends n
 
 		validateChoicesLength(choices.length, this.choices);
 
-		for (const { name, name_localizations, value } of choices) {
+		for (const { name, nameLocalizations, value } of choices) {
 			// Validate the value
 			if (this.type === ApplicationCommandOptionType.String) {
 				stringPredicate.parse(value);
@@ -45,7 +45,7 @@ export class ApplicationCommandOptionWithChoicesAndAutocompleteMixin<T extends n
 				numberPredicate.parse(value);
 			}
 
-			this.choices!.push({ name, name_localizations, value });
+			this.choices!.push({ name, nameLocalizations, value });
 		}
 
 		return this;

--- a/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -4,11 +4,11 @@ import { validateDescription, validateLocale, validateName } from '../Assertions
 export class SharedNameAndDescription {
 	public readonly name!: string;
 
-	public readonly name_localizations?: LocalizationMap;
+	public readonly nameLocalizations?: LocalizationMap;
 
 	public readonly description!: string;
 
-	public readonly description_localizations?: LocalizationMap;
+	public readonly descriptionLocalizations?: LocalizationMap;
 
 	/**
 	 * Sets the name
@@ -45,20 +45,20 @@ export class SharedNameAndDescription {
 	 * @param localizedName - The localized description for the given locale
 	 */
 	public setNameLocalization(locale: LocaleString, localizedName: string | null) {
-		if (!this.name_localizations) {
-			Reflect.set(this, 'name_localizations', {});
+		if (!this.nameLocalizations) {
+			Reflect.set(this, 'nameLocalizations', {});
 		}
 
 		const parsedLocale = validateLocale(locale);
 
 		if (localizedName === null) {
-			this.name_localizations![parsedLocale] = null;
+			this.nameLocalizations![parsedLocale] = null;
 			return this;
 		}
 
 		validateName(localizedName);
 
-		this.name_localizations![parsedLocale] = localizedName;
+		this.nameLocalizations![parsedLocale] = localizedName;
 		return this;
 	}
 
@@ -69,11 +69,11 @@ export class SharedNameAndDescription {
 	 */
 	public setNameLocalizations(localizedNames: LocalizationMap | null) {
 		if (localizedNames === null) {
-			Reflect.set(this, 'name_localizations', null);
+			Reflect.set(this, 'nameLocalizations', null);
 			return this;
 		}
 
-		Reflect.set(this, 'name_localizations', {});
+		Reflect.set(this, 'nameLocalizations', {});
 
 		for (const args of Object.entries(localizedNames)) {
 			this.setNameLocalization(...(args as [LocaleString, string | null]));
@@ -89,20 +89,20 @@ export class SharedNameAndDescription {
 	 * @param localizedDescription - The localized description for the given locale
 	 */
 	public setDescriptionLocalization(locale: LocaleString, localizedDescription: string | null) {
-		if (!this.description_localizations) {
-			Reflect.set(this, 'description_localizations', {});
+		if (!this.descriptionLocalizations) {
+			Reflect.set(this, 'descriptionLocalizations', {});
 		}
 
 		const parsedLocale = validateLocale(locale);
 
 		if (localizedDescription === null) {
-			this.description_localizations![parsedLocale] = null;
+			this.descriptionLocalizations![parsedLocale] = null;
 			return this;
 		}
 
 		validateDescription(localizedDescription);
 
-		this.description_localizations![parsedLocale] = localizedDescription;
+		this.descriptionLocalizations![parsedLocale] = localizedDescription;
 		return this;
 	}
 
@@ -113,11 +113,11 @@ export class SharedNameAndDescription {
 	 */
 	public setDescriptionLocalizations(localizedDescriptions: LocalizationMap | null) {
 		if (localizedDescriptions === null) {
-			Reflect.set(this, 'description_localizations', null);
+			Reflect.set(this, 'descriptionLocalizations', null);
 			return this;
 		}
 
-		Reflect.set(this, 'description_localizations', {});
+		Reflect.set(this, 'descriptionLocalizations', {});
 		for (const args of Object.entries(localizedDescriptions)) {
 			this.setDescriptionLocalization(...(args as [LocaleString, string | null]));
 		}

--- a/packages/builders/src/interactions/slashCommands/options/integer.ts
+++ b/packages/builders/src/interactions/slashCommands/options/integer.ts
@@ -20,7 +20,7 @@ export class SlashCommandIntegerOption
 	public setMaxValue(max: number): this {
 		numberValidator.parse(max);
 
-		Reflect.set(this, 'max_value', max);
+		Reflect.set(this, 'maxValue', max);
 
 		return this;
 	}
@@ -31,7 +31,7 @@ export class SlashCommandIntegerOption
 	public setMinValue(min: number): this {
 		numberValidator.parse(min);
 
-		Reflect.set(this, 'min_value', min);
+		Reflect.set(this, 'minValuevalue', min);
 
 		return this;
 	}

--- a/packages/builders/src/interactions/slashCommands/options/number.ts
+++ b/packages/builders/src/interactions/slashCommands/options/number.ts
@@ -20,7 +20,7 @@ export class SlashCommandNumberOption
 	public setMaxValue(max: number): this {
 		numberValidator.parse(max);
 
-		Reflect.set(this, 'max_value', max);
+		Reflect.set(this, 'maxValue', max);
 
 		return this;
 	}
@@ -31,7 +31,7 @@ export class SlashCommandNumberOption
 	public setMinValue(min: number): this {
 		numberValidator.parse(min);
 
-		Reflect.set(this, 'min_value', min);
+		Reflect.set(this, 'minValuevalue', min);
 
 		return this;
 	}

--- a/packages/builders/src/interactions/slashCommands/options/string.ts
+++ b/packages/builders/src/interactions/slashCommands/options/string.ts
@@ -11,9 +11,9 @@ const maxLengthValidator = s.number.greaterThanOrEqual(1).lessThanOrEqual(6_000)
 export class SlashCommandStringOption extends ApplicationCommandOptionBase {
 	public readonly type = ApplicationCommandOptionType.String as const;
 
-	public readonly max_length?: number;
+	public readonly maxLength?: number;
 
-	public readonly min_length?: number;
+	public readonly minLength?: number;
 
 	/**
 	 * Sets the maximum length of this string option.
@@ -23,7 +23,7 @@ export class SlashCommandStringOption extends ApplicationCommandOptionBase {
 	public setMaxLength(max: number): this {
 		maxLengthValidator.parse(max);
 
-		Reflect.set(this, 'max_length', max);
+		Reflect.set(this, 'maxLength', max);
 
 		return this;
 	}
@@ -36,7 +36,7 @@ export class SlashCommandStringOption extends ApplicationCommandOptionBase {
 	public setMinLength(min: number): this {
 		minLengthValidator.parse(min);
 
-		Reflect.set(this, 'min_length', min);
+		Reflect.set(this, 'minLength', min);
 
 		return this;
 	}


### PR DESCRIPTION
### Please describe the changes this PR makes and why it should be merged:
**Changes:**
This pull request makes changes in the `SlashCommandBuilder` and `ContextMenuBuilder` to make sure they return properties in `camelCase` as the rest of the `discord.js` library does. To ensure no conflicts with the API, functions were already implemented to transform the properties before creating the commands with the API. See [ApplicationCommandManager](https://github.com/discordjs/discord.js/blob/8b70f497a1207e30edebdecd12b926c981c13d28/packages/discord.js/src/managers/ApplicationCommandManager.js#L233-L262) & [ApplicationCommand](https://github.com/discordjs/discord.js/blob/8b70f497a1207e30edebdecd12b926c981c13d28/packages/discord.js/src/structures/ApplicationCommand.js#L549-L587)
**Reason:**
This makes is possible to compare the data from the Builders with the data from the [ApplicationCommandManager.fetch()](https://discord.js.org/#/docs/discord.js/main/class/ApplicationCommandManager?scrollTo=fetch) method, which returns a [ApplicationCommand](https://discord.js.org/#/docs/discord.js/main/class/ApplicationCommand) or a collection of those with `camelCase` properties

**See also:**
For further information see #9083 

Follow up from #9084 
_I made sure to only edit properties which are not accessed by the API, as I didn't use search&replace this time_



