### PR TITLE
fix(WebSocketShard): cancel initial heartbeat in destroy

### DIFF
--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -575,16 +575,14 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 				const firstWait = Math.floor(payload.d.heartbeat_interval * jitter);
 				this.debug([`Preparing first heartbeat of the connection with a jitter of ${jitter}; waiting ${firstWait}ms`]);
 
-				const controller = new AbortController();
-				this.initialHeartbeatTimeoutController = controller;
-
-				const cancelled = await sleep<boolean>(firstWait, false, { signal: controller.signal })
-					.catch(() => true)
-					.finally(() => {
-						this.initialHeartbeatTimeoutController = null;
-					});
-				if (cancelled) {
+				try {
+					const controller = new AbortController();
+					this.initialHeartbeatTimeoutController = controller;
+					await sleep(firstWait, undefined, { signal: controller.signal });
+				} catch {
 					return;
+				} finally {
+					this.initialHeartbeatTimeoutController = null;
 				}
 
 				await this.heartbeat();

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -580,6 +580,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 					this.initialHeartbeatTimeoutController = controller;
 					await sleep(firstWait, undefined, { signal: controller.signal });
 				} catch {
+					this.debug(['Cancelled initial heartbeat due to #destroy being called']);
 					return;
 				} finally {
 					this.initialHeartbeatTimeoutController = null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Bug introduced by #9223 

See https://canary.discord.com/channels/222078108977594368/1086244458900750367/1086618807059087470 or https://canary.discord.com/channels/222078108977594368/1086616622959177788/1086616763086680134 (internal)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

