### PR TITLE
ci: don't run issue triage on edit

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,7 +1,7 @@
 name: 'Issue Labeler'
 on:
   issues:
-    types: [opened, edited]
+    types: [opened]
 
 jobs:
   issue-triage:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This has become a nuisance. Not sure how the implementation is wrong, but it should be fine anyway to check only when opened.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
