### PR TITLE
fix(website): switch signature with overload

### DIFF
--- a/apps/website/src/components/model/method/Method.tsx
+++ b/apps/website/src/components/model/method/Method.tsx
@@ -5,6 +5,7 @@ import type {
 	ApiMethodSignature,
 } from '@microsoft/api-extractor-model';
 import dynamic from 'next/dynamic';
+import { Fragment } from 'react';
 import { MethodDocumentation } from './MethodDocumentation';
 import { MethodHeader } from './MethodHeader';
 
@@ -20,17 +21,14 @@ export function Method({
 	if (method.getMergedSiblings().length > 1) {
 		// We have overloads, use the overload switcher, but render
 		// each overload node on the server.
-		const overloads = method
-			.getMergedSiblings()
-			.map((sibling, idx) => (
-				<MethodDocumentation key={`${sibling.displayName}-${idx}`} method={sibling as ApiMethod | ApiMethodSignature} />
-			));
+		const overloads = method.getMergedSiblings().map((sibling, idx) => (
+			<Fragment key={`${sibling.displayName}-${idx}`}>
+				<MethodHeader method={sibling as ApiMethod | ApiMethodSignature} />
+				<MethodDocumentation method={sibling as ApiMethod | ApiMethodSignature} />
+			</Fragment>
+		));
 
-		return (
-			<OverloadSwitcher overloads={overloads}>
-				<MethodHeader method={method} />
-			</OverloadSwitcher>
-		);
+		return <OverloadSwitcher overloads={overloads} />;
 	}
 
 	// We have just a single method, render it on the server.


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When switching overloads the method signature will now switch to reflect the overload selected

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes

- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:


- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
