### PR TITLE
chore: Add directory to package.json

### DIFF
--- a/apps/guide/package.json
+++ b/apps/guide/package.json
@@ -37,7 +37,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "apps/guide"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -38,7 +38,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "apps/website"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -32,7 +32,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/actions"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/api-extractor-utils/package.json
+++ b/packages/api-extractor-utils/package.json
@@ -24,7 +24,8 @@
 	"license": "Apache-2.0",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/api-extractor-utils"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/brokers/package.json
+++ b/packages/brokers/package.json
@@ -50,7 +50,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/brokers"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -48,7 +48,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/builders"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -44,7 +44,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/collection"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,8 @@
 	"keywords": [],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/core"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -42,7 +42,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/discordjs/discord.js.git"
+    "url": "https://github.com/discordjs/discord.js.git",
+    "directory": "packages/discord.js"
   },
   "bugs": {
     "url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -33,7 +33,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/docgen"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -38,7 +38,8 @@
 	"keywords": [],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/formatters"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -45,7 +45,8 @@
 	"keywords": [],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/next"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/proxy-container/package.json
+++ b/packages/proxy-container/package.json
@@ -36,7 +36,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/proxy-container"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -48,7 +48,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/proxy"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -46,7 +46,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/rest"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -36,7 +36,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/scripts"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/scripts/src/createPackage.ts
+++ b/packages/scripts/src/createPackage.ts
@@ -45,6 +45,9 @@ export async function createPackage(packageName: string, packageDescription?: st
 
 	// Edit changelog script
 	packageJSON.scripts.changelog = packageJSON.scripts.changelog.replace('{name}', packageName);
+	
+	// Edit repository directory
+	packageJSON.repository.directory = packageJSON.repository.directory.replace('{name}', packageName);
 
 	// Create package.json
 	await writeFile(`package.json`, JSON.stringify(packageJSON, null, 2));

--- a/packages/scripts/src/createPackage.ts
+++ b/packages/scripts/src/createPackage.ts
@@ -45,7 +45,7 @@ export async function createPackage(packageName: string, packageDescription?: st
 
 	// Edit changelog script
 	packageJSON.scripts.changelog = packageJSON.scripts.changelog.replace('{name}', packageName);
-	
+
 	// Edit repository directory
 	packageJSON.repository.directory = packageJSON.repository.directory.replace('{name}', packageName);
 

--- a/packages/scripts/src/template/template.package.json
+++ b/packages/scripts/src/template/template.package.json
@@ -25,7 +25,9 @@
 		"lib": "src",
 		"test": "__tests__"
 	},
-	"files": ["dist"],
+	"files": [
+		"dist"
+	],
 	"contributors": [
 		"Crawl <icrawltogo@gmail.com>",
 		"SpaceEEC <spaceeec@yahoo.com>",
@@ -36,7 +38,8 @@
 	"keywords": [],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/{name}"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/scripts/src/template/template.package.json
+++ b/packages/scripts/src/template/template.package.json
@@ -25,9 +25,7 @@
 		"lib": "src",
 		"test": "__tests__"
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"contributors": [
 		"Crawl <icrawltogo@gmail.com>",
 		"SpaceEEC <spaceeec@yahoo.com>",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,8 @@
 	"keywords": [],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/ui"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -45,7 +45,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/util"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -46,7 +46,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/voice"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -52,7 +52,8 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/discordjs/discord.js.git"
+		"url": "https://github.com/discordjs/discord.js.git",
+		"directory": "packages/ws"
 	},
 	"bugs": {
 		"url": "https://github.com/discordjs/discord.js/issues"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds the directory property to the repository in all the `package.json`'s inside the monorepo (apps and packages).

https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository
> If the `package.json` for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
```json
{
  "repository": {
    "type": "git",
    "url": "https://github.com/facebook/react.git",
    "directory": "packages/react-dom"
  }
}
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
