### PR TITLE
refactor(website): extract shared code heading styling into component

### DIFF
--- a/apps/website/src/components/CodeHeading.tsx
+++ b/apps/website/src/components/CodeHeading.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react';
+import { Anchor } from './Anchor';
+
+export interface CodeListingProps {
+	/**
+	 * The value of this heading.
+	 */
+	children: ReactNode;
+	/**
+	 * Additional class names to apply to the root element.
+	 */
+	className?: string | undefined;
+	/**
+	 * The href of this heading.
+	 */
+	href?: string | undefined;
+}
+
+export function CodeHeading({ href, className, children }: CodeListingProps) {
+	return (
+		<div
+			className={`flex flex-row flex-wrap place-items-center gap-1 break-all font-mono text-lg font-bold ${className}`}
+		>
+			{href ? <Anchor href={href} /> : null}
+			{children}
+		</div>
+	);
+}

--- a/apps/website/src/components/NameText.tsx
+++ b/apps/website/src/components/NameText.tsx
@@ -1,3 +1,0 @@
-export function NameText({ name }: { name: string }) {
-	return <h4 className="break-all font-mono text-lg font-bold">{name}</h4>;
-}

--- a/apps/website/src/components/Property.tsx
+++ b/apps/website/src/components/Property.tsx
@@ -5,7 +5,7 @@ import type {
 	ApiPropertySignature,
 } from '@microsoft/api-extractor-model';
 import type { PropsWithChildren } from 'react';
-import { Anchor } from './Anchor';
+import { CodeHeading } from './CodeHeading';
 import { ExcerptText } from './ExcerptText';
 import { InheritanceText } from './InheritanceText';
 import { TSDoc } from './documentation/tsdoc/TSDoc';
@@ -55,21 +55,13 @@ export function Property({
 						) : null}
 					</div>
 				) : null}
-				<div className="flex flex-row flex-wrap place-items-center gap-1">
-					<Anchor href={`#${item.displayName}`} />
-					<h4 className="break-all font-mono text-lg font-bold">
-						{item.displayName}
-						{item.isOptional ? '?' : ''}
-					</h4>
+				<CodeHeading href={`#${item.displayName}`}>
+					{`${item.displayName}${item.isOptional ? '?' : ''}`}
+					<span>{separator}</span>
 					{item.propertyTypeExcerpt.text ? (
-						<>
-							<h4 className="font-mono text-lg font-bold">{separator}</h4>
-							<h4 className="break-all font-mono text-lg font-bold">
-								<ExcerptText excerpt={item.propertyTypeExcerpt} model={item.getAssociatedModel()!} />
-							</h4>
-						</>
+						<ExcerptText excerpt={item.propertyTypeExcerpt} model={item.getAssociatedModel()!} />
 					) : null}
