### PR TITLE
refactor(rest): switch api to fetch-like and provide strategies

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 16.9.0 or newer is required.**
+**Node.js 18.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,7 +64,7 @@
 	"devDependencies": {
 		"@favware/cliff-jumper": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.8",
-		"@types/node": "16.18.25",
+		"@types/node": "18.15.11",
 		"@vitest/coverage-c8": "^0.31.0",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.1.0",
@@ -78,7 +78,7 @@
 		"vitest": "^0.31.0"
 	},
 	"engines": {
-		"node": ">=16.9.0"
+		"node": ">=18.12.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -53,7 +53,7 @@
     "@discordjs/builders": "workspace:^",
     "@discordjs/collection": "workspace:^",
     "@discordjs/formatters": "workspace:^",
-    "@discordjs/rest": "workspace:^",
+    "@discordjs/rest": "^1.7.1",
     "@discordjs/util": "workspace:^",
     "@discordjs/ws": "workspace:^",
     "@sapphire/snowflake": "^3.4.2",

--- a/packages/proxy-container/package.json
+++ b/packages/proxy-container/package.json
@@ -49,7 +49,7 @@
 		"tslib": "^2.5.0"
 	},
 	"devDependencies": {
-		"@types/node": "16.18.25",
+		"@types/node": "18.15.11",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.39.0",
 		"eslint-config-neon": "^0.1.46",
@@ -60,7 +60,7 @@
 		"typescript": "^5.0.4"
 	},
 	"engines": {
-		"node": ">=16.9.0"
+		"node": ">=18.12.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 16.9.0 or newer is required.**
+**Node.js 18.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/proxy

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -64,7 +64,7 @@
 	"devDependencies": {
 		"@favware/cliff-jumper": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.8",
-		"@types/node": "16.18.25",
+		"@types/node": "18.15.11",
 		"@types/supertest": "^2.0.12",
 		"@vitest/coverage-c8": "^0.31.0",
 		"cross-env": "^7.0.3",
@@ -79,7 +79,7 @@
 		"vitest": "^0.31.0"
 	},
 	"engines": {
-		"node": ">=16.9.0"
+		"node": ">=18.12.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/proxy/src/util/responseHelpers.ts
+++ b/packages/proxy/src/util/responseHelpers.ts
@@ -1,7 +1,7 @@
 import type { ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
-import { DiscordAPIError, HTTPError, RateLimitError } from '@discordjs/rest';
-import type { Dispatcher } from 'undici';
+import { DiscordAPIError, HTTPError, RateLimitError, type ResponseLike } from '@discordjs/rest';
 
 /**
  * Populates a server response with the data from a Discord 2xx REST response
@@ -9,19 +9,21 @@ import type { Dispatcher } from 'undici';
  * @param res - The server response to populate
  * @param data - The data to populate the response with
  */
-export async function populateSuccessfulResponse(res: ServerResponse, data: Dispatcher.ResponseData): Promise<void> {
-	res.statusCode = data.statusCode;
+export async function populateSuccessfulResponse(res: ServerResponse, data: ResponseLike): Promise<void> {
+	res.statusCode = data.status;
 
-	for (const header of Object.keys(data.headers)) {
+	for (const [header, value] of data.headers) {
 		// Strip ratelimit headers
-		if (header.startsWith('x-ratelimit')) {
+		if (/^x-ratelimit/i.test(header)) {
 			continue;
 		}
 
-		res.setHeader(header, data.headers[header]!);
+		res.setHeader(header, value);
 	}
 
-	await pipeline(data.body, res);
+	if (data.body) {
+		await pipeline(data.body instanceof Readable ? data.body : Readable.fromWeb(data.body), res);
+	}
 }
 
 /**

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 16.9.0 or newer is required.**
+**Node.js 18.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/rest
@@ -73,6 +73,25 @@ try {
 		body: {
 			name: 'Thread',
 			auto_archive_duration: 60,
+		},
+	});
+} catch (error) {
+	console.error(error);
+}
+```
+
+Send a basic message in an edge environment:
+
+```js
+import { REST } from '@discordjs/rest';
+import { Routes } from 'discord-api-types/v10';
+
+const rest = new REST({ version: '10', makeRequest: fetch }).setToken(TOKEN);
+
+try {
+	await rest.post(Routes.channelMessages(CHANNEL_ID), {
+		body: {
+			content: 'A message via REST from the edge!',
 		},
 	});
 } catch (error) {

--- a/packages/rest/__tests__/BurstHandler.test.ts
+++ b/packages/rest/__tests__/BurstHandler.test.ts
@@ -3,7 +3,7 @@
 import { performance } from 'node:perf_hooks';
 import { MockAgent, setGlobalDispatcher } from 'undici';
 import type { Interceptable, MockInterceptor } from 'undici/types/mock-interceptor';
-import { beforeEach, afterEach, test, expect, vitest } from 'vitest';
+import { beforeEach, afterEach, test, expect } from 'vitest';
 import { DiscordAPIError, REST, BurstHandlerMajorIdKey } from '../src/index.js';
 import { BurstHandler } from '../src/lib/handlers/BurstHandler.js';
 import { genPath } from './util.js';
@@ -46,6 +46,7 @@ test('Interaction callback creates burst handler', async () => {
 			auth: false,
 			body: { type: 4, data: { content: 'Reply' } },
 		}),
+		// TODO: This should be ArrayBuffer, there is a bug in undici request
 	).toBeInstanceOf(Uint8Array);
 	expect(api.requestManager.handlers.get(callbackKey)).toBeInstanceOf(BurstHandler);
 });

--- a/packages/rest/__tests__/REST.test.ts
+++ b/packages/rest/__tests__/REST.test.ts
@@ -3,10 +3,10 @@ import { URLSearchParams } from 'node:url';
 import { DiscordSnowflake } from '@sapphire/snowflake';
 import type { Snowflake } from 'discord-api-types/v10';
 import { Routes } from 'discord-api-types/v10';
-import type { FormData } from 'undici';
+import { type FormData, fetch } from 'undici';
 import { File as UndiciFile, MockAgent, setGlobalDispatcher } from 'undici';
 import type { Interceptable, MockInterceptor } from 'undici/types/mock-interceptor.js';
-import { beforeEach, afterEach, test, expect } from 'vitest';
+import { beforeEach, afterEach, test, expect, vitest } from 'vitest';
 import { REST } from '../src/index.js';
 import { genPath } from './util.js';
 
@@ -15,6 +15,10 @@ const File = NativeFile ?? UndiciFile;
 const newSnowflake: Snowflake = DiscordSnowflake.generate().toString();
 
 const api = new REST().setToken('A-Very-Fake-Token');
+
+const makeRequestMock = vitest.fn(fetch);
+
+const fetchApi = new REST({ makeRequest: makeRequestMock }).setToken('A-Very-Fake-Token');
 
 // @discordjs/rest uses the `content-type` header to detect whether to parse
 // the response as JSON or as an ArrayBuffer.
@@ -114,6 +118,22 @@ test('simple POST', async () => {
 	expect(await api.post('/simplePost')).toStrictEqual({ test: true });
 });
 
+test('simple POST with fetch', async () => {
+	mockPool
+		.intercept({
+			path: genPath('/fetchSimplePost'),
+			method: 'POST',
+		})
+		.reply(() => ({
+			data: { test: true },
+			statusCode: 200,
+			responseOptions,
+		}));
+
+	expect(await fetchApi.post('/fetchSimplePost')).toStrictEqual({ test: true });
+	expect(makeRequestMock).toHaveBeenCalledTimes(1);
+});
+
 test('simple PUT 2', async () => {
 	mockPool
 		.intercept({
@@ -159,11 +179,11 @@ test('getAuth', async () => {
 			path: genPath('/getAuth'),
 			method: 'GET',
 		})
-		.reply((from) => ({
-			data: { auth: (from.headers as unknown as Record<string, string | undefined>).Authorization ?? null },
-			statusCode: 200,
+		.reply(
+			200,
+			(from) => ({ auth: (from.headers as unknown as Record<string, string | undefined>).Authorization ?? null }),
 			responseOptions,
-		}))
+		)
 		.times(3);
 
 	// default
@@ -190,11 +210,13 @@ test('getReason', async () => {
 			path: genPath('/getReason'),
 			method: 'GET',
 		})
-		.reply((from) => ({
-			data: { reason: (from.headers as unknown as Record<string, string | undefined>)['X-Audit-Log-Reason'] ?? null },
-			statusCode: 200,
+		.reply(
+			200,
+			(from) => ({
+				reason: (from.headers as unknown as Record<string, string | undefined>)['X-Audit-Log-Reason'] ?? null,
+			}),
 			responseOptions,
-		}))
+		)
 		.times(3);
 
 	// default

--- a/packages/rest/__tests__/RequestHandler.test.ts
+++ b/packages/rest/__tests__/RequestHandler.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable id-length */
 /* eslint-disable promise/prefer-await-to-then */
 import { performance } from 'node:perf_hooks';
-import { setInterval, clearInterval, setTimeout } from 'node:timers';
+import { setInterval, clearInterval } from 'node:timers';
 import { MockAgent, setGlobalDispatcher } from 'undici';
 import type { Interceptable, MockInterceptor } from 'undici/types/mock-interceptor.js';
 import { beforeEach, afterEach, test, expect, vitest } from 'vitest';
@@ -492,7 +492,7 @@ test('server responding too slow', async () => {
 
 	const promise = api2.get('/slow');
 
-	await expect(promise).rejects.toThrowError('Request aborted');
+	await expect(promise).rejects.toThrowError('aborted');
 }, 1_000);
 
 test('Unauthorized', async () => {
@@ -570,8 +570,8 @@ test('abort', async () => {
 	controller.abort();
 
 	// Abort mid-execution:
-	await expect(bP2).rejects.toThrowError('Request aborted');
+	await expect(bP2).rejects.toThrowError('aborted');
 
 	// Abort scheduled:
-	await expect(cP2).rejects.toThrowError('Request aborted');
+	await expect(cP2).rejects.toThrowError('Request aborted manually');
 });

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -18,9 +18,16 @@
 	"module": "./dist/index.mjs",
 	"typings": "./dist/index.d.ts",
 	"exports": {
-		"types": "./dist/index.d.ts",
-		"import": "./dist/index.mjs",
-		"require": "./dist/index.js"
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.js"
+		},
+		"./*": {
+			"types": "./dist/strategies/*.d.ts",
+			"import": "./dist/strategies/*.mjs",
+			"require": "./dist/strategies/*.js"
+		}
 	},
 	"directories": {
 		"lib": "src",
@@ -66,7 +73,7 @@
 	"devDependencies": {
 		"@favware/cliff-jumper": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.8",
-		"@types/node": "16.18.25",
+		"@types/node": "18.15.11",
 		"@vitest/coverage-c8": "^0.31.0",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.1.0",
@@ -80,7 +87,7 @@
 		"vitest": "^0.31.0"
 	},
 	"engines": {
-		"node": ">=16.9.0"
+		"node": ">=18.12.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'node:events';
+import type { Readable } from 'node:stream';
+import type { ReadableStream } from 'node:stream/web';
 import type { Collection } from '@discordjs/collection';
-import type { request, Dispatcher } from 'undici';
+import type { Dispatcher, RequestInit, Response } from 'undici';
 import { CDN } from './CDN.js';
 import {
 	RequestManager,
@@ -11,7 +13,7 @@ import {
 	type RequestData,
 	type RouteLike,
 } from './RequestManager.js';
-import type { IHandler } from './handlers/IHandler.js';
+import type { IHandler } from './interfaces/Handler.js';
 import { DefaultRestOptions, RESTEvents } from './utils/constants.js';
 import { parseResponse } from './utils/utils.js';
 
@@ -22,7 +24,7 @@ export interface RESTOptions {
 	/**
 	 * The agent to set globally
 	 */
-	agent: Dispatcher;
+	agent: Dispatcher | null;
 	/**
 	 * The base api path, without version
 	 *
@@ -79,6 +81,13 @@ export interface RESTOptions {
 	 * @defaultValue `0`
 	 */
 	invalidRequestWarningInterval: number;
+	/**
+	 * The method called to perform the actual HTTP request given a url and web `fetch` options
+	 * For example, to use global fetch, simply provide `makeRequest: fetch`
+	 *
+	 * @defaultValue `undici.request`
+	 */
+	makeRequest(url: string, init: RequestInit): Promise<ResponseLike>;
 	/**
 	 * The extra offset to add to rate limits in milliseconds
 	 *
@@ -179,7 +188,7 @@ export interface APIRequest {
 	/**
 	 * Additional HTTP options for this request
 	 */
-	options: RequestOptions;
+	options: RequestInit;
 	/**
 	 * The full path used to make the request
 	 */
@@ -192,6 +201,11 @@ export interface APIRequest {
 	 * The API route identifying the ratelimit for this request
 	 */
 	route: string;
+}
+
+export interface ResponseLike
+	extends Pick<Response, 'arrayBuffer' | 'bodyUsed' | 'headers' | 'json' | 'ok' | 'status' | 'text'> {
+	body: Readable | ReadableStream | null;
 }
 
 export interface InvalidRequestWarningData {
@@ -212,7 +226,7 @@ export interface RestEvents {
 	newListener: [name: string, listener: (...args: any) => void];
 	rateLimited: [rateLimitInfo: RateLimitData];
 	removeListener: [name: string, listener: (...args: any) => void];
-	response: [request: APIRequest, response: Dispatcher.ResponseData];
+	response: [request: APIRequest, response: ResponseLike];
 	restDebug: [info: string];
 }
 
@@ -232,8 +246,6 @@ export interface REST {
 	removeAllListeners: (<K extends keyof RestEvents>(event?: K) => this) &
 		(<S extends string | symbol>(event?: Exclude<S, keyof RestEvents>) => this);
 }
-
-export type RequestOptions = Exclude<Parameters<typeof request>[1], undefined>;
 
 export class REST extends EventEmitter {
 	public readonly cdn: CDN;

--- a/packages/rest/src/lib/global/fetch.d.ts
+++ b/packages/rest/src/lib/global/fetch.d.ts
@@ -1,0 +1,5 @@
+import type * as undici from 'undici';
+
+declare global {
+	export const { fetch, FormData, Headers, Request, Response }: typeof undici;
+}

--- a/packages/rest/src/lib/handlers/BurstHandler.ts
+++ b/packages/rest/src/lib/handlers/BurstHandler.ts
@@ -1,10 +1,10 @@
 import { setTimeout as sleep } from 'node:timers/promises';
-import type { Dispatcher } from 'undici';
-import type { RequestOptions } from '../REST.js';
+import type { RequestInit } from 'undici';
+import type { ResponseLike } from '../REST.js';
 import type { HandlerRequestData, RequestManager, RouteData } from '../RequestManager.js';
+import type { IHandler } from '../interfaces/Handler.js';
 import { RESTEvents } from '../utils/constants.js';
-import { onRateLimit, parseHeader } from '../utils/utils.js';
-import type { IHandler } from './IHandler.js';
+import { onRateLimit } from '../utils/utils.js';
 import { handleErrors, incrementInvalidCount, makeNetworkRequest } from './Shared.js';
 
 /**
@@ -54,9 +54,9 @@ export class BurstHandler implements IHandler {
 	public async queueRequest(
 		routeId: RouteData,
 		url: string,
-		options: RequestOptions,
+		options: RequestInit,
 		requestData: HandlerRequestData,
-	): Promise<Dispatcher.ResponseData> {
+	): Promise<ResponseLike> {
 		return this.runRequest(routeId, url, options, requestData);
 	}
 
@@ -72,10 +72,10 @@ export class BurstHandler implements IHandler {
 	private async runRequest(
 		routeId: RouteData,
 		url: string,
-		options: RequestOptions,
+		options: RequestInit,
 		requestData: HandlerRequestData,
 		retries = 0,
-	): Promise<Dispatcher.ResponseData> {
+	): Promise<ResponseLike> {
 		const method = options.method ?? 'get';
 
 		const res = await makeNetworkRequest(this.manager, routeId, url, options, requestData, retries);
@@ -86,9 +86,9 @@ export class BurstHandler implements IHandler {
 			return this.runRequest(routeId, url, options, requestData, ++retries);
 		}
 
-		const status = res.statusCode;
+		const status = res.status;
 		let retryAfter = 0;
-		const retry = parseHeader(res.headers['retry-after']);
+		const retry = res.headers.get('Retry-After');
 
 		// Amount of time in milliseconds until we should retry if rate limited (globally or otherwise)
 		if (retry) retryAfter = Number(retry) * 1_000 + this.manager.options.offset;
@@ -102,7 +102,7 @@ export class BurstHandler implements IHandler {
 			return res;
 		} else if (status === 429) {
 			// Unexpected ratelimit
-			const isGlobal = res.headers['x-ratelimit-global'] !== undefined;
+			const isGlobal = res.headers.has('X-RateLimit-Global');
 			await onRateLimit(this.manager, {
 				timeToReset: retryAfter,
 				limit: Number.POSITIVE_INFINITY,

--- a/packages/rest/src/lib/interfaces/Handler.ts
+++ b/packages/rest/src/lib/interfaces/Handler.ts
@@ -1,5 +1,5 @@
-import type { Dispatcher } from 'undici';
-import type { RequestOptions } from '../REST.js';
+import type { RequestInit } from 'undici';
+import type { ResponseLike } from '../REST.js';
 import type { HandlerRequestData, RouteData } from '../RequestManager.js';
 
 export interface IHandler {
@@ -22,13 +22,7 @@ export interface IHandler {
 	queueRequest(
 		routeId: RouteData,
 		url: string,
-		options: RequestOptions,
+		options: RequestInit,
 		requestData: HandlerRequestData,
-	): Promise<Dispatcher.ResponseData>;
-}
-
-export interface PolyFillAbortSignal {
-	readonly aborted: boolean;
-	addEventListener(type: 'abort', listener: () => void): void;
-	removeEventListener(type: 'abort', listener: () => void): void;
+	): Promise<ResponseLike>;
 }

--- a/packages/rest/src/lib/utils/constants.ts
+++ b/packages/rest/src/lib/utils/constants.ts
@@ -1,7 +1,11 @@
 import process from 'node:process';
+import { lazy } from '@discordjs/util';
 import { APIVersion } from 'discord-api-types/v10';
-import { Agent } from 'undici';
 import type { RESTOptions } from '../REST.js';
+
+const getUndiciRequest = lazy(async () => {
+	return import('../../strategies/undiciRequest.js');
+});
 
 export const DefaultUserAgent =
 	`DiscordBot (https://discord.js.org, [VI]{{inject}}[/VI])` as `DiscordBot (https://discord.js.org, ${string})`;
@@ -12,13 +16,7 @@ export const DefaultUserAgent =
 export const DefaultUserAgentAppendix = process.release?.name === 'node' ? `Node.js/${process.version}` : '';
 
 export const DefaultRestOptions = {
-	get agent() {
-		return new Agent({
-			connect: {
-				timeout: 30_000,
-			},
-		});
-	},
+	agent: null,
 	api: 'https://discord.com/api',
 	authPrefix: 'Bot',
 	cdn: 'https://cdn.discordapp.com',
@@ -34,6 +32,10 @@ export const DefaultRestOptions = {
 	hashSweepInterval: 14_400_000, // 4 Hours
 	hashLifetime: 86_400_000, // 24 Hours
 	handlerSweepInterval: 3_600_000, // 1 Hour
+	async makeRequest(...args) {
+		const strategy = await getUndiciRequest();
+		return strategy.makeRequest(...args);
+	},
 } as const satisfies Required<RESTOptions>;
 
 /**

--- a/packages/rest/src/lib/utils/utils.ts
+++ b/packages/rest/src/lib/utils/utils.ts
@@ -1,19 +1,8 @@
-import { Blob, Buffer } from 'node:buffer';
 import { URLSearchParams } from 'node:url';
-import { types } from 'node:util';
 import type { RESTPatchAPIChannelJSONBody } from 'discord-api-types/v10';
-import { FormData, type Dispatcher, type RequestInit } from 'undici';
-import type { RateLimitData, RequestOptions } from '../REST.js';
+import type { RateLimitData, ResponseLike } from '../REST.js';
 import { type RequestManager, RequestMethod } from '../RequestManager.js';
 import { RateLimitError } from '../errors/RateLimitError.js';
-
-export function parseHeader(header: string[] | string | undefined): string | undefined {
-	if (header === undefined || typeof header === 'string') {
-		return header;
-	}
-
-	return header.join(';');
-}
 
 function serializeSearchParam(value: unknown): string | null {
 	switch (typeof value) {
@@ -61,13 +50,12 @@ export function makeURLSearchParams<T extends object>(options?: Readonly<T>) {
  *
  * @param res - The fetch response
  */
-export async function parseResponse(res: Dispatcher.ResponseData): Promise<unknown> {
-	const header = parseHeader(res.headers['content-type']);
-	if (header?.startsWith('application/json')) {
-		return res.body.json();
+export async function parseResponse(res: ResponseLike): Promise<unknown> {
+	if (res.headers.get('Content-Type')?.startsWith('application/json')) {
+		return res.json();
 	}
 
-	return res.body.arrayBuffer();
+	return res.arrayBuffer();
 }
 
 /**
@@ -92,49 +80,6 @@ export function hasSublimit(bucketRoute: string, body?: unknown, method?: string
 
 	// If we are checking if a request has a sublimit on a route not checked above, sublimit all requests to avoid a flood of 429s
 	return true;
-}
-
-export async function resolveBody(body: RequestInit['body']): Promise<RequestOptions['body']> {
-	// eslint-disable-next-line no-eq-null, eqeqeq
-	if (body == null) {
-		return null;
-	} else if (typeof body === 'string') {
-		return body;
-	} else if (types.isUint8Array(body)) {
-		return body;
-	} else if (types.isArrayBuffer(body)) {
-		return new Uint8Array(body);
-	} else if (body instanceof URLSearchParams) {
-		return body.toString();
-	} else if (body instanceof DataView) {
-		return new Uint8Array(body.buffer);
-	} else if (body instanceof Blob) {
-		return new Uint8Array(await body.arrayBuffer());
-	} else if (body instanceof FormData) {
-		return body;
-	} else if ((body as Iterable<Uint8Array>)[Symbol.iterator]) {
-		const chunks = [...(body as Iterable<Uint8Array>)];
-		const length = chunks.reduce((a, b) => a + b.length, 0);
-
-		const uint8 = new Uint8Array(length);
-		let lengthUsed = 0;
-
-		return chunks.reduce((a, b) => {
-			a.set(b, lengthUsed);
-			lengthUsed += b.length;
-			return a;
-		}, uint8);
-	} else if ((body as AsyncIterable<Uint8Array>)[Symbol.asyncIterator]) {
-		const chunks: Uint8Array[] = [];
-
-		for await (const chunk of body as AsyncIterable<Uint8Array>) {
-			chunks.push(chunk);
-		}
-
-		return Buffer.concat(chunks);
-	}
-
-	throw new TypeError(`Unable to resolve body.`);
 }
 
 /**

--- a/packages/rest/src/strategies/undiciRequest.ts
+++ b/packages/rest/src/strategies/undiciRequest.ts
@@ -1,0 +1,70 @@
+import { Buffer } from 'node:buffer';
+import { URLSearchParams } from 'node:url';
+import { types } from 'node:util';
+import { type RequestInit, request } from 'undici';
+import type { ResponseLike } from '../index.js';
+
+export type RequestOptions = Exclude<Parameters<typeof request>[1], undefined>;
+
+export async function makeRequest(url: string, init: RequestInit): Promise<ResponseLike> {
+	// The cast is necessary because `headers` and `method` are narrower types in `undici.request`
+	// our request path guarantees they are of acceptable type for `undici.request`
+	const options = {
+		...init,
+		body: await resolveBody(init.body),
+	} as RequestOptions;
+	const res = await request(url, options);
+	return {
+		body: res.body,
+		async arrayBuffer() {
+			return res.body.arrayBuffer();
+		},
+		async json() {
+			return res.body.json();
+		},
+		async text() {
+			return res.body.text();
+		},
+		get bodyUsed() {
+			return res.body.bodyUsed;
+		},
+		headers: new Headers(res.headers as Record<string, string[] | string>),
+		status: res.statusCode,
+		ok: res.statusCode >= 200 && res.statusCode < 300,
+	};
+}
+
+export async function resolveBody(body: RequestInit['body']): Promise<Exclude<RequestOptions['body'], undefined>> {
+	// eslint-disable-next-line no-eq-null, eqeqeq
+	if (body == null) {
+		return null;
+	} else if (typeof body === 'string') {
+		return body;
+	} else if (types.isUint8Array(body)) {
+		return body;
+	} else if (types.isArrayBuffer(body)) {
+		return new Uint8Array(body);
+	} else if (body instanceof URLSearchParams) {
+		return body.toString();
+	} else if (body instanceof DataView) {
+		return new Uint8Array(body.buffer);
+	} else if (body instanceof Blob) {
+		return new Uint8Array(await body.arrayBuffer());
+	} else if (body instanceof FormData) {
+		return body;
+	} else if ((body as Iterable<Uint8Array>)[Symbol.iterator]) {
+		const chunks = [...(body as Iterable<Uint8Array>)];
+
+		return Buffer.concat(chunks);
+	} else if ((body as AsyncIterable<Uint8Array>)[Symbol.asyncIterator]) {
+		const chunks: Uint8Array[] = [];
+
+		for await (const chunk of body as AsyncIterable<Uint8Array>) {
+			chunks.push(chunk);
+		}
+
+		return Buffer.concat(chunks);
+	}
+
+	throw new TypeError(`Unable to resolve body.`);
+}

--- a/packages/rest/tsup.config.ts
+++ b/packages/rest/tsup.config.ts
@@ -2,5 +2,6 @@ import { esbuildPluginVersionInjector } from 'esbuild-plugin-version-injector';
 import { createTsupConfig } from '../../tsup.config.js';
 
 export default createTsupConfig({
+	entry: ['src/index.ts', 'src/strategies/*.ts'],
 	esbuildPlugins: [esbuildPluginVersionInjector()],
 });

--- a/packages/ws/README.md
+++ b/packages/ws/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 16.9.0 or newer is required.**
+**Node.js 18.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/ws

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -74,7 +74,7 @@
 	"devDependencies": {
 		"@favware/cliff-jumper": "^2.0.0",
 		"@microsoft/api-extractor": "^7.34.8",
-		"@types/node": "16.18.25",
+		"@types/node": "18.15.11",
 		"@vitest/coverage-c8": "^0.31.0",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.1.0",
@@ -91,7 +91,7 @@
 		"zlib-sync": "^0.1.8"
 	},
 	"engines": {
-		"node": ">=16.9.0"
+		"node": ">=18.12.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 			exclude: [
 				// All ts files that only contain types, due to ALL
 				'**/*.{interface,type,d}.ts',
+				'**/{interfaces,types}/*.ts',
 				// All index files that *should* only contain exports from other files
 				'**/index.{js,ts}',
 				// All exports files that make subpackages available as submodules

--- a/yarn.lock
+++ b/yarn.lock
@@ -2102,7 +2102,7 @@ __metadata:
     "@favware/cliff-jumper": ^2.0.0
     "@microsoft/api-extractor": ^7.34.8
     "@sapphire/snowflake": ^3.4.2
-    "@types/node": 16.18.25
+    "@types/node": 18.15.11
     "@vitest/coverage-c8": ^0.31.0
     "@vladfrangu/async_event_emitter": ^2.2.1
     cross-env: ^7.0.3
@@ -2274,7 +2274,7 @@ __metadata:
   dependencies:
     "@discordjs/proxy": "workspace:^"
     "@discordjs/rest": "workspace:^"
-    "@types/node": 16.18.25
+    "@types/node": 18.15.11
     cross-env: ^7.0.3
     eslint: ^8.39.0
     eslint-config-neon: ^0.1.46
@@ -2295,7 +2295,7 @@ __metadata:
     "@discordjs/util": "workspace:^"
     "@favware/cliff-jumper": ^2.0.0
     "@microsoft/api-extractor": ^7.34.8
-    "@types/node": 16.18.25
+    "@types/node": 18.15.11
     "@types/supertest": ^2.0.12
     "@vitest/coverage-c8": ^0.31.0
     cross-env: ^7.0.3
@@ -2313,7 +2313,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@discordjs/rest@workspace:^, @discordjs/rest@workspace:packages/rest":
+"@discordjs/rest@^1.7.1, @discordjs/rest@workspace:^, @discordjs/rest@workspace:packages/rest":
   version: 0.0.0-use.local
   resolution: "@discordjs/rest@workspace:packages/rest"
   dependencies:
@@ -2323,7 +2323,7 @@ __metadata:
     "@microsoft/api-extractor": ^7.34.8
     "@sapphire/async-queue": ^1.5.0
     "@sapphire/snowflake": ^3.4.2
-    "@types/node": 16.18.25
+    "@types/node": 18.15.11
     "@vitest/coverage-c8": ^0.31.0
     cross-env: ^7.0.3
     discord-api-types: ^0.37.41
@@ -2533,7 +2533,7 @@ __metadata:
     "@favware/cliff-jumper": ^2.0.0
     "@microsoft/api-extractor": ^7.34.8
     "@sapphire/async-queue": ^1.5.0
-    "@types/node": 16.18.25
+    "@types/node": 18.15.11
     "@types/ws": ^8.5.4
     "@vitest/coverage-c8": ^0.31.0
     "@vladfrangu/async_event_emitter": ^2.2.1
@@ -6654,6 +6654,13 @@ __metadata:
   version: 16.18.25
   resolution: "@types/node@npm:16.18.25"
   checksum: 181760ad6b54fcc498dfeb249e98bbf0be51d7c35e92e760e1a82004fa42b86e8c33a8f8dd7743b5ef872bda0753d9e6a5b8e3f0aed63e9eb79b4e65760c1fbe
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:18.15.11":
+  version: 18.15.11
+  resolution: "@types/node@npm:18.15.11"
+  checksum: 977b4ad04708897ff0eb049ecf82246d210939c82461922d20f7d2dcfd81bbc661582ba3af28869210f7e8b1934529dcd46bff7d448551400f9d48b9d3bddec3
   languageName: node
   linkType: hard
 
@@ -11335,7 +11342,7 @@ __metadata:
     "@discordjs/collection": "workspace:^"
     "@discordjs/docgen": "workspace:^"
     "@discordjs/formatters": "workspace:^"
-    "@discordjs/rest": "workspace:^"
+    "@discordjs/rest": ^1.7.1
     "@discordjs/util": "workspace:^"
     "@discordjs/ws": "workspace:^"
     "@favware/cliff-jumper": ^2.0.0


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Undici request was originally chosen for performance reasons. ~~At the scale of discord bots, this performance difference is irrelevant.~~ This instead is the first step towards cross environment compatability.

This refactor also changes the actual network request portion into a strategy. By default, this will use `undici.request`. This strategy has also been provided and exported as /undiciRequest

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
