### PR TITLE
feat(User): add `isPomelo` function

### DIFF
--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -224,6 +224,11 @@ class User extends Base {
       : null;
   }
 
+  get isPomelo() {
+    if(this.tag.endsWith("#0")) return true;
+    return false;
+  }
+
   /**
    * The global name of this user, or their username if they don't have one
    * @type {?string}

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -224,8 +224,14 @@ class User extends Base {
       : null;
   }
 
+  /**
+   * Whether the user uses the new username system
+   * <info>Returns true if the user uses the new username system</info>
+   * @type {?boolean}
+   * @readonly
+   */
   get isPomelo() {
-    if(this.tag.endsWith("#0")) return true;
+    if(this.discriminator === "0") return true;
     return false;
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds a new function called `isPomelo`, which returns `true` if the user uses the new username system (aka Pomelo). This can be helpful for bots if they want to quickly check if a user is using the new username system or not.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)