### PR TITLE
feat(create-discord-bot): inherit stdio when installing deps

### DIFF
--- a/packages/create-discord-bot/src/helpers/packageManager.ts
+++ b/packages/create-discord-bot/src/helpers/packageManager.ts
@@ -60,5 +60,8 @@ export function install(packageManager: PackageManager) {
 	}
 
 	console.log(`Installing dependencies with ${packageManager}...`);
-	execSync(installCommand);
+
+	execSync(installCommand, {
+		stdio: 'inherit',
+	});
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at c64b705</samp>

### Summary
📢🔧🚀

<!--
1.  📢 - This emoji can represent the idea of outputting or announcing something, which is what the `stdio` option does by inheriting the console stream.
2.  🔧 - This emoji can represent the idea of modifying or fixing something, which is what the `execSync` function does by passing a different option value.
3.  🚀 - This emoji can represent the idea of improving or speeding up something, which is what the user feedback and visibility of the installation process does by showing the progress and status.
-->
Improved console output of installation command in `create-discord-bot` package. Modified `execSync` function in `packageManager.ts` to inherit the standard input/output/error streams.

> _`execSync` changed_
> _Show installation output_
> _Console blooms in spring_

### Walkthrough
*  Enable output of installation command to console by passing `stdio: 'inherit'` to `execSync` ([link](https://github.com/discordjs/discord.js/pull/9543/files?diff=unified&w=0#diff-99e478cabaf77a3cb0d22c86cfd2367157b6fa5ebe88637dc9967de783081486L63-R66))



**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
