### PR TITLE
fix(ThreadManager): Fix crash

### DIFF
--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -189,7 +189,10 @@ class ThreadManager extends CachedManager {
 
     // Discord sends the thread id as id in this object
     const threadMembers = rawThreads.members.reduce(
-      (coll, raw) => coll.set(raw.user_id, threads.get(raw.id).members._add(raw)),
+      (coll, raw) => {
+        const thread = threads.get(raw.id);
+        return thread ? coll.set(raw.user_id, thread.members._add(raw)) : coll;
+      },
       new Collection(),
     );
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`threads.get(raw.id)` can be `undefined` when `raw` is not a child thread of `parent`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating