### PR TITLE
docs(WebhookEditOptions): Add all of the types

### DIFF
--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -264,7 +264,8 @@ class Webhook {
    * @typedef {Object} WebhookEditOptions
    * @property {string} [name=this.name] The new name for the webhook
    * @property {?(BufferResolvable)} [avatar] The new avatar for the webhook
-   * @property {GuildTextChannelResolvable} [channel] The new channel for the webhook
+   * @property {GuildTextChannelResolvable|VoiceChannel|StageChannel|ForumChannel} [channel]
+   * The new channel for the webhook
    * @property {string} [reason] Reason for editing the webhook
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
These were already typed, but not documented:

https://github.com/discordjs/discord.js/blob/aa27775c753cc9ee2afc97dd9bc52d04c78fe376/packages/discord.js/typings/index.d.ts#L6400-L6405

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
