### PR TITLE
fix: Typo in `src/util/MessageFlags.js`

### DIFF
--- a/src/util/MessageFlags.js
+++ b/src/util/MessageFlags.js
@@ -44,7 +44,7 @@ MessageFlags.FLAGS = {
   HAS_THREAD: 1 << 5,
   EPHEMERAL: 1 << 6,
   LOADING: 1 << 7,
-  SUPPRESS_NOTIFICATIONS: 1 >> 12,
+  SUPPRESS_NOTIFICATIONS: 1 << 12,
 };
 
 module.exports = MessageFlags;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fix a little typo which added in #9184
