### PR TITLE
feat(InteractionResponse): add new methods

### DIFF
--- a/packages/discord.js/src/structures/InteractionResponse.js
+++ b/packages/discord.js/src/structures/InteractionResponse.js
@@ -72,7 +72,7 @@ class InteractionResponse {
   }
 
   /**
-   * Fetches the response as a Message object.
+   * Fetches the response as a {@link Message} object.
    * @returns {Promise<Message>}
    */
   fetch() {

--- a/packages/discord.js/src/structures/InteractionResponse.js
+++ b/packages/discord.js/src/structures/InteractionResponse.js
@@ -86,6 +86,7 @@ class InteractionResponse {
   delete() {
     return this.interaction.deleteReply();
   }
+
   /**
    * @param {string|MessagePayload|WebhookMessageEditOptions} options The new options for the response.
    * @returns {Promise<Message>}

--- a/packages/discord.js/src/structures/InteractionResponse.js
+++ b/packages/discord.js/src/structures/InteractionResponse.js
@@ -70,6 +70,29 @@ class InteractionResponse {
       interactionType: InteractionType.MessageComponent,
     });
   }
+
+  /**
+   * Fetches the response as a Message object.
+   * @returns {Promise<Message>}
+   */
+  fetch() {
+    return this.interaction.fetchReply();
+  }
+
+  /**
+   * Deletes the response.
+   * @returns {Promise<void>}
+   */
+  delete() {
+    return this.interaction.deleteReply();
+  }
+  /**
+   * @param {string|MessagePayload|WebhookMessageEditOptions} options The new options for the response.
+   * @returns {Promise<Message>}
+   */
+  edit(options) {
+    return this.interaction.editReply(options);
+  }
 }
 
 // eslint-disable-next-line import/order

--- a/packages/discord.js/src/structures/InteractionResponse.js
+++ b/packages/discord.js/src/structures/InteractionResponse.js
@@ -88,6 +88,7 @@ class InteractionResponse {
   }
 
   /**
+   * Edits the response.
    * @param {string|MessagePayload|WebhookMessageEditOptions} options The new options for the response.
    * @returns {Promise<Message>}
    */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -580,7 +580,7 @@ export class InteractionResponse<Cached extends boolean = boolean> {
     options?: MessageCollectorOptionsParams<T, Cached>,
   ): InteractionCollector<MappedInteractionTypes<Cached>[T]>;
   public delete(): Promise<void>;
-  public edit(options: WebhookMessageEditOptions): Promise<Message>;
+  public edit(options: string | MessagePayload | WebhookMessageEditOptions): Promise<Message>;
   public fetch(): Promise<Message>;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -579,6 +579,9 @@ export class InteractionResponse<Cached extends boolean = boolean> {
   public createMessageComponentCollector<T extends MessageComponentType>(
     options?: MessageCollectorOptionsParams<T, Cached>,
   ): InteractionCollector<MappedInteractionTypes<Cached>[T]>;
+  public delete(): Promise<void>;
+  public edit(options: WebhookMessageEditOptions): Promise<Message>;
+  public fetch(): Promise<Message>;
 }
 
 export abstract class BaseGuild extends Base {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the `delete`, `edit`, and `fetch` methods to the `InteractionResponse` class.
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
