### PR TITLE
fix(Emoji): `id` set as `undefined` edge case

### DIFF
--- a/packages/discord.js/src/structures/Emoji.js
+++ b/packages/discord.js/src/structures/Emoji.js
@@ -29,7 +29,7 @@ class Emoji extends Base {
      * The emoji's id
      * @type {?Snowflake}
      */
-    this.id = emoji.id;
+    this.id = emoji.id ?? null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #9948
Regression from #7772

Previously, the `resolvePartialEmoji()` function returned `id: null` for Unicode emojis, but it was changed in the mentioned pull request. This makes it so the emoji is parsed as `{ animated: false, name: "<unicode>", id: undefined }`
https://github.com/discordjs/discord.js/blob/f0ec70dfdab55e477e7fc2782064c33b87670e68/packages/discord.js/src/util/Util.js#L100

Most of the time, a MESSAGE_REACTION_ADD gateway event is received before the REST call resolves, meaning the emoji will have an `id` set to `null` (in the case of Unicode emojis). However, if the REST call resolves before the gateway event arrives, the `id` property will be set to `undefined`, as that's what it was parsed as

https://github.com/discordjs/discord.js/blob/f0ec70dfdab55e477e7fc2782064c33b87670e68/packages/discord.js/src/structures/Message.js#L807-L815

https://github.com/discordjs/discord.js/blob/f0ec70dfdab55e477e7fc2782064c33b87670e68/packages/discord.js/src/client/actions/MessageReactionAdd.js#L35-L39

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
