### PR TITLE
fix(ThreadManager): Respect `cache` and `force` in fetching

### DIFF
--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -94,7 +94,7 @@ class ThreadManager extends CachedManager {
    *   .then(channel => console.log(channel.name))
    *   .catch(console.error);
    */
-  fetch(options, { cache = true, force = false } = {}) {
+  fetch(options, { cache, force } = {}) {
     if (!options) return this.fetchActive(cache);
     const channel = this.client.channels.resolveId(options);
     if (channel) return this.client.channels.fetch(channel, { cache, force });

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -97,7 +97,7 @@ class ThreadManager extends CachedManager {
   fetch(options, { cache = true, force = false } = {}) {
     if (!options) return this.fetchActive(cache);
     const channel = this.client.channels.resolveId(options);
-    if (channel) return this.client.channels.fetch(channel, cache, force);
+    if (channel) return this.client.channels.fetch(channel, { cache, force });
     if (options.archived) {
       return this.fetchArchived(options.archived, cache);
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This method was internally not passing `cache` and `force` correctly:

https://github.com/discordjs/discord.js/blob/51edba78bc4d4cb44b4dd2b79e4bbc515dc46f5b/packages/discord.js/src/managers/ChannelManager.js#L106-L117
 
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
