### PR TITLE
fix(ThreadManager): add `members` and conditionally include `hasMore`

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -451,7 +451,14 @@ class GuildChannelManager extends CachedManager {
   }
 
   /**
-   * Obtains all active thread channels in the guild from Discord
+   * Data returned from fetching threads.
+   * @typedef {Object} FetchedThreads
+   * @property {Collection<Snowflake, ThreadChannel>} threads The threads that were fetched
+   * @property {Collection<Snowflake, ThreadMember>} members The thread members in the received threads
+   */
+
+  /**
+   * Obtains all active thread channels in the guild.
    * @param {boolean} [cache=true] Whether to cache the fetched data
    * @returns {Promise<FetchedThreads>}
    * @example

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -87,7 +87,8 @@ class ThreadManager extends CachedManager {
    * ThreadChannelResolvable then the specified thread will be fetched. Fetches all active threads if `undefined`
    * @param {BaseFetchOptions} [cacheOptions] Additional options for this fetch. <warn>The `force` field gets ignored
    * if `options` is not a {@link ThreadChannelResolvable}</warn>
-   * @returns {Promise<?(ThreadChannel|FetchedThreads)>}
+   * @returns {Promise<?(ThreadChannel|FetchedThreads|FetchedThreadsMore)>}
+   * {@link FetchedThreads} if active & {@link FetchedThreadsMore} if archived.
    * @example
    * // Fetch a thread by its id
    * channel.threads.fetch('831955138126104859')
@@ -125,9 +126,8 @@ class ThreadManager extends CachedManager {
    */
 
   /**
-   * The data returned from a thread fetch that returns multiple threads.
-   * @typedef {Object} FetchedThreads
-   * @property {Collection<Snowflake, ThreadChannel>} threads The threads that were fetched, with any members returned
+   * Data returned from fetching multiple threads.
+   * @typedef {FetchedThreads} FetchedThreadsMore
    * @property {?boolean} hasMore Whether there are potentially additional threads that require a subsequent call
    */
 
@@ -137,7 +137,7 @@ class ThreadManager extends CachedManager {
    * in the parent channel.</info>
    * @param {FetchArchivedThreadOptions} [options] The options to fetch archived threads
    * @param {boolean} [cache=true] Whether to cache the new thread objects if they aren't already
-   * @returns {Promise<FetchedThreads>}
+   * @returns {Promise<FetchedThreadsMore>}
    */
   async fetchArchived({ type = 'public', fetchAll = false, before, limit } = {}, cache = true) {
     let path = Routes.channelThreads(this.channel.id, type);
@@ -172,15 +172,13 @@ class ThreadManager extends CachedManager {
   }
 
   /**
-   * Obtains the accessible active threads from Discord.
-   * <info>This method requires the {@link PermissionFlagsBits.ReadMessageHistory} permission
-   * in the parent channel.</info>
-   * @param {boolean} [cache=true] Whether to cache the new thread objects if they aren't already
+   * Obtains all active thread channels in the guild.
+   * This internally calls {@link GuildChannelManager#fetchActiveThreads}.
+   * @param {boolean} [cache=true] Whether to cache the fetched data
    * @returns {Promise<FetchedThreads>}
    */
-  async fetchActive(cache = true) {
-    const raw = await this.client.rest.get(Routes.guildActiveThreads(this.channel.guild.id));
-    return this.constructor._mapThreads(raw, this.client, { parent: this.channel, cache });
+  fetchActive(cache = true) {
+    return this.channel.guild.channels.fetchActiveThreads(cache);
   }
 
   static _mapThreads(rawThreads, client, { parent, guild, cache }) {
@@ -189,12 +187,18 @@ class ThreadManager extends CachedManager {
       if (parent && thread.parentId !== parent.id) return coll;
       return coll.set(thread.id, thread);
     }, new Collection());
+
     // Discord sends the thread id as id in this object
-    for (const rawMember of rawThreads.members) client.channels.cache.get(rawMember.id)?.members._add(rawMember);
-    return {
-      threads,
-      hasMore: rawThreads.has_more ?? false,
-    };
+    const threadMembers = rawThreads.members.reduce(
+      (coll, raw) => coll.set(raw.user_id, threads.get(raw.id).members._add(raw)),
+      new Collection(),
+    );
+
+    const response = { threads, members: threadMembers };
+
+    // The GET `/guilds/{guild.id}/threads/active` route does not return `has_more`.
+    if ('has_more' in rawThreads) response.hasMore = rawThreads.has_more;
+    return response;
   }
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4109,7 +4109,10 @@ export class ThreadManager<Forum extends boolean = boolean> extends CachedManage
   protected constructor(channel: TextChannel | NewsChannel | ForumChannel, iterable?: Iterable<RawThreadChannelData>);
   public channel: If<Forum, ForumChannel, TextChannel | NewsChannel>;
   public fetch(options: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<AnyThreadChannel | null>;
-  public fetch(options: Required<FetchThreadsOptions>, cacheOptions?: { cache?: boolean }): Promise<FetchedThreadsMore>;
+  public fetch(
+    options: FetchThreadsOptions & { archived: FetchArchivedThreadOptions },
+    cacheOptions?: { cache?: boolean },
+  ): Promise<FetchedThreadsMore>;
   public fetch(options?: FetchThreadsOptions, cacheOptions?: { cache?: boolean }): Promise<FetchedThreads>;
   public fetchArchived(options?: FetchArchivedThreadOptions, cache?: boolean): Promise<FetchedThreadsMore>;
   public fetchActive(cache?: boolean): Promise<FetchedThreads>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4109,8 +4109,9 @@ export class ThreadManager<Forum extends boolean = boolean> extends CachedManage
   protected constructor(channel: TextChannel | NewsChannel | ForumChannel, iterable?: Iterable<RawThreadChannelData>);
   public channel: If<Forum, ForumChannel, TextChannel | NewsChannel>;
   public fetch(options: ThreadChannelResolvable, cacheOptions?: BaseFetchOptions): Promise<AnyThreadChannel | null>;
+  public fetch(options: Required<FetchThreadsOptions>, cacheOptions?: { cache?: boolean }): Promise<FetchedThreadsMore>;
   public fetch(options?: FetchThreadsOptions, cacheOptions?: { cache?: boolean }): Promise<FetchedThreads>;
-  public fetchArchived(options?: FetchArchivedThreadOptions, cache?: boolean): Promise<FetchedThreads>;
+  public fetchArchived(options?: FetchArchivedThreadOptions, cache?: boolean): Promise<FetchedThreadsMore>;
   public fetchActive(cache?: boolean): Promise<FetchedThreads>;
 }
 
@@ -5148,7 +5149,11 @@ export interface FetchChannelOptions extends BaseFetchOptions {
 
 export interface FetchedThreads {
   threads: Collection<Snowflake, AnyThreadChannel>;
-  hasMore?: boolean;
+  members: Collection<Snowflake, ThreadMember>;
+}
+
+export interface FetchedThreadsMore extends FetchedThreads {
+  hasMore: boolean;
 }
 
 export interface FetchGuildOptions extends BaseFetchOptions {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -160,6 +160,9 @@ import {
   PublicThreadChannel,
   GuildMemberManager,
   GuildMemberFlagsBitField,
+  ThreadManager,
+  FetchedThreads,
+  FetchedThreadsMore,
 } from '.';
 import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import type { ContextMenuCommandBuilder, SlashCommandBuilder } from '@discordjs/builders';
@@ -1477,6 +1480,18 @@ declare const guildChannelManager: GuildChannelManager;
   expectType<MessageMentions<false>>(message.mentions);
   expectType<null>(message.mentions.guild);
   expectType<null>(message.mentions.members);
+}
+
+declare const threadManager: ThreadManager;
+{
+  expectType<Promise<AnyThreadChannel | null>>(threadManager.fetch('12345678901234567'));
+  expectType<Promise<AnyThreadChannel | null>>(threadManager.fetch('12345678901234567', { cache: true, force: false }));
+  expectType<Promise<FetchedThreads>>(threadManager.fetch());
+  expectType<Promise<FetchedThreads>>(threadManager.fetch({}));
+  expectType<Promise<FetchedThreadsMore>>(threadManager.fetch({ archived: { limit: 4 } }));
+
+  // @ts-expect-error The force option has no effect here.
+  threadManager.fetch({ archived: {} }, { force: true });
 }
 
 declare const guildForumThreadManager: GuildForumThreadManager;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Fetching active threads in a guild does not yield the `has_more` property.[^1]
- `has_more` does not appear to be marked as missing or potentially `null`.[^2][^3][^4]
- `members` was not returned when fetching active threads in a guild.
- The permission requirement to fetch active threads in the guild did not seem to be true. Discord's API documentation does not state this,[^1] but does for other thread-fetching methods.[^2][^3][^4]

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

[^1]: https://discord.com/developers/docs/resources/guild#list-active-guild-threads
[^2]: https://discord.com/developers/docs/resources/channel#list-public-archived-threads
[^3]: https://discord.com/developers/docs/resources/channel#list-private-archived-threads
[^4]: https://discord.com/developers/docs/resources/channel#list-joined-private-archived-threads