### PR TITLE
types(ModalSubmitFields): components is an array

### DIFF
--- a/packages/discord.js/src/structures/ModalSubmitInteraction.js
+++ b/packages/discord.js/src/structures/ModalSubmitInteraction.js
@@ -88,12 +88,13 @@ class ModalSubmitInteraction extends BaseInteraction {
    * @returns {ModalData[]}
    */
   static transformComponent(rawComponent) {
-    return {
-      value: rawComponent.value,
-      type: rawComponent.type,
-      customId: rawComponent.custom_id,
-      components: rawComponent.components?.map(c => this.transformComponent(c)),
-    };
+    return rawComponent.components
+      ? { type: rawComponent.type, components: rawComponent.components.map(c => this.transformComponent(c)) }
+      : {
+          value: rawComponent.value,
+          type: rawComponent.type,
+          customId: rawComponent.custom_id,
+        };
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2217,17 +2217,15 @@ export interface TextInputModalData extends BaseModalData {
 
 export interface ActionRowModalData {
   type: ComponentType.ActionRow;
-  components: ModalData[];
+  components: TextInputModalData[];
 }
-
-export type ModalData = TextInputModalData | ActionRowModalData;
 
 export class ModalSubmitFields {
   constructor(components: ModalActionRowComponent[][]);
-  public components: ActionRow<ModalActionRowComponent>[];
+  public components: ActionRowModalData[];
   public fields: Collection<string, ModalActionRowComponent>;
-  public getField<T extends ComponentType>(customId: string, type: T): { type: T } & ModalData;
-  public getField(customId: string, type?: ComponentType): ModalData;
+  public getField<T extends ComponentType>(customId: string, type: T): { type: T } & TextInputModalData;
+  public getField(customId: string, type?: ComponentType): TextInputModalData;
   public getTextInputValue(customId: string): string;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2224,7 +2224,7 @@ export type ModalData = TextInputModalData | ActionRowModalData;
 
 export class ModalSubmitFields {
   constructor(components: ModalActionRowComponent[][]);
-  public components: ActionRow<ModalActionRowComponent>;
+  public components: ActionRow<ModalActionRowComponent>[];
   public fields: Collection<string, ModalActionRowComponent>;
   public getField<T extends ComponentType>(customId: string, type: T): { type: T } & ModalData;
   public getField(customId: string, type?: ComponentType): ModalData;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR simply fixes an issue in ModalSubmitFields#components as it wasn't marked as an array and instead was simply an action row

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
