### PR TITLE
fix(Client): safe call for possibly null WebSocket

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -325,7 +325,7 @@ class WebSocketManager extends EventEmitter {
     // TODO: Make a util for getting a stack
     this.debug(`Manager was destroyed. Called by:\n${new Error().stack}`);
     this.destroyed = true;
-    this._ws.destroy({ code: CloseCodes.Normal });
+    this._ws?.destroy({ code: CloseCodes.Normal });
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I use the client itself as an event emitter for testing, without callling login.

I have overridden the `destroy()` method to include file io closing and realized that the application crashes because `._ws` is null

**Status and versioning classification:**

this is a patch

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating