### PR TITLE
fix(Constants): Ordering and missing information

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -1547,14 +1547,15 @@ function createEnum(keys) {
  * @property {Object<ApplicationCommandType, number>} ApplicationCommandTypes
  * The type of an {@link ApplicationCommand} object.
  * @property {Object<ApplicationRoleConnectionMetadataType, number>} ApplicationRoleConnectionMetadataTypes
- * @property {Object<AutoModerationRuleTriggerType, number>} AutoModerationRuleTriggerTypes Characterizes the type
- * of content which can trigger the rule.
+ * The type of an {@link ApplicationRoleConnectionMetadata} object.
  * @property {Object<AutoModerationActionType, number>} AutoModerationActionTypes
  * A type of an action which executes whenever a rule is triggered.
+ * @property {Object<AutoModerationRuleEventType, number>} AutoModerationRuleEventTypes Indicates in what event context
+ * a rule should be checked.
  * @property {Object<AutoModerationRuleKeywordPresetType, number>} AutoModerationRuleKeywordPresetTypes
  * The internally pre-defined wordsetswhich will be searched for in content
- * @property {Object<AutoModerationRuleEventType, number>} AutoModerationRuleEventTypes Indicates in what event context
- *  a rule should be checked.
+ * @property {Object<AutoModerationRuleTriggerType, number>} AutoModerationRuleTriggerTypes Characterizes the type
+ * of content which can trigger the rule.
  * @property {Object<ChannelType, number>} ChannelTypes All available channel types.
  * @property {ClientApplicationAssetTypes} ClientApplicationAssetTypes The types of an {@link ApplicationAsset} object.
  * @property {Object<Color, number>} Colors An object with regularly used colors.
@@ -1575,9 +1576,11 @@ function createEnum(keys) {
  * @property {Object<InteractionResponseType, number>} InteractionResponseTypes The type of an interaction response.
  * @property {Object<InteractionType, number>} InteractionTypes The type of an {@link Interaction} object.
  * @property {InviteScope[]} InviteScopes The scopes of an invite.
+ * @property {number} MaxBulkDeletableMessageAge Max bulk deletable message age
  * @property {Object<MembershipState, number>} MembershipStates The value set for a team members membership state.
  * @property {Object<MessageButtonStyle, number>} MessageButtonStyles The style of a message button.
  * @property {Object<MessageComponentType, number>} MessageComponentTypes The type of a message component.
+ * @property {MessageType[]} MessageTypes The type of a {@link Message} object.
  * @property {Object<MFALevel, number>} MFALevels The required MFA level for a guild.
  * @property {Object<NSFWLevel, number>} NSFWLevels NSFW level of a guild.
  * @property {Opcodes} Opcodes The types of Opcodes sent to the Gateway.
@@ -1593,7 +1596,7 @@ function createEnum(keys) {
  * @property {SweeperKey[]} SweeperKeys The name of an item to be swept in Sweepers.
  * @property {SystemMessageType[]} SystemMessageTypes The types of messages that are `System`.
  * @property {Object<TextInputStyle, number>} TextInputStyles The style of a text input component.
- * @property {number} MaxBulkDeletableMessageAge Max bulk deletable message age
+ * @property {ThreadChannelTypes[]} ThreadChannelTypes The type of a {@link ThreadChannel} object.
  * @property {string} UserAgent The user agent used for requests.
  * @property {Object<VerificationLevel, number>} VerificationLevels
  * The value set for the verification levels for a guild.

--- a/typings/enums.d.ts
+++ b/typings/enums.d.ts
@@ -185,11 +185,6 @@ export const enum MessageComponentTypes {
   TEXT_INPUT = 4,
 }
 
-export const enum ModalComponentTypes {
-  ACTION_ROW = 1,
-  TEXT_INPUT = 4,
-}
-
 export const enum MFALevels {
   NONE = 0,
   ELEVATED = 1,

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -79,7 +79,6 @@ import {
   MessageButtonStyles,
   MessageComponentTypes,
   MessageTypes,
-  ModalComponentTypes,
   MFALevels,
   NSFWLevels,
   OverwriteTypes,
@@ -3056,146 +3055,140 @@ export type EnumHolder<T> = { [P in keyof T]: T[P] };
 export type ExcludeEnum<T, K extends keyof T> = Exclude<keyof T | T[keyof T], K | T[K]>;
 
 export const Constants: {
-  Package: {
-    name: string;
-    version: string;
-    description: string;
-    license: string;
-    main: string;
-    types: string;
-    homepage: string;
-    keywords: string[];
-    bugs: { url: string };
-    repository: { type: string; url: string };
-    scripts: Record<string, string>;
-    engines: Record<string, string>;
-    dependencies: Record<string, string>;
-    devDependencies: Record<string, string>;
-    [key: string]: unknown;
-  };
-  MaxBulkDeletableMessageAge: 1_209_600_000;
-  UserAgent: string;
+  ActivityTypes: EnumHolder<typeof ActivityTypes>;
+  APIErrors: APIErrors;
+  ApplicationCommandOptionTypes: EnumHolder<typeof ApplicationCommandOptionTypes>;
+  ApplicationCommandPermissionTypes: EnumHolder<typeof ApplicationCommandPermissionTypes>;
+  ApplicationCommandTypes: EnumHolder<typeof ApplicationCommandTypes>;
+  ApplicationRoleConnectionMetadataTypes: EnumHolder<typeof ApplicationRoleConnectionMetadataTypes>;
+  AutoModerationActionTypes: EnumHolder<typeof AutoModerationActionTypes>;
+  AutoModerationRuleEventTypes: EnumHolder<typeof AutoModerationRuleEventTypes>;
+  AutoModerationRuleKeywordPresetTypes: EnumHolder<typeof AutoModerationRuleKeywordPresetTypes>;
+  AutoModerationRuleTriggerTypes: EnumHolder<typeof AutoModerationRuleTriggerTypes>;
+  ChannelTypes: EnumHolder<typeof ChannelTypes>;
+  ClientApplicationAssetTypes: ConstantsClientApplicationAssetTypes;
+  Colors: ConstantsColors;
+  DefaultMessageNotificationLevels: EnumHolder<typeof DefaultMessageNotificationLevels>;
   Endpoints: {
-    botGateway: string;
-    invite: (root: string, code: string, eventId?: Snowflake) => string;
-    scheduledEvent: (root: string, guildId: Snowflake, eventId: Snowflake) => string;
-    CDN: (root: string) => {
-      Emoji: (emojiId: Snowflake, format: DynamicImageFormat) => string;
-      Asset: (name: string) => string;
-      DefaultAvatar: (discriminator: number) => string;
-      Avatar: (
+    CDN(root: string): {
+      AppAsset(
+        appId: Snowflake,
+        hash: string,
+        { format, size }: { format: AllowedImageFormat; size: AllowedImageSize },
+      ): string;
+      AppIcon(
+        appId: Snowflake,
+        hash: string,
+        { format, size }: { format: AllowedImageFormat; size: AllowedImageSize },
+      ): string;
+      Asset(name: string): string;
+      Avatar(
         userId: Snowflake,
         hash: string,
         format: DynamicImageFormat,
         size: AllowedImageSize,
         dynamic: boolean,
-      ) => string;
-      Banner: (
-        id: Snowflake,
-        hash: string,
-        format: DynamicImageFormat,
-        size: AllowedImageSize,
-        dynamic: boolean,
-      ) => string;
-      GuildMemberAvatar: (
+      ): string;
+      Banner(id: Snowflake, hash: string, format: DynamicImageFormat, size: AllowedImageSize, dynamic: boolean): string;
+      DefaultAvatar(discriminator: number): string;
+      DiscoverySplash(guildId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize): string;
+      Emoji(emojiId: Snowflake, format: DynamicImageFormat): string;
+      GDMIcon(channelId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize): string;
+      GuildMemberAvatar(
         guildId: Snowflake,
         memberId: Snowflake,
         hash: string,
         format?: DynamicImageFormat,
         size?: AllowedImageSize,
         dynamic?: boolean,
-      ) => string;
-      Icon: (
+      ): string;
+      Icon(
         guildId: Snowflake,
         hash: string,
         format: DynamicImageFormat,
         size: AllowedImageSize,
         dynamic: boolean,
-      ) => string;
-      AppIcon: (
-        appId: Snowflake,
-        hash: string,
-        { format, size }: { format: AllowedImageFormat; size: AllowedImageSize },
-      ) => string;
-      AppAsset: (
-        appId: Snowflake,
-        hash: string,
-        { format, size }: { format: AllowedImageFormat; size: AllowedImageSize },
-      ) => string;
-      StickerPackBanner: (bannerId: Snowflake, format: AllowedImageFormat, size: AllowedImageSize) => string;
-      GDMIcon: (channelId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
-      Splash: (guildId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
-      DiscoverySplash: (guildId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
-      TeamIcon: (
+      ): string;
+      RoleIcon(roleId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize): string;
+      Splash(guildId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize): string;
+      Sticker(stickerId: Snowflake, stickerFormat: StickerFormatType): string;
+      StickerPackBanner(bannerId: Snowflake, format: AllowedImageFormat, size: AllowedImageSize): string;
+      TeamIcon(
         teamId: Snowflake,
         hash: string,
         { format, size }: { format: AllowedImageFormat; size: AllowedImageSize },
-      ) => string;
-      Sticker: (stickerId: Snowflake, stickerFormat: StickerFormatType) => string;
-      RoleIcon: (roleId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
+      ): string;
     };
-  };
-  WSCodes: {
-    1000: 'WS_CLOSE_REQUESTED';
-    1011: 'INTERNAL_ERROR';
-    4004: 'TOKEN_INVALID';
-    4010: 'SHARDING_INVALID';
-    4011: 'SHARDING_REQUIRED';
-    4013: 'INVALID_INTENTS';
-    4014: 'DISALLOWED_INTENTS';
+    botGateway: string;
+    invite(root: string, code: string, eventId?: Snowflake): string;
+    scheduledEvent(root: string, guildId: Snowflake, eventId: Snowflake): string;
   };
   Events: ConstantsEvents;
-  ShardEvents: ConstantsShardEvents;
+  ExplicitContentFilterLevels: EnumHolder<typeof ExplicitContentFilterLevels>;
+  GuildScheduledEventEntityTypes: EnumHolder<typeof GuildScheduledEventEntityTypes>;
+  GuildScheduledEventPrivacyLevels: EnumHolder<typeof GuildScheduledEventPrivacyLevels>;
+  GuildScheduledEventStatuses: EnumHolder<typeof GuildScheduledEventStatuses>;
+  IntegrationExpireBehaviors: IntegrationExpireBehaviors[];
+  InteractionResponseTypes: EnumHolder<typeof InteractionResponseTypes>;
+  InteractionTypes: EnumHolder<typeof InteractionTypes>;
+  InviteScopes: InviteScope[];
+  MaxBulkDeletableMessageAge: 1_209_600_000;
+  MembershipStates: EnumHolder<typeof MembershipStates>;
+  MessageButtonStyles: EnumHolder<typeof MessageButtonStyles>;
+  MessageComponentTypes: EnumHolder<typeof MessageComponentTypes>;
+  MessageTypes: MessageType[];
+  MFALevels: EnumHolder<typeof MFALevels>;
+  NSFWLevels: EnumHolder<typeof NSFWLevels>;
+  Opcodes: ConstantsOpcodes;
+  OverwriteTypes: EnumHolder<typeof OverwriteTypes>;
+  Package: {
+    [key: string]: unknown;
+    bugs: { url: string };
+    dependencies: Record<string, string>;
+    description: string;
+    devDependencies: Record<string, string>;
+    engines: Record<string, string>;
+    homepage: string;
+    keywords: string[];
+    license: string;
+    main: string;
+    name: string;
+    repository: { type: string; url: string };
+    scripts: Record<string, string>;
+    types: string;
+    version: string;
+  };
   PartialTypes: {
     [K in PartialTypes]: K;
+  };
+  PremiumTiers: EnumHolder<typeof PremiumTiers>;
+  PrivacyLevels: EnumHolder<typeof PrivacyLevels>;
+  ShardEvents: ConstantsShardEvents;
+  Status: ConstantsStatus;
+  StickerFormatTypes: EnumHolder<typeof StickerFormatTypes>;
+  StickerTypes: EnumHolder<typeof StickerTypes>;
+  SweeperKeys: SweeperKey[];
+  SystemMessageTypes: SystemMessageType[];
+  TextBasedChannelTypes: TextBasedChannelTypes[];
+  TextInputStyles: EnumHolder<typeof TextInputStyles>;
+  ThreadChannelTypes: ThreadChannelTypes[];
+  UserAgent: string;
+  VerificationLevels: EnumHolder<typeof VerificationLevels>;
+  VideoQualityModes: EnumHolder<typeof VideoQualityModes>;
+  VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
+  WebhookTypes: EnumHolder<typeof WebhookTypes>;
+  WSCodes: {
+    1_000: 'WS_CLOSE_REQUESTED';
+    1_011: 'INTERNAL_ERROR';
+    4_004: 'TOKEN_INVALID';
+    4_010: 'SHARDING_INVALID';
+    4_011: 'SHARDING_REQUIRED';
+    4_013: 'INVALID_INTENTS';
+    4_014: 'DISALLOWED_INTENTS';
   };
   WSEvents: {
     [K in WSEventType]: K;
   };
-  Colors: ConstantsColors;
-  Status: ConstantsStatus;
-  Opcodes: ConstantsOpcodes;
-  APIErrors: APIErrors;
-  ChannelTypes: EnumHolder<typeof ChannelTypes>;
-  ThreadChannelTypes: ThreadChannelTypes[];
-  TextBasedChannelTypes: TextBasedChannelTypes[];
-  VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
-  ClientApplicationAssetTypes: ConstantsClientApplicationAssetTypes;
-  IntegrationExpireBehaviors: IntegrationExpireBehaviors[];
-  InviteScopes: InviteScope[];
-  MessageTypes: MessageType[];
-  SystemMessageTypes: SystemMessageType[];
-  ActivityTypes: EnumHolder<typeof ActivityTypes>;
-  StickerTypes: EnumHolder<typeof StickerTypes>;
-  StickerFormatTypes: EnumHolder<typeof StickerFormatTypes>;
-  OverwriteTypes: EnumHolder<typeof OverwriteTypes>;
-  ExplicitContentFilterLevels: EnumHolder<typeof ExplicitContentFilterLevels>;
-  DefaultMessageNotificationLevels: EnumHolder<typeof DefaultMessageNotificationLevels>;
-  VerificationLevels: EnumHolder<typeof VerificationLevels>;
-  MembershipStates: EnumHolder<typeof MembershipStates>;
-  AutoModerationRuleTriggerTypes: EnumHolder<typeof AutoModerationRuleTriggerTypes>;
-  AutoModerationRuleKeywordPresetTypes: EnumHolder<typeof AutoModerationRuleKeywordPresetTypes>;
-  AutoModerationActionTypes: EnumHolder<typeof AutoModerationActionTypes>;
-  AutoModerationRuleEventTypes: EnumHolder<typeof AutoModerationRuleEventTypes>;
-
-  ApplicationCommandPermissionTypes: EnumHolder<typeof ApplicationCommandPermissionTypes>;
-  InteractionTypes: EnumHolder<typeof InteractionTypes>;
-  InteractionResponseTypes: EnumHolder<typeof InteractionResponseTypes>;
-  MessageComponentTypes: EnumHolder<typeof MessageComponentTypes>;
-  MessageButtonStyles: EnumHolder<typeof MessageButtonStyles>;
-  ModalComponentTypes: EnumHolder<typeof ModalComponentTypes>;
-  TextInputStyles: EnumHolder<typeof TextInputStyles>;
-  MFALevels: EnumHolder<typeof MFALevels>;
-  NSFWLevels: EnumHolder<typeof NSFWLevels>;
-  PrivacyLevels: EnumHolder<typeof PrivacyLevels>;
-  WebhookTypes: EnumHolder<typeof WebhookTypes>;
-  PremiumTiers: EnumHolder<typeof PremiumTiers>;
-  ApplicationCommandTypes: EnumHolder<typeof ApplicationCommandTypes>;
-  GuildScheduledEventEntityTypes: EnumHolder<typeof GuildScheduledEventEntityTypes>;
-  GuildScheduledEventStatuses: EnumHolder<typeof GuildScheduledEventStatuses>;
-  GuildScheduledEventPrivacyLevels: EnumHolder<typeof GuildScheduledEventPrivacyLevels>;
-  VideoQualityModes: EnumHolder<typeof VideoQualityModes>;
-  SweeperKeys: SweeperKey[];
 };
 
 export const version: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
After sorting the TypeScript constant alphabetically, I began to notice inconsistencies.

- #8886 removed `ApplicationCommandOptionTypes` from the typings
- #7431 added `ModalComponentTypes` in the typings, but it is not used anywhere or exported in JavaScript
- #9072 did not add `ApplicationRoleConnectionMetadataTypes` to the typings
- `MessageTypes` was never documented (yes, this is very old)
- #5570 added `ThreadChannelTypes` in the typings but was lacking documentation

Also sorted the JavaScript constant. It should be easier to detect these things when comparing them now.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
