### PR TITLE
feat: add GuildBasedTextChannelTypes

### DIFF
--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -117,7 +117,7 @@ exports.GuildTextBasedChannelTypes = [
  * * {@link ChannelType.GuildStageVoice}
  * @typedef {ChannelType[]} TextBasedChannelTypes
  */
-exports.TextBasedChannelTypes = [...exports.TextBasedChannelTypes, ChannelType.DM];
+exports.TextBasedChannelTypes = [...exports.GuildTextBasedChannelTypes, ChannelType.DM];
 
 /**
  * The types of channels that are threads. The available types are:

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -71,6 +71,27 @@ exports.NonSystemMessageTypes = [
  */
 
 /**
+ * The types of channels that are text-based. The available types are:
+ * * {@link ChannelType.GuildText}
+ * * {@link ChannelType.GuildAnnouncement}
+ * * {@link ChannelType.AnnouncementThread}
+ * * {@link ChannelType.PublicThread}
+ * * {@link ChannelType.PrivateThread}
+ * * {@link ChannelType.GuildVoice}
+ * * {@link ChannelType.GuildStageVoice}
+ * @typedef {ChannelType[]} GuildTextBasedChannelTypes
+ */
+exports.GuildTextBasedChannelTypes = [
+  ChannelType.GuildText,
+  ChannelType.GuildAnnouncement,
+  ChannelType.AnnouncementThread,
+  ChannelType.PublicThread,
+  ChannelType.PrivateThread,
+  ChannelType.GuildVoice,
+  ChannelType.GuildStageVoice,
+];
+
+/**
  * The channels that are text-based.
  * * DMChannel
  * * GuildTextBasedChannel
@@ -96,16 +117,7 @@ exports.NonSystemMessageTypes = [
  * * {@link ChannelType.GuildStageVoice}
  * @typedef {ChannelType[]} TextBasedChannelTypes
  */
-exports.TextBasedChannelTypes = [
-  ChannelType.DM,
-  ChannelType.GuildText,
-  ChannelType.GuildAnnouncement,
-  ChannelType.AnnouncementThread,
-  ChannelType.PublicThread,
-  ChannelType.PrivateThread,
-  ChannelType.GuildVoice,
-  ChannelType.GuildStageVoice,
-];
+exports.TextBasedChannelTypes = [...exports.TextBasedChannelTypes, ChannelType.DM];
 
 /**
  * The types of channels that are threads. The available types are:

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -71,7 +71,7 @@ exports.NonSystemMessageTypes = [
  */
 
 /**
- * The types of channels that are text-based. The available types are:
+ * The types of guild channels that are text-based. The available types are:
  * * {@link ChannelType.GuildText}
  * * {@link ChannelType.GuildAnnouncement}
  * * {@link ChannelType.AnnouncementThread}

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3478,6 +3478,7 @@ export const Constants: {
   SweeperKeys: SweeperKey[];
   NonSystemMessageTypes: NonSystemMessageType[];
   TextBasedChannelTypes: TextBasedChannelTypes[];
+  GuildTextBasedChannelTypes: GuildTextBasedChannelTypes[];
   ThreadChannelTypes: ThreadChannelType[];
   VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
   SelectMenuTypes: SelectMenuType[];
@@ -6205,6 +6206,8 @@ export type TextBasedChannel = Exclude<
 >;
 
 export type TextBasedChannelTypes = TextBasedChannel['type'];
+
+export type GuildTextBasedChannelTypes = Exclude<TextBasedChannelTypes, ChannelType.DM>;
 
 export type VoiceBasedChannel = Extract<Channel, { bitrate: number }>;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since 14.8.0, Constants.TextBasedChannelTypes is no longer assignable to ApplicationCommand#channelTypes due to the DM type not being accepted, so this fixes that
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
