### PR TITLE
feat(api): add `getMemberBans()` query options and `getMemberBan()`

### DIFF
--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -11,6 +11,8 @@ import type {
 	RESTGetAPIAuditLogResult,
 	RESTGetAPIAutoModerationRuleResult,
 	RESTGetAPIAutoModerationRulesResult,
+	RESTGetAPIGuildBanResult,
+	RESTGetAPIGuildBansQuery,
 	RESTGetAPIGuildBansResult,
 	RESTGetAPIGuildChannelsResult,
 	RESTGetAPIGuildEmojiResult,
@@ -241,12 +243,32 @@ export class GuildsAPI {
 	/**
 	 * Fetches a guild member ban
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-bans}
+	 * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-ban}
 	 * @param guildId - The id of the guild to fetch the ban from
-	 * @param options - The options for fetching the guild member ban
+	 * @param userId - The id of the user to fetch the ban
+	 * @param options - The options for fetching the ban
 	 */
-	public async getMemberBans(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildBans(guildId), { signal }) as Promise<RESTGetAPIGuildBansResult>;
+	public async getMemberBan(guildId: Snowflake, userId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+		return this.rest.get(Routes.guildBan(guildId, userId), { signal }) as Promise<RESTGetAPIGuildBanResult>;
+	}
+
+	/**
+	 * Fetches guild member bans
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/guild#get-guild-bans}
+	 * @param guildId - The id of the guild to fetch the bans from
+	 * @param query - The query options for fetching the bans
+	 * @param options - The options for fetching the bans
+	 */
+	public async getMemberBans(
+		guildId: Snowflake,
+		query: RESTGetAPIGuildBansQuery = {},
+		{ signal }: Pick<RequestData, 'signal'> = {},
+	) {
+		return this.rest.get(Routes.guildBans(guildId), {
+			query: makeURLSearchParams(query),
+			signal,
+		}) as Promise<RESTGetAPIGuildBansResult>;
 	}
 
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`getMemberBan()` isn't implemented at all and `getMemberBans()` currently doesn't support query options.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
