### PR TITLE
fix(Message#deletable): add check for deletable message types

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -631,8 +631,9 @@ class Message extends Base {
     // This flag allows deleting even if timed out
     if (permissions.has(PermissionFlagsBits.Administrator, false)) return true;
 
+    // The auto moderation action message author is the reference message author
     return Boolean(
-      this.author.id === this.client.user.id ||
+      (this.type !== MessageType.AutoModerationAction && this.author.id === this.client.user.id) ||
         (permissions.has(PermissionFlagsBits.ManageMessages, false) &&
           this.guild.members.me.communicationDisabledUntilTimestamp < Date.now()),
     );

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -632,10 +632,9 @@ class Message extends Base {
     if (permissions.has(PermissionFlagsBits.Administrator, false)) return true;
 
     // The auto moderation action message author is the reference message author
-    return Boolean(
+    return (
       (this.type !== MessageType.AutoModerationAction && this.author.id === this.client.user.id) ||
-        (permissions.has(PermissionFlagsBits.ManageMessages, false) &&
-          this.guild.members.me.communicationDisabledUntilTimestamp < Date.now()),
+      (permissions.has(PermissionFlagsBits.ManageMessages, false) && !this.guild.members.me.isCommunicationDisabled())
     );
   }
 

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -22,7 +22,7 @@ const { Sticker } = require('./Sticker');
 const { DiscordjsError, ErrorCodes } = require('../errors');
 const ReactionManager = require('../managers/ReactionManager');
 const { createComponent } = require('../util/Components');
-const { NonSystemMessageTypes, MaxBulkDeletableMessageAge } = require('../util/Constants');
+const { NonSystemMessageTypes, MaxBulkDeletableMessageAge, DeletableMessageTypes } = require('../util/Constants');
 const MessageFlagsBitField = require('../util/MessageFlagsBitField');
 const PermissionsBitField = require('../util/PermissionsBitField');
 const { cleanContent, resolvePartialEmoji } = require('../util/Util');
@@ -616,6 +616,8 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
+    if (!DeletableMessageTypes.includes(this.type)) return false;
+
     if (!this.guild) {
       return this.author.id === this.client.user.id;
     }

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -139,6 +139,54 @@ exports.SelectMenuTypes = [
 ];
 
 /**
+ * The types of messages that can be deleted. The available types are:
+ * * {@link MessageType.AutoModerationAction}
+ * * {@link MessageType.ChannelFollowAdd}
+ * * {@link MessageType.ChannelPinnedMessage}
+ * * {@link MessageType.ChatInputCommand}
+ * * {@link MessageType.ContextMenuCommand}
+ * * {@link MessageType.Default}
+ * * {@link MessageType.GuildBoost}
+ * * {@link MessageType.GuildBoostTier1}
+ * * {@link MessageType.GuildBoostTier2}
+ * * {@link MessageType.GuildBoostTier3}
+ * * {@link MessageType.GuildInviteReminder}
+ * * {@link MessageType.InteractionPremiumUpsell}
+ * * {@link MessageType.Reply}
+ * * {@link MessageType.RoleSubscriptionPurchase}
+ * * {@link MessageType.StageEnd}
+ * * {@link MessageType.StageRaiseHand}
+ * * {@link MessageType.StageSpeaker}
+ * * {@link MessageType.StageStart}
+ * * {@link MessageType.StageTopic}
+ * * {@link MessageType.ThreadCreated}
+ * * {@link MessageType.UserJoin}
+ */
+exports.DeletableMessageTypes = [
+  MessageType.AutoModerationAction,
+  MessageType.ChannelFollowAdd,
+  MessageType.ChannelPinnedMessage,
+  MessageType.ChatInputCommand,
+  MessageType.ContextMenuCommand,
+  MessageType.Default,
+  MessageType.GuildBoost,
+  MessageType.GuildBoostTier1,
+  MessageType.GuildBoostTier2,
+  MessageType.GuildBoostTier3,
+  MessageType.GuildInviteReminder,
+  MessageType.InteractionPremiumUpsell,
+  MessageType.Reply,
+  MessageType.RoleSubscriptionPurchase,
+  MessageType.StageEnd,
+  MessageType.StageRaiseHand,
+  MessageType.StageSpeaker,
+  MessageType.StageStart,
+  MessageType.StageTopic,
+  MessageType.ThreadCreated,
+  MessageType.UserJoin,
+];
+
+/**
  * A mapping between sticker formats and their respective image formats.
  * * {@link StickerFormatType.PNG} -> {@link ImageFormat.PNG}
  * * {@link StickerFormatType.APNG} -> {@link ImageFormat.PNG}

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -161,6 +161,7 @@ exports.SelectMenuTypes = [
  * * {@link MessageType.StageTopic}
  * * {@link MessageType.ThreadCreated}
  * * {@link MessageType.UserJoin}
+ * @typedef {MessageType[]} DeletableMessageTypes
  */
 exports.DeletableMessageTypes = [
   MessageType.AutoModerationAction,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3445,6 +3445,29 @@ export type NonSystemMessageType =
   | MessageType.ChatInputCommand
   | MessageType.ContextMenuCommand;
 
+export type DeletableMessageType =
+  | MessageType.AutoModerationAction
+  | MessageType.ChannelFollowAdd
+  | MessageType.ChannelPinnedMessage
+  | MessageType.ChatInputCommand
+  | MessageType.ContextMenuCommand
+  | MessageType.Default
+  | MessageType.GuildBoost
+  | MessageType.GuildBoostTier1
+  | MessageType.GuildBoostTier2
+  | MessageType.GuildBoostTier3
+  | MessageType.GuildInviteReminder
+  | MessageType.InteractionPremiumUpsell
+  | MessageType.Reply
+  | MessageType.RoleSubscriptionPurchase
+  | MessageType.StageEnd
+  | MessageType.StageRaiseHand
+  | MessageType.StageSpeaker
+  | MessageType.StageStart
+  | MessageType.StageTopic
+  | MessageType.ThreadCreated
+  | MessageType.UserJoin;
+
 export const Constants: {
   MaxBulkDeletableMessageAge: 1_209_600_000;
   SweeperKeys: SweeperKey[];
@@ -3453,6 +3476,7 @@ export const Constants: {
   ThreadChannelTypes: ThreadChannelType[];
   VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
   SelectMenuTypes: SelectMenuType[];
+  DeletableMessageTypes: DeletableMessageType[];
   StickerFormatExtensionMap: Record<StickerFormatType, ImageFormat>;
 };
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds check for deletable message types in `Message#deletable`
https://github.com/discord/discord-api-docs/pull/5148

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
