### PR TITLE
perf(RoleManager): dont call Role#position getter twice per role

### DIFF
--- a/packages/discord.js/src/managers/RoleManager.js
+++ b/packages/discord.js/src/managers/RoleManager.js
@@ -307,11 +307,14 @@ class RoleManager extends CachedManager {
       throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'role', 'Role nor a Snowflake');
     }
 
-    if (resolvedRole1.position === resolvedRole2.position) {
+    const role1Position = resolvedRole1.position;
+    const role2Position = resolvedRole2.position;
+
+    if (role1Position === role2Position) {
       return Number(BigInt(resolvedRole2.id) - BigInt(resolvedRole1.id));
     }
 
-    return resolvedRole1.position - resolvedRole2.position;
+    return role1Position - role2Position;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Stored the position of the roles to not call the `position` getter twice per role as it is a reasonably heavy operation

<details>
<summary>Role#position</summary>

https://github.com/discordjs/discord.js/blob/b2eec5f9fcf37ebb3b7f87a67a6ee3160c182183/packages/discord.js/src/structures/Role.js#L186-L189
https://github.com/discordjs/discord.js/blob/b2eec5f9fcf37ebb3b7f87a67a6ee3160c182183/packages/discord.js/src/structures/Guild.js#L1296-L1298
https://github.com/discordjs/discord.js/blob/b2eec5f9fcf37ebb3b7f87a67a6ee3160c182183/packages/discord.js/src/util/Util.js#L270-L277
</details>

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
