### PR TITLE
fix(Bun): Fix typo for Bun template

### DIFF
--- a/packages/create-discord-bot/src/create-discord-bot.ts
+++ b/packages/create-discord-bot/src/create-discord-bot.ts
@@ -58,10 +58,10 @@ export async function createDiscordBot({ directory, installPackages, typescript,
 
 		if (typescript) {
 			await cp(
-				new URL('../template/Bun/Typescript/tsconfig.eslint.json', import.meta.url),
+				new URL('../template/Bun/TypeScript/tsconfig.eslint.json', import.meta.url),
 				`${root}/tsconfig.eslint.json`,
 			);
-			await cp(new URL('../template/Bun/Typescript/tsconfig.json', import.meta.url), `${root}/tsconfig.json`);
+			await cp(new URL('../template/Bun/TypeScript/tsconfig.json', import.meta.url), `${root}/tsconfig.json`);
 		}
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
There was a typo in `create-discord-bot` for `Bun/TypeScript` template which caused it to throw errors at time of install.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
