### PR TITLE
fix(WebSocketManager): always cache result of fetchGatewayInformation

### DIFF
--- a/packages/ws/src/ws/WebSocketManager.ts
+++ b/packages/ws/src/ws/WebSocketManager.ts
@@ -234,6 +234,7 @@ export class WebSocketManager extends AsyncEventEmitter<ManagerShardEventsMap> {
 
 		const data = (await this.options.rest.get(Routes.gatewayBot())) as RESTGetAPIGatewayBotResult;
 
+		// For single sharded bots session_start_limit.reset_after will be 0, use 5 seconds as a minimum expiration time
 		this.gatewayInformation = { data, expiresAt: Date.now() + (data.session_start_limit.reset_after || 5_000) };
 		return this.gatewayInformation.data;
 	}

--- a/packages/ws/src/ws/WebSocketManager.ts
+++ b/packages/ws/src/ws/WebSocketManager.ts
@@ -234,7 +234,7 @@ export class WebSocketManager extends AsyncEventEmitter<ManagerShardEventsMap> {
 
 		const data = (await this.options.rest.get(Routes.gatewayBot())) as RESTGetAPIGatewayBotResult;
 
-		this.gatewayInformation = { data, expiresAt: Date.now() + data.session_start_limit.reset_after };
+		this.gatewayInformation = { data, expiresAt: Date.now() + (data.session_start_limit.reset_after || 5_000) };
 		return this.gatewayInformation.data;
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

For small bots with only one shard the result of `WebSocketManager#fetchGatewayInformation()` wasn't cached, because discord sends `session_start_limit.reset_after` of 0 in that case.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating


<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
