### PR TITLE
typings: Make activity name required

### DIFF
--- a/packages/discord.js/src/structures/ClientUser.js
+++ b/packages/discord.js/src/structures/ClientUser.js
@@ -98,7 +98,7 @@ class ClientUser extends User {
   /**
    * Options for setting activities
    * @typedef {Object} ActivitiesOptions
-   * @property {string} [name] Name of the activity
+   * @property {string} name Name of the activity
    * @property {ActivityType} [type] Type of the activity
    * @property {string} [url] Twitch / YouTube stream URL
    */
@@ -149,7 +149,7 @@ class ClientUser extends User {
   /**
    * Options for setting an activity.
    * @typedef {Object} ActivityOptions
-   * @property {string} [name] Name of the activity
+   * @property {string} name Name of the activity
    * @property {string} [url] Twitch / YouTube stream URL
    * @property {ActivityType} [type] Type of the activity
    * @property {number|number[]} [shardId] Shard Id(s) to have the activity set on
@@ -157,7 +157,7 @@ class ClientUser extends User {
 
   /**
    * Sets the activity the client user is playing.
-   * @param {string|ActivityOptions} [name] Activity being played, or options for setting the activity
+   * @param {string|ActivityOptions} name Activity being played, or options for setting the activity
    * @param {ActivityOptions} [options] Options for setting the activity
    * @returns {ClientPresence}
    * @example

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1044,7 +1044,7 @@ export class ClientUser extends User {
   public verified: boolean;
   public edit(options: ClientUserEditOptions): Promise<this>;
   public setActivity(options?: ActivityOptions): ClientPresence;
-  public setActivity(name: string, options?: ActivityOptions): ClientPresence;
+  public setActivity(name: string, options?: Omit<ActivityOptions, 'name'>): ClientPresence;
   public setAFK(afk?: boolean, shardId?: number | number[]): ClientPresence;
   public setAvatar(avatar: BufferResolvable | Base64Resolvable | null): Promise<this>;
   public setPresence(data: PresenceData): ClientPresence;
@@ -4322,7 +4322,7 @@ export interface WebhookFields extends PartialWebhookFields {
 export type ActivitiesOptions = Omit<ActivityOptions, 'shardId'>;
 
 export interface ActivityOptions {
-  name?: string;
+  name: string;
   url?: string;
   type?: Exclude<ActivityType, ActivityType.Custom>;
   shardId?: number | readonly number[];


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Discord docs says that the activity name is required, discord,js also checks that  
https://github.com/discordjs/discord.js/blob/b3c85d34a6ced8a8e2cd15a6e3879fb2dd5121d0/packages/discord.js/src/structures/ClientPresence.js#L51-L53
**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.