### PR TITLE
perf: linear speed position getters

### DIFF
--- a/src/structures/GuildChannel.js
+++ b/src/structures/GuildChannel.js
@@ -5,7 +5,6 @@ const { Error } = require('../errors');
 const PermissionOverwriteManager = require('../managers/PermissionOverwriteManager');
 const { VoiceBasedChannelTypes, ChannelTypes } = require('../util/Constants');
 const Permissions = require('../util/Permissions');
-const SnowflakeUtil = require('../util/SnowflakeUtil');
 const Util = require('../util/Util');
 
 /**

--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -228,8 +228,13 @@ class Role extends Base {
    * @readonly
    */
   get position() {
-    const sorted = this.guild._sortedRoles();
-    return [...sorted.values()].indexOf(sorted.get(this.id));
+    let count = 0;
+    for (const role of this.guild.roles.cache.values()) {
+      if (this.rawPosition > role.rawPosition) count++;
+      else if (this.rawPosition === role.rawPosition && BigInt(this.id) > BigInt(role.id)) count++;
+    }
+
+    return count;
   }
 
   /**

--- a/src/util/Util.js
+++ b/src/util/Util.js
@@ -4,7 +4,7 @@ const { parse } = require('node:path');
 const process = require('node:process');
 const { Collection } = require('@discordjs/collection');
 const fetch = require('node-fetch');
-const { Colors, Endpoints } = require('./Constants');
+const { Colors, Endpoints, ChannelTypes } = require('./Constants');
 const Options = require('./Options');
 const { Error: DiscordError, RangeError, TypeError } = require('../errors');
 const has = (o, k) => Object.prototype.hasOwnProperty.call(o, k);
@@ -13,6 +13,9 @@ const isObject = d => typeof d === 'object' && d !== null;
 let deprecationEmittedForSplitMessage = false;
 let deprecationEmittedForRemoveMentions = false;
 let deprecationEmittedForResolveAutoArchiveMaxLimit = false;
+
+const TextSortableGroupTypes = [ChannelTypes.GUILD_TEXT, ChannelTypes.GUILD_ANNOUCMENT, ChannelTypes.GUILD_FORUM];
+const CategorySortableGroupTypes = [ChannelTypes.GUILD_CATEGORY];
 
 /**
  * Contains various general-purpose utility methods.
@@ -740,6 +743,28 @@ class Util extends null {
       emoji_id: defaultReaction.id,
       emoji_name: defaultReaction.name,
     };
+  }
+
+  /**
+   * Gets an array of the channel types that can be moved in the channel group. For example, a GuildText channel would
+   * return an array containing the types that can be ordered within the text channels (always at the top), and a voice
+   * channel would return an array containing the types that can be ordered within the voice channels (always at the
+   * bottom).
+   * @param {ChannelType} type The type of the channel
+   * @returns {ChannelType[]}
+   * @ignore
+   */
+  static getSortableGroupTypes(type) {
+    switch (type) {
+      case ChannelTypes.GUILD_TEXT:
+      case ChannelTypes.GUILD_ANNOUNCEMENT:
+      case ChannelTypes.GUILD_FORUM:
+        return TextSortableGroupTypes;
+      case ChannelTypes.GUILD_CATEGORY:
+        return CategorySortableGroupTypes;
+      default:
+        return [type];
+    }
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Backports:
- https://github.com/discordjs/discord.js/pull/9497

The other [pr](https://github.com/discordjs/discord.js/pull/9493) isnt backported as current performance is 59 ms per 100_000 iterations
Where kyra's is 132 ms

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.