### PR TITLE
types: fix type of Attachment#name

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1979,7 +1979,7 @@ export class Attachment {
   public ephemeral: boolean;
   public height: number | null;
   public id: Snowflake;
-  public name: string | null;
+  public name: string;
   public proxyURL: string;
   public size: number;
   public get spoiler(): boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
this PR fixes the type of Attachment#name which previously allowed null.

**Status and versioning classification:**

References
https://discord-api-types.dev/api/discord-api-types-v10/interface/APIAttachment
https://discord.js.org/#/docs/discord.js/main/class/Attachment?scrollTo=name
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
