### PR TITLE
Add property `type` to SlashCommandBuilder

### DIFF
--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -66,6 +66,11 @@ export class SlashCommandBuilder {
 	public readonly dm_permission: boolean | undefined = undefined;
 
 	/**
+	 * The type of this command
+	 */
+	public readonly type: ContextMenuCommandType = 1;
+
+	/**
 	 * Whether this command is NSFW
 	 */
 	public readonly nsfw: boolean | undefined = undefined;

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -68,7 +68,7 @@ export class SlashCommandBuilder {
 	/**
 	 * The type of this command
 	 */
-	public readonly type: ContextMenuCommandType = 1;
+	public readonly type = 1;
 
 	/**
 	 * Whether this command is NSFW

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -1,5 +1,6 @@
 import type {
 	APIApplicationCommandOption,
+	ApplicationCommandType,
 	LocalizationMap,
 	Permissions,
 	RESTPostAPIChatInputApplicationCommandsJSONBody,
@@ -68,7 +69,7 @@ export class SlashCommandBuilder {
 	/**
 	 * The type of this command
 	 */
-	public readonly type = 1;
+	public readonly type: ApplicationCommandType.ChatInput = 1;
 
 	/**
 	 * Whether this command is NSFW


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Might help if people want to categorize their commands, instead of checking if the builder is a SlashCommandBuilder, they can simply check the `type` property of builder, very much like how `ContextMenuCommandBuilder` does it

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