-				</div>
+				</CodeHeading>
 			</div>
 			{hasSummary || inheritedFrom ? (
 				<div className="mb-4 flex flex-col gap-4">

--- a/apps/website/src/components/model/enum/EnumMember.tsx
+++ b/apps/website/src/components/model/enum/EnumMember.tsx
@@ -1,20 +1,20 @@
 import type { ApiEnumMember } from '@microsoft/api-extractor-model';
-import { Anchor } from '../../Anchor';
-import { NameText } from '../../NameText';
 import { SignatureText } from '../../SignatureText';
 import { TSDoc } from '../../documentation/tsdoc/TSDoc';
+import { CodeHeading } from '~/components/CodeHeading';
 
 export function EnumMember({ member }: { member: ApiEnumMember }) {
+	const value = member.initializerExcerpt ? (
+		<SignatureText excerpt={member.initializerExcerpt} model={member.getAssociatedModel()!} />
+	) : null;
+
 	return (
 		<div className="flex flex-col scroll-mt-30" id={member.displayName}>
-			<div className="flex flex-col gap-2 md:flex-row md:place-items-center md:-ml-8.5">
-				<Anchor href={`#${member.displayName}`} />
-				<NameText name={member.name} />
-				<h4 className="font-bold">=</h4>
-				{member.initializerExcerpt ? (
-					<SignatureText excerpt={member.initializerExcerpt} model={member.getAssociatedModel()!} />
-				) : null}
-			</div>
+			<CodeHeading className="md:-ml-8.5" href={`#${member.displayName}`}>
+				{member.name}
+				<span>=</span>
+				{value}
+			</CodeHeading>
 			{member.tsdocComment ? <TSDoc item={member} tsdoc={member.tsdocComment.summarySection} /> : null}
 		</div>
 	);

--- a/apps/website/src/components/model/enum/EnumMember.tsx
+++ b/apps/website/src/components/model/enum/EnumMember.tsx
@@ -4,16 +4,14 @@ import { TSDoc } from '../../documentation/tsdoc/TSDoc';
 import { CodeHeading } from '~/components/CodeHeading';
 
 export function EnumMember({ member }: { member: ApiEnumMember }) {
-	const value = member.initializerExcerpt ? (
-		<SignatureText excerpt={member.initializerExcerpt} model={member.getAssociatedModel()!} />
-	) : null;
-
 	return (
 		<div className="flex flex-col scroll-mt-30" id={member.displayName}>
 			<CodeHeading className="md:-ml-8.5" href={`#${member.displayName}`}>
 				{member.name}
 				<span>=</span>
-				{value}
+				{member.initializerExcerpt ? (
+					<SignatureText excerpt={member.initializerExcerpt} model={member.getAssociatedModel()!} />
+				) : null}
 			</CodeHeading>
 			{member.tsdocComment ? <TSDoc item={member} tsdoc={member.tsdocComment.summarySection} /> : null}
 		</div>

--- a/apps/website/src/components/model/method/MethodHeader.tsx
+++ b/apps/website/src/components/model/method/MethodHeader.tsx
@@ -1,7 +1,7 @@
 import type { ApiMethod, ApiMethodSignature } from '@microsoft/api-extractor-model';
 import { ApiItemKind } from '@microsoft/api-extractor-model';
 import { useMemo } from 'react';
-import { Anchor } from '~/components/Anchor';
+import { CodeHeading } from '~/components/CodeHeading';
 import { ExcerptText } from '~/components/ExcerptText';
 import { resolveParameters } from '~/util/model';
 
@@ -49,14 +49,11 @@ export function MethodHeader({ method }: { method: ApiMethod | ApiMethodSignatur
 						) : null}
 					</div>
 				) : null}
-				<div className="flex flex-row flex-wrap place-items-center gap-1">
-					<Anchor href={`#${key}`} />
-					<h4 className="break-all font-mono text-lg font-bold">{getShorthandName(method)}</h4>
-					<h4 className="font-mono text-lg font-bold">:</h4>
-					<h4 className="break-all font-mono text-lg font-bold">
-						<ExcerptText excerpt={method.returnTypeExcerpt} model={method.getAssociatedModel()!} />
-					</h4>
-				</div>
+				<CodeHeading href={`#${key}`}>
+					{getShorthandName(method)}
+					<span>:</span>
+					<ExcerptText excerpt={method.returnTypeExcerpt} model={method.getAssociatedModel()!} />
+				</CodeHeading>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Status and versioning classification:**

There was a lot of duplicated code for code headings, this PR extracts the commonalities into a reusable component.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6da24e9</samp>

*  Add a new component `CodeHeading` that renders a heading with an optional anchor and a monospaced font ([link](https://github.com/discordjs/discord.js/pull/9414/files?diff=unified&w=0#diff-ae931ddc86c011d3827740e68c6647feb7ddef0b429bede2289aae4f7b2146baR1-R28))
*  Replace the `div` elements that render code-related headings in `EnumMember`, `MethodHeader`, and `Property` components with `CodeHeading`, passing the relevant values as children and the href as a prop ( [link](https://github.com/discordjs/discord.js/pull/9414/files?diff=unified&w=0#diff-b2c59877c6a27ca521f19e1618377902dea31ec20f48aaa37456d8686c5470c8L52-R56), [link](https://github.com/discordjs/discord.js/pull/9414/files?diff=unified&w=0#diff-ac30668b4717c4333a4a90c56f4a32c12577aec6605b3b0f279fd4c077363959L58-R64))
*  Remove the unused imports of `Anchor` and `NameText` components in `EnumMember`, `MethodHeader`, and `Property` components ([link](https://github.com/discordjs/discord.js/pull/9414/files?diff=unified&w=0#diff-c2b5c0722cb1b4b18bd441dc3ffe7641768b5ded01fb84c2177a166ff43c4896L2-R17), [link](https://github.com/discordjs/discord.js/pull/9414/files?diff=unified&w=0#diff-b2c59877c6a27ca521f19e1618377902dea31ec20f48aaa37456d8686c5470c8L4-R4), [link](https://github.com/discordjs/discord.js/pull/9414/files?diff=unified&w=0#diff-ac30668b4717c4333a4a90c56f4a32c12577aec6605b3b0f279fd4c077363959L8-R8))
*  Delete the unused component `NameText` ([link](https://github.com/discordjs/discord.js/pull/9414/files?diff=unified&w=0#diff-f1e051d7a50a26d6a67a82b46418ed341d1669c33fa801ff4f6915e0c57142eb))
