### PR TITLE
docs: Use `@link` in `@see`

### DIFF
--- a/packages/brokers/src/brokers/Broker.ts
+++ b/packages/brokers/src/brokers/Broker.ts
@@ -26,7 +26,9 @@ export interface BaseBrokerOptions {
 	 */
 	maxChunk?: number;
 	/**
-	 * Unique consumer name. See: https://redis.io/commands/xreadgroup/
+	 * Unique consumer name.
+	 *
+	 * @see {@link https://redis.io/commands/xreadgroup/}
 	 */
 	name?: string;
 }

--- a/packages/brokers/src/brokers/redis/BaseRedis.ts
+++ b/packages/brokers/src/brokers/redis/BaseRedis.ts
@@ -32,7 +32,7 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 	implements IBaseBroker<TEvents>
 {
 	/**
-	 * Used for Redis queues, see the 3rd argument taken by {@link https://redis.io/commands/xadd | xadd }
+	 * Used for Redis queues, see the 3rd argument taken by {@link https://redis.io/commands/xadd | xadd}
 	 */
 	public static readonly STREAM_DATA_KEY = 'data';
 

--- a/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
+++ b/packages/builders/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
@@ -84,7 +84,7 @@ export class ContextMenuCommandBuilder {
 	 * @remarks
 	 * If set to `false`, you will have to later `PUT` the permissions for this command.
 	 * @param value - Whether or not to enable this command by default
-	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
+	 * @see {@link https://discord.com/developers/docs/interactions/application-commands#permissions}
 	 * @deprecated Use {@link ContextMenuCommandBuilder.setDefaultMemberPermissions} or {@link ContextMenuCommandBuilder.setDMPermission} instead.
 	 */
 	public setDefaultPermission(value: boolean) {
@@ -102,7 +102,7 @@ export class ContextMenuCommandBuilder {
 	 * @remarks
 	 * You can set this to `'0'` to disable the command by default.
 	 * @param permissions - The permissions bit field to set
-	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
+	 * @see {@link https://discord.com/developers/docs/interactions/application-commands#permissions}
 	 */
 	public setDefaultMemberPermissions(permissions: Permissions | bigint | number | null | undefined) {
 		// Assert the value and parse it
@@ -118,7 +118,7 @@ export class ContextMenuCommandBuilder {
 	 * By default, commands are visible.
 	 *
 	 * @param enabled - If the command should be enabled in DMs
-	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
+	 * @see {@link https://discord.com/developers/docs/interactions/application-commands#permissions}
 	 */
 	public setDMPermission(enabled: boolean | null | undefined) {
 		// Assert the value matches the conditions

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -95,7 +95,7 @@ export class SlashCommandBuilder {
 	 * @remarks
 	 * If set to `false`, you will have to later `PUT` the permissions for this command.
 	 * @param value - Whether or not to enable this command by default
-	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
+	 * @see {@link https://discord.com/developers/docs/interactions/application-commands#permissions}
 	 * @deprecated Use {@link (SlashCommandBuilder:class).setDefaultMemberPermissions} or {@link (SlashCommandBuilder:class).setDMPermission} instead.
 	 */
 	public setDefaultPermission(value: boolean) {
@@ -113,7 +113,7 @@ export class SlashCommandBuilder {
 	 * @remarks
 	 * You can set this to `'0'` to disable the command by default.
 	 * @param permissions - The permissions bit field to set
-	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
+	 * @see {@link https://discord.com/developers/docs/interactions/application-commands#permissions}
 	 */
 	public setDefaultMemberPermissions(permissions: Permissions | bigint | number | null | undefined) {
 		// Assert the value and parse it
@@ -129,7 +129,7 @@ export class SlashCommandBuilder {
 	 * By default, commands are visible.
 	 *
 	 * @param enabled - If the command should be enabled in DMs
-	 * @see https://discord.com/developers/docs/interactions/application-commands#permissions
+	 * @see {@link https://discord.com/developers/docs/interactions/application-commands#permissions}
 	 */
 	public setDMPermission(enabled: boolean | null | undefined) {
 		// Assert the value matches the conditions

--- a/packages/builders/src/interactions/slashCommands/SlashCommandSubcommands.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandSubcommands.ts
@@ -13,7 +13,7 @@ import { SharedSlashCommandOptions } from './mixins/SharedSlashCommandOptions.js
 /**
  * Represents a folder for subcommands
  *
- * For more information, go to https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups}
  */
 @mix(SharedNameAndDescription)
 export class SlashCommandSubcommandGroupBuilder implements ToAPIApplicationCommandOptions {
@@ -79,7 +79,7 @@ export interface SlashCommandSubcommandGroupBuilder extends SharedNameAndDescrip
 /**
  * Represents a subcommand
  *
- * For more information, go to https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups
+ * @see {@link https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups}
  */
 @mix(SharedNameAndDescription, SharedSlashCommandOptions)
 export class SlashCommandSubcommandBuilder implements ToAPIApplicationCommandOptions {

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -94,7 +94,7 @@ export class EmbedBuilder {
 	 *
 	 * @remarks
 	 * This method behaves similarly
-	 * to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice}.
+	 * to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
 	 * The maximum amount of fields that can be added is 25.
 	 *
 	 * It's useful for modifying and adjusting order of the already-existing fields of an embed.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As stated in [`@see`](https://tsdoc.org/pages/tags/see), an explicit `@link` tag is required for linking. Wherever we put a link, it must be in a `@link` tag.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
