### PR TITLE
feat(cleanContent): add missing emojis & slash mentions

### DIFF
--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -315,8 +315,8 @@ function basename(path, ext) {
  * @returns {string}
  */
 function cleanContent(str, channel) {
-  return str.replaceAll(/<(@[!&]?|#)(\d{17,19})>/g, (match, type, id) => {
-    switch (type) {
+  return str.replaceAll(/<(?:(@[!&]?|#)|([/:])([\w ]+):)(\d{17,19})>/g, (match, type, prefix, name, id) => {
+    switch (type ?? prefix) {
       case '@':
       case '@!': {
         const member = channel.guild?.members.cache.get(id);
@@ -336,6 +336,10 @@ function cleanContent(str, channel) {
         const mentionedChannel = channel.client.channels.cache.get(id);
         return mentionedChannel ? `#${mentionedChannel.name}` : match;
       }
+      case '/':
+        return `/${name}`;
+      case ':':
+        return `:${name}:`;
       default: {
         return match;
       }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The function `<Util>.cleanContent` function replace all mentions by the text equivalent.
This PR add the two missing mentions types : 
- **Commands mentions**: `</command:318312854816161792>`.
- **Custom emojis mentions**:  `<:emoji:318312854816161792>`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
