### PR TITLE
fix(WebSocketShard): #send race condition due to ready state

### DIFF
--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -383,14 +383,9 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			d,
 		});
 
-		const { ok } = await this.bubbleWaitForEventError(
+		await this.bubbleWaitForEventError(
 			this.waitForEvent(WebSocketShardEvents.Ready, this.strategy.options.readyTimeout),
 		);
-		if (!ok) {
-			return;
-		}
-
-		this.#status = WebSocketShardStatus.Ready;
 	}
 
 	private async resume(session: SessionInfo) {
@@ -499,7 +494,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 				// eslint-disable-next-line sonarjs/no-nested-switch
 				switch (payload.t) {
 					case GatewayDispatchEvents.Ready: {
-						this.emit(WebSocketShardEvents.Ready, { data: payload.d });
+						this.#status = WebSocketShardStatus.Ready;
 
 						this.session ??= {
 							sequence: payload.s,
@@ -510,6 +505,8 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 						};
 
 						await this.strategy.updateSessionInfo(this.id, this.session);
+
+						this.emit(WebSocketShardEvents.Ready, { data: payload.d });
 						break;
 					}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Prior to this PR, calling `#send` in a `Ready` listener will cause `#send` to infinitely hang due to how we set the internal `status`.

Also guarantees session info will be up-to-date when ready is fired.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating