### PR TITLE
chore: No identifier base in development versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 	"devDependencies": {
 		"@commitlint/cli": "^17.7.1",
 		"@commitlint/config-angular": "^17.7.0",
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@favware/npm-deprecate": "^1.0.7",
 		"@types/lodash.merge": "^4.6.7",
 		"@unocss/eslint-plugin": "^0.55.3",

--- a/packages/brokers/.cliff-jumperrc.json
+++ b/packages/brokers/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "brokers",
 	"org": "discordjs",
-	"packagePath": "packages/brokers"
+	"packagePath": "packages/brokers",
+	"identifierBase": false
 }

--- a/packages/brokers/package.json
+++ b/packages/brokers/package.json
@@ -71,7 +71,7 @@
 		"ioredis": "^5.3.2"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "16.18.44",
 		"@vitest/coverage-v8": "^0.34.3",

--- a/packages/builders/.cliff-jumperrc.json
+++ b/packages/builders/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "builders",
 	"org": "discordjs",
-	"packagePath": "packages/builders"
+	"packagePath": "packages/builders",
+	"identifierBase": false
 }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -73,7 +73,7 @@
 		"tslib": "^2.6.2"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "16.18.44",
 		"@vitest/coverage-v8": "^0.34.3",

--- a/packages/collection/.cliff-jumperrc.json
+++ b/packages/collection/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "collection",
 	"org": "discordjs",
-	"packagePath": "packages/collection"
+	"packagePath": "packages/collection",
+	"identifierBase": false
 }

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -60,7 +60,7 @@
 	},
 	"homepage": "https://discord.js.org",
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "16.18.44",
 		"@vitest/coverage-v8": "^0.34.3",

--- a/packages/core/.cliff-jumperrc.json
+++ b/packages/core/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "core",
 	"org": "discordjs",
-	"packagePath": "packages/core"
+	"packagePath": "packages/core",
+	"identifierBase": false
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,7 +72,7 @@
 		"discord-api-types": "0.37.59"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "18.17.9",
 		"@vitest/coverage-v8": "^0.34.3",

--- a/packages/create-discord-bot/.cliff-jumperrc.json
+++ b/packages/create-discord-bot/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "create-discord-bot",
 	"packagePath": "packages/create-discord-bot",
-	"tagTemplate": "{{name}}/{{new-version}}"
+	"tagTemplate": "{{name}}/{{new-version}}",
+	"identifierBase": false
 }

--- a/packages/create-discord-bot/package.json
+++ b/packages/create-discord-bot/package.json
@@ -55,7 +55,7 @@
 		"validate-npm-package-name": "^5.0.0"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "16.18.44",
 		"@types/prompts": "^2.4.4",

--- a/packages/discord.js/.cliff-jumperrc.json
+++ b/packages/discord.js/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
   "name": "discord.js",
   "packagePath": "packages/discord.js",
-  "tagTemplate": "{{new-version}}"
+  "tagTemplate": "{{new-version}}",
+  "identifierBase": false
 }

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -68,7 +68,7 @@
   },
   "devDependencies": {
     "@discordjs/docgen": "workspace:^",
-    "@favware/cliff-jumper": "2.1.1",
+    "@favware/cliff-jumper": "2.2.0",
     "@types/node": "16.18.44",
     "cross-env": "^7.0.3",
     "dtslint": "4.2.1",

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -65,7 +65,7 @@
 		"typedoc": "^0.25.0"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@types/jsdoc-to-markdown": "^7.0.3",
 		"@types/node": "16.18.44",
 		"cross-env": "^7.0.3",

--- a/packages/formatters/.cliff-jumperrc.json
+++ b/packages/formatters/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "formatters",
 	"org": "discordjs",
-	"packagePath": "packages/formatters"
+	"packagePath": "packages/formatters",
+	"identifierBase": false
 }

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -57,7 +57,7 @@
 		"discord-api-types": "0.37.59"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "16.18.44",
 		"@vitest/coverage-v8": "^0.34.3",

--- a/packages/next/.cliff-jumperrc.json
+++ b/packages/next/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "next",
 	"org": "discordjs",
