### PR TITLE
fix(website): link dapi-types to proper website

### DIFF
--- a/apps/website/src/components/ExcerptText.tsx
+++ b/apps/website/src/components/ExcerptText.tsx
@@ -1,5 +1,6 @@
 import type { ApiModel, Excerpt } from '@microsoft/api-extractor-model';
 import { ExcerptTokenKind } from '@microsoft/api-extractor-model';
+import Link from 'next/link';
 import { ItemLink } from './ItemLink';
 import { resolveItemURI } from './documentation/util';
 
@@ -20,8 +21,22 @@ export interface ExcerptTextProps {
 export function ExcerptText({ model, excerpt }: ExcerptTextProps) {
 	return (
 		<>
-			{excerpt.spannedTokens.map((token) => {
+			{excerpt.spannedTokens.map((token, idx) => {
 				if (token.kind === ExcerptTokenKind.Reference) {
+					const source = token.canonicalReference?.source;
+
+					if (source && 'packageName' in source && source.packageName === 'discord-api-types') {
+						const base = 'https://discord-api-types.dev/api/discord-api-types-v10';
+						const meaning = token.canonicalReference.symbol?.meaning;
+						const href = meaning === 'type' ? `${base}#${token.text}` : `${base}/${meaning}/${token.text}`;
+
+						return (
+							<Link className="text-blurple" href={href} key={idx}>
+								{token.text}
+							</Link>
+						);
+					}
+
 					const item = model.resolveDeclarationReference(token.canonicalReference!, model).resolvedApiItem;
 
 					if (!item) {

--- a/apps/website/src/components/ExcerptText.tsx
+++ b/apps/website/src/components/ExcerptText.tsx
@@ -1,8 +1,8 @@
 import type { ApiModel, Excerpt } from '@microsoft/api-extractor-model';
 import { ExcerptTokenKind } from '@microsoft/api-extractor-model';
-import Link from 'next/link';
 import { ItemLink } from './ItemLink';
 import { resolveItemURI } from './documentation/util';
+import { DISCORD_API_TYPES_DOCS_URL } from '~/util/constants';
 
 export interface ExcerptTextProps {
 	/**
@@ -26,14 +26,16 @@ export function ExcerptText({ model, excerpt }: ExcerptTextProps) {
 					const source = token.canonicalReference?.source;
 
 					if (source && 'packageName' in source && source.packageName === 'discord-api-types') {
-						const base = 'https://discord-api-types.dev/api/discord-api-types-v10';
 						const meaning = token.canonicalReference.symbol?.meaning;
-						const href = meaning === 'type' ? `${base}#${token.text}` : `${base}/${meaning}/${token.text}`;
+						const href =
+							meaning === 'type'
+								? `${DISCORD_API_TYPES_DOCS_URL}#${token.text}`
+								: `${DISCORD_API_TYPES_DOCS_URL}/${meaning}/${token.text}`;
 
 						return (
-							<Link className="text-blurple" href={href} key={idx}>
+							<a className="text-blurple" href={href} key={idx} rel="external noreferrer noopener" target="_blank">
 								{token.text}
-							</Link>
+							</a>
 						);
 					}
 

--- a/apps/website/src/util/constants.ts
+++ b/apps/website/src/util/constants.ts
@@ -38,3 +38,6 @@ client.on('interactionCreate', async (interaction) => {
 });
 
 await client.login(TOKEN);`;
+
+export const DISCORD_API_TYPES_VERSION = 'v10';
+export const DISCORD_API_TYPES_DOCS_URL = `https://discord-api-types.dev/api/discord-api-types-${DISCORD_API_TYPES_VERSION}`;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes [DJS-26](https://linear.app/discord-js/issue/DJS-26/discord-api-types-automatic-linking-no-longer-functioning)

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 91d3966</samp>

### Summary
📝🔗🚀

<!--
1.  📝 - This emoji represents documentation or writing, and could be used to indicate that the `ExcerptText` component was updated to create links to the documentation of another package.
2.  🔗 - This emoji represents links or connections, and could be used to indicate that the `ExcerptText` component was updated to use the `Link` component from `next/link`, which creates dynamic and optimized links for the Next.js framework.
3.  🚀 - This emoji represents launch or improvement, and could be used to indicate that the `ExcerptText` component was updated to enhance the documentation website's usability and consistency, which could benefit the users and developers of the package.
-->
Updated the `ExcerptText` component to use `next/link` for `discord-api-types` links. This improves the documentation website's navigation and style.

> _We're sailing on the web with `next/link` in hand_
> _We're making docs more useful with `discord-api-types`_
> _We'll heave away and haul away with every pull request_
> _We're the `ExcerptText` crew and we aim to do our best_

### Walkthrough
*  Import `Link` component from `next/link` to create external links ([link](https://github.com/discordjs/discord.js/pull/9388/files?diff=unified&w=0#diff-bff30f02e821decd9f9565639370b55e00383a834a7d857bb0f0eb0af6a70a6fR3))
*  Modify `ExcerptText` component to handle references to `discord-api-types` package ([link](https://github.com/discordjs/discord.js/pull/9388/files?diff=unified&w=0#diff-bff30f02e821decd9f9565639370b55e00383a834a7d857bb0f0eb0af6a70a6fL23-R39))

