### PR TITLE
feat(ui): support embed image, thumbnail, author url, and url

### DIFF
--- a/packages/ui/src/lib/components/discord/DiscordMessages.stories.tsx
+++ b/packages/ui/src/lib/components/discord/DiscordMessages.stories.tsx
@@ -74,7 +74,7 @@ export const Default = {
 							username: 'Guide Bot',
 						}}
 						footer={{ content: "When one amazing title just wasn't enough." }}
-						thumbnail="/assets/discordjs.png"
+						thumbnail={{ alt: 'discord.js logo', image: '/assets/discordjs.png' }}
 						title={{ title: 'Another amazing title' }}
 					>
 						Multiple embeds!
@@ -107,11 +107,12 @@ export const Default = {
 						]}
 						footer={{ timestamp: 'Today at 21:02' }}
 						image={{
+							alt: 'discord.js logo',
 							url: '/assets/discordjs.png',
 							width: 300,
 							height: 300,
 						}}
-						thumbnail="/assets/discordjs.png"
+						thumbnail={{ alt: 'discord.js logo', image: '/assets/discordjs.png' }}
 						title={{ title: 'Fields are also supported!' }}
 					/>
 				</>

--- a/packages/ui/src/lib/components/discord/DiscordMessages.stories.tsx
+++ b/packages/ui/src/lib/components/discord/DiscordMessages.stories.tsx
@@ -73,6 +73,7 @@ export const Default = {
 							username: 'Guide Bot',
 						}}
 						footer={{ content: "When one amazing title just wasn't enough." }}
+						thumbnail="/assets/discordjs.png"
 						title={{ title: 'Another amazing title' }}
 					>
 						Multiple embeds!
@@ -104,6 +105,12 @@ export const Default = {
 							},
 						]}
 						footer={{ timestamp: 'Today at 21:02' }}
+						image={{
+							url: '/assets/discordjs.png',
+							width: 300,
+							height: 300,
+						}}
+						thumbnail="/assets/discordjs.png"
 						title={{ title: 'Fields are also supported!' }}
 					/>
 				</>

