### PR TITLE
Only update name of GuildScheduledEvent if found in data

### DIFF
--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -50,11 +50,15 @@ class GuildScheduledEvent extends Base {
       this.creatorId ??= null;
     }
 
-    /**
-     * The name of the guild scheduled event
-     * @type {string}
-     */
-    this.name = data.name;
+    if ('name' in data) {
+      /**
+       * The name of the guild scheduled event
+       * @type {string}
+       */
+      this.name = data.name;
+    } else {
+      this.name ??= null;
+    }
 
     if ('description' in data) {
       /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When e. g. the event "guildScheduledEventUserAdd" is fired, it runs the _patch function of the GuildScheduledEvent object with just the data parameters "id" and "guild_id". Without checking if "name" is in the data object, the name is set to "undefined" when a user subscribes to the event and no longer retrievable unless one fetches the event again.

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
