### PR TITLE
fix: Correct `@link` tags that involve parents

### DIFF
--- a/apps/website/src/components/documentation/util.ts
+++ b/apps/website/src/components/documentation/util.ts
@@ -8,6 +8,7 @@ import type {
 	ApiPropertySignature,
 } from '@microsoft/api-extractor-model';
 import type { TableOfContentsSerialized } from '../TableOfContentItems';
+import { METHOD_SEPARATOR, OVERLOAD_SEPARATOR } from '~/util/constants';
 import { resolveMembers } from '~/util/members';
 
 export function hasProperties(item: ApiItemContainerMixin) {
@@ -23,7 +24,11 @@ export function hasMethods(item: ApiItemContainerMixin) {
 }
 
 export function resolveItemURI(item: ApiItem): string {
-	return `${item.displayName}:${item.kind}`;
+	return item.parent?.kind === ApiItemKind.EntryPoint
+		? `${item.displayName}${OVERLOAD_SEPARATOR}${item.kind}`
+		: `${item.parent?.displayName ?? 'Unknown'}${OVERLOAD_SEPARATOR}${
+				item.parent?.kind ?? 'Unknown'
+		  }${METHOD_SEPARATOR}${item.displayName}`;
 }
 
 function memberPredicate(item: ApiItem): item is ApiMethod | ApiMethodSignature | ApiProperty | ApiPropertySignature {

--- a/apps/website/src/components/documentation/util.ts
+++ b/apps/website/src/components/documentation/util.ts
@@ -24,7 +24,7 @@ export function hasMethods(item: ApiItemContainerMixin) {
 }
 
 export function resolveItemURI(item: ApiItem): string {
-	return !item.parent || item.parent?.kind === ApiItemKind.EntryPoint
+	return !item.parent || item.parent.kind === ApiItemKind.EntryPoint
 		? `${item.displayName}${OVERLOAD_SEPARATOR}${item.kind}`
 		: `${item.parent.displayName}${OVERLOAD_SEPARATOR}${item.parent.kind}${METHOD_SEPARATOR}${item.displayName}`;
 }

--- a/apps/website/src/components/documentation/util.ts
+++ b/apps/website/src/components/documentation/util.ts
@@ -24,11 +24,9 @@ export function hasMethods(item: ApiItemContainerMixin) {
 }
 
 export function resolveItemURI(item: ApiItem): string {
-	return item.parent?.kind === ApiItemKind.EntryPoint
+	return !item.parent || item.parent?.kind === ApiItemKind.EntryPoint
 		? `${item.displayName}${OVERLOAD_SEPARATOR}${item.kind}`
-		: `${item.parent?.displayName ?? 'Unknown'}${OVERLOAD_SEPARATOR}${
-				item.parent?.kind ?? 'Unknown'
-		  }${METHOD_SEPARATOR}${item.displayName}`;
+		: `${item.parent.displayName}${OVERLOAD_SEPARATOR}${item.parent.kind}${METHOD_SEPARATOR}${item.displayName}`;
 }
 
 function memberPredicate(item: ApiItem): item is ApiMethod | ApiMethodSignature | ApiProperty | ApiPropertySignature {

--- a/apps/website/src/util/constants.ts
+++ b/apps/website/src/util/constants.ts
@@ -16,6 +16,8 @@ export const N_RECENT_VERSIONS = 2;
 
 export const OVERLOAD_SEPARATOR = ':';
 
+export const METHOD_SEPARATOR = '#';
+
 export const DESCRIPTION =
 	"discord.js is a powerful Node.js module that allows you to interact with the Discord API very easily. It takes a much more object-oriented approach than most other JS Discord libraries, making your bot's code significantly tidier and easier to comprehend.";
 

--- a/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/packages/builders/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -50,7 +50,7 @@ export class SlashCommandBuilder {
 	 * Whether the command is enabled by default when the app is added to a guild
 	 *
 	 * @deprecated This property is deprecated and will be removed in the future.
-	 * You should use {@link (SlashCommandBuilder:class).setDefaultMemberPermissions} or {@link (SlashCommandBuilder:class).setDMPermission} instead.
+	 * You should use {@link SlashCommandBuilder.setDefaultMemberPermissions} or {@link SlashCommandBuilder.setDMPermission} instead.
 	 */
 	public readonly default_permission: boolean | undefined = undefined;
 
@@ -96,7 +96,7 @@ export class SlashCommandBuilder {
 	 * If set to `false`, you will have to later `PUT` the permissions for this command.
 	 * @param value - Whether or not to enable this command by default
 	 * @see {@link https://discord.com/developers/docs/interactions/application-commands#permissions}
-	 * @deprecated Use {@link (SlashCommandBuilder:class).setDefaultMemberPermissions} or {@link (SlashCommandBuilder:class).setDMPermission} instead.
+	 * @deprecated Use {@link SlashCommandBuilder.setDefaultMemberPermissions} or {@link SlashCommandBuilder.setDMPermission} instead.
 	 */
 	public setDefaultPermission(value: boolean) {
 		// Assert the value matches the conditions


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently, the only `@link`s that work are those that do not have parents. Those look like `{@link JSONEncodable}`, `{@link RedisBrokerOptions}`, `{@link JSONEncodable}` etc. However, if we were to do `{@link JSONEncodable.toJSON}`, the link becomes malformed. We are looking for the `toJSON` symbol of `JSONEncodable`, but the code had no parent check.

I have opted to fix this by checking if the parent is the `ApiItemKind.EntryPoint`. If this condition is met, it _should_ have no parent and we proceed as we always have. If it is not `ApiItemKind.EntryPoint`, then we can parse the parent.