### PR TITLE
refactor: compare with `undefined` directly

### DIFF
--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -84,7 +84,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public first(): V | undefined;
 	public first(amount: number): V[];
 	public first(amount?: number): V | V[] | undefined {
-		if (typeof amount === 'undefined') return this.values().next().value;
+		if (amount === undefined) return this.values().next().value;
 		if (amount < 0) return this.last(amount * -1);
 		amount = Math.min(this.size, amount);
 		const iter = this.values();
@@ -101,7 +101,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public firstKey(): K | undefined;
 	public firstKey(amount: number): K[];
 	public firstKey(amount?: number): K | K[] | undefined {
-		if (typeof amount === 'undefined') return this.keys().next().value;
+		if (amount === undefined) return this.keys().next().value;
 		if (amount < 0) return this.lastKey(amount * -1);
 		amount = Math.min(this.size, amount);
 		const iter = this.keys();
@@ -119,7 +119,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public last(amount: number): V[];
 	public last(amount?: number): V | V[] | undefined {
 		const arr = [...this.values()];
-		if (typeof amount === 'undefined') return arr[arr.length - 1];
+		if (amount === undefined) return arr[arr.length - 1];
 		if (amount < 0) return this.first(amount * -1);
 		if (!amount) return [];
 		return arr.slice(-amount);
@@ -136,7 +136,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public lastKey(amount: number): K[];
 	public lastKey(amount?: number): K | K[] | undefined {
 		const arr = [...this.keys()];
-		if (typeof amount === 'undefined') return arr[arr.length - 1];
+		if (amount === undefined) return arr[arr.length - 1];
 		if (amount < 0) return this.firstKey(amount * -1);
 		if (!amount) return [];
 		return arr.slice(-amount);
@@ -178,7 +178,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public random(amount: number): V[];
 	public random(amount?: number): V | V[] | undefined {
 		const arr = [...this.values()];
-		if (typeof amount === 'undefined') return arr[Math.floor(Math.random() * arr.length)];
+		if (amount === undefined) return arr[Math.floor(Math.random() * arr.length)];
 		if (!arr.length || !amount) return [];
 		return Array.from(
 			{ length: Math.min(amount, arr.length) },
@@ -196,7 +196,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public randomKey(amount: number): K[];
 	public randomKey(amount?: number): K | K[] | undefined {
 		const arr = [...this.keys()];
-		if (typeof amount === 'undefined') return arr[Math.floor(Math.random() * arr.length)];
+		if (amount === undefined) return arr[Math.floor(Math.random() * arr.length)];
 		if (!arr.length || !amount) return [];
 		return Array.from(
 			{ length: Math.min(amount, arr.length) },
@@ -238,7 +238,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public find<This>(fn: (this: This, value: V, key: K, collection: this) => unknown, thisArg: This): V | undefined;
 	public find(fn: (value: V, key: K, collection: this) => unknown, thisArg?: unknown): V | undefined {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
-		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		for (const [key, val] of this) {
 			if (fn(val, key, this)) return val;
 		}
@@ -267,7 +267,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public findKey<This>(fn: (this: This, value: V, key: K, collection: this) => unknown, thisArg: This): K | undefined;
 	public findKey(fn: (value: V, key: K, collection: this) => unknown, thisArg?: unknown): K | undefined {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
-		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		for (const [key, val] of this) {
 			if (fn(val, key, this)) return key;
 		}
@@ -286,7 +286,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public sweep<T>(fn: (this: T, value: V, key: K, collection: this) => unknown, thisArg: T): number;
 	public sweep(fn: (value: V, key: K, collection: this) => unknown, thisArg?: unknown): number {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
-		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		const previousSize = this.size;
 		for (const [key, val] of this) {
 			if (fn(val, key, this)) this.delete(key);
@@ -321,7 +321,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public filter<This>(fn: (this: This, value: V, key: K, collection: this) => unknown, thisArg: This): Collection<K, V>;
 	public filter(fn: (value: V, key: K, collection: this) => unknown, thisArg?: unknown): Collection<K, V> {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
-		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		const results = new this.constructor[Symbol.species]<K, V>();
 		for (const [key, val] of this) {
 			if (fn(val, key, this)) results.set(key, val);
@@ -365,7 +365,7 @@ export class Collection<K, V> extends Map<K, V> {
 		thisArg?: unknown,
 	): [Collection<K, V>, Collection<K, V>] {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
-		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		const results: [Collection<K, V>, Collection<K, V>] = [
 			new this.constructor[Symbol.species]<K, V>(),
 			new this.constructor[Symbol.species]<K, V>(),
@@ -418,7 +418,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public map<This, T>(fn: (this: This, value: V, key: K, collection: this) => T, thisArg: This): T[];
 	public map<T>(fn: (value: V, key: K, collection: this) => T, thisArg?: unknown): T[] {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
-		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		const iter = this.entries();
 		return Array.from({ length: this.size }, (): T => {
 			const [key, value] = iter.next().value;
@@ -441,7 +441,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public mapValues<This, T>(fn: (this: This, value: V, key: K, collection: this) => T, thisArg: This): Collection<K, T>;
 	public mapValues<T>(fn: (value: V, key: K, collection: this) => T, thisArg?: unknown): Collection<K, T> {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
-		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		const coll = new this.constructor[Symbol.species]<K, T>();
 		for (const [key, val] of this) coll.set(key, fn(val, key, this));
 		return coll;
@@ -462,7 +462,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public some<T>(fn: (this: T, value: V, key: K, collection: this) => unknown, thisArg: T): boolean;
 	public some(fn: (value: V, key: K, collection: this) => unknown, thisArg?: unknown): boolean {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
-		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		for (const [key, val] of this) {
 			if (fn(val, key, this)) return true;
 		}
@@ -495,7 +495,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public every<This>(fn: (this: This, value: V, key: K, collection: this) => unknown, thisArg: This): boolean;
 	public every(fn: (value: V, key: K, collection: this) => unknown, thisArg?: unknown): boolean {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
-		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		for (const [key, val] of this) {
 			if (!fn(val, key, this)) return false;
 		}
@@ -519,7 +519,7 @@ export class Collection<K, V> extends Map<K, V> {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
 		let accumulator!: T;
 
-		if (typeof initialValue !== 'undefined') {
+		if (initialValue !== undefined) {
 			accumulator = initialValue;
 			for (const [key, val] of this) accumulator = fn(accumulator, val, key, this);
 			return accumulator;
@@ -585,7 +585,7 @@ export class Collection<K, V> extends Map<K, V> {
 	public tap<T>(fn: (this: T, collection: this) => void, thisArg: T): this;
 	public tap(fn: (collection: this) => void, thisArg?: unknown): this {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
-		if (typeof thisArg !== 'undefined') fn = fn.bind(thisArg);
+		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		fn(this);
 		return this;
 	}

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -307,7 +307,7 @@ class Client extends BaseClient {
    *   .catch(console.error);
    */
   async fetchWebhook(id, token) {
-    const data = await this.rest.get(Routes.webhook(id, token), { auth: typeof token === 'undefined' });
+    const data = await this.rest.get(Routes.webhook(id, token), { auth: token === undefined });
     return new Webhook(this, { token, ...data });
   }
 
@@ -411,7 +411,7 @@ class Client extends BaseClient {
     if (!this.application) throw new DiscordjsError(ErrorCodes.ClientNotReady, 'generate an invite link');
 
     const { scopes } = options;
-    if (typeof scopes === 'undefined') {
+    if (scopes === undefined) {
       throw new DiscordjsTypeError(ErrorCodes.InvalidMissingScopes);
     }
     if (!Array.isArray(scopes)) {
@@ -485,7 +485,7 @@ class Client extends BaseClient {
    * @private
    */
   _validateOptions(options = this.options) {
-    if (typeof options.intents === 'undefined') {
+    if (options.intents === undefined) {
       throw new DiscordjsTypeError(ErrorCodes.ClientMissingIntents);
     } else {
       options.intents = new IntentsBitField(options.intents).freeze();

--- a/packages/discord.js/src/managers/GuildBanManager.js
+++ b/packages/discord.js/src/managers/GuildBanManager.js
@@ -103,7 +103,7 @@ class GuildBanManager extends CachedManager {
     const resolvedUser = this.client.users.resolveId(user ?? options);
     if (resolvedUser) return this._fetchSingle({ user: resolvedUser, cache, force });
 
-    if (!before && !after && !limit && typeof cache === 'undefined') {
+    if (!before && !after && !limit && cache === undefined) {
       return Promise.reject(new DiscordjsError(ErrorCodes.FetchBanResolveId));
     }
 
@@ -156,7 +156,7 @@ class GuildBanManager extends CachedManager {
     const id = this.client.users.resolveId(user);
     if (!id) throw new DiscordjsError(ErrorCodes.BanResolveId, true);
 
-    if (typeof options.deleteMessageDays !== 'undefined' && !deprecationEmittedForDeleteMessageDays) {
+    if (options.deleteMessageDays !== undefined && !deprecationEmittedForDeleteMessageDays) {
       process.emitWarning(
         // eslint-disable-next-line max-len
         'The deleteMessageDays option for GuildBanManager#create() is deprecated. Use the deleteMessageSeconds option instead.',

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -275,7 +275,7 @@ class GuildChannelManager extends CachedManager {
 
     const parent = options.parent && this.client.channels.resolveId(options.parent);
 
-    if (typeof options.position !== 'undefined') {
+    if (options.position !== undefined) {
       await this.setPosition(channel, options.position, { position: options.position, reason: options.reason });
     }
 
@@ -440,7 +440,7 @@ class GuildChannelManager extends CachedManager {
       id: this.client.channels.resolveId(r.channel),
       position: r.position,
       lock_permissions: r.lockPermissions,
-      parent_id: typeof r.parent !== 'undefined' ? this.resolveId(r.parent) : undefined,
+      parent_id: r.parent !== undefined ? this.resolveId(r.parent) : undefined,
     }));
 
     await this.client.rest.patch(Routes.guildChannels(this.guild.id), { body: channelPositions });

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -186,7 +186,7 @@ class GuildManager extends CachedManager {
           ...options,
           color: color && resolveColor(color),
           permissions:
-            typeof permissions === 'undefined' ? undefined : PermissionsBitField.resolve(permissions).toString(),
+            permissions === undefined ? undefined : PermissionsBitField.resolve(permissions).toString(),
         })),
         channels: channels.map(
           ({
@@ -205,8 +205,8 @@ class GuildManager extends CachedManager {
             video_quality_mode: videoQualityMode,
             permission_overwrites: permissionOverwrites?.map(({ allow, deny, ...permissionOverwriteOptions }) => ({
               ...permissionOverwriteOptions,
-              allow: typeof allow === 'undefined' ? undefined : PermissionsBitField.resolve(allow).toString(),
-              deny: typeof deny === 'undefined' ? undefined : PermissionsBitField.resolve(deny).toString(),
+              allow: allow === undefined ? undefined : PermissionsBitField.resolve(allow).toString(),
+              deny: deny === undefined ? undefined : PermissionsBitField.resolve(deny).toString(),
             })),
             rate_limit_per_user: rateLimitPerUser,
           }),
@@ -215,7 +215,7 @@ class GuildManager extends CachedManager {
         afk_timeout: afkTimeout,
         system_channel_id: systemChannelId,
         system_channel_flags:
-          typeof systemChannelFlags === 'undefined'
+          systemChannelFlags === undefined
             ? undefined
             : SystemChannelFlagsBitField.resolve(systemChannelFlags),
       },

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -185,8 +185,7 @@ class GuildManager extends CachedManager {
         roles: roles.map(({ color, permissions, ...options }) => ({
           ...options,
           color: color && resolveColor(color),
-          permissions:
-            permissions === undefined ? undefined : PermissionsBitField.resolve(permissions).toString(),
+          permissions: permissions === undefined ? undefined : PermissionsBitField.resolve(permissions).toString(),
         })),
         channels: channels.map(
           ({
@@ -215,9 +214,7 @@ class GuildManager extends CachedManager {
         afk_timeout: afkTimeout,
         system_channel_id: systemChannelId,
         system_channel_flags:
-          systemChannelFlags === undefined
-            ? undefined
-            : SystemChannelFlagsBitField.resolve(systemChannelFlags),
+          systemChannelFlags === undefined ? undefined : SystemChannelFlagsBitField.resolve(systemChannelFlags),
       },
     });
 

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -358,7 +358,7 @@ class GuildMemberManager extends CachedManager {
     }
     options.roles &&= options.roles.map(role => (role instanceof Role ? role.id : role));
 
-    if (typeof options.communicationDisabledUntil !== 'undefined') {
+    if (options.communicationDisabledUntil !== undefined) {
       options.communication_disabled_until =
         // eslint-disable-next-line eqeqeq
         options.communicationDisabledUntil != null
@@ -366,7 +366,7 @@ class GuildMemberManager extends CachedManager {
           : options.communicationDisabledUntil;
     }
 
-    if (typeof options.flags !== 'undefined') {
+    if (options.flags !== undefined) {
       options.flags = GuildMemberFlagsBitField.resolve(options.flags);
     }
 

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -85,12 +85,12 @@ class GuildScheduledEventManager extends CachedManager {
 
     let entity_metadata, channel_id;
     if (entityType === GuildScheduledEventEntityType.External) {
-      channel_id = typeof channel === 'undefined' ? channel : null;
+      channel_id = channel === undefined ? channel : null;
       entity_metadata = { location: entityMetadata?.location };
     } else {
       channel_id = this.guild.channels.resolveId(channel);
       if (!channel_id) throw new DiscordjsError(ErrorCodes.GuildVoiceChannelResolve);
-      entity_metadata = typeof entityMetadata === 'undefined' ? entityMetadata : null;
+      entity_metadata = entityMetadata === undefined ? entityMetadata : null;
     }
 
     const data = await this.client.rest.post(Routes.guildScheduledEvents(this.guild.id), {
@@ -214,7 +214,7 @@ class GuildScheduledEventManager extends CachedManager {
 
     const data = await this.client.rest.patch(Routes.guildScheduledEvent(this.guild.id, guildScheduledEventId), {
       body: {
-        channel_id: typeof channel === 'undefined' ? channel : this.guild.channels.resolveId(channel),
+        channel_id: channel === undefined ? channel : this.guild.channels.resolveId(channel),
         name,
         privacy_level: privacyLevel,
         scheduled_start_time: scheduledStartTime ? new Date(scheduledStartTime).toISOString() : undefined,

--- a/packages/discord.js/src/managers/RoleManager.js
+++ b/packages/discord.js/src/managers/RoleManager.js
@@ -200,8 +200,7 @@ class RoleManager extends CachedManager {
       name: options.name,
       color: options.color === undefined ? undefined : resolveColor(options.color),
       hoist: options.hoist,
-      permissions:
-        options.permissions === undefined ? undefined : new PermissionsBitField(options.permissions),
+      permissions: options.permissions === undefined ? undefined : new PermissionsBitField(options.permissions),
       mentionable: options.mentionable,
       icon,
       unicode_emoji: options.unicodeEmoji,

--- a/packages/discord.js/src/managers/RoleManager.js
+++ b/packages/discord.js/src/managers/RoleManager.js
@@ -137,7 +137,7 @@ class RoleManager extends CachedManager {
   async create(options = {}) {
     let { name, color, hoist, permissions, position, mentionable, reason, icon, unicodeEmoji } = options;
     color &&= resolveColor(color);
-    if (typeof permissions !== 'undefined') permissions = new PermissionsBitField(permissions);
+    if (permissions !== undefined) permissions = new PermissionsBitField(permissions);
     if (icon) {
       const guildEmojiURL = this.guild.emojis.resolve(icon)?.url;
       icon = guildEmojiURL ? await DataResolver.resolveImage(guildEmojiURL) : await DataResolver.resolveImage(icon);
@@ -198,10 +198,10 @@ class RoleManager extends CachedManager {
 
     const body = {
       name: options.name,
-      color: typeof options.color === 'undefined' ? undefined : resolveColor(options.color),
+      color: options.color === undefined ? undefined : resolveColor(options.color),
       hoist: options.hoist,
       permissions:
-        typeof options.permissions === 'undefined' ? undefined : new PermissionsBitField(options.permissions),
+        options.permissions === undefined ? undefined : new PermissionsBitField(options.permissions),
       mentionable: options.mentionable,
       icon,
       unicode_emoji: options.unicodeEmoji,

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -147,7 +147,7 @@ class ThreadManager extends CachedManager {
     let timestamp;
     let id;
     const query = makeURLSearchParams({ limit });
-    if (typeof before !== 'undefined') {
+    if (before !== undefined) {
       if (before instanceof ThreadChannel || /^\d{16,19}$/.test(String(before))) {
         id = this.resolveId(before);
         timestamp = this.resolve(before)?.archivedAt?.toISOString();

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -389,7 +389,7 @@ class ApplicationCommand extends Base {
       // TODO: remove ?? 0 on each when nullable
       (command.options?.length ?? 0) !== (this.options?.length ?? 0) ||
       defaultMemberPermissions !== (this.defaultMemberPermissions?.bitfield ?? null) ||
-      (typeof dmPermission !== 'undefined' && dmPermission !== this.dmPermission) ||
+      (dmPermission !== undefined && dmPermission !== this.dmPermission) ||
       !isEqual(command.nameLocalizations ?? command.name_localizations ?? {}, this.nameLocalizations ?? {}) ||
       !isEqual(
         command.descriptionLocalizations ?? command.description_localizations ?? {},

--- a/packages/discord.js/src/structures/ClientPresence.js
+++ b/packages/discord.js/src/structures/ClientPresence.js
@@ -21,7 +21,7 @@ class ClientPresence extends Presence {
   set(presence) {
     const packet = this._parse(presence);
     this._patch(packet);
-    if (typeof presence.shardId === 'undefined') {
+    if (presence.shardId === undefined) {
       this.client.ws.broadcast({ op: GatewayOpcodes.PresenceUpdate, d: packet });
     } else if (Array.isArray(presence.shardId)) {
       for (const shardId of presence.shardId) {

--- a/packages/discord.js/src/structures/ClientUser.js
+++ b/packages/discord.js/src/structures/ClientUser.js
@@ -55,7 +55,7 @@ class ClientUser extends User {
    * @returns {Promise<ClientUser>}
    */
   async edit(options) {
-    if (typeof options.avatar !== 'undefined') options.avatar = await DataResolver.resolveImage(options.avatar);
+    if (options.avatar !== undefined) options.avatar = await DataResolver.resolveImage(options.avatar);
     const newData = await this.client.rest.patch(Routes.user(), { body: options });
     this.client.token = newData.token;
     this.client.rest.setToken(newData.token);

--- a/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
+++ b/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
@@ -97,7 +97,7 @@ class CommandInteractionOptionResolver {
       return null;
     } else if (!allowedTypes.includes(option.type)) {
       throw new DiscordjsTypeError(ErrorCodes.CommandInteractionOptionType, name, option.type, allowedTypes.join(', '));
-    } else if (required && properties.every(prop => option[prop] === null || typeof option[prop] === 'undefined')) {
+    } else if (required && properties.every(prop => option[prop] === null || option[prop] === undefined)) {
       throw new DiscordjsTypeError(ErrorCodes.CommandInteractionOptionEmpty, name, option.type);
     }
     return option;

--- a/packages/discord.js/src/structures/DMChannel.js
+++ b/packages/discord.js/src/structures/DMChannel.js
@@ -68,7 +68,7 @@ class DMChannel extends BaseChannel {
    * @readonly
    */
   get partial() {
-    return typeof this.lastMessageId === 'undefined';
+    return this.lastMessageId === undefined;
   }
 
   /**

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -820,7 +820,7 @@ class Guild extends AnonymousGuild {
         banner: banner && (await DataResolver.resolveImage(banner)),
         system_channel_id: systemChannel && this.client.channels.resolveId(systemChannel),
         system_channel_flags:
-          typeof systemChannelFlags === 'undefined'
+          systemChannelFlags === undefined
             ? undefined
             : SystemChannelFlagsBitField.resolve(systemChannelFlags),
         rules_channel_id: rulesChannel && this.client.channels.resolveId(rulesChannel),

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -820,9 +820,7 @@ class Guild extends AnonymousGuild {
         banner: banner && (await DataResolver.resolveImage(banner)),
         system_channel_id: systemChannel && this.client.channels.resolveId(systemChannel),
         system_channel_flags:
-          systemChannelFlags === undefined
-            ? undefined
-            : SystemChannelFlagsBitField.resolve(systemChannelFlags),
+          systemChannelFlags === undefined ? undefined : SystemChannelFlagsBitField.resolve(systemChannelFlags),
         rules_channel_id: rulesChannel && this.client.channels.resolveId(rulesChannel),
         public_updates_channel_id: publicUpdatesChannel && this.client.channels.resolveId(publicUpdatesChannel),
         preferred_locale: preferredLocale,

--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -131,8 +131,8 @@ class GuildChannel extends BaseChannel {
 
       // Compare overwrites
       return (
-        typeof channelVal !== 'undefined' &&
-        typeof parentVal !== 'undefined' &&
+        channelVal !== undefined &&
+        parentVal !== undefined &&
         channelVal.deny.bitfield === parentVal.deny.bitfield &&
         channelVal.allow.bitfield === parentVal.allow.bitfield
       );

--- a/packages/discord.js/src/structures/InviteGuild.js
+++ b/packages/discord.js/src/structures/InviteGuild.js
@@ -16,7 +16,7 @@ class InviteGuild extends AnonymousGuild {
      * @type {?WelcomeScreen}
      */
     this.welcomeScreen =
-      typeof data.welcome_screen !== 'undefined' ? new WelcomeScreen(this, data.welcome_screen) : null;
+      data.welcome_screen !== undefined ? new WelcomeScreen(this, data.welcome_screen) : null;
   }
 }
 

--- a/packages/discord.js/src/structures/InviteGuild.js
+++ b/packages/discord.js/src/structures/InviteGuild.js
@@ -15,8 +15,7 @@ class InviteGuild extends AnonymousGuild {
      * The welcome screen for this invite guild
      * @type {?WelcomeScreen}
      */
-    this.welcomeScreen =
-      data.welcome_screen !== undefined ? new WelcomeScreen(this, data.welcome_screen) : null;
+    this.welcomeScreen = data.welcome_screen !== undefined ? new WelcomeScreen(this, data.welcome_screen) : null;
   }
 }
 

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -107,7 +107,7 @@ class MessagePayload {
     let content;
     if (this.options.content === null) {
       content = '';
-    } else if (typeof this.options.content !== 'undefined') {
+    } else if (this.options.content !== undefined) {
       content = verifyString(this.options.content, DiscordjsRangeError, ErrorCodes.MessageContentType, true);
     }
 
@@ -127,7 +127,7 @@ class MessagePayload {
     const tts = Boolean(this.options.tts);
 
     let nonce;
-    if (typeof this.options.nonce !== 'undefined') {
+    if (this.options.nonce !== undefined) {
       nonce = this.options.nonce;
       if (typeof nonce === 'number' ? !Number.isInteger(nonce) : typeof nonce !== 'string') {
         throw new DiscordjsRangeError(ErrorCodes.MessageNonceType);
@@ -147,8 +147,8 @@ class MessagePayload {
 
     let flags;
     if (
-      typeof this.options.flags !== 'undefined' ||
-      (this.isMessage && typeof this.options.reply === 'undefined') ||
+      this.options.flags !== undefined ||
+      (this.isMessage && this.options.reply === undefined) ||
       this.isMessageManager
     ) {
       flags =
@@ -163,11 +163,11 @@ class MessagePayload {
     }
 
     let allowedMentions =
-      typeof this.options.allowedMentions === 'undefined'
+      this.options.allowedMentions === undefined
         ? this.target.client.options.allowedMentions
         : this.options.allowedMentions;
 
-    if (typeof allowedMentions?.repliedUser !== 'undefined') {
+    if (allowedMentions?.repliedUser !== undefined) {
       allowedMentions = { ...allowedMentions, replied_user: allowedMentions.repliedUser };
       delete allowedMentions.repliedUser;
     }
@@ -205,7 +205,7 @@ class MessagePayload {
       username,
       avatar_url: avatarURL,
       allowed_mentions:
-        typeof content === 'undefined' && typeof message_reference === 'undefined' ? undefined : allowedMentions,
+        content === undefined && message_reference === undefined ? undefined : allowedMentions,
       flags,
       message_reference,
       attachments: this.options.attachments,

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -204,8 +204,7 @@ class MessagePayload {
       components,
       username,
       avatar_url: avatarURL,
-      allowed_mentions:
-        content === undefined && message_reference === undefined ? undefined : allowedMentions,
+      allowed_mentions: content === undefined && message_reference === undefined ? undefined : allowedMentions,
       flags,
       message_reference,
       attachments: this.options.attachments,

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -224,7 +224,7 @@ class VoiceState extends Base {
 
     const target = this.client.user.id === this.id ? '@me' : this.id;
 
-    if (target !== '@me' && typeof options.requestToSpeak !== 'undefined') {
+    if (target !== '@me' && options.requestToSpeak !== undefined) {
       throw new DiscordjsError(ErrorCodes.VoiceStateNotOwn);
     }
 

--- a/packages/discord.js/src/util/BitField.js
+++ b/packages/discord.js/src/util/BitField.js
@@ -164,7 +164,7 @@ class BitField {
     if (bit instanceof BitField) return bit.bitfield;
     if (Array.isArray(bit)) return bit.map(p => this.resolve(p)).reduce((prev, p) => prev | p, DefaultBit);
     if (typeof bit === 'string') {
-      if (typeof this.Flags[bit] !== 'undefined') return this.Flags[bit];
+      if (this.Flags[bit] !== undefined) return this.Flags[bit];
       if (!isNaN(bit)) return typeof DefaultBit === 'bigint' ? BigInt(bit) : Number(bit);
     }
     throw new DiscordjsRangeError(ErrorCodes.BitFieldInvalid, bit);

--- a/packages/docgen/src/types/param.ts
+++ b/packages/docgen/src/types/param.ts
@@ -13,7 +13,7 @@ export class DocumentedParam extends DocumentedItem<Param | ParameterReflection>
 				name: data.name,
 				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing, no-param-reassign
 				description: data.comment?.summary?.reduce((prev, curr) => (prev += curr.text), '').trim() || undefined,
-				optional: data.flags.isOptional || typeof data.defaultValue !== 'undefined',
+				optional: data.flags.isOptional || data.defaultValue !== undefined,
 				default:
 					(data.defaultValue === '...' ? undefined : data.defaultValue) ??
 					(data.comment?.blockTags

--- a/packages/docgen/src/types/typedef.ts
+++ b/packages/docgen/src/types/typedef.ts
@@ -86,7 +86,7 @@ export class DocumentedTypeDef extends DocumentedItem<DeclarationReflection | Ty
 							// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing, no-param-reassign
 							child.signatures?.[0]?.comment?.summary?.reduce((prev, curr) => (prev += curr.text), '').trim() ||
 							undefined,
-						optional: child.flags.isOptional || typeof child.defaultValue !== 'undefined',
+						optional: child.flags.isOptional || child.defaultValue !== undefined,
 						default:
 							(child.defaultValue === '...' ? undefined : child.defaultValue) ??
 							(child.comment?.blockTags
@@ -131,7 +131,7 @@ export class DocumentedTypeDef extends DocumentedItem<DeclarationReflection | Ty
 						name: param.name,
 						// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing, no-param-reassign
 						description: param.comment?.summary?.reduce((prev, curr) => (prev += curr.text), '').trim() || undefined,
-						optional: param.flags.isOptional || typeof param.defaultValue !== 'undefined',
+						optional: param.flags.isOptional || param.defaultValue !== undefined,
 						default:
 							(param.defaultValue === '...' ? undefined : param.defaultValue) ??
 							(param.comment?.blockTags

--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -16,7 +16,7 @@ export function codeBlock<C extends string>(content: C): `\`\`\`\n${C}\n\`\`\``;
  */
 export function codeBlock<L extends string, C extends string>(language: L, content: C): `\`\`\`${L}\n${C}\n\`\`\``;
 export function codeBlock(language: string, content?: string): string {
-	return typeof content === 'undefined' ? `\`\`\`\n${language}\n\`\`\`` : `\`\`\`${language}\n${content}\n\`\`\``;
+	return content === undefined ? `\`\`\`\n${language}\n\`\`\`` : `\`\`\`${language}\n${content}\n\`\`\``;
 }
 
 /**
@@ -238,11 +238,11 @@ export function chatInputApplicationCommandMention<
 	subcommandName?: S,
 	commandId?: I,
 ): `</${N} ${G} ${S}:${I}>` | `</${N} ${G}:${S}>` | `</${N}:${G}>` {
-	if (typeof commandId !== 'undefined') {
+	if (commandId !== undefined) {
 		return `</${commandName} ${subcommandGroupName} ${subcommandName!}:${commandId}>`;
 	}
 
-	if (typeof subcommandName !== 'undefined') {
+	if (subcommandName !== undefined) {
 		return `</${commandName} ${subcommandGroupName}:${subcommandName}>`;
 	}
 
@@ -336,7 +336,7 @@ export function messageLink<C extends Snowflake, M extends Snowflake, G extends 
 	messageId: M,
 	guildId?: G,
 ): `https://discord.com/channels/@me/${C}/${M}` | `https://discord.com/channels/${G}/${C}/${M}` {
-	return `${typeof guildId === 'undefined' ? channelLink(channelId) : channelLink(channelId, guildId)}/${messageId}`;
+	return `${guildId === undefined ? channelLink(channelId) : channelLink(channelId, guildId)}/${messageId}`;
 }
 
 /**

--- a/packages/voice/src/DataStore.ts
+++ b/packages/voice/src/DataStore.ts
@@ -184,6 +184,6 @@ export function deleteAudioPlayer(player: AudioPlayer) {
 	audioPlayers.splice(index, 1);
 	if (audioPlayers.length === 0) {
 		nextTime = -1;
-		if (typeof audioCycleInterval !== 'undefined') clearTimeout(audioCycleInterval);
+		if (audioCycleInterval !== undefined) clearTimeout(audioCycleInterval);
 	}
 }

--- a/packages/voice/src/VoiceConnection.ts
+++ b/packages/voice/src/VoiceConnection.ts
@@ -354,8 +354,8 @@ export class VoiceConnection extends EventEmitter {
 	private addStatePacket(packet: GatewayVoiceStateUpdateDispatchData) {
 		this.packets.state = packet;
 
-		if (typeof packet.self_deaf !== 'undefined') this.joinConfig.selfDeaf = packet.self_deaf;
-		if (typeof packet.self_mute !== 'undefined') this.joinConfig.selfMute = packet.self_mute;
+		if (packet.self_deaf !== undefined) this.joinConfig.selfDeaf = packet.self_deaf;
+		if (packet.self_mute !== undefined) this.joinConfig.selfMute = packet.self_mute;
 		if (packet.channel_id) this.joinConfig.channelId = packet.channel_id;
 		/*
 			the channel_id being null doesn't necessarily mean it was intended for the client to leave the voice channel

--- a/packages/voice/src/audio/AudioResource.ts
+++ b/packages/voice/src/audio/AudioResource.ts
@@ -258,7 +258,7 @@ export function createAudioResource<T>(
 	// string inputs can only be used with FFmpeg
 	if (typeof input === 'string') {
 		inputType = StreamType.Arbitrary;
-	} else if (typeof inputType === 'undefined') {
+	} else if (inputType === undefined) {
 		const analysis = inferStreamType(input);
 		inputType = analysis.streamType;
 		needsInlineVolume = needsInlineVolume && !analysis.hasVolume;

--- a/packages/voice/src/networking/Networking.ts
+++ b/packages/voice/src/networking/Networking.ts
@@ -498,7 +498,7 @@ export class Networking extends EventEmitter {
 	public dispatchAudio() {
 		const state = this.state;
 		if (state.code !== NetworkingStatusCode.Ready) return false;
-		if (typeof state.preparedPacket !== 'undefined') {
+		if (state.preparedPacket !== undefined) {
 			this.playAudioPacket(state.preparedPacket);
 			state.preparedPacket = undefined;
 			return true;

--- a/packages/voice/src/networking/VoiceWebSocket.ts
+++ b/packages/voice/src/networking/VoiceWebSocket.ts
@@ -161,7 +161,7 @@ export class VoiceWebSocket extends EventEmitter {
 	 * @param ms - The interval in milliseconds. If negative, the interval will be unset
 	 */
 	public setHeartbeatInterval(ms: number) {
-		if (typeof this.heartbeatInterval !== 'undefined') clearInterval(this.heartbeatInterval);
+		if (this.heartbeatInterval !== undefined) clearInterval(this.heartbeatInterval);
 		if (ms > 0) {
 			this.heartbeatInterval = setInterval(() => {
 				if (this.lastHeartbeatSend !== 0 && this.missedHeartbeats >= 3) {

--- a/packages/voice/src/receive/AudioReceiveStream.ts
+++ b/packages/voice/src/receive/AudioReceiveStream.ts
@@ -69,7 +69,7 @@ export class AudioReceiveStream extends Readable {
 			buffer &&
 			(this.end.behavior === EndBehaviorType.AfterInactivity ||
 				(this.end.behavior === EndBehaviorType.AfterSilence &&
-					(buffer.compare(SILENCE_FRAME) !== 0 || typeof this.endTimeout === 'undefined')))
+					(buffer.compare(SILENCE_FRAME) !== 0 || this.endTimeout === undefined)))
 		) {
 			this.renewEndTimeout(this.end);
 		}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Updated all of the `typeof x === "undefined"` into `x === undefined` (also !==) as it is needlessly verbose since in strict mode the only reason to use `typeof` is if `x` might not be declared

This also brings in more consistency since `x === undefined` was already being used in some places (!== too), e.g.
https://github.com/discordjs/discord.js/blob/dc142c47e4021d6d37712453cc2fad6e4fe4e9f7/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionWithChoicesAndAutocompleteMixin.ts#L34
https://github.com/discordjs/discord.js/blob/dc142c47e4021d6d37712453cc2fad6e4fe4e9f7/packages/discord.js/src/managers/ChannelManager.js#L22

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
