### PR TITLE
docs: Fix `AutoModerationRuleTriggerTypes` link

### DIFF
--- a/src/managers/AutoModerationRuleManager.js
+++ b/src/managers/AutoModerationRuleManager.js
@@ -84,9 +84,11 @@ class AutoModerationRuleManager extends CachedManager {
    * @property {AutoModerationRuleEventType} eventType The event type of the auto moderation rule
    * @property {AutoModerationRuleTriggerType} triggerType The trigger type of the auto moderation rule
    * @property {AutoModerationTriggerMetadataOptions} [triggerMetadata] The trigger metadata of the auto moderation rule
-   * <info>This property is required if using a `triggerType` of
-   * {@link AutoModerationRuleTriggerTypes.KEYWORD}, {@link AutoModerationRuleTriggerTypes.KEYWORD_PRESET},
-   * or {@link AutoModerationRuleTriggerTypes.MENTION_SPAM}.</info>
+   * <info>This property is required if the following `triggerType`s are used:
+   * * {@link AutoModerationRuleTriggerType.KEYWORD KEYWORD}
+   * * {@link AutoModerationRuleTriggerType.KEYWORD_PRESET KEYWORD_PRESET}
+   * * {@link AutoModerationRuleTriggerType.MENTION_SPAM MENTION_SPAM}
+   * </info>
    * @property {AutoModerationActionOptions[]} actions
    * The actions that will execute when the auto moderation rule is triggered
    * @property {boolean} [enabled] Whether the auto moderation rule should be enabled

--- a/src/structures/AutoModerationRule.js
+++ b/src/structures/AutoModerationRule.js
@@ -71,7 +71,7 @@ class AutoModerationRule extends Base {
        * @property {AutoModerationRuleKeywordPresetType[]} presets
        * The internally pre-defined wordsets which will be searched for in the content
        * @property {string[]} allowList The substrings that will be exempt from triggering
-       * {@link AutoModerationRuleTriggerTypes.KEYWORD} and {@link AutoModerationRuleTriggerTypes.KEYWORD_PRESET}
+       * {@link AutoModerationRuleTriggerType.KEYWORD} and {@link AutoModerationRuleTriggerType.KEYWORD_PRESET}
        * @property {?number} mentionTotalLimit The total number of role & user mentions allowed per message
        */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`AutoModerationRuleTriggerTypes` does not exist. The correct documentation link is [`AutoModerationRuleTriggerType`](https://old.discordjs.dev/#/docs/discord.js/v13/typedef/AutoModerationRuleTriggerType).

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
