### PR TITLE
fix(proxy-container): docker builds

### DIFF
--- a/packages/proxy-container/Dockerfile
+++ b/packages/proxy-container/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /usr/proxy
 
 COPY manifests .
 
-RUN yarn install --immutable
+RUN npm install --global is-ci husky
+
+RUN yarn install --immutable --inline-builds
 RUN rm -rf .yarn/cache
 
 FROM node:18-alpine AS runner


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Closes #9088

because apparently root cli dev deps were inaccessible in the late stage of `yarn` ??

either way, once https://github.com/vercel/turbo/issues/2791 is completely resolved, we can move to something like this:
```dockerfile
FROM node:18-alpine as builder

RUN apk update
RUN apk add --no-cache libc6-compat

WORKDIR /usr/proxy

COPY . .
RUN yarn dlx turbo prune --scope=@discordjs/proxy-container --docker

FROM node:18-alpine AS installer

RUN apk update
RUN apk add --no-cache libc6-compat

WORKDIR /usr/proxy

COPY .gitignore .gitignore
COPY .yarn/ .yarn/
COPY .yarnrc.yml .yarnrc.yml
COPY --from=builder /usr/proxy/out/json/ .
COPY --from=builder /usr/proxy/out/yarn.lock ./yarn.lock

RUN yarn install --immutable --inline-builds

COPY tsup.config.ts tsup.config.ts
COPY turbo.json turbo.json
COPY tsconfig.json tsconfig.json
RUN yarn turbo run build --filter=@discordjs/proxy-container

RUN yarn workspaces focus @discordjs/proxy-container --production

FROM node:18-alpine AS runner

WORKDIR /usr/proxy

RUN addgroup --system --gid 1001 nodejs
RUN adduser --system --uid 1001 proxy
USER proxy

COPY --from=installer /usr/proxy .

CMD ["node", "--enable-source-maps", "packages/proxy-container/dist/index.js"]
```

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
