### PR TITLE
refactor: Move `getNode`/`canEnableFFmpegOptimizations` into a lazy loaded call

### DIFF
--- a/packages/api-extractor-utils/src/parse.ts
+++ b/packages/api-extractor-utils/src/parse.ts
@@ -13,7 +13,7 @@ import {
 	ApiDeclaredItem,
 } from '@microsoft/api-extractor-model';
 import type { DocNode, DocParagraph, DocPlainText } from '@microsoft/tsdoc';
-import { type Meaning, ModuleSource } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference';
+import { type Meaning, ModuleSource } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference.js';
 import type { DocBlockJSON } from './tsdoc/CommentBlock.js';
 import { createCommentNode } from './tsdoc/index.js';
 

--- a/packages/voice/src/audio/TransformerGraph.ts
+++ b/packages/voice/src/audio/TransformerGraph.ts
@@ -123,7 +123,7 @@ function canEnableFFmpegOptimizations(): boolean {
 	return false;
 }
 
-function initializeNodes() : Map<StreamType, Node> {
+function initializeNodes(): Map<StreamType, Node> {
 	let nodes = new Map<StreamType, Node>();
 	for (const streamType of Object.values(StreamType)) {
 		nodes.set(streamType, new Node(streamType));

--- a/packages/voice/src/audio/TransformerGraph.ts
+++ b/packages/voice/src/audio/TransformerGraph.ts
@@ -124,7 +124,7 @@ function canEnableFFmpegOptimizations(): boolean {
 }
 
 function initializeNodes(): Map<StreamType, Node> {
-	let nodes = new Map<StreamType, Node>();
+	const nodes = new Map<StreamType, Node>();
 	for (const streamType of Object.values(StreamType)) {
 		nodes.set(streamType, new Node(streamType));
 	}

--- a/packages/voice/src/audio/TransformerGraph.ts
+++ b/packages/voice/src/audio/TransformerGraph.ts
@@ -129,37 +129,37 @@ function initializeNodes() : Map<StreamType, Node> {
 		nodes.set(streamType, new Node(streamType));
 	}
 
-	getNode(StreamType.Raw).addEdge({
+	nodes.get(StreamType.Raw)!.addEdge({
 		type: TransformerType.OpusEncoder,
-		to: getNode(StreamType.Opus),
+		to: nodes.get(StreamType.Opus)!,
 		cost: 1.5,
 		transformer: () => new prism.opus.Encoder({ rate: 48_000, channels: 2, frameSize: 960 }),
 	});
 
-	getNode(StreamType.Opus).addEdge({
+	nodes.get(StreamType.Opus)!.addEdge({
 		type: TransformerType.OpusDecoder,
-		to: getNode(StreamType.Raw),
+		to: nodes.get(StreamType.Raw)!,
 		cost: 1.5,
 		transformer: () => new prism.opus.Decoder({ rate: 48_000, channels: 2, frameSize: 960 }),
 	});
 
-	getNode(StreamType.OggOpus).addEdge({
+	nodes.get(StreamType.OggOpus)!.addEdge({
 		type: TransformerType.OggOpusDemuxer,
-		to: getNode(StreamType.Opus),
+		to: nodes.get(StreamType.Opus)!,
 		cost: 1,
 		transformer: () => new prism.opus.OggDemuxer(),
 	});
 
-	getNode(StreamType.WebmOpus).addEdge({
+	nodes.get(StreamType.WebmOpus)!.addEdge({
 		type: TransformerType.WebmOpusDemuxer,
-		to: getNode(StreamType.Opus),
+		to: nodes.get(StreamType.Opus)!,
 		cost: 1,
 		transformer: () => new prism.opus.WebmDemuxer(),
 	});
 
 	const FFMPEG_PCM_EDGE: Omit<Edge, 'from'> = {
 		type: TransformerType.FFmpegPCM,
-		to: getNode(StreamType.Raw),
+		to: nodes.get(StreamType.Raw)!,
 		cost: 2,
 		transformer: (input) =>
 			new prism.FFmpeg({
@@ -167,13 +167,13 @@ function initializeNodes() : Map<StreamType, Node> {
 			}),
 	};
 
-	getNode(StreamType.Arbitrary).addEdge(FFMPEG_PCM_EDGE);
-	getNode(StreamType.OggOpus).addEdge(FFMPEG_PCM_EDGE);
-	getNode(StreamType.WebmOpus).addEdge(FFMPEG_PCM_EDGE);
+	nodes.get(StreamType.Arbitrary)!.addEdge(FFMPEG_PCM_EDGE);
+	nodes.get(StreamType.OggOpus)!.addEdge(FFMPEG_PCM_EDGE);
+	nodes.get(StreamType.WebmOpus)!.addEdge(FFMPEG_PCM_EDGE);
 
-	getNode(StreamType.Raw).addEdge({
+	nodes.get(StreamType.Raw)!.addEdge({
 		type: TransformerType.InlineVolume,
-		to: getNode(StreamType.Raw),
+		to: nodes.get(StreamType.Raw)!,
 		cost: 0.5,
 		transformer: () => new prism.VolumeTransformer({ type: 's16le' }),
 	});
@@ -181,19 +181,19 @@ function initializeNodes() : Map<StreamType, Node> {
 	if (canEnableFFmpegOptimizations()) {
 		const FFMPEG_OGG_EDGE: Omit<Edge, 'from'> = {
 			type: TransformerType.FFmpegOgg,
-			to: getNode(StreamType.OggOpus),
+			to: nodes.get(StreamType.OggOpus)!,
 			cost: 2,
 			transformer: (input) =>
 				new prism.FFmpeg({
 					args: ['-i', typeof input === 'string' ? input : '-', ...FFMPEG_OPUS_ARGUMENTS],
 				}),
 		};
-		getNode(StreamType.Arbitrary).addEdge(FFMPEG_OGG_EDGE);
+		nodes.get(StreamType.Arbitrary)!.addEdge(FFMPEG_OGG_EDGE);
 		// Include Ogg and WebM as well in case they have different sampling rates or are mono instead of stereo
 		// at the moment, this will not do anything. However, if/when detection for correct Opus headers is
 		// implemented, this will help inform the voice engine that it is able to transcode the audio.
-		getNode(StreamType.OggOpus).addEdge(FFMPEG_OGG_EDGE);
-		getNode(StreamType.WebmOpus).addEdge(FFMPEG_OGG_EDGE);
+		nodes.get(StreamType.OggOpus)!.addEdge(FFMPEG_OGG_EDGE);
+		nodes.get(StreamType.WebmOpus)!.addEdge(FFMPEG_OGG_EDGE);
 	}
 
 	return nodes;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Lazy calls the functions in the root of `TransformerGraph.ts`, which are called the first time the file is imported(which is through any time **@discordjs/voice** is imported. More importantly, the call to `canEnableFFmpegOptimizations`, [which is a loop that synchronously spawns child processes](https://github.com/amishshah/prism-media/blob/4ef1d6f9f53042c085c1f68627e889003e248d77/src/core/FFmpeg.js#L123C1-L123C1) is now deferred until the first time you actually attempt to play audio. 

This improves bot startup time by 100ms for people importing @discordjs/voice:
Before:
![image](https://github.com/discordjs/discord.js/assets/877114/5a2cf5c4-07a8-4f3a-8fae-7c910d1bb56a)
After:
![image](https://github.com/discordjs/discord.js/assets/877114/fee99f23-1775-4c5e-90bb-6ebbd2ae1312)

I tested this locally and can confirm audio plays correctly and the call is only called then. 

Resolves #9859 

**Status and versioning classification:**
- Patch

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
