### PR TITLE
ci: Stop documentation upload for create-discord-bot

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,7 @@ on:
       - 'main'
     paths:
       - 'packages/*/src/**'
+      - '!packages/create-discord-bot/**'
     tags:
       - '**'
   workflow_dispatch:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This package has no documentation, so it is bound to always fail as seen [here](https://github.com/discordjs/discord.js/actions/runs/5895202930).

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
