### PR TITLE
docs: Consolidate API types

### DIFF
--- a/packages/discord.js/src/managers/ApplicationCommandPermissionsManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandPermissionsManager.js
@@ -424,11 +424,6 @@ module.exports = ApplicationCommandPermissionsManager;
 
 /* eslint-disable max-len */
 /**
- * @external APIApplicationCommandPermissions
- * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure}
- */
-
-/**
  * Data that resolves to an id used for an application command permission
  * @typedef {UserResolvable|RoleResolvable|GuildChannelResolvable|RolePermissionConstant|ChannelPermissionConstant} ApplicationCommandPermissionIdResolvable
  */

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -591,16 +591,6 @@ module.exports = ApplicationCommand;
 
 /* eslint-disable max-len */
 /**
- * @external APIApplicationCommand
- * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure}
- */
-
-/**
- * @external APIApplicationCommandOption
- * @see {@link https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure}
- */
-
-/**
  * @external ApplicationCommandOptionAllowedChannelTypes
  * @see {@link https://discord.js.org/docs/packages/builders/stable/ApplicationCommandOptionAllowedChannelTypes:TypeAlias}
  */

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -105,11 +105,6 @@ class AttachmentBuilder {
 module.exports = AttachmentBuilder;
 
 /**
- * @external APIAttachment
- * @see {@link https://discord.com/developers/docs/resources/channel#attachment-object}
- */
-
-/**
  * @typedef {Object} AttachmentData
  * @property {string} [name] The name of the attachment
  * @property {string} [description] The description of the attachment

--- a/packages/discord.js/src/structures/ClientPresence.js
+++ b/packages/discord.js/src/structures/ClientPresence.js
@@ -36,7 +36,7 @@ class ClientPresence extends Presence {
   /**
    * Parses presence data into a packet ready to be sent to Discord
    * @param {PresenceData} presence The data to parse
-   * @returns {APIPresence}
+   * @returns {GatewayPresenceUpdateData}
    * @private
    */
   _parse({ status, since, afk, activities }) {
@@ -82,9 +82,3 @@ class ClientPresence extends Presence {
 }
 
 module.exports = ClientPresence;
-
-/* eslint-disable max-len */
-/**
- * @external APIPresence
- * @see {@link https://discord.com/developers/docs/rich-presence/how-to#updating-presence-update-presence-payload-fields}
- */

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -216,9 +216,3 @@ class CommandInteraction extends BaseInteraction {
 InteractionResponses.applyToClass(CommandInteraction, ['deferUpdate', 'update']);
 
 module.exports = CommandInteraction;
-
-/* eslint-disable max-len */
-/**
- * @external APIInteractionDataResolved
- * @see {@link https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-object-resolved-data-structure}
- */

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -1371,8 +1371,3 @@ class Guild extends AnonymousGuild {
 }
 
 exports.Guild = Guild;
-
-/**
- * @external APIGuild
- * @see {@link https://discord.com/developers/docs/resources/guild#guild-object}
- */

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -513,8 +513,3 @@ class GuildMember extends Base {
 TextBasedChannel.applyToClass(GuildMember);
 
 exports.GuildMember = GuildMember;
-
-/**
- * @external APIGuildMember
- * @see {@link https://discord.com/developers/docs/resources/guild#guild-member-object}
- */

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -289,11 +289,6 @@ module.exports = MessagePayload;
  */
 
 /**
- * @external APIMessage
- * @see {@link https://discord.com/developers/docs/resources/channel#message-object}
- */
-
-/**
  * @external RawFile
  * @see {@link https://discord.js.org/docs/packages/rest/stable/RawFile:Interface}
  */

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -464,8 +464,3 @@ class Role extends Base {
 }
 
 exports.Role = Role;
-
-/**
- * @external APIRole
- * @see {@link https://discord.com/developers/docs/topics/permissions#role-object}
- */

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -265,8 +265,3 @@ class Sticker extends Base {
 }
 
 exports.Sticker = Sticker;
-
-/**
- * @external APISticker
- * @see {@link https://discord.com/developers/docs/resources/sticker#sticker-object}
- */

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -373,8 +373,3 @@ class User extends Base {
 TextBasedChannel.applyToClass(User);
 
 module.exports = User;
-
-/**
- * @external APIUser
- * @see {@link https://discord.com/developers/docs/resources/user#user-object}
- */

--- a/packages/discord.js/src/util/APITypes.js
+++ b/packages/discord.js/src/util/APITypes.js
@@ -86,8 +86,18 @@
  */
 
 /**
+ * @external APIGuildMember
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIGuildMember}
+ */
+
+/**
  * @external APIInteraction
  * @see {@link https://discord-api-types.dev/api/discord-api-types-v10#APIInteraction}
+ */
+
+/**
+ * @external APIInteractionDataResolved
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIInteractionDataResolved}
  */
 
 /**
@@ -151,8 +161,8 @@
  */
 
 /**
- * @external APIPresence
- * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIPresence}
+ * @external APIRole
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APIRole}
  */
 
 /**
@@ -163,6 +173,11 @@
 /**
  * @external APISelectMenuOption
  * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APISelectMenuOption}
+ */
+
+/**
+ * @external APISticker
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/APISticker}
  */
 
 /**
@@ -283,6 +298,11 @@
 /**
  * @external GatewayOpcodes
  * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/GatewayOpcodes}
+ */
+
+/**
+ * @external GatewayPresenceUpdateData
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/interface/GatewayPresenceUpdateData}
  */
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I've moved all remaining API type definitions into APITypes.js. There were some deviations:

- `APIAttachment` was unused
- `APIApplicationCommandPermissions` was unused
- `APIEmoji` will move with #9880
- `APIPresence` should be `GatewayPresenceUpdateData`

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
