### PR TITLE
chore: fix \n breaks

### DIFF
--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -9,9 +9,9 @@ packages:core:
 packages:discord.js:
   - '### Which package is this (bug report|feature request) for\?\n\ndiscord.js'
 packages:formatters:
-  - '### Which package is this (bug report|feature request) for\?\n\formatters'
+  - '### Which package is this (bug report|feature request) for\?\n\nformatters'
 packages:next:
-  - '### Which package is this (bug report|feature request) for\?\n\next'
+  - '### Which package is this (bug report|feature request) for\?\n\nnext'
 packages:proxy:
   - '### Which package is this (bug report|feature request) for\?\n\nproxy'
 packages:proxy-container:


### PR DESCRIPTION

**Please describe the changes this PR makes and why it should be merged:**

on formatters and next the n of \n was missing

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

