### PR TITLE
docs: Change `Channel` to `BaseChannel`

### DIFF
--- a/packages/discord.js/src/structures/ChannelSelectMenuInteraction.js
+++ b/packages/discord.js/src/structures/ChannelSelectMenuInteraction.js
@@ -20,7 +20,7 @@ class ChannelSelectMenuInteraction extends MessageComponentInteraction {
 
     /**
      * Collection of the selected channels
-     * @type {Collection<Snowflake, Channel|APIChannel>}
+     * @type {Collection<Snowflake, BaseChannel|APIChannel>}
      */
     this.channels = new Collection();
 

--- a/packages/discord.js/src/util/Channels.js
+++ b/packages/discord.js/src/util/Channels.js
@@ -20,7 +20,7 @@ const getForumChannel = lazy(() => require('../structures/ForumChannel'));
  * @param {APIChannel} data The data of the channel to create
  * @param {Guild} [guild] The guild where this channel belongs
  * @param {Object} [extras] Extra information to supply for creating this channel
- * @returns {Channel} Any kind of channel.
+ * @returns {BaseChannel} Any kind of channel.
  * @ignore
  */
 function createChannel(client, data, guild, { allowUnknownGuild } = {}) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Channel` does not exist in our definitions. The correct one is `BaseChannel`.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
