### PR TITLE
feat: user avatar decorations

### DIFF
--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -122,6 +122,16 @@ class User extends Base {
        */
       this.flags = new UserFlags(data.public_flags);
     }
+
+    if ('avatar_decoration' in data) {
+      /**
+       * The user avatar decoration's hash
+       * @type {?string}
+       */
+      this.avatarDecoration = data.avatar_decoration;
+    } else {
+      this.avatarDecoration ??= null;
+    }
   }
 
   /**
@@ -159,6 +169,16 @@ class User extends Base {
   avatarURL({ format, size, dynamic } = {}) {
     if (!this.avatar) return null;
     return this.client.rest.cdn.Avatar(this.id, this.avatar, format, size, dynamic);
+  }
+
+  /**
+   * A link to the user's avatar decoration.
+   * @param {StaticImageURLOptions} [options={}] Options for the image URL
+   * @returns {?string}
+   */
+  avatarDecorationURL({ format, size } = {}) {
+    if (!this.avatarDecoration) return null;
+    return this.client.rest.cdn.AvatarDecoration(this.id, this.avatarDecoration, format, size);
   }
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -98,7 +98,8 @@ exports.Endpoints = {
         makeImageUrl(`${root}/discovery-splashes/${guildId}/${hash}`, { size, format }),
       TeamIcon: (teamId, hash, options) => makeImageUrl(`${root}/team-icons/${teamId}/${hash}`, options),
       Sticker: (stickerId, stickerFormat) =>
-        `${root}/stickers/${stickerId}.${stickerFormat === 'LOTTIE' ? 'json' : stickerFormat === 'GIF' ? 'gif' : 'png'
+        `${root}/stickers/${stickerId}.${
+          stickerFormat === 'LOTTIE' ? 'json' : stickerFormat === 'GIF' ? 'gif' : 'png'
         }`,
       RoleIcon: (roleId, hash, format = 'webp', size) =>
         makeImageUrl(`${root}/role-icons/${roleId}/${hash}`, { size, format }),

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -73,6 +73,8 @@ exports.Endpoints = {
         if (dynamic && hash.startsWith('a_')) format = 'gif';
         return makeImageUrl(`${root}/avatars/${userId}/${hash}`, { format, size });
       },
+      AvatarDecoration: (userId, hash, format = 'png', size) =>
+        makeImageUrl(`${root}/avatar-decorations/${userId}/${hash}`, { format, size }),
       GuildMemberAvatar: (guildId, memberId, hash, format = 'webp', size, dynamic = false) => {
         if (dynamic && hash.startsWith('a_')) format = 'gif';
         return makeImageUrl(`${root}/guilds/${guildId}/users/${memberId}/avatars/${hash}`, { format, size });
@@ -96,8 +98,7 @@ exports.Endpoints = {
         makeImageUrl(`${root}/discovery-splashes/${guildId}/${hash}`, { size, format }),
       TeamIcon: (teamId, hash, options) => makeImageUrl(`${root}/team-icons/${teamId}/${hash}`, options),
       Sticker: (stickerId, stickerFormat) =>
-        `${root}/stickers/${stickerId}.${
-          stickerFormat === 'LOTTIE' ? 'json' : stickerFormat === 'GIF' ? 'gif' : 'png'
+        `${root}/stickers/${stickerId}.${stickerFormat === 'LOTTIE' ? 'json' : stickerFormat === 'GIF' ? 'gif' : 'png'
         }`,
       RoleIcon: (roleId, hash, format = 'webp', size) =>
         makeImageUrl(`${root}/role-icons/${roleId}/${hash}`, { size, format }),

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3097,7 +3097,7 @@ export const Constants: {
         size: AllowedImageSize,
         dynamic: boolean,
       ): string;
-      AvatarDecoration: (userId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
+      AvatarDecoration(userId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize): string;
       Banner(id: Snowflake, hash: string, format: DynamicImageFormat, size: AllowedImageSize, dynamic: boolean): string;
       DefaultAvatar(index: number): string;
       DiscoverySplash(guildId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3097,12 +3097,7 @@ export const Constants: {
         size: AllowedImageSize,
         dynamic: boolean,
       ): string;
-      AvatarDecoration: (
-        userId: Snowflake,
-        hash: string,
-        format: AllowedImageFormat,
-        size: AllowedImageSize,
-      ) => string;
+      AvatarDecoration: (userId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize) => string;
       Banner(id: Snowflake, hash: string, format: DynamicImageFormat, size: AllowedImageSize, dynamic: boolean): string;
       DefaultAvatar(index: number): string;
       DiscoverySplash(guildId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize): string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -2698,6 +2698,7 @@ export class User extends PartialTextBasedChannel(Base) {
 
   public accentColor: number | null | undefined;
   public avatar: string | null;
+  public avatarDecoration: string | null;
   public banner: string | null | undefined;
   public bot: boolean;
   public readonly createdAt: Date;
@@ -2715,6 +2716,7 @@ export class User extends PartialTextBasedChannel(Base) {
   public readonly tag: string;
   public username: string;
   public avatarURL(options?: ImageURLOptions): string | null;
+  public avatarDecorationURL(options?: StaticImageURLOptions): string | null;
   public bannerURL(options?: ImageURLOptions): string | null;
   public createDM(force?: boolean): Promise<DMChannel>;
   public deleteDM(): Promise<DMChannel>;
@@ -3095,6 +3097,12 @@ export const Constants: {
         size: AllowedImageSize,
         dynamic: boolean,
       ): string;
+      AvatarDecoration: (
+        userId: Snowflake,
+        hash: string,
+        format: AllowedImageFormat,
+        size: AllowedImageSize,
+      ) => string;
       Banner(id: Snowflake, hash: string, format: DynamicImageFormat, size: AllowedImageSize, dynamic: boolean): string;
       DefaultAvatar(index: number): string;
       DiscoverySplash(guildId: Snowflake, hash: string, format: AllowedImageFormat, size: AllowedImageSize): string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

v14: #8914 
Supersedes: #9018 

> Added:

- `User#avatarDecoration`
- `User#avatarDecorationURL()`

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR does not include any braking changes
