### PR TITLE
docs: Remove `JSONEncondable`

### DIFF
--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -66,12 +66,10 @@ class ApplicationCommandManager extends CachedManager {
    * @typedef {ApplicationCommand|Snowflake} ApplicationCommandResolvable
    */
 
-  /* eslint-disable max-len */
   /**
    * Data that resolves to the data of an ApplicationCommand
-   * @typedef {ApplicationCommandData|APIApplicationCommand|JSONEncodable<APIApplicationCommand>} ApplicationCommandDataResolvable
+   * @typedef {ApplicationCommandData|APIApplicationCommand} ApplicationCommandDataResolvable
    */
-  /* eslint-enable max-len */
 
   /**
    * Options used to fetch data from Discord

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -35,7 +35,7 @@ class GuildStickerManager extends CachedManager {
   /**
    * Options used to create a guild sticker.
    * @typedef {Object} GuildStickerCreateOptions
-   * @property {BufferResolvable|Stream|JSONEncodable<AttachmentPayload>} file The file for the sticker
+   * @property {AttachmentPayload|BufferResolvable|Stream} file The file for the sticker
    * @property {string} name The name for the sticker
    * @property {string} tags The Discord name of a unicode emoji representing the sticker's expression
    * @property {?string} [description] The description for the sticker

--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -151,7 +151,7 @@ class MessageManager extends CachedManager {
   /**
    * Options that can be passed to edit a message.
    * @typedef {BaseMessageOptions} MessageEditOptions
-   * @property {Array<JSONEncodable<AttachmentPayload>>} [attachments] An array of attachments to keep,
+   * @property {AttachmentPayload[]} [attachments] An array of attachments to keep,
    * all attachments will be kept if omitted
    * @property {MessageFlags} [flags] Which flags to set for the message
    * <info>Only the {@link MessageFlags.SuppressEmbeds} flag can be modified.</info>

--- a/packages/discord.js/src/structures/ActionRow.js
+++ b/packages/discord.js/src/structures/ActionRow.js
@@ -25,7 +25,7 @@ class ActionRow extends Component {
    * Creates a new action row builder from JSON data
    * @method from
    * @memberof ActionRow
-   * @param {JSONEncodable<APIActionRowComponent>|APIActionRowComponent} other The other data
+   * @param {ActionRowBuilder|ActionRow|APIActionRowComponent} other The other data
    * @returns {ActionRowBuilder}
    * @deprecated Use {@link ActionRowBuilder.from} instead.
    */

--- a/packages/discord.js/src/structures/ActionRowBuilder.js
+++ b/packages/discord.js/src/structures/ActionRowBuilder.js
@@ -18,15 +18,11 @@ class ActionRowBuilder extends BuildersActionRow {
 
   /**
    * Creates a new action row builder from JSON data
-   * @param {JSONEncodable<APIActionRowComponent<APIActionRowComponentTypes>>
-   * |APIActionRowComponent<APIActionRowComponentTypes>} other The other data
+   * @param {ActionRow|ActionRowBuilder|APIActionRowComponent} other The other data
    * @returns {ActionRowBuilder}
    */
   static from(other) {
-    if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
-    }
-    return new this(other);
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
   }
 }
 

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -91,7 +91,7 @@ class AttachmentBuilder {
 
   /**
    * Makes a new builder instance from a preexisting attachment structure.
-   * @param {JSONEncodable<AttachmentPayload>} other The builder to construct a new instance from
+   * @param {AttachmentBuilder|Attachment|AttachmentPayload} other The builder to construct a new instance from
    * @returns {AttachmentBuilder}
    */
   static from(other) {

--- a/packages/discord.js/src/structures/ButtonBuilder.js
+++ b/packages/discord.js/src/structures/ButtonBuilder.js
@@ -27,14 +27,11 @@ class ButtonBuilder extends BuildersButton {
 
   /**
    * Creates a new button builder from JSON data
-   * @param {JSONEncodable<APIButtonComponent>|APIButtonComponent} other The other data
+   * @param {ButtonBuilder|ButtonComponent|APIButtonComponent} other The other data
    * @returns {ButtonBuilder}
    */
   static from(other) {
-    if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
-    }
-    return new this(other);
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
   }
 }
 

--- a/packages/discord.js/src/structures/ChannelSelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/ChannelSelectMenuBuilder.js
@@ -13,15 +13,12 @@ class ChannelSelectMenuBuilder extends BuildersChannelSelectMenu {
   }
 
   /**
-   * Creates a new select menu builder from json data
-   * @param {JSONEncodable<APISelectMenuComponent> | APISelectMenuComponent} other The other data
+   * Creates a new select menu builder from JSON data
+   * @param {ChannelSelectMenuBuilder|ChannelSelectMenuComponent|APIChannelSelectComponent} other The other data
    * @returns {ChannelSelectMenuBuilder}
    */
   static from(other) {
-    if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
-    }
-    return new this(other);
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
   }
 }
 

