### PR TITLE
feat: backport `chatInputApplicationCommandMention`

### DIFF
--- a/src/util/Formatters.js
+++ b/src/util/Formatters.js
@@ -53,6 +53,36 @@ Formatters.bold = bold;
 Formatters.channelMention = channelMention;
 
 /**
+ * Formats an application command name, subcommand group name, subcommand name, and ID
+ * into an application command mention
+ * @method chatInputApplicationCommandMention
+ * @memberof Formatters
+ * @param {string} commandName The name of the application command
+ * @param {string|Snowflake} subcommandGroupOrSubOrId
+ * The subcommand group name, subcommand name, or application command id
+ * @param {?(string|Snowflake)} [subcommandNameOrId] The subcommand name or application command id
+ * @param {?Snowflake} [commandId] The id of the application command
+ * @returns {string}
+ * @static
+ */
+Formatters.chatInputApplicationCommandMention = function chatInputApplicationCommandMention(
+  commandName,
+  subcommandGroupOrSubOrId,
+  subcommandNameOrId,
+  commandId,
+) {
+  if (typeof commandId !== 'undefined') {
+    return `</${commandName} ${subcommandGroupOrSubOrId} ${subcommandNameOrId}:${commandId}>`;
+  }
+
+  if (typeof subcommandNameOrId !== 'undefined') {
+    return `</${commandName} ${subcommandGroupOrSubOrId}:${subcommandNameOrId}>`;
+  }
+
+  return `</${commandName}:${subcommandGroupOrSubOrId}>`;
+};
+
+/**
  * Wraps the content inside a code block with an optional language.
  * @method codeBlock
  * @memberof Formatters

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2738,6 +2738,10 @@ export class Formatters extends null {
   public static blockQuote: typeof blockQuote;
   public static bold: typeof bold;
   public static channelMention: typeof channelMention;
+  public static chatInputApplicationCommandMention
+    <N extends string, G extends string, S extends string, I extends Snowflake>(commandName: N, subcommandGroupName: G, subcommandName: S, commandId: I): `</${N} ${G} ${S}:${I}>`;
+  public static chatInputApplicationCommandMention<N extends string, S extends string, I extends Snowflake>(commandName: N, subcommandName: S, commandId: I): `</${N} ${S}:${I}>`;
+  public static chatInputApplicationCommandMention<N extends string, I extends Snowflake>(commandName: N, commandId: I): `</${N}:${I}>`;
   public static codeBlock: typeof codeBlock;
   public static formatEmoji: typeof formatEmoji;
   public static hideLinkEmbed: typeof hideLinkEmbed;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
 Backports `chatInputApplicationCommandMention` formatter
 Its done in *manual* way as builders cannot be updated
**Status and versioning classification:**
- I know how to update typings and have done so
- This PR changes the library's interface (methods or parameters added)
