### PR TITLE
fix(TextBasedChannelTypes): add `GuildStageVoice`

### DIFF
--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -93,6 +93,7 @@ exports.NonSystemMessageTypes = [
  * * {@link ChannelType.PublicThread}
  * * {@link ChannelType.PrivateThread}
  * * {@link ChannelType.GuildVoice}
+ * * {@link ChannelType.GuildStageVoice}
  * @typedef {ChannelType[]} TextBasedChannelTypes
  */
 exports.TextBasedChannelTypes = [
@@ -103,6 +104,7 @@ exports.TextBasedChannelTypes = [
   ChannelType.PublicThread,
   ChannelType.PrivateThread,
   ChannelType.GuildVoice,
+  ChannelType.GuildStageVoice,
 ];
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds `GuildStageVoice` channel type to the TextBasedChannelTypes constant, which was already present in the typings.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
