### PR TITLE
fix(WebSocketShard): close errors not being catchable

### DIFF
--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -142,7 +142,9 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 		void this.internalConnect();
 
 		try {
-			await promise;
+			await promise?.catch(({ error }) => {
+				throw error;
+			});
 		} finally {
 			// cleanup hanging listeners
 			controller.abort();
@@ -710,7 +712,9 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			}
 
 			case GatewayCloseCodes.AuthenticationFailed: {
-				throw new Error('Authentication failed');
+				return this.emit(WebSocketShardEvents.Error, {
+					error: new Error('Authentication failed'),
+				});
 			}
 
 			case GatewayCloseCodes.AlreadyAuthenticated: {
@@ -734,23 +738,33 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			}
 
 			case GatewayCloseCodes.InvalidShard: {
-				throw new Error('Invalid shard');
+				return this.emit(WebSocketShardEvents.Error, {
+					error: new Error('Invalid shard'),
+				});
 			}
 
 			case GatewayCloseCodes.ShardingRequired: {
-				throw new Error('Sharding is required');
+				return this.emit(WebSocketShardEvents.Error, {
+					error: new Error('Sharding is required'),
+				});
 			}
 
 			case GatewayCloseCodes.InvalidAPIVersion: {
-				throw new Error('Used an invalid API version');
+				return this.emit(WebSocketShardEvents.Error, {
+					error: new Error('Used an invalid API version'),
+				});
 			}
 
 			case GatewayCloseCodes.InvalidIntents: {
-				throw new Error('Used invalid intents');
+				return this.emit(WebSocketShardEvents.Error, {
+					error: new Error('Used invalid intents'),
+				});
 			}
 
 			case GatewayCloseCodes.DisallowedIntents: {
-				throw new Error('Used disallowed intents');
+				return this.emit(WebSocketShardEvents.Error, {
+					error: new Error('Used disallowed intents'),
+				});
 			}
 
 			default: {

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -142,9 +142,9 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 		void this.internalConnect();
 
 		try {
-			await promise?.catch(({ error }) => {
-				throw error;
-			});
+			await promise;
+		} catch ({ error }: any) {
+			throw error;
 		} finally {
 			// cleanup hanging listeners
 			controller.abort();
@@ -712,9 +712,10 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			}
 
 			case GatewayCloseCodes.AuthenticationFailed: {
-				return this.emit(WebSocketShardEvents.Error, {
+				this.emit(WebSocketShardEvents.Error, {
 					error: new Error('Authentication failed'),
 				});
+				return this.destroy({ code });
 			}
 
 			case GatewayCloseCodes.AlreadyAuthenticated: {
@@ -738,33 +739,38 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			}
 
 			case GatewayCloseCodes.InvalidShard: {
-				return this.emit(WebSocketShardEvents.Error, {
+				this.emit(WebSocketShardEvents.Error, {
 					error: new Error('Invalid shard'),
 				});
+				return this.destroy({ code });
 			}
 
 			case GatewayCloseCodes.ShardingRequired: {
-				return this.emit(WebSocketShardEvents.Error, {
+				this.emit(WebSocketShardEvents.Error, {
 					error: new Error('Sharding is required'),
 				});
+				return this.destroy({ code });
 			}
 
 			case GatewayCloseCodes.InvalidAPIVersion: {
-				return this.emit(WebSocketShardEvents.Error, {
+				this.emit(WebSocketShardEvents.Error, {
 					error: new Error('Used an invalid API version'),
 				});
+				return this.destroy({ code });
 			}
 
 			case GatewayCloseCodes.InvalidIntents: {
-				return this.emit(WebSocketShardEvents.Error, {
+				this.emit(WebSocketShardEvents.Error, {
 					error: new Error('Used invalid intents'),
 				});
+				return this.destroy({ code });
 			}
 
 			case GatewayCloseCodes.DisallowedIntents: {
-				return this.emit(WebSocketShardEvents.Error, {
+				this.emit(WebSocketShardEvents.Error, {
 					error: new Error('Used disallowed intents'),
 				});
+				return this.destroy({ code });
 			}
 
 			default: {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #9621.

~~It seems like the errors could only occur when using `WebSocketShard#connect` (and I didn't want to modify much code), so my approach was to listen to the close event and throw the errors directly from `connect`, therefore making them catchable.~~

Swaps all `throw`s on close errors with emitting `WebSocketShardEvents.Error`, then catching and throwing them directly inside of `connect`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
