### PR TITLE
fix: Keep symbols in actions manager

### DIFF
--- a/packages/discord.js/scripts/generateRequires.mjs
+++ b/packages/discord.js/scripts/generateRequires.mjs
@@ -19,7 +19,18 @@ async function writeWebsocketHandlerImports() {
 }
 
 async function writeClientActionImports() {
-  const lines = ["'use strict';\n", 'class ActionsManager {', '  constructor(client) {', '    this.client = client;\n'];
+  const lines = [
+    "'use strict';\n",
+    'class ActionsManager {',
+    '  // These symbols represent fully built data that we inject at times when calling actions manually.',
+    '  // Action#getUser, for example, will return the injected data (which is assumed to be a built structure)',
+    '  // instead of trying to make it from provided data',
+    "  injectedUser = Symbol('djs.actions.injectedUser');",
+    "  injectedChannel = Symbol('djs.actions.injectedChannel');",
+    "  injectedMessage = Symbol('djs.actions.injectedMessage');\n",
+    '  constructor(client) {',
+    '    this.client = client;\n',
+  ];
 
   const actionsDirectory = new URL('../src/client/actions', import.meta.url);
   for (const file of (await readdir(actionsDirectory)).sort()) {

--- a/packages/discord.js/src/client/actions/ActionsManager.js
+++ b/packages/discord.js/src/client/actions/ActionsManager.js
@@ -1,9 +1,9 @@
 'use strict';
 
 class ActionsManager {
-  // These symbols represent fully built data that we inject at times when calling actions manually. Action#getUser,
-  // for example, will return the injected data (which is assumed to be a built structure) instead of trying to make it
-  // from provided data
+  // These symbols represent fully built data that we inject at times when calling actions manually.
+  // Action#getUser, for example, will return the injected data (which is assumed to be a built structure)
+  // instead of trying to make it from provided data
   injectedUser = Symbol('djs.actions.injectedUser');
   injectedChannel = Symbol('djs.actions.injectedChannel');
   injectedMessage = Symbol('djs.actions.injectedMessage');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #9289 by ensuring symbols are kept.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
