### PR TITLE
refactor(utils): remove `mergeDefault`

### DIFF
--- a/packages/discord.js/src/client/BaseClient.js
+++ b/packages/discord.js/src/client/BaseClient.js
@@ -5,7 +5,7 @@ const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v10');
 const { DiscordjsTypeError, ErrorCodes } = require('../errors');
 const Options = require('../util/Options');
-const { mergeDefault, flatten } = require('../util/Util');
+const { flatten } = require('../util/Util');
 
 /**
  * The base class for all clients.
@@ -23,15 +23,21 @@ class BaseClient extends EventEmitter {
      * The options the client was instantiated with
      * @type {ClientOptions}
      */
-    this.options = mergeDefault(Options.createDefault(), {
+    const defaultOptions = Options.createDefault();
+    this.options = {
+      ...defaultOptions,
       ...options,
+      ws: {
+        ...defaultOptions.ws,
+        ...options.ws,
+      },
       rest: {
         ...options.rest,
         userAgentAppendix: options.rest?.userAgentAppendix
           ? `${Options.userAgentAppendix} ${options.rest.userAgentAppendix}`
           : undefined,
       },
-    });
+    };
 
     /**
      * The REST manager of the client

--- a/packages/discord.js/src/sharding/ShardingManager.js
+++ b/packages/discord.js/src/sharding/ShardingManager.js
@@ -49,7 +49,7 @@ class ShardingManager extends EventEmitter {
    */
   constructor(file, options) {
     super();
-    options = {
+    const _options = {
       totalShards: 'auto',
       mode: 'process',
       respawn: true,
@@ -74,7 +74,7 @@ class ShardingManager extends EventEmitter {
      * List of shards this sharding manager spawns
      * @type {string|number[]}
      */
-    this.shardList = options.shardList ?? 'auto';
+    this.shardList = _options.shardList ?? 'auto';
     if (this.shardList !== 'auto') {
       if (!Array.isArray(this.shardList)) {
         throw new DiscordjsTypeError(ErrorCodes.ClientInvalidOption, 'shardList', 'an array.');
@@ -96,7 +96,7 @@ class ShardingManager extends EventEmitter {
      * Amount of shards that all sharding managers spawn in total
      * @type {number}
      */
-    this.totalShards = options.totalShards || 'auto';
+    this.totalShards = _options.totalShards || 'auto';
     if (this.totalShards !== 'auto') {
       if (typeof this.totalShards !== 'number' || isNaN(this.totalShards)) {
         throw new DiscordjsTypeError(ErrorCodes.ClientInvalidOption, 'Amount of shards', 'a number.');
@@ -113,7 +113,7 @@ class ShardingManager extends EventEmitter {
      * Mode for shards to spawn with
      * @type {ShardingManagerMode}
      */
-    this.mode = options.mode;
+    this.mode = _options.mode;
     if (this.mode !== 'process' && this.mode !== 'worker') {
       throw new DiscordjsRangeError(ErrorCodes.ClientInvalidOption, 'Sharding mode', '"process" or "worker"');
     }
@@ -122,31 +122,31 @@ class ShardingManager extends EventEmitter {
      * Whether shards should automatically respawn upon exiting
      * @type {boolean}
      */
-    this.respawn = options.respawn;
+    this.respawn = _options.respawn;
 
     /**
      * Whether to pass the silent flag to child process (only when {@link ShardingManager#mode} is `process`)
      * @type {boolean}
      */
-    this.silent = options.silent;
+    this.silent = _options.silent;
 
     /**
      * An array of arguments to pass to shards (only when {@link ShardingManager#mode} is `process`)
      * @type {string[]}
      */
-    this.shardArgs = options.shardArgs;
+    this.shardArgs = _options.shardArgs;
 
     /**
      * An array of arguments to pass to the executable (only when {@link ShardingManager#mode} is `process`)
      * @type {string[]}
      */
-    this.execArgv = options.execArgv;
+    this.execArgv = _options.execArgv;
 
     /**
      * Token to use for obtaining the automatic shard count, and passing to shards
      * @type {?string}
      */
-    this.token = options.token?.replace(/^Bot\s*/i, '') ?? null;
+    this.token = _options.token?.replace(/^Bot\s*/i, '') ?? null;
 
     /**
      * A collection of shards that this manager has spawned

--- a/packages/discord.js/src/sharding/ShardingManager.js
+++ b/packages/discord.js/src/sharding/ShardingManager.js
@@ -8,7 +8,7 @@ const { setTimeout: sleep } = require('node:timers/promises');
 const { Collection } = require('@discordjs/collection');
 const Shard = require('./Shard');
 const { DiscordjsError, DiscordjsTypeError, DiscordjsRangeError, ErrorCodes } = require('../errors');
-const { mergeDefault, fetchRecommendedShardCount } = require('../util/Util');
+const { fetchRecommendedShardCount } = require('../util/Util');
 
 /**
  * This is a utility class that makes multi-process sharding of a bot an easy and painless experience.
@@ -47,20 +47,18 @@ class ShardingManager extends EventEmitter {
    * @param {string} file Path to your shard script file
    * @param {ShardingManagerOptions} [options] Options for the sharding manager
    */
-  constructor(file, options = {}) {
+  constructor(file, options) {
     super();
-    options = mergeDefault(
-      {
-        totalShards: 'auto',
-        mode: 'process',
-        respawn: true,
-        silent: false,
-        shardArgs: [],
-        execArgv: [],
-        token: process.env.DISCORD_TOKEN,
-      },
-      options,
-    );
+    options = {
+      totalShards: 'auto',
+      mode: 'process',
+      respawn: true,
+      silent: false,
+      shardArgs: [],
+      execArgv: [],
+      token: process.env.DISCORD_TOKEN,
+      ...options,
+    };
 
     /**
      * Path to the shard script file

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -123,26 +123,6 @@ function resolvePartialEmoji(emoji) {
 }
 
 /**
- * Sets default properties on an object that aren't already specified.
- * @param {Object} def Default properties
- * @param {Object} given Object to assign defaults to
- * @returns {Object}
- * @private
- */
-function mergeDefault(def, given) {
-  if (!given) return def;
-  for (const key in def) {
-    if (!Object.hasOwn(given, key) || given[key] === undefined) {
-      given[key] = def[key];
-    } else if (given[key] === Object(given[key])) {
-      given[key] = mergeDefault(def[key], given[key]);
-    }
-  }
-
-  return given;
-}
-
-/**
  * Options used to make an error object.
  * @typedef {Object} MakeErrorOptions
  * @property {string} name Error type
@@ -434,7 +414,6 @@ module.exports = {
   fetchRecommendedShardCount,
   parseEmoji,
   resolvePartialEmoji,
-  mergeDefault,
   makeError,
   makePlainError,
   getSortableGroupTypes,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3207,7 +3207,6 @@ export function fetchRecommendedShardCount(token: string, options?: FetchRecomme
 export function flatten(obj: unknown, ...props: Record<string, boolean | string>[]): unknown;
 export function makeError(obj: MakeErrorOptions): Error;
 export function makePlainError(err: Error): MakeErrorOptions;
-export function mergeDefault(def: unknown, given: unknown): unknown;
 export function moveElementInArray(array: unknown[], element: unknown, newIndex: number, offset?: boolean): number;
 export function parseEmoji(text: string): PartialEmoji | null;
 export function resolveColor(color: ColorResolvable): number;


### PR DESCRIPTION

**Please describe the changes this PR makes and why it should be merged:**

Removes `mergeDefault`, which not only mutates, but also has an incomplete implementation that doesn't handle cases some edge cases.

On the other hand, `BaseClient`'s constructor and `ShardingManager`'s constructor not longer mutate the `options` parameter.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
