### PR TITLE
types: use `Snowflake` instead of `string` for snowflakes

### DIFF
--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -102,7 +102,7 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild
 	 * @param options - The options for fetching the guild
 	 */
-	public async get(guildId: string, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async get(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
 		return this.rest.get(Routes.guild(guildId), { signal }) as Promise<RESTGetAPIGuildResult>;
 	}
 

--- a/packages/core/src/api/webhook.ts
+++ b/packages/core/src/api/webhook.ts
@@ -272,7 +272,7 @@ export class WebhooksAPI {
 		id: Snowflake,
 		token: string,
 		messageId: Snowflake,
-		query: { thread_id?: string } = {},
+		query: { thread_id?: Snowflake } = {},
 		{ signal }: Pick<RequestData, 'signal'> = {},
 	) {
 		await this.rest.delete(Routes.webhookMessage(id, token, messageId), {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There were two instances where `string` instead of `Snowflake` were being used.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
