### PR TITLE
docs: use lowercase object type

### DIFF
--- a/packages/discord.js/.eslintrc.json
+++ b/packages/discord.js/.eslintrc.json
@@ -42,7 +42,7 @@
               "Number": "number",
               "Boolean": "boolean",
               "Symbol": "symbol",
-              "object": "Object",
+              "Object": "object",
               "function": "Function",
               "array": "Array",
               "date": "Date",

--- a/packages/discord.js/src/client/BaseClient.js
+++ b/packages/discord.js/src/client/BaseClient.js
@@ -66,7 +66,7 @@ class BaseClient extends EventEmitter {
 
   /**
    * Options used for deleting a webhook.
-   * @typedef {Object} WebhookDeleteOptions
+   * @typedef {object} WebhookDeleteOptions
    * @property {string} [token] Token of the webhook
    * @property {string} [reason] The reason for deleting the webhook
    */

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -257,7 +257,7 @@ class Client extends BaseClient {
 
   /**
    * Options used when fetching an invite from Discord.
-   * @typedef {Object} ClientFetchInviteOptions
+   * @typedef {object} ClientFetchInviteOptions
    * @property {Snowflake} [guildScheduledEventId] The id of the guild scheduled event to include with
    * the invite
    */
@@ -399,7 +399,7 @@ class Client extends BaseClient {
 
   /**
    * Options for {@link Client#generateInvite}.
-   * @typedef {Object} InviteGenerationOptions
+   * @typedef {object} InviteGenerationOptions
    * @property {OAuth2Scopes[]} scopes Scopes that should be requested
    * @property {PermissionResolvable} [permissions] Permissions to request
    * @property {GuildResolvable} [guild] Guild to preselect

--- a/packages/discord.js/src/client/WebhookClient.js
+++ b/packages/discord.js/src/client/WebhookClient.js
@@ -13,14 +13,14 @@ const { parseWebhookURL } = require('../util/Util');
 class WebhookClient extends BaseClient {
   /**
    * Represents the credentials used for a webhook in the form of its id and token.
-   * @typedef {Object} WebhookClientDataIdWithToken
+   * @typedef {object} WebhookClientDataIdWithToken
    * @property {Snowflake} id The webhook's id
    * @property {string} token The webhook's token
    */
 
   /**
    * Represents the credentials used for a webhook in the form of a URL.
-   * @typedef {Object} WebhookClientDataURL
+   * @typedef {object} WebhookClientDataURL
    * @property {string} url The full URL for the webhook
    */
 
@@ -31,7 +31,7 @@ class WebhookClient extends BaseClient {
 
   /**
    * Options for a webhook client.
-   * @typedef {Object} WebhookClientOptions
+   * @typedef {object} WebhookClientOptions
    * @property {MessageMentionOptions} [allowedMentions] Default value for {@link BaseMessageOptions#allowedMentions}
    * @property {RESTOptions} [rest] Options for the REST manager
    */

--- a/packages/discord.js/src/client/actions/ApplicationCommandPermissionsUpdate.js
+++ b/packages/discord.js/src/client/actions/ApplicationCommandPermissionsUpdate.js
@@ -5,7 +5,7 @@ const Events = require('../../util/Events');
 
 /**
  * The data received in the {@link Client#event:applicationCommandPermissionsUpdate} event
- * @typedef {Object} ApplicationCommandPermissionsUpdateData
+ * @typedef {object} ApplicationCommandPermissionsUpdateData
  * @property {Snowflake} id The id of the command or global entity that was updated
  * @property {Snowflake} guildId The id of the guild in which permissions were updated
  * @property {Snowflake} applicationId The id of the application that owns the command or entity being updated

--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -78,7 +78,7 @@ class WebSocketManager extends EventEmitter {
 
     /**
      * An array of queued events before this WebSocketManager became ready
-     * @type {Object[]}
+     * @type {object[]}
      * @private
      * @name WebSocketManager#packetQueue
      */
@@ -310,7 +310,7 @@ class WebSocketManager extends EventEmitter {
 
   /**
    * Broadcasts a packet to every shard this manager handles.
-   * @param {Object} packet The packet to send
+   * @param {object} packet The packet to send
    * @private
    */
   broadcast(packet) {
@@ -331,7 +331,7 @@ class WebSocketManager extends EventEmitter {
 
   /**
    * Processes a packet and queues it if this WebSocketManager is not ready.
-   * @param {Object} [packet] The packet to be handled
+   * @param {object} [packet] The packet to be handled
    * @param {WebSocketShard} [shard] The shard that will handle this packet
    * @returns {boolean}
    * @private

--- a/packages/discord.js/src/client/websocket/WebSocketShard.js
+++ b/packages/discord.js/src/client/websocket/WebSocketShard.js
@@ -125,7 +125,7 @@ class WebSocketShard extends EventEmitter {
 
   /**
    * Called when the shard receives the READY payload.
-   * @param {Object} packet The received packet
+   * @param {object} packet The received packet
    * @private
    */
   onReadyPacket(packet) {
@@ -212,7 +212,7 @@ class WebSocketShard extends EventEmitter {
    * <warn>If you use this method, make sure you understand that you need to provide
    * a full [Payload](https://discord.com/developers/docs/topics/gateway#commands-and-events-gateway-commands).
    * Do not use this method if you don't know what you're doing.</warn>
-   * @param {Object} data The full packet to send
+   * @param {object} data The full packet to send
    * @param {boolean} [important=false] If this packet should be added first in queue
    * <warn>This parameter is **deprecated**. Important payloads are determined by their opcode instead.</warn>
    */

--- a/packages/discord.js/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
+++ b/packages/discord.js/src/client/websocket/handlers/GUILD_MEMBERS_CHUNK.js
@@ -15,7 +15,7 @@ module.exports = (client, { d: data }) => {
 
   /**
    * Represents the properties of a guild members chunk
-   * @typedef {Object} GuildMembersChunk
+   * @typedef {object} GuildMembersChunk
    * @property {number} index Index of the received chunk
    * @property {number} count Number of chunks the client should receive
    * @property {Array<*>} notFound An array of whatever could not be found

--- a/packages/discord.js/src/errors/ErrorCodes.js
+++ b/packages/discord.js/src/errors/ErrorCodes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * @typedef {Object} DiscordjsErrorCodes
+ * @typedef {object} DiscordjsErrorCodes
 
  * @property {'ClientInvalidOption'} ClientInvalidOption
  * @property {'ClientInvalidProvidedShards'} ClientInvalidProvidedShards

--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -73,7 +73,7 @@ class ApplicationCommandManager extends CachedManager {
 
   /**
    * Options used to fetch data from Discord
-   * @typedef {Object} BaseFetchOptions
+   * @typedef {object} BaseFetchOptions
    * @property {boolean} [cache=true] Whether to cache the fetched data if it wasn't already
    * @property {boolean} [force=false] Whether to skip the cache check and request the API
    */

--- a/packages/discord.js/src/managers/ApplicationCommandPermissionsManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandPermissionsManager.js
@@ -57,7 +57,7 @@ class ApplicationCommandPermissionsManager extends BaseManager {
   /* eslint-disable max-len */
   /**
    * The object returned when fetching permissions for an application command.
-   * @typedef {Object} ApplicationCommandPermissions
+   * @typedef {object} ApplicationCommandPermissions
    * @property {Snowflake} id The role, user, or channel's id. Can also be a
    * {@link https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-constants permission constant}.
    * @property {ApplicationCommandPermissionType} type Whether this permission is for a role or a user
@@ -69,7 +69,7 @@ class ApplicationCommandPermissionsManager extends BaseManager {
    * Options for managing permissions for one or more Application Commands
    * <warn>When passing these options to a manager where `guildId` is `null`,
    * `guild` is a required parameter</warn>
-   * @typedef {Object} BaseApplicationCommandPermissionsOptions
+   * @typedef {object} BaseApplicationCommandPermissionsOptions
    * @property {GuildResolvable} [guild] The guild to modify / check permissions for
    * <warn>Ignored when the manager has a non-null `guildId` property</warn>
    * @property {ApplicationCommandResolvable} [command] The command to modify / check permissions for

--- a/packages/discord.js/src/managers/AutoModerationRuleManager.js
+++ b/packages/discord.js/src/managers/AutoModerationRuleManager.js
@@ -50,7 +50,7 @@ class AutoModerationRuleManager extends CachedManager {
 
   /**
    * Options used to set the trigger metadata of an auto moderation rule.
-   * @typedef {Object} AutoModerationTriggerMetadataOptions
+   * @typedef {object} AutoModerationTriggerMetadataOptions
    * @property {string[]} [keywordFilter] The substrings that will be searched for in the content
    * @property {string[]} [regexPatterns] The regular expression patterns which will be matched against the content
    * <info>Only Rust-flavored regular expressions are supported.</info>
@@ -64,7 +64,7 @@ class AutoModerationRuleManager extends CachedManager {
 
   /**
    * Options used to set the actions of an auto moderation rule.
-   * @typedef {Object} AutoModerationActionOptions
+   * @typedef {object} AutoModerationActionOptions
    * @property {AutoModerationActionType} type The type of this auto moderation rule action
    * @property {AutoModerationActionMetadataOptions} [metadata] Additional metadata needed during execution
    * <info>This property is required if using a `type` of
@@ -73,7 +73,7 @@ class AutoModerationRuleManager extends CachedManager {
 
   /**
    * Options used to set the metadata of an auto moderation rule action.
-   * @typedef {Object} AutoModerationActionMetadataOptions
+   * @typedef {object} AutoModerationActionMetadataOptions
    * @property {GuildTextChannelResolvable|ThreadChannel} [channel] The channel to which content will be logged
    * @property {number} [durationSeconds] The timeout duration in seconds
    * @property {string} [customMessage] The custom message that is shown whenever a message is blocked
@@ -81,7 +81,7 @@ class AutoModerationRuleManager extends CachedManager {
 
   /**
    * Options used to create an auto moderation rule.
-   * @typedef {Object} AutoModerationRuleCreateOptions
+   * @typedef {object} AutoModerationRuleCreateOptions
    * @property {string} name The name of the auto moderation rule
    * @property {AutoModerationRuleEventType} eventType The event type of the auto moderation rule
    * @property {AutoModerationRuleTriggerType} triggerType The trigger type of the auto moderation rule
@@ -148,7 +148,7 @@ class AutoModerationRuleManager extends CachedManager {
 
   /**
    * Options used to edit an auto moderation rule.
-   * @typedef {Object} AutoModerationRuleEditOptions
+   * @typedef {object} AutoModerationRuleEditOptions
    * @property {string} [name] The name of the auto moderation rule
    * @property {AutoModerationRuleEventType} [eventType] The event type of the auto moderation rule
    * @property {AutoModerationTriggerMetadataOptions} [triggerMetadata] The trigger metadata of the auto moderation rule
@@ -219,7 +219,7 @@ class AutoModerationRuleManager extends CachedManager {
 
   /**
    * Options used to fetch all auto moderation rules from a guild.
-   * @typedef {Object} FetchAutoModerationRulesOptions
+   * @typedef {object} FetchAutoModerationRulesOptions
    * @property {boolean} [cache] Whether to cache the fetched auto moderation rules
    */
 

--- a/packages/discord.js/src/managers/CategoryChannelChildManager.js
+++ b/packages/discord.js/src/managers/CategoryChannelChildManager.js
@@ -37,7 +37,7 @@ class CategoryChannelChildManager extends DataManager {
 
   /**
    * Options for creating a channel using {@link CategoryChannel#createChannel}.
-   * @typedef {Object} CategoryCreateChannelOptions
+   * @typedef {object} CategoryCreateChannelOptions
    * @property {string} name The name for the new channel
    * @property {ChannelType} [type=ChannelType.GuildText] The type of the new channel.
    * @property {string} [topic] The topic for the new channel

--- a/packages/discord.js/src/managers/DataManager.js
+++ b/packages/discord.js/src/managers/DataManager.js
@@ -33,8 +33,8 @@ class DataManager extends BaseManager {
 
   /**
    * Resolves a data entry to a data Object.
-   * @param {string|Object} idOrInstance The id or instance of something in this Manager
-   * @returns {?Object} An instance from this Manager
+   * @param {string|object} idOrInstance The id or instance of something in this Manager
+   * @returns {?object} An instance from this Manager
    */
   resolve(idOrInstance) {
     if (idOrInstance instanceof this.holds) return idOrInstance;
@@ -44,7 +44,7 @@ class DataManager extends BaseManager {
 
   /**
    * Resolves a data entry to an instance id.
-   * @param {string|Object} idOrInstance The id or instance of something in this Manager
+   * @param {string|object} idOrInstance The id or instance of something in this Manager
    * @returns {?Snowflake}
    */
   resolveId(idOrInstance) {

--- a/packages/discord.js/src/managers/GuildBanManager.js
+++ b/packages/discord.js/src/managers/GuildBanManager.js
@@ -60,7 +60,7 @@ class GuildBanManager extends CachedManager {
 
   /**
    * Options used to fetch multiple bans from a guild.
-   * @typedef {Object} FetchBansOptions
+   * @typedef {object} FetchBansOptions
    * @property {number} [limit] The maximum number of bans to return
    * @property {Snowflake} [before] Consider only bans before this id
    * @property {Snowflake} [after] Consider only bans after this id
@@ -130,7 +130,7 @@ class GuildBanManager extends CachedManager {
 
   /**
    * Options used to ban a user from a guild.
-   * @typedef {Object} BanOptions
+   * @typedef {object} BanOptions
    * @property {number} [deleteMessageDays] Number of days of messages to delete, must be between 0 and 7, inclusive
    * <warn>This property is deprecated. Use `deleteMessageSeconds` instead.</warn>
    * @property {number} [deleteMessageSeconds] Number of seconds of messages to delete,

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -233,7 +233,7 @@ class GuildChannelManager extends CachedManager {
 
   /**
    * Options used to edit a guild channel.
-   * @typedef {Object} GuildChannelEditOptions
+   * @typedef {object} GuildChannelEditOptions
    * @property {string} [name] The name of the channel
    * @property {ChannelType} [type] The type of the channel (only conversion between text and news is supported)
    * @property {number} [position] The position of the channel
@@ -422,7 +422,7 @@ class GuildChannelManager extends CachedManager {
 
   /**
    * The data needed for updating a channel's position.
-   * @typedef {Object} ChannelPosition
+   * @typedef {object} ChannelPosition
    * @property {GuildChannel|Snowflake} channel Channel to update
    * @property {number} [position] New position for the channel
    * @property {CategoryChannelResolvable} [parent] Parent channel for this channel
@@ -456,7 +456,7 @@ class GuildChannelManager extends CachedManager {
 
   /**
    * Data returned from fetching threads.
-   * @typedef {Object} FetchedThreads
+   * @typedef {object} FetchedThreads
    * @property {Collection<Snowflake, ThreadChannel>} threads The threads that were fetched
    * @property {Collection<Snowflake, ThreadMember>} members The thread members in the received threads
    */

--- a/packages/discord.js/src/managers/GuildEmojiManager.js
+++ b/packages/discord.js/src/managers/GuildEmojiManager.js
@@ -27,7 +27,7 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
 
   /**
    * Options used for creating an emoji in a guild.
-   * @typedef {Object} GuildEmojiCreateOptions
+   * @typedef {object} GuildEmojiCreateOptions
    * @property {BufferResolvable|Base64Resolvable} attachment The image for the emoji
    * @property {string} name The name for the emoji
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles to limit the emoji to

--- a/packages/discord.js/src/managers/GuildInviteManager.js
+++ b/packages/discord.js/src/managers/GuildInviteManager.js
@@ -72,7 +72,7 @@ class GuildInviteManager extends CachedManager {
 
   /**
    * Options used to fetch a single invite from a guild.
-   * @typedef {Object} FetchInviteOptions
+   * @typedef {object} FetchInviteOptions
    * @property {InviteResolvable} code The invite to fetch
    * @property {boolean} [cache=true] Whether or not to cache the fetched invite
    * @property {boolean} [force=false] Whether to skip the cache check and request the API
@@ -80,7 +80,7 @@ class GuildInviteManager extends CachedManager {
 
   /**
    * Options used to fetch all invites from a guild.
-   * @typedef {Object} FetchInvitesOptions
+   * @typedef {object} FetchInvitesOptions
    * @property {GuildInvitableChannelResolvable} [channelId]
    * The channel to fetch all invites from
    * @property {boolean} [cache=true] Whether or not to cache the fetched invites

--- a/packages/discord.js/src/managers/GuildManager.js
+++ b/packages/discord.js/src/managers/GuildManager.js
@@ -57,7 +57,7 @@ class GuildManager extends CachedManager {
 
   /**
    * Partial data for a Role.
-   * @typedef {Object} PartialRoleData
+   * @typedef {object} PartialRoleData
    * @property {Snowflake|number} [id] The role's id, used to set channel overrides.
    * This is a placeholder and will be replaced by the API after consumption
    * @property {string} [name] The name of the role
@@ -70,7 +70,7 @@ class GuildManager extends CachedManager {
 
   /**
    * Partial overwrite data.
-   * @typedef {Object} PartialOverwriteData
+   * @typedef {object} PartialOverwriteData
    * @property {Snowflake|number} id The id of the {@link Role} or {@link User} this overwrite belongs to
    * @property {OverwriteType} [type] The type of this overwrite
    * @property {PermissionResolvable} [allow] The permissions to allow
@@ -79,7 +79,7 @@ class GuildManager extends CachedManager {
 
   /**
    * Partial data for a Channel.
-   * @typedef {Object} PartialChannelData
+   * @typedef {object} PartialChannelData
    * @property {Snowflake|number} [id] The channel's id, used to set its parent.
    * This is a placeholder and will be replaced by the API after consumption
    * @property {Snowflake|number} [parentId] The parent id for this channel
@@ -140,7 +140,7 @@ class GuildManager extends CachedManager {
 
   /**
    * Options used to create a guild.
-   * @typedef {Object} GuildCreateOptions
+   * @typedef {object} GuildCreateOptions
    * @property {string} name The name of the guild
    * @property {?(BufferResolvable|Base64Resolvable)} [icon=null] The icon for the guild
    * @property {GuildVerificationLevel} [verificationLevel] The verification level for the guild
@@ -250,7 +250,7 @@ class GuildManager extends CachedManager {
 
   /**
    * Options used to fetch multiple guilds.
-   * @typedef {Object} FetchGuildsOptions
+   * @typedef {object} FetchGuildsOptions
    * @property {Snowflake} [before] Get guilds before this guild id
    * @property {Snowflake} [after] Get guilds after this guild id
    * @property {number} [limit] Maximum number of guilds to request (1-200)

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -73,7 +73,7 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * Options used to add a user to a guild using OAuth2.
-   * @typedef {Object} AddGuildMemberOptions
+   * @typedef {object} AddGuildMemberOptions
    * @property {string} accessToken An OAuth2 access token for the user with the {@link OAuth2Scopes.GuildsJoin}
    * scope granted to the bot's application
    * @property {string} [nick] The nickname to give to the member
@@ -158,7 +158,7 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * Options used to fetch multiple members from a guild.
-   * @typedef {Object} FetchMembersOptions
+   * @typedef {object} FetchMembersOptions
    * @property {UserResolvable|UserResolvable[]} [user] The user(s) to fetch
    * @property {?string} [query] Limit fetch to members with similar usernames
    * @property {number} [limit=0] Maximum number of members to request
@@ -282,7 +282,7 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * Options used for searching guild members.
-   * @typedef {Object} GuildSearchMembersOptions
+   * @typedef {object} GuildSearchMembersOptions
    * @property {string} query Filter members whose username or nickname start with this query
    * @property {number} [limit] Maximum number of members to search
    * @property {boolean} [cache=true] Whether or not to cache the fetched member(s)
@@ -302,7 +302,7 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * Options used for listing guild members.
-   * @typedef {Object} GuildListMembersOptions
+   * @typedef {object} GuildListMembersOptions
    * @property {Snowflake} [after] Limit fetching members to those with an id greater than the supplied id
    * @property {number} [limit] Maximum number of members to list
    * @property {boolean} [cache=true] Whether or not to cache the fetched member(s)
@@ -321,7 +321,7 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * The data for editing a guild member.
-   * @typedef {Object} GuildMemberEditOptions
+   * @typedef {object} GuildMemberEditOptions
    * @property {?string} [nick] The nickname to set for the member
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] The roles or role ids to apply
    * @property {boolean} [mute] Whether or not the member should be muted
@@ -389,7 +389,7 @@ class GuildMemberManager extends CachedManager {
    * Options used for pruning guild members.
    * <info>It's recommended to set {@link GuildPruneMembersOptions#count options.count}
    * to `false` for large guilds.</info>
-   * @typedef {Object} GuildPruneMembersOptions
+   * @typedef {object} GuildPruneMembersOptions
    * @property {number} [days] Number of days of inactivity required to kick
    * @property {boolean} [dry=false] Get the number of users that will be kicked, without actually kicking them
    * @property {boolean} [count] Whether or not to return the number of users that have been kicked.
@@ -502,7 +502,7 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * Options used for adding or removing a role from a member.
-   * @typedef {Object} AddOrRemoveGuildMemberRoleOptions
+   * @typedef {object} AddOrRemoveGuildMemberRoleOptions
    * @property {GuildMemberResolvable} user The user to add/remove the role from
    * @property {RoleResolvable} role The role to add/remove
    * @property {string} [reason] Reason for adding/removing the role

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -38,7 +38,7 @@ class GuildScheduledEventManager extends CachedManager {
 
   /**
    * Options used to create a guild scheduled event.
-   * @typedef {Object} GuildScheduledEventCreateOptions
+   * @typedef {object} GuildScheduledEventCreateOptions
    * @property {string} name The name of the guild scheduled event
    * @property {DateResolvable} scheduledStartTime The time to schedule the event at
    * @property {DateResolvable} [scheduledEndTime] The time to end the event at
@@ -58,7 +58,7 @@ class GuildScheduledEventManager extends CachedManager {
 
   /**
    * Options used to set entity metadata of a guild scheduled event.
-   * @typedef {Object} GuildScheduledEventEntityMetadataOptions
+   * @typedef {object} GuildScheduledEventEntityMetadataOptions
    * @property {string} [location] The location of the guild scheduled event
    * <warn>This is required if `entityType` is {@link GuildScheduledEventEntityType.External}</warn>
    */
@@ -120,7 +120,7 @@ class GuildScheduledEventManager extends CachedManager {
 
   /**
    * Options used to fetch multiple guild scheduled events from a guild.
-   * @typedef {Object} FetchGuildScheduledEventsOptions
+   * @typedef {object} FetchGuildScheduledEventsOptions
    * @property {boolean} [cache] Whether or not to cache the fetched guild scheduled events
    * @property {boolean} [withUserCount=true] Whether to fetch the number of users subscribed to each scheduled event
    * should be returned
@@ -163,7 +163,7 @@ class GuildScheduledEventManager extends CachedManager {
 
   /**
    * Options used to edit a guild scheduled event.
-   * @typedef {Object} GuildScheduledEventEditOptions
+   * @typedef {object} GuildScheduledEventEditOptions
    * @property {string} [name] The name of the guild scheduled event
    * @property {DateResolvable} [scheduledStartTime] The time to schedule the event at
    * @property {DateResolvable} [scheduledEndTime] The time to end the event at
@@ -245,7 +245,7 @@ class GuildScheduledEventManager extends CachedManager {
 
   /**
    * Options used to fetch subscribers of a guild scheduled event
-   * @typedef {Object} FetchGuildScheduledEventSubscribersOptions
+   * @typedef {object} FetchGuildScheduledEventSubscribersOptions
    * @property {number} [limit] The maximum numbers of users to fetch
    * @property {boolean} [withMember] Whether to fetch guild member data of the users
    * @property {Snowflake} [before] Consider only users before this user id
@@ -255,7 +255,7 @@ class GuildScheduledEventManager extends CachedManager {
 
   /**
    * Represents a subscriber of a {@link GuildScheduledEvent}
-   * @typedef {Object} GuildScheduledEventUser
+   * @typedef {object} GuildScheduledEventUser
    * @property {Snowflake} guildScheduledEventId The id of the guild scheduled event which the user subscribed to
    * @property {User} user The user that subscribed to the guild scheduled event
    * @property {?GuildMember} member The guild member associated with the user, if any

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -34,7 +34,7 @@ class GuildStickerManager extends CachedManager {
 
   /**
    * Options used to create a guild sticker.
-   * @typedef {Object} GuildStickerCreateOptions
+   * @typedef {object} GuildStickerCreateOptions
    * @property {AttachmentPayload|BufferResolvable|Stream} file The file for the sticker
    * @property {string} name The name for the sticker
    * @property {string} tags The Discord name of a unicode emoji representing the sticker's expression

--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -54,7 +54,7 @@ class MessageManager extends CachedManager {
   /**
    * Options used to fetch multiple messages.
    * <info>The `before`, `after`, and `around` parameters are mutually exclusive.</info>
-   * @typedef {Object} FetchMessagesOptions
+   * @typedef {object} FetchMessagesOptions
    * @property {number} [limit] The maximum number of messages to return
    * @property {Snowflake} [before] Consider only messages before this id
    * @property {Snowflake} [after] Consider only messages after this id
@@ -155,7 +155,7 @@ class MessageManager extends CachedManager {
 
   /**
    * Data used to reference an attachment.
-   * @typedef {Object} MessageEditAttachmentData
+   * @typedef {object} MessageEditAttachmentData
    * @property {Snowflake} id The id of the attachment
    */
 

--- a/packages/discord.js/src/managers/PermissionOverwriteManager.js
+++ b/packages/discord.js/src/managers/PermissionOverwriteManager.js
@@ -78,7 +78,7 @@ class PermissionOverwriteManager extends CachedManager {
 
   /**
    * Extra information about the overwrite.
-   * @typedef {Object} GuildChannelOverwriteOptions
+   * @typedef {object} GuildChannelOverwriteOptions
    * @property {string} [reason] The reason for creating/editing this overwrite
    * @property {OverwriteType} [type] The type of overwrite. Use this to bypass automatic resolution of `type`
    * that results in an error for an uncached structure

--- a/packages/discord.js/src/managers/ReactionUserManager.js
+++ b/packages/discord.js/src/managers/ReactionUserManager.js
@@ -30,7 +30,7 @@ class ReactionUserManager extends CachedManager {
 
   /**
    * Options used to fetch users who gave a reaction.
-   * @typedef {Object} FetchReactionUsersOptions
+   * @typedef {object} FetchReactionUsersOptions
    * @property {number} [limit=100] The maximum amount of users to fetch, defaults to `100`
    * @property {Snowflake} [after] Limit fetching users to those with an id greater than the supplied id
    */

--- a/packages/discord.js/src/managers/RoleManager.js
+++ b/packages/discord.js/src/managers/RoleManager.js
@@ -100,7 +100,7 @@ class RoleManager extends CachedManager {
 
   /**
    * Options used to create a new role.
-   * @typedef {Object} RoleCreateOptions
+   * @typedef {object} RoleCreateOptions
    * @property {string} [name] The name of the new role
    * @property {ColorResolvable} [color] The data to create the role with
    * @property {boolean} [hoist] Whether or not the new role should be hoisted
@@ -264,7 +264,7 @@ class RoleManager extends CachedManager {
 
   /**
    * The data needed for updating a guild role's position
-   * @typedef {Object} GuildRolePosition
+   * @typedef {object} GuildRolePosition
    * @property {RoleResolvable} role The role's id
    * @property {number} position The position to update
    */

--- a/packages/discord.js/src/managers/StageInstanceManager.js
+++ b/packages/discord.js/src/managers/StageInstanceManager.js
@@ -28,7 +28,7 @@ class StageInstanceManager extends CachedManager {
 
   /**
    * Options used to create a stage instance.
-   * @typedef {Object} StageInstanceCreateOptions
+   * @typedef {object} StageInstanceCreateOptions
    * @property {string} topic The topic of the stage instance
    * @property {StageInstancePrivacyLevel} [privacyLevel] The privacy level of the stage instance
    * @property {boolean} [sendStartNotification] Whether to notify `@everyone` that the stage instance has started
@@ -104,7 +104,7 @@ class StageInstanceManager extends CachedManager {
 
   /**
    * Options used to edit an existing stage instance.
-   * @typedef {Object} StageInstanceEditOptions
+   * @typedef {object} StageInstanceEditOptions
    * @property {string} [topic] The new topic of the stage instance
    * @property {StageInstancePrivacyLevel} [privacyLevel] The new privacy level of the stage instance
    */

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -79,7 +79,7 @@ class ThreadManager extends CachedManager {
 
   /**
    * Options for fetching multiple threads.
-   * @typedef {Object} FetchThreadsOptions
+   * @typedef {object} FetchThreadsOptions
    * @property {FetchArchivedThreadOptions} [archived] Options used to fetch archived threads
    */
 
@@ -117,7 +117,7 @@ class ThreadManager extends CachedManager {
 
   /**
    * The options used to fetch archived threads.
-   * @typedef {Object} FetchArchivedThreadOptions
+   * @typedef {object} FetchArchivedThreadOptions
    * @property {string} [type='public'] The type of threads to fetch (`public` or `private`)
    * @property {boolean} [fetchAll=false] Whether to fetch **all** archived threads when `type` is `private`
    * <info>This property requires the {@link PermissionFlagsBits.ManageThreads} permission if `true`.</info>

--- a/packages/discord.js/src/managers/ThreadMemberManager.js
+++ b/packages/discord.js/src/managers/ThreadMemberManager.js
@@ -122,7 +122,7 @@ class ThreadMemberManager extends CachedManager {
   /**
    * Options used to fetch multiple thread members with guild member data.
    * <info>With `withMember` set to `true`, pagination is enabled.</info>
-   * @typedef {Object} FetchThreadMembersWithGuildMemberDataOptions
+   * @typedef {object} FetchThreadMembersWithGuildMemberDataOptions
    * @property {true} withMember Whether to also return the guild member data
    * @property {Snowflake} [after] Consider only thread members after this id
    * @property {number} [limit] The maximum number of thread members to return
@@ -131,7 +131,7 @@ class ThreadMemberManager extends CachedManager {
 
   /**
    * Options used to fetch multiple thread members without guild member data.
-   * @typedef {Object} FetchThreadMembersWithoutGuildMemberDataOptions
+   * @typedef {object} FetchThreadMembersWithoutGuildMemberDataOptions
    * @property {false} [withMember] Whether to also return the guild member data
    * @property {boolean} [cache] Whether to cache the fetched thread members
    */

--- a/packages/discord.js/src/sharding/Shard.js
+++ b/packages/discord.js/src/sharding/Shard.js
@@ -62,7 +62,7 @@ class Shard extends EventEmitter {
 
     /**
      * Environment variables for the shard's process, or workerData for the shard's worker
-     * @type {Object}
+     * @type {object}
      */
     this.env = Object.assign({}, process.env, {
       SHARDING_MANAGER: true,
@@ -207,7 +207,7 @@ class Shard extends EventEmitter {
 
   /**
    * Options used to respawn a shard.
-   * @typedef {Object} ShardRespawnOptions
+   * @typedef {object} ShardRespawnOptions
    * @property {number} [delay=500] How long to wait between killing the process/worker and
    * restarting it (in milliseconds)
    * @property {number} [timeout=30000] The amount in milliseconds to wait until the {@link Client}

--- a/packages/discord.js/src/sharding/ShardingManager.js
+++ b/packages/discord.js/src/sharding/ShardingManager.js
@@ -29,7 +29,7 @@ class ShardingManager extends EventEmitter {
 
   /**
    * The options to spawn shards with for a {@link ShardingManager}.
-   * @typedef {Object} ShardingManagerOptions
+   * @typedef {object} ShardingManagerOptions
    * @property {string|number} [totalShards='auto'] Number of total shards of all shard managers or "auto"
    * @property {string|number[]} [shardList='auto'] List of shards to spawn or "auto"
    * @property {ShardingManagerMode} [mode='process'] Which mode to use for shards
@@ -180,7 +180,7 @@ class ShardingManager extends EventEmitter {
 
   /**
    * Options used to spawn multiple shards.
-   * @typedef {Object} MultipleShardSpawnOptions
+   * @typedef {object} MultipleShardSpawnOptions
    * @property {number|string} [amount=this.totalShards] Number of shards to spawn
    * @property {number} [delay=5500] How long to wait in between spawning each shard (in milliseconds)
    * @property {number} [timeout=30000] The amount in milliseconds to wait until the {@link Client} has become ready
@@ -247,7 +247,7 @@ class ShardingManager extends EventEmitter {
 
   /**
    * Options for {@link ShardingManager#broadcastEval} and {@link ShardClientUtil#broadcastEval}.
-   * @typedef {Object} BroadcastEvalOptions
+   * @typedef {object} BroadcastEvalOptions
    * @property {number} [shard] Shard to run script on, all if undefined
    * @property {*} [context] The JSON-serializable values to call the script with
    */
@@ -306,7 +306,7 @@ class ShardingManager extends EventEmitter {
 
   /**
    * Options used to respawn all shards.
-   * @typedef {Object} MultipleShardRespawnOptions
+   * @typedef {object} MultipleShardRespawnOptions
    * @property {number} [shardDelay=5000] How long to wait between shards (in milliseconds)
    * @property {number} [respawnDelay=500] How long to wait between killing a shard's process and restarting it
    * (in milliseconds)

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -73,7 +73,7 @@ class ApplicationCommand extends Base {
     if ('name_localizations' in data) {
       /**
        * The name localizations for this command
-       * @type {?Object<Locale, string>}
+       * @type {?Record<Locale, string>}
        */
       this.nameLocalizations = data.name_localizations;
     } else {
@@ -101,7 +101,7 @@ class ApplicationCommand extends Base {
     if ('description_localizations' in data) {
       /**
        * The description localizations for this command
-       * @type {?Object<Locale, string>}
+       * @type {?Record<Locale, string>}
        */
       this.descriptionLocalizations = data.description_localizations;
     } else {
@@ -189,13 +189,13 @@ class ApplicationCommand extends Base {
 
   /**
    * Data for creating or editing an application command.
-   * @typedef {Object} ApplicationCommandData
+   * @typedef {object} ApplicationCommandData
    * @property {string} name The name of the command, must be in all lowercase if type is
    * {@link ApplicationCommandType.ChatInput}
-   * @property {Object<Locale, string>} [nameLocalizations] The localizations for the command name
+   * @property {Record<Locale, string>} [nameLocalizations] The localizations for the command name
    * @property {string} description The description of the command, if type is {@link ApplicationCommandType.ChatInput}
    * @property {boolean} [nsfw] Whether the command is age-restricted
-   * @property {Object<Locale, string>} [descriptionLocalizations] The localizations for the command description,
+   * @property {Record<Locale, string>} [descriptionLocalizations] The localizations for the command description,
    * if type is {@link ApplicationCommandType.ChatInput}
    * @property {ApplicationCommandType} [type=ApplicationCommandType.ChatInput] The type of the command
    * @property {ApplicationCommandOptionData[]} [options] Options for the command
@@ -210,12 +210,12 @@ class ApplicationCommand extends Base {
    * API style `snake_case` properties can be used for compatibility with generators like `@discordjs/builders`.</info>
    * <warn>Note that providing a value for the `camelCase` counterpart for any `snake_case` property
    * will discard the provided `snake_case` property.</warn>
-   * @typedef {Object} ApplicationCommandOptionData
+   * @typedef {object} ApplicationCommandOptionData
    * @property {ApplicationCommandOptionType} type The type of the option
    * @property {string} name The name of the option
-   * @property {Object<Locale, string>} [nameLocalizations] The name localizations for the option
+   * @property {Record<Locale, string>} [nameLocalizations] The name localizations for the option
    * @property {string} description The description of the option
-   * @property {Object<Locale, string>} [descriptionLocalizations] The description localizations for the option
+   * @property {Record<Locale, string>} [descriptionLocalizations] The description localizations for the option
    * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a
    * {@link ApplicationCommandOptionType.String}, {@link ApplicationCommandOptionType.Integer} or
    * {@link ApplicationCommandOptionType.Number} option
@@ -235,9 +235,9 @@ class ApplicationCommand extends Base {
    */
 
   /**
-   * @typedef {Object} ApplicationCommandOptionChoiceData
+   * @typedef {object} ApplicationCommandOptionChoiceData
    * @property {string} name The name of the choice
-   * @property {Object<Locale, string>} [nameLocalizations] The localized names for this choice
+   * @property {Record<Locale, string>} [nameLocalizations] The localized names for this choice
    * @property {string|number} value The value of the choice
    */
 
@@ -268,7 +268,7 @@ class ApplicationCommand extends Base {
 
   /**
    * Edits the localized names of this ApplicationCommand
-   * @param {Object<Locale, string>} nameLocalizations The new localized names for the command
+   * @param {Record<Locale, string>} nameLocalizations The new localized names for the command
    * @returns {Promise<ApplicationCommand>}
    * @example
    * // Edit the name localizations of this command
@@ -294,7 +294,7 @@ class ApplicationCommand extends Base {
 
   /**
    * Edits the localized descriptions of this ApplicationCommand
-   * @param {Object<Locale, string>} descriptionLocalizations The new localized descriptions for the command
+   * @param {Record<Locale, string>} descriptionLocalizations The new localized descriptions for the command
    * @returns {Promise<ApplicationCommand>}
    * @example
    * // Edit the description localizations of this command
@@ -504,13 +504,13 @@ class ApplicationCommand extends Base {
 
   /**
    * An option for an application command or subcommand.
-   * @typedef {Object} ApplicationCommandOption
+   * @typedef {object} ApplicationCommandOption
    * @property {ApplicationCommandOptionType} type The type of the option
    * @property {string} name The name of the option
-   * @property {Object<Locale, string>} [nameLocalizations] The localizations for the option name
+   * @property {Record<Locale, string>} [nameLocalizations] The localizations for the option name
    * @property {string} [nameLocalized] The localized name for this option
    * @property {string} description The description of the option
-   * @property {Object<Locale, string>} [descriptionLocalizations] The localizations for the option description
+   * @property {Record<Locale, string>} [descriptionLocalizations] The localizations for the option description
    * @property {string} [descriptionLocalized] The localized description for this option
    * @property {boolean} [required] Whether the option is required
    * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a
@@ -532,10 +532,10 @@ class ApplicationCommand extends Base {
 
   /**
    * A choice for an application command option.
-   * @typedef {Object} ApplicationCommandOptionChoice
+   * @typedef {object} ApplicationCommandOptionChoice
    * @property {string} name The name of the choice
    * @property {?string} nameLocalized The localized name of the choice in the provided locale, if any
-   * @property {?Object<string, string>} [nameLocalizations] The localized names for this choice
+   * @property {?Record<string, string>} [nameLocalizations] The localized names for this choice
    * @property {string|number} value The value of the choice
    */
 

--- a/packages/discord.js/src/structures/ApplicationRoleConnectionMetadata.js
+++ b/packages/discord.js/src/structures/ApplicationRoleConnectionMetadata.js
@@ -13,7 +13,7 @@ class ApplicationRoleConnectionMetadata {
 
     /**
      * The name localizations for this metadata field
-     * @type {?Object<Locale, string>}
+     * @type {?Record<Locale, string>}
      */
     this.nameLocalizations = data.name_localizations ?? null;
 
@@ -25,7 +25,7 @@ class ApplicationRoleConnectionMetadata {
 
     /**
      * The description localizations for this metadata field
-     * @type {?Object<Locale, string>}
+     * @type {?Record<Locale, string>}
      */
     this.descriptionLocalizations = data.description_localizations ?? null;
 

--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -4,7 +4,7 @@ const AttachmentFlagsBitField = require('../util/AttachmentFlagsBitField.js');
 const { basename, flatten } = require('../util/Util');
 
 /**
- * @typedef {Object} AttachmentPayload
+ * @typedef {object} AttachmentPayload
  * @property {?string} name The name of the attachment
  * @property {Stream|BufferResolvable} attachment The attachment in this payload
  * @property {?string} description The description of the attachment

--- a/packages/discord.js/src/structures/AttachmentBuilder.js
+++ b/packages/discord.js/src/structures/AttachmentBuilder.js
@@ -105,7 +105,7 @@ class AttachmentBuilder {
 module.exports = AttachmentBuilder;
 
 /**
- * @typedef {Object} AttachmentData
+ * @typedef {object} AttachmentData
  * @property {string} [name] The name of the attachment
  * @property {string} [description] The description of the attachment
  */

--- a/packages/discord.js/src/structures/AutoModerationRule.js
+++ b/packages/discord.js/src/structures/AutoModerationRule.js
@@ -59,7 +59,7 @@ class AutoModerationRule extends Base {
     if ('trigger_metadata' in data) {
       /**
        * Additional data used to determine whether an auto moderation rule should be triggered.
-       * @typedef {Object} AutoModerationTriggerMetadata
+       * @typedef {object} AutoModerationTriggerMetadata
        * @property {string[]} keywordFilter The substrings that will be searched for in the content
        * @property {string[]} regexPatterns The regular expression patterns which will be matched against the content
        * <info>Only Rust-flavored regular expressions are supported.</info>
@@ -88,14 +88,14 @@ class AutoModerationRule extends Base {
     if ('actions' in data) {
       /**
        * An object containing information about an auto moderation rule action.
-       * @typedef {Object} AutoModerationAction
+       * @typedef {object} AutoModerationAction
        * @property {AutoModerationActionType} type The type of this auto moderation rule action
        * @property {AutoModerationActionMetadata} metadata Additional metadata needed during execution
        */
 
       /**
        * Additional data used when an auto moderation rule is executed.
-       * @typedef {Object} AutoModerationActionMetadata
+       * @typedef {object} AutoModerationActionMetadata
        * @property {?Snowflake} channelId The id of the channel to which content will be logged
        * @property {?number} durationSeconds The timeout duration in seconds
        * @property {?string} customMessage The custom message that is shown whenever a message is blocked

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -135,7 +135,7 @@ class BaseGuildTextChannel extends GuildChannel {
 
   /**
    * Options used to create an invite to a guild channel.
-   * @typedef {Object} InviteCreateOptions
+   * @typedef {object} InviteCreateOptions
    * @property {boolean} [temporary] Whether members that joined via the invite should be automatically
    * kicked after 24 hours if they have not yet received a role
    * @property {number} [maxAge] How long the invite should last (in seconds, 0 for forever)

--- a/packages/discord.js/src/structures/ClientApplication.js
+++ b/packages/discord.js/src/structures/ClientApplication.js
@@ -10,7 +10,7 @@ const DataResolver = require('../util/DataResolver');
 const PermissionsBitField = require('../util/PermissionsBitField');
 
 /**
- * @typedef {Object} ClientApplicationInstallParams
+ * @typedef {object} ClientApplicationInstallParams
  * @property {OAuth2Scopes[]} scopes The scopes to add the application to the server with
  * @property {Readonly<PermissionsBitField>} permissions The permissions this bot will request upon joining
  */
@@ -191,7 +191,7 @@ class ClientApplication extends Application {
 
   /**
    * Options used for editing an application.
-   * @typedef {Object} ClientApplicationEditOptions
+   * @typedef {object} ClientApplicationEditOptions
    * @property {string} [customInstallURL] The application's custom installation URL
    * @property {string} [description] The application's description
    * @property {string} [roleConnectionsVerificationURL] The application's role connection verification URL
@@ -259,11 +259,11 @@ class ClientApplication extends Application {
 
   /**
    * Data for creating or editing an application role connection metadata.
-   * @typedef {Object} ApplicationRoleConnectionMetadataEditOptions
+   * @typedef {object} ApplicationRoleConnectionMetadataEditOptions
    * @property {string} name The name of the metadata field
-   * @property {?Object<Locale, string>} [nameLocalizations] The name localizations for the metadata field
+   * @property {?Record<Locale, string>} [nameLocalizations] The name localizations for the metadata field
    * @property {string} description The description of the metadata field
-   * @property {?Object<Locale, string>} [descriptionLocalizations] The description localizations for the metadata field
+   * @property {?Record<Locale, string>} [descriptionLocalizations] The description localizations for the metadata field
    * @property {string} key The dictionary key of the metadata field
    * @property {ApplicationRoleConnectionMetadataType} type The type of the metadata field
    */

--- a/packages/discord.js/src/structures/ClientUser.js
+++ b/packages/discord.js/src/structures/ClientUser.js
@@ -44,7 +44,7 @@ class ClientUser extends User {
 
   /**
    * Data used to edit the logged in client
-   * @typedef {Object} ClientUserEditOptions
+   * @typedef {object} ClientUserEditOptions
    * @property {string} [username] The new username
    * @property {?(BufferResolvable|Base64Resolvable)} [avatar] The new avatar
    */
@@ -97,7 +97,7 @@ class ClientUser extends User {
 
   /**
    * Options for setting activities
-   * @typedef {Object} ActivitiesOptions
+   * @typedef {object} ActivitiesOptions
    * @property {string} name Name of the activity
    * @property {string} [state] State of the activity
    * @property {ActivityType} [type] Type of the activity
@@ -106,7 +106,7 @@ class ClientUser extends User {
 
   /**
    * Data resembling a raw Discord presence.
-   * @typedef {Object} PresenceData
+   * @typedef {object} PresenceData
    * @property {PresenceStatusData} [status] Status of the user
    * @property {boolean} [afk] Whether the user is AFK
    * @property {ActivitiesOptions[]} [activities] Activity the user is playing
@@ -149,7 +149,7 @@ class ClientUser extends User {
 
   /**
    * Options for setting an activity.
-   * @typedef {Object} ActivityOptions
+   * @typedef {object} ActivityOptions
    * @property {string} name Name of the activity
    * @property {string} [state] State of the activity
    * @property {string} [url] Twitch / YouTube stream URL

--- a/packages/discord.js/src/structures/CommandInteraction.js
+++ b/packages/discord.js/src/structures/CommandInteraction.js
@@ -81,7 +81,7 @@ class CommandInteraction extends BaseInteraction {
 
   /**
    * Represents the resolved data of a received command interaction.
-   * @typedef {Object} CommandInteractionResolvedData
+   * @typedef {object} CommandInteractionResolvedData
    * @property {Collection<Snowflake, User>} [users] The resolved users
    * @property {Collection<Snowflake, GuildMember|APIGuildMember>} [members] The resolved guild members
    * @property {Collection<Snowflake, Role|APIRole>} [roles] The resolved roles
@@ -92,7 +92,7 @@ class CommandInteraction extends BaseInteraction {
 
   /**
    * Represents an option of a received command interaction.
-   * @typedef {Object} CommandInteractionOption
+   * @typedef {object} CommandInteractionOption
    * @property {string} name The name of the option
    * @property {ApplicationCommandOptionType} type The type of the option
    * @property {boolean} [autocomplete] Whether the autocomplete interaction is enabled for a

--- a/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
+++ b/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
@@ -285,7 +285,7 @@ class CommandInteractionOptionResolver {
 
   /**
    * The full autocomplete option object.
-   * @typedef {Object} AutocompleteFocusedOption
+   * @typedef {object} AutocompleteFocusedOption
    * @property {string} name The name of the option
    * @property {ApplicationCommandOptionType} type The type of the application command option
    * @property {string} value The value of the option

--- a/packages/discord.js/src/structures/Embed.js
+++ b/packages/discord.js/src/structures/Embed.js
@@ -71,7 +71,7 @@ class Embed {
   }
 
   /**
-   * @typedef {Object} EmbedAssetData
+   * @typedef {object} EmbedAssetData
    * @property {?string} url The URL of the image
    * @property {?string} proxyURL The proxy URL of the image
    * @property {?number} height The height of the image
@@ -124,7 +124,7 @@ class Embed {
   }
 
   /**
-   * @typedef {Object} EmbedAuthorData
+   * @typedef {object} EmbedAuthorData
    * @property {string} name The name of the author
    * @property {?string} url The URL of the author
    * @property {?string} iconURL The icon URL of the author
@@ -156,7 +156,7 @@ class Embed {
   }
 
   /**
-   * @typedef {Object} EmbedFooterData
+   * @typedef {object} EmbedFooterData
    * @property {string} text The text of the footer
    * @property {?string} iconURL The URL of the icon
    * @property {?string} proxyIconURL The proxy URL of the icon

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -636,7 +636,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * An object containing information about a guild's vanity invite.
-   * @typedef {Object} Vanity
+   * @typedef {object} Vanity
    * @property {?string} code Vanity invite code
    * @property {number} uses How many times this invite has been used
    */
@@ -692,7 +692,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Data for the Guild Widget Settings object
-   * @typedef {Object} GuildWidgetSettings
+   * @typedef {object} GuildWidgetSettings
    * @property {boolean} enabled Whether the widget is enabled
    * @property {?(TextChannel|NewsChannel|VoiceChannel|StageChannel|ForumChannel|MediaChannel)} channel
    * The widget invite channel
@@ -700,7 +700,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * The Guild Widget Settings object
-   * @typedef {Object} GuildWidgetSettingsData
+   * @typedef {object} GuildWidgetSettingsData
    * @property {boolean} enabled Whether the widget is enabled
    * @property {?(TextChannel|NewsChannel|VoiceChannel|StageChannel|ForumChannel|MediaChannel|Snowflake)} channel
    * The widget invite channel
@@ -736,7 +736,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Options used to fetch audit logs.
-   * @typedef {Object} GuildAuditLogsFetchOptions
+   * @typedef {object} GuildAuditLogsFetchOptions
    * @property {Snowflake|GuildAuditLogsEntry} [before] Consider only entries before this entry
    * @property {Snowflake|GuildAuditLogsEntry} [after] Consider only entries after this entry
    * @property {number} [limit] The number of entries to return
@@ -783,7 +783,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * The data for editing a guild.
-   * @typedef {Object} GuildEditOptions
+   * @typedef {object} GuildEditOptions
    * @property {string} [name] The name of the guild
    * @property {?GuildVerificationLevel} [verificationLevel] The verification level of the guild
    * @property {?GuildDefaultMessageNotifications} [defaultMessageNotifications] The default message
@@ -884,7 +884,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Options used to edit the guild onboarding.
-   * @typedef {Object} GuildOnboardingEditOptions
+   * @typedef {object} GuildOnboardingEditOptions
    * @property {GuildOnboardingPromptData[]|Collection<Snowflake, GuildOnboardingPrompt>} [prompts]
    * The prompts shown during onboarding and in customize community
    * @property {ChannelResolvable[]|Collection<Snowflake, GuildChannel>} [defaultChannels]
@@ -896,7 +896,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Data for editing a guild onboarding prompt.
-   * @typedef {Object} GuildOnboardingPromptData
+   * @typedef {object} GuildOnboardingPromptData
    * @property {Snowflake} [id] The id of the prompt
    * @property {string} title The title for the prompt
    * @property {boolean} [singleSelect] Whether users are limited to selecting one option for the prompt
@@ -909,7 +909,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Data for editing a guild onboarding prompt option.
-   * @typedef {Object} GuildOnboardingPromptOptionData
+   * @typedef {object} GuildOnboardingPromptOptionData
    * @property {?Snowflake} [id] The id of the option
    * @property {ChannelResolvable[]|Collection<Snowflake, GuildChannel>} [channels]
    * The channels a member is added to when the option is selected
@@ -963,7 +963,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Welcome channel data
-   * @typedef {Object} WelcomeChannelData
+   * @typedef {object} WelcomeChannelData
    * @property {string} description The description to show for this welcome channel
    * @property {TextChannel|NewsChannel|ForumChannel|MediaChannel|Snowflake} channel
    * The channel to link for this welcome channel
@@ -972,7 +972,7 @@ class Guild extends AnonymousGuild {
 
   /**
    * Welcome screen edit data
-   * @typedef {Object} WelcomeScreenEditOptions
+   * @typedef {object} WelcomeScreenEditOptions
    * @property {boolean} [enabled] Whether the welcome screen is enabled
    * @property {string} [description] The description for the welcome screen
    * @property {WelcomeChannelData[]} [welcomeChannels] The welcome channel data for the welcome screen

--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -51,7 +51,7 @@ const Targets = {
  * * An auto moderation rule
  * * An object with an id key if target was deleted or fake entity
  * * An object where the keys represent either the new value or the old value
- * @typedef {?(Object|Guild|BaseChannel|User|Role|Invite|Webhook|GuildEmoji|Message|Integration|StageInstance|Sticker|
+ * @typedef {?(object|Guild|BaseChannel|User|Role|Invite|Webhook|GuildEmoji|Message|Integration|StageInstance|Sticker|
  * GuildScheduledEvent|ApplicationCommand|AutoModerationRule)} AuditLogEntryTarget
  */
 
@@ -86,8 +86,8 @@ const Targets = {
 /**
  * Constructs an object of known properties for a structure from an array of changes.
  * @param {AuditLogChange[]} changes The array of changes
- * @param {Object} [initialData={}] The initial data passed to the function
- * @returns {Object}
+ * @param {object} [initialData={}] The initial data passed to the function
+ * @returns {object}
  * @ignore
  */
 function changesReduce(changes, initialData = {}) {
@@ -103,7 +103,7 @@ function changesReduce(changes, initialData = {}) {
 class GuildAuditLogsEntry {
   /**
    * Key mirror of all available audit log targets.
-   * @type {Object<string, string>}
+   * @type {Record<string, string>}
    * @memberof GuildAuditLogsEntry
    */
   static Targets = Targets;
@@ -152,7 +152,7 @@ class GuildAuditLogsEntry {
 
     /**
      * An entry in the audit log representing a specific change.
-     * @typedef {Object} AuditLogChange
+     * @typedef {object} AuditLogChange
      * @property {string} key The property that was changed, e.g. `nick` for nickname changes
      * <warn>For application command permissions updates the key is the id of the user, channel,
      * role, or a permission constant that was updated instead of an actual property name</warn>
@@ -175,7 +175,7 @@ class GuildAuditLogsEntry {
 
     /**
      * Any extra data from the entry
-     * @type {?(Object|Role|GuildMember)}
+     * @type {?(object|Role|GuildMember)}
      */
     this.extra = null;
     switch (data.action_type) {

--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -315,7 +315,7 @@ class GuildChannel extends BaseChannel {
 
   /**
    * Options used to set the parent of a channel.
-   * @typedef {Object} SetParentOptions
+   * @typedef {object} SetParentOptions
    * @property {boolean} [lockPermissions=true] Whether to lock the permissions to what the parent's permissions are
    * @property {string} [reason] The reason for modifying the parent of the channel
    */
@@ -341,7 +341,7 @@ class GuildChannel extends BaseChannel {
 
   /**
    * Options used to set the position of a channel.
-   * @typedef {Object} SetChannelPositionOptions
+   * @typedef {object} SetChannelPositionOptions
    * @property {boolean} [relative=false] Whether or not to change the position relative to its current value
    * @property {string} [reason] The reason for changing the position
    */

--- a/packages/discord.js/src/structures/GuildEmoji.js
+++ b/packages/discord.js/src/structures/GuildEmoji.js
@@ -78,7 +78,7 @@ class GuildEmoji extends BaseGuildEmoji {
 
   /**
    * Data for editing an emoji.
-   * @typedef {Object} GuildEmojiEditOptions
+   * @typedef {object} GuildEmojiEditOptions
    * @property {string} [name] The name of the emoji
    * @property {Collection<Snowflake, Role>|RoleResolvable[]} [roles] Roles to restrict emoji to
    * @property {string} [reason] Reason for editing this emoji

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -159,7 +159,7 @@ class GuildScheduledEvent extends Base {
     /**
      * Represents the additional metadata for a {@link GuildScheduledEvent}
      * @see {@link https://discord.com/developers/docs/resources/guild-scheduled-event#guild-scheduled-event-object-guild-scheduled-event-entity-metadata}
-     * @typedef {Object} GuildScheduledEventEntityMetadata
+     * @typedef {object} GuildScheduledEventEntityMetadata
      * @property {?string} location The location of the guild scheduled event
      */
     /* eslint-enable max-len */

--- a/packages/discord.js/src/structures/GuildTemplate.js
+++ b/packages/discord.js/src/structures/GuildTemplate.js
@@ -155,7 +155,7 @@ class GuildTemplate extends Base {
 
   /**
    * Options used to edit a guild template.
-   * @typedef {Object} GuildTemplateEditOptions
+   * @typedef {object} GuildTemplateEditOptions
    * @property {string} [name] The name of this template
    * @property {string} [description] The description of this template
    */

--- a/packages/discord.js/src/structures/Integration.js
+++ b/packages/discord.js/src/structures/Integration.js
@@ -6,7 +6,7 @@ const IntegrationApplication = require('./IntegrationApplication');
 
 /**
  * The information account for an integration
- * @typedef {Object} IntegrationAccount
+ * @typedef {object} IntegrationAccount
  * @property {Snowflake|string} id The id of the account
  * @property {string} name The name of the account
  */

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -201,7 +201,7 @@ class Message extends Base {
     if ('role_subscription_data' in data) {
       /**
        * Role subscription data found on {@link MessageType.RoleSubscriptionPurchase} messages.
-       * @typedef {Object} RoleSubscriptionData
+       * @typedef {object} RoleSubscriptionData
        * @property {Snowflake} roleSubscriptionListingId The id of the SKU and listing the user is subscribed to
        * @property {string} tierName The name of the tier the user is subscribed to
        * @property {number} totalMonthsSubscribed The total number of months the user has been subscribed for
@@ -226,7 +226,7 @@ class Message extends Base {
     if ('resolved' in data) {
       /**
        * Resolved data from auto-populated select menus.
-       * @typedef {Object} CommandInteractionResolvedData
+       * @typedef {object} CommandInteractionResolvedData
        */
       this.resolved = transformResolved(
         { client: this.client, guild: this.guild, channel: this.channel },
@@ -358,7 +358,7 @@ class Message extends Base {
      * * {@link MessageType.Reply}
      * * {@link MessageType.ThreadStarterMessage}
      * @see {@link https://discord.com/developers/docs/resources/channel#message-types}
-     * @typedef {Object} MessageReference
+     * @typedef {object} MessageReference
      * @property {Snowflake} channelId The channel's id the message was referenced
      * @property {?Snowflake} guildId The guild's id the message was referenced
      * @property {?Snowflake} messageId The message's id that was referenced
@@ -384,7 +384,7 @@ class Message extends Base {
 
     /**
      * Partial data of the interaction that a message is a reply to
-     * @typedef {Object} MessageInteraction
+     * @typedef {object} MessageInteraction
      * @property {Snowflake} id The interaction's id
      * @property {InteractionType} type The type of the interaction
      * @property {string} commandName The name of the interaction's application command,
@@ -575,7 +575,7 @@ class Message extends Base {
 
   /**
    * An object containing the same properties as CollectorOptions, but a few more:
-   * @typedef {Object} AwaitMessageComponentOptions
+   * @typedef {object} AwaitMessageComponentOptions
    * @property {CollectorFilter} [filter] The filter applied to this collector
    * @property {number} [time] Time to wait for an interaction before rejecting
    * @property {ComponentType} [componentType] The type of component interaction to collect
@@ -866,7 +866,7 @@ class Message extends Base {
 
   /**
    * Options for starting a thread on a message.
-   * @typedef {Object} StartThreadOptions
+   * @typedef {object} StartThreadOptions
    * @property {string} name The name of the new thread
    * @property {ThreadAutoArchiveDuration} [autoArchiveDuration=this.channel.defaultAutoArchiveDuration] The amount of
    * time after which the thread should automatically archive in case of no recent activity

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -150,7 +150,7 @@ class MessageMentions {
 
     /**
      * Crossposted channel data.
-     * @typedef {Object} CrosspostedChannel
+     * @typedef {object} CrosspostedChannel
      * @property {Snowflake} channelId The mentioned channel's id
      * @property {Snowflake} guildId The id of the guild that has the channel
      * @property {ChannelType} type The channel's type
@@ -242,7 +242,7 @@ class MessageMentions {
 
   /**
    * Options used to check for a mention.
-   * @typedef {Object} MessageMentionsHasOptions
+   * @typedef {object} MessageMentionsHasOptions
    * @property {boolean} [ignoreDirect=false] Whether to ignore direct mentions to the item
    * @property {boolean} [ignoreRoles=false] Whether to ignore role mentions to a guild member
    * @property {boolean} [ignoreRepliedUser=false] Whether to ignore replied user mention to an user

--- a/packages/discord.js/src/structures/ModalSubmitInteraction.js
+++ b/packages/discord.js/src/structures/ModalSubmitInteraction.js
@@ -9,14 +9,14 @@ const InteractionResponses = require('./interfaces/InteractionResponses');
 const getMessage = lazy(() => require('./Message').Message);
 
 /**
- * @typedef {Object} ModalData
+ * @typedef {object} ModalData
  * @property {string} value The value of the field
  * @property {ComponentType} type The component type of the field
  * @property {string} customId The custom id of the field
  */
 
 /**
- * @typedef {Object} ActionRowModalData
+ * @typedef {object} ActionRowModalData
  * @property {ModalData[]} components The components of this action row
  * @property {ComponentType} type The component type of the action row
  */

--- a/packages/discord.js/src/structures/PartialGroupDMChannel.js
+++ b/packages/discord.js/src/structures/PartialGroupDMChannel.js
@@ -28,7 +28,7 @@ class PartialGroupDMChannel extends BaseChannel {
 
     /**
      * Recipient data received in a {@link PartialGroupDMChannel}.
-     * @typedef {Object} PartialRecipient
+     * @typedef {object} PartialRecipient
      * @property {string} username The username of the recipient
      */
 

--- a/packages/discord.js/src/structures/PermissionOverwrites.js
+++ b/packages/discord.js/src/structures/PermissionOverwrites.js
@@ -103,11 +103,11 @@ class PermissionOverwrites extends Base {
    *  'AttachFiles': false,
    * }
    * ```
-   * @typedef {Object} PermissionOverwriteOptions
+   * @typedef {object} PermissionOverwriteOptions
    */
 
   /**
-   * @typedef {Object} ResolvedOverwriteOptions
+   * @typedef {object} ResolvedOverwriteOptions
    * @property {PermissionsBitField} allow The allowed permissions
    * @property {PermissionsBitField} deny The denied permissions
    */
@@ -140,7 +140,7 @@ class PermissionOverwrites extends Base {
 
   /**
    * The raw data for a permission overwrite
-   * @typedef {Object} RawOverwriteData
+   * @typedef {object} RawOverwriteData
    * @property {Snowflake} id The id of the {@link Role} or {@link User} this overwrite belongs to
    * @property {string} allow The permissions to allow
    * @property {string} deny The permissions to deny
@@ -156,7 +156,7 @@ class PermissionOverwrites extends Base {
 
   /**
    * Data that can be used for a permission overwrite
-   * @typedef {Object} OverwriteData
+   * @typedef {object} OverwriteData
    * @property {GuildMemberResolvable|RoleResolvable} id Member or role this overwrite is for
    * @property {PermissionResolvable} [allow] The permissions to allow
    * @property {PermissionResolvable} [deny] The permissions to deny

--- a/packages/discord.js/src/structures/Presence.js
+++ b/packages/discord.js/src/structures/Presence.js
@@ -7,7 +7,7 @@ const { flatten } = require('../util/Util');
 
 /**
  * Activity sent in a message.
- * @typedef {Object} MessageActivity
+ * @typedef {object} MessageActivity
  * @property {string} [partyId] Id of the party represented in activity
  * @property {MessageActivityType} type Type of activity sent
  */
@@ -94,7 +94,7 @@ class Presence extends Base {
     if ('client_status' in data) {
       /**
        * The devices this presence is on
-       * @type {?Object}
+       * @type {?object}
        * @property {?ClientPresenceStatus} web The current presence in the web application
        * @property {?ClientPresenceStatus} mobile The current presence in the mobile application
        * @property {?ClientPresenceStatus} desktop The current presence in the desktop application
@@ -187,7 +187,7 @@ class Activity {
 
     /**
      * Represents timestamps of an activity
-     * @typedef {Object} ActivityTimestamps
+     * @typedef {object} ActivityTimestamps
      * @property {?Date} start When the activity started
      * @property {?Date} end When the activity will end
      */
@@ -205,7 +205,7 @@ class Activity {
 
     /**
      * Represents a party of an activity
-     * @typedef {Object} ActivityParty
+     * @typedef {object} ActivityParty
      * @property {?string} id The party's id
      * @property {number[]} size Size of the party as `[current, max]`
      */

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -115,7 +115,7 @@ class Role extends Base {
 
     /**
      * The tags this role has
-     * @type {?Object}
+     * @type {?object}
      * @property {Snowflake} [botId] The id of the bot this role belongs to
      * @property {Snowflake|string} [integrationId] The id of the integration this role belongs to
      * @property {true} [premiumSubscriberRole] Whether this is the guild's premium subscription role
@@ -228,7 +228,7 @@ class Role extends Base {
 
   /**
    * The data for a role.
-   * @typedef {Object} RoleData
+   * @typedef {object} RoleData
    * @property {string} [name] The name of the role
    * @property {ColorResolvable} [color] The color of the role, either a hex string or a base 10 number
    * @property {boolean} [hoist] Whether or not the role should be hoisted
@@ -378,7 +378,7 @@ class Role extends Base {
 
   /**
    * Options used to set the position of a role.
-   * @typedef {Object} SetRolePositionOptions
+   * @typedef {object} SetRolePositionOptions
    * @property {boolean} [relative=false] Whether to change the position relative to its current value or not
    * @property {string} [reason] The reason for changing the position
    */

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -198,7 +198,7 @@ class Sticker extends Base {
 
   /**
    * Data for editing a sticker.
-   * @typedef {Object} GuildStickerEditOptions
+   * @typedef {object} GuildStickerEditOptions
    * @property {string} [name] The name of the sticker
    * @property {?string} [description] The description of the sticker
    * @property {string} [tags] The Discord name of a unicode emoji representing the sticker's expression

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -320,7 +320,7 @@ class ThreadChannel extends BaseChannel {
 
   /**
    * The options used to edit a thread channel
-   * @typedef {Object} ThreadEditOptions
+   * @typedef {object} ThreadEditOptions
    * @property {string} [name] The new name for the thread
    * @property {boolean} [archived] Whether the thread is archived
    * @property {ThreadAutoArchiveDuration} [autoArchiveDuration] The amount of time after which the thread

--- a/packages/discord.js/src/structures/ThreadOnlyChannel.js
+++ b/packages/discord.js/src/structures/ThreadOnlyChannel.js
@@ -6,13 +6,13 @@ const GuildForumThreadManager = require('../managers/GuildForumThreadManager');
 const { transformAPIGuildForumTag, transformAPIGuildDefaultReaction } = require('../util/Channels');
 
 /**
- * @typedef {Object} GuildForumTagEmoji
+ * @typedef {object} GuildForumTagEmoji
  * @property {?Snowflake} id The id of a guild's custom emoji
  * @property {?string} name The unicode character of the emoji
  */
 
 /**
- * @typedef {Object} GuildForumTag
+ * @typedef {object} GuildForumTag
  * @property {Snowflake} id The id of the tag
  * @property {string} name The name of the tag
  * @property {boolean} moderated Whether this tag can only be added to or removed from threads
@@ -21,7 +21,7 @@ const { transformAPIGuildForumTag, transformAPIGuildDefaultReaction } = require(
  */
 
 /**
- * @typedef {Object} GuildForumTagData
+ * @typedef {object} GuildForumTagData
  * @property {Snowflake} [id] The id of the tag
  * @property {string} name The name of the tag
  * @property {boolean} [moderated] Whether this tag can only be added to or removed from threads
@@ -30,7 +30,7 @@ const { transformAPIGuildForumTag, transformAPIGuildDefaultReaction } = require(
  */
 
 /**
- * @typedef {Object} DefaultReactionEmoji
+ * @typedef {object} DefaultReactionEmoji
  * @property {?Snowflake} id The id of a guild's custom emoji
  * @property {?string} name The unicode character of the emoji
  */

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -208,7 +208,7 @@ class VoiceState extends Base {
 
   /**
    * Data to edit the logged in user's own voice state with, when in a stage channel
-   * @typedef {Object} VoiceStateEditOptions
+   * @typedef {object} VoiceStateEditOptions
    * @property {boolean} [requestToSpeak] Whether or not the client is requesting to become a speaker.
    * <info>Only available to the logged in user's own voice state.</info>
    * @property {boolean} [suppressed] Whether or not the user should be suppressed.

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -232,7 +232,7 @@ class Webhook {
 
   /**
    * Sends a raw slack message with this webhook.
-   * @param {Object} body The raw body to send
+   * @param {object} body The raw body to send
    * @returns {Promise<boolean>}
    * @example
    * // Send a slack message
@@ -261,7 +261,7 @@ class Webhook {
 
   /**
    * Options used to edit a {@link Webhook}.
-   * @typedef {Object} WebhookEditOptions
+   * @typedef {object} WebhookEditOptions
    * @property {string} [name=this.name] The new name for the webhook
    * @property {?(BufferResolvable)} [avatar] The new avatar for the webhook
    * @property {GuildTextChannelResolvable|VoiceChannel|StageChannel|ForumChannel|MediaChannel} [channel]

--- a/packages/discord.js/src/structures/WelcomeChannel.js
+++ b/packages/discord.js/src/structures/WelcomeChannel.js
@@ -25,7 +25,7 @@ class WelcomeChannel extends Base {
 
     /**
      * The raw emoji data
-     * @type {Object}
+     * @type {object}
      * @private
      */
     this._emoji = {

--- a/packages/discord.js/src/structures/Widget.js
+++ b/packages/discord.js/src/structures/Widget.js
@@ -17,7 +17,7 @@ class Widget extends Base {
 
   /**
    * Represents a channel in a Widget
-   * @typedef {Object} WidgetChannel
+   * @typedef {object} WidgetChannel
    * @property {Snowflake} id Id of the channel
    * @property {string} name Name of the channel
    * @property {number} position Position of the channel

--- a/packages/discord.js/src/structures/WidgetMember.js
+++ b/packages/discord.js/src/structures/WidgetMember.js
@@ -9,7 +9,7 @@ const Base = require('./Base');
 class WidgetMember extends Base {
   /**
    * Activity sent in a {@link WidgetMember}.
-   * @typedef {Object} WidgetActivity
+   * @typedef {object} WidgetActivity
    * @property {string} name The name of the activity
    */
 

--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -16,7 +16,7 @@ const { flatten } = require('../../util/Util');
 
 /**
  * Options to be applied to the collector.
- * @typedef {Object} CollectorOptions
+ * @typedef {object} CollectorOptions
  * @property {CollectorFilter} [filter] The filter applied to this collector
  * @property {number} [time] How long to run the collector for in milliseconds
  * @property {number} [idle] How long to stop the collector after inactivity in milliseconds
@@ -235,7 +235,7 @@ class Collector extends EventEmitter {
 
   /**
    * Options used to reset the timeout and idle timer of a {@link Collector}.
-   * @typedef {Object} CollectorResetTimerOptions
+   * @typedef {object} CollectorResetTimerOptions
    * @property {number} [time] How long to run the collector for (in milliseconds)
    * @property {number} [idle] How long to wait to stop the collector after inactivity (in milliseconds)
    */

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -8,7 +8,7 @@ const InteractionResponse = require('../InteractionResponse');
 const MessagePayload = require('../MessagePayload');
 
 /**
- * @typedef {Object} ModalComponentData
+ * @typedef {object} ModalComponentData
  * @property {string} title The title of the modal
  * @property {string} customId The custom id of the modal
  * @property {ActionRow[]} components The components within this modal
@@ -21,14 +21,14 @@ const MessagePayload = require('../MessagePayload');
 class InteractionResponses {
   /**
    * Options for deferring the reply to an {@link BaseInteraction}.
-   * @typedef {Object} InteractionDeferReplyOptions
+   * @typedef {object} InteractionDeferReplyOptions
    * @property {boolean} [ephemeral] Whether the reply should be ephemeral
    * @property {boolean} [fetchReply] Whether to fetch the reply
    */
 
   /**
    * Options for deferring and updating the reply to a {@link MessageComponentInteraction}.
-   * @typedef {Object} InteractionDeferUpdateOptions
+   * @typedef {object} InteractionDeferUpdateOptions
    * @property {boolean} [fetchReply] Whether to fetch the reply
    */
 
@@ -262,7 +262,7 @@ class InteractionResponses {
 
   /**
    * An object containing the same properties as {@link CollectorOptions}, but a few less:
-   * @typedef {Object} AwaitModalSubmitOptions
+   * @typedef {object} AwaitModalSubmitOptions
    * @property {CollectorFilter} [filter] The filter applied to this collector
    * @property {number} time Time in milliseconds to wait for an interaction before rejecting
    */

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -54,7 +54,7 @@ class TextBasedChannel {
 
   /**
    * The base message options for messages.
-   * @typedef {Object} BaseMessageOptions
+   * @typedef {object} BaseMessageOptions
    * @property {?string} [content=''] The content for the message. This can only be `null` when editing a message.
    * @property {Array<(EmbedBuilder|Embed|APIEmbed)>} [embeds] The embeds for the message
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
@@ -67,7 +67,7 @@ class TextBasedChannel {
 
   /**
    * Options for sending a message with a reply.
-   * @typedef {Object} ReplyOptions
+   * @typedef {object} ReplyOptions
    * @property {MessageResolvable} messageReference The message to reply to (must be in the same channel and not system)
    * @property {boolean} [failIfNotExists=this.client.options.failIfNotExists] Whether to error if the referenced
    * message does not exist (creates a standard message in this case when false)
@@ -91,7 +91,7 @@ class TextBasedChannel {
 
   /**
    * Options provided to control parsing of mentions by Discord
-   * @typedef {Object} MessageMentionOptions
+   * @typedef {object} MessageMentionOptions
    * @property {MessageMentionTypes[]} [parse] Types of mentions to be parsed
    * @property {Snowflake[]} [users] Snowflakes of Users to be parsed as mentions
    * @property {Snowflake[]} [roles] Snowflakes of Roles to be parsed as mentions
@@ -327,7 +327,7 @@ class TextBasedChannel {
 
   /**
    * Options used to create a {@link Webhook}.
-   * @typedef {Object} ChannelWebhookCreateOptions
+   * @typedef {object} ChannelWebhookCreateOptions
    * @property {string} name The name of the webhook
    * @property {?(BufferResolvable|Base64Resolvable)} [avatar] Avatar for the webhook
    * @property {string} [reason] Reason for creating the webhook

--- a/packages/discord.js/src/util/BitField.js
+++ b/packages/discord.js/src/util/BitField.js
@@ -9,7 +9,7 @@ class BitField {
   /**
    * Numeric bitfield flags.
    * <info>Defined in extension classes</info>
-   * @type {Object}
+   * @type {object}
    * @memberof BitField
    * @abstract
    */
@@ -113,7 +113,7 @@ class BitField {
    * Gets an object mapping field names to a {@link boolean} indicating whether the
    * bit is available.
    * @param {...*} hasParams Additional parameters for the has method, if any
-   * @returns {Object}
+   * @returns {object}
    */
   serialize(...hasParams) {
     const serialized = {};

--- a/packages/discord.js/src/util/Channels.js
+++ b/packages/discord.js/src/util/Channels.js
@@ -20,7 +20,7 @@ const getMediaChannel = lazy(() => require('../structures/MediaChannel'));
  * @param {Client} client The client
  * @param {APIChannel} data The data of the channel to create
  * @param {Guild} [guild] The guild where this channel belongs
- * @param {Object} [extras] Extra information to supply for creating this channel
+ * @param {object} [extras] Extra information to supply for creating this channel
  * @returns {BaseChannel} Any kind of channel.
  * @ignore
  */

--- a/packages/discord.js/src/util/Colors.js
+++ b/packages/discord.js/src/util/Colors.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * @typedef {Object} Colors
+ * @typedef {object} Colors
  * @property {number} Default 0x000000 | rgb(0,0,0)
  * @property {number} White 0xFFFFFF | rgb(255,255,255)
  * @property {number} Aqua 0x1ABC9C | rgb(26,188,156)

--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -4,7 +4,7 @@
 const { ComponentBuilder } = require('@discordjs/builders');
 const { ComponentType } = require('discord-api-types/v10');
 /**
- * @typedef {Object} BaseComponentData
+ * @typedef {object} BaseComponentData
  * @property {ComponentType} type The type of component
  */
 

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -208,7 +208,7 @@ exports.DeletableMessageTypes = [
  * * {@link StickerFormatType.APNG} -> {@link ImageFormat.PNG}
  * * {@link StickerFormatType.Lottie} -> {@link ImageFormat.Lottie}
  * * {@link StickerFormatType.GIF} -> {@link ImageFormat.GIF}
- * @typedef {Object} StickerFormatExtensionMap
+ * @typedef {object} StickerFormatExtensionMap
  */
 exports.StickerFormatExtensionMap = {
   [StickerFormatType.PNG]: ImageFormat.PNG,
@@ -218,7 +218,7 @@ exports.StickerFormatExtensionMap = {
 };
 
 /**
- * @typedef {Object} Constants Constants that can be used in an enum or object-like way.
+ * @typedef {object} Constants Constants that can be used in an enum or object-like way.
  * @property {number} MaxBulkDeletableMessageAge Max bulk deletable message age
  * @property {SweeperKey[]} SweeperKeys The possible names of items that can be swept in sweepers
  * @property {NonSystemMessageTypes} NonSystemMessageTypes The types of messages that are not deemed a system type
@@ -226,5 +226,5 @@ exports.StickerFormatExtensionMap = {
  * @property {ThreadChannelTypes} ThreadChannelTypes The types of channels that are threads
  * @property {VoiceBasedChannelTypes} VoiceBasedChannelTypes The types of channels that are voice-based
  * @property {SelectMenuTypes} SelectMenuTypes The types of components that are select menus.
- * @property {Object} StickerFormatExtensionMap A mapping between sticker formats and their respective image formats.
+ * @property {object} StickerFormatExtensionMap A mapping between sticker formats and their respective image formats.
  */

--- a/packages/discord.js/src/util/DataResolver.js
+++ b/packages/discord.js/src/util/DataResolver.js
@@ -101,7 +101,7 @@ class DataResolver extends null {
    */
 
   /**
-   * @typedef {Object} ResolvedFile
+   * @typedef {object} ResolvedFile
    * @property {Buffer} data Buffer containing the file data
    * @property {string} [contentType] Content type of the file
    */

--- a/packages/discord.js/src/util/Events.js
+++ b/packages/discord.js/src/util/Events.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * @typedef {Object} Events
+ * @typedef {object} Events
  * @property {string} ApplicationCommandPermissionsUpdate applicationCommandPermissionsUpdate
  * @property {string} AutoModerationActionExecution autoModerationActionExecution
  * @property {string} AutoModerationRuleCreate autoModerationRuleCreate

--- a/packages/discord.js/src/util/Formatters.js
+++ b/packages/discord.js/src/util/Formatters.js
@@ -377,7 +377,7 @@ class Formatters extends null {
   /**
    * The message formatting timestamp
    * [styles](https://discord.com/developers/docs/reference#message-formatting-timestamp-styles) supported by Discord.
-   * @type {Object<string, TimestampStylesString>}
+   * @type {Record<string, TimestampStylesString>}
    * @memberof Formatters
    * @deprecated Import this property directly from discord.js instead.
    */

--- a/packages/discord.js/src/util/LimitedCollection.js
+++ b/packages/discord.js/src/util/LimitedCollection.js
@@ -5,7 +5,7 @@ const { DiscordjsTypeError, ErrorCodes } = require('../errors');
 
 /**
  * Options for defining the behavior of a LimitedCollection
- * @typedef {Object} LimitedCollectionOptions
+ * @typedef {object} LimitedCollectionOptions
  * @property {?number} [maxSize=Infinity] The maximum size of the Collection
  * @property {?Function} [keepOverLimit=null] A function, which is passed the value and key of an entry, ran to decide
  * to keep an entry past the maximum size

--- a/packages/discord.js/src/util/Options.js
+++ b/packages/discord.js/src/util/Options.js
@@ -15,7 +15,7 @@ const { version } = require('../../package.json');
 
 /**
  * Options for a client.
- * @typedef {Object} ClientOptions
+ * @typedef {object} ClientOptions
  * @property {number|number[]|string} [shards] The shard's id to run, or an array of shard ids. If not specified,
  * the client will spawn {@link ClientOptions#shardCount} shards. If set to `auto`, it will fetch the
  * recommended amount of shards from Discord and spawn that amount
@@ -45,12 +45,12 @@ const { version } = require('../../package.json');
 
 /**
  * Options for {@link Sweepers} defining the behavior of cache sweeping
- * @typedef {Object<SweeperKey, SweepOptions>} SweeperOptions
+ * @typedef {Record<SweeperKey, SweepOptions>} SweeperOptions
  */
 
 /**
  * Options for sweeping a single type of item from cache
- * @typedef {Object} SweepOptions
+ * @typedef {object} SweepOptions
  * @property {number} interval The interval (in seconds) at which to perform sweeping of the item
  * @property {number} [lifetime] How long an item should stay in cache until it is considered sweepable.
  * <warn>This property is only valid for the `invites`, `messages`, and `threads` keys. The `filter` property
@@ -84,7 +84,7 @@ const { version } = require('../../package.json');
 
 /**
  * WebSocket options (these are left as snake_case to match the API)
- * @typedef {Object} WebsocketOptions
+ * @typedef {object} WebsocketOptions
  * @property {number} [large_threshold=50] Number of members in a guild after which offline users will no longer be
  * sent in the initial guild member list, must be between 50 and 250
  * @property {number} [version=10] The Discord gateway version to use <warn>Changing this can break the library;
@@ -133,7 +133,7 @@ class Options extends null {
 
   /**
    * Create a cache factory using predefined settings to sweep or limit.
-   * @param {Object<string, LimitedCollectionOptions|number>} [settings={}] Settings passed to the relevant constructor.
+   * @param {Record<string, LimitedCollectionOptions|number>} [settings={}] Settings passed to the relevant constructor.
    * If no setting is provided for a manager, it uses Collection.
    * If a number is provided for a manager, it uses that number as the max size for a LimitedCollection.
    * If LimitedCollectionOptions are provided for a manager, it uses those settings to form a LimitedCollection.
@@ -188,7 +188,7 @@ class Options extends null {
    * * `MessageManager` - Limit to 200 messages
    * <info>If you want to keep default behavior and add on top of it you can use this object and add on to it, e.g.
    * `makeCache: Options.cacheWithLimits({ ...Options.DefaultMakeCacheSettings, ReactionManager: 0 })`</info>
-   * @type {Object<string, LimitedCollectionOptions|number>}
+   * @type {Record<string, LimitedCollectionOptions|number>}
    */
   static get DefaultMakeCacheSettings() {
     return {

--- a/packages/discord.js/src/util/Partials.js
+++ b/packages/discord.js/src/util/Partials.js
@@ -17,7 +17,7 @@ const { createEnum } = require('./Enums');
  *   ]
  * });
  * ```
- * @typedef {Object} Partials
+ * @typedef {object} Partials
  * @property {number} User The partial to receive uncached users.
  * @property {number} Channel The partial to receive uncached channels.
  * <info>This is required to receive direct messages!</info>

--- a/packages/discord.js/src/util/ShardEvents.js
+++ b/packages/discord.js/src/util/ShardEvents.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * @typedef {Object} ShardEvents
+ * @typedef {object} ShardEvents
  * @property {string} Death death
  * @property {string} Disconnect disconnect
  * @property {string} Error error

--- a/packages/discord.js/src/util/Status.js
+++ b/packages/discord.js/src/util/Status.js
@@ -3,7 +3,7 @@
 const { createEnum } = require('./Enums');
 
 /**
- * @typedef {Object} Status
+ * @typedef {object} Status
  * @property {number} Ready
  * @property {number} Connecting
  * @property {number} Reconnecting

--- a/packages/discord.js/src/util/Sweepers.js
+++ b/packages/discord.js/src/util/Sweepers.js
@@ -32,7 +32,7 @@ class Sweepers {
 
     /**
      * A record of interval timeout that is used to sweep the indicated items, or null if not being swept
-     * @type {Object<SweeperKey, ?Timeout>}
+     * @type {Record<SweeperKey, ?Timeout>}
      */
     this.intervals = Object.fromEntries(SweeperKeys.map(key => [key, null]));
 
@@ -303,7 +303,7 @@ class Sweepers {
 
   /**
    * Options for generating a filter function based on lifetime
-   * @typedef {Object} LifetimeFilterOptions
+   * @typedef {object} LifetimeFilterOptions
    * @property {number} [lifetime=14400] How long, in seconds, an entry should stay in the collection
    * before it is considered sweepable.
    * @property {Function} [getComparisonTimestamp=e => e?.createdTimestamp] A function that takes an entry, key,
@@ -385,7 +385,7 @@ class Sweepers {
 
   /**
    * Configuration options for emitting the cache sweep client event
-   * @typedef {Object} SweepEventOptions
+   * @typedef {object} SweepEventOptions
    * @property {boolean} [emit=true] Whether to emit the client event in this method
    * @property {string} [outputName] A name to output in the client event if it should differ from the key
    * @private
@@ -396,7 +396,7 @@ class Sweepers {
    * @param {string} key The name of the property
    * @param {Function} filter Filter function passed to sweep
    * @param {SweepEventOptions} [eventOptions={}] Options for the Client event emitted here
-   * @returns {Object} Object containing the number of guilds swept and the number of items swept
+   * @returns {object} Object containing the number of guilds swept and the number of items swept
    * @private
    */
   _sweepGuildDirectProp(key, filter, { emit = true, outputName } = {}) {
@@ -450,7 +450,7 @@ class Sweepers {
    * Initialize an interval for sweeping
    * @param {string} intervalKey The name of the property that stores the interval for this sweeper
    * @param {string} sweepKey The name of the function that sweeps the desired caches
-   * @param {Object} opts Validated options for a sweep
+   * @param {object} opts Validated options for a sweep
    * @private
    */
   _initInterval(intervalKey, sweepKey, opts) {

--- a/packages/discord.js/src/util/ThreadMemberFlagsBitField.js
+++ b/packages/discord.js/src/util/ThreadMemberFlagsBitField.js
@@ -9,7 +9,7 @@ const BitField = require('./BitField');
 class ThreadMemberFlagsBitField extends BitField {
   /**
    * Numeric thread member flags. There are currently no bitflags relevant to bots for this.
-   * @type {Object<string, number>}
+   * @type {Record<string, number>}
    * @memberof ThreadMemberFlagsBitField
    */
   static Flags = {};

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -10,9 +10,9 @@ const isObject = d => typeof d === 'object' && d !== null;
 
 /**
  * Flatten an object. Any properties that are collections will get converted to an array of keys.
- * @param {Object} obj The object to flatten.
- * @param {...Object<string, boolean|string>} [props] Specific properties to include/exclude.
- * @returns {Object}
+ * @param {object} obj The object to flatten.
+ * @param {...Record<string, boolean|string>} [props] Specific properties to include/exclude.
+ * @returns {object}
  */
 function flatten(obj, ...props) {
   if (!isObject(obj)) return obj;
@@ -54,7 +54,7 @@ function flatten(obj, ...props) {
 }
 
 /**
- * @typedef {Object} FetchRecommendedShardCountOptions
+ * @typedef {object} FetchRecommendedShardCountOptions
  * @property {number} [guildsPerShard=1000] Number of guilds assigned per shard
  * @property {number} [multipleOf=1] The multiple the shard count should round up to. (16 for large bot sharding)
  */
@@ -81,7 +81,7 @@ async function fetchRecommendedShardCount(token, { guildsPerShard = 1_000, multi
 
 /**
  * A partial emoji object.
- * @typedef {Object} PartialEmoji
+ * @typedef {object} PartialEmoji
  * @property {boolean} animated Whether the emoji is animated
  * @property {Snowflake|undefined} id The id of the emoji
  * @property {string} name The name of the emoji
@@ -104,7 +104,7 @@ function parseEmoji(text) {
 
 /**
  * A partial emoji object with only an id.
- * @typedef {Object} PartialEmojiOnlyId
+ * @typedef {object} PartialEmojiOnlyId
  * @property {Snowflake} id The id of the emoji
  */
 
@@ -124,7 +124,7 @@ function resolvePartialEmoji(emoji) {
 
 /**
  * Options used to make an error object.
- * @typedef {Object} MakeErrorOptions
+ * @typedef {object} MakeErrorOptions
  * @property {string} name Error type
  * @property {string} message Message for the error
  * @property {string} stack Stack for the error
@@ -411,7 +411,7 @@ function parseWebhookURL(url) {
 
 /**
  * Supportive data for interaction resolved data.
- * @typedef {Object} SupportingInteractionResolvedData
+ * @typedef {object} SupportingInteractionResolvedData
  * @property {Client} client The client
  * @property {Guild} [guild] A guild
  * @property {GuildTextBasedChannel} [channel] A channel

--- a/packages/discord.js/src/util/WebSocketShardEvents.js
+++ b/packages/discord.js/src/util/WebSocketShardEvents.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * @typedef {Object} WebSocketShardEvents
+ * @typedef {object} WebSocketShardEvents
  * @property {string} Close close
  * @property {string} Destroyed destroyed
  * @property {string} InvalidSession invalidSession


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Use `object` instead of `Object`, and `Record<X, Y>` instead of `Object<X, Y>`. The old documentation website supports both of these, while the new one only supports `object` and `Record<X, Y>` (documentation link wise)
https://github.com/discordjs/website/blob/a20e892d5d056f5caec26b69f1d136af13a2568e/src/store.ts#L301
https://github.com/discordjs/website/blob/a20e892d5d056f5caec26b69f1d136af13a2568e/src/store.ts#L327

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