--- a/packages/ui/src/lib/components/discord/DiscordMessages.stories.tsx
+++ b/packages/ui/src/lib/components/discord/DiscordMessages.stories.tsx
@@ -57,13 +57,14 @@ export const Default = {
 						author={{
 							avatar: '/assets/discordjs.png',
 							username: 'Guide Bot',
+							url: 'https://discord.js.org',
 						}}
 						footer={{
 							content: 'Sometimes, titles just have to be.',
 							icon: '/assets/discordjs.png',
 							timestamp: 'Today at 21:02',
 						}}
-						title={{ title: 'An amazing title' }}
+						title={{ title: 'An amazing title', url: 'https://discord.js.org' }}
 					>
 						This is a description. You can put a description here. It must be descriptive!
 					</DiscordMessageEmbed>

--- a/packages/ui/src/lib/components/discord/MessageEmbed.tsx
+++ b/packages/ui/src/lib/components/discord/MessageEmbed.tsx
@@ -3,6 +3,8 @@ import { DiscordMessageEmbedAuthor, type IDiscordMessageEmbedAuthor } from './Me
 import type { IDiscordMessageEmbedField } from './MessageEmbedField.jsx';
 import { DiscordMessageEmbedFields } from './MessageEmbedFields.jsx';
 import { DiscordMessageEmbedFooter, type IDiscordMessageEmbedFooter } from './MessageEmbedFooter.jsx';
+import { DiscordMessageEmbedImage, type IDiscordMessageEmbedImage } from './MessageEmbedImage.jsx';
+import { DiscordMessageEmbedThumbnail } from './MessageEmbedThumbnail.jsx';
 import { DiscordMessageEmbedTitle, type IDiscordMessageEmbedTitle } from './MessageEmbedTitle.jsx';
 
 export interface IDiscordMessageEmbed {
@@ -11,7 +13,8 @@ export interface IDiscordMessageEmbed {
 	fields?: IDiscordMessageEmbedField[];
 	footer?: IDiscordMessageEmbedFooter | undefined;
 	footerNode?: ReactNode | undefined;
-	timestamp?: string;
+	image?: IDiscordMessageEmbedImage;
+	thumbnail?: string;
 	title?: IDiscordMessageEmbedTitle | undefined;
 	titleNode?: ReactNode | undefined;
 }
@@ -22,21 +25,26 @@ export function DiscordMessageEmbed({
 	fields,
 	title,
 	titleNode,
+	image,
 	children,
+	thumbnail,
 	footer,
 	footerNode,
 }: PropsWithChildren<IDiscordMessageEmbed>) {
 	return (
 		<div className="py-0.5" id="outer-embed-wrapper">
 			<div className="grid max-w-max border-l-4 border-l-blurple rounded bg-[rgb(47_49_54)]" id="embed-wrapper">
-				<div className="max-w-128">
+				<div className="max-w-128 flex">
 					<div className="pb-4 pl-3 pr-4 pt-2">
 						{author ? <DiscordMessageEmbedAuthor {...author} /> : authorNode ?? null}
 						{title ? <DiscordMessageEmbedTitle {...title} /> : titleNode ?? null}
 						{children ? <div className="mt-2 text-sm">{children}</div> : null}
 						{fields ? <DiscordMessageEmbedFields fields={fields} /> : null}
+						{image ? <DiscordMessageEmbedImage {...image} /> : null}
 						{footer ? <DiscordMessageEmbedFooter {...footer} /> : footerNode ?? null}
 					</div>
+
+					{thumbnail ? <DiscordMessageEmbedThumbnail image={thumbnail} /> : null}
 				</div>
 			</div>
 		</div>

--- a/packages/ui/src/lib/components/discord/MessageEmbed.tsx
+++ b/packages/ui/src/lib/components/discord/MessageEmbed.tsx
@@ -4,7 +4,7 @@ import type { IDiscordMessageEmbedField } from './MessageEmbedField.jsx';
 import { DiscordMessageEmbedFields } from './MessageEmbedFields.jsx';
 import { DiscordMessageEmbedFooter, type IDiscordMessageEmbedFooter } from './MessageEmbedFooter.jsx';
 import { DiscordMessageEmbedImage, type IDiscordMessageEmbedImage } from './MessageEmbedImage.jsx';
-import { DiscordMessageEmbedThumbnail } from './MessageEmbedThumbnail.jsx';
+import { DiscordMessageEmbedThumbnail, type IDiscordMessageEmbedThumbnail } from './MessageEmbedThumbnail.jsx';
 import { DiscordMessageEmbedTitle, type IDiscordMessageEmbedTitle } from './MessageEmbedTitle.jsx';
 
 export interface IDiscordMessageEmbed {
@@ -14,7 +14,7 @@ export interface IDiscordMessageEmbed {
 	footer?: IDiscordMessageEmbedFooter | undefined;
 	footerNode?: ReactNode | undefined;
 	image?: IDiscordMessageEmbedImage;
-	thumbnail?: string;
+	thumbnail?: IDiscordMessageEmbedThumbnail;
 	title?: IDiscordMessageEmbedTitle | undefined;
 	titleNode?: ReactNode | undefined;
 }
@@ -44,7 +44,7 @@ export function DiscordMessageEmbed({
 						{footer ? <DiscordMessageEmbedFooter {...footer} /> : footerNode ?? null}
 					</div>
 
-					{thumbnail ? <DiscordMessageEmbedThumbnail image={thumbnail} /> : null}
+					{thumbnail ? <DiscordMessageEmbedThumbnail {...thumbnail} /> : null}
 				</div>
 			</div>
 		</div>

--- a/packages/ui/src/lib/components/discord/MessageEmbedAuthor.tsx
+++ b/packages/ui/src/lib/components/discord/MessageEmbedAuthor.tsx
@@ -1,13 +1,20 @@
 export interface IDiscordMessageEmbedAuthor {
 	avatar: string;
+	url?: string;
 	username: string;
 }
 
-export function DiscordMessageEmbedAuthor({ avatar, username }: IDiscordMessageEmbedAuthor) {
+export function DiscordMessageEmbedAuthor({ avatar, url, username }: IDiscordMessageEmbedAuthor) {
 	return (
 		<div className="mt-2 flex place-items-center">
 			<img alt={`${username}'s avatar`} className="mr-2 h-6 w-6 select-none rounded-full" src={avatar} />
-			<span className="text-sm font-medium hover:underline">{username}</span>
+			{url ? (
+				<a className="text-sm font-medium hover:underline" href={url} rel="noreferrer" target="_blank">
+					{username}
+				</a>
+			) : (
+				<span className="text-sm font-medium">{username}</span>
+			)}
 		</div>
 	);
 }

--- a/packages/ui/src/lib/components/discord/MessageEmbedAuthor.tsx
+++ b/packages/ui/src/lib/components/discord/MessageEmbedAuthor.tsx
@@ -9,7 +9,12 @@ export function DiscordMessageEmbedAuthor({ avatar, url, username }: IDiscordMes
 		<div className="mt-2 flex place-items-center">
 			<img alt={`${username}'s avatar`} className="mr-2 h-6 w-6 select-none rounded-full" src={avatar} />
 			{url ? (
-				<a className="text-sm font-medium hover:underline" href={url} rel="noreferrer" target="_blank">
+				<a
+					className="text-sm font-medium hover:underline"
+					href={url}
+					rel="noreferrer noopener external"
+					target="_blank"
+				>
 					{username}
 				</a>
 			) : (

--- a/packages/ui/src/lib/components/discord/MessageEmbedImage.tsx
+++ b/packages/ui/src/lib/components/discord/MessageEmbedImage.tsx
@@ -1,0 +1,9 @@
+export interface IDiscordMessageEmbedImage {
+	height: number;
+	url: string;
+	width: number;
+}
+
+export function DiscordMessageEmbedImage({ url, height, width }: IDiscordMessageEmbedImage) {
+	return <img className="mt-4" height={height} src={url} width={width} />;
+}

--- a/packages/ui/src/lib/components/discord/MessageEmbedImage.tsx
+++ b/packages/ui/src/lib/components/discord/MessageEmbedImage.tsx
@@ -1,9 +1,10 @@
 export interface IDiscordMessageEmbedImage {
+	alt: string;
 	height: number;
 	url: string;
 	width: number;
 }
 
-export function DiscordMessageEmbedImage({ url, height, width }: IDiscordMessageEmbedImage) {
-	return <img className="mt-4" height={height} src={url} width={width} />;
+export function DiscordMessageEmbedImage({ alt, height, url, width }: IDiscordMessageEmbedImage) {
+	return <img alt={alt} className="mt-4" height={height} src={url} width={width} />;
 }

--- a/packages/ui/src/lib/components/discord/MessageEmbedThumbnail.tsx
+++ b/packages/ui/src/lib/components/discord/MessageEmbedThumbnail.tsx
@@ -1,7 +1,8 @@
 export interface IDiscordMessageEmbedThumbnail {
+	alt: string;
 	image: string;
 }
 
-export function DiscordMessageEmbedThumbnail({ image }: IDiscordMessageEmbedThumbnail) {
-	return <img className="mr-4 mt-4 aspect-square h-20" height={80} src={image} width={80} />;
+export function DiscordMessageEmbedThumbnail({ alt, image }: IDiscordMessageEmbedThumbnail) {
+	return <img alt={alt} className="mr-4 mt-4 aspect-square h-20" height={80} src={image} width={80} />;
 }

--- a/packages/ui/src/lib/components/discord/MessageEmbedThumbnail.tsx
+++ b/packages/ui/src/lib/components/discord/MessageEmbedThumbnail.tsx
@@ -1,0 +1,7 @@
+export interface IDiscordMessageEmbedThumbnail {
+	image: string;
+}
+
+export function DiscordMessageEmbedThumbnail({ image }: IDiscordMessageEmbedThumbnail) {
+	return <img className="mr-4 mt-4 aspect-square h-20" height={80} src={image} width={80} />;
+}

--- a/packages/ui/src/lib/components/discord/MessageEmbedTitle.tsx
+++ b/packages/ui/src/lib/components/discord/MessageEmbedTitle.tsx
@@ -5,7 +5,12 @@ export interface IDiscordMessageEmbedTitle {
 
 export function DiscordMessageEmbedTitle({ title, url }: IDiscordMessageEmbedTitle) {
 	return url ? (
-		<a className="mt-2 font-medium text-blue-500 hover:underline" href={url} rel="noreferrer" target="_blank">
+		<a
+			className="mt-2 font-medium text-blue-500 hover:underline"
+			href={url}
+			rel="noreferrer noopener external"
+			target="_blank"
+		>
 			{title}
 		</a>
 	) : (

--- a/packages/ui/src/lib/components/discord/MessageEmbedTitle.tsx
+++ b/packages/ui/src/lib/components/discord/MessageEmbedTitle.tsx
@@ -1,7 +1,14 @@
 export interface IDiscordMessageEmbedTitle {
 	title: string;
+	url?: string;
 }
 
-export function DiscordMessageEmbedTitle({ title }: IDiscordMessageEmbedTitle) {
-	return <div className="mt-2 font-medium">{title}</div>;
+export function DiscordMessageEmbedTitle({ title, url }: IDiscordMessageEmbedTitle) {
+	return url ? (
+		<a className="mt-2 font-medium text-blue-500 hover:underline" href={url} rel="noreferrer" target="_blank">
+			{title}
+		</a>
+	) : (
+		<div className="mt-2 font-medium">{title}</div>
+	);
 }


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at f6c621f</samp>

### Summary
🖼️🔗✨

<!--
1.  🖼️ - This emoji represents the image and thumbnail features of the embeds, which are visual elements that can enhance the appearance and information of the messages.
2.  🔗 - This emoji represents the URL links for authors and titles, which are interactive elements that can redirect the user to external sources related to the messages.
3.  ✨ - This emoji represents the new features and enhancements that this pull request adds to the component and its stories, which can improve the user experience and functionality of the component.
-->
This pull request adds URL, image, and thumbnail features to the `DiscordMessages` and `MessageEmbed` components and their stories. These features allow the components to display more information and media from discord messages and embeds. The pull request also adds new files and updates existing files to support these features.

> _We are the authors of our fate, we link our words with power_
> _We are the images of our vision, we embed our signs with fire_
> _We are the titles of our story, we shine our names with glory_
> _We are the DiscordMessages, we rock the world with fury_

### Walkthrough
*  Add URL support for embed author and title components ([link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-d804261d10d2ed0209874aa8739645e572fb1f23af55da6000878c9806cf841fR60), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-d804261d10d2ed0209874aa8739645e572fb1f23af55da6000878c9806cf841fL66-R67), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-695edd802a4ae54a271b97c1477010d4af4e8a526019812bae531efc97cd5795L3-R17), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-44e486f82d70e796a4df7a79463371f4ac3bec4f2524c5fdd763c841b6d46d29L3-R13))
* Add image and thumbnail support for embed component ([link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-d804261d10d2ed0209874aa8739645e572fb1f23af55da6000878c9806cf841fR77), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-d804261d10d2ed0209874aa8739645e572fb1f23af55da6000878c9806cf841fR109-R114), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-6f5aefec90bdb9d1acaf865cf78fc435fecceb81dc34ba91d4749ee938cd0b68R6-R7), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-6f5aefec90bdb9d1acaf865cf78fc435fecceb81dc34ba91d4749ee938cd0b68L14-R17), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-6f5aefec90bdb9d1acaf865cf78fc435fecceb81dc34ba91d4749ee938cd0b68L25-R30), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-6f5aefec90bdb9d1acaf865cf78fc435fecceb81dc34ba91d4749ee938cd0b68L32-R37), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-6f5aefec90bdb9d1acaf865cf78fc435fecceb81dc34ba91d4749ee938cd0b68L38-R47), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-dba224ed7057e16caf1fbfae1d9ff87c4dcd933413c92d03f4a73c9a67044e0aR1-R9), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-5dba4e67b6976903bbc62c77aab7ae90386f19f281dc7874252fe37bfd5ae950R1-R7))
* Demonstrate new features of embed components in `DiscordMessages.stories.tsx` file ([link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-d804261d10d2ed0209874aa8739645e572fb1f23af55da6000878c9806cf841fR60), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-d804261d10d2ed0209874aa8739645e572fb1f23af55da6000878c9806cf841fL66-R67), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-d804261d10d2ed0209874aa8739645e572fb1f23af55da6000878c9806cf841fR77), [link](https://github.com/discordjs/discord.js/pull/9478/files?diff=unified&w=0#diff-d804261d10d2ed0209874aa8739645e572fb1f23af55da6000878c9806cf841fR109-R114))

