### PR TITLE
feat(Emoji): Add `imageURL()`

### DIFF
--- a/packages/discord.js/src/structures/BaseGuildEmoji.js
+++ b/packages/discord.js/src/structures/BaseGuildEmoji.js
@@ -53,4 +53,23 @@ class BaseGuildEmoji extends Emoji {
   }
 }
 
+/**
+ * Returns a URL for the emoji.
+ * @method imageURL
+ * @memberof BaseGuildEmoji
+ * @instance
+ * @param {BaseImageURLOptions} [options] Options for the image URL
+ * @returns {string}
+ */
+
+/**
+ * Returns a URL for the emoji.
+ * @name url
+ * @memberof BaseGuildEmoji
+ * @instance
+ * @type {string}
+ * @readonly
+ * @deprecated Use {@link BaseGuildEmoji#imageURL} instead.
+ */
+
 module.exports = BaseGuildEmoji;

--- a/packages/discord.js/src/structures/Emoji.js
+++ b/packages/discord.js/src/structures/Emoji.js
@@ -1,7 +1,10 @@
 'use strict';
 
+const process = require('node:process');
 const { DiscordSnowflake } = require('@sapphire/snowflake');
 const Base = require('./Base');
+
+let deprecationEmittedForURL = false;
 
 /**
  * Represents an emoji, see {@link GuildEmoji} and {@link ReactionEmoji}.
@@ -40,12 +43,27 @@ class Emoji extends Base {
   }
 
   /**
-   * The URL to the emoji file if it's a custom emoji
+   * Returns a URL for the emoji or `null` if this is not a custom emoji.
+   * @param {BaseImageURLOptions} [options] Options for the image URL
+   * @returns {?string}
+   */
+  imageURL(options) {
+    return this.id && this.client.rest.cdn.emoji(this.id, options);
+  }
+
+  /**
+   * Returns a URL for the emoji or `null` if this is not a custom emoji.
    * @type {?string}
    * @readonly
+   * @deprecated Use {@link Emoji#imageURL} instead.
    */
   get url() {
-    return this.id && this.client.rest.cdn.emoji(this.id, this.animated ? 'gif' : 'png');
+    if (!deprecationEmittedForURL) {
+      process.emitWarning('The Emoji#url getter is deprecated. Use Emoji#imageURL() instead.', 'DeprecationWarning');
+      deprecationEmittedForURL = true;
+    }
+
+    return this.imageURL({ extension: this.animated ? 'gif' : 'png' });
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -627,6 +627,8 @@ export abstract class BaseGuild extends Base {
 
 export class BaseGuildEmoji extends Emoji {
   protected constructor(client: Client<true>, data: RawGuildEmojiData, guild: Guild | GuildPreview);
+  public imageURL(options?: BaseImageURLOptions): string;
+  public get url(): string;
   public available: boolean | null;
   public get createdAt(): Date;
   public get createdTimestamp(): number;
@@ -1312,6 +1314,7 @@ export class Emoji extends Base {
   public id: Snowflake | null;
   public name: string | null;
   public get identifier(): string;
+  public imageURL(options?: BaseImageURLOptions): string | null;
   public get url(): string | null;
   public toJSON(): unknown;
   public toString(): string;
@@ -1530,7 +1533,6 @@ export class GuildEmoji extends BaseGuildEmoji {
   public guild: Guild;
   public author: User | null;
   public get roles(): GuildEmojiRoleManager;
-  public get url(): string;
   public delete(reason?: string): Promise<GuildEmoji>;
   public edit(options: GuildEmojiEditOptions): Promise<GuildEmoji>;
   public equals(other: GuildEmoji | unknown): boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Supersedes #8493.

This allows both `extension` and `size`. The getter has been deprecated in favour of the method, which is consistent with every other image URL method. `forceStatic` cannot be used as that option relies on a hash which does not exist for emojis.

Requires:

- #9787

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
