### PR TITLE
docs(stickers): Reveal link in the website

### DIFF
--- a/packages/core/src/api/sticker.ts
+++ b/packages/core/src/api/sticker.ts
@@ -26,7 +26,7 @@ export class StickersAPI {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/sticker#list-sticker-packs}
 	 * @param options - The options for fetching the sticker packs
-	 * @deprecated Use {@link getStickers} instead.
+	 * @deprecated Use {@link StickersAPI.getStickers} instead.
 	 */
 	public async getNitroStickers(options: Pick<RequestData, 'signal'> = {}) {
 		return this.getStickers(options);


### PR DESCRIPTION
The deprecation message does not contain the link.[^1] Using the class name should fix it.

[^1]: https://discordjs.dev/docs/packages/core/main/StickersAPI:Class#getNitroStickers