### PR TITLE
types: don't include dom types

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -170,7 +170,7 @@ import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { Stream } from 'node:stream';
 import { MessagePort, Worker } from 'node:worker_threads';
-import * as WebSocket from 'ws';
+import { Data as WebSocketData, WebSocket } from 'ws';
 import {
   RawActivityData,
   RawAnonymousGuildData,
@@ -5895,7 +5895,7 @@ export type MessageChannelComponentCollectorOptions<T extends CollectedMessageIn
 >;
 
 export interface MessageEvent {
-  data: WebSocket.Data;
+  data: WebSocketData;
   type: string;
   target: WebSocket;
 }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1,6 +1,3 @@
-// DOM types required for undici
-/// <reference lib="dom" />
-
 import {
   ActionRowBuilder as BuilderActionRow,
   MessageActionRowComponentBuilder,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

> As soon as discord.js is imported, typescript/vscode will start suggesting browser-only variables and classes. This makes this issue unavoidable, since it occours in your whole project as soon as you simply import discord.js, which is why I'd argue that this is not low priority.

There isn't really a reason to include DOM types for undici, and the commit that introduced it doesn't explain any further behind the reasons for this change

Closes #9737

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
