### PR TITLE
feat: support `voiceChannelEffectSend` event

### DIFF
--- a/src/client/actions/ActionsManager.js
+++ b/src/client/actions/ActionsManager.js
@@ -67,6 +67,7 @@ class ActionsManager {
     this.register(require('./ThreadMembersUpdate'));
     this.register(require('./TypingStart'));
     this.register(require('./UserUpdate'));
+    this.register(require('./VoiceChannelEffectSend'));
     this.register(require('./VoiceStateUpdate'));
     this.register(require('./WebhooksUpdate'));
   }

--- a/src/client/actions/VoiceChannelEffectSend.js
+++ b/src/client/actions/VoiceChannelEffectSend.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const Action = require('./Action');
-const VoiceChannelEffect = require('../../../structures/VoiceChannelEffect');
-const Events = require('../../../util/Events');
+const VoiceChannelEffect = require('../../structures/VoiceChannelEffect');
+const { Events } = require('../../util/Constants');
 
 class VoiceChannelEffectSendAction extends Action {
   handle(data) {

--- a/src/client/actions/VoiceChannelEffectSend.js
+++ b/src/client/actions/VoiceChannelEffectSend.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const Action = require('./Action');
+const VoiceChannelEffect = require('../../../structures/VoiceChannelEffect');
+const Events = require('../../../util/Events');
+
+class VoiceChannelEffectSendAction extends Action {
+  handle(data) {
+    const client = this.client;
+    const guild = client.guilds.cache.get(data.guild_id);
+    if (!guild) return;
+    /**
+     * Emmited when someone sends an effect, such as an emoji reaction,
+     * in a voice channel the current user is connected to.
+     * @event Client#voiceChannelEffectSend
+     * @param {VoiceChannelEffect} voiceChannelEffect The sent voice channel effect
+     */
+    client.emit(Events.VOICE_CHANNEL_EFFECT_SEND, new VoiceChannelEffect(data, guild););
+  }
+}
+
+module.exports = VoiceChannelEffectSendAction;

--- a/src/client/actions/VoiceChannelEffectSend.js
+++ b/src/client/actions/VoiceChannelEffectSend.js
@@ -15,7 +15,7 @@ class VoiceChannelEffectSendAction extends Action {
      * @event Client#voiceChannelEffectSend
      * @param {VoiceChannelEffect} voiceChannelEffect The sent voice channel effect
      */
-    client.emit(Events.VOICE_CHANNEL_EFFECT_SEND, new VoiceChannelEffect(data, guild););
+    client.emit(Events.VOICE_CHANNEL_EFFECT_SEND, new VoiceChannelEffect(data, guild));
   }
 }
 

--- a/src/client/websocket/handlers/VOICE_CHANNEL_EFFECT_SEND.js
+++ b/src/client/websocket/handlers/VOICE_CHANNEL_EFFECT_SEND.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = (client, packet) => {
+  client.actions.VoiceChannelEffectSend.handle(packet.d);
+};

--- a/src/client/websocket/handlers/index.js
+++ b/src/client/websocket/handlers/index.js
@@ -49,6 +49,7 @@ const handlers = Object.fromEntries([
   ['USER_UPDATE', require('./USER_UPDATE')],
   ['PRESENCE_UPDATE', require('./PRESENCE_UPDATE')],
   ['TYPING_START', require('./TYPING_START')],
+  ['VOICE_CHANNEL_EFFECT_SEND', require('./VOICE_CHANNEL_EFFECT_SEND')],
   ['VOICE_STATE_UPDATE', require('./VOICE_STATE_UPDATE')],
   ['VOICE_SERVER_UPDATE', require('./VOICE_SERVER_UPDATE')],
   ['WEBHOOKS_UPDATE', require('./WEBHOOKS_UPDATE')],

--- a/src/index.js
+++ b/src/index.js
@@ -155,6 +155,7 @@ exports.Typing = require('./structures/Typing');
 exports.User = require('./structures/User');
 exports.UserContextMenuInteraction = require('./structures/UserContextMenuInteraction');
 exports.VoiceChannel = require('./structures/VoiceChannel');
+exports.VoiceChannelEffect = require('./structures/VoiceChannelEffect');
 exports.VoiceRegion = require('./structures/VoiceRegion');
 exports.VoiceState = require('./structures/VoiceState');
 exports.Webhook = require('./structures/Webhook');

--- a/src/structures/VoiceChannelEffect.js
+++ b/src/structures/VoiceChannelEffect.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { Emoji } = require('./Emoji');
+
+/**
+ * Represents an effect used in a {@link VoiceChannel}.
+ */
+class VoiceChannelEffect {
+  constructor(data, guild) {
+    /**
+     * The guild where the effect was sent from.
+     * @type {Guild}
+     */
+    this.guild = guild;
+
+    /**
+     * The id of the channel the effect was sent in.
+     * @type {Snowflake}
+     */
+    this.channelId = data.channel_id;
+
+    /**
+     * The id of the user that sent the effect.
+     * @type {Snowflake}
+     */
+    this.userId = data.user_id;
+
+    /**
+     * The emoji of the effect.
+     * @type {?Emoji}
+     */
+    this.emoji = data.emoji ? new Emoji(guild.client, data.emoji) : null;
+
+    /**
+     * The animation type of the effect.
+     * @type {?AnimationType}
+     */
+    this.animationType = data.animation_type ?? null;
+
+    /**
+     * The animation id of the effect.
+     * @type {?number}
+     */
+    this.animationId = data.animation_id ?? null;
+  }
+
+  /**
+   * The channel the effect was sent in.
+   * @type {?VoiceChannel}
+   * @readonly
+   */
+  get channel() {
+    return this.guild.channels.resolve(this.channelId);
+  }
+}
+
+module.exports = VoiceChannelEffect;

--- a/src/structures/VoiceChannelEffect.js
+++ b/src/structures/VoiceChannelEffect.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { AnimationTypes } = require('../util/Constants');
 const { Emoji } = require('./Emoji');
+const { AnimationTypes } = require('../util/Constants');
 
 /**
  * Represents an effect used in a {@link VoiceChannel}.

--- a/src/structures/VoiceChannelEffect.js
+++ b/src/structures/VoiceChannelEffect.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { AnimationTypes } = require('../util/Constants');
 const { Emoji } = require('./Emoji');
 
 /**
@@ -35,7 +36,7 @@ class VoiceChannelEffect {
      * The animation type of the effect.
      * @type {?AnimationType}
      */
-    this.animationType = data.animation_type ?? null;
+    this.animationType = data.animation_type ? AnimationTypes[data.animation_type] : null;
 
     /**
      * The animation id of the effect.

--- a/src/structures/VoiceChannelEffect.js
+++ b/src/structures/VoiceChannelEffect.js
@@ -50,7 +50,16 @@ class VoiceChannelEffect {
    * @readonly
    */
   get channel() {
-    return this.guild.channels.resolve(this.channelId);
+    return this.guild.channels.cache.get(this.channelId) ?? null;
+  }
+
+  /**
+   * The member that sent the effect.
+   * @type {?GuildMember}
+   * @readonly
+   */
+  get member() {
+    return this.guild.members.cache.get(this.userId) ?? null;
   }
 }
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -1519,7 +1519,7 @@ exports.ForumLayoutTypes = createEnum(['NOT_SET', 'LIST_VIEW', 'GALLERY_VIEW']);
  * * PREMIUM
  * * BASIC
  * @typedef {string} AnimationType
- * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-channel-effect-send-animation-type}
+ * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-channel-effect-send-animation-types}
  */
 exports.AnimationTypes = createEnum(['PREMIUM', 'BASIC']);
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -221,6 +221,7 @@ exports.Opcodes = {
  * * THREAD_MEMBERS_UPDATE: threadMembersUpdate
  * * USER_UPDATE: userUpdate
  * * PRESENCE_UPDATE: presenceUpdate
+ * * VOICE_CHANNEL_EFFECT_SEND: voiceChannelEffectSend
  * * VOICE_SERVER_UPDATE: voiceServerUpdate
  * * VOICE_STATE_UPDATE: voiceStateUpdate
  * * TYPING_START: typingStart
@@ -305,6 +306,7 @@ exports.Events = {
   THREAD_MEMBERS_UPDATE: 'threadMembersUpdate',
   USER_UPDATE: 'userUpdate',
   PRESENCE_UPDATE: 'presenceUpdate',
+  VOICE_CHANNEL_EFFECT_SEND: 'voiceChannelEffectSend',
   VOICE_SERVER_UPDATE: 'voiceServerUpdate',
   VOICE_STATE_UPDATE: 'voiceStateUpdate',
   TYPING_START: 'typingStart',
@@ -417,6 +419,7 @@ exports.PartialTypes = keyMirror(['USER', 'CHANNEL', 'GUILD_MEMBER', 'MESSAGE', 
  * * USER_UPDATE
  * * PRESENCE_UPDATE
  * * TYPING_START
+ * * VOICE_CHANNEL_EFFECT_SEND
  * * VOICE_STATE_UPDATE
  * * VOICE_SERVER_UPDATE
  * * WEBHOOKS_UPDATE
@@ -482,6 +485,7 @@ exports.WSEvents = keyMirror([
   'USER_UPDATE',
   'PRESENCE_UPDATE',
   'TYPING_START',
+  'VOICE_CHANNEL_EFFECT_SEND',
   'VOICE_STATE_UPDATE',
   'VOICE_SERVER_UPDATE',
   'WEBHOOKS_UPDATE',
@@ -1510,6 +1514,15 @@ exports.SortOrderTypes = createEnum([null, 'LATEST_ACTIVITY', 'CREATION_DATE']);
  */
 exports.ForumLayoutTypes = createEnum(['NOT_SET', 'LIST_VIEW', 'GALLERY_VIEW']);
 
+/**
+ * The animation type of the voice channel effect
+ * * PREMIUM
+ * * BASIC
+ * @typedef {string} AnimationType
+ * @see {@link https://discord.com/developers/docs/topics/gateway-events#voice-channel-effect-send-animation-type}
+ */
+exports.AnimationTypes = createEnum(['PREMIUM', 'BASIC']);
+
 exports._cleanupSymbol = Symbol('djsCleanup');
 
 function keyMirror(arr) {
@@ -1531,6 +1544,7 @@ function createEnum(keys) {
 /**
  * @typedef {Object} Constants Constants that can be used in an enum or object-like way.
  * @property {Object<ActivityType, number>} ActivityTypes The type of an activity of a users presence.
+ * @property {Object<AnimationType, number>} AnimationTypes The animation type of the voice channel effect.
  * @property {Object<APIError, number>} APIErrors An error encountered while performing an API request.
  * @property {Object<ApplicationCommandOptionType, number>} ApplicationCommandOptionTypes
  * The type of an {@link ApplicationCommandOption} object.

--- a/typings/enums.d.ts
+++ b/typings/enums.d.ts
@@ -10,6 +10,11 @@ export const enum ActivityTypes {
   COMPETING = 5,
 }
 
+export const enum AnimationTypes {
+  PREMIUM = 0,
+  BASIC = 1,
+}
+
 export const enum ApplicationCommandTypes {
   CHAT_INPUT = 1,
   USER = 2,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2812,13 +2812,14 @@ export class VoiceChannel extends TextBasedChannelMixin(BaseGuildVoiceChannel, [
 
 export class VoiceChannelEffect {
   private constructor(data: unknown, guild: Guild);
-  public guild: Guild;
-  public channelId: Snowflake;
-  public userId: Snowflake;
-  public emoji: Emoji | null;
   public animationType: AnimationTypes | null;
   public animationId: number | null;
-  public get channel(): VoiceChannel | null;
+  public readonly channel: VoiceChannel | null;
+  public channelId: Snowflake;
+  public emoji: Emoji | null;
+  public guild: Guild;
+  public readonly member: GuildMember | null;
+  public userId: Snowflake;
 }
 
 export class VoiceRegion {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -97,6 +97,7 @@ import {
   SortOrderType,
   ForumLayoutType,
   ApplicationRoleConnectionMetadataTypes,
+  AnimationTypes,
 } from './enums';
 import {
   APIApplicationRoleConnectionMetadata,
@@ -2809,6 +2810,17 @@ export class VoiceChannel extends TextBasedChannelMixin(BaseGuildVoiceChannel, [
   public setVideoQualityMode(videoQualityMode: VideoQualityMode | number, reason?: string): Promise<VoiceChannel>;
 }
 
+export class VoiceChannelEffect {
+  private constructor(data: unknown, guild: Guild);
+  public guild: Guild;
+  public channelId: Snowflake;
+  public userId: Snowflake;
+  public emoji: Emoji | null;
+  public animationType: AnimationTypes | null;
+  public animationId: number | null;
+  public get channel(): VoiceChannel | null;
+}
+
 export class VoiceRegion {
   private constructor(data: RawVoiceRegionData);
   public custom: boolean;
@@ -3154,6 +3166,7 @@ export const Constants: {
   DefaultMessageNotificationLevels: EnumHolder<typeof DefaultMessageNotificationLevels>;
   VerificationLevels: EnumHolder<typeof VerificationLevels>;
   MembershipStates: EnumHolder<typeof MembershipStates>;
+  AnimationTypes: EnumHolder<typeof AnimationTypes>;
   AutoModerationRuleTriggerTypes: EnumHolder<typeof AutoModerationRuleTriggerTypes>;
   AutoModerationRuleKeywordPresetTypes: EnumHolder<typeof AutoModerationRuleKeywordPresetTypes>;
   AutoModerationActionTypes: EnumHolder<typeof AutoModerationActionTypes>;
@@ -4569,6 +4582,7 @@ export interface ClientEvents extends BaseClientEvents {
   threadUpdate: [oldThread: ThreadChannel, newThread: ThreadChannel];
   typingStart: [typing: Typing];
   userUpdate: [oldUser: User | PartialUser, newUser: User];
+  voiceChannelEffectSend: [voiceChannelEffect: VoiceChannelEffect];
   voiceStateUpdate: [oldState: VoiceState, newState: VoiceState];
   webhookUpdate: [channel: TextChannel | NewsChannel | VoiceChannel | ForumChannel];
   /** @deprecated Use interactionCreate instead */
@@ -4827,6 +4841,7 @@ export interface ConstantsEvents {
   THREAD_MEMBERS_UPDATE: 'threadMembersUpdate';
   USER_UPDATE: 'userUpdate';
   PRESENCE_UPDATE: 'presenceUpdate';
+  VOICE_CHANNEL_EFFECT_SEND: 'voiceChaannelEffectSend';
   VOICE_SERVER_UPDATE: 'voiceServerUpdate';
   VOICE_STATE_UPDATE: 'voiceStateUpdate';
   TYPING_START: 'typingStart';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -161,6 +161,7 @@ import {
   RawWelcomeScreenData,
   RawWidgetData,
   RawWidgetMemberData,
+  VoiceChannelEffectData,
 } from './rawDataTypes';
 
 //#region Classes
@@ -2811,7 +2812,7 @@ export class VoiceChannel extends TextBasedChannelMixin(BaseGuildVoiceChannel, [
 }
 
 export class VoiceChannelEffect {
-  private constructor(data: unknown, guild: Guild);
+  private constructor(data: VoiceChannelEffectData, guild: Guild);
   public animationType: AnimationTypes | null;
   public animationId: number | null;
   public readonly channel: VoiceChannel | null;
@@ -6562,6 +6563,7 @@ export type WSEventType =
   | 'USER_UPDATE'
   | 'PRESENCE_UPDATE'
   | 'TYPING_START'
+  | 'VOICE_CHANNEL_EFFECT_SEND'
   | 'VOICE_STATE_UPDATE'
   | 'VOICE_SERVER_UPDATE'
   | 'WEBHOOKS_UPDATE'

--- a/typings/rawDataTypes.d.ts
+++ b/typings/rawDataTypes.d.ts
@@ -90,7 +90,8 @@ import type {
   AutoModerationRuleTriggerTypes,
   InteractionTypes,
   MessageComponentTypes,
-  ApplicationRoleConnectionMetadataTypes
+  ApplicationRoleConnectionMetadataTypes,
+  AnimationTypes
 } from './enums';
 
 export type RawActivityData = GatewayActivity;
@@ -278,4 +279,13 @@ export interface APIApplicationRoleConnectionMetadata {
   name_localizations?: LocalizationMap;
   description: string;
   description_localizations?: LocalizationMap;
+}
+
+export interface VoiceChannelEffectData {
+	channel_id: Snowflake;
+	guild_id: Snowflake;
+	user_id: Snowflake;
+	emoji?: APIEmoji | null;
+	animation_type?: AnimationTypes;
+	animation_id?: number;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- https://github.com/discord/discord-api-docs/pull/6025

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 0c36226</samp>

### Summary
🎙️🎭🚀

<!--
1.  🎙️ - This emoji represents the voice channel feature and the effect that is sent in the channel.
2.  🎭 - This emoji represents the animation and the expression of the effect, such as an emoji reaction.
3.  🚀 - This emoji represents the action and the handler that are added to the library to handle the new event and the new opcode.
-->
This pull request adds a new feature to the discord.js library that allows listening for voice channel effects, such as emoji reactions, sent by users. It defines a new event, a new structure, a new action, and a new handler for the feature. It also updates the `Constants.js`, `ActionsManager.js`, and `index.js` files to support the feature.

> _Sing, O Muse, of the cunning coder who devised_
> _A new action for the discordant gateway, and thus_
> _Enabled the voice channel effect, a wondrous sight_
> _Like the flashing thunderbolts of Zeus the cloud-gatherer._

### Walkthrough
*  Register a new action class for handling voice channel effect send events ([link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-d6e2e8560342ba8ebf3c312c8b6422526aaade8d4b4e1a514f941700d78ac0d3R70))
*  Define the `VoiceChannelEffectSendAction` class that emits a `voiceChannelEffectSend` event on the client with a new `VoiceChannelEffect` structure ([link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-5ad5ee7c76436cc08434601d1ced823745de00216aea226f009288668095abbbR1-R22))
*  Add a new handler function for the `VOICE_CHANNEL_EFFECT_SEND` opcode from the gateway ([link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-30e4d02ef9592db56c7b511d9c7fe9b07b9daada3d7e16a22b5c4bfeb3c18e8fR52), [link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-cdac85faaf16edb602f3a0c315cce713589035b40a79757d450902af608a625bR1-R5))
*  Define the `VoiceChannelEffect` class that represents an effect used in a voice channel, such as an emoji reaction ([link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-aec50ff0741e21db16ed6d3f15906ab4cb1491efc1873411a5d539702dabd203R1-R67), [link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556R158))
*  Add a new event name, documentation, and parameter type for the `voiceChannelEffectSend` event to the `Constants.js` file ([link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-1c714d0a8a5ad05fd5427eb604e7666f098bf10ca0105e610a43330c4a5d1e1bR224), [link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-1c714d0a8a5ad05fd5427eb604e7666f098bf10ca0105e610a43330c4a5d1e1bR309), [link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-1c714d0a8a5ad05fd5427eb604e7666f098bf10ca0105e610a43330c4a5d1e1bR422))
*  Define the possible animation types of the voice channel effect using the `createEnum` function ([link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-1c714d0a8a5ad05fd5427eb604e7666f098bf10ca0105e610a43330c4a5d1e1bR1517-R1525), [link](https://github.com/discordjs/discord.js/pull/9308/files?diff=unified&w=0#diff-1c714d0a8a5ad05fd5427eb604e7666f098bf10ca0105e610a43330c4a5d1e1bR1547))



**Status and versioning classification:**
- I know how to update typings and have done so
- This PR changes the library's interface (methods or parameters added)