### PR TITLE
chore(SlashCommandBuilder): improve message when missing required params

### DIFF
--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -116,12 +116,12 @@ describe('Slash Commands', () => {
 
 		test('GIVEN missing required parameters THEN throw error', () => {
 			expect(() => SlashCommandAssertions.validateRequiredParameters(null, 'My name is missing', [])).toThrowError(
-				'Expected a string primitive',
+				'Required parameter "name" is missing',
 			);
 
 			expect(() =>
 				SlashCommandAssertions.validateRequiredParameters('my-description-is-missing', null, []),
-			).toThrowError('Expected a string primitive');
+			).toThrowError('Required parameter "description" is missing');
 		});
 	});
 

--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -113,6 +113,16 @@ describe('Slash Commands', () => {
 				),
 			).not.toThrowError();
 		});
+
+		test('GIVEN missing required parameters THEN throw error', () => {
+			expect(() => SlashCommandAssertions.validateRequiredParameters(null, 'My name is missing', [])).toThrowError(
+				'Expected a string primitive',
+			);
+
+			expect(() =>
+				SlashCommandAssertions.validateRequiredParameters('my-description-is-missing', null, []),
+			).toThrowError('Expected a string primitive');
+		});
 	});
 
 	describe('SlashCommandBuilder', () => {

--- a/packages/builders/src/interactions/slashCommands/Assertions.ts
+++ b/packages/builders/src/interactions/slashCommands/Assertions.ts
@@ -5,6 +5,11 @@ import type { ToAPIApplicationCommandOptions } from './SlashCommandBuilder.js';
 import type { SlashCommandSubcommandBuilder, SlashCommandSubcommandGroupBuilder } from './SlashCommandSubcommands.js';
 import type { ApplicationCommandOptionBase } from './mixins/ApplicationCommandOptionBase.js';
 
+export class MissingRequiredParameterError extends Error {
+	public constructor(missingParameter: string) {
+		super(`Required parameter "${missingParameter}" is missing`);
+	}
+}
 const namePredicate = s.string
 	.lengthGreaterThanOrEqual(1)
 	.lengthLessThanOrEqual(32)
@@ -35,14 +40,22 @@ export function validateMaxOptionsLength(options: unknown): asserts options is T
 }
 
 export function validateRequiredParameters(
-	name: string,
-	description: string,
+	name: string | undefined,
+	description: string | undefined,
 	options: ToAPIApplicationCommandOptions[],
 ) {
 	// Assert name matches all conditions
+	if (!name) {
+		throw new MissingRequiredParameterError('name');
+	}
+
 	validateName(name);
 
 	// Assert description conditions
+	if (!description) {
+		throw new MissingRequiredParameterError('description');
+	}
+
 	validateDescription(description);
 
 	// Assert options conditions


### PR DESCRIPTION
When you try to call `toJSON` on a `SlashCommandBuilder` that has not had a name or description set, or has any options that are missing a name or description, you get the following error:

```
.../node_modules/@sapphire/shapeshift/src/validators/StringValidator.ts:73
                return this.ip(6);
                  ^
Error: Expected a string primitive
    at StringValidator.handle (.../node_modules/@sapphire/shapeshift/src/validators/StringValidator.ts:73:19)
```

In my opinion, this error message is a bit cryptic and makes it difficult to figure out what the issue is. This PR adds explicit checks for missing command/options names/descriptions, and throws a more useful error message.

**Status and versioning classification:**

- This PR changes the library's interface (methods or parameters added)
  - It changes the type of error that is thrown by SlashCommandBuilder::toJSON
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
  - If any dependents are making checks against the error thrown by SlashCommandBuilder::toJSON, this PR would break that

