### PR TITLE
fix: button for outline on small screens

### DIFF
--- a/apps/website/src/components/Header.tsx
+++ b/apps/website/src/components/Header.tsx
@@ -2,7 +2,6 @@
 
 import { FiCommand } from '@react-icons/all-files/fi/FiCommand';
 import { VscGithubInverted } from '@react-icons/all-files/vsc/VscGithubInverted';
-import { VscListSelection } from '@react-icons/all-files/vsc/VscListSelection';
 import { VscMenu } from '@react-icons/all-files/vsc/VscMenu';
 import { VscSearch } from '@react-icons/all-files/vsc/VscSearch';
 import { Button } from 'ariakit/button';
@@ -20,7 +19,7 @@ const ThemeSwitcher = dynamic(async () => import('./ThemeSwitcher'));
 export default function Header() {
 	const pathname = usePathname();
 	const { setOpened } = useNav();
-	const setOutlineOpened = useOutline().setOpened;
+	const { setOpened: setOutlineOpened } = useOutline();
 	const dialog = useCmdK();
 
 	const pathElements = useMemo(
@@ -71,28 +70,16 @@ export default function Header() {
 		<header className="sticky top-4 z-20 border border-light-900 rounded-md bg-white/75 shadow backdrop-blur-md dark:border-dark-100 dark:bg-dark-600/75">
 			<div className="block h-16 px-6">
 				<div className="h-full flex flex-row place-content-between place-items-center gap-8">
-					<div className="flex flex-row place-items-center gap-4">
-						<Button
-							aria-label="Menu"
-							className="h-6 w-6 flex flex-row transform-gpu cursor-pointer select-none appearance-none place-items-center border-0 rounded bg-transparent p-0 text-sm font-semibold leading-none no-underline outline-none lg:hidden active:translate-y-px focus:ring focus:ring-width-2 focus:ring-blurple"
-							onClick={() => {
-								setOpened((open) => !open);
-								setOutlineOpened(false);
-							}}
-						>
-							<VscMenu size={24} />
-						</Button>
-						<Button
-							aria-label="Menu"
-							className="h-6 w-6 flex flex-row transform-gpu cursor-pointer select-none appearance-none place-items-center border-0 rounded bg-transparent p-0 text-sm font-semibold leading-none no-underline outline-none lg:hidden active:translate-y-px focus:ring focus:ring-width-2 focus:ring-blurple"
-							onClick={() => {
-								setOpened(false);
-								setOutlineOpened((open) => !open);
-							}}
-						>
-							<VscListSelection size={24} className="relative top-.37" />
-						</Button>
-					</div>
+					<Button
+						aria-label="Menu"
+						className="h-6 w-6 flex flex-row transform-gpu cursor-pointer select-none appearance-none place-items-center border-0 rounded bg-transparent p-0 text-sm font-semibold leading-none no-underline outline-none lg:hidden active:translate-y-px focus:ring focus:ring-width-2 focus:ring-blurple"
+						onClick={() => {
+							setOpened((open) => !open);
+							setOutlineOpened(false);
+						}}
+					>
+						<VscMenu size={24} />
+					</Button>
 					<div className="hidden lg:flex lg:grow lg:flex-row lg:overflow-hidden">{breadcrumbs}</div>
 					<Button
 						as="div"

--- a/apps/website/src/components/Header.tsx
+++ b/apps/website/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { FiCommand } from '@react-icons/all-files/fi/FiCommand';
 import { VscGithubInverted } from '@react-icons/all-files/vsc/VscGithubInverted';
+import { VscListSelection } from '@react-icons/all-files/vsc/VscListSelection';
 import { VscMenu } from '@react-icons/all-files/vsc/VscMenu';
 import { VscSearch } from '@react-icons/all-files/vsc/VscSearch';
 import { Button } from 'ariakit/button';
@@ -12,12 +13,14 @@ import { usePathname } from 'next/navigation';
 import { Fragment, useMemo } from 'react';
 import { useCmdK } from '~/contexts/cmdK';
 import { useNav } from '~/contexts/nav';
+import { useOutline } from '~/contexts/outline';
 
 const ThemeSwitcher = dynamic(async () => import('./ThemeSwitcher'));
 
 export default function Header() {
 	const pathname = usePathname();
 	const { setOpened } = useNav();
+	const setOutlineOpened = useOutline().setOpened;
 	const dialog = useCmdK();
 
 	const pathElements = useMemo(
@@ -68,13 +71,28 @@ export default function Header() {
 		<header className="sticky top-4 z-20 border border-light-900 rounded-md bg-white/75 shadow backdrop-blur-md dark:border-dark-100 dark:bg-dark-600/75">
 			<div className="block h-16 px-6">
 				<div className="h-full flex flex-row place-content-between place-items-center gap-8">
-					<Button
-						aria-label="Menu"
-						className="h-6 w-6 flex flex-row transform-gpu cursor-pointer select-none appearance-none place-items-center border-0 rounded bg-transparent p-0 text-sm font-semibold leading-none no-underline outline-none lg:hidden active:translate-y-px focus:ring focus:ring-width-2 focus:ring-blurple"
-						onClick={() => setOpened((open) => !open)}
-					>
-						<VscMenu size={24} />
-					</Button>
+					<div className="flex flex-row place-items-center gap-4">
+						<Button
+							aria-label="Menu"
+							className="h-6 w-6 flex flex-row transform-gpu cursor-pointer select-none appearance-none place-items-center border-0 rounded bg-transparent p-0 text-sm font-semibold leading-none no-underline outline-none lg:hidden active:translate-y-px focus:ring focus:ring-width-2 focus:ring-blurple"
+							onClick={() => {
+								setOpened((open) => !open);
+								setOutlineOpened(false);
+							}}
+						>
+							<VscMenu size={24} />
+						</Button>
+						<Button
+							aria-label="Menu"
+							className="h-6 w-6 flex flex-row transform-gpu cursor-pointer select-none appearance-none place-items-center border-0 rounded bg-transparent p-0 text-sm font-semibold leading-none no-underline outline-none lg:hidden active:translate-y-px focus:ring focus:ring-width-2 focus:ring-blurple"
+							onClick={() => {
+								setOpened(false);
+								setOutlineOpened((open) => !open);
+							}}
+						>
+							<VscListSelection size={24} className="relative top-.37" />
+						</Button>
+					</div>
 					<div className="hidden lg:flex lg:grow lg:flex-row lg:overflow-hidden">{breadcrumbs}</div>
 					<Button
 						as="div"

--- a/apps/website/src/components/Outline.tsx
+++ b/apps/website/src/components/Outline.tsx
@@ -5,7 +5,7 @@ import { Scrollbars } from './Scrollbars';
 import { TableOfContentItems } from './TableOfContentItems';
 
 export function Outline() {
-	const { members } = useOutline();
+	const { members, opened } = useOutline();
 
 	if (!members) {
 		return null;
@@ -13,7 +13,11 @@ export function Outline() {
 
 	return (
 		<div className="lg:sticky lg:top-23 lg:h-[calc(100vh_-_105px)]">
-			<aside className="fixed bottom-4 left-4 right-4 top-22 z-20 mx-auto hidden max-w-5xl border border-light-900 rounded-md bg-white/75 shadow backdrop-blur-md lg:sticky lg:block lg:h-full lg:max-w-xs lg:min-w-xs lg:w-full dark:border-dark-100 dark:bg-dark-600/75">
+			<aside
+				className={`fixed bottom-4 left-4 right-4 top-22 z-20 mx-auto max-w-5xl border border-light-900 rounded-md bg-white/75 shadow backdrop-blur-md ${
+					opened ? 'block' : 'hidden'
+				} lg:sticky lg:block lg:h-full lg:max-w-xs lg:min-w-xs lg:w-full dark:border-dark-100 dark:bg-dark-600/75`}
+			>
 				<Scrollbars
 					autoHide
 					className="[&>div]:overscroll-none"

--- a/apps/website/src/components/Outline.tsx
+++ b/apps/website/src/components/Outline.tsx
@@ -20,7 +20,7 @@ export function Outline() {
 			<aside
 				className={`fixed block bottom-4 top-22 z-20 mx-auto max-w-5xl border border-light-900 rounded-md bg-white/75 shadow backdrop-blur-md transition-all duration-300 ${
 					opened ? 'left-4 right-4 ' : 'left-full -right-[calc(100vw_-_32px)]'
-				} lg:sticky lg:block lg:h-full lg:max-w-xs lg:min-w-xs lg:w-full dark:border-dark-100 dark:bg-dark-600/75`}
+				} lg:sticky lg:h-full lg:max-w-xs lg:min-w-xs lg:w-full dark:border-dark-100 dark:bg-dark-600/75`}
 			>
 				<Button
 					aria-label="Menu"

--- a/apps/website/src/components/Outline.tsx
+++ b/apps/website/src/components/Outline.tsx
@@ -24,9 +24,9 @@ export function Outline() {
 			>
 				<Button
 					aria-label="Menu"
-					className={`absolute top-1/2 z-1 h-8 w-6 flex transition-all duration-300 flex-row transform-gpu cursor-pointer select-none appearance-none place-items-center border-0 rounded bg-transparent p-0 text-sm font-semibold leading-none no-underline outline-none backdrop-blur-md ${
+					className={`absolute top-1/2 z-1 h-8 w-6 flex transition-all duration-300 flex-row transform-gpu cursor-pointer select-none appearance-none place-items-center border-0 rounded bg-transparent p-0 text-sm font-semibold leading-none no-underline outline-none ${
 						opened ? 'left-1 rotate-180' : navOpened ? 'left-1' : '-left-6'
-					} active:translate-y-px`}
+					} active:translate-y-px lg:hidden`}
 					onClick={() => {
 						setOpened(false);
 						setOutlineOpened((open) => !open);

--- a/apps/website/src/components/Outline.tsx
+++ b/apps/website/src/components/Outline.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import { VscChevronLeft } from '@react-icons/all-files/vsc/VscChevronLeft';
+import { Button } from 'ariakit/button';
+import { useNav } from '~/contexts/nav';
 import { useOutline } from '~/contexts/outline';
 import { Scrollbars } from './Scrollbars';
 import { TableOfContentItems } from './TableOfContentItems';
 
 export function Outline() {
-	const { members, opened } = useOutline();
+	const { members, opened, setOpened: setOutlineOpened } = useOutline();
+	const { opened: navOpened, setOpened } = useNav();
 
 	if (!members) {
 		return null;
@@ -14,10 +18,22 @@ export function Outline() {
 	return (
 		<div className="lg:sticky lg:top-23 lg:h-[calc(100vh_-_105px)]">
 			<aside
-				className={`fixed bottom-4 left-4 right-4 top-22 z-20 mx-auto max-w-5xl border border-light-900 rounded-md bg-white/75 shadow backdrop-blur-md ${
-					opened ? 'block' : 'hidden'
+				className={`fixed block bottom-4 top-22 z-20 mx-auto max-w-5xl border border-light-900 rounded-md bg-white/75 shadow backdrop-blur-md transition-all duration-300 ${
+					opened ? 'left-4 right-4 ' : 'left-full -right-[calc(100vw_-_32px)]'
 				} lg:sticky lg:block lg:h-full lg:max-w-xs lg:min-w-xs lg:w-full dark:border-dark-100 dark:bg-dark-600/75`}
 			>
+				<Button
+					aria-label="Menu"
+					className={`absolute top-1/2 z-1 h-8 w-6 flex transition-all duration-300 flex-row transform-gpu cursor-pointer select-none appearance-none place-items-center border-0 rounded bg-transparent p-0 text-sm font-semibold leading-none no-underline outline-none backdrop-blur-md ${
+						opened ? 'left-1 rotate-180' : navOpened ? 'left-1' : '-left-6'
+					} active:translate-y-px`}
+					onClick={() => {
+						setOpened(false);
+						setOutlineOpened((open) => !open);
+					}}
+				>
+					<VscChevronLeft viewBox="0 0 16 16" size={24} />
+				</Button>
 				<Scrollbars
 					autoHide
 					className="[&>div]:overscroll-none"

--- a/apps/website/src/components/TableOfContentItems.tsx
+++ b/apps/website/src/components/TableOfContentItems.tsx
@@ -5,6 +5,7 @@ import { VscSymbolEvent } from '@react-icons/all-files/vsc/VscSymbolEvent';
 import { VscSymbolMethod } from '@react-icons/all-files/vsc/VscSymbolMethod';
 import { VscSymbolProperty } from '@react-icons/all-files/vsc/VscSymbolProperty';
 import { useMemo } from 'react';
+import { useOutline } from '~/contexts/outline';
 
 export interface TableOfContentsSerializedMethod {
 	kind: 'Method' | 'MethodSignature';
@@ -32,12 +33,14 @@ export interface TableOfContentsItemProps {
 }
 
 export function TableOfContentsPropertyItem({ property }: { readonly property: TableOfContentsSerializedProperty }) {
+	const setOutlineOpened = useOutline().setOpened;
 	return (
 		<a
 			className="ml-[10px] border-l border-light-800 p-[5px] pl-6.5 text-sm outline-none focus:border-0 dark:border-dark-100 focus:rounded active:bg-light-800 hover:bg-light-700 focus:ring focus:ring-width-2 focus:ring-blurple dark:active:bg-dark-100 dark:hover:bg-dark-200"
 			href={`#${property.name}`}
 			key={`${property.name}-${property.kind}`}
 			title={property.name}
+			onClick={() => setOutlineOpened(false)}
 		>
 			<span className="line-clamp-1">{property.name}</span>
 		</a>
@@ -45,6 +48,7 @@ export function TableOfContentsPropertyItem({ property }: { readonly property: T
 }
 
 export function TableOfContentsMethodItem({ method }: { readonly method: TableOfContentsSerializedMethod }) {
+	const setOutlineOpened = useOutline().setOpened;
 	if (method.overloadIndex && method.overloadIndex > 1) {
 		return null;
 	}
@@ -57,6 +61,7 @@ export function TableOfContentsMethodItem({ method }: { readonly method: TableOf
 			href={`#${key}`}
 			key={key}
 			title={method.name}
+			onClick={() => setOutlineOpened(false)}
 		>
 			<span className="line-clamp-1">{method.name}</span>
 			{method.overloadIndex && method.overloadIndex > 1 ? (
@@ -67,12 +72,14 @@ export function TableOfContentsMethodItem({ method }: { readonly method: TableOf
 }
 
 export function TableOfContentsEventItem({ event }: { readonly event: TableOfContentsSerializedEvent }) {
+	const setOutlineOpened = useOutline().setOpened;
 	return (
 		<a
 			className="ml-[10px] border-l border-light-800 p-[5px] pl-6.5 text-sm outline-none focus:border-0 dark:border-dark-100 focus:rounded active:bg-light-800 hover:bg-light-700 focus:ring focus:ring-width-2 focus:ring-blurple dark:active:bg-dark-100 dark:hover:bg-dark-200"
 			href={`#${event.name}`}
 			key={`${event.name}-${event.kind}`}
 			title={event.name}
+			onClick={() => setOutlineOpened(false)}
 		>
 			<span className="line-clamp-1">{event.name}</span>
 		</a>

--- a/apps/website/src/components/TableOfContentItems.tsx
+++ b/apps/website/src/components/TableOfContentItems.tsx
@@ -33,14 +33,14 @@ export interface TableOfContentsItemProps {
 }
 
 export function TableOfContentsPropertyItem({ property }: { readonly property: TableOfContentsSerializedProperty }) {
-	const setOutlineOpened = useOutline().setOpened;
+	const { setOpened } = useOutline();
 	return (
 		<a
 			className="ml-[10px] border-l border-light-800 p-[5px] pl-6.5 text-sm outline-none focus:border-0 dark:border-dark-100 focus:rounded active:bg-light-800 hover:bg-light-700 focus:ring focus:ring-width-2 focus:ring-blurple dark:active:bg-dark-100 dark:hover:bg-dark-200"
 			href={`#${property.name}`}
 			key={`${property.name}-${property.kind}`}
 			title={property.name}
-			onClick={() => setOutlineOpened(false)}
+			onClick={() => setOpened(false)}
 		>
 			<span className="line-clamp-1">{property.name}</span>
 		</a>
@@ -48,7 +48,7 @@ export function TableOfContentsPropertyItem({ property }: { readonly property: T
 }
 
 export function TableOfContentsMethodItem({ method }: { readonly method: TableOfContentsSerializedMethod }) {
-	const setOutlineOpened = useOutline().setOpened;
+	const { setOpened } = useOutline();
 	if (method.overloadIndex && method.overloadIndex > 1) {
 		return null;
 	}
@@ -61,7 +61,7 @@ export function TableOfContentsMethodItem({ method }: { readonly method: TableOf
 			href={`#${key}`}
 			key={key}
 			title={method.name}
-			onClick={() => setOutlineOpened(false)}
+			onClick={() => setOpened(false)}
 		>
 			<span className="line-clamp-1">{method.name}</span>
 			{method.overloadIndex && method.overloadIndex > 1 ? (
@@ -72,14 +72,14 @@ export function TableOfContentsMethodItem({ method }: { readonly method: TableOf
 }
 
 export function TableOfContentsEventItem({ event }: { readonly event: TableOfContentsSerializedEvent }) {
-	const setOutlineOpened = useOutline().setOpened;
+	const { setOpened } = useOutline();
 	return (
 		<a
 			className="ml-[10px] border-l border-light-800 p-[5px] pl-6.5 text-sm outline-none focus:border-0 dark:border-dark-100 focus:rounded active:bg-light-800 hover:bg-light-700 focus:ring focus:ring-width-2 focus:ring-blurple dark:active:bg-dark-100 dark:hover:bg-dark-200"
 			href={`#${event.name}`}
 			key={`${event.name}-${event.kind}`}
 			title={event.name}
-			onClick={() => setOutlineOpened(false)}
+			onClick={() => setOpened(false)}
 		>
 			<span className="line-clamp-1">{event.name}</span>
 		</a>

--- a/apps/website/src/contexts/outline.tsx
+++ b/apps/website/src/contexts/outline.tsx
@@ -6,13 +6,16 @@ import type { TableOfContentsSerialized } from '~/components/TableOfContentItems
 
 export const OutlineContext = createContext<{
 	members: TableOfContentsSerialized[] | null | undefined;
+	opened: boolean;
 	setMembers: Dispatch<SetStateAction<TableOfContentsSerialized[] | null | undefined>>;
-}>({ members: undefined, setMembers: (_) => {} });
+	setOpened: Dispatch<SetStateAction<boolean>>;
+}>({ members: undefined, setMembers: (_) => {}, opened: false, setOpened: (_) => {} });
 
 export const OutlineProvider = ({ children }: PropsWithChildren) => {
 	const [members, setMembers] = useState<TableOfContentsSerialized[] | null | undefined>(undefined);
+	const [opened, setOpened] = useState(false);
 
-	const value = useMemo(() => ({ members, setMembers }), [members]);
+	const value = useMemo(() => ({ members, setMembers, opened, setOpened }), [members, opened]);
 
 	return <OutlineContext.Provider value={value}>{children}</OutlineContext.Provider>;
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds button in header to expand table of contents on smaller screens.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
