### PR TITLE
docs: use preferred nullable syntax (`?T` over `T | null`)

### DIFF
--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -93,7 +93,7 @@ class GuildMemberManager extends CachedManager {
    * <info>This method requires the {@link PermissionFlagsBits.CreateInstantInvite} permission.
    * @param {UserResolvable} user The user to add to the guild
    * @param {AddGuildMemberOptions} options Options for adding the user to the guild
-   * @returns {Promise<GuildMember|null>}
+   * @returns {Promise<?GuildMember>}
    */
   async add(user, options) {
     const userId = this.client.users.resolveId(user);
@@ -326,9 +326,9 @@ class GuildMemberManager extends CachedManager {
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles or role ids to apply
    * @property {boolean} [mute] Whether or not the member should be muted
    * @property {boolean} [deaf] Whether or not the member should be deafened
-   * @property {GuildVoiceChannelResolvable|null} [channel] Channel to move the member to
+   * @property {?GuildVoiceChannelResolvable} [channel] Channel to move the member to
    * (if they are connected to voice), or `null` if you want to disconnect them from voice
-   * @property {DateResolvable|null} [communicationDisabledUntil] The date or timestamp
+   * @property {?DateResolvable} [communicationDisabledUntil] The date or timestamp
    * for the member's communication to be disabled until. Provide `null` to enable communication again.
    * @property {GuildMemberFlagsResolvable} [flags] The flags to set for the member
    * @property {string} [reason] Reason for editing this user
@@ -400,7 +400,7 @@ class GuildMemberManager extends CachedManager {
   /**
    * Prunes members from the guild based on how long they have been inactive.
    * @param {GuildPruneMembersOptions} [options] Options for pruning
-   * @returns {Promise<number|null>} The number of members that were/will be kicked
+   * @returns {Promise<?number>} The number of members that were/will be kicked
    * @example
    * // See how many members will be pruned
    * guild.members.prune({ dry: true })

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -144,7 +144,7 @@ class ApplicationCommand extends Base {
       /**
        * Whether the command can be used in DMs
        * <info>This property is always `null` on guild commands</info>
-       * @type {boolean|null}
+       * @type {?boolean}
        */
       this.dmPermission = data.dm_permission;
     } else {

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -404,7 +404,7 @@ class GuildMember extends Base {
 
   /**
    * Times this guild member out.
-   * @param {DateResolvable|null} communicationDisabledUntil The date or timestamp
+   * @param {?DateResolvable} communicationDisabledUntil The date or timestamp
    * for the member's communication to be disabled until. Provide `null` to remove the timeout.
    * @param {string} [reason] The reason for this timeout.
    * @returns {Promise<GuildMember>}
@@ -425,7 +425,7 @@ class GuildMember extends Base {
 
   /**
    * Times this guild member out.
-   * @param {number|null} timeout The duration in milliseconds
+   * @param {?number} timeout The duration in milliseconds
    * for the member's communication to be disabled. Provide `null` to remove the timeout.
    * @param {string} [reason] The reason for this timeout.
    * @returns {Promise<GuildMember>}

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -310,7 +310,7 @@ class ThreadChannel extends BaseChannel {
    * or when the original message in the parent channel is deleted.
    * If you just need the id of that message, use {@link ThreadChannel#id} instead.</info>
    * @param {BaseFetchOptions} [options] Additional options for this fetch
-   * @returns {Promise<Message<true>|null>}
+   * @returns {Promise<?Message<true>>}
    */
   // eslint-disable-next-line require-await
   async fetchStarterMessage(options) {

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -197,7 +197,7 @@ class VoiceState extends Base {
 
   /**
    * Moves the member to a different channel, or disconnects them from the one they're in.
-   * @param {GuildVoiceChannelResolvable|null} channel Channel to move the member to, or `null` if you want to
+   * @param {?GuildVoiceChannelResolvable} channel Channel to move the member to, or `null` if you want to
    * disconnect them from voice.
    * @param {string} [reason] Reason for moving member to another channel or disconnecting
    * @returns {Promise<GuildMember>}

--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -81,7 +81,7 @@ class Collector extends EventEmitter {
 
     /**
      * The reason the collector ended
-     * @type {string|null}
+     * @type {?string}
      * @private
      */
     this._endReason = null;

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -55,7 +55,7 @@ class TextBasedChannel {
   /**
    * The base message options for messages.
    * @typedef {Object} BaseMessageOptions
-   * @property {string|null} [content=''] The content for the message. This can only be `null` when editing a message.
+   * @property {?string} [content=''] The content for the message. This can only be `null` when editing a message.
    * @property {Array<(EmbedBuilder|Embed|APIEmbed)>} [embeds] The embeds for the message
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
    * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)

--- a/packages/discord.js/src/util/Sweepers.js
+++ b/packages/discord.js/src/util/Sweepers.js
@@ -7,7 +7,7 @@ const { DiscordjsTypeError, ErrorCodes } = require('../errors');
 
 /**
  * @typedef {Function} GlobalSweepFilter
- * @returns {Function|null} Return `null` to skip sweeping, otherwise a function passed to `sweep()`,
+ * @returns {?Function} Return `null` to skip sweeping, otherwise a function passed to `sweep()`,
  * See {@link [Collection#sweep](https://discord.js.org/docs/packages/collection/stable/Collection:Class#sweep)}
  * for the definition of this function.
  */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Nullable values in JSDocs should be `?T` rather than `T | null` as that's the preferred convention, this PR updates the remaining instances of the latter into the former.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
