### PR TITLE
fix(WebSocketManager): emit raw ws events again

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -233,6 +233,7 @@ class WebSocketManager extends EventEmitter {
     this._ws.on(WSWebSocketShardEvents.Debug, ({ message, shardId }) => this.debug(message, shardId));
     this._ws.on(WSWebSocketShardEvents.Dispatch, ({ data, shardId }) => {
       this.client.emit(Events.Raw, data, shardId);
+      this.emit(data.t, data.d, shardId);
       const shard = this.shards.get(shardId);
       this.handlePacket(data, shard);
       if (shard.status === Status.WaitingForGuilds && WaitingForGuildEvents.includes(data.t)) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes the missing emitting of raw WebSocketManager events.
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
