### PR TITLE
fix(website): dont crash when serviceWorker is not available

### DIFF
--- a/apps/website/src/hooks/useUnregisterServiceWorker.ts
+++ b/apps/website/src/hooks/useUnregisterServiceWorker.ts
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 export function useUnregisterServiceWorker() {
 	useEffect(() => {
 		// eslint-disable-next-line promise/prefer-await-to-then
-		void navigator.serviceWorker.getRegistrations().then((registrations) => {
+		void navigator.serviceWorker?.getRegistrations().then((registrations) => {
 			for (const registration of registrations) {
 				void registration.unregister();
 			}


### PR DESCRIPTION
Fixes #9323 

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d522d78</samp>

### Summary
🌐🚀♿

<!--
1.  🌐 This emoji represents the web or the internet, and can be used to indicate that the changes are related to the website or the service worker, which is a web feature that enables offline functionality and background tasks.
2.  🚀 This emoji represents speed, performance, or launching something new, and can be used to indicate that the changes are intended to improve the website performance and reduce potential errors or delays caused by the service worker.
3.  ♿ This emoji represents accessibility, inclusion, or disability, and can be used to indicate that the changes are also aimed at enhancing the website accessibility and user experience for people who may have difficulties accessing the service worker or the web in general.
-->
Added optional chaining to `navigator.serviceWorker` in `useUnregisterServiceWorker.ts` to prevent errors. This improves the website performance and accessibility.

> _`?.` for service_
> _worker, graceful fallback_
> _winter of no swipes_

### Walkthrough
*  Add optional chaining to `navigator.serviceWorker` to prevent errors ([link](https://github.com/discordjs/discord.js/pull/9331/files?diff=unified&w=0#diff-4cb432dfc49f57a32bd1663baaa43d74d1672b1f89c5d2a75a865cd3a3155a7dL8-R8))

