### PR TITLE
fix(Role): calculate position correctly when rawPositions are equal

### DIFF
--- a/src/structures/Role.js
+++ b/src/structures/Role.js
@@ -231,7 +231,7 @@ class Role extends Base {
     let count = 0;
     for (const role of this.guild.roles.cache.values()) {
       if (this.rawPosition > role.rawPosition) count++;
-      else if (this.rawPosition === role.rawPosition && BigInt(this.id) > BigInt(role.id)) count++;
+      else if (this.rawPosition === role.rawPosition && BigInt(this.id) < BigInt(role.id)) count++;
     }
 
     return count;


### PR DESCRIPTION
Diplopia of #9871 

**Please describe the changes this PR makes and why it should be merged:**

Positions were not calculated right if a guild had raw positions equal across roles

This happened due to not noticing the previous sorting behavior which was (cleaned up from old v13)

```js
function discordSort(collection) {
  return collection.sorted(
    (a, b) => a.rawPosition - b.rawPosition || Number(BigInt(b.id) - BigInt(a.id)),
  );
}
```

Peep the order: `b.id - a.id`. In current code, it's equivalent to `a.id - b.id`

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
