### PR TITLE
feat(Attachment): voice messages

### DIFF
--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -102,7 +102,8 @@ class Attachment {
 
     if ('duration_secs' in data) {
       /**
-       * The duration of this attachment in seconds (if an audio)
+       * The duration of this attachment in seconds
+       * <info>This will only be available if the attachment is an audio file.</info>
        * @type {?number}
        */
       this.duration = data.duration_secs;
@@ -112,7 +113,8 @@ class Attachment {
 
     if ('waveform' in data) {
       /**
-       * The base64 encoded bytearray representing a sampled waveform (if an audio)
+       * The base64 encoded byte array representing a sampled waveform
+       * <info>This will only be available if the attachment is an audio file.</info>
        * @type {?string}
        */
       this.waveform = data.waveform;

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -99,6 +99,26 @@ class Attachment {
      * @type {boolean}
      */
     this.ephemeral = data.ephemeral ?? false;
+
+    if ('duration_secs' in data) {
+      /**
+       * The duration of this attachment in seconds (if an audio)
+       * @type {?number}
+       */
+      this.duration = data.duration_secs;
+    } else {
+      this.duration ??= null;
+    }
+
+    if ('waveform' in data) {
+      /**
+       * The base64 encoded bytearray representing a sampled waveform (if an audio)
+       * @type {?string}
+       */
+      this.waveform = data.waveform;
+    } else {
+      this.waveform ??= null;
+    }
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2014,6 +2014,7 @@ export class Attachment {
   private attachment: BufferResolvable | Stream;
   public contentType: string | null;
   public description: string | null;
+  public duration: number | null;
   public ephemeral: boolean;
   public height: number | null;
   public id: Snowflake;
@@ -2022,6 +2023,7 @@ export class Attachment {
   public size: number;
   public get spoiler(): boolean;
   public url: string;
+  public waveform: string | null;
   public width: number | null;
   public toJSON(): unknown;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Upstream:
- https://github.com/discord/discord-api-docs/pull/6082

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e499142</samp>

### Summary
🎵📊🕒

<!--
1.  🎵 - This emoji represents the audio or music aspect of the change, as it adds properties related to audio files and their playback.
2.  📊 - This emoji represents the waveform property, which is a graphical representation of the sound amplitude over time. This emoji can also suggest data analysis or visualization.
3.  🕒 - This emoji represents the duration property, which is the length of the audio file in seconds. This emoji can also suggest time or duration.
-->
Add support for audio attachments by introducing `duration` and `waveform` properties to the `Attachment` class. Use nullish coalescing to handle optional data.

> _`Attachment` grows_
> _Two new fields for audio_
> _Winter silence ?? null_

### Walkthrough
*  Add `duration` and `waveform` properties to `Attachment` class ([link](https://github.com/discordjs/discord.js/pull/9392/files?diff=unified&w=0#diff-9c01b1ca3384a4b375daf5cda7150584781231ecbb2b86ead440a4a7ce024d23R102-R121),   )



**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
