### PR TITLE
fix(Actions): inject built data by using a symbol

### DIFF
--- a/packages/discord.js/src/client/actions/Action.js
+++ b/packages/discord.js/src/client/actions/Action.js
@@ -34,7 +34,7 @@ class GenericAction {
   getChannel(data) {
     const id = data.channel_id ?? data.id;
     return (
-      data.channel ??
+      data[this.client.actions.injectedChannel] ??
       this.getPayload(
         {
           id,
@@ -51,7 +51,7 @@ class GenericAction {
   getMessage(data, channel, cache) {
     const id = data.message_id ?? data.id;
     return (
-      data.message ??
+      data[this.client.actions.injectedMessage] ??
       this.getPayload(
         {
           id,
@@ -86,7 +86,7 @@ class GenericAction {
 
   getUser(data) {
     const id = data.user_id;
-    return data.user ?? this.getPayload({ id }, this.client.users, id, Partials.User);
+    return data[this.client.actions.injectedUser] ?? this.getPayload({ id }, this.client.users, id, Partials.User);
   }
 
   getUserFromMember(data) {

--- a/packages/discord.js/src/client/actions/ActionsManager.js
+++ b/packages/discord.js/src/client/actions/ActionsManager.js
@@ -1,6 +1,13 @@
 'use strict';
 
 class ActionsManager {
+  // These symbols represent fully built data that we inject at times when calling actions manually. Action#getUser,
+  // for example, will return the injected data (which is assumed to be a built structure) instead of trying to make it
+  // from provided data
+  injectedUser = Symbol('djs.actions.injectedUser');
+  injectedChannel = Symbol('djs.actions.injectedChannel');
+  injectedMessage = Symbol('djs.actions.injectedMessage');
+
   constructor(client) {
     this.client = client;
 

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -787,9 +787,9 @@ class Message extends Base {
 
     return this.client.actions.MessageReactionAdd.handle(
       {
-        user: this.client.user,
-        channel: this.channel,
-        message: this,
+        [this.client.actions.injectedUser]: this.client.user,
+        [this.client.actions.injectedChannel]: this.channel,
+        [this.client.actions.injectedMessage]: this,
         emoji: resolvePartialEmoji(emoji),
       },
       true,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes the hard crash encountered from message component/ context menu interactions where a `channel` property was added to them, causing hard crashes

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
