### PR TITLE
fix: Add extension

### DIFF
--- a/packages/api-extractor-utils/src/parse.ts
+++ b/packages/api-extractor-utils/src/parse.ts
@@ -13,7 +13,7 @@ import {
 	ApiDeclaredItem,
 } from '@microsoft/api-extractor-model';
 import type { DocNode, DocParagraph, DocPlainText } from '@microsoft/tsdoc';
-import { type Meaning, ModuleSource } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference';
+import { type Meaning, ModuleSource } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference.js';
 import type { DocBlockJSON } from './tsdoc/CommentBlock.js';
 import { createCommentNode } from './tsdoc/index.js';
 


### PR DESCRIPTION
One could not run the build:search_indices script in website because the script requires this file which lacks the .js reference.