### PR TITLE
fix(util): Remove extra slash

### DIFF
--- a/apps/website/src/components/documentation/util.ts
+++ b/apps/website/src/components/documentation/util.ts
@@ -23,7 +23,7 @@ export function hasMethods(item: ApiItemContainerMixin) {
 }
 
 export function resolveItemURI(item: ApiItem): string {
-	return `/${item.displayName}:${item.kind}`;
+	return `${item.displayName}:${item.kind}`;
 }
 
 function memberPredicate(item: ApiItem): item is ApiMethod | ApiMethodSignature | ApiProperty | ApiPropertySignature {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This method is called in three different places:

https://github.com/discordjs/discord.js/blob/1b9d07f941dc3edf20cd5e65c56b70d009880893/apps/website/src/app/docs/packages/%5Bpackage%5D/%5Bversion%5D/layout.tsx#L40-L47

https://github.com/discordjs/discord.js/blob/1b9d07f941dc3edf20cd5e65c56b70d009880893/apps/website/src/components/InheritanceText.tsx#L5-L17

https://github.com/discordjs/discord.js/blob/1b9d07f941dc3edf20cd5e65c56b70d009880893/apps/website/src/components/documentation/tsdoc/TSDoc.tsx#L40-L48

An extra `/` was being prepended unnecessarily, causing URLs to have `//` somewhere. This pull request removes that.