### PR TITLE
fix(AutocompleteInteraction): Prevent snake casing of locales

### DIFF
--- a/packages/discord.js/src/structures/AutocompleteInteraction.js
+++ b/packages/discord.js/src/structures/AutocompleteInteraction.js
@@ -87,9 +87,9 @@ class AutocompleteInteraction extends BaseInteraction {
       body: {
         type: InteractionResponseType.ApplicationCommandAutocompleteResult,
         data: {
-          choices: options.map(option => ({
+          choices: options.map(({ nameLocalizations, ...option }) => ({
             ...this.client.options.jsonTransformer(option),
-            name_localizations: option.nameLocalizations,
+            name_localizations: nameLocalizations,
           })),
         },
       },

--- a/packages/discord.js/src/structures/AutocompleteInteraction.js
+++ b/packages/discord.js/src/structures/AutocompleteInteraction.js
@@ -86,7 +86,12 @@ class AutocompleteInteraction extends BaseInteraction {
     await this.client.rest.post(Routes.interactionCallback(this.id, this.token), {
       body: {
         type: InteractionResponseType.ApplicationCommandAutocompleteResult,
-        data: { choices: this.client.options.jsonTransformer(options) },
+        data: {
+          choices: options.map(option => ({
+            ...this.client.options.jsonTransformer(option),
+            name_localizations: option.nameLocalizations,
+          })),
+        },
       },
       auth: false,
     });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `jsonTransformer()` was converting locales like `zh-TW` to `zh_TW` resulting in an API error being returned.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
