### PR TITLE
fix(website): correct docs link

### DIFF
--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function Page() {
 					<div className="flex flex-row gap-4">
 						<Link
 							className="bg-blurple focus:ring-width-2 flex h-11 transform-gpu cursor-pointer select-none appearance-none flex-row place-items-center rounded border-0 px-6 text-base font-semibold leading-none text-white no-underline outline-0 focus:ring focus:ring-white active:translate-y-px"
-							href="/docs"
+							href="/docs/packages"
 						>
 							Docs
 						</Link>


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 807b177</samp>

### Summary
📚🔗📦

<!--
1.  📚 This emoji can be used to indicate that the change is related to documentation or books. It conveys the idea of learning, reading, or writing, and can also be used as a shorthand for docs.
2.  🔗 This emoji can be used to indicate that the change is related to links, URLs, or references. It conveys the idea of connecting, navigating, or pointing to something, and can also be used as a shorthand for href.
3.  📦 This emoji can be used to indicate that the change is related to packages, modules, or dependencies. It conveys the idea of bundling, delivering, or installing something, and can also be used as a shorthand for packages.
-->
Updated the website's `Link` component to point to the new packages overview page instead of the main docs page. This is part of a redesign of the documentation website.

> _`Link` href updated_
> _To show packages overview_
> _A fresh spring website_

### Walkthrough
* Redirect users to packages overview page instead of main docs page by changing `href` attribute of `Link` component ([link](https://github.com/discordjs/discord.js/pull/9333/files?diff=unified&w=0#diff-149efc25407f13009a436bda2625f7223097d1c1f85adc6d78faecccec0105c0L25-R25))

