### PR TITLE
refactor(proxy): rely on auth header instead

### DIFF
--- a/packages/proxy-container/README.md
+++ b/packages/proxy-container/README.md
@@ -23,7 +23,7 @@
 
 Quickly spin up an instance:
 
-`docker run -d --restart unless-stopped --name proxy -p 127.0.0.1:8080:8080 -e DISCORD_TOKEN=abc discordjs/proxy`
+`docker run -d --restart unless-stopped --name proxy -p 127.0.0.1:8080:8080 discordjs/proxy`
 
 Use it:
 
@@ -47,6 +47,9 @@ const rest = new REST({
 	api: 'http://localhost:8080/api',
 });
 ```
+
+**Do note that you should not use the proxy with multiple bots. We cannot gurantee you won't hit ratelimits.
+Webhooks or things that don't include the Authorization header are okay, though!**
 
 ## Links
 

--- a/packages/proxy-container/README.md
+++ b/packages/proxy-container/README.md
@@ -48,7 +48,7 @@ const rest = new REST({
 });
 ```
 
-**Do note that you should not use the proxy with multiple bots. We cannot guarantee you won't hit rate limits.
+**Do note that you should not use the same proxy with multiple bots. We cannot guarantee you won't hit rate limits.
 Webhooks or things that don't include the Authorization header are okay, though!**
 
 ## Links

--- a/packages/proxy-container/README.md
+++ b/packages/proxy-container/README.md
@@ -49,7 +49,7 @@ const rest = new REST({
 ```
 
 **Do note that you should not use the same proxy with multiple bots. We cannot guarantee you won't hit rate limits.
-Webhooks or things that don't include the Authorization header are okay, though!**
+Webhooks with tokens or other requests that don't include the Authorization header are okay, though!**
 
 ## Links
 

--- a/packages/proxy-container/README.md
+++ b/packages/proxy-container/README.md
@@ -48,7 +48,7 @@ const rest = new REST({
 });
 ```
 
-**Do note that you should not use the proxy with multiple bots. We cannot gurantee you won't hit ratelimits.
+**Do note that you should not use the proxy with multiple bots. We cannot guarantee you won't hit rate limits.
 Webhooks or things that don't include the Authorization header are okay, though!**
 
 ## Links

--- a/packages/proxy-container/src/index.ts
+++ b/packages/proxy-container/src/index.ts
@@ -3,12 +3,8 @@ import process from 'node:process';
 import { proxyRequests } from '@discordjs/proxy';
 import { REST } from '@discordjs/rest';
 
-if (!process.env.DISCORD_TOKEN) {
-	throw new Error('A DISCORD_TOKEN env var is required');
-}
-
 // We want to let upstream handle retrying
-const api = new REST({ rejectOnRateLimit: () => true, retries: 0 }).setToken(process.env.DISCORD_TOKEN);
+const api = new REST({ rejectOnRateLimit: () => true, retries: 0 });
 const server = createServer(proxyRequests(api));
 
 const port = Number.parseInt(process.env.PORT ?? '8080', 10);

--- a/packages/proxy/src/handlers/proxyRequests.ts
+++ b/packages/proxy/src/handlers/proxyRequests.ts
@@ -47,7 +47,7 @@ export function proxyRequests(rest: REST): RequestHandler {
 
 			await populateSuccessfulResponse(res, discordResponse);
 		} catch (error) {
-			const knownError = await populateErrorResponse(res, error);
+			const knownError = populateErrorResponse(res, error);
 			if (!knownError) {
 				// Unclear if there's better course of action here for unknown errors.
 				// Any web framework allows to pass in an error handler for something like this

--- a/packages/proxy/src/handlers/proxyRequests.ts
+++ b/packages/proxy/src/handlers/proxyRequests.ts
@@ -38,7 +38,7 @@ export function proxyRequests(rest: REST): RequestHandler {
 				fullRoute,
 				// This type cast is technically incorrect, but we want Discord to throw Method Not Allowed for us
 				method: method as RequestMethod,
-				// We forward the auth header anwyay
+				// We forward the auth header anyway
 				auth: false,
 				passThroughBody: true,
 				query: parsedUrl.searchParams,

--- a/packages/proxy/src/util/responseHelpers.ts
+++ b/packages/proxy/src/util/responseHelpers.ts
@@ -67,7 +67,7 @@ export function populateAbortErrorResponse(res: ServerResponse): void {
  * @param error - The error to check and use
  * @returns - True if the error is known and the response object was populated, otherwise false
  */
-export async function populateErrorResponse(res: ServerResponse, error: unknown): Promise<boolean> {
+export function populateErrorResponse(res: ServerResponse, error: unknown): boolean {
 	if (error instanceof DiscordAPIError || error instanceof HTTPError) {
 		populateGeneralErrorResponse(res, error);
 	} else if (error instanceof RateLimitError) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This more or less acts as a fix for `auth: false` being completely disregarded by the proxy if a client were to use it, which can run us into the nasty 401 bug.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at eb414a9</samp>

> _We are the proxy of doom, we forward the headers of fate_
> _We don't need a token of lies, we break the chains of the gate_
> _We handle the errors of wrath, we populate the response of hate_
> _We fix the imports of death, we are the proxy of doom_

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
