### PR TITLE
fix: cross package links again

### DIFF
--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -1724,7 +1724,7 @@ export class ApiModelGenerator {
 							?.astEntity as AstImport | undefined);
 					const astSymbol = astEntity instanceof AstImport ? astEntity.astSymbol : astEntity;
 					const match = astEntity instanceof AstImport ? moduleNameRegEx.exec(astEntity.modulePath) : null;
-					const pkg = match?.groups?.package ?? this._apiModel.packages[0]!.name;
+					const pkg = match?.groups!.package ?? this._apiModel.packages[0]!.name;
 					return [
 						...arr,
 						{

--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -46,7 +46,7 @@ import { JsonFile, Path } from '@rushstack/node-core-library';
 import * as ts from 'typescript';
 import type { AstDeclaration } from '../analyzer/AstDeclaration.js';
 import type { AstEntity } from '../analyzer/AstEntity.js';
-import type { AstImport } from '../analyzer/AstImport.js';
+import { AstImport } from '../analyzer/AstImport.js';
 import type { AstModule } from '../analyzer/AstModule.js';
 import { AstNamespaceImport } from '../analyzer/AstNamespaceImport.js';
 import { AstSymbol } from '../analyzer/AstSymbol.js';
@@ -212,6 +212,8 @@ interface IProcessAstEntityContext {
 
 const linkRegEx =
 	/{@link\s(?:(?<class>\w+)(?:[#.](?<event>event:)?(?<prop>[\w()]+))?|(?<url>https?:\/\/[^\s}]*))(?<name>\s[^}]*)?}/g;
+
+const moduleNameRegEx = /^(?<package>(?:@[\w.-]+\/)?[\w.-]+)(?<path>(?:\/[\w.-]+)+)?$/i;
 
 function filePathFromJson(meta: DocgenMetaJson): string {
 	return `${meta.path.slice('packages/discord.js/'.length)}/${meta.file}`;
@@ -1713,39 +1715,37 @@ export class ApiModelGenerator {
 		};
 		return mapper
 			.flatMap((typ, index) => {
-				const result = typ.reduce<IExcerptToken[]>(
-					(arr, [type, symbol]) => [
+				const result = typ.reduce<IExcerptToken[]>((arr, [type, symbol]) => {
+					const astEntity =
+						(this._collector.entities.find(
+							(entity) => entity.nameForEmit === type && 'astDeclarations' in entity.astEntity,
+						)?.astEntity as AstSymbol | undefined) ??
+						(this._collector.entities.find((entity) => entity.nameForEmit === type && 'astSymbol' in entity.astEntity)
+							?.astEntity as AstImport | undefined);
+					const astSymbol = astEntity instanceof AstImport ? astEntity.astSymbol : astEntity;
+					const match = astEntity instanceof AstImport ? moduleNameRegEx.exec(astEntity.modulePath) : null;
+					const pkg = match?.groups?.package ?? this._apiModel.packages[0]!.name;
+					return [
 						...arr,
 						{
 							kind: type?.includes("'") ? ExcerptTokenKind.Content : ExcerptTokenKind.Reference,
 							text: fixPrimitiveTypes(type ?? 'unknown', symbol),
 							canonicalReference: type?.includes("'")
 								? undefined
-								: DeclarationReference.package(this._apiModel.packages[0]!.name)
+								: DeclarationReference.package(pkg)
 										.addNavigationStep(
 											Navigation.Members as any,
 											DeclarationReference.parseComponent(type ?? 'unknown'),
 										)
 										.withMeaning(
-											lookup[
-												(
-													(this._collector.entities.find(
-														(entity) => entity.nameForEmit === type && 'astDeclarations' in entity.astEntity,
-													)?.astEntity as AstSymbol | undefined) ??
-													(
-														this._collector.entities.find(
-															(entity) => entity.nameForEmit === type && 'astSymbol' in entity.astEntity,
-														)?.astEntity as AstImport | undefined
-													)?.astSymbol
-												)?.astDeclarations[0]?.declaration.kind ?? ts.SyntaxKind.ClassDeclaration
-											] ?? ('class' as any),
+											lookup[astSymbol?.astDeclarations[0]?.declaration.kind ?? ts.SyntaxKind.ClassDeclaration] ??
+												('class' as any),
 										)
 										.toString(),
 						},
 						{ kind: ExcerptTokenKind.Content, text: symbol ?? '' },
-					],
-					[],
-				);
+					];
+				}, []);
 				return index === 0 ? result : [{ kind: ExcerptTokenKind.Content, text: ' | ' }, ...result];
 			})
 			.filter((excerpt) => excerpt.text.length);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Links to other packages still were sometimes wrong, if the property or method was documented in the inheriting class while only being defined in the inherited class. For example `cache` in Managers.

Fixes #9982

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
