### PR TITLE
fix(Action): Do not set `undefined` values

### DIFF
--- a/packages/discord.js/src/client/actions/Action.js
+++ b/packages/discord.js/src/client/actions/Action.js
@@ -28,20 +28,15 @@ class GenericAction {
   }
 
   getChannel(data) {
+    const payloadData = { recipients: data.recipients ?? [data.author ?? data.user ?? { id: data.user_id }] };
     const id = data.channel_id ?? data.id;
+    if (id !== undefined) payloadData.id = id;
+    if ('guild_id' in data) payloadData.guild_id = data.guild_id;
+    if ('last_message_id' in data) payloadData.last_message_id = data.last_message_id;
+
     return (
       data[this.client.actions.injectedChannel] ??
-      this.getPayload(
-        {
-          id,
-          guild_id: data.guild_id,
-          recipients: data.recipients ?? [data.author ?? data.user ?? { id: data.user_id }],
-          last_message_id: data.last_message_id,
-        },
-        this.client.channels,
-        id,
-        Partials.Channel,
-      )
+      this.getPayload(payloadData, this.client.channels, id, Partials.Channel)
     );
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #9754.

The object being sent to `GenericAction#getPayload()` might contain keys that were `undefined`. In this specific case, an ephemeral message with the direct messages intent would not contain a `guild_id`.[^1] In combination with the partial, this would lead to `manager._add(data, cache)` which would then lead to here:

https://github.com/discordjs/discord.js/blob/7295a3a94a853086f781e7810b37c77d0c7e5283/packages/discord.js/src/structures/GuildChannel.js#L66-L68

Causing `guildId` to lose its value.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

[^1]: https://discord.com/developers/docs/topics/gateway-events#messages