### PR TITLE
ci: fix npm dev release workflow

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -60,6 +60,6 @@ jobs:
       - name: Publish package
         run: |
           pnpm --filter=${{ matrix.package }} run release --preid "dev.$(date +%s)-$(git rev-parse --short HEAD)"
-          pnpm --filter=${{ matrix.package }} publish --tag dev || true
+          pnpm --filter=${{ matrix.package }} publish --no-git-checks --tag dev || true
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`pnpm` does not allow publishing with an unclean git tree by default, as seen [here.](https://github.com/discordjs/discord.js/actions/runs/6049153994/job/16415895720#step:6:23)

I'm not entirely sure why we do the whole `|| true` thing in the workflow, since it made it not fail despite clearly failing. I assume it's a workaround for cases where we publish a version that's already been published (e.g. due to manual workflow triggers or things of that sort), so I didn't touch it.

