### PR TITLE
fix(roleConnections): Fix `body` type for `updateMetadataRecords()`

### DIFF
--- a/packages/core/src/api/roleConnections.ts
+++ b/packages/core/src/api/roleConnections.ts
@@ -5,7 +5,7 @@ import {
 	Routes,
 	type RESTGetAPIApplicationRoleConnectionMetadataResult,
 	type RESTPutAPIApplicationRoleConnectionMetadataResult,
-	type RESTPutAPIApplicationCommandPermissionsJSONBody,
+	type RESTPutAPIApplicationRoleConnectionMetadataJSONBody,
 	type Snowflake,
 } from 'discord-api-types/v10';
 
@@ -35,7 +35,7 @@ export class RoleConnectionsAPI {
 	 */
 	public async updateMetadataRecords(
 		applicationId: Snowflake,
-		body: RESTPutAPIApplicationCommandPermissionsJSONBody,
+		body: RESTPutAPIApplicationRoleConnectionMetadataJSONBody,
 		{ signal }: Pick<RequestData, 'signal'> = {},
 	) {
 		return this.rest.put(Routes.applicationRoleConnectionMetadata(applicationId), {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`RESTPutAPIApplicationCommandPermissionsJSONBody` is the wrong type for this. The correct type is `RESTPutAPIApplicationRoleConnectionMetadataJSONBody` (as evident from the name).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
