### PR TITLE
fix(collection): `filter()` markdown

### DIFF
--- a/apps/guide/src/content/03-additional-info/02-collections.mdx
+++ b/apps/guide/src/content/03-additional-info/02-collections.mdx
@@ -106,7 +106,7 @@ collection.sweep((user) => user.username === 'Bob');
 </CH.Code>
 
 A more complicated method is _`partition`_, which splits a single Collection into two new Collections based on the provided function.
-You can think of it as two \_`filter`\_s, but done at the same time:
+You can think of it as two \_`filter`\_ methods, but done at the same time:
 
 <CH.Code>
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Seems `/[a-z]/i` after this markdown disrupts it. I've added a word after so it properly applies markdown.