### PR TITLE
fix(oauth2): pass through body

### DIFF
--- a/packages/core/src/api/oauth2.ts
+++ b/packages/core/src/api/oauth2.ts
@@ -39,6 +39,7 @@ export class OAuth2API {
 	public async tokenExchange(options: RESTPostOAuth2AccessTokenURLEncodedData) {
 		return this.rest.post(Routes.oauth2TokenExchange(), {
 			body: makeURLSearchParams(options),
+			passThroughBody: true,
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},
@@ -54,6 +55,7 @@ export class OAuth2API {
 	public async refreshToken(options: RESTPostOAuth2RefreshTokenURLEncodedData) {
 		return this.rest.post(Routes.oauth2TokenExchange(), {
 			body: makeURLSearchParams(options),
+			passThroughBody: true,
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},
@@ -71,6 +73,7 @@ export class OAuth2API {
 	public async getToken(options: RESTPostOAuth2ClientCredentialsURLEncodedData) {
 		return this.rest.post(Routes.oauth2TokenExchange(), {
 			body: makeURLSearchParams(options),
+			passThroughBody: true,
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
https://discord.com/channels/222078108977594368/1070696353434452038/1070696353434452038

Pass the `body` (`URLSearchParams`) as it is instead of `JSON.stringify()`ing it and overriding the content-type header

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
