### PR TITLE
feat(website): only show anchor link icons when hovering

### DIFF
--- a/apps/website/src/components/Anchor.tsx
+++ b/apps/website/src/components/Anchor.tsx
@@ -2,7 +2,10 @@ import { FiLink } from '@react-icons/all-files/fi/FiLink';
 
 export function Anchor({ href }: { href: string }) {
 	return (
-		<a className="mr-1 inline-block rounded outline-0 focus:ring focus:ring-width-2 focus:ring-blurple" href={href}>
+		<a
+			className="mr-1 inline-block rounded outline-0 group-hover:visible sm:visible lg:invisible focus:ring focus:ring-width-2 focus:ring-blurple"
+			href={href}
+		>
 			<FiLink size={20} />
 		</a>
 	);

--- a/apps/website/src/components/Property.tsx
+++ b/apps/website/src/components/Property.tsx
@@ -55,7 +55,7 @@ export function Property({
 						) : null}
 					</div>
 				) : null}
-				<div className="flex flex-row flex-wrap place-items-center gap-1">
+				<div className="group flex flex-row flex-wrap place-items-center gap-1">
 					<Anchor href={`#${item.displayName}`} />
 					<h4 className="break-all font-mono text-lg font-bold">
 						{item.displayName}

--- a/apps/website/src/components/model/method/MethodHeader.tsx
+++ b/apps/website/src/components/model/method/MethodHeader.tsx
@@ -46,7 +46,7 @@ export function MethodHeader({ method }: { method: ApiMethod | ApiMethodSignatur
 						) : null}
 					</div>
 				) : null}
-				<div className="flex flex-row flex-wrap place-items-center gap-1">
+				<div className="group flex flex-row flex-wrap place-items-center gap-1">
 					<Anchor href={`#${key}`} />
 					<h4 className="break-all font-mono text-lg font-bold">{getShorthandName(method)}</h4>
 					<h4 className="font-mono text-lg font-bold">:</h4>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously anchor icons were always visible for headings inside of an API item. Now they only appear when hovering over the headings. On mobile they still are always present.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3bfeefa</samp>

*  Make anchor elements visible only on small screens or when parent element is hovered, and invisible on large screens ([link](https://github.com/discordjs/discord.js/pull/9396/files?diff=unified&w=0#diff-31ec587f981167eddd11a3b2f9756abcee55fa051334536b07646a8ef71c0c45L5-R8), [link](https://github.com/discordjs/discord.js/pull/9396/files?diff=unified&w=0#diff-b2c59877c6a27ca521f19e1618377902dea31ec20f48aaa37456d8686c5470c8L49-R49), [link](https://github.com/discordjs/discord.js/pull/9396/files?diff=unified&w=0#diff-ac30668b4717c4333a4a90c56f4a32c12577aec6605b3b0f279fd4c077363959L58-R58))
  * Modify `Anchor` component to add `group-hover:visible sm:visible lg:invisible` class to anchor element ([link](https://github.com/discordjs/discord.js/pull/9396/files?diff=unified&w=0#diff-31ec587f981167eddd11a3b2f9756abcee55fa051334536b07646a8ef71c0c45L5-R8))
  * Modify `MethodHeader` and `Property` components to add `group` class to div element that wraps anchor and heading elements ([link](https://github.com/discordjs/discord.js/pull/9396/files?diff=unified&w=0#diff-b2c59877c6a27ca521f19e1618377902dea31ec20f48aaa37456d8686c5470c8L49-R49), [link](https://github.com/discordjs/discord.js/pull/9396/files?diff=unified&w=0#diff-ac30668b4717c4333a4a90c56f4a32c12577aec6605b3b0f279fd4c077363959L58-R58))