### PR TITLE
Revert "chore: disable scope-case rule for commitlint"

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -5,7 +5,6 @@
 			2,
 			"always",
 			["chore", "build", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test", "types", "typings"]
-		],
-		"scope-case": [0]
+		]
 	}
 }


### PR DESCRIPTION
Reverts discordjs/discord.js#7507