### PR TITLE
refactor(BitField): reverse iterator/toArray responsibilities

### DIFF
--- a/packages/discord.js/src/util/BitField.js
+++ b/packages/discord.js/src/util/BitField.js
@@ -127,7 +127,7 @@ class BitField {
    * @returns {string[]}
    */
   toArray(...hasParams) {
-    return Object.keys(this.constructor.Flags).filter(bit => this.has(bit, ...hasParams));
+    return [...this[Symbol.iterator](...hasParams)];
   }
 
   toJSON() {
@@ -138,8 +138,10 @@ class BitField {
     return this.bitfield;
   }
 
-  *[Symbol.iterator]() {
-    yield* this.toArray();
+  *[Symbol.iterator](...hasParams) {
+    for (const bitName of Object.keys(this.constructor.Flags)) {
+      if (this.has(bitName, ...hasParams)) yield bitName;
+    }
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The iterator should only calculate (and yield) values that the user consumes, while the current implementation calculates all of the values by calling `toArray()`, and then yields them

This PR makes the iterator do the calculations, which `toArray()` consumes. The end-user behaviour is still the same

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
