### PR TITLE
Fix a rare error regarding interactions

### DIFF
--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -11,7 +11,7 @@ const {
 } = require('../util/Constants');
 
 function parseResponse(res) {
-  if (res.headers.get('content-type').startsWith('application/json')) return res.json();
+  if (res.headers.get('content-type')?.startsWith('application/json')) return res.json();
   return res.buffer();
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I use a proxy with discord.js and when deferring interaction responses, I get the following error:
```
TypeError: Cannot read properties of null (reading 'startsWith')
at parseResponse (/node_modules/discord.js/src/rest/RequestHandler.js:14:38)
```
In the main branch, this issue has been fixed already, although a bit more extensively. I'm still on v13 myself and this small change fixed the error for me and hasn't caused any other issues.

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
