### PR TITLE
refactor(ThreadMemberManager): #remove accepts UserResolvable

### DIFF
--- a/packages/discord.js/src/managers/ThreadMemberManager.js
+++ b/packages/discord.js/src/managers/ThreadMemberManager.js
@@ -103,11 +103,13 @@ class ThreadMemberManager extends CachedManager {
 
   /**
    * Remove a user from the thread.
-   * @param {Snowflake|'@me'} id The id of the member to remove
+   * @param {UserResolvable|'@me'} member The member to remove
    * @param {string} [reason] The reason for removing this member from the thread
    * @returns {Promise<Snowflake>}
    */
-  async remove(id, reason) {
+  async remove(member, reason) {
+    const id = member === '@me' ? member : this.client.users.resolveId(member);
+    if (!id) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'member', 'UserResolvable');
     await this.client.rest.delete(Routes.threadMembers(this.thread.id, id), { reason });
     return id;
   }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4320,7 +4320,7 @@ export class ThreadMemberManager extends CachedManager<Snowflake, ThreadMember, 
 
   public fetch(options?: FetchThreadMembersWithoutGuildMemberDataOptions): Promise<Collection<Snowflake, ThreadMember>>;
   public fetchMe(options?: BaseFetchOptions): Promise<ThreadMember>;
-  public remove(id: Snowflake | '@me', reason?: string): Promise<Snowflake>;
+  public remove(member: UserResolvable | '@me', reason?: string): Promise<Snowflake>;
 }
 
 export class UserManager extends CachedManager<Snowflake, User, UserResolvable> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds the ability to pass a resolvable to `ThreadMemberManager#remove`, in keeping with other manager functions.

Note that this deliberately accepts a UserResolvable to pass to `UserManager#resolveId`, rather than a ThreadMemberResolvable to pass to `ThreadMemberManager#resolveId`. There are two reasons for this:
- `UserManager#resolveId` accepts a ThreadMember as an argument anyway;
- If the client lacks the privileged GUILD_MEMBERS intent, then the ThreadMemberManager cache is never populated, so `ThreadMemberManager#resolveId` always returns null. ([ref](https://discord.com/developers/docs/topics/gateway-events#thread-members-update))

The new argument type is a superset of the old one, and so this is suitable for semver:patch.

**Discussion:**

- Both `ThreadMemberManager#add` and `#remove` accept a reason argument, but neither API endpoint supports the X-Audit-Log-Reason header, as neither event is loggable. I've left them there, as removing the arguments would technically be a breaking change, but these should probably be removed at some point.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
