### PR TITLE
Type Checking for slash commands

### DIFF
--- a/feature-addition.md
+++ b/feature-addition.md
@@ -1,0 +1,5 @@
+Adding extra type checking properties `SlashCommandBuilder.StringOption`
+- type()  // any popular type checking module on npm
+- errorMesage() // optional, type BaseMessageCreateOptions
+
+Upon receiving interaction discord.js will check the type


### PR DESCRIPTION
Asking if i should implement this feature

**Adding extra type checking properties** to `SlashCommandBuilder.StringOption`
- type()  // any popular type checking module on npm
- errorMesage() // optional, type BaseMessageCreateOptions

Upon receiving interaction discord.js will check the type, and send the error message as response to interaction.
