### PR TITLE
fix(ThreadChannel): insert starter message from threads created in forum channels

### DIFF
--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -46,6 +46,8 @@ class ThreadChannel extends BaseChannel {
   _patch(data, partial = false) {
     super._patch(data);
 
+    if ('message' in data) this.messages._add(data.message);
+
     if ('name' in data) {
       /**
        * The name of the thread


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Threads created in forum channels return the message object within the payload[^1]. discord.js ignored detecting if `message` was in `data` here leaving it to the later `MESSAGE_CREATE` event to populate, but we can do this straight away.

One may ask if it could be possible for both the handler and the WebSocket to inject a duplicate message into the cache here. I have found that the gateway does not emit the message—only via REST it does.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

[^1]: https://discord.com/developers/docs/resources/channel#start-thread-in-forum-channel