### PR TITLE
fix: replace Object< with Record<

### DIFF
--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -219,12 +219,12 @@ function filePathFromJson(meta: DocgenMetaJson): string {
 	return `${meta.path.slice('packages/discord.js/'.length)}/${meta.file}`;
 }
 
-function fixPrimitiveTypes(type: string) {
+function fixPrimitiveTypes(type: string, symbol: string | undefined) {
 	switch (type) {
 		case '*':
 			return 'any';
 		case 'Object':
-			return 'object';
+			return symbol === '<' ? 'Record' : 'object';
 		default:
 			return type;
 	}
@@ -1682,7 +1682,7 @@ export class ApiModelGenerator {
 						...arr,
 						{
 							kind: type?.includes("'") ? ExcerptTokenKind.Content : ExcerptTokenKind.Reference,
-							text: fixPrimitiveTypes(type ?? 'unknown'),
+							text: fixPrimitiveTypes(type ?? 'unknown', symbol),
 							canonicalReference: type?.includes("'")
 								? undefined
 								: DeclarationReference.package(this._apiModel.packages[0]!.name)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Object<` in docgen should be `Record<` in api-extractor, not `object`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
