### PR TITLE
fix(website): type alias search symbol

### DIFF
--- a/apps/website/src/components/CmdK.tsx
+++ b/apps/website/src/components/CmdK.tsx
@@ -4,7 +4,6 @@ import type { ApiItemKind } from '@microsoft/api-extractor-model';
 import { VscArrowRight } from '@react-icons/all-files/vsc/VscArrowRight';
 import { VscSymbolClass } from '@react-icons/all-files/vsc/VscSymbolClass';
 import { VscSymbolEnum } from '@react-icons/all-files/vsc/VscSymbolEnum';
-import { VscSymbolField } from '@react-icons/all-files/vsc/VscSymbolField';
 import { VscSymbolInterface } from '@react-icons/all-files/vsc/VscSymbolInterface';
 import { VscSymbolMethod } from '@react-icons/all-files/vsc/VscSymbolMethod';
 import { VscSymbolProperty } from '@react-icons/all-files/vsc/VscSymbolProperty';
@@ -28,7 +27,7 @@ function resolveIcon(item: keyof typeof ApiItemKind) {
 		case 'Property':
 			return <VscSymbolProperty className="shrink-0" size={25} />;
 		case 'TypeAlias':
-			return <VscSymbolField className="shrink-0" size={25} />;
+			return <VscSymbolVariable className="shrink-0" size={25} />;
 		case 'Variable':
 			return <VscSymbolVariable className="shrink-0" size={25} />;
 		default:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes the symbol for type aliases an the search.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
