### PR TITLE
chore: bump discord-api-types and undici

### DIFF
--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -58,7 +58,7 @@
 		"@discordjs/formatters": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"@sapphire/shapeshift": "^3.8.1",
-		"discord-api-types": "^0.37.27",
+		"discord-api-types": "^0.37.35",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.2",
 		"tslib": "^2.4.1"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
 		"@discordjs/ws": "workspace:^",
 		"@sapphire/snowflake": "^3.4.0",
 		"@vladfrangu/async_event_emitter": "^2.1.3",
-		"discord-api-types": "^0.37.27"
+		"discord-api-types": "^0.37.35"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^1.10.0",

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -56,7 +56,7 @@
     "@discordjs/util": "workspace:^",
     "@sapphire/snowflake": "^3.4.0",
     "@types/ws": "^8.5.4",
-    "discord-api-types": "^0.37.28",
+    "discord-api-types": "^0.37.35",
     "fast-deep-equal": "^3.1.3",
     "lodash.snakecase": "^4.1.1",
     "tslib": "^2.4.1",

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -60,7 +60,7 @@
     "fast-deep-equal": "^3.1.3",
     "lodash.snakecase": "^4.1.1",
     "tslib": "^2.4.1",
-    "undici": "^5.15.0",
+    "undici": "^5.19.1",
     "ws": "^8.12.0"
   },
   "devDependencies": {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6133,7 +6133,8 @@ export type Channel =
 
 export type TextBasedChannel = Exclude<
   Extract<Channel, { type: TextChannelType }>,
-  PartialGroupDMChannel | ForumChannel
+  // TODO: Remove stage channel upon implementation of text-in-stage.
+  PartialGroupDMChannel | ForumChannel | StageChannel
 >;
 
 export type TextBasedChannelTypes = TextBasedChannel['type'];

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -45,7 +45,7 @@
 	},
 	"homepage": "https://discord.js.org",
 	"dependencies": {
-		"discord-api-types": "^0.37.27"
+		"discord-api-types": "^0.37.35"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^1.10.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -59,7 +59,7 @@
 		"@discordjs/rest": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"@discordjs/ws": "workspace:^",
-		"discord-api-types": "^0.37.27"
+		"discord-api-types": "^0.37.35"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^1.10.0",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -58,7 +58,7 @@
 		"@discordjs/rest": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"tslib": "^2.4.1",
-		"undici": "^5.15.0"
+		"undici": "^5.19.1"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^1.10.0",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -57,7 +57,7 @@
 		"@discordjs/util": "workspace:^",
 		"@sapphire/async-queue": "^1.5.0",
 		"@sapphire/snowflake": "^3.4.0",
-		"discord-api-types": "^0.37.27",
+		"discord-api-types": "^0.37.35",
 		"file-type": "^18.1.0",
 		"tslib": "^2.4.1",
 		"undici": "^5.15.0"

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -60,7 +60,7 @@
 		"discord-api-types": "^0.37.35",
 		"file-type": "^18.1.0",
 		"tslib": "^2.4.1",
-		"undici": "^5.15.0"
+		"undici": "^5.19.1"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^1.10.0",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -50,7 +50,7 @@
 		"commander": "^9.5.0",
 		"fs-extra": "^11.1.0",
 		"tslib": "^2.4.1",
-		"undici": "^5.15.0",
+		"undici": "^5.19.1",
 		"yaml": "^2.2.1"
 	},
 	"devDependencies": {

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -54,7 +54,7 @@
 	"homepage": "https://discord.js.org",
 	"dependencies": {
 		"@types/ws": "^8.5.4",
-		"discord-api-types": "^0.37.27",
+		"discord-api-types": "^0.37.35",
 		"prism-media": "^1.3.4",
 		"tslib": "^2.4.1",
 		"ws": "^8.12.0"

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -65,7 +65,7 @@
 		"@sapphire/async-queue": "^1.5.0",
 		"@types/ws": "^8.5.4",
 		"@vladfrangu/async_event_emitter": "^2.1.3",
-		"discord-api-types": "^0.37.27",
+		"discord-api-types": "^0.37.35",
 		"tslib": "^2.4.1",
 		"ws": "^8.12.0"
 	},

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -83,7 +83,7 @@
 		"prettier": "^2.8.2",
 		"tsup": "^6.5.0",
 		"typescript": "^4.9.4",
-		"undici": "^5.15.0",
+		"undici": "^5.19.1",
 		"vitest": "^0.27.1",
 		"zlib-sync": "^0.1.7"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2064,7 +2064,7 @@ __metadata:
     "@types/node": 16.18.11
     "@vitest/coverage-c8": ^0.27.1
     cross-env: ^7.0.3
-    discord-api-types: ^0.37.27
+    discord-api-types: ^0.37.35
     downlevel-dts: ^0.11.0
     esbuild-plugin-version-injector: ^1.0.2
     eslint: ^8.31.0
@@ -2114,7 +2114,7 @@ __metadata:
     "@vitest/coverage-c8": ^0.27.1
     "@vladfrangu/async_event_emitter": ^2.1.3
     cross-env: ^7.0.3
-    discord-api-types: ^0.37.27
+    discord-api-types: ^0.37.35
     eslint: ^8.31.0
     eslint-config-neon: ^0.1.40
     eslint-formatter-pretty: ^4.1.0
@@ -2177,7 +2177,7 @@ __metadata:
     "@types/node": 16.18.11
     "@vitest/coverage-c8": ^0.27.1
     cross-env: ^7.0.3
-    discord-api-types: ^0.37.27
+    discord-api-types: ^0.37.35
     eslint: ^8.31.0
     eslint-config-neon: ^0.1.40
     eslint-formatter-pretty: ^4.1.0
@@ -2255,7 +2255,7 @@ __metadata:
     "@types/node": 18.11.18
     "@vitest/coverage-c8": ^0.27.1
     cross-env: ^7.0.3
-    discord-api-types: ^0.37.27
+    discord-api-types: ^0.37.35
     esbuild-plugin-version-injector: ^1.0.2
     eslint: ^8.31.0
     eslint-config-neon: ^0.1.40
@@ -2323,7 +2323,7 @@ __metadata:
     "@types/node": 16.18.11
     "@vitest/coverage-c8": ^0.27.1
     cross-env: ^7.0.3
-    discord-api-types: ^0.37.27
+    discord-api-types: ^0.37.35
     esbuild-plugin-version-injector: ^1.0.2
     eslint: ^8.31.0
     eslint-config-neon: ^0.1.40
@@ -2427,7 +2427,7 @@ __metadata:
     "@types/node": 16.18.11
     "@types/ws": ^8.5.4
     cross-env: ^7.0.3
-    discord-api-types: ^0.37.27
+    discord-api-types: ^0.37.35
     esbuild-plugin-version-injector: ^1.0.2
     eslint: ^8.31.0
     eslint-config-neon: ^0.1.40
@@ -2518,7 +2518,7 @@ __metadata:
     "@vitest/coverage-c8": ^0.27.1
     "@vladfrangu/async_event_emitter": ^2.1.3
     cross-env: ^7.0.3
-    discord-api-types: ^0.37.27
+    discord-api-types: ^0.37.35
     esbuild-plugin-version-injector: ^1.0.2
     eslint: ^8.31.0
     eslint-config-neon: ^0.1.40
@@ -8436,10 +8436,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"discord-api-types@npm:^0.37.27, discord-api-types@npm:^0.37.28":
-  version: 0.37.28
-  resolution: "discord-api-types@npm:0.37.28"
-  checksum: c033b9c82d5ecb3f273d563db578e21e982a35d106cc66e7ea42d7ef0a79817ca43badd3aade8a5ddb491bc8679ed08b1bcccc105e64ecd1ea5a53a11c2b1f8b
+"discord-api-types@npm:^0.37.35":
+  version: 0.37.35
+  resolution: "discord-api-types@npm:0.37.35"
+  checksum: 0a65234eefb9675c6faf82f42be6b0a4ee75bf8b2c901eecefea6ca539cd4e2a501b7fc195415884912fdb5040c98727dbd0c5a1f6bc15951948be37d1be162b
   languageName: node
   linkType: hard
 
@@ -8457,7 +8457,7 @@ __metadata:
     "@sapphire/snowflake": ^3.4.0
     "@types/node": 16.18.11
     "@types/ws": ^8.5.4
-    discord-api-types: ^0.37.28
+    discord-api-types: ^0.37.35
     dtslint: ^4.2.1
     eslint: ^8.31.0
     eslint-formatter-pretty: ^4.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,7 +2305,7 @@ __metadata:
     tslib: ^2.4.1
     tsup: ^6.5.0
     typescript: ^4.9.4
-    undici: ^5.15.0
+    undici: ^5.19.1
     vitest: ^0.27.1
   languageName: unknown
   linkType: soft
@@ -2333,7 +2333,7 @@ __metadata:
     tslib: ^2.4.1
     tsup: ^6.5.0
     typescript: ^4.9.4
-    undici: ^5.15.0
+    undici: ^5.19.1
     vitest: ^0.27.1
   languageName: unknown
   linkType: soft
@@ -2359,7 +2359,7 @@ __metadata:
     tslib: ^2.4.1
     tsup: ^6.5.0
     typescript: ^4.9.4
-    undici: ^5.15.0
+    undici: ^5.19.1
     vitest: ^0.27.1
     yaml: ^2.2.1
   languageName: unknown
@@ -2528,7 +2528,7 @@ __metadata:
     tslib: ^2.4.1
     tsup: ^6.5.0
     typescript: ^4.9.4
-    undici: ^5.15.0
+    undici: ^5.19.1
     vitest: ^0.27.1
     ws: ^8.12.0
     zlib-sync: ^0.1.7
@@ -8469,7 +8469,7 @@ __metadata:
     tslib: ^2.4.1
     tslint: ^6.1.3
     typescript: ^4.9.4
-    undici: ^5.15.0
+    undici: ^5.19.1
     ws: ^8.12.0
   languageName: unknown
   linkType: soft
@@ -20335,12 +20335,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.12.0, undici@npm:^5.15.0":
+"undici@npm:^5.12.0":
   version: 5.15.0
   resolution: "undici@npm:5.15.0"
   dependencies:
     busboy: ^1.6.0
   checksum: cdc03ceff8d2b76a5ae08dc48d0b9d44dcb970f6e89e8a3cfe7031b9351dd3c90b223c143565c153a5f1165cd573aae1b128e6b9f557b4af4eb36da337a2a345
+  languageName: node
+  linkType: hard
+
+"undici@npm:^5.19.1":
+  version: 5.19.1
+  resolution: "undici@npm:5.19.1"
+  dependencies:
+    busboy: ^1.6.0
+  checksum: 57ee94ee74d944faa41dbcb2faf4e0c90069708d3aaae860185884e51376b5d457728352a8396d69a3c9cb752b62ff99a19a664c5aacb7ee61cc488af499a01c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20335,16 +20335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^5.12.0":
-  version: 5.15.0
-  resolution: "undici@npm:5.15.0"
-  dependencies:
-    busboy: ^1.6.0
-  checksum: cdc03ceff8d2b76a5ae08dc48d0b9d44dcb970f6e89e8a3cfe7031b9351dd3c90b223c143565c153a5f1165cd573aae1b128e6b9f557b4af4eb36da337a2a345
-  languageName: node
-  linkType: hard
-
-"undici@npm:^5.19.1":
+"undici@npm:^5.12.0, undici@npm:^5.19.1":
   version: 5.19.1
   resolution: "undici@npm:5.19.1"
   dependencies:


### PR DESCRIPTION
Bumps discord-api-types to 0.37.35 and undici to 5.19.1 (see #9138).