### PR TITLE
feat: add profile url property

### DIFF
--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -151,6 +151,15 @@ class User extends Base {
     return new Date(this.createdTimestamp);
   }
 
+   /**
+   * A link to the user's profile
+   * @type {string}
+   * @readonly
+   */
+  get profileURL() {
+    return `https://discord.com/users/${this.id}`;
+  }
+
   /**
    * A link to the user's avatar.
    * @param {ImageURLOptions} [options={}] Options for the image URL


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Added profile url. This will be useful for moderator bots which need to give profile url to the discord mod to check user's profile.
Other use cases include giving author url in embeds.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)


<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
