### PR TITLE
fix(Message#editable): update editable check in threads locked

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -604,7 +604,7 @@ class Message extends Base {
     const precheck = Boolean(this.author.id === this.client.user.id && (!this.guild || this.channel?.viewable));
 
     // Regardless of permissions thread messages cannot be edited if
-    // the thread is archived or the thread is locked and the bot does not have permission to manage threads
+    // the thread is archived or the thread is locked and the bot does not have permission to manage threads.
     if (this.channel?.isThread()) {
       if (this.channel.archived) return false;
       if (this.channel.locked) {

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -604,8 +604,10 @@ class Message extends Base {
     const precheck = Boolean(this.author.id === this.client.user.id && (!this.guild || this.channel?.viewable));
 
     // Regardless of permissions thread messages cannot be edited if
-    // the thread is locked and the bot if the thread is locked and the bot does not have permission to manage threads.
+    // the thread is archived or the thread is locked and the bot does not have permission to manage threads
     if (this.channel?.isThread()) {
+      if (this.channel.archived) return false;
+
       const permissions = this.permissionsFor(this.client.user);
       if (!permissions?.has(PermissionFlagsBits.ManageThreads, true)) return false;
     }

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -602,11 +602,14 @@ class Message extends Base {
    */
   get editable() {
     const precheck = Boolean(this.author.id === this.client.user.id && (!this.guild || this.channel?.viewable));
+
     // Regardless of permissions thread messages cannot be edited if
-    // the thread is locked.
+    // the thread is locked and the bot if the thread is locked and the bot does not have permission to manage threads.
     if (this.channel?.isThread()) {
-      return precheck && !this.channel.locked;
+      const permissions = this.permissionsFor(this.client.user);
+      if (!permissions?.has(PermissionFlagsBits.ManageThreads, true)) return false;
     }
+
     return precheck;
   }
 

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -607,9 +607,10 @@ class Message extends Base {
     // the thread is archived or the thread is locked and the bot does not have permission to manage threads
     if (this.channel?.isThread()) {
       if (this.channel.archived) return false;
-
-      const permissions = this.permissionsFor(this.client.user);
-      if (!permissions?.has(PermissionFlagsBits.ManageThreads, true)) return false;
+      if (this.channel.locked) {
+        const permissions = this.permissionsFor(this.client.user);
+        if (!permissions?.has(PermissionFlagsBits.ManageThreads, true)) return false;
+      }
     }
 
     return precheck;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

[Recent changes](https://discord.com/developers/docs/change-log#update-to-locked-threads) regarding locked threads were rolled out this week.
If a bot does not have permission to manage threads, it will not be able to edit its own message even if the thread is not archived.
I've also added a check that was probably forgotten, a bot can't edit its own message if the thread is archived.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
