### PR TITLE
fix(Voice): send keep alives without awaiting a response

### DIFF
--- a/packages/voice/__tests__/VoiceUDPSocket.test.ts
+++ b/packages/voice/__tests__/VoiceUDPSocket.test.ts
@@ -121,23 +121,6 @@ describe('VoiceUDPSocket#performIPDiscovery', () => {
 		expect(closed).toEqual(false);
 	});
 
-	test('Emits an error when no response received to keep alive messages', async () => {
-		const fake = new FakeSocket();
-		fake.send = jest.fn();
-		createSocket.mockImplementation(() => fake as any);
-		socket = new VoiceUDPSocket({ ip: '1.2.3.4', port: 25_565 });
-
-		let closed = false;
-		socket.on('close', () => (closed = true));
-
-		for (let index = 0; index < 15; index++) {
-			jest.advanceTimersToNextTimer();
-			await wait();
-		}
-
-		expect(closed).toEqual(true);
-	});
-
 	test('Recovers from intermittent responses', async () => {
 		const fake = new FakeSocket();
 		const fakeSend = jest.fn();

--- a/packages/voice/src/networking/VoiceUDPSocket.ts
+++ b/packages/voice/src/networking/VoiceUDPSocket.ts
@@ -79,6 +79,8 @@ export class VoiceUDPSocket extends EventEmitter {
 
 	/**
 	 * The time taken to receive a response to keep alive messages.
+	 *
+	 * @deprecated This field is no longer updated as keep alive messages are no longer tracked.
 	 */
 	public ping?: number;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Supersedes #9195 
Takes a part in solving part of #8482 and #9185 as recommended in DDevs. While UDP keepAlives aren't documented (and technically not needed either), we need to keep them in order to ensure voice receivers still work.

Tested too on a bot, and this change helped the audio not cut out after 1 minute (ala 12 keep alives packets sent)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes