### PR TITLE
docs(MessageManager): add clarification to fetch messages

### DIFF
--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -49,8 +49,7 @@ class MessageManager extends CachedManager {
 
   /**
    * Options used to fetch multiple messages.
-   * <info>The `before`, `after`, and `around` parameters are mutually exclusive,
-   * only one may be passed at a time.</info>
+   * <info>The `before`, `after`, and `around` parameters are mutually exclusive.</info>
    * @typedef {Object} FetchMessagesOptions
    * @property {number} [limit] The maximum number of messages to return
    * @property {Snowflake} [before] Consider only messages before this id

--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -49,6 +49,8 @@ class MessageManager extends CachedManager {
 
   /**
    * Options used to fetch multiple messages.
+   * <info>The `before`, `after`, and `around` parameters are mutually exclusive,
+   * only one may be passed at a time.</info>
    * @typedef {Object} FetchMessagesOptions
    * @property {number} [limit] The maximum number of messages to return
    * @property {Snowflake} [before] Consider only messages before this id


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:** [Discord's documentation](https://discord.com/developers/docs/resources/channel#get-channel-messages) mentions that you can only use `before`, `after` or `around` when fetching messages. This is not mentioned in D.JS documentation, and after some time trying to figure out why I was getting more messages than I should, decided to read the documentation.
This only changes the documentation.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are **no code changes**
- I know how to update typings and have done so, **or typings don't need updating**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

*I submitted this before on #9220 but I messed up with something on my side for the second commit*