### PR TITLE
feat(GuildScheduledEvent): add partial and fetch support

### DIFF
--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -165,6 +165,15 @@ class GuildScheduledEvent extends Base {
   }
 
   /**
+   * Whether this GuildScheduledEvent is a partial
+   * @type {boolean}
+   * @readonly
+   */
+  get partial() {
+    return typeof this.name !== 'string';
+  }
+
+  /**
    * The URL of this scheduled event's cover image
    * @param {BaseImageURLOptions} [options={}] Options for image URL
    * @returns {?string}
@@ -390,6 +399,15 @@ class GuildScheduledEvent extends Base {
    */
   fetchSubscribers(options) {
     return this.guild.scheduledEvents.fetchSubscribers(this.id, options);
+  }
+
+  /**
+   * Fetches this scheduled event.
+   * @param {boolean} [force=true] Whether to skip the cache check and request the API
+   * @returns {Promise<GuildScheduledEvent>}
+   */
+  fetch(force = true) {
+    return this.guild.scheduledEvents.fetch({ guildScheduledEvent: this.id, force: force });
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The [documentation](https://discordjs.guide/popular-topics/partials.html#enabling-partials) specifies that the `GuildScheduledEvent` class supports partials but it is not fully implemented:

`TypeError: guildScheduledEvent.fetch is not a function`


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)

---
**Local Testing**
```js
console.log(`Received GuildScheduledEventUserAdd`);
if (guildScheduledEvent.partial) {
    console.log("Partial guildScheduledEvent, fetching...");
    await guildScheduledEvent.fetch();
}
console.log(guildScheduledEvent);
```

Output:
```js
Received GuildScheduledEventUserAdd
Partial guildScheduledEvent, fetching...
GuildScheduledEvent {
  id: '1144080228373770280',
  guildId: '859588661548417086',
  channelId: '859588662606168077',
  creatorId: '163032275074678784',
  name: 'tset',
  description: '',
  scheduledStartTimestamp: 1692842400207,
  scheduledEndTimestamp: null,
  privacyLevel: 2,
  status: 1,
  entityType: 2,
  entityId: null,
  userCount: 1,
  creator: User {
    id: '163032275074678784',
    bot: false,
    system: false,
    flags: UserFlagsBitField { bitfield: 0 },
    username: '.grob',
    globalName: 'grob',
    discriminator: '0',
    avatar: '3bf4e6f77edfa65ed5398b4b16c14ded',
    banner: null,
    accentColor: 1710104,
    avatarDecoration: null
  },
  entityMetadata: { location: null },
  image: null
}
```
<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
