### PR TITLE
refactor(User): remove deprecation warning from tag

### DIFF
--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -7,7 +7,6 @@ const Base = require('./Base');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const UserFlagsBitField = require('../util/UserFlagsBitField');
 
-
 /**
  * Represents a user on Discord.
  * @implements {TextBasedChannel}

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -209,14 +209,8 @@ class User extends Base {
    * if they're using the legacy username system</info>
    * @type {?string}
    * @readonly
-   * @deprecated Use {@link User#username} instead.
    */
   get tag() {
-    if (!tagDeprecationEmitted) {
-      process.emitWarning('User#tag is deprecated. Use User#username instead.', 'DeprecationWarning');
-      tagDeprecationEmitted = true;
-    }
-
     return typeof this.username === 'string'
       ? this.discriminator === '0'
         ? this.username

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const process = require('node:process');
 const { userMention } = require('@discordjs/builders');
 const { calculateUserDefaultAvatarIndex } = require('@discordjs/rest');
 const { DiscordSnowflake } = require('@sapphire/snowflake');
@@ -8,7 +7,6 @@ const Base = require('./Base');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const UserFlagsBitField = require('../util/UserFlagsBitField');
 
-let tagDeprecationEmitted = false;
 
 /**
  * Represents a user on Discord.

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3067,7 +3067,6 @@ export class User extends PartialTextBasedChannel(Base) {
   public id: Snowflake;
   public get partial(): false;
   public system: boolean;
-  /** @deprecated Use {@link User#username} instead. */
   public get tag(): string;
   public username: string;
   public avatarURL(options?: ImageURLOptions): string | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes the deprecation warning from User#tag, simply because, as Discord stated, bots will continue on the legacy username system for the time being, so it's still needed, as well as with users that haven't completed the migration yet/haven't had accesses to it, thus there is no reasonable way a developer can remove all access to the tag property just yet. I would even argue that there's no need to check for discriminators equal to "0" here and let devs do that check on their end, but that's out of the scope of this PR and something I'd rather not touch on.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