-	"packagePath": "packages/next"
+	"packagePath": "packages/next",
+	"identifierBase": false
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -74,7 +74,7 @@
 		"discord-api-types": "0.37.59"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "18.17.9",
 		"@vitest/coverage-v8": "^0.34.3",

--- a/packages/proxy/.cliff-jumperrc.json
+++ b/packages/proxy/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "proxy",
 	"org": "discordjs",
-	"packagePath": "packages/proxy"
+	"packagePath": "packages/proxy",
+	"identifierBase": false
 }

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -70,7 +70,7 @@
 		"undici": "5.23.0"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "18.17.9",
 		"@types/supertest": "^2.0.12",

--- a/packages/rest/.cliff-jumperrc.json
+++ b/packages/rest/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "rest",
 	"org": "discordjs",
-	"packagePath": "packages/rest"
+	"packagePath": "packages/rest",
+	"identifierBase": false
 }

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -93,7 +93,7 @@
 		"undici": "5.23.0"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "18.17.9",
 		"@vitest/coverage-v8": "^0.34.3",

--- a/packages/scripts/turbo/generators/templates/.cliff-jumperrc.json.hbs
+++ b/packages/scripts/turbo/generators/templates/.cliff-jumperrc.json.hbs
@@ -1,1 +1,1 @@
-{ "name": "{{name}}", "org": "discordjs", "packagePath": "packages/{{name}}" }
+{ "name": "{{name}}", "org": "discordjs", "packagePath": "packages/{{name}}", "identifierBase": false }

--- a/packages/ui/.cliff-jumperrc.json
+++ b/packages/ui/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "ui",
 	"org": "discordjs",
-	"packagePath": "packages/ui"
+	"packagePath": "packages/ui",
+	"identifierBase": false
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -57,7 +57,7 @@
 		"react-dom": "^18.2.0"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@react-icons/all-files": "^4.1.0",
 		"@storybook/addon-essentials": "^7.3.2",
 		"@storybook/addon-interactions": "^7.3.2",

--- a/packages/util/.cliff-jumperrc.json
+++ b/packages/util/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "util",
 	"org": "discordjs",
-	"packagePath": "packages/util"
+	"packagePath": "packages/util",
+	"identifierBase": false
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -61,7 +61,7 @@
 	},
 	"homepage": "https://discord.js.org",
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "16.18.44",
 		"@vitest/coverage-v8": "^0.34.3",

--- a/packages/voice/.cliff-jumperrc.json
+++ b/packages/voice/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "voice",
 	"org": "discordjs",
-	"packagePath": "packages/voice"
+	"packagePath": "packages/voice",
+	"identifierBase": false
 }

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -72,7 +72,7 @@
 		"@babel/core": "^7.22.11",
 		"@babel/preset-env": "^7.22.10",
 		"@babel/preset-typescript": "^7.22.11",
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/jest": "^29.5.4",
 		"@types/node": "16.18.44",

--- a/packages/ws/.cliff-jumperrc.json
+++ b/packages/ws/.cliff-jumperrc.json
@@ -1,5 +1,6 @@
 {
 	"name": "ws",
 	"org": "discordjs",
-	"packagePath": "packages/ws"
+	"packagePath": "packages/ws",
+	"identifierBase": false
 }

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -83,7 +83,7 @@
 		"ws": "^8.13.0"
 	},
 	"devDependencies": {
-		"@favware/cliff-jumper": "^2.1.1",
+		"@favware/cliff-jumper": "^2.2.0",
 		"@microsoft/api-extractor": "^7.36.4",
 		"@types/node": "18.17.9",
 		"@vitest/coverage-v8": "^0.34.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^17.7.0
         version: 17.7.0
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@favware/npm-deprecate':
         specifier: ^1.0.7
         version: 1.0.7
@@ -82,7 +82,7 @@ importers:
         version: 32.1.0
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3(terser@5.19.2)
 
   apps/guide:
     dependencies:
@@ -488,8 +488,8 @@ importers:
         version: 5.3.2
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@16.18.44)
@@ -525,7 +525,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3(terser@5.19.2)
 
   packages/builders:
     dependencies:
@@ -552,8 +552,8 @@ importers:
         version: 2.6.2
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@16.18.44)
@@ -600,8 +600,8 @@ importers:
   packages/collection:
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@16.18.44)
@@ -640,7 +640,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3(terser@5.19.2)
 
   packages/core:
     dependencies:
@@ -664,8 +664,8 @@ importers:
         version: 0.37.59
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@18.17.9)
@@ -725,8 +725,8 @@ importers:
         version: 5.0.0
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@16.18.44)
@@ -819,8 +819,8 @@ importers:
         specifier: workspace:^
         version: link:../docgen
       '@favware/cliff-jumper':
-        specifier: 2.1.1
-        version: 2.1.1
+        specifier: 2.2.0
+        version: 2.2.0
       '@types/node':
         specifier: 16.18.44
         version: 16.18.44
@@ -871,8 +871,8 @@ importers:
         version: 0.25.0(typescript@5.2.2)
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@types/jsdoc-to-markdown':
         specifier: ^7.0.3
         version: 7.0.3
@@ -911,8 +911,8 @@ importers:
         version: 0.37.59
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@16.18.44)
@@ -978,8 +978,8 @@ importers:
         version: 0.37.59
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@18.17.9)
@@ -1036,8 +1036,8 @@ importers:
         version: 5.23.0
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@18.17.9)
@@ -1079,7 +1079,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3(terser@5.19.2)
 
   packages/proxy-container:
     dependencies:
@@ -1152,8 +1152,8 @@ importers:
         version: 5.23.0
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@18.17.9)
@@ -1271,8 +1271,8 @@ importers:
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@storybook/addon-essentials':
         specifier: ^7.3.2
         version: 7.3.2(@types/react-dom@18.2.7)(@types/react@18.2.21)(react-dom@18.2.0)(react@18.2.0)
@@ -1359,13 +1359,13 @@ importers:
         version: 3.5.2(@types/node@16.18.44)(typescript@5.2.2)(vite@4.4.9)
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3(terser@5.19.2)
 
   packages/util:
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@16.18.44)
@@ -1404,7 +1404,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3(terser@5.19.2)
 
   packages/voice:
     dependencies:
@@ -1434,8 +1434,8 @@ importers:
         specifier: ^7.22.11
         version: 7.22.11(@babel/core@7.22.11)
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@16.18.44)
@@ -1516,8 +1516,8 @@ importers:
         version: 8.13.0
     devDependencies:
       '@favware/cliff-jumper':
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       '@microsoft/api-extractor':
         specifier: ^7.36.4
         version: 7.36.4(@types/node@18.17.9)
@@ -4024,29 +4024,21 @@ packages:
     resolution:
       { integrity: sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ== }
 
-  /@favware/cliff-jumper@2.1.1:
+  /@favware/cliff-jumper@2.2.0:
     resolution:
-      { integrity: sha512-3VFXJMkSiMMtYccvtBEee3mK5tk5XCnQQqwMtTFCzuYCG01xE0rWvN4tUO9gZwph+vtn03/gTpO7yHVK+uWhSQ== }
+      { integrity: sha512-uFfaxTxWICRp5CUX9CX8SUhalKmQBMn9soejUR9rLYaxyLTr8JLqhxjXQoDhyuUy4jPYsqpiC7S7xSjL8urIHg== }
     engines: { node: '>=v16' }
     hasBin: true
     dependencies:
-      '@favware/conventional-changelog-angular': 5.0.15
       '@sapphire/result': 2.6.4
-      '@sapphire/utilities': 3.12.0
+      '@sapphire/utilities': 3.13.0
       colorette: 2.0.20
-      commander: 10.0.1
-      conventional-recommended-bump: 7.0.1
-      git-cliff: 1.2.0
+      commander: 11.0.0
+      compare-func: 2.0.0
+      conventional-recommended-bump: 9.0.0
+      git-cliff: 1.3.0
       js-yaml: 4.1.0
       semver: 7.5.4
-    dev: true
-
-  /@favware/conventional-changelog-angular@5.0.15:
-    resolution:
-      { integrity: sha512-A6RsOBnXwcwS293ZDd6XkwhfT/SoNlGWnEZ5PBGXIN2scvtdZu+T/92q/Ghj2SpKyFHGh8kAuaApEnOqy84waw== }
-    engines: { node: '>=14' }
-    dependencies:
-      compare-func: 2.0.0
     dev: true
 
   /@favware/npm-deprecate@1.0.7:
@@ -6114,12 +6106,6 @@ packages:
       { integrity: sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA== }
     engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
     dev: false
-
-  /@sapphire/utilities@3.12.0:
-    resolution:
-      { integrity: sha512-y1JP4FdPBkZjJGJcb5Zx0ok64mtpGvz0TLOC49HTwYsfBQL8tsTct93yoYdEEMWSZFmOF1ZvV8L6jIJ1CW8bJw== }
-    engines: { node: '>=v14.0.0', npm: '>=7.0.0' }
-    dev: true
 
   /@sapphire/utilities@3.13.0:
     resolution:
@@ -11009,6 +10995,12 @@ packages:
     engines: { node: '>=14' }
     dev: true
 
+  /conventional-changelog-preset-loader@4.1.0:
+    resolution:
+      { integrity: sha512-HozQjJicZTuRhCRTq4rZbefaiCzRM2pr6u2NL3XhrmQm4RMnDXfESU6JKu/pnKwx5xtdkYfNCsbhN5exhiKGJA== }
+    engines: { node: '>=16' }
+    dev: true
+
   /conventional-changelog-writer@6.0.1:
     resolution:
       { integrity: sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ== }
@@ -11051,6 +11043,12 @@ packages:
       modify-values: 1.0.1
     dev: true
 
+  /conventional-commits-filter@4.0.0:
+    resolution:
+      { integrity: sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A== }
+    engines: { node: '>=16' }
+    dev: true
+
   /conventional-commits-parser@4.0.0:
     resolution:
       { integrity: sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg== }
@@ -11063,19 +11061,30 @@ packages:
       split2: 3.2.2
     dev: true
 
-  /conventional-recommended-bump@7.0.1:
+  /conventional-commits-parser@5.0.0:
     resolution:
-      { integrity: sha512-Ft79FF4SlOFvX4PkwFDRnaNiIVX7YbmqGU0RwccUaiGvgp3S0a8ipR2/Qxk31vclDNM+GSdJOVs2KrsUCjblVA== }
-    engines: { node: '>=14' }
+      { integrity: sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA== }
+    engines: { node: '>=16' }
     hasBin: true
     dependencies:
-      concat-stream: 2.0.0
-      conventional-changelog-preset-loader: 3.0.0
-      conventional-commits-filter: 3.0.0
-      conventional-commits-parser: 4.0.0
-      git-raw-commits: 3.0.0
-      git-semver-tags: 5.0.1
-      meow: 8.1.2
+      JSONStream: 1.3.5
+      is-text-path: 2.0.0
+      meow: 12.1.1
+      split2: 4.2.0
+    dev: true
+
+  /conventional-recommended-bump@9.0.0:
+    resolution:
+      { integrity: sha512-HR1yD0G5HgYAu6K0wJjLd7QGRK8MQDqqj6Tn1n/ja1dFwBCE6QmV+iSgQ5F7hkx7OUR/8bHpxJqYtXj2f/opPQ== }
+    engines: { node: '>=16' }
+    hasBin: true
+    dependencies:
+      conventional-changelog-preset-loader: 4.1.0
+      conventional-commits-filter: 4.0.0
+      conventional-commits-parser: 5.0.0
+      git-raw-commits: 4.0.0
+      git-semver-tags: 7.0.1
+      meow: 12.1.1
     dev: true
 
   /convert-hrtime@3.0.0:
@@ -11352,6 +11361,12 @@ packages:
     resolution:
       { integrity: sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg== }
     engines: { node: '>=8' }
+    dev: true
+
+  /dargs@8.1.0:
+    resolution:
+      { integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw== }
+    engines: { node: '>=12' }
     dev: true
 
   /dashdash@1.14.1:
@@ -14033,71 +14048,71 @@ packages:
       - supports-color
     dev: true
 
-  /git-cliff-darwin-arm64@1.2.0:
+  /git-cliff-darwin-arm64@1.3.0:
     resolution:
-      { integrity: sha512-zWkTEnB1SenJULqi4QzQzs8Sp2yvGkvglEH75Gia+cBe32jXar6zDw9gI3D3ikcuboyCrFNpERT+pbNIJlOT6w== }
+      { integrity: sha512-K0EfOmW3OUHsdzTh+wJqI8TNXNvKnBKjZb6zFrMJfvP+XUUzx9SxKVkQ0dyNsb66CU3VR/FuEcNLZ4/LxMrbaw== }
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /git-cliff-darwin-x64@1.2.0:
+  /git-cliff-darwin-x64@1.3.0:
     resolution:
-      { integrity: sha512-ye4AfgaDPhNGnDx2r09Wvaic2nJRVE4PZltupABjVNWoBEIiTjEA0kw32WjgdZjVkJipAwkqh27HnKnR2lVvyQ== }
+      { integrity: sha512-fAkMP3Hg8bpNPaySqPgHlnfmTAfXJn1sdHuoiLfrDjcugk8wMWMEla/FkFdZS+GGMIseq5EN0tZJVWbuf7GZMw== }
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /git-cliff-linux-arm64@1.2.0:
+  /git-cliff-linux-arm64@1.3.0:
     resolution:
-      { integrity: sha512-C6A/UAq6M1UFso4r9gfG5FF1wAyj5ysPX8X6KFVS2UgU+zJJqNBQKD5kYxDDHRsCq/bMV8oVHyYJlt2wVKAo+A== }
+      { integrity: sha512-xqcJXjwlfoWFnnfYOAFDHIZYrukZOjn7kc86bu2J1iQUv25SYSKrg+7FuQ49Pna3wrg9BHdInyiAjhZsTbttOg== }
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /git-cliff-linux-x64@1.2.0:
+  /git-cliff-linux-x64@1.3.0:
     resolution:
-      { integrity: sha512-nT9QPYO1XigDrNJie4EMonBvWtZaZmOQsiYd10zt9b15uYfbadymkQJXZy2w1OaqVsl82zRDzjpdQ2x6qFbK8g== }
+      { integrity: sha512-FSWEEbj5b0BqPprQ0RhogcslHdwMn4xm0oO4R2PcO8b9MR4prdud7g7NCe4yAkCS4PrfmGD1+hwW0qScoyfr5g== }
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /git-cliff-windows-arm64@1.2.0:
+  /git-cliff-windows-arm64@1.3.0:
     resolution:
-      { integrity: sha512-peEdb0MRhLb5bcpLGdDcITAk42Tp0oWvPApAr/PVZbcuz441VppIrEoXsJeZYqKM6cuD/x0N2uC96sRrrV5Gig== }
+      { integrity: sha512-6VDHgsD3QyUKgmXcx1K5gV8MZYlgtkBgRG5l7YE3WF2Oi48gLQfEi+eLG4pf5Nk7wdgXv4O7m/vKpf9NASQPAg== }
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /git-cliff-windows-x64@1.2.0:
+  /git-cliff-windows-x64@1.3.0:
     resolution:
-      { integrity: sha512-PZ3QwZOGEaRQ02c8F4khYRQC2VHAJDmYn9ZVEdSBYArPJr8xFe3QLib/T33kz4rs7P1050pr1Ze9dnOAbdMaJQ== }
+      { integrity: sha512-rVBOL92fbXC3jB6i6XIOOohZH5wOdLLi94d1iK0Rw9k4m2ViJ7cjFQL3IOHBrwETOkumfGAG72WRV8kCocPXpw== }
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /git-cliff@1.2.0:
+  /git-cliff@1.3.0:
     resolution:
