### PR TITLE
Fix TypeError in InteractionResponses.js

### DIFF
--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -77,7 +77,7 @@ class InteractionResponses {
     });
     this.deferred = true;
 
-    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this);
+    return options?.fetchReply ? this.fetchReply() : new InteractionResponse(this);
   }
 
   /**
@@ -118,7 +118,7 @@ class InteractionResponses {
     });
     this.replied = true;
 
-    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this);
+    return options?.fetchReply ? this.fetchReply() : new InteractionResponse(this);
   }
 
   /**
@@ -205,7 +205,7 @@ class InteractionResponses {
     });
     this.deferred = true;
 
-    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this, this.message?.interaction?.id);
+    return options?.fetchReply ? this.fetchReply() : new InteractionResponse(this, this.message?.interaction?.id);
   }
 
   /**
@@ -240,7 +240,7 @@ class InteractionResponses {
     });
     this.replied = true;
 
-    return options.fetchReply ? this.fetchReply() : new InteractionResponse(this, this.message.interaction?.id);
+    return options?.fetchReply ? this.fetchReply() : new InteractionResponse(this, this.message.interaction?.id);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
This pull request addresses a `TypeError` in `InteractionResponses.js` file, which were causing issues with the `fetchReply `property. The error occurred when attempting to read properties of `undefined`.

 I have added optional chaining (`options?.fetchReply`) to ensure that the `fetchReply` property is only accessed if options is defined. This prevents the `TypeError` from occurring when options is `undefined`.
 
**Testing:**

I have thoroughly tested these changes by reproducing the issue and verifying that the `TypeError` no longer occurs after applying this pull request. Additionally, I have ensured that the existing functionality remains intact.