### PR TITLE
fix: update module to `NodeNext` in tsconfig.json

### DIFF
--- a/packages/create-discord-bot/template/TypeScript/tsconfig.json
+++ b/packages/create-discord-bot/template/TypeScript/tsconfig.json
@@ -4,7 +4,7 @@
 	"compilerOptions": {
 		"declaration": false,
 		"declarationMap": false,
-		"module": "ESNext",
+		"module": "NodeNext",
 		"moduleResolution": "NodeNext",
 		"target": "ESNext",
 		"outDir": "dist",


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `module` in `tsconfig.json` was changed as it was causing an error because since the `moduleResolution` is set to `NodeNext`, it must also be set to `NodeNext`.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
