### PR TITLE
docs: remove markdown

### DIFF
--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -596,11 +596,11 @@ export enum Faces {
  */
 export enum GuildNavigationMentions {
 	/**
-	 * _Browse Channels_ tab.
+	 * Browse Channels tab.
 	 */
 	Browse = '<id:browse>',
 	/**
-	 * _Customize_ tab with the server's {@link https://discord.com/developers/docs/resources/guild#guild-onboarding-object | onboarding prompts}.
+	 * Customize tab with the server's {@link https://discord.com/developers/docs/resources/guild#guild-onboarding-object | onboarding prompts}.
 	 */
 	Customize = '<id:customize>',
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The documentation website does not support rendering markdown

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
