### PR TITLE
feat(WebhooksAPI): allow `with token` requests without bot auth

### DIFF
--- a/packages/core/src/api/webhook.ts
+++ b/packages/core/src/api/webhook.ts
@@ -27,11 +27,16 @@ export class WebhooksAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/webhook#get-webhook}
 	 * @see {@link https://discord.com/developers/docs/resources/webhook#get-webhook-with-token}
 	 * @param id - The id of the webhook
-	 * @param token - The token of the webhook
 	 * @param options - The options for fetching the webhook
 	 */
-	public async get(id: Snowflake, token?: string, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.webhook(id, token), { signal }) as Promise<RESTGetAPIWebhookResult>;
+	public async get(
+		id: Snowflake,
+		{ token, signal }: Pick<RequestData, 'signal'> & { token?: string | undefined } = {},
+	) {
+		return this.rest.get(Routes.webhook(id, token), {
+			signal,
+			auth: !token,
+		}) as Promise<RESTGetAPIWebhookResult>;
 	}
 
 	/**
@@ -52,6 +57,7 @@ export class WebhooksAPI {
 			reason,
 			body,
 			signal,
+			auth: !token,
 		}) as Promise<RESTPatchAPIWebhookResult>;
 	}
 
@@ -67,7 +73,11 @@ export class WebhooksAPI {
 		id: Snowflake,
 		{ token, reason, signal }: Pick<RequestData, 'reason' | 'signal'> & { token?: string | undefined } = {},
 	) {
-		await this.rest.delete(Routes.webhook(id, token), { reason, signal });
+		await this.rest.delete(Routes.webhook(id, token), {
+			reason,
+			signal,
+			auth: !token,
+		});
 	}
 
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Allows [Get Webhook with Token](https://discord.com/developers/docs/resources/webhook#get-webhook-with-token), [Modify Webhook with Token](https://discord.com/developers/docs/resources/webhook#modify-webhook-with-token), and [Delete Webhook with Token](https://discord.com/developers/docs/resources/webhook#delete-webhook-with-token) to be used without bot authentication.

Also moves `get`'s `token` parameter to options.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
