### PR TITLE
docs(FetchArchivedThreadOptions): `before` respects `archive_timestamp`, not creation timestamp

### DIFF
--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -118,7 +118,7 @@ class ThreadManager extends CachedManager {
    * @property {string} [type='public'] The type of threads to fetch (`public` or `private`)
    * @property {boolean} [fetchAll=false] Whether to fetch **all** archived threads when `type` is `private`
    * <info>This property requires the {@link PermissionFlagsBits.ManageThreads} permission if `true`.</info>
-   * @property {DateResolvable|ThreadChannelResolvable} [before] Only return threads that were created before this Date
+   * @property {DateResolvable|ThreadChannelResolvable} [before] Only return threads that were archived before this Date
    * or Snowflake
    * <warn>Must be a {@link ThreadChannelResolvable} when `type` is `private` and `fetchAll` is `false`.</warn>
    * @property {number} [limit] Maximum number of threads to return


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The API uses the `archive_timestamp` when using `before`.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
