### PR TITLE
fix(website): add equals to enum members

### DIFF
--- a/apps/website/src/components/model/enum/EnumMember.tsx
+++ b/apps/website/src/components/model/enum/EnumMember.tsx
@@ -10,6 +10,7 @@ export function EnumMember({ member }: { member: ApiEnumMember }) {
 			<div className="flex flex-col gap-2 md:flex-row md:place-items-center md:-ml-8.5">
 				<Anchor href={`#${member.displayName}`} />
 				<NameText name={member.name} />
+				<h4 className="font-bold">=</h4>
 				{member.initializerExcerpt ? (
 					<SignatureText excerpt={member.initializerExcerpt} model={member.getAssociatedModel()!} />
 				) : null}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds the missing `=` seperator to enum members.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e05ba09</samp>

*  Add `=` sign to enum member rendering ([link](https://github.com/discordjs/discord.js/pull/9405/files?diff=unified&w=0#diff-c2b5c0722cb1b4b18bd441dc3ffe7641768b5ded01fb84c2177a166ff43c4896R13))