### PR TITLE
ci: Use non-deprecated output parameters

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -52,22 +52,23 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Check the current development version
-        id: pre-release
+        id: release-check
         run: |
           if [[ $(npm view ${{ matrix.package }}@dev version | grep -e "$(git rev-parse --short HEAD)") ]]; \
-          then echo '::set-output name=release::false'; \
-          else echo '::set-output name=release::true'; fi
+            then echo "RELEASE=0" >> "$GITHUB_OUTPUT"; \
+            else echo "RELEASE=1" >> "$GITHUB_OUTPUT"; \
+          fi
 
       - name: Install dependencies
-        if: steps.pre-release.outputs.release == 'true'
+        if: steps.release-check.outputs.release == '1'
         uses: ./packages/actions/src/pnpmCache
 
       - name: Build dependencies
-        if: steps.pre-release.outputs.release == 'true'
+        if: steps.release-check.outputs.release == '1'
         run: pnpm run build
 
       - name: Publish package
-        if: steps.pre-release.outputs.release == 'true'
+        if: steps.release-check.outputs.release == '1'
         run: |
           pnpm --filter=${{ matrix.package }} run release --preid "dev.$(date +%s)-$(git rev-parse --short HEAD)"
           pnpm --filter=${{ matrix.package }} publish --no-git-checks --tag dev || true
@@ -75,7 +76,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
       - name: Deprecate prior development releases
-        if: steps.pre-release.outputs.release == 'true'
+        if: steps.release-check.outputs.release == '1'
         run: pnpm exec npm-deprecate --name "*dev*" --message "This version is deprecated. Please use a newer version." --package ${{ matrix.package }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`::set-output` is deprecated per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands. This is tested with a [release needed](https://github.com/discordjs/discord.js/actions/runs/6443524641) & [not needed](https://github.com/discordjs/discord.js/actions/runs/6443560000).

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
