### PR TITLE
feat: return entries instead of values in toJSON method

### DIFF
--- a/packages/collection/__tests__/collection.test.ts
+++ b/packages/collection/__tests__/collection.test.ts
@@ -828,9 +828,14 @@ describe('tap() tests', () => {
 });
 
 describe('toJSON() tests', () => {
-	test('it returns the values as an array', () => {
+	test('it returns the entries of the collection', () => {
 		const c = createTestCollection();
-		expect(c.toJSON()).toStrictEqual([1, 2, 3]);
+
+		expect(c.toJSON()).toStrictEqual([
+			['a', 1],
+			['b', 2],
+			['c', 3],
+		]);
 	});
 });
 

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -933,7 +933,7 @@ export class Collection<K, V> extends Map<K, V> {
 
 	public toJSON() {
 		// toJSON is called recursively by JSON.stringify.
-		return [...this.values()];
+		return [...this.entries()];
 	}
 
 	private static defaultSort<V>(firstValue: V, secondValue: V): number {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR modifies the toJSON method in the collection package to return entries instead of just values. Currently, the toJSON method only returns values from the collection, which makes it impossible to create a new collection from the JSON output.

To fix this issue, this PR modifies the toJSON method to return entries instead of just values. This will preserve the keys and allow the creation of a new collection/map from the returned data. (FIXES #9310 ).

**Status and versioning classification:**
    - Code changes have been tested against the Discord API, or there are no code changes
    - This PR changes the library's interface (methods or parameters added)
    - (Status Classification) This PR includes breaking changes (method(s) removed or renamed, parameters moved or removed)


Please review this PR and let me know if any changes are required.