### PR TITLE
fix(WebSocketShard): handle initial connect being a resume

### DIFF
--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -128,10 +128,28 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 	}
 
 	public async connect() {
-		const promise = this.initialConnectResolved ? Promise.resolve() : once(this, WebSocketShardEvents.Ready);
+		const controller = new AbortController();
+		let promise;
+
+		if (!this.initialConnectResolved) {
+			// Sleep for the remaining time, but if the connection closes in the meantime, we shouldn't wait the remainder to avoid blocking the new conn
+			promise = Promise.race([
+				once(this, WebSocketShardEvents.Ready, { signal: controller.signal }),
+				once(this, WebSocketShardEvents.Resumed, { signal: controller.signal }),
+			]);
+
+			controller.abort();
+		}
+
 		void this.internalConnect();
 
-		await promise;
+		try {
+			await promise;
+		} finally {
+			// cleanup hanging listeners
+			controller.abort();
+		}
+
 		this.initialConnectResolved = true;
 	}
 

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -137,8 +137,6 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 				once(this, WebSocketShardEvents.Ready, { signal: controller.signal }),
 				once(this, WebSocketShardEvents.Resumed, { signal: controller.signal }),
 			]);
-
-			controller.abort();
 		}
 
 		void this.internalConnect();


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Closes #9548 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
