### PR TITLE
fix(GuildManager#fetch): inject shard id

### DIFF
--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -6,6 +6,7 @@ const { Collection } = require('@discordjs/collection');
 const { makeURLSearchParams } = require('@discordjs/rest');
 const { Routes, RouteBases } = require('discord-api-types/v10');
 const CachedManager = require('./CachedManager');
+const ShardClientUtil = require('../sharding/ShardClientUtil');
 const { Guild } = require('../structures/Guild');
 const GuildChannel = require('../structures/GuildChannel');
 const GuildEmoji = require('../structures/GuildEmoji');
@@ -272,6 +273,7 @@ class GuildManager extends CachedManager {
       const data = await this.client.rest.get(Routes.guild(id), {
         query: makeURLSearchParams({ with_counts: options.withCounts ?? true }),
       });
+      data.shardId = ShardClientUtil.shardIdForGuildId(id, this.client.options.shardCount);
       return this._add(data, options.cache);
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9bc0d99</samp>

### Summary
:sparkles::wrench::floppy_disk:

<!--
1.  :sparkles: - This emoji represents the addition of a new feature or enhancement, which is sharding support for guild creation and caching.
2.  :wrench: - This emoji represents the adjustment or improvement of an existing functionality, which is using `ShardClientUtil` to assign `data.shardId` for each guild.
3.  :floppy_disk: - This emoji represents the saving or caching of data, which is what the guild creation and caching process does.
-->
This PR adds required for the Guild injection of the shard id

> _To handle more guilds in the bot_
> _We added some sharding support_
> _We imported `ShardClientUtil`_
> _To assign each guild a `shardId` too_
> _And cached them for better report_

### Walkthrough
* Import `ShardClientUtil` module to calculate shard IDs for guilds ([link](https://github.com/discordjs/discord.js/pull/9921/files?diff=unified&w=0#diff-d88269307bf05a7fe080d383536a9a0772ae1887a3c55d8178e72694c89c5ed4R9))
* Assign `data.shardId` the value of the shard ID for the guild ID ([link](https://github.com/discordjs/discord.js/pull/9921/files?diff=unified&w=0#diff-d88269307bf05a7fe080d383536a9a0772ae1887a3c55d8178e72694c89c5ed4R276))



**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
