### PR TITLE
fix(djs-types): fixed `index.d.ts` for discord.js typings

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6407,6 +6407,5 @@ export type InternalDiscordGatewayAdapterCreator = (
 // External
 export * from 'discord-api-types/v10';
 export * from '@discordjs/builders';
-export * from '@discordjs/formatters';
 export * from '@discordjs/rest';
 export * from '@discordjs/util';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

There is a pretty critical bug that makes it so all end-users who currently use a TypeScript + DiscordJS stack cannot compile without `skipLibCheck`. The issues comes from `discord.js` exporting all of `/formatters`, but `/builders` does so too which causes these errors:

<details>
<summary>TSC errors</summary>

```
node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'EscapeMarkdownOptions'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'Faces'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'TimestampStyles'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'TimestampStylesString'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'blockQuote'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'bold'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'channelLink'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'channelMention'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'chatInputApplicationCommandMention'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'codeBlock'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeBold'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeBulletedList'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeCodeBlock'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeEscape'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeHeading'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeInlineCode'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeItalic'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeMarkdown'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeMaskedLink'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeNumberedList'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeSpoiler'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeStrikethrough'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'escapeUnderline'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'formatEmoji'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'hideLinkEmbed'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'hyperlink'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'inlineCode'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'italic'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'messageLink'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'quote'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'roleMention'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'spoiler'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'strikethrough'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'time'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'underscore'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/discord.js/typings/index.d.ts:6410:1 - error TS2308: Module '@discordjs/builders' has already exported a member named 'userMention'. Consider explicitly re-exporting to resolve the ambiguity.

6410 export * from '@discordjs/formatters';
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 36 errors in the same file, starting at: node_modules/discord.js/typings/index.d.ts:6410
```

</details>

A very small code base to repro these errors:
[repro.zip](https://github.com/discordjs/discord.js/files/11131784/repro.zip)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
