### PR TITLE
feat(User): return just the username in `tag` for new usernames

### DIFF
--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -193,6 +193,10 @@ class User extends Base {
    * @readonly
    */
   get tag() {
+    if (this.discriminator === "0" || this.discriminator === "0000") {
+      return typeof this.username === 'string' ? this.username : null;
+    }
+
     return typeof this.username === 'string' ? `${this.username}#${this.discriminator}` : null;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Makes `User.tag` return just the username instead of `username#0` for new (Pomelo) usernames.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
