### PR TITLE
fix: import picocolors as default

### DIFF
--- a/packages/create-discord-bot/bin/index.ts
+++ b/packages/create-discord-bot/bin/index.ts
@@ -3,7 +3,7 @@
 // eslint-disable-next-line n/shebang
 import process from 'node:process';
 import { Option, program } from 'commander';
-import { red, yellow, green } from 'picocolors';
+import picocolors from 'picocolors';
 import prompts from 'prompts';
 import validateProjectName from 'validate-npm-package-name';
 import packageJSON from '../package.json' assert { type: 'json' };
@@ -34,7 +34,7 @@ program
 	.version(packageJSON.version)
 	.description('Create a basic discord.js bot.')
 	.argument('[directory]', 'What is the name of the directory you want to create this project in?')
-	.usage(`${green('<directory>')}`)
+	.usage(`${picocolors.green('<directory>')}`)
 	.action((directory) => {
 		projectDirectory = directory;
 	})
@@ -68,13 +68,13 @@ if (!projectDirectory) {
 					const errors = [];
 
 					for (const error of [...(validationResult.errors ?? []), ...(validationResult.warnings ?? [])]) {
-						errors.push(red(`- ${error}`));
+						errors.push(picocolors.red(`- ${error}`));
 					}
 
-					return red(
-						`Cannot create a project named ${yellow(
+					return picocolors.red(
+						`Cannot create a project named ${picocolors.yellow(
 							`"${directory}"`,
-						)} due to npm naming restrictions.\n\nErrors:\n${errors.join('\n')}\n\n${red(
+						)} due to npm naming restrictions.\n\nErrors:\n${errors.join('\n')}\n\n${picocolors.red(
 							'\nSee https://docs.npmjs.com/cli/configuring-npm/package-json for more details.',
 						)}}`,
 					);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Running: `npm create discord-bot@0.2.2` throws commonjs module error caused by importing picocolors

![image](https://github.com/discordjs/discord.js/assets/76836550/4ea6f4db-8233-4f97-9b8a-34b8c9f0e1c0)


**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
