### PR TITLE
fix(guide): Fix unknown component in v14 update guide

### DIFF
--- a/apps/guide/src/components/DocsLink.tsx
+++ b/apps/guide/src/components/DocsLink.tsx
@@ -19,7 +19,7 @@ interface DocsLinkOptions {
 	 *
 	 * @example `'Client'`
 	 */
-	parent: string;
+	parent?: string;
 	/**
 	 * Whether to reference a static property.
 	 *
@@ -40,7 +40,7 @@ interface DocsLinkOptions {
 	 * @example `'class'`
 	 * @example `'Function'`
 	 */
-	type: string;
+	type?: string;
 }
 
 export function DocsLink({
@@ -51,23 +51,28 @@ export function DocsLink({
 	brackets,
 	static: staticReference,
 }: DocsLinkOptions) {
-	const bracketText = brackets || type.toUpperCase() === 'FUNCTION' ? '()' : '';
-	const trimmedSymbol = symbol;
-	let url;
-	let text;
+	// In the case of no type and no parent, this will default to the entry point of the respective documentation.
+	let url = docs === PACKAGES[0] ? `${BASE_URL_LEGACY}/${VERSION}/general/welcome` : `${BASE_URL}/${docs}/stable`;
+	let text = `${docs === PACKAGES[0] ? '' : '@discordjs/'}${docs}`;
 
-	if (docs === PACKAGES[0]) {
-		url = `${BASE_URL_LEGACY}/${VERSION}/${type}/${parent}`;
-		if (trimmedSymbol) url += `?scrollTo=${trimmedSymbol}`;
+	// If there is a type and parent, we need to do some parsing.
+	if (type && parent) {
+		const bracketText = brackets || type?.toUpperCase() === 'FUNCTION' ? '()' : '';
 
-		text = `${parent}${trimmedSymbol ? (trimmedSymbol.startsWith('s-') ? '.' : '#') : ''}${
-			// eslint-disable-next-line prefer-named-capture-group
-			trimmedSymbol ? `${trimmedSymbol.replace(/(e|s)-/, '')}` : ''
-		}${bracketText}`;
-	} else {
-		url = `${BASE_URL}/${docs}/stable/${parent}:${type}`;
-		if (trimmedSymbol) url += `#${trimmedSymbol}`;
-		text = `${parent}${trimmedSymbol ? `${staticReference ? '.' : '#'}${trimmedSymbol}` : ''}${bracketText}`;
+		// Legacy discord.js documentation parsing.
+		if (docs === PACKAGES[0]) {
+			url = `${BASE_URL_LEGACY}/${VERSION}/${type}/${parent}`;
+			if (symbol) url += `?scrollTo=${symbol}`;
+
+			text = `${parent}${symbol ? (symbol.startsWith('s-') ? '.' : '#') : ''}${
+				// eslint-disable-next-line prefer-named-capture-group
+				symbol ? `${symbol.replace(/(e|s)-/, '')}` : ''
+			}${bracketText}`;
+		} else {
+			url += `/${parent}:${type}`;
+			if (symbol) url += `#${symbol}`;
+			text = `${parent}${symbol ? `${staticReference ? '.' : '#'}${symbol}` : ''}${bracketText}`;
+		}
 	}
 
 	return (

--- a/apps/guide/src/content/05-additional-info/03-updating-to-v14.mdx
+++ b/apps/guide/src/content/05-additional-info/03-updating-to-v14.mdx
@@ -419,7 +419,7 @@ The base interaction class is now <DocsLink type="class" parent="BaseInteraction
 
 ### MessageManager
 
-The second parameter of <DocsLink type="class" parent="MessageManager" symbol="fetch" brackets /> has been removed. The <DocsLink type="class" parent="BaseFetchOptions" /> the second parameter once was is now merged into the first parameter.
+The second parameter of <DocsLink type="class" parent="MessageManager" symbol="fetch" brackets /> has been removed. The <DocsLink type="typedef" parent="BaseFetchOptions" /> the second parameter once was is now merged into the first parameter.
 
 <CH.Code>
 
@@ -807,7 +807,7 @@ Added the _`threadName`_ property in <DocsLink type="typedef" parent="WebhookMes
 
 ### WebSocketManager
 
-discord.js uses <PackageLink name="ws" /> internally.
+discord.js uses <DocsLink package="ws" /> internally.
 
 [^1]: https://github.com/discordjs/discord.js/pull/7188
 [^2]: https://github.com/discordjs/discord.js/pull/6492

--- a/apps/guide/src/util/constants.ts
+++ b/apps/guide/src/util/constants.ts
@@ -24,4 +24,4 @@ export const PACKAGES = [
 /**
  * The stable version of discord.js.
  */
-export const VERSION = '14.10.0' as const;
+export const VERSION = '14.10.2' as const;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
An unfortunate port introduced `<PackageLink name="ws" />`. This component does not exist.

`DocsLink` has been tweaked to allow _only_ a package, which then links to their entry points in the documentation.

I also updated the discord.js version to 14.10.2 and fixed the `BaseFetchOptions` link I happened to come across (this is a `typedef`, not a `class`).