### PR TITLE
docs: Remove hyphen after `@returns`

### DIFF
--- a/packages/proxy/src/util/responseHelpers.ts
+++ b/packages/proxy/src/util/responseHelpers.ts
@@ -67,7 +67,7 @@ export function populateAbortErrorResponse(res: ServerResponse): void {
  *
  * @param res - The server response to populate
  * @param error - The error to check and use
- * @returns - True if the error is known and the response object was populated, otherwise false
+ * @returns `true` if the error is known and the response object was populated, otherwise `false`
  */
 export function populateErrorResponse(res: ServerResponse, error: unknown): boolean {
 	if (error instanceof DiscordAPIError || error instanceof HTTPError) {

--- a/packages/rest/src/lib/handlers/Shared.ts
+++ b/packages/rest/src/lib/handlers/Shared.ts
@@ -115,7 +115,7 @@ export async function makeNetworkRequest(
  * @param url - The fully resolved url to make the request to
  * @param requestData - Extra data from the user's request needed for errors and additional processing
  * @param retries - The number of retries this request has already attempted (recursion occurs on the handler)
- * @returns - The response if the status code is not handled or null to request a retry
+ * @returns The response if the status code is not handled or null to request a retry
  */
 export async function handleErrors(
 	manager: REST,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The `@returns` tag does not require a hyphen, otherwise, this leads to this description starting with a hyphen in the documentation.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
