### PR TITLE
refactor(GuildChannel): simplify constructor

### DIFF
--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -20,7 +20,7 @@ const PermissionsBitField = require('../util/PermissionsBitField');
  */
 class GuildChannel extends BaseChannel {
   constructor(guild, data, client, immediatePatch = true) {
-    super(guild?.client ?? client, data, false);
+    super(client, data, false);
 
     /**
      * The guild the channel is in
@@ -33,8 +33,6 @@ class GuildChannel extends BaseChannel {
      * @type {Snowflake}
      */
     this.guildId = guild?.id ?? data.guild_id;
-
-    this.parentId = this.parentId ?? null;
     /**
      * A manager of permission overwrites that belong to this channel
      * @type {PermissionOverwriteManager}
@@ -73,6 +71,8 @@ class GuildChannel extends BaseChannel {
        * @type {?Snowflake}
        */
       this.parentId = data.parent_id;
+    } else {
+      this.parentId ??= null;
     }
 
     if ('permission_overwrites' in data) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- `this.parentId = this.parentId ?? null` was an useless call since `this.parentId` is `undefined` at construct (as the parent class doesn't assign it either), therefore the check was moved to the `_patch` method with a default, consistent with the rest of structures.
- `guild?.client` is an unnecessary check when `client` is already passed and always guaranteed to exist. Removing this check allows us to reduce some overhead when creating channels.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6a83a0f</samp>

> _Oh we're the coders of the sea, and we like to keep things neat_
> _We simplify the `GuildChannel` class, and make the `parentId` complete_
> _We use the nullish operators, to avoid the extra work_
> _And when we're done we push the code, and give ourselves a smirk_

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
