### PR TITLE
feat(website): use tsdoc parameter names wherever possible

### DIFF
--- a/apps/website/src/components/ParameterTable.tsx
+++ b/apps/website/src/components/ParameterTable.tsx
@@ -1,24 +1,27 @@
-import type { ApiParameterListMixin } from '@microsoft/api-extractor-model';
+import type { ApiDocumentedItem, ApiParameterListMixin } from '@microsoft/api-extractor-model';
 import { useMemo } from 'react';
 import { ExcerptText } from './ExcerptText';
 import { Table } from './Table';
 import { TSDoc } from './documentation/tsdoc/TSDoc';
+import { resolveParameters } from '~/util/model';
 
 const columnStyles = {
 	Name: 'font-mono whitespace-nowrap',
 	Type: 'font-mono whitespace-pre-wrap break-normal',
 };
 
-export function ParameterTable({ item }: { item: ApiParameterListMixin }) {
+export function ParameterTable({ item }: { item: ApiDocumentedItem & ApiParameterListMixin }) {
+	const params = resolveParameters(item);
+
 	const rows = useMemo(
 		() =>
-			item.parameters.map((param) => ({
+			params.map((param) => ({
 				Name: param.name,
 				Type: <ExcerptText excerpt={param.parameterTypeExcerpt} model={item.getAssociatedModel()!} />,
 				Optional: param.isOptional ? 'Yes' : 'No',
-				Description: param.tsdocParamBlock ? <TSDoc item={item} tsdoc={param.tsdocParamBlock.content} /> : 'None',
+				Description: param.description ? <TSDoc item={item} tsdoc={param.description!} /> : 'None',
 			})),
-		[item],
+		[item, params],
 	);
 
 	return (

--- a/apps/website/src/components/ParameterTable.tsx
+++ b/apps/website/src/components/ParameterTable.tsx
@@ -19,7 +19,7 @@ export function ParameterTable({ item }: { item: ApiDocumentedItem & ApiParamete
 				Name: param.name,
 				Type: <ExcerptText excerpt={param.parameterTypeExcerpt} model={item.getAssociatedModel()!} />,
 				Optional: param.isOptional ? 'Yes' : 'No',
-				Description: param.description ? <TSDoc item={item} tsdoc={param.description!} /> : 'None',
+				Description: param.description ? <TSDoc item={item} tsdoc={param.description} /> : 'None',
 			})),
 		[item, params],
 	);

--- a/apps/website/src/components/documentation/section/ParametersSection.tsx
+++ b/apps/website/src/components/documentation/section/ParametersSection.tsx
@@ -1,9 +1,9 @@
-import type { ApiParameterListMixin } from '@microsoft/api-extractor-model';
+import type { ApiDocumentedItem, ApiParameterListMixin } from '@microsoft/api-extractor-model';
 import { VscSymbolParameter } from '@react-icons/all-files/vsc/VscSymbolParameter';
 import { ParameterTable } from '../../ParameterTable';
 import { DocumentationSection } from './DocumentationSection';
 
-export function ParameterSection({ item }: { item: ApiParameterListMixin }) {
+export function ParameterSection({ item }: { item: ApiDocumentedItem & ApiParameterListMixin }) {
 	return (
 		<DocumentationSection icon={<VscSymbolParameter size={20} />} padded title="Parameters">
 			<ParameterTable item={item} />

--- a/apps/website/src/components/model/method/MethodHeader.tsx
+++ b/apps/website/src/components/model/method/MethodHeader.tsx
@@ -3,9 +3,12 @@ import { ApiItemKind } from '@microsoft/api-extractor-model';
 import { useMemo } from 'react';
 import { Anchor } from '~/components/Anchor';
 import { ExcerptText } from '~/components/ExcerptText';
+import { resolveParameters } from '~/util/model';
 
 function getShorthandName(method: ApiMethod | ApiMethodSignature) {
-	return `${method.name}${method.isOptional ? '?' : ''}(${method.parameters.reduce((prev, cur, index) => {
+	const params = resolveParameters(method);
+
+	return `${method.name}${method.isOptional ? '?' : ''}(${params.reduce((prev, cur, index) => {
 		if (index === 0) {
 			return `${prev}${cur.isOptional ? `${cur.name}?` : cur.name}`;
 		}

--- a/apps/website/src/util/model.ts
+++ b/apps/website/src/util/model.ts
@@ -34,7 +34,9 @@ interface ResolvedParameter {
  * @remarks
  * This is different from accessing `Parameter#name` or `Parameter.tsdocBlockComment` as this method cross-references the associated tsdoc
  * parameter names and descriptions and uses them as a higher precedence to the source code.
+ *
  * @param item - The api item to resolve parameter data for
+ *
  * @returns An array of parameters
  */
 export function resolveParameters(item: ApiDocumentedItem & ApiParameterListMixin): ResolvedParameter[] {

--- a/apps/website/src/util/model.ts
+++ b/apps/website/src/util/model.ts
@@ -34,9 +34,7 @@ interface ResolvedParameter {
  * @remarks
  * This is different from accessing `Parameter#name` or `Parameter.tsdocBlockComment` as this method cross-references the associated tsdoc
  * parameter names and descriptions and uses them as a higher precedence to the source code.
- *
  * @param item - The api item to resolve parameter data for
- *
  * @returns An array of parameters
  */
 export function resolveParameters(item: ApiDocumentedItem & ApiParameterListMixin): ResolvedParameter[] {

--- a/apps/website/src/util/model.ts
+++ b/apps/website/src/util/model.ts
@@ -1,4 +1,11 @@
-import type { ApiEntryPoint, ApiModel } from '@microsoft/api-extractor-model';
+import type {
+	ApiDocumentedItem,
+	ApiEntryPoint,
+	ApiModel,
+	ApiParameterListMixin,
+	Excerpt,
+} from '@microsoft/api-extractor-model';
+import type { DocSection } from '@microsoft/tsdoc';
 
 export function findMemberByKey(model: ApiModel, packageName: string, containerKey: string) {
 	const pkg = model.tryGetPackageByName(`@discordjs/${packageName}`)!;
@@ -12,4 +19,33 @@ export function findMember(model: ApiModel, packageName: string, memberName: str
 
 	const pkg = model.tryGetPackageByName(`@discordjs/${packageName}`)!;
 	return pkg.entryPoints[0]?.findMembersByName(memberName)[0];
+}
+
+interface ResolvedParameter {
+	description?: DocSection | undefined;
+	isOptional: boolean;
+	name: string;
+	parameterTypeExcerpt: Excerpt;
+}
+
+/**
+ * This takes an api item with a parameter list and resolves the names and descriptions of all the parameters.
+ *
+ * @remarks
+ * This is different from accessing `Parameter#name` or `Parameter.tsdocBlockComment` as this method cross-references the associated tsdoc
+ * parameter names and descriptions and uses them as a higher precedence to the source code.
+ * @param item - The api item to resolve parameter data for
+ * @returns An array of parameters
+ */
+export function resolveParameters(item: ApiDocumentedItem & ApiParameterListMixin): ResolvedParameter[] {
+	return item.parameters.map((param, idx) => {
+		const tsdocAnalog = item.tsdocComment?.params.blocks[idx];
+
+		return {
+			name: param.tsdocParamBlock?.parameterName ?? tsdocAnalog?.parameterName ?? param.name,
+			description: param.tsdocParamBlock?.content ?? tsdocAnalog?.content,
+			isOptional: param.isOptional,
+			parameterTypeExcerpt: param.parameterTypeExcerpt,
+		};
+	});
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR puts a higher precedence on tsdoc parameter names over source parameter names. This helps prevent situations like destructured parameters where the less readable { foo, bar } is used instead of the more readable tsdoc name "fooOptions".

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 07f710f</samp>

*  Add `resolveParameters` function to `~/util/model` module ([link](https://github.com/discordjs/discord.js/pull/9413/files?diff=unified&w=0#diff-c34bb64d4ce2b3584f952be0daf74b7a45bf965b73d1207041f37c95e514c1d2R23-R51)) to extract parameter information from tsdoc comment or source code
*  Modify `ParameterTable` component to use `resolveParameters` function and display parameter name and description from tsdoc comment if available ([link](https://github.com/discordjs/discord.js/pull/9413/files?diff=unified&w=0#diff-91e4ee520e5ad07289886c8812af623fb13097559ed59747ea6665b1b621e09eL12-R24), [link](https://github.com/discordjs/discord.js/pull/9413/files?diff=unified&w=0#diff-91e4ee520e5ad07289886c8812af623fb13097559ed59747ea6665b1b621e09eL1-R6))
*  Modify `getShorthandName` function to use `resolveParameters` function and display parameter name from tsdoc comment if available ([link](https://github.com/discordjs/discord.js/pull/9413/files?diff=unified&w=0#diff-b2c59877c6a27ca521f19e1618377902dea31ec20f48aaa37456d8686c5470c8L6-R11))
*  Modify `ParameterSection` component to accept items with parameter list and tsdoc comment and pass them to `ParameterTable` component ([link](https://github.com/discordjs/discord.js/pull/9413/files?diff=unified&w=0#diff-cd9f62ad11532599b05ec9e62fe700f0d0b3c058f01608613f34cefb0b8fc392L1-R6))
