### PR TITLE
fix(website): right-align search bar

### DIFF
--- a/apps/website/src/components/Header.tsx
+++ b/apps/website/src/components/Header.tsx
@@ -74,7 +74,7 @@ export default function Header() {
 					>
 						<VscMenu size={24} />
 					</Button>
-					<div className="hidden lg:flex lg:flex-row lg:overflow-hidden">{breadcrumbs}</div>
+					<div className="hidden lg:flex lg:grow lg:flex-row lg:overflow-hidden">{breadcrumbs}</div>
 					<Button
 						as="div"
 						className="w-56 grow rounded bg-white px-4 py-2.5 outline-0 sm:grow-0 dark:bg-dark-800 focus:ring focus:ring-width-2 focus:ring-blurple"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes an issue where the search bar on the website would move positions depending on the width of the text in the breadcrumb.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4690c9d</samp>

*  Add `lg:grow` class to the div element that contains the breadcrumbs to improve the layout and alignment of the header components on large screens ([link](https://github.com/discordjs/discord.js/pull/9395/files?diff=unified&w=0#diff-ac467ef87392b7a5f95f0b73cab0295be6c96bacdbd85931fcabfde0d960c172L77-R77))