### PR TITLE
fix(WebSocketShard): close errors not being catchable updated

### DIFF
--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -710,7 +710,13 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			}
 
 			case GatewayCloseCodes.AuthenticationFailed: {
-				throw new Error('Authentication failed');
+				this.onError(
+					Object.assign(new Error('Authentication failed'), {
+						name: 'AuthenticationFailed',
+						code: 'AUTHENTICATION_FAILED',
+					}),
+				);
+				return this.destroy({ code });
 			}
 
 			case GatewayCloseCodes.AlreadyAuthenticated: {
@@ -746,13 +752,22 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			}
 
 			case GatewayCloseCodes.InvalidIntents: {
-				throw new Error('Used invalid intents');
+				this.onError(
+					Object.assign(new Error('Used invalid intents'), { name: 'InvalidIntents', code: 'INVALID_INTENTS' }),
+				);
+				return this.destroy({ code });
 			}
 
 			case GatewayCloseCodes.DisallowedIntents: {
-				throw new Error('Used disallowed intents');
+				this.onError(
+					Object.assign(new Error('Used disallowed intents'), {
+						name: 'DisallowedIntents',
+						code: 'DISALLOWED_INTENTS',
+					}),
+				);
+				return this.destroy({ code });
 			}
-
+				
 			default: {
 				this.debug([
 					`The gateway closed with an unexpected code ${code}, attempting to ${


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

Resolves #9621 

It seems like the errors could only occur when using WebSocketShard#connect (and I didn't want to modify much code), so my approach was to was added just to call the onError function, therefore making them catchable.

Status and versioning classification:

Code changes have been tested against the Discord API, or there are no code changes I know how to update typings and have done so, or typings don't need updating

**Please describe the changes this PR makes and why it should be merged:**

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
