### PR TITLE
fix(website): discord-api-types links, URL links and some minor doc issues

### DIFF
--- a/apps/website/src/components/ExcerptText.tsx
+++ b/apps/website/src/components/ExcerptText.tsx
@@ -38,9 +38,13 @@ export function ExcerptText({ excerpt }: ExcerptTextProps) {
 
 						// dapi-types doesn't have routes for class members
 						// so we can assume this member is for an enum
-						if (meaning === 'member' && path && 'parent' in path) href += `/enum/${path.parent}#${path.component}`;
-						else if (meaning === 'type' || meaning === 'var') href += `#${token.text}`;
-						else href += `/${meaning}/${token.text}`;
+						if (meaning === 'member' && path && 'parent' in path) {
+							href += `/enum/${path.parent}#${path.component}`;
+						} else if (meaning === 'type' || meaning === 'var') {
+							href += `#${token.text}`;
+						} else {
+							href += `/${meaning}/${token.text}`;
+						}
 
 						return (
 							<DocumentationLink key={`${token.text}-${idx}`} href={href}>

--- a/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
+++ b/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
@@ -1,13 +1,5 @@
 import { type ApiItem, ApiItemKind } from '@discordjs/api-extractor-model';
-import type {
-	DocComment,
-	DocFencedCode,
-	DocInlineTag,
-	DocLinkTag,
-	DocNode,
-	DocNodeContainer,
-	DocPlainText,
-} from '@microsoft/tsdoc';
+import type { DocComment, DocFencedCode, DocLinkTag, DocNode, DocNodeContainer, DocPlainText } from '@microsoft/tsdoc';
 import { DocNodeKind, StandardTags } from '@microsoft/tsdoc';
 import type { Route } from 'next';
 import Link from 'next/link';

--- a/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
+++ b/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
@@ -62,9 +62,13 @@ export function TSDoc({ item, tsdoc }: { readonly item: ApiItem; readonly tsdoc:
 
 							// dapi-types doesn't have routes for class members
 							// so we can assume this member is for an enum
-							if (kind === 'enum' && members?.[0]) href += `/enum/${displayName}#${members[0].displayName}`;
-							else if (kind === 'type' || kind === 'var') href += `#${displayName}`;
-							else href += `/${kind}/${displayName}`;
+							if (kind === 'enum' && members?.[0]) {
+								href += `/enum/${displayName}#${members[0].displayName}`;
+							} else if (kind === 'type' || kind === 'var') {
+								href += `#${displayName}`;
+							} else {
+								href += `/${kind}/${displayName}`;
+							}
 
 							return (
 								<DocumentationLink key={`${containerKey}-${idx}`} href={href}>

--- a/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
+++ b/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
@@ -9,7 +9,7 @@ import { BuiltinDocumentationLinks } from '~/util/builtinDocumentationLinks';
 import { DISCORD_API_TYPES_DOCS_URL } from '~/util/constants';
 import { ItemLink } from '../../ItemLink';
 import { SyntaxHighlighter } from '../../SyntaxHighlighter';
-import { mapKindToMeaning, resolveCanonicalReference, resolveItemURI } from '../util';
+import { resolveCanonicalReference, resolveItemURI } from '../util';
 import { DefaultValueBlock, DeprecatedBlock, ExampleBlock, RemarksBlock, ReturnsBlock, SeeBlock } from './BlockComment';
 
 export function TSDoc({ item, tsdoc }: { readonly item: ApiItem; readonly tsdoc: DocNode }): JSX.Element {
@@ -62,9 +62,9 @@ export function TSDoc({ item, tsdoc }: { readonly item: ApiItem; readonly tsdoc:
 
 							// dapi-types doesn't have routes for class members
 							// so we can assume this member is for an enum
-							if (kind === 'enum' && members[0]) href += `/enum/${displayName}#${members[0].displayName}`;
+							if (kind === 'enum' && members?.[0]) href += `/enum/${displayName}#${members[0].displayName}`;
 							else if (kind === 'type' || kind === 'var') href += `#${displayName}`;
-							else href += `/${mapKindToMeaning(kind)}/${displayName}`;
+							else href += `/${kind}/${displayName}`;
 
 							return (
 								<DocumentationLink key={`${containerKey}-${idx}`} href={href}>

--- a/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
+++ b/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
@@ -1,4 +1,4 @@
-import { type ApiItem, ApiItemKind } from '@discordjs/api-extractor-model';
+import type { ApiItem } from '@discordjs/api-extractor-model';
 import type { DocComment, DocFencedCode, DocLinkTag, DocNode, DocNodeContainer, DocPlainText } from '@microsoft/tsdoc';
 import { DocNodeKind, StandardTags } from '@microsoft/tsdoc';
 import type { Route } from 'next';

--- a/apps/website/src/components/documentation/util.ts
+++ b/apps/website/src/components/documentation/util.ts
@@ -18,17 +18,13 @@ import { resolveMembers } from '~/util/members';
 import { resolveParameters } from '~/util/model';
 import type { TableOfContentsSerialized } from '../TableOfContentItems';
 
-export type ApiItemLike = {
-	[K in keyof ApiItem]?: K extends 'displayName'
-		? ApiItem[K]
-		: K extends 'kind'
-		  ? string
-		  : K extends 'parent'
-		    ? ApiItemLike | undefined
-		    : K extends 'members'
-		      ? readonly ApiItemLike[]
-		      : ApiItem[K] | undefined;
-};
+export interface ApiItemLike {
+	containerKey?: string;
+	displayName: string;
+	kind: string;
+	members?: readonly ApiItemLike[];
+	parent?: ApiItemLike | undefined;
+}
 
 interface ResolvedCanonicalReference {
 	item: ApiItemLike;

--- a/apps/website/src/components/documentation/util.ts
+++ b/apps/website/src/components/documentation/util.ts
@@ -31,6 +31,23 @@ interface ResolvedCanonicalReference {
 	package: string | undefined;
 }
 
+const kindToMeaning = new Map([
+	[ApiItemKind.CallSignature, Meaning.CallSignature],
+	[ApiItemKind.Class, Meaning.Class],
+	[ApiItemKind.ConstructSignature, Meaning.ConstructSignature],
+	[ApiItemKind.Constructor, Meaning.Constructor],
+	[ApiItemKind.Enum, Meaning.Enum],
+	[ApiItemKind.Event, Meaning.Event],
+	[ApiItemKind.Function, Meaning.Function],
+	[ApiItemKind.IndexSignature, Meaning.IndexSignature],
+	[ApiItemKind.Interface, Meaning.Interface],
+	[ApiItemKind.Property, Meaning.Member],
+	[ApiItemKind.Namespace, Meaning.Namespace],
+	[ApiItemKind.None, Meaning.ComplexType],
+	[ApiItemKind.TypeAlias, Meaning.TypeAlias],
+	[ApiItemKind.Variable, Meaning.Variable],
+]);
+
 export function hasProperties(item: ApiItemContainerMixin) {
 	return resolveMembers(item, memberPredicate).some(
 		({ item: member }) => member.kind === ApiItemKind.Property || member.kind === ApiItemKind.PropertySignature,
@@ -86,6 +103,9 @@ export function resolveCanonicalReference(
 				kind: member.selector!.selector as ApiItemKind,
 				displayName: member.memberIdentifier!.identifier,
 				containerKey: `|${member.selector!.selector}|${member.memberIdentifier!.identifier}`,
+				members: canonicalReference.memberReferences
+					.slice(1)
+					.map((member) => ({ kind: member.kind, displayName: member.memberIdentifier?.identifier })),
 			},
 		};
 	}
@@ -93,37 +113,12 @@ export function resolveCanonicalReference(
 	return null;
 }
 
-function mapMeaningToKind(meaning: Meaning): ApiItemKind {
-	switch (meaning) {
-		case Meaning.CallSignature:
-			return ApiItemKind.CallSignature;
-		case Meaning.Class:
-			return ApiItemKind.Class;
-		case Meaning.ComplexType:
-			throw new Error('Not a valid canonicalReference: Meaning.ComplexType');
-		case Meaning.ConstructSignature:
-			return ApiItemKind.ConstructSignature;
-		case Meaning.Constructor:
-			return ApiItemKind.Constructor;
-		case Meaning.Enum:
-			return ApiItemKind.Enum;
-		case Meaning.Event:
-			return ApiItemKind.Event;
-		case Meaning.Function:
-			return ApiItemKind.Function;
-		case Meaning.IndexSignature:
-			return ApiItemKind.IndexSignature;
-		case Meaning.Interface:
-			return ApiItemKind.Interface;
-		case Meaning.Member:
-			return ApiItemKind.Property;
-		case Meaning.Namespace:
-			return ApiItemKind.Namespace;
-		case Meaning.TypeAlias:
-			return ApiItemKind.TypeAlias;
-		case Meaning.Variable:
-			return ApiItemKind.Variable;
-	}
+export function mapMeaningToKind(meaning: Meaning): ApiItemKind {
+	return [...kindToMeaning.entries()].find((mapping) => mapping[1] === meaning)?.[0];
+}
+
+export function mapKindToMeaning(kind: ApiItemKind): Meaning {
+	return kindToMeaning.get(kind);
 }
 
 export function memberPredicate(

--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -1053,7 +1053,7 @@ export class ApiModelGenerator {
 									.join('') ?? ''
 							}${
 								jsDoc.returns?.length && !Array.isArray(jsDoc.returns[0])
-									? ` * @returns ${this._fixLinkTags(jsDoc.returns[0]!.description) ?? ''}`
+									? ` * @returns ${this._fixLinkTags(jsDoc.returns[0]!.description) ?? ''}\n`
 									: ''
 							}${
 								jsDoc.examples?.map((example) => ` * @example\n * \`\`\`js\n * ${example}\n * \`\`\`\n`).join('') ?? ''
@@ -1143,7 +1143,7 @@ export class ApiModelGenerator {
 									.join('') ?? ''
 							}${
 								jsDoc.returns?.length && !Array.isArray(jsDoc.returns[0])
-									? ` * @returns ${this._fixLinkTags(jsDoc.returns[0]!.description) ?? ''}`
+									? ` * @returns ${this._fixLinkTags(jsDoc.returns[0]!.description) ?? ''}\n`
 									: ''
 							}${
 								jsDoc.deprecated
@@ -1409,9 +1409,9 @@ export class ApiModelGenerator {
 								: ''
 						}${
 							'returns' in jsDoc
-								? jsDoc.returns.map(
-										(ret) => ` * @returns ${Array.isArray(ret) ? '' : this._fixLinkTags(ret.description) ?? ''}\n`,
-								  )
+								? jsDoc.returns
+										.map((ret) => ` * @returns ${Array.isArray(ret) ? '' : this._fixLinkTags(ret.description) ?? ''}\n`)
+										.join('')
 								: ''
 						} */`,
 				  ).docComment
@@ -1854,7 +1854,7 @@ export class ApiModelGenerator {
 						.join('') ?? ''
 				}${
 					method.returns?.length && !Array.isArray(method.returns[0])
-						? ` * @returns ${this._fixLinkTags(method.returns[0]!.description) ?? ''}`
+						? ` * @returns ${this._fixLinkTags(method.returns[0]!.description) ?? ''}\n`
 						: ''
 				}${method.examples?.map((example) => ` * @example\n * \`\`\`js\n * ${example}\n * \`\`\`\n`).join('') ?? ''}${
 					method.deprecated

--- a/packages/discord.js/src/client/BaseClient.js
+++ b/packages/discord.js/src/client/BaseClient.js
@@ -19,11 +19,11 @@ class BaseClient extends EventEmitter {
       throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'options', 'object', true);
     }
 
+    const defaultOptions = Options.createDefault();
     /**
      * The options the client was instantiated with
      * @type {ClientOptions}
      */
-    const defaultOptions = Options.createDefault();
     this.options = {
       ...defaultOptions,
       ...options,

--- a/packages/discord.js/src/client/voice/ClientVoiceManager.js
+++ b/packages/discord.js/src/client/voice/ClientVoiceManager.js
@@ -16,7 +16,7 @@ class ClientVoiceManager {
     Object.defineProperty(this, 'client', { value: client });
 
     /**
-     * Maps guild ids to voice adapters created for use with @discordjs/voice.
+     * Maps guild ids to voice adapters created for use with `@discordjs/voice`.
      * @type {Map<Snowflake, Object>}
      */
     this.adapters = new Map();

--- a/packages/discord.js/src/structures/Guild.js
+++ b/packages/discord.js/src/structures/Guild.js
@@ -1405,7 +1405,7 @@ class Guild extends AnonymousGuild {
   }
 
   /**
-   * The voice state adapter for this guild that can be used with @discordjs/voice to play audio in voice
+   * The voice state adapter for this guild that can be used with `@discordjs/voice` to play audio in voice
    * and stage channels.
    * @type {Function}
    * @readonly

--- a/packages/discord.js/src/util/Sweepers.js
+++ b/packages/discord.js/src/util/Sweepers.js
@@ -8,7 +8,7 @@ const { DiscordjsTypeError, ErrorCodes } = require('../errors');
 /**
  * @typedef {Function} GlobalSweepFilter
  * @returns {?Function} Return `null` to skip sweeping, otherwise a function passed to `sweep()`,
- * See {@link [Collection#sweep](https://discord.js.org/docs/packages/collection/stable/Collection:Class#sweep)}
+ * See {@link https://discord.js.org/docs/packages/collection/stable/Collection:Class#sweep Collection#sweep}
  * for the definition of this function.
  */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- fixes `@link` tags linking to discord-api-types or URL links directly not showing correctly on new docs site
- some minor doc comment issues in mainlib

supersedes #9988 
fixes #9984 

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