-      { integrity: sha512-nuruES3361gZPi0p9C+vNRW8o/e7W6Y2iuriiQnukWhy9zjlZ4Qx2uCLV8iTTKfms9EoG54x6FCP4cnSAXL9Kg== }
+      { integrity: sha512-7xesZnD2GHxbnBVkNFI7LAU3IOL4dlOyg3wvxHNuRi9O6bDZhpzESRON9y6bw21CLmDipQNzz+a2cYwiufxovQ== }
     hasBin: true
     optionalDependencies:
-      git-cliff-darwin-arm64: 1.2.0
-      git-cliff-darwin-x64: 1.2.0
-      git-cliff-linux-arm64: 1.2.0
-      git-cliff-linux-x64: 1.2.0
-      git-cliff-windows-arm64: 1.2.0
-      git-cliff-windows-x64: 1.2.0
+      git-cliff-darwin-arm64: 1.3.0
+      git-cliff-darwin-x64: 1.3.0
+      git-cliff-linux-arm64: 1.3.0
+      git-cliff-linux-x64: 1.3.0
+      git-cliff-windows-arm64: 1.3.0
+      git-cliff-windows-x64: 1.3.0
     dev: true
 
   /git-raw-commits@2.0.11:
@@ -14124,6 +14139,17 @@ packages:
       split2: 3.2.2
     dev: true
 
+  /git-raw-commits@4.0.0:
+    resolution:
+      { integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ== }
+    engines: { node: '>=16' }
+    hasBin: true
+    dependencies:
+      dargs: 8.1.0
+      meow: 12.1.1
+      split2: 4.2.0
+    dev: true
+
   /git-remote-origin-url@2.0.0:
     resolution:
       { integrity: sha512-eU+GGrZgccNJcsDH5LkXR3PB9M958hxc7sbA8DFJjrv9j4L2P/eZfKhM+QD6wyzpiv+b1BpK0XrYCxkovtjSLw== }
@@ -14140,6 +14166,16 @@ packages:
     hasBin: true
     dependencies:
       meow: 8.1.2
+      semver: 7.5.4
+    dev: true
+
+  /git-semver-tags@7.0.1:
+    resolution:
+      { integrity: sha512-NY0ZHjJzyyNXHTDZmj+GG7PyuAKtMsyWSwh07CR2hOZFa+/yoTsXci/nF2obzL8UDhakFNkD9gNdt/Ed+cxh2Q== }
+    engines: { node: '>=16' }
+    hasBin: true
+    dependencies:
+      meow: 12.1.1
       semver: 7.5.4
     dev: true
 
@@ -15529,6 +15565,14 @@ packages:
     engines: { node: '>=0.10.0' }
     dependencies:
       text-extensions: 1.9.0
+    dev: true
+
+  /is-text-path@2.0.0:
+    resolution:
+      { integrity: sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw== }
+    engines: { node: '>=8' }
+    dependencies:
+      text-extensions: 2.4.0
     dev: true
 
   /is-typed-array@1.1.12:
@@ -17499,6 +17543,12 @@ packages:
   /meow@12.1.0:
     resolution:
       { integrity: sha512-SvSqzS5ktjGoySdCwxQI16iO/ID1LtxM03QvJ4FF2H5cCtXLN7YbfKBCL9btqXSSuJ5TNG4UH6wvWtXZuvgvrw== }
+    engines: { node: '>=16.10' }
+    dev: true
+
+  /meow@12.1.1:
+    resolution:
+      { integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw== }
     engines: { node: '>=16.10' }
     dev: true
 
@@ -21317,6 +21367,12 @@ packages:
       readable-stream: 3.6.2
     dev: true
 
+  /split2@4.2.0:
+    resolution:
+      { integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg== }
+    engines: { node: '>= 10.x' }
+    dev: true
+
   /split@1.0.1:
     resolution:
       { integrity: sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg== }
@@ -22014,6 +22070,12 @@ packages:
     resolution:
       { integrity: sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ== }
     engines: { node: '>=0.10' }
+    dev: true
+
+  /text-extensions@2.4.0:
+    resolution:
+      { integrity: sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g== }
+    engines: { node: '>=8' }
     dev: true
 
   /text-table@0.2.0:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Setting `identifierBase` to `false` will remove those troublesome trailing `.0`s in our development versions.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
