### PR TITLE
feat: Support `@defaultValue`

### DIFF
--- a/apps/website/src/components/documentation/tsdoc/BlockComment.tsx
+++ b/apps/website/src/components/documentation/tsdoc/BlockComment.tsx
@@ -18,7 +18,7 @@ export function ExampleBlock({
 }
 
 export function DefaultValueBlock({ children }: PropsWithChildren): JSX.Element {
-	return <Block title="Default Value">{children}</Block>;
+	return <Block title="Default value">{children}</Block>;
 }
 
 export function RemarksBlock({ children }: PropsWithChildren): JSX.Element {

--- a/apps/website/src/components/documentation/tsdoc/BlockComment.tsx
+++ b/apps/website/src/components/documentation/tsdoc/BlockComment.tsx
@@ -18,7 +18,7 @@ export function ExampleBlock({
 }
 
 export function DefaultValueBlock({ children }: PropsWithChildren): JSX.Element {
-	return <Block title="Default value">{children}</Block>;
+	return <Block title="Default Value">{children}</Block>;
 }
 
 export function RemarksBlock({ children }: PropsWithChildren): JSX.Element {

--- a/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
+++ b/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
@@ -6,7 +6,7 @@ import { Fragment, useCallback, type ReactNode } from 'react';
 import { ItemLink } from '../../ItemLink';
 import { SyntaxHighlighter } from '../../SyntaxHighlighter';
 import { resolveItemURI } from '../util';
-import { DeprecatedBlock, ExampleBlock, RemarksBlock, SeeBlock } from './BlockComment';
+import { DefaultValueBlock, DeprecatedBlock, ExampleBlock, RemarksBlock, SeeBlock } from './BlockComment';
 
 export function TSDoc({ item, tsdoc }: { item: ApiItem; tsdoc: DocNode }): JSX.Element {
 	const createNode = useCallback(
@@ -84,12 +84,19 @@ export function TSDoc({ item, tsdoc }: { item: ApiItem; tsdoc: DocNode }): JSX.E
 						(block) => block.blockTag.tagName.toUpperCase() === StandardTags.example.tagNameWithUpperCase,
 					);
 
+					const defaultValueBlock = comment.customBlocks.find(
+						(block) => block.blockTag.tagName.toUpperCase() === StandardTags.defaultValue.tagNameWithUpperCase,
+					);
+
 					return (
 						<div className="flex flex-col space-y-2">
 							{comment.deprecatedBlock ? (
 								<DeprecatedBlock>{createNode(comment.deprecatedBlock.content)}</DeprecatedBlock>
 							) : null}
 							{comment.summarySection ? createNode(comment.summarySection) : null}
+							{defaultValueBlock ? (
+								<DefaultValueBlock>{createNode(defaultValueBlock.content)}</DefaultValueBlock>
+							) : null}
 							{comment.remarksBlock ? <RemarksBlock>{createNode(comment.remarksBlock.content)}</RemarksBlock> : null}
 							{exampleBlocks.length
 								? exampleBlocks.map((block, idx) => <ExampleBlock key={idx}>{createNode(block.content)}</ExampleBlock>)

--- a/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
+++ b/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
@@ -94,10 +94,10 @@ export function TSDoc({ item, tsdoc }: { item: ApiItem; tsdoc: DocNode }): JSX.E
 								<DeprecatedBlock>{createNode(comment.deprecatedBlock.content)}</DeprecatedBlock>
 							) : null}
 							{comment.summarySection ? createNode(comment.summarySection) : null}
+							{comment.remarksBlock ? <RemarksBlock>{createNode(comment.remarksBlock.content)}</RemarksBlock> : null}
 							{defaultValueBlock ? (
 								<DefaultValueBlock>{createNode(defaultValueBlock.content)}</DefaultValueBlock>
 							) : null}
-							{comment.remarksBlock ? <RemarksBlock>{createNode(comment.remarksBlock.content)}</RemarksBlock> : null}
 							{exampleBlocks.length
 								? exampleBlocks.map((block, idx) => <ExampleBlock key={idx}>{createNode(block.content)}</ExampleBlock>)
 								: null}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds support for the `@defaultValue` tag. Like the `@example` tag, this had to be found in the custom blocks.