### PR TITLE
fix(snowflake): snowflakes length

### DIFF
--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -148,7 +148,7 @@ class ThreadManager extends CachedManager {
     let id;
     const query = makeURLSearchParams({ limit });
     if (typeof before !== 'undefined') {
-      if (before instanceof ThreadChannel || /^\d{16,20}$/.test(String(before))) {
+      if (before instanceof ThreadChannel || /^\d{17,19}$/.test(String(before))) {
         id = this.resolveId(before);
         timestamp = this.resolve(before)?.archivedAt?.toISOString();
         const toUse = type === 'private' && !fetchAll ? id : timestamp;

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -148,7 +148,7 @@ class ThreadManager extends CachedManager {
     let id;
     const query = makeURLSearchParams({ limit });
     if (typeof before !== 'undefined') {
-      if (before instanceof ThreadChannel || /^\d{16,19}$/.test(String(before))) {
+      if (before instanceof ThreadChannel || /^\d{16,20}$/.test(String(before))) {
         id = this.resolveId(before);
         timestamp = this.resolve(before)?.archivedAt?.toISOString();
         const toUse = type === 'private' && !fetchAll ? id : timestamp;

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -90,7 +90,7 @@ async function fetchRecommendedShardCount(token, { guildsPerShard = 1_000, multi
 function parseEmoji(text) {
   if (text.includes('%')) text = decodeURIComponent(text);
   if (!text.includes(':')) return { animated: false, name: text, id: undefined };
-  const match = text.match(/<?(?:(a):)?(\w{2,32}):(\d{16,20})?>?/);
+  const match = text.match(/<?(?:(a):)?(\w{2,32}):(\d{17,19})?>?/);
   return match && { animated: Boolean(match[1]), name: match[2], id: match[3] };
 }
 
@@ -102,7 +102,7 @@ function parseEmoji(text) {
  */
 function resolvePartialEmoji(emoji) {
   if (!emoji) return null;
-  if (typeof emoji === 'string') return /^\d{16,20}$/.test(emoji) ? { id: emoji } : parseEmoji(emoji);
+  if (typeof emoji === 'string') return /^\d{17,19}$/.test(emoji) ? { id: emoji } : parseEmoji(emoji);
   const { id, name, animated } = emoji;
   if (!id && !name) return null;
   return { id, name, animated: Boolean(animated) };
@@ -315,7 +315,7 @@ function basename(path, ext) {
  * @returns {string}
  */
 function cleanContent(str, channel) {
-  return str.replaceAll(/<(@[!&]?|#)(\d{16,20})>/g, (match, type, id) => {
+  return str.replaceAll(/<(@[!&]?|#)(\d{17,19})>/g, (match, type, id) => {
     switch (type) {
       case '@':
       case '@!': {
@@ -359,7 +359,7 @@ function cleanCodeBlockContent(text) {
  */
 function parseWebhookURL(url) {
   const matches = url.match(
-    /https?:\/\/(?:ptb\.|canary\.)?discord\.com\/api(?:\/v\d{1,2})?\/webhooks\/(\d{16,20})\/([\w-]{68})/i,
+    /https?:\/\/(?:ptb\.|canary\.)?discord\.com\/api(?:\/v\d{1,2})?\/webhooks\/(\d{17,19})\/([\w-]{68})/i,
   );
 
   if (!matches || matches.length <= 2) return null;

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -90,7 +90,7 @@ async function fetchRecommendedShardCount(token, { guildsPerShard = 1_000, multi
 function parseEmoji(text) {
   if (text.includes('%')) text = decodeURIComponent(text);
   if (!text.includes(':')) return { animated: false, name: text, id: undefined };
-  const match = text.match(/<?(?:(a):)?(\w{2,32}):(\d{17,19})?>?/);
+  const match = text.match(/<?(?:(a):)?(\w{2,32}):(\d{16,20})?>?/);
   return match && { animated: Boolean(match[1]), name: match[2], id: match[3] };
 }
 
@@ -102,7 +102,7 @@ function parseEmoji(text) {
  */
 function resolvePartialEmoji(emoji) {
   if (!emoji) return null;
-  if (typeof emoji === 'string') return /^\d{17,19}$/.test(emoji) ? { id: emoji } : parseEmoji(emoji);
+  if (typeof emoji === 'string') return /^\d{16,20}$/.test(emoji) ? { id: emoji } : parseEmoji(emoji);
   const { id, name, animated } = emoji;
   if (!id && !name) return null;
   return { id, name, animated: Boolean(animated) };
@@ -315,7 +315,7 @@ function basename(path, ext) {
  * @returns {string}
  */
 function cleanContent(str, channel) {
-  return str.replaceAll(/<(@[!&]?|#)(\d{17,19})>/g, (match, type, id) => {
+  return str.replaceAll(/<(@[!&]?|#)(\d{16,20})>/g, (match, type, id) => {
     switch (type) {
       case '@':
       case '@!': {
@@ -359,7 +359,7 @@ function cleanCodeBlockContent(text) {
  */
 function parseWebhookURL(url) {
   const matches = url.match(
-    /https?:\/\/(?:ptb\.|canary\.)?discord\.com\/api(?:\/v\d{1,2})?\/webhooks\/(\d{17,19})\/([\w-]{68})/i,
+    /https?:\/\/(?:ptb\.|canary\.)?discord\.com\/api(?:\/v\d{1,2})?\/webhooks\/(\d{16,20})\/([\w-]{68})/i,
   );
 
   if (!matches || matches.length <= 2) return null;

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -499,14 +499,14 @@ export class RequestManager extends EventEmitter {
 	 * @internal
 	 */
 	private static generateRouteData(endpoint: RouteLike, method: RequestMethod): RouteData {
-		const majorIdMatch = /^\/(?:channels|guilds|webhooks)\/(\d{16,19})/.exec(endpoint);
+		const majorIdMatch = /^\/(?:channels|guilds|webhooks)\/(\d{16,20})/.exec(endpoint);
 
 		// Get the major id for this route - global otherwise
 		const majorId = majorIdMatch?.[1] ?? 'global';
 
 		const baseRoute = endpoint
 			// Strip out all ids
-			.replaceAll(/\d{16,19}/g, ':id')
+			.replaceAll(/\d{16,20}/g, ':id')
 			// Strip out reaction as they fall under the same bucket
 			.replace(/\/reactions\/(.*)/, '/reactions/:reaction');
 
@@ -515,7 +515,7 @@ export class RequestManager extends EventEmitter {
 		// Hard-Code Old Message Deletion Exception (2 week+ old messages are a different bucket)
 		// https://github.com/discord/discord-api-docs/issues/1295
 		if (method === RequestMethod.Delete && baseRoute === '/channels/:id/messages/:id') {
-			const id = /\d{16,19}$/.exec(endpoint)![0]!;
+			const id = /\d{16,20}$/.exec(endpoint)![0]!;
 			const timestamp = DiscordSnowflake.timestampFrom(id);
 			if (Date.now() - timestamp > 1_000 * 60 * 60 * 24 * 14) {
 				exceptions += '/Delete Old Message';

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -499,14 +499,14 @@ export class RequestManager extends EventEmitter {
 	 * @internal
 	 */
 	private static generateRouteData(endpoint: RouteLike, method: RequestMethod): RouteData {
-		const majorIdMatch = /^\/(?:channels|guilds|webhooks)\/(\d{16,20})/.exec(endpoint);
+		const majorIdMatch = /^\/(?:channels|guilds|webhooks)\/(\d{17,19})/.exec(endpoint);
 
 		// Get the major id for this route - global otherwise
 		const majorId = majorIdMatch?.[1] ?? 'global';
 
 		const baseRoute = endpoint
 			// Strip out all ids
-			.replaceAll(/\d{16,20}/g, ':id')
+			.replaceAll(/\d{17,19}/g, ':id')
 			// Strip out reaction as they fall under the same bucket
 			.replace(/\/reactions\/(.*)/, '/reactions/:reaction');
 
@@ -515,7 +515,7 @@ export class RequestManager extends EventEmitter {
 		// Hard-Code Old Message Deletion Exception (2 week+ old messages are a different bucket)
 		// https://github.com/discord/discord-api-docs/issues/1295
 		if (method === RequestMethod.Delete && baseRoute === '/channels/:id/messages/:id') {
-			const id = /\d{16,20}$/.exec(endpoint)![0]!;
+			const id = /\d{17,19}$/.exec(endpoint)![0]!;
 			const timestamp = DiscordSnowflake.timestampFrom(id);
 			if (Date.now() - timestamp > 1_000 * 60 * 60 * 24 * 14) {
 				exceptions += '/Delete Old Message';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Snowflakes length depends on the UInt64 max value length and the Discord epoch.
- `2^64` max length is 20.
- A snowflake created a week after Discord epoch is 16 length minimum.

This PR change all snowflakes regex to `\d{16,20}`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
