### PR TITLE
ci: close ancient prs

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -106,6 +106,8 @@
   color: e8be8b
 - name: sharding
   color: 80c042
+- name: stale
+  color: ffffff
 - name: tests
   color: f06dff
 - name: threads

--- a/.github/workflows/stale-pr.yml
+++ b/.github/workflows/stale-pr.yml
@@ -1,0 +1,18 @@
+name: 'Stale PR'
+on:
+  schedule:
+    - cron: '0 16 * * *'
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-pr-message: ''
+          stale-pr-label: 'stale'
+          days-before-stale: 90
+          days-before-close: 7
+          exempt-pr-labels: 'blocked'


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds a workflow for locking and adding labels to stale PRs using [`actions/stale@v8`](https://github.com/actions/stale). And adds a `stale` label.

Configuration:
- 90 days before marked as stale*
- 7 days before closed after being marked as stale
- does not run when PR has `blocked` label
- no message when marked as stale*

_*Might need adjustment, not sure what others think_

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
