### PR TITLE
chore(deps): pin `@discordjs/ws` version in discord.js

### DIFF
--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -55,7 +55,7 @@
     "@discordjs/formatters": "workspace:^",
     "@discordjs/rest": "^1.7.1",
     "@discordjs/util": "workspace:^",
-    "@discordjs/ws": "workspace:^",
+    "@discordjs/ws": "^0.8.3",
     "@sapphire/snowflake": "^3.4.2",
     "@types/ws": "^8.5.4",
     "discord-api-types": "^0.37.41",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2523,7 +2523,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@discordjs/ws@workspace:^, @discordjs/ws@workspace:packages/ws":
+"@discordjs/ws@^0.8.3, @discordjs/ws@workspace:^, @discordjs/ws@workspace:packages/ws":
   version: 0.0.0-use.local
   resolution: "@discordjs/ws@workspace:packages/ws"
   dependencies:
@@ -11344,7 +11344,7 @@ __metadata:
     "@discordjs/formatters": "workspace:^"
     "@discordjs/rest": ^1.7.1
     "@discordjs/util": "workspace:^"
-    "@discordjs/ws": "workspace:^"
+    "@discordjs/ws": ^0.8.3
     "@favware/cliff-jumper": ^2.0.0
     "@sapphire/snowflake": ^3.4.2
     "@types/node": 16.18.25


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
#9416 pinned the version of `/rest` in discord.js but `/ws` also had the node version bump and it's being used in discord.js, which is a breaking change

![image](https://user-images.githubusercontent.com/53496941/236674962-6fcdc35a-65ff-4715-aa0e-6081dbb572dd.png)

![image](https://user-images.githubusercontent.com/53496941/236675014-1331c7c4-1f48-46e8-8462-6f9439e92249.png)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
