### PR TITLE
feat: remove `BitField#toArray()`

### DIFF
--- a/packages/discord.js/src/util/PermissionsBitField.js
+++ b/packages/discord.js/src/util/PermissionsBitField.js
@@ -93,11 +93,11 @@ class PermissionsBitField extends BitField {
   }
 
   /**
-   * Gets an {@link Array} of bitfield names based on the permissions available.
-   * @returns {string[]}
+   * Allows permissions bit fields to be consumed with for-of loops
+   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of}
    */
-  toArray() {
-    return super.toArray(false);
+  *[Symbol.iterator]() {
+    yield* super[Symbol.iterator](false);
   }
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -652,10 +652,9 @@ export class BitField<S extends string, N extends number | bigint = number> {
   public missing(bits: BitFieldResolvable<S, N>, ...hasParams: readonly unknown[]): S[];
   public remove(...bits: BitFieldResolvable<S, N>[]): BitField<S, N>;
   public serialize(...hasParams: readonly unknown[]): Record<S, boolean>;
-  public toArray(...hasParams: readonly unknown[]): S[];
   public toJSON(): N extends number ? number : string;
   public valueOf(): N;
-  public [Symbol.iterator](): IterableIterator<S>;
+  public [Symbol.iterator](...hasParams: readonly unknown[]): IterableIterator<N>;
   public static Flags: EnumLike<unknown, number | bigint>;
   public static resolve(bit?: BitFieldResolvable<string, number | bigint>): number | bigint;
 }
@@ -2343,7 +2342,7 @@ export class PermissionsBitField extends BitField<PermissionsString, bigint> {
   public has(permission: PermissionResolvable, checkAdmin?: boolean): boolean;
   public missing(bits: BitFieldResolvable<PermissionsString, bigint>, checkAdmin?: boolean): PermissionsString[];
   public serialize(checkAdmin?: boolean): Record<PermissionsString, boolean>;
-  public toArray(): PermissionsString[];
+  public [Symbol.iterator](): IterableIterator<bigint>;
 
   public static All: bigint;
   public static Default: bigint;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

We don't need `BitField#toArray()` since we can do `Array.from(<BitField>)` or `[...<BitField>]`. Also there was `<Collection>.array()` which cached values, but the method was removed and not just the caching.

Users use this method to convert bits to human readable strings with a map.
```js
const permissionsMap = {
  'SendMessages': `Send Messages`,
}
```
They shouldn't use strings for keys, but enums.

```js
const permissionsMap = {
  [PermissionFlagsBits.SendMessages]: `Send Messages`,
}
```
So the iterator should return an array of bits instead of enum key names.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
