### PR TITLE
fix: correctly import from ESM generated types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,12 @@ const typeScriptRuleset = merge(...typescript, {
 		parserOptions: {
 			warnOnUnsupportedTypeScriptVersion: false,
 			allowAutomaticSingleRunInference: true,
-			project: ['tsconfig.eslint.json', 'apps/*/tsconfig.eslint.json', 'packages/*/tsconfig.eslint.json'],
+			project: [
+				'tsconfig.eslint.json',
+				'scripts/tsconfig.eslint.json',
+				'apps/*/tsconfig.eslint.json',
+				'packages/*/tsconfig.eslint.json',
+			],
 		},
 	},
 	rules: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
 	"description": "A thinly abstracted wrapper around the rest API, and gateway.",
 	"scripts": {
 		"test": "vitest run",
-		"build": "tsc --noEmit && tsup",
+		"build": "tsc --noEmit && tsup && node ../../scripts/fixMtsImports.mjs files-",
 		"build:docs": "tsc -p tsconfig.docs.json",
 		"lint": "prettier --check . && cross-env TIMING=1 eslint --format=pretty src",
 		"format": "prettier --write . && cross-env TIMING=1 eslint --fix --format=pretty src",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -5,7 +5,7 @@
 	"description": "The REST API for discord.js",
 	"scripts": {
 		"test": "vitest run",
-		"build": "tsc --noEmit && tsup",
+		"build": "tsc --noEmit && tsup && node ../../scripts/fixMtsImports.mjs types-",
 		"build:docs": "tsc -p tsconfig.docs.json",
 		"lint": "prettier --check . && cross-env TIMING=1 eslint --format=pretty src __tests__",
 		"format": "prettier --write . && cross-env TIMING=1 eslint --fix --format=pretty src __tests__",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+  - 'scripts/*'

--- a/scripts/fixMtsImports.mjs
+++ b/scripts/fixMtsImports.mjs
@@ -1,0 +1,52 @@
+import { readdir, readFile, writeFile, opendir } from 'node:fs/promises';
+import process from 'node:process';
+
+const importPattern = process.argv[2];
+
+const files = await readdir('dist');
+
+const filesToCorrect = files.filter((file) => file.startsWith(importPattern));
+
+if (filesToCorrect.length === 0) {
+	process.exit(0);
+}
+
+if (filesToCorrect.length > 1) {
+	console.warn(
+		`Found ${filesToCorrect.length} files to correct. This is unexpected. Please make the import pattern more specific. Received: ${importPattern}`,
+	);
+	console.warn('Files to correct:', filesToCorrect);
+	console.warn('Correcting first file only.');
+}
+
+const fileToCorrect = filesToCorrect[0];
+
+// Copy the input file to its mts counterpart
+console.log('Copying', fileToCorrect, 'to', fileToCorrect.replace('d.ts', 'd.mts'));
+const originalContent = await readFile(`dist/${fileToCorrect}`, 'utf8');
+const newPath = fileToCorrect.replace('d.ts', 'd.mts');
+await writeFile(`dist/${newPath}`, originalContent);
+
+await walkDirectory(fileToCorrect.replace('d.ts', 'js'));
+
+/**
+ * @param {string} importFileName
+ * @param {string} [path]
+ */
+async function walkDirectory(importFileName, path = 'dist') {
+	for await (const entry of await opendir(path)) {
+		if (entry.isDirectory()) {
+			await walkDirectory(importFileName, `${path}/${entry.name}`);
+		}
+
+		// We only want to change d.mts files
+		if (!entry.name.endsWith('.d.mts')) {
+			continue;
+		}
+
+		console.log('Correcting', `${path}/${entry.name}`);
+		const content = await readFile(`${path}/${entry.name}`, 'utf8');
+		const newContent = content.replaceAll(importFileName, importFileName.replace('.js', '.mjs'));
+		await writeFile(`${path}/${entry.name}`, newContent);
+	}
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,7 @@
+{
+	"private": true,
+	"name": "@discordjs/scripts",
+	"devDependencies": {
+		"@types/node": "^20.9.0"
+	}
+}

--- a/scripts/tsconfig.eslint.json
+++ b/scripts/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../tsconfig.eslint.json",
+	"include": ["*.mjs"]
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"lib": ["ESNext"]
+	},
+	"include": ["*.mjs"]
+}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes an issue where the following code wouldn't work:

```ts
import { API, Client } from '@discordjs/core';
import { REST } from '@discordjs/rest';

const rest = new REST().setToken('');
new API(rest);
```

This was due to the fact that `core` and `rest` get a "common" declaration file generated at build time which TS interprets as `CJS` regardless of the mode you are running in.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
