### PR TITLE
docs(BaseMessageOptions): Fix embeds and components

### DIFF
--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -56,12 +56,12 @@ class TextBasedChannel {
    * The base message options for messages.
    * @typedef {Object} BaseMessageOptions
    * @property {string|null} [content=''] The content for the message. This can only be `null` when editing a message.
-   * @property {Embed[]|APIEmbed[]} [embeds] The embeds for the message
+   * @property {Array<(EmbedBuilder|Embed|APIEmbed)>} [embeds] The embeds for the message
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
-   * @property {AttachmentBuilder[]|Attachment[]|AttachmentPayload[]|BufferResolvable[]} [files]
+   * @property {Array<(AttachmentBuilder|Attachment|AttachmentPayload|BufferResolvable)>} [files]
    * The files to send with the message.
-   * @property {ActionRow[]|ActionRowBuilder[]} [components]
+   * @property {Array<(ActionRowBuilder|ActionRow|APIActionRowComponent)>} [components]
    * Action rows containing interactive components for the message (buttons, select menus)
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
For embeds, an array of `EmbedBuilder`s were missing.
For action rows, an array of `APIActionRowComponent`s were missing (this is typed already).

Also, they're now all within the same array as we simply call the JSON transformer or rebuild from the passed data, so it's technically accurate now.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
