### PR TITLE
fix(Role): calculate position correctly when rawPositions are equal

### DIFF
--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -205,7 +205,7 @@ class Role extends Base {
       (acc, role) =>
         acc +
         (this.rawPosition === role.rawPosition
-          ? BigInt(this.id) > BigInt(role.id)
+          ? BigInt(this.id) < BigInt(role.id)
           : this.rawPosition > role.rawPosition),
       0,
     );


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Positions were not calculated right if a guild had raw positions equal across roles

This happened due to not noticing the previous sorting behavior which was (cleaned up from old v13)

```js
function discordSort(collection) {
  return collection.sorted(
    (a, b) => a.rawPosition - b.rawPosition || Number(BigInt(b.id) - BigInt(a.id)),
  );
}
```

Peep the order: `b.id - a.id`. In current code, it's equivalent to `a.id - b.id`

v13 PR: #9872

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
