### PR TITLE
types(REST): Add body type info (for post, delete, patch, put)

### DIFF
--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -312,7 +312,7 @@ export class REST extends EventEmitter {
 	 * @param fullRoute - The full route to query
 	 * @param options - Optional request options
 	 */
-	public async delete(fullRoute: RouteLike, options: RequestData = {}) {
+	public async delete<T = unknown>(fullRoute: RouteLike, options: RequestData<T> = {}) {
 		return this.request({ ...options, fullRoute, method: RequestMethod.Delete });
 	}
 
@@ -322,7 +322,7 @@ export class REST extends EventEmitter {
 	 * @param fullRoute - The full route to query
 	 * @param options - Optional request options
 	 */
-	public async post(fullRoute: RouteLike, options: RequestData = {}) {
+	public async post<T = unknown>(fullRoute: RouteLike, options: RequestData<T> = {}) {
 		return this.request({ ...options, fullRoute, method: RequestMethod.Post });
 	}
 
@@ -332,7 +332,7 @@ export class REST extends EventEmitter {
 	 * @param fullRoute - The full route to query
 	 * @param options - Optional request options
 	 */
-	public async put(fullRoute: RouteLike, options: RequestData = {}) {
+	public async put<T = unknown>(fullRoute: RouteLike, options: RequestData<T> = {}) {
 		return this.request({ ...options, fullRoute, method: RequestMethod.Put });
 	}
 
@@ -342,7 +342,7 @@ export class REST extends EventEmitter {
 	 * @param fullRoute - The full route to query
 	 * @param options - Optional request options
 	 */
-	public async patch(fullRoute: RouteLike, options: RequestData = {}) {
+	public async patch<T = unknown>(fullRoute: RouteLike, options: RequestData<T> = {}) {
 		return this.request({ ...options, fullRoute, method: RequestMethod.Patch });
 	}
 

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -69,7 +69,7 @@ export interface RequestData<T = unknown> {
 	 * The body to send to this request.
 	 * If providing as BodyInit, set `passThroughBody: true`
 	 */
-	body?: T | BodyInit;
+	body?: BodyInit | T;
 	/**
 	 * The {@link https://undici.nodejs.org/#/docs/api/Agent | Agent} to use for the request.
 	 */

--- a/packages/rest/src/lib/RequestManager.ts
+++ b/packages/rest/src/lib/RequestManager.ts
@@ -48,7 +48,7 @@ export interface RawFile {
 /**
  * Represents possible data to be given to an endpoint
  */
-export interface RequestData {
+export interface RequestData<T = unknown> {
 	/**
 	 * Whether to append JSON data to form data instead of `payload_json` when sending files
 	 */
@@ -69,7 +69,7 @@ export interface RequestData {
 	 * The body to send to this request.
 	 * If providing as BodyInit, set `passThroughBody: true`
 	 */
-	body?: BodyInit | unknown;
+	body?: T | BodyInit;
 	/**
 	 * The {@link https://undici.nodejs.org/#/docs/api/Agent | Agent} to use for the request.
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently `RequestData.body` is unknown without BodyInit. This change will allow users of the library to check for the type of body by putting the type of body in the generics.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
