### PR TITLE
fix(Action): Do not add the client user as a recipient

### DIFF
--- a/packages/discord.js/src/client/actions/Action.js
+++ b/packages/discord.js/src/client/actions/Action.js
@@ -28,8 +28,17 @@ class GenericAction {
   }
 
   getChannel(data) {
-    const payloadData = { recipients: data.recipients ?? [data.author ?? data.user ?? { id: data.user_id }] };
+    const payloadData = {};
     const id = data.channel_id ?? data.id;
+
+    if ('recipients' in data) {
+      payloadData.recipients = data.recipients;
+    } else {
+      // Try to resolve the recipient, but do not add the client user.
+      const recipient = data.author ?? data.user ?? { id: data.user_id };
+      if (recipient.id !== this.client.user.id) payloadData.recipients = [recipient];
+    }
+
     if (id !== undefined) payloadData.id = id;
     if ('guild_id' in data) payloadData.guild_id = data.guild_id;
     if ('last_message_id' in data) payloadData.last_message_id = data.last_message_id;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
With this code sample:

```JavaScript
const user = await client.users.fetch("user_id");
const dm = await user.createDM();
await user.send("Hi");
```

`dm.recipientId` would change from `user_id` to the client user's id during `await user.send("Hi");`.

When `await user.send("Hi")` is called, we receive that message from the gateway and it eventually finds its way to `GenericAction#getChannel()`:

https://github.com/discordjs/discord.js/blob/188877c50af70f0d5cffb246620fa277435c6ce6/packages/discord.js/src/client/actions/MessageCreate.js#L9

https://github.com/discordjs/discord.js/blob/188877c50af70f0d5cffb246620fa277435c6ce6/packages/discord.js/src/client/actions/Action.js#L30-L41

The issue is line 31 here. The payload when a message is sent contains no `recipient`, but an `author`. Therefore, discord.js transforms this author object, which would be the client user, to the recipient. Assuming we have the `Channel` partial, we hit `manager._add(data, cache)` which leads here:

https://github.com/discordjs/discord.js/blob/188877c50af70f0d5cffb246620fa277435c6ce6/packages/discord.js/src/structures/DMChannel.js#L32-L44

The client user object has just overwritten the recipient.

<hr>

Doing nothing when the resolved recipient is the client user should fix this bug as the recipient would be kept as-is.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
