### PR TITLE
types: use wrapper utilities

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6647,7 +6647,7 @@ export type Serialized<Value> = Value extends symbol | bigint | (() => any)
   ? never
   : Value extends number | string | boolean | undefined
   ? Value
-  : Value extends { toJSON(): infer JSONResult }
+  : Value extends JSONEncodable<infer JSONResult>
   ? JSONResult
   : Value extends ReadonlyArray<infer ItemType>
   ? Serialized<ItemType>[]

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1129,7 +1129,7 @@ export abstract class Collector<Key, Value, Extras extends unknown[] = []> exten
   public toJSON(): unknown;
 
   protected listener: (...args: any[]) => void;
-  public abstract collect(...args: unknown[]): Key | null | Promise<Key | null>;
+  public abstract collect(...args: unknown[]): Awaitable<Key | null>;
   public abstract dispose(...args: unknown[]): Key | null;
 
   public on<EventKey extends keyof CollectorEventTypes<Key, Value, Extras>>(
@@ -5066,7 +5066,7 @@ export interface CloseEvent {
   reason: string;
 }
 
-export type CollectorFilter<Arguments extends unknown[]> = (...args: Arguments) => boolean | Promise<boolean>;
+export type CollectorFilter<Arguments extends unknown[]> = (...args: Arguments) => Awaitable<boolean>;
 
 export interface CollectorOptions<FilterArguments extends unknown[]> {
   filter?: CollectorFilter<FilterArguments>;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -185,6 +185,7 @@ import {
   PartialEmojiOnlyId,
   Emoji,
   PartialEmoji,
+  Awaitable,
 } from '.';
 import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import type { ContextMenuCommandBuilder, SlashCommandBuilder } from '@discordjs/builders';
@@ -412,7 +413,7 @@ client.on('messageCreate', async message => {
       (
         test: ButtonInteraction<'cached'>,
         items: Collection<Snowflake, ButtonInteraction<'cached'>>,
-      ) => boolean | Promise<boolean>
+      ) => Awaitable<boolean>
     >(buttonCollector.filter);
     expectType<GuildTextBasedChannel>(message.channel);
     expectType<Guild>(message.guild);

--- a/packages/rest/src/lib/utils/types.ts
+++ b/packages/rest/src/lib/utils/types.ts
@@ -1,6 +1,7 @@
 import type { Readable } from 'node:stream';
 import type { ReadableStream } from 'node:stream/web';
 import type { Collection } from '@discordjs/collection';
+import type { Awaitable } from '@discordjs/util';
 import type { Agent, Dispatcher, RequestInit, BodyInit, Response } from 'undici';
 import type { IHandler } from '../interfaces/Handler.js';
 
@@ -183,7 +184,7 @@ export interface RateLimitData {
 /**
  * A function that determines whether the rate limit hit should throw an Error
  */
-export type RateLimitQueueFilter = (rateLimitData: RateLimitData) => Promise<boolean> | boolean;
+export type RateLimitQueueFilter = (rateLimitData: RateLimitData) => Awaitable<boolean>;
 
 export interface APIRequest {
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

There were some places where the `Promise<T> | T` pattern was still used, despite having moved to `Awaitable<T>` in most places. This PR fixes that by using `Awaitable<T>` where applicable.

Furthermore there was an instance of `{ toJSON: () => T }` being used which could be refactored to `JSONEncodable<T>`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
