### PR TITLE
refactor(ui): add 'use client' directives to client-only components

### DIFF
--- a/packages/ui/src/lib/components/Alert.tsx
+++ b/packages/ui/src/lib/components/Alert.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { VscFlame } from '@react-icons/all-files/vsc/VscFlame';
 import { VscInfo } from '@react-icons/all-files/vsc/VscInfo';
 import { VscWarning } from '@react-icons/all-files/vsc/VscWarning';

--- a/packages/ui/src/lib/components/Section.tsx
+++ b/packages/ui/src/lib/components/Section.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { VscChevronDown } from '@react-icons/all-files/vsc/VscChevronDown';
 import { Disclosure, DisclosureContent, useDisclosureState } from 'ariakit/disclosure';
 import type { PropsWithChildren } from 'react';


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 478103a</samp>

### Summary
🎨🔧🚀

<!--
1.  🎨 This emoji is often used to indicate code style or formatting changes, such as adding a directive or comment. In this case, it could also imply a visual change, since the directive affects how the React components are rendered in the browser.
2.  🔧 This emoji is often used to indicate configuration or tooling changes, such as modifying the TypeScript compiler options or settings. In this case, it could also imply a structural change, since the directive affects how the client and server code are separated and organized.
3.  🚀 This emoji is often used to indicate a new feature or improvement, such as adding a new component or functionality. In this case, it could also imply a performance or compatibility change, since the directive affects how the React components interact with the discord.js library and the Discord API.
-->
Added `'use client';` directives to `Alert.tsx` and `Section.tsx` files to enable client-side TypeScript configuration and types. This is part of a refactor to separate client and server code in discord.js.

> _`use client` tells_
> _TypeScript to split the code_
> _like autumn leaves fall_

### Walkthrough
*  Add `'use client';` directive to `Alert.tsx` and `Section.tsx` files to use client-side TypeScript configuration and types ([link](https://github.com/discordjs/discord.js/pull/9330/files?diff=unified&w=0#diff-8eecb0ed4b14a0a7cfb3876219ead71480bace18a7b09c6412e0648589181213R1-R2), [link](https://github.com/discordjs/discord.js/pull/9330/files?diff=unified&w=0#diff-b958615e8074888802ec10ac80f2ac17a061384a5f91d4b46d5592ee6dd0f3bbR1-R2))


