### PR TITLE
fix: InteractionWebhooknot returning a webhook

### DIFF
--- a/src/structures/InteractionWebhook.js
+++ b/src/structures/InteractionWebhook.js
@@ -1,18 +1,21 @@
 'use strict';
 
+const BaseClient = require('../client/BaseClient');
 const Webhook = require('./Webhook');
 
 /**
  * Represents a webhook for an Interaction
  * @implements {Webhook}
+ * @extends {BaseClient}
  */
-class InteractionWebhook {
+class InteractionWebhook extends BaseClient {
   /**
    * @param {Client} client The instantiating client
    * @param {Snowflake} id The application's id
    * @param {string} token The interaction's token
    */
   constructor(client, id, token) {
+    super(client.options);
     /**
      * The client that instantiated the interaction webhook
      * @name InteractionWebhook#client


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The client doesn't get defined in the property when thus line gets called:
`Object.defineProperty(this, 'client', { value: client });` 
because the InteractionWebhook class doesn't inherit client class. 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating