### PR TITLE
refactor(WebSocketManager): passing in strategy

### DIFF
--- a/packages/ws/README.md
+++ b/packages/ws/README.md
@@ -107,12 +107,11 @@ const manager = new WebSocketManager({
 	intents: 0,
 	rest,
 	shardCount: 6,
+	// This will cause 3 workers to spawn, 2 shards per each
+	buildStrategy: (manager) => new WorkerShardingStrategy(manager, { shardsPerWOrker: 2 }),
+	// Or maybe you want all your shards under a single worker
+	buildStrategy: (manager) => new WorkerShardingStrategy(manager, { shardsPerWorker: 'all' }),
 });
-
-// This will cause 3 workers to spawn, 2 shards per each
-manager.setStrategy(new WorkerShardingStrategy(manager, { shardsPerWorker: 2 }));
-// Or maybe you want all your shards under a single worker
-manager.setStrategy(new WorkerShardingStrategy(manager, { shardsPerWorker: 'all' }));
 ```
 
 **Note**: By default, this will cause the workers to effectively only be responsible for the WebSocket connection, they simply pass up all the events back to the main process for the manager to emit. If you want to have the workers handle events as well, you can pass in a `workerPath` option to the `WorkerShardingStrategy` constructor:
@@ -126,14 +125,12 @@ const manager = new WebSocketManager({
 	token: process.env.DISCORD_TOKEN,
 	intents: 0,
 	rest,
+	buildStrategy: (manager) =>
+		new WorkerShardingStrategy(manager, {
+			shardsPerWOrker: 2,
+			workerPath: './worker.js',
+		}),
 });
-
-manager.setStrategy(
-	new WorkerShardingStrategy(manager, {
-		shardsPerWorker: 2,
-		workerPath: './worker.js',
-	}),
-);
 ```
 
 And your `worker.ts` file:

--- a/packages/ws/README.md
+++ b/packages/ws/README.md
@@ -108,7 +108,7 @@ const manager = new WebSocketManager({
 	rest,
 	shardCount: 6,
 	// This will cause 3 workers to spawn, 2 shards per each
-	buildStrategy: (manager) => new WorkerShardingStrategy(manager, { shardsPerWOrker: 2 }),
+	buildStrategy: (manager) => new WorkerShardingStrategy(manager, { shardsPerWorker: 2 }),
 	// Or maybe you want all your shards under a single worker
 	buildStrategy: (manager) => new WorkerShardingStrategy(manager, { shardsPerWorker: 'all' }),
 });
@@ -127,7 +127,7 @@ const manager = new WebSocketManager({
 	rest,
 	buildStrategy: (manager) =>
 		new WorkerShardingStrategy(manager, {
-			shardsPerWOrker: 2,
+			shardsPerWorker: 2,
 			workerPath: './worker.js',
 		}),
 });

--- a/packages/ws/__tests__/strategy/WorkerShardingStrategy.test.ts
+++ b/packages/ws/__tests__/strategy/WorkerShardingStrategy.test.ts
@@ -163,6 +163,7 @@ test('spawn, connect, send a message, session info, and destroy', async () => {
 		shardIds: [0, 1],
 		retrieveSessionInfo: mockRetrieveSessionInfo,
 		updateSessionInfo: mockUpdateSessionInfo,
+		buildStrategy: (manager) => new WorkerShardingStrategy(manager, { shardsPerWorker: 'all' }),
 	});
 
 	const managerEmitSpy = vi.spyOn(manager, 'emit');
@@ -190,9 +191,6 @@ test('spawn, connect, send a message, session info, and destroy', async () => {
 				},
 			},
 		}));
-
-	const strategy = new WorkerShardingStrategy(manager, { shardsPerWorker: 'all' });
-	manager.setStrategy(strategy);
 
 	await manager.connect();
 	expect(mockConstructor).toHaveBeenCalledWith(

--- a/packages/ws/__tests__/ws/WebSocketManager.test.ts
+++ b/packages/ws/__tests__/ws/WebSocketManager.test.ts
@@ -177,7 +177,11 @@ test('strategies', async () => {
 		public destroy = vi.fn();
 
 		public send = vi.fn();
+
+		public fetchStatus = vi.fn();
 	}
+
+	const strategy = new MockStrategy();
 
 	const rest = new REST().setAgent(mockAgent).setToken('A-Very-Fake-Token');
 	const shardIds = [0, 1, 2];
@@ -186,7 +190,7 @@ test('strategies', async () => {
 		intents: 0,
 		rest,
 		shardIds,
-		buildStrategy: () => new MockStrategy(),
+		buildStrategy: () => strategy,
 	});
 
 	const data: APIGatewayBotInfo = {

--- a/packages/ws/__tests__/ws/WebSocketManager.test.ts
+++ b/packages/ws/__tests__/ws/WebSocketManager.test.ts
@@ -181,10 +181,13 @@ test('strategies', async () => {
 
 	const rest = new REST().setAgent(mockAgent).setToken('A-Very-Fake-Token');
 	const shardIds = [0, 1, 2];
-	const manager = new WebSocketManager({ token: 'A-Very-Fake-Token', intents: 0, rest, shardIds });
-
-	const strategy = new MockStrategy();
-	manager.setStrategy(strategy);
+	const manager = new WebSocketManager({
+		token: 'A-Very-Fake-Token',
+		intents: 0,
+		rest,
+		shardIds,
+		buildStrategy: () => new MockStrategy(),
+	});
 
 	const data: APIGatewayBotInfo = {
 		shards: 1,

--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -2,6 +2,7 @@ import process from 'node:process';
 import { Collection } from '@discordjs/collection';
 import { lazy } from '@discordjs/util';
 import { APIVersion, GatewayOpcodes } from 'discord-api-types/v10';
+import { SimpleShardingStrategy } from '../strategies/sharding/SimpleShardingStrategy.js';
 import type { SessionInfo, OptionalWebSocketManagerOptions } from '../ws/WebSocketManager.js';
 import type { SendRateLimitState } from '../ws/WebSocketShard.js';
 
@@ -27,6 +28,7 @@ const getDefaultSessionStore = lazy(() => new Collection<number, SessionInfo | n
  * Default options used by the manager
  */
 export const DefaultWebSocketManagerOptions = {
+	buildStrategy: (manager) => new SimpleShardingStrategy(manager),
 	shardCount: null,
 	shardIds: null,
 	largeThreshold: null,

--- a/packages/ws/src/ws/WebSocketManager.ts
+++ b/packages/ws/src/ws/WebSocketManager.ts
@@ -76,7 +76,7 @@ export interface OptionalWebSocketManagerOptions {
 	 * @example
 	 * ```ts
 	 * const manager = new WebSocketManager({
-	 * 	token: process.env.DISCORD_TOKEN,
+	 *  token: process.env.DISCORD_TOKEN,
 	 *  intents: 0, // for no intents
 	 *  rest,
 	 *  buildStrategy: (manager) => new WorkerShardingStrategy(manager, { shardsPerWorker: 2 }),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes `manager#setStrategy` in favor of a new `buildStrategy` manager option.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
