### PR TITLE
fix(website): generate right dapi-types URLs for enum members

### DIFF
--- a/apps/website/src/components/ExcerptText.tsx
+++ b/apps/website/src/components/ExcerptText.tsx
@@ -24,13 +24,16 @@ export function ExcerptText({ model, excerpt }: ExcerptTextProps) {
 			{excerpt.spannedTokens.map((token, idx) => {
 				if (token.kind === ExcerptTokenKind.Reference) {
 					const source = token.canonicalReference?.source;
+					const symbol = token.canonicalReference?.symbol;
+					if (source && 'packageName' in source && source.packageName === 'discord-api-types' && symbol) {
+						const { meaning, componentPath: path } = symbol;
+						let href = DISCORD_API_TYPES_DOCS_URL;
 
-					if (source && 'packageName' in source && source.packageName === 'discord-api-types') {
-						const meaning = token.canonicalReference.symbol?.meaning;
-						const href =
-							meaning === 'type'
-								? `${DISCORD_API_TYPES_DOCS_URL}#${token.text}`
-								: `${DISCORD_API_TYPES_DOCS_URL}/${meaning}/${token.text}`;
+						// dapi-types doesn't have routes for class members
+						// so we can assume this member is for an enum
+						if (meaning === 'member' && path && 'parent' in path) href += `/enum/${path.parent}#${path.component}`;
+						else if (meaning === 'type') href += `#${token.text}`;
+						else href += `/${meaning}/${token.text}`;
 
 						return (
 							<a className="text-blurple" href={href} key={idx} rel="external noreferrer noopener" target="_blank">


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #9780

Previous:
![image](https://github.com/discordjs/discord.js/assets/15116870/dfe6982a-c8ef-4c1d-a20c-d7953f055600)

Corrected [link](https://discord-api-types.dev/api/discord-api-types-v10/enum/ApplicationCommandOptionType#Attachment):
![image](https://github.com/discordjs/discord.js/assets/15116870/d736671b-04cd-4cdb-82e0-7c1ae3be5ffc)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
