### PR TITLE
build: Bump discord-api-types to 0.37.60

### DIFF
--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -67,7 +67,7 @@
 		"@discordjs/formatters": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"@sapphire/shapeshift": "^3.9.2",
-		"discord-api-types": "0.37.59",
+		"discord-api-types": "0.37.60",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.3",
 		"tslib": "^2.6.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,7 @@
 		"@discordjs/ws": "workspace:^",
 		"@sapphire/snowflake": "^3.5.1",
 		"@vladfrangu/async_event_emitter": "^2.2.2",
-		"discord-api-types": "0.37.59"
+		"discord-api-types": "0.37.60"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^2.2.0",

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -59,7 +59,7 @@
     "@discordjs/ws": "workspace:^",
     "@sapphire/snowflake": "3.5.1",
     "@types/ws": "8.5.5",
-    "discord-api-types": "0.37.59",
+    "discord-api-types": "0.37.60",
     "fast-deep-equal": "3.1.3",
     "lodash.snakecase": "4.1.1",
     "tslib": "2.6.2",

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -54,7 +54,7 @@
 	},
 	"homepage": "https://discord.js.org",
 	"dependencies": {
-		"discord-api-types": "0.37.59"
+		"discord-api-types": "0.37.60"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^2.2.0",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -71,7 +71,7 @@
 		"@discordjs/rest": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"@discordjs/ws": "workspace:^",
-		"discord-api-types": "0.37.59"
+		"discord-api-types": "0.37.60"
 	},
 	"devDependencies": {
 		"@favware/cliff-jumper": "^2.2.0",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -87,7 +87,7 @@
 		"@sapphire/async-queue": "^1.5.0",
 		"@sapphire/snowflake": "^3.5.1",
 		"@vladfrangu/async_event_emitter": "^2.2.2",
-		"discord-api-types": "0.37.59",
+		"discord-api-types": "0.37.60",
 		"magic-bytes.js": "^1.0.15",
 		"tslib": "^2.6.2",
 		"undici": "5.23.0"

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -63,7 +63,7 @@
 	"homepage": "https://discord.js.org",
 	"dependencies": {
 		"@types/ws": "^8.5.5",
-		"discord-api-types": "0.37.59",
+		"discord-api-types": "0.37.60",
 		"prism-media": "^1.3.5",
 		"tslib": "^2.6.2",
 		"ws": "^8.13.0"

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -78,7 +78,7 @@
 		"@sapphire/async-queue": "^1.5.0",
 		"@types/ws": "^8.5.5",
 		"@vladfrangu/async_event_emitter": "^2.2.2",
-		"discord-api-types": "0.37.59",
+		"discord-api-types": "0.37.60",
 		"tslib": "^2.6.2",
 		"ws": "^8.13.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,8 +539,8 @@ importers:
         specifier: ^3.9.2
         version: 3.9.2
       discord-api-types:
-        specifier: 0.37.59
-        version: 0.37.59
+        specifier: 0.37.60
+        version: 0.37.60
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -595,7 +595,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3
 
   packages/collection:
     devDependencies:
@@ -660,8 +660,8 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2
       discord-api-types:
-        specifier: 0.37.59
-        version: 0.37.59
+        specifier: 0.37.60
+        version: 0.37.60
     devDependencies:
       '@favware/cliff-jumper':
         specifier: ^2.2.0
@@ -704,7 +704,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3
 
   packages/create-discord-bot:
     dependencies:
@@ -797,8 +797,8 @@ importers:
         specifier: 8.5.5
         version: 8.5.5
       discord-api-types:
-        specifier: 0.37.59
-        version: 0.37.59
+        specifier: 0.37.60
+        version: 0.37.60
       fast-deep-equal:
         specifier: 3.1.3
         version: 3.1.3
@@ -907,8 +907,8 @@ importers:
   packages/formatters:
     dependencies:
       discord-api-types:
-        specifier: 0.37.59
-        version: 0.37.59
+        specifier: 0.37.60
+        version: 0.37.60
     devDependencies:
       '@favware/cliff-jumper':
         specifier: ^2.2.0
@@ -948,7 +948,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3
 
   packages/next:
     dependencies:
@@ -974,8 +974,8 @@ importers:
         specifier: workspace:^
         version: link:../ws
       discord-api-types:
-        specifier: 0.37.59
-        version: 0.37.59
+        specifier: 0.37.60
+        version: 0.37.60
     devDependencies:
       '@favware/cliff-jumper':
         specifier: ^2.2.0
@@ -1018,7 +1018,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3
 
   packages/proxy:
     dependencies:
@@ -1139,8 +1139,8 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2
       discord-api-types:
-        specifier: 0.37.59
-        version: 0.37.59
+        specifier: 0.37.60
+        version: 0.37.60
       magic-bytes.js:
         specifier: ^1.0.15
         version: 1.0.15
@@ -1192,7 +1192,7 @@ importers:
         version: 5.2.2
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3
 
   packages/scripts:
     dependencies:
@@ -1412,8 +1412,8 @@ importers:
         specifier: ^8.5.5
         version: 8.5.5
       discord-api-types:
-        specifier: 0.37.59
-        version: 0.37.59
+        specifier: 0.37.60
+        version: 0.37.60
       prism-media:
         specifier: ^1.3.5
         version: 1.3.5
@@ -1506,8 +1506,8 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2
       discord-api-types:
-        specifier: 0.37.59
-        version: 0.37.59
+        specifier: 0.37.60
+        version: 0.37.60
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -1562,7 +1562,7 @@ importers:
         version: 5.23.0
       vitest:
         specifier: ^0.34.3
-        version: 0.34.3(happy-dom@10.11.0)
+        version: 0.34.3
       zlib-sync:
         specifier: ^0.1.8
         version: 0.1.8
@@ -8758,7 +8758,7 @@ packages:
       std-env: 3.4.3
       test-exclude: 6.0.0
       v8-to-istanbul: 9.1.0
-      vitest: 0.34.3(happy-dom@10.11.0)
+      vitest: 0.34.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11778,9 +11778,9 @@ packages:
       path-type: 4.0.0
     dev: true
 
-  /discord-api-types@0.37.59:
+  /discord-api-types@0.37.60:
     resolution:
-      { integrity: sha512-75CxNb6dtxlgsIa3mD2ohoDLIZLMv/upsadRCYlqv2UgPTJ/p2MzSSbrH2AGBvL90/fAsB6fj8hCPOWzBkPkZQ== }
+      { integrity: sha512-5BELXTsv7becqVHrD81nZrqT4oEyXXWBwbsO/kwDDu6X3u19VV1tYDB5I5vaVAK+c1chcDeheI9zACBLm41LiQ== }
     dev: false
 
   /dmd@6.2.0:
@@ -11866,7 +11866,7 @@ packages:
     dependencies:
       semver: 7.5.4
       shelljs: 0.8.5
-      typescript: 5.3.0-dev.20231003
+      typescript: 5.3.0-dev.20231007
     dev: true
 
   /dts-critic@3.3.11(typescript@5.2.2):
@@ -22885,9 +22885,9 @@ packages:
     engines: { node: '>=14.17' }
     hasBin: true
 
-  /typescript@5.3.0-dev.20231003:
+  /typescript@5.3.0-dev.20231007:
     resolution:
-      { integrity: sha512-OyUdPjo1wNYs+PVDr9ARcEPs0aOqdxterOFzQzWK6DR4tsadKPbrOx8JgTOvSUwhkNOxBOEh7BonqV2uNsTxvA== }
+      { integrity: sha512-yNeHmU15JtC5TgUuiCaywQqtVJ6Q1T6mNwDg5N1ObnctoaqBrZ0FGy37NP0Y/UnJUhZxgcYrIb1gcial4fUiyA== }
     engines: { node: '>=14.17' }
     hasBin: true
     dev: true
@@ -23513,6 +23513,29 @@ packages:
       unist-util-stringify-position: 3.0.3
       vfile-message: 3.1.4
 
+  /vite-node@0.34.3(@types/node@18.17.9):
+    resolution:
+      { integrity: sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig== }
+    engines: { node: '>=v14.18.0' }
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      mlly: 1.4.1
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 4.4.9(@types/node@18.17.9)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-node@0.34.3(@types/node@18.17.9)(terser@5.19.2):
     resolution:
       { integrity: sha512-+0TzJf1g0tYXj6tR2vEyiA42OPq68QkRZCu/ERSo2PtsDJfBpDyEfuKbRvLmZqi/CgC7SCBtyC+WjTGNMRIaig== }
@@ -23598,6 +23621,43 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /vite@4.4.9(@types/node@18.17.9):
+    resolution:
+      { integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA== }
+    engines: { node: ^14.18.0 || >=16.0.0 }
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.17.9
+      esbuild: 0.18.20
+      postcss: 8.4.28
+      rollup: 3.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /vite@4.4.9(@types/node@18.17.9)(terser@5.19.2):
     resolution:
       { integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA== }
@@ -23634,6 +23694,72 @@ packages:
       terser: 5.19.2
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vitest@0.34.3:
+    resolution:
+      { integrity: sha512-7+VA5Iw4S3USYk+qwPxHl8plCMhA5rtfwMjgoQXMT7rO5ldWcdsdo3U1QD289JgglGK4WeOzgoLTsGFu6VISyQ== }
+    engines: { node: '>=v14.18.0' }
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.5
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.17.9
+      '@vitest/expect': 0.34.3
+      '@vitest/runner': 0.34.3
+      '@vitest/snapshot': 0.34.3
+      '@vitest/spy': 0.34.3
+      '@vitest/utils': 0.34.3
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.8
+      debug: 4.3.4
+      local-pkg: 0.4.3
+      magic-string: 0.30.3
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.4.3
+      strip-literal: 1.3.0
+      tinybench: 2.5.0
+      tinypool: 0.7.0
+      vite: 4.4.9(@types/node@18.17.9)
+      vite-node: 0.34.3(@types/node@18.17.9)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vitest@0.34.3(happy-dom@10.11.0):


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Bumps discord-api-types to 0.37.60 which unblocks #9709.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
