### PR TITLE
setNameLocalization typo

### DIFF
--- a/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -54,7 +54,7 @@ export class SharedNameAndDescription {
 	}
 
 	/**
-	 * SSets a name localization for this command.
+	 * Sets a name localization for this command.
 	 *
 	 * @param locale - The locale to set
 	 * @param localizedName - The localized name for the given `locale`


### PR DESCRIPTION
setNameLocalization typo

**Please describe the changes this PR makes and why it should be merged:**
fixed a JSDoc typo in NameAndDescription.ts > setNameLocalization

**Status and versioning classification:**
This PR **only** includes non-code changes, like changes to documentation, README, etc.
