### PR TITLE
Fix: TypeScript thinks channel.send doesn't exist

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6472,23 +6472,29 @@ export interface LimitedCollectionOptions<Key, Value> {
   keepOverLimit?: (value: Value, key: Key, collection: LimitedCollection<Key, Value>) => boolean;
 }
 
+type ChannelWithSend = 
+  { send: (message: unknown) => Promise<Message<boolean>> } &
+  (
+    | CategoryChannel
+    | DMChannel
+    | PartialDMChannel
+    | PartialGroupDMChannel
+    | NewsChannel
+    | StageChannel
+    | TextChannel
+    | AnyThreadChannel
+    | VoiceChannel
+  );
+
 export type Channel =
-  | CategoryChannel
-  | DMChannel
-  | PartialDMChannel
-  | PartialGroupDMChannel
-  | NewsChannel
-  | StageChannel
-  | TextChannel
-  | AnyThreadChannel
-  | VoiceChannel
+  | ChannelWithSend
   | ForumChannel
   | MediaChannel;
 
 export type TextBasedChannel = Exclude<
   Extract<Channel, { type: TextChannelType }>,
   PartialGroupDMChannel | ForumChannel | MediaChannel
-> & { send: (message: unknown) => Promise<Message<boolean>> };
+>;
 
 export type TextBasedChannelTypes = TextBasedChannel['type'];
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6488,7 +6488,7 @@ export type Channel =
 export type TextBasedChannel = Exclude<
   Extract<Channel, { type: TextChannelType }>,
   PartialGroupDMChannel | ForumChannel | MediaChannel
->;
+> & { send: (message: unknown) => Promise<Message<boolean>> };
 
 export type TextBasedChannelTypes = TextBasedChannel['type'];
 


### PR DESCRIPTION
Before this PR, calling channel.send using TS would result in getting error that such function doesn't exist ( which is obviously incorrect, because it does ). This PR will change it.