### PR TITLE
refactor: remove `@discordjs/util` re-export

### DIFF
--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -59,7 +59,6 @@ export * from './interactions/contextMenuCommands/ContextMenuCommandBuilder.js';
 export * from './util/componentUtil.js';
 export * from './util/normalizeArray.js';
 export * from './util/validation.js';
-export * from '@discordjs/util';
 
 /**
  * The {@link https://github.com/discordjs/discord.js/blob/main/packages/builders#readme | @discordjs/builders} version


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f022357</samp>

> _`@discordjs/util`_
> _Circular dependency_
> _Cut by `builders`_

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
