### PR TITLE
fix(website): Overload switcher duplicates reference links

### DIFF
--- a/apps/website/src/components/ExcerptText.tsx
+++ b/apps/website/src/components/ExcerptText.tsx
@@ -49,7 +49,7 @@ export function ExcerptText({ model, excerpt }: ExcerptTextProps) {
 						<ItemLink
 							className="text-blurple"
 							itemURI={resolveItemURI(item)}
-							key={`${item.displayName}-${item.containerKey}`}
+							key={`${item.displayName}-${item.containerKey}-${idx}`}
 							packageName={item.getAssociatedPackage()?.displayName.replace('@discordjs/', '')}
 						>
 							{token.text}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes the duplicate keys in the ItemLinks which causes the duplication of elements.

resolves #9599

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
