### PR TITLE
fix: forward x-audit-log-reason header

### DIFF
--- a/packages/proxy/src/handlers/proxyRequests.ts
+++ b/packages/proxy/src/handlers/proxyRequests.ts
@@ -32,6 +32,10 @@ export function proxyRequests(rest: REST): RequestHandler {
 			headers.authorization = req.headers.authorization;
 		}
 
+		if (req.headers['x-audit-log-reason']) {
+			headers['x-audit-log-reason'] = req.headers['x-audit-log-reason'] as string;
+		}
+
 		try {
 			const discordResponse = await rest.queueRequest({
 				body: req,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves an issue with djs/proxy where the `X-Audit-Log-Reason` header was not being forwarded, preventing audit log reasons from appearing for any requests that specified them.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
