### PR TITLE
fix(ThreadChannel): fetch starter message properly

### DIFF
--- a/src/structures/ThreadChannel.js
+++ b/src/structures/ThreadChannel.js
@@ -310,7 +310,7 @@ class ThreadChannel extends Channel {
   // eslint-disable-next-line require-await
   async fetchStarterMessage(options) {
     const channel = this.parent?.type === 'GUILD_FORUM' ? this : this.parent;
-    return channel?.messages.fetch({ message: this.id, ...options }) ?? null;
+    return channel?.messages.fetch(this.id, options) ?? null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
v13 does not use `.fetch({ message })`. This PR fixes internal code for `ThreadChannel#fetchStarterMessage()` which uses that syntax.
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
