### PR TITLE
feat(create-discord-bot): throw error if the directory is a file

### DIFF
--- a/packages/create-discord-bot/src/create-discord-bot.ts
+++ b/packages/create-discord-bot/src/create-discord-bot.ts
@@ -35,9 +35,11 @@ export async function createDiscordBot({ typescript, javascript, directory }: Op
 		throw error;
 	});
 
-	// If a directory exists and it's not empty, throw an error.
-	if (directoryStats.isDirectory() && (await readdir(root)).length > 0) {
-		console.error(chalk.red(`The directory ${chalk.yellow(`"${directoryName}"`)} is not empty.`));
+	// If the directory is actually a file or if it's not empty, throw an error.
+	if (!directoryStats.isDirectory() || (await readdir(root)).length > 0) {
+		console.error(
+			chalk.red(`The directory ${chalk.yellow(`"${directoryName}"`)} is either not a directory or is not empty.`),
+		);
 		console.error(chalk.red(`Please specify an empty directory.`));
 		process.exit(1);
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Throw an error if the given directory is not actually a directory.

See [#9570 (review)](https://github.com/discordjs/discord.js/pull/9570#discussion_r1264713786).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
