### PR TITLE
build: resolve issue with esbuild-plugin-version-injector not working

### DIFF
--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -70,7 +70,7 @@
 		"@vitest/coverage-c8": "^0.29.1",
 		"cross-env": "^7.0.3",
 		"downlevel-dts": "^0.11.0",
-		"esbuild-plugin-version-injector": "^1.0.3",
+		"esbuild-plugin-version-injector": "^1.1.0",
 		"eslint": "^8.35.0",
 		"eslint-config-neon": "^0.1.40",
 		"eslint-formatter-pretty": "^4.1.0",

--- a/packages/builders/tsconfig.json
+++ b/packages/builders/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "../../tsconfig.json",
 	"compilerOptions": {
+		"emitDecoratorMetadata": true,
 		"exactOptionalPropertyTypes": false
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -56,7 +56,7 @@
 		"@types/node": "16.18.13",
 		"@vitest/coverage-c8": "^0.29.1",
 		"cross-env": "^7.0.3",
-		"esbuild-plugin-version-injector": "^1.0.3",
+		"esbuild-plugin-version-injector": "^1.1.0",
 		"eslint": "^8.35.0",
 		"eslint-config-neon": "^0.1.40",
 		"eslint-formatter-pretty": "^4.1.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -67,7 +67,7 @@
 		"@types/node": "18.14.2",
 		"@vitest/coverage-c8": "^0.29.1",
 		"cross-env": "^7.0.3",
-		"esbuild-plugin-version-injector": "^1.0.3",
+		"esbuild-plugin-version-injector": "^1.1.0",
 		"eslint": "^8.35.0",
 		"eslint-config-neon": "^0.1.40",
 		"eslint-formatter-pretty": "^4.1.0",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -68,7 +68,7 @@
 		"@types/node": "16.18.13",
 		"@vitest/coverage-c8": "^0.29.1",
 		"cross-env": "^7.0.3",
-		"esbuild-plugin-version-injector": "^1.0.3",
+		"esbuild-plugin-version-injector": "^1.1.0",
 		"eslint": "^8.35.0",
 		"eslint-config-neon": "^0.1.40",
 		"eslint-formatter-pretty": "^4.1.0",

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -68,7 +68,7 @@
 		"@types/jest": "^29.4.0",
 		"@types/node": "16.18.13",
 		"cross-env": "^7.0.3",
-		"esbuild-plugin-version-injector": "^1.0.3",
+		"esbuild-plugin-version-injector": "^1.1.0",
 		"eslint": "^8.35.0",
 		"eslint-config-neon": "^0.1.40",
 		"eslint-formatter-pretty": "^4.1.0",

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -75,7 +75,7 @@
 		"@types/node": "16.18.13",
 		"@vitest/coverage-c8": "^0.29.1",
 		"cross-env": "^7.0.3",
-		"esbuild-plugin-version-injector": "^1.0.3",
+		"esbuild-plugin-version-injector": "^1.1.0",
 		"eslint": "^8.35.0",
 		"eslint-config-neon": "^0.1.40",
 		"eslint-formatter-pretty": "^4.1.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,6 @@
 		"forceConsistentCasingInFileNames": true,
 
 		// Language and Environment
-		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"lib": ["ESNext"],
 		"target": "ES2021",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2066,7 +2066,7 @@ __metadata:
     cross-env: ^7.0.3
     discord-api-types: ^0.37.35
     downlevel-dts: ^0.11.0
-    esbuild-plugin-version-injector: ^1.0.3
+    esbuild-plugin-version-injector: ^1.1.0
     eslint: ^8.35.0
     eslint-config-neon: ^0.1.40
     eslint-formatter-pretty: ^4.1.0
@@ -2089,7 +2089,7 @@ __metadata:
     "@types/node": 16.18.13
     "@vitest/coverage-c8": ^0.29.1
     cross-env: ^7.0.3
-    esbuild-plugin-version-injector: ^1.0.3
+    esbuild-plugin-version-injector: ^1.1.0
     eslint: ^8.35.0
     eslint-config-neon: ^0.1.40
     eslint-formatter-pretty: ^4.1.0
@@ -2256,7 +2256,7 @@ __metadata:
     "@vitest/coverage-c8": ^0.29.1
     cross-env: ^7.0.3
     discord-api-types: ^0.37.35
-    esbuild-plugin-version-injector: ^1.0.3
+    esbuild-plugin-version-injector: ^1.1.0
     eslint: ^8.35.0
     eslint-config-neon: ^0.1.40
     eslint-formatter-pretty: ^4.1.0
@@ -2324,7 +2324,7 @@ __metadata:
     "@vitest/coverage-c8": ^0.29.1
     cross-env: ^7.0.3
     discord-api-types: ^0.37.35
-    esbuild-plugin-version-injector: ^1.0.3
+    esbuild-plugin-version-injector: ^1.1.0
     eslint: ^8.35.0
     eslint-config-neon: ^0.1.40
     eslint-formatter-pretty: ^4.1.0
@@ -2428,7 +2428,7 @@ __metadata:
     "@types/ws": ^8.5.4
     cross-env: ^7.0.3
     discord-api-types: ^0.37.35
-    esbuild-plugin-version-injector: ^1.0.3
+    esbuild-plugin-version-injector: ^1.1.0
     eslint: ^8.35.0
     eslint-config-neon: ^0.1.40
     eslint-formatter-pretty: ^4.1.0
@@ -2519,7 +2519,7 @@ __metadata:
     "@vladfrangu/async_event_emitter": ^2.1.4
     cross-env: ^7.0.3
     discord-api-types: ^0.37.35
-    esbuild-plugin-version-injector: ^1.0.3
+    esbuild-plugin-version-injector: ^1.1.0
     eslint: ^8.35.0
     eslint-config-neon: ^0.1.40
     eslint-formatter-pretty: ^4.1.0
@@ -10202,12 +10202,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-plugin-version-injector@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "esbuild-plugin-version-injector@npm:1.0.3"
+"esbuild-plugin-version-injector@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "esbuild-plugin-version-injector@npm:1.1.0"
   dependencies:
     "@sapphire/result": ^2.6.0
-  checksum: 12c9e8bf55fd6dc80979b93a1fc0acfc5e9d94b2fed5a0e645cdac768d73841750edccde2d21641619f7d9e143d248ec3400a11ebcda81dfecd7c36e9acc83d7
+  checksum: 441a379eba7979eae9423056097aab7db9ea049967f322a3a65bec8fc361cf352d41425383954d0954a05cb38c3b5c035e8d11e629e78b9d85dae9f7b9360eea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Mentioning @vladfrangu and @didinele here as they were part of a discussion on this topic on Discord.

---

My attempt at summarizing it all for other readers:

The issue was two-fold.

First of all, tsup starts using swc when `emitDecoratorMetadata` and `@swc/core` is installed. `@swc/core` is installed transiently, which still causes the problem. Okay, sure, so we move the `emitDecoratorMetadata` option to just `packages/builders/tsconfig.json` seeing as the other packages don't use decorators anyway. But that still leaves solving the issue for builders. @vladfrangu ended up finding out that there was a bug in how esbuild handles plugins causing the esbuild-plugin-version-injector plugin to not get loaded. This is solved in v1.1.0 where the content is also replaced using the `onEnd` hook, if it wasn't replaced by `onLoad` yet.

Some screenshots showing the issue has been fixed:
<img width="418" alt="CleanShot 2023-03-18 at 22 46 23@2x" src="https://user-images.githubusercontent.com/4019718/226141944-105108a1-16d1-48f6-b27f-367a398b7734.png">
<img width="442" alt="CleanShot 2023-03-18 at 22 46 55@2x" src="https://user-images.githubusercontent.com/4019718/226142034-87dd4c29-56d7-457d-9d73-3c7be07c6614.png">


**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.