### PR TITLE
docs: no `@type` description and reveal info block

### DIFF
--- a/packages/discord.js/src/structures/AutoModerationActionExecution.js
+++ b/packages/discord.js/src/structures/AutoModerationActionExecution.js
@@ -43,8 +43,8 @@ class AutoModerationActionExecution {
 
     /**
      * The id of the message that triggered this action.
-     * @type {?Snowflake}
      * <info>This will not be present if the message was blocked or the content was not part of any message.</info>
+     * @type {?Snowflake}
      */
     this.messageId = data.message_id ?? null;
 

--- a/packages/discord.js/src/structures/ModalSubmitFields.js
+++ b/packages/discord.js/src/structures/ModalSubmitFields.js
@@ -11,13 +11,13 @@ class ModalSubmitFields {
   constructor(components) {
     /**
      * The components within the modal
-     * @type {ActionRowModalData[]} The components in the modal
+     * @type {ActionRowModalData[]}
      */
     this.components = components;
 
     /**
      * The extracted fields from the modal
-     * @type {Collection<string, ModalData>} The fields in the modal
+     * @type {Collection<string, ModalData>}
      */
     this.fields = components.reduce((accumulator, next) => {
       next.components.forEach(c => accumulator.set(c.customId, c));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
[`@type`](https://jsdoc.app/tags-type.html#syntax) has no description, causing some text to not show up in the documentation.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
