### PR TITLE
types(BaseMessageOptions): Add ActionRowBuilder<AnyComponentBuilder>

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5834,6 +5834,7 @@ export interface BaseMessageOptions {
     | JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>
     | ActionRowData<MessageActionRowComponentData | MessageActionRowComponentBuilder>
     | APIActionRowComponent<APIMessageActionRowComponent>
+    | ActionRowBuilder<AnyComponentBuilder>
   )[];
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Small type change that allows for ActionRowBuilder to be used in a BaseMessage's components.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I _"know"_ how to update typings and have done so, or typings don't need updating

minor change - bug fix. This resolves an issue where one is unable to use ActionRowBuilder in a message. Example:

```typescript
   // ...
    const buttons = new ActionRowBuilder().addComponents(button1, button2);

    await interaction.reply({
      components: [buttons],
    });
```

The above code would/will fail due to a typing issue.

