### PR TITLE
fix: treat primitives as references instead of content

### DIFF
--- a/packages/api-extractor/src/generators/ExcerptBuilder.ts
+++ b/packages/api-extractor/src/generators/ExcerptBuilder.ts
@@ -147,6 +147,7 @@ export class ExcerptBuilder {
 			case ts.SyntaxKind.SymbolKeyword:
 			case ts.SyntaxKind.UnknownKeyword:
 			case ts.SyntaxKind.VoidKeyword:
+			case ts.SyntaxKind.TypeOfKeyword:
 				return true;
 			default:
 				return false;

--- a/packages/api-extractor/src/generators/ExcerptBuilder.ts
+++ b/packages/api-extractor/src/generators/ExcerptBuilder.ts
@@ -135,6 +135,24 @@ export class ExcerptBuilder {
 		return { startIndex: 0, endIndex: 0, typeParameters: [] };
 	}
 
+	public static isPrimitiveKeyword(node: ts.Node): boolean {
+		switch (node.kind) {
+			case ts.SyntaxKind.AnyKeyword:
+			case ts.SyntaxKind.BigIntKeyword:
+			case ts.SyntaxKind.BooleanKeyword:
+			case ts.SyntaxKind.NeverKeyword:
+			case ts.SyntaxKind.NumberKeyword:
+			case ts.SyntaxKind.ObjectKeyword:
+			case ts.SyntaxKind.StringKeyword:
+			case ts.SyntaxKind.SymbolKeyword:
+			case ts.SyntaxKind.UnknownKeyword:
+			case ts.SyntaxKind.VoidKeyword:
+				return true;
+			default:
+				return false;
+		}
+	}
+
 	private static _buildSpan(excerptTokens: IExcerptToken[], span: Span, state: IBuildSpanState): boolean {
 		if (span.kind === ts.SyntaxKind.JSDocComment) {
 			// Discard any comments
@@ -162,6 +180,8 @@ export class ExcerptBuilder {
 
 			if (canonicalReference) {
 				ExcerptBuilder._appendToken(excerptTokens, ExcerptTokenKind.Reference, span.prefix, canonicalReference);
+			} else if (ExcerptBuilder.isPrimitiveKeyword(span.node)) {
+				ExcerptBuilder._appendToken(excerptTokens, ExcerptTokenKind.Reference, span.prefix);
 			} else {
 				ExcerptBuilder._appendToken(excerptTokens, ExcerptTokenKind.Content, span.prefix);
 			}

--- a/packages/api-extractor/src/generators/ExcerptBuilder.ts
+++ b/packages/api-extractor/src/generators/ExcerptBuilder.ts
@@ -148,6 +148,8 @@ export class ExcerptBuilder {
 			case ts.SyntaxKind.UnknownKeyword:
 			case ts.SyntaxKind.VoidKeyword:
 			case ts.SyntaxKind.TypeOfKeyword:
+			case ts.SyntaxKind.UndefinedKeyword:
+			case ts.SyntaxKind.NullKeyword:
 				return true;
 			default:
 				return false;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This transforms primitives that are considered keywords to psuedo-referenced types in the api-extractor. This allows for downstream tasks of syntax highlighting and linking for primitives rather than it being merged with surrounding plain text.

Before api-extractor would give the following tokens for `Promise<string>`
```
[
	{
		text: "Promise"
		kind: Reference,
	},
	{
		text: "<string>",
		kind: Content
	}
]
```

Now it more accurately gives:
```
[
	{
		text: "Promise"
		kind: Reference,
	},
	{
		text: "<",
		kind: Content
	},
	{
		text: "string",
		kind: Reference
	},
	{
		text: ">",
		kind: Content
	},
]
```

This should prevent the need for a lot of the edge cases found in #9913 