### PR TITLE
feat(Message): add 'referencedMessage' property

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -2,6 +2,7 @@
 
 const { messageLink } = require('@discordjs/builders');
 const { Collection } = require('@discordjs/collection');
+const { lazy } = require('@discordjs/util');
 const { DiscordSnowflake } = require('@sapphire/snowflake');
 const {
   InteractionType,
@@ -26,6 +27,7 @@ const { NonSystemMessageTypes, MaxBulkDeletableMessageAge, DeletableMessageTypes
 const MessageFlagsBitField = require('../util/MessageFlagsBitField');
 const PermissionsBitField = require('../util/PermissionsBitField');
 const { cleanContent, resolvePartialEmoji } = require('../util/Util');
+const getMessage = lazy(() => require('./Message').Message);
 
 /**
  * Represents a message on Discord.
@@ -366,7 +368,15 @@ class Message extends Base {
     }
 
     if (data.referenced_message) {
-      this.channel?.messages._add({ guild_id: data.message_reference?.guild_id, ...data.referenced_message });
+      /**
+       * Message reference
+       * @type {?Message}
+       */
+      this.referencedMessage =
+        this.channel?.messages._add({ guild_id: data.message_reference?.guild_id, ...data.referenced_message }) ??
+        new (getMessage())(this.client, { guild_id: data.message_reference?.guild_id, ...data.referenced_message });
+    } else {
+      this.referencedMessage = null;
     }
 
     /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2026,6 +2026,7 @@ export class Message<InGuild extends boolean = boolean> extends Base {
   public webhookId: Snowflake | null;
   public flags: Readonly<MessageFlagsBitField>;
   public reference: MessageReference | null;
+  public referencedMessage: Message | null;
   public awaitMessageComponent<T extends MessageComponentType>(
     options?: AwaitMessageCollectorOptionsParams<T, InGuild>,
   ): Promise<MappedInteractionTypes<InGuild>[T]>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Allow to get referenced message synchronously without a need to fetch it from Discord API

**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
