### PR TITLE
fix: use `super` on webhook delete

### DIFF
--- a/packages/discord.js/src/client/WebhookClient.js
+++ b/packages/discord.js/src/client/WebhookClient.js
@@ -59,6 +59,15 @@ class WebhookClient extends BaseClient {
   }
 
   /**
+   * Deletes the webhook.
+   * @param {string} [reason] Reason for deleting this webhook
+   * @returns {Promise<void>}
+   */
+  delete(reason) {
+    return super.delete(reason);
+  }
+
+  /**
    * The options the webhook client was instantiated with.
    * @type {WebhookClientOptions}
    * @name WebhookClient#options
@@ -91,7 +100,6 @@ class WebhookClient extends BaseClient {
 
   sendSlackMessage() {}
   edit() {}
-  delete() {}
   deleteMessage() {}
   get createdTimestamp() {}
   get createdAt() {}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Supersedes:
- https://github.com/discordjs/discord.js/pull/9786

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating