### PR TITLE
fix(rest): remove `const enum`s in favour of regular enums

### DIFF
--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -113,7 +113,7 @@ export interface RequestHeaders {
 /**
  * Possible API methods to be used when doing requests
  */
-export const enum RequestMethod {
+export enum RequestMethod {
 	Delete = 'DELETE',
 	Get = 'GET',
 	Patch = 'PATCH',

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -21,7 +21,7 @@ import type { IHandler } from './IHandler.js';
 let invalidCount = 0;
 let invalidCountResetTime: number | null = null;
 
-enum QueueType {
+const enum QueueType {
 	Standard,
 	Sublimit,
 }

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -21,7 +21,7 @@ import type { IHandler } from './IHandler.js';
 let invalidCount = 0;
 let invalidCountResetTime: number | null = null;
 
-const enum QueueType {
+enum QueueType {
 	Standard,
 	Sublimit,
 }

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -34,7 +34,7 @@ export const DefaultRestOptions = {
 /**
  * The events that the REST manager emits
  */
-export const enum RESTEvents {
+export enum RESTEvents {
 	Debug = 'restDebug',
 	HandlerSweep = 'handlerSweep',
 	HashSweep = 'hashSweep',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,6 @@
 		"newLine": "lf",
 		"noEmitHelpers": true,
 		"outDir": "dist",
-		"preserveConstEnums": true,
 		"removeComments": false,
 		"sourceMap": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The motivation is that `const enum` produces ambient const enums when compiling which in turn causes issues with TypeScript 5.x when `verbatimModuleSyntax` is enabled.

Furthermore, the generally accepted best practice is to avoid `const enum`s when writing libraries. Can back this up with statements from TS maintainers if needed, I know they made them, I just can't be bothered to find the GitHub links lmao. @vladfrangu will probably be able to find those links much easier than me as it was also the motivation to remove `const enum`'s from discord-api-types.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating