### PR TITLE
fix(CachedManager): allow overriding constructor for makeCache

### DIFF
--- a/packages/discord.js/src/managers/CachedManager.js
+++ b/packages/discord.js/src/managers/CachedManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const DataManager = require('./DataManager');
+const { MakeCacheOverrideSymbol } = require('../util/Symbols');
 
 /**
  * Manages the API methods of a data model with a mutable cache of instances.
@@ -18,7 +19,9 @@ class CachedManager extends DataManager {
      * @readonly
      * @name CachedManager#_cache
      */
-    Object.defineProperty(this, '_cache', { value: this.client.options.makeCache(this.constructor, this.holds) });
+    Object.defineProperty(this, '_cache', {
+      value: this.client.options.makeCache(this.constructor[MakeCacheOverrideSymbol] ?? this.constructor, this.holds),
+    });
 
     if (iterable) {
       for (const item of iterable) {

--- a/packages/discord.js/src/managers/CachedManager.js
+++ b/packages/discord.js/src/managers/CachedManager.js
@@ -20,7 +20,11 @@ class CachedManager extends DataManager {
      * @name CachedManager#_cache
      */
     Object.defineProperty(this, '_cache', {
-      value: this.client.options.makeCache(this.constructor[MakeCacheOverrideSymbol] ?? this.constructor, this.holds),
+      value: this.client.options.makeCache(
+        this.constructor[MakeCacheOverrideSymbol] ?? this.constructor,
+        this.holds,
+        this.constructor,
+      ),
     });
 
     if (iterable) {

--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -7,6 +7,7 @@ const CachedManager = require('./CachedManager');
 const { DiscordjsTypeError, ErrorCodes } = require('../errors');
 const { Message } = require('../structures/Message');
 const MessagePayload = require('../structures/MessagePayload');
+const { MakeCacheOverrideSymbol } = require('../util/Symbols');
 const { resolvePartialEmoji } = require('../util/Util');
 
 /**
@@ -15,6 +16,8 @@ const { resolvePartialEmoji } = require('../util/Util');
  * @abstract
  */
 class MessageManager extends CachedManager {
+  static [MakeCacheOverrideSymbol] = MessageManager;
+
   constructor(channel, iterable) {
     super(channel.client, Message, iterable);
 

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -6,12 +6,15 @@ const { Routes } = require('discord-api-types/v10');
 const CachedManager = require('./CachedManager');
 const { DiscordjsTypeError, ErrorCodes } = require('../errors');
 const ThreadChannel = require('../structures/ThreadChannel');
+const { MakeCacheOverrideSymbol } = require('../util/Symbols');
 
 /**
  * Manages API methods for thread-based channels and stores their cache.
  * @extends {CachedManager}
  */
 class ThreadManager extends CachedManager {
+  static [MakeCacheOverrideSymbol] = ThreadManager;
+
   constructor(channel, iterable) {
     super(channel.client, ThreadChannel, iterable);
 

--- a/packages/discord.js/src/util/Options.js
+++ b/packages/discord.js/src/util/Options.js
@@ -4,10 +4,12 @@ const { DefaultRestOptions, DefaultUserAgentAppendix } = require('@discordjs/res
 const { toSnakeCase } = require('./Transformers');
 const { version } = require('../../package.json');
 
+// TODO(ckohen): switch order of params so full manager is first and "type" is optional
 /**
  * @typedef {Function} CacheFactory
- * @param {Function} manager The manager class the cache is being requested from.
+ * @param {Function} managerType The base manager class the cache is being requested from.
  * @param {Function} holds The class that the cache will hold.
+ * @param {Function} manager The fully extended manager class the cache is being requested from.
  * @returns {Collection} A Collection used to store the cache of the manager.
  */
 
@@ -150,8 +152,8 @@ class Options extends null {
     const { Collection } = require('@discordjs/collection');
     const LimitedCollection = require('./LimitedCollection');
 
-    return manager => {
-      const setting = settings[manager.name];
+    return (managerType, _, manager) => {
+      const setting = settings[manager.name] ?? settings[managerType.name];
       /* eslint-disable-next-line eqeqeq */
       if (setting == null) {
         return new Collection();

--- a/packages/discord.js/src/util/Symbols.js
+++ b/packages/discord.js/src/util/Symbols.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.MakeCacheOverrideSymbol = Symbol('djs.managers.makeCacheOverride');

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4717,17 +4717,23 @@ export interface Caches {
   AutoModerationRuleManager: [manager: typeof AutoModerationRuleManager, holds: typeof AutoModerationRule];
   ApplicationCommandManager: [manager: typeof ApplicationCommandManager, holds: typeof ApplicationCommand];
   BaseGuildEmojiManager: [manager: typeof BaseGuildEmojiManager, holds: typeof GuildEmoji];
+  DMMessageManager: [manager: typeof MessageManager, holds: typeof Message<false>];
   GuildEmojiManager: [manager: typeof GuildEmojiManager, holds: typeof GuildEmoji];
   // TODO: ChannelManager: [manager: typeof ChannelManager, holds: typeof Channel];
   // TODO: GuildChannelManager: [manager: typeof GuildChannelManager, holds: typeof GuildChannel];
   // TODO: GuildManager: [manager: typeof GuildManager, holds: typeof Guild];
   GuildMemberManager: [manager: typeof GuildMemberManager, holds: typeof GuildMember];
   GuildBanManager: [manager: typeof GuildBanManager, holds: typeof GuildBan];
-  GuildForumThreadManager: [manager: typeof GuildForumThreadManager, holds: typeof ThreadChannel];
+  GuildForumThreadManager: [
+    manager: typeof GuildForumThreadManager,
+    holds: typeof ThreadChannel<true>,
+    overriden: true,
+  ];
   GuildInviteManager: [manager: typeof GuildInviteManager, holds: typeof Invite];
+  GuildMessageManager: [manager: typeof GuildMessageManager, holds: typeof Message<true>];
   GuildScheduledEventManager: [manager: typeof GuildScheduledEventManager, holds: typeof GuildScheduledEvent];
   GuildStickerManager: [manager: typeof GuildStickerManager, holds: typeof Sticker];
-  GuildTextThreadManager: [manager: typeof GuildTextThreadManager, holds: typeof ThreadChannel];
+  GuildTextThreadManager: [manager: typeof GuildTextThreadManager, holds: typeof ThreadChannel<false>, overriden: true];
   MessageManager: [manager: typeof MessageManager, holds: typeof Message];
   // TODO: PermissionOverwriteManager: [manager: typeof PermissionOverwriteManager, holds: typeof PermissionOverwrites];
   PresenceManager: [manager: typeof PresenceManager, holds: typeof Presence];
@@ -4745,11 +4751,18 @@ export type CacheConstructors = {
   [K in keyof Caches]: Caches[K][0] & { name: K };
 };
 
+type OverridenCaches =
+  | 'DMMessageManager'
+  | 'GuildForumThreadManager'
+  | 'GuildMessageManager'
+  | 'GuildTextThreadManager';
+
 // This doesn't actually work the way it looks 😢.
 // Narrowing the type of `manager.name` doesn't propagate type information to `holds` and the return type.
 export type CacheFactory = (
-  manager: CacheConstructors[keyof Caches],
+  managerType: CacheConstructors[Exclude<keyof Caches, OverridenCaches>],
   holds: Caches[(typeof manager)['name']][1],
+  manager: CacheConstructors[keyof Caches],
 ) => (typeof manager)['prototype'] extends DataManager<infer K, infer V, any> ? Collection<K, V> : never;
 
 export type CacheWithLimitsOptions = {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4724,16 +4724,12 @@ export interface Caches {
   // TODO: GuildManager: [manager: typeof GuildManager, holds: typeof Guild];
   GuildMemberManager: [manager: typeof GuildMemberManager, holds: typeof GuildMember];
   GuildBanManager: [manager: typeof GuildBanManager, holds: typeof GuildBan];
-  GuildForumThreadManager: [
-    manager: typeof GuildForumThreadManager,
-    holds: typeof ThreadChannel<true>,
-    overriden: true,
-  ];
+  GuildForumThreadManager: [manager: typeof GuildForumThreadManager, holds: typeof ThreadChannel<true>];
   GuildInviteManager: [manager: typeof GuildInviteManager, holds: typeof Invite];
   GuildMessageManager: [manager: typeof GuildMessageManager, holds: typeof Message<true>];
   GuildScheduledEventManager: [manager: typeof GuildScheduledEventManager, holds: typeof GuildScheduledEvent];
   GuildStickerManager: [manager: typeof GuildStickerManager, holds: typeof Sticker];
-  GuildTextThreadManager: [manager: typeof GuildTextThreadManager, holds: typeof ThreadChannel<false>, overriden: true];
+  GuildTextThreadManager: [manager: typeof GuildTextThreadManager, holds: typeof ThreadChannel<false>];
   MessageManager: [manager: typeof MessageManager, holds: typeof Message];
   // TODO: PermissionOverwriteManager: [manager: typeof PermissionOverwriteManager, holds: typeof PermissionOverwrites];
   PresenceManager: [manager: typeof PresenceManager, holds: typeof Presence];
@@ -4751,7 +4747,7 @@ export type CacheConstructors = {
   [K in keyof Caches]: Caches[K][0] & { name: K };
 };
 
-type OverridenCaches =
+type OverriddenCaches =
   | 'DMMessageManager'
   | 'GuildForumThreadManager'
   | 'GuildMessageManager'
@@ -4760,7 +4756,7 @@ type OverridenCaches =
 // This doesn't actually work the way it looks 😢.
 // Narrowing the type of `manager.name` doesn't propagate type information to `holds` and the return type.
 export type CacheFactory = (
-  managerType: CacheConstructors[Exclude<keyof Caches, OverridenCaches>],
+  managerType: CacheConstructors[Exclude<keyof Caches, OverriddenCaches>],
   holds: Caches[(typeof manager)['name']][1],
   manager: CacheConstructors[keyof Caches],
 ) => (typeof manager)['prototype'] extends DataManager<infer K, infer V, any> ? Collection<K, V> : never;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

I think this has only been breaking for MessageManager and ThreadManager. It probably applies to others as well though long term.

fixes: #9759 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
