### PR TITLE
Fix for voice connection issues (heartbeating, signalling stall)

### DIFF
--- a/packages/voice/src/networking/VoiceUDPSocket.ts
+++ b/packages/voice/src/networking/VoiceUDPSocket.ts
@@ -130,7 +130,7 @@ export class VoiceUDPSocket extends EventEmitter {
 	private onMessage(buffer: Buffer): void {
 		// Handle keep alive message
 		if (buffer.length === 8) {
-			const counter = buffer.readUInt32LE(0);
+			const counter = buffer.readUInt32LE(4);
 			const index = this.keepAlives.findIndex(({ value }) => value === counter);
 			if (index === -1) return;
 			this.ping = Date.now() - this.keepAlives[index]!.timestamp;
@@ -152,7 +152,8 @@ export class VoiceUDPSocket extends EventEmitter {
 			return;
 		}
 
-		this.keepAliveBuffer.writeUInt32LE(this.keepAliveCounter, 0);
+		this.keepAliveBuffer.writeUInt32BE(0x1337cafe, 0);
+		this.keepAliveBuffer.writeUInt32LE(this.keepAliveCounter, 4);
 		this.send(this.keepAliveBuffer);
 		this.keepAlives.push({
 			value: this.keepAliveCounter,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
VoiceUDPSocket: Fix for udp heartbeating. Discord servers only recognize 0x1337cafe as the header prefix

The following is source code from the discord app's discord_voice.node:
![image](https://user-images.githubusercontent.com/40158558/222806289-fb19a61d-7544-49cf-8368-09805a269ecb.png)

VoiceConnection: Fix reconnecting after disconnect

It seems like discord doesn't send a new server packet if nothing else
has changed. Reconnect if we already have a server packet and session_id
matches

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating