### PR TITLE
types(MessageEditOptions): Correct `attachments` type

### DIFF
--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -153,10 +153,16 @@ class MessageManager extends CachedManager {
    */
 
   /**
+   * Data used to reference an attachment.
+   * @typedef {Object} MessageEditAttachmentData
+   * @property {Snowflake} id The id of the attachment
+   */
+
+  /**
    * Options that can be passed to edit a message.
    * @typedef {BaseMessageOptions} MessageEditOptions
-   * @property {AttachmentPayload[]} [attachments] An array of attachments to keep,
-   * all attachments will be kept if omitted
+   * @property {Array<Attachment|MessageEditAttachmentData>} [attachments] An array of attachments to keep.
+   * All attachments will be kept if omitted
    * @property {MessageFlags} [flags] Which flags to set for the message
    * <info>Only the {@link MessageFlags.SuppressEmbeds} flag can be modified.</info>
    */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6003,9 +6003,13 @@ export interface MessageCreateOptions extends BaseMessageOptions {
 export type GuildForumThreadMessageCreateOptions = BaseMessageOptions &
   Pick<MessageCreateOptions, 'flags' | 'stickers'>;
 
+export interface MessageEditAttachmentData {
+  id: Snowflake;
+}
+
 export interface MessageEditOptions extends Omit<BaseMessageOptions, 'content'> {
   content?: string | null;
-  attachments?: JSONEncodable<AttachmentPayload>[];
+  attachments?: (Attachment | MessageEditAttachmentData)[];
   flags?: BitFieldResolvable<Extract<MessageFlagsString, 'SuppressEmbeds'>, MessageFlags.SuppressEmbeds>;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #9667.

As pointed out in that issue, `JSONEncodable<AttachmentPayload>[]` was the wrong type.

Discord's documentation states that only the `id` is required.[^1][^2] It also states that descriptions are optional, but that is handled already via `files`. Therefore, an array of `Attachment` and `MessageEditAttachmentData` would be the correct type.

No change in code is needed.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

[^1]: https://discord.com/developers/docs/resources/channel#edit-message-jsonform-params
[^2]: https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure