### PR TITLE
types: Wrap arrays in `Readonly<>`

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1165,7 +1165,7 @@ export class CommandInteractionOptionResolver<Cached extends CacheType = CacheTy
   public getChannel<T extends ChannelType = ChannelType>(
     name: string,
     required: true,
-    channelTypes?: T[],
+    channelTypes?: Readonly<T[]>,
   ): Extract<
     NonNullable<CommandInteractionOption<Cached>['channel']>,
     {
@@ -1180,7 +1180,7 @@ export class CommandInteractionOptionResolver<Cached extends CacheType = CacheTy
   public getChannel<T extends ChannelType = ChannelType>(
     name: string,
     required?: boolean,
-    channelTypes?: T[],
+    channelTypes?: Readonly<T[]>,
   ): Extract<
     NonNullable<CommandInteractionOption<Cached>['channel']>,
     {
@@ -4331,13 +4331,13 @@ export type ApplicationCommandData =
 
 export interface ApplicationCommandChannelOptionData extends BaseApplicationCommandOptionsData {
   type: CommandOptionChannelResolvableType;
-  channelTypes?: ApplicationCommandOptionAllowedChannelTypes[];
-  channel_types?: ApplicationCommandOptionAllowedChannelTypes[];
+  channelTypes?: Readonly<ApplicationCommandOptionAllowedChannelTypes[]>;
+  channel_types?: Readonly<ApplicationCommandOptionAllowedChannelTypes[]>;
 }
 
 export interface ApplicationCommandChannelOption extends BaseApplicationCommandOptionsData {
   type: ApplicationCommandOptionType.Channel;
-  channelTypes?: ApplicationCommandOptionAllowedChannelTypes[];
+  channelTypes?: Readonly<ApplicationCommandOptionAllowedChannelTypes[]>;
 }
 
 export interface ApplicationCommandRoleOptionData extends BaseApplicationCommandOptionsData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Readonly<>` has been added to some arrays to allow immutable arrays through (`as const`).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
