### PR TITLE
Update wording for GuildMember.timeout parameter documentation

### DIFF
--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -425,8 +425,8 @@ class GuildMember extends Base {
 
   /**
    * Times this guild member out.
-   * @param {number|null} timeout The time in milliseconds
-   * for the member's communication to be disabled until. Provide `null` to remove the timeout.
+   * @param {number|null} timeout The duration in milliseconds
+   * for the member's communication to be disabled. Provide `null` to remove the timeout.
    * @param {string} [reason] The reason for this timeout.
    * @returns {Promise<GuildMember>}
    * @example


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The current wording for the `timeout` parameter of `GuildMember.timeout` strikes me as easily misinterpretable as the end-time at which the member's communications will be disable until, rather than a duration. This is a tiny documentation pr to improve the wording.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.