### PR TITLE
types(Partials): add toString() method to supported Partials

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6115,11 +6115,15 @@ export type Partialize<
   [K in keyof Omit<T, 'client' | 'id' | 'partial' | E>]: K extends N ? null : K extends M ? T[K] | null : T[K];
 };
 
-export interface PartialDMChannel extends Partialize<DMChannel, null, null, 'lastMessageId'> {
+export interface PartialDMChannel extends Partialize<DMChannel, null, null, 'lastMessageId' | 'toString'> {
   lastMessageId: undefined;
+  toString(): UserMention;
 }
 
-export interface PartialGuildMember extends Partialize<GuildMember, 'joinedAt' | 'joinedTimestamp' | 'pending'> {}
+export interface PartialGuildMember
+  extends Partialize<GuildMember, 'joinedAt' | 'joinedTimestamp' | 'pending', null, 'toString'> {
+  toString(): UserMention;
+}
 
 export interface PartialMessage
   extends Partialize<Message, 'type' | 'system' | 'pinned' | 'tts', 'content' | 'cleanContent' | 'author'> {}
@@ -6149,7 +6153,9 @@ export enum Partials {
   ThreadMember,
 }
 
-export interface PartialUser extends Partialize<User, 'username' | 'tag' | 'discriminator'> {}
+export interface PartialUser extends Partialize<User, 'username' | 'tag' | 'discriminator', null, 'toString'> {
+  toString(): UserMention;
+}
 
 export type PresenceStatusData = ClientPresenceStatus | 'invisible';
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add `toString()` method to `PartialDMChannel`, `PartialGuildMember` and `PartialUser` in typings.
The following Partials do not support a `toString()` method and thus remain unchanged:
- `PartialMessage`, since `<PartialMessage>.content` is always null
- `PartialMessageReaction`, since `MessageReaction` has no `toString()` method
- `PartialThreadMember`, since `ThreadMember` has no `toString()` method

Fixes #9833 

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
