### PR TITLE
fix(Message): `bulkDeletable` permissions should be retrieved later for DMs

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -645,12 +645,11 @@ class Message extends Base {
    * channel.bulkDelete(messages.filter(message => message.bulkDeletable));
    */
   get bulkDeletable() {
-    const permissions = this.channel?.permissionsFor(this.client.user);
     return (
       (this.inGuild() &&
         Date.now() - this.createdTimestamp < MaxBulkDeletableMessageAge &&
         this.deletable &&
-        permissions?.has(PermissionFlagsBits.ManageMessages, false)) ??
+        this.channel?.permissionsFor(this.client.user)?.has(PermissionFlagsBits.ManageMessages, false)) ??
       false
     );
   }

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -649,7 +649,7 @@ class Message extends Base {
       (this.inGuild() &&
         Date.now() - this.createdTimestamp < MaxBulkDeletableMessageAge &&
         this.deletable &&
-        this.channel?.permissionsFor(this.client.user)?.has(PermissionFlagsBits.ManageMessages, false)) ??
+        this.channel?.permissionsFor(this.client.user).has(PermissionFlagsBits.ManageMessages, false)) ??
       false
     );
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR fixes an issue in which attempting to use the  `bulkDeletable` getter on a message originating from a DM channel will throw an error.

**Status and versioning classification:** minor

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating