### PR TITLE
docs(GuildMember): clarify display color

### DIFF
--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -202,7 +202,7 @@ class GuildMember extends Base {
   }
 
   /**
-   * The displayed color of this member in base 10
+   * The displayed role color of this member in base 10
    * @type {number}
    * @readonly
    */
@@ -211,7 +211,7 @@ class GuildMember extends Base {
   }
 
   /**
-   * The displayed color of this member in hexadecimal
+   * The displayed role color of this member in hexadecimal
    * @type {string}
    * @readonly
    */


### PR DESCRIPTION
Fixes #9842

Clarifies that GuildMember display color is based on user's role.


**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
