### PR TITLE
docs(BaseChannel): Remove `APIChannel`

### DIFF
--- a/packages/discord.js/src/structures/BaseChannel.js
+++ b/packages/discord.js/src/structures/BaseChannel.js
@@ -153,8 +153,3 @@ class BaseChannel extends Base {
 }
 
 exports.BaseChannel = BaseChannel;
-
-/**
- * @external APIChannel
- * @see {@link https://discord.com/developers/docs/resources/channel#channel-object}
- */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This already exists (and was being overwritten) here:

https://github.com/discordjs/discord.js/blob/bc83cabfdad76fec9352ddb9a7d488e058ede180/packages/discord.js/src/util/APITypes.js#L43-L46

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
