### PR TITLE
docs(Message): remove duplicated word 'of' in description

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -148,7 +148,7 @@ class Message extends Base {
 
     if ('components' in data) {
       /**
-       * An array of of action rows in the message.
+       * An array of action rows in the message.
        * <info>This property requires the {@link GatewayIntentBits.MessageContent} privileged intent
        * in a guild for messages that do not mention the client.</info>
        * @type {ActionRow[]}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This commit removes the secondary 'of' in the description for the Message structure. This doesn't change anything drastically in terms of the actual code as it's just a JSDoc comment.

**Status and versioning classification:**

N/A

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
