### PR TITLE
fix(types): fixed CachedManager constructor arguments in type

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3734,7 +3734,7 @@ export abstract class DataManager<K, Holds, R> extends BaseManager {
 }
 
 export abstract class CachedManager<K, Holds, R> extends DataManager<K, Holds, R> {
-  protected constructor(client: Client<true>, holds: Constructable<Holds>);
+  protected constructor(client: Client<true>, holds: Constructable<Holds>, iterable?: Iterable<Holds>);
   private readonly _cache: Collection<K, Holds>;
   private _add(data: unknown, cache?: boolean, { id, extras }?: { id: K; extras: unknown[] }): Holds;
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The CachedManager's constructor has three arguments in the JS files but only two in the type declaration. I fixed that so it matches.

**Status and versioning classification:**
- There are no code changes
- I know how to update typings and have done so
- This PR changes the library's interface (methods or parameters added)