### PR TITLE
types(Message): mark author as nullable

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1936,7 +1936,7 @@ export class Message<InGuild extends boolean = boolean> extends Base {
   public activity: MessageActivity | null;
   public applicationId: Snowflake | null;
   public attachments: Collection<Snowflake, Attachment>;
-  public author: User;
+  public author: User | null;
   public get bulkDeletable(): boolean;
   public get channel(): If<InGuild, GuildTextBasedChannel, TextBasedChannel>;
   public channelId: Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently, the discord.js docs site shows [`<Message>.author` as `?User`](https://discord.js.org/#/docs/discord.js/main/class/Message?scrollTo=author), but the TypeScript types do not reflect this. 

Just ran into an instance where not having this field marked as nullable caused a runtime error that could have been prevented.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
