### PR TITLE
feat: add resume event in shard

### DIFF
--- a/packages/discord.js/src/sharding/Shard.js
+++ b/packages/discord.js/src/sharding/Shard.js
@@ -370,6 +370,11 @@ class Shard extends EventEmitter {
       // Shard has resumed
       if (message._resume) {
         this.ready = true;
+        /**
+         * Emitted upon the shard's {@link Client#event:shardResume} event.
+         * @event Shard#resume
+         */
+        this.emit(ShardEvents.Resume);
         return;
       }
 

--- a/packages/discord.js/src/util/ShardEvents.js
+++ b/packages/discord.js/src/util/ShardEvents.js
@@ -8,6 +8,7 @@
  * @property {string} Message message
  * @property {string} Ready ready
  * @property {string} Reconnecting reconnecting
+ * @property {string} Resume resume
  * @property {string} Spawn spawn
  */
 
@@ -23,5 +24,6 @@ module.exports = {
   Message: 'message',
   Ready: 'ready',
   Reconnecting: 'reconnecting',
+  Resume: 'resume',
   Spawn: 'spawn',
 };

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2635,6 +2635,7 @@ export interface ShardEventTypes {
   message: [message: any];
   ready: [];
   reconnecting: [];
+  resume: [];
   spawn: [process: ChildProcess | Worker];
 }
 
@@ -5039,6 +5040,7 @@ export enum ShardEvents {
   Message = 'message',
   Ready = 'ready',
   Reconnecting = 'reconnecting',
+  Resume = 'resume',
   Spawn = 'spawn',
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
With #9626, `resume` events can now be received within the sharding process.
Therefore, this PR is to make it possible to listen to the `Shard#resume` event even in shards.
This allows modern code using callbacks to know when to resume without having to check the `Shard#ready` flag regularly.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