--- a/packages/discord.js/src/structures/EmbedBuilder.js
+++ b/packages/discord.js/src/structures/EmbedBuilder.js
@@ -24,14 +24,11 @@ class EmbedBuilder extends BuildersEmbed {
 
   /**
    * Creates a new embed builder from JSON data
-   * @param {JSONEncodable<APIEmbed>|APIEmbed} other The other data
+   * @param {EmbedBuilder|Embed|APIEmbed} other The other data
    * @returns {EmbedBuilder}
    */
   static from(other) {
-    if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
-    }
-    return new this(other);
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
   }
 }
 

--- a/packages/discord.js/src/structures/MentionableSelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/MentionableSelectMenuBuilder.js
@@ -13,15 +13,13 @@ class MentionableSelectMenuBuilder extends BuildersMentionableSelectMenu {
   }
 
   /**
-   * Creates a new select menu builder from json data
-   * @param {JSONEncodable<APISelectMenuComponent> | APISelectMenuComponent} other The other data
+   * Creates a new select menu builder from JSON data
+   * @param {MentionableSelectMenuBuilder|MentionableSelectMenuComponent|APIMentionableSelectComponent} other
+   * The other data
    * @returns {MentionableSelectMenuBuilder}
    */
   static from(other) {
-    if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
-    }
-    return new this(other);
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
   }
 }
 

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -227,8 +227,7 @@ class MessagePayload {
 
   /**
    * Resolves a single file into an object sendable to the API.
-   * @param {BufferResolvable|Stream|JSONEncodable<AttachmentPayload>} fileLike Something that could
-   * be resolved to a file
+   * @param {AttachmentPayload|BufferResolvable|Stream} fileLike Something that could be resolved to a file
    * @returns {Promise<RawFile>}
    */
   static async resolveFile(fileLike) {

--- a/packages/discord.js/src/structures/ModalBuilder.js
+++ b/packages/discord.js/src/structures/ModalBuilder.js
@@ -17,14 +17,11 @@ class ModalBuilder extends BuildersModal {
 
   /**
    * Creates a new modal builder from JSON data
-   * @param {JSONEncodable<APIModalComponent>|APIModalComponent} other The other data
+   * @param {ModalBuilder|APIModalComponent} other The other data
    * @returns {ModalBuilder}
    */
   static from(other) {
-    if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
-    }
-    return new this(other);
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
   }
 }
 

--- a/packages/discord.js/src/structures/RoleSelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/RoleSelectMenuBuilder.js
@@ -13,15 +13,12 @@ class RoleSelectMenuBuilder extends BuildersRoleSelectMenu {
   }
 
   /**
-   * Creates a new select menu builder from json data
-   * @param {JSONEncodable<APISelectMenuComponent> | APISelectMenuComponent} other The other data
+   * Creates a new select menu builder from JSON data
+   * @param {RoleSelectMenuBuilder|RoleSelectMenuComponent|APIRoleSelectComponent} other The other data
    * @returns {RoleSelectMenuBuilder}
    */
   static from(other) {
-    if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
-    }
-    return new this(other);
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
   }
 }
 

--- a/packages/discord.js/src/structures/StringSelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/StringSelectMenuBuilder.js
@@ -23,7 +23,7 @@ class StringSelectMenuBuilder extends BuildersSelectMenu {
 
   /**
    * Normalizes a select menu option emoji
-   * @param {SelectMenuOptionData|JSONEncodable<APISelectMenuOption>} selectMenuOption The option to normalize
+   * @param {SelectMenuOptionData|APISelectMenuOption} selectMenuOption The option to normalize
    * @returns {SelectMenuOptionBuilder|APISelectMenuOption}
    * @private
    */
@@ -59,7 +59,7 @@ class StringSelectMenuBuilder extends BuildersSelectMenu {
 
   /**
    * Creates a new select menu builder from json data
-   * @param {JSONEncodable<APISelectMenuComponent> | APISelectMenuComponent} other The other data
+   * @param {StringSelectMenuBuilder|StringSelectMenuComponent|APIStringSelectComponent} other The other data
    * @returns {StringSelectMenuBuilder}
    */
   static from(other) {

--- a/packages/discord.js/src/structures/StringSelectMenuOptionBuilder.js
+++ b/packages/discord.js/src/structures/StringSelectMenuOptionBuilder.js
@@ -32,14 +32,11 @@ class StringSelectMenuOptionBuilder extends BuildersSelectMenuOption {
 
   /**
    * Creates a new select menu option builder from JSON data
-   * @param {JSONEncodable<APISelectMenuOption>|APISelectMenuOption} other The other data
+   * @param {StringSelectMenuOptionBuilder|APISelectMenuOption} other The other data
    * @returns {StringSelectMenuOptionBuilder}
    */
   static from(other) {
-    if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
-    }
-    return new this(other);
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
   }
 }
 

--- a/packages/discord.js/src/structures/TextInputBuilder.js
+++ b/packages/discord.js/src/structures/TextInputBuilder.js
@@ -14,14 +14,11 @@ class TextInputBuilder extends BuildersTextInput {
 
   /**
    * Creates a new text input builder from JSON data
-   * @param {JSONEncodable<APITextInputComponent>|APITextInputComponent} other The other data
+   * @param {TextInputBuilder|TextInputComponent|APITextInputComponent} other The other data
    * @returns {TextInputBuilder}
    */
   static from(other) {
-    if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
-    }
-    return new this(other);
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
   }
 }
 

--- a/packages/discord.js/src/structures/UserSelectMenuBuilder.js
+++ b/packages/discord.js/src/structures/UserSelectMenuBuilder.js
@@ -13,15 +13,12 @@ class UserSelectMenuBuilder extends BuildersUserSelectMenu {
   }
 
   /**
-   * Creates a new select menu builder from json data
-   * @param {JSONEncodable<APISelectMenuComponent> | APISelectMenuComponent} other The other data
+   * Creates a new select menu builder from JSON data
+   * @param {UserSelectMenuBuilder|UserSelectMenuComponent|APIUserSelectComponent} other The other data
    * @returns {UserSelectMenuBuilder}
    */
   static from(other) {
-    if (isJSONEncodable(other)) {
-      return new this(other.toJSON());
-    }
-    return new this(other);
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
   }
 }
 

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -59,7 +59,7 @@ class TextBasedChannel {
    * @property {Embed[]|APIEmbed[]} [embeds] The embeds for the message
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
-   * @property {Array<JSONEncodable<AttachmentPayload>>|BufferResolvable[]|Attachment[]|AttachmentBuilder[]} [files]
+   * @property {AttachmentBuilder[]|Attachment[]|AttachmentPayload[]|BufferResolvable[]} [files]
    * The files to send with the message.
    * @property {ActionRow[]|ActionRowBuilder[]} [components]
    * Action rows containing interactive components for the message (buttons, select menus)

--- a/packages/discord.js/src/util/APITypes.js
+++ b/packages/discord.js/src/util/APITypes.js
@@ -44,6 +44,11 @@
  */
 
 /**
+ * @external APIChannelSelectComponent
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10#APIChannelSelectComponent}
+ */
+
+/**
  * @external APIEmbed
  * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIEmbed}
  */
@@ -99,6 +104,11 @@
  */
 
 /**
+ * @external APIMentionableSelectComponent
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10#APIMentionableSelectComponent}
+ */
+
+/**
  * @external APIMessage
  * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIMessage}
  */
@@ -139,13 +149,13 @@
  */
 
 /**
- * @external APISelectMenuComponent
- * @see {@link https://discord-api-types.dev/api/discord-api-types-v10#APISelectMenuComponent}
+ * @external APISelectMenuOption
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APISelectMenuOption}
  */
 
 /**
- * @external APISelectMenuOption
- * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APISelectMenuOption}
+ * @external APIStringSelectComponent
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIStringSelectComponent}
  */
 
 /**

--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -150,8 +150,3 @@ const TextInputBuilder = require('../structures/TextInputBuilder');
 const TextInputComponent = require('../structures/TextInputComponent');
 const UserSelectMenuBuilder = require('../structures/UserSelectMenuBuilder');
 const UserSelectMenuComponent = require('../structures/UserSelectMenuComponent');
-
-/**
- * @external JSONEncodable
- * @see {@link https://discord.js.org/docs/packages/util/main/JSONEncodable:Interface}
- */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I think we should stop referencing this TypeScript interface in our _JavaScript_ documentation.

Look at this:

https://github.com/discordjs/discord.js/blob/1b9d07f941dc3edf20cd5e65c56b70d009880893/packages/discord.js/src/structures/ActionRowBuilder.js#L19-L31

`JSONEncodable<APIActionRowComponent<APIActionRowComponentTypes>>|APIActionRowComponent<APIActionRowComponentTypes>`. Well damn. This is the same type duplicated with `JSONEncodable`.

The proposed modification: `ActionRow|ActionRowBuilder|APIActionRowComponent`. Wow, much more _understandable_, right?

JavaScript users only need to know what they can pass without needing to deeply understand all associated typings. One may pass a received (immutable) `ActionRow` from the API, an `ActionRowBuilder`, or use raw API data. This is the exact same behaviour from before but is documented in a simpler way that could be understood with ease.

I believe this change will allow users to understand this part of the documentation better.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
