### PR TITLE
types: omit unnecessary methods from <ContextMenuCommandInteraction>.options

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -542,6 +542,8 @@ export abstract class CommandInteraction<Cached extends CacheType = CacheType> e
     | 'getFocused'
     | 'getMentionable'
     | 'getRole'
+    | 'getUser'
+    | 'getMember'
     | 'getAttachment'
     | 'getNumber'
     | 'getInteger'
@@ -1269,19 +1271,6 @@ export class CommandInteractionOptionResolver<Cached extends CacheType = CacheTy
 
 export class ContextMenuCommandInteraction<Cached extends CacheType = CacheType> extends CommandInteraction<Cached> {
   public commandType: ApplicationCommandType.Message | ApplicationCommandType.User;
-  public options: Omit<
-    CommandInteractionOptionResolver<Cached>,
-    | 'getFocused'
-    | 'getMentionable'
-    | 'getRole'
-    | 'getNumber'
-    | 'getInteger'
-    | 'getString'
-    | 'getChannel'
-    | 'getBoolean'
-    | 'getSubcommandGroup'
-    | 'getSubcommand'
-  >;
   public targetId: Snowflake;
   public inGuild(): this is ContextMenuCommandInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is ContextMenuCommandInteraction<'cached'>;
@@ -2222,6 +2211,21 @@ export class MessageContextMenuCommandInteraction<
   Cached extends CacheType = CacheType,
 > extends ContextMenuCommandInteraction<Cached> {
   public commandType: ApplicationCommandType.Message;
+  public options: Omit<
+    CommandInteractionOptionResolver<Cached>,
+    | 'getFocused'
+    | 'getMentionable'
+    | 'getRole'
+    | 'getUser'
+    | 'getNumber'
+    | 'getAttachment'
+    | 'getInteger'
+    | 'getString'
+    | 'getChannel'
+    | 'getBoolean'
+    | 'getSubcommandGroup'
+    | 'getSubcommand'
+  >;
   public get targetMessage(): NonNullable<CommandInteractionOption<Cached>['message']>;
   public inGuild(): this is MessageContextMenuCommandInteraction<'raw' | 'cached'>;
   public inCachedGuild(): this is MessageContextMenuCommandInteraction<'cached'>;
@@ -3231,6 +3235,20 @@ export class UserContextMenuCommandInteraction<
   Cached extends CacheType = CacheType,
 > extends ContextMenuCommandInteraction<Cached> {
   public commandType: ApplicationCommandType.User;
+  public options: Omit<
+    CommandInteractionOptionResolver<Cached>,
+    | 'getMessage'
+    | 'getFocused'
+    | 'getMentionable'
+    | 'getRole'
+    | 'getNumber'
+    | 'getInteger'
+    | 'getString'
+    | 'getChannel'
+    | 'getBoolean'
+    | 'getSubcommandGroup'
+    | 'getSubcommand'
+  >;
   public get targetUser(): User;
   public get targetMember(): CacheTypeReducer<Cached, GuildMember, APIInteractionGuildMember> | null;
   public inGuild(): this is UserContextMenuCommandInteraction<'raw' | 'cached'>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3242,6 +3242,7 @@ export class UserContextMenuCommandInteraction<
     | 'getMentionable'
     | 'getRole'
     | 'getNumber'
+    | 'getAttachment'
     | 'getInteger'
     | 'getString'
     | 'getChannel'

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1508,26 +1508,6 @@ declare const applicationCommandSubGroup: ApplicationCommandSubGroup;
   applicationCommandSubGroup.options = [] as const;
 }
 
-declare const userContextMenuCommandInteraction: UserContextMenuCommandInteraction;
-{
-  expectType<User | null>(userContextMenuCommandInteraction.options.getUser('useroption'));
-  expectType<User>(userContextMenuCommandInteraction.options.getUser('useroption', true));
-  expectType<GuildMember | APIInteractionDataResolvedGuildMember | null>(
-    userContextMenuCommandInteraction.options.getMember('useroption'),
-  );
-  if (userContextMenuCommandInteraction.inCachedGuild()) {
-    expectType<GuildMember | null>(userContextMenuCommandInteraction.options.getMember('useroption'));
-  }
-}
-
-declare const messageContextMenuCommandInteraction: MessageContextMenuCommandInteraction;
-{
-  expectType<Message>(messageContextMenuCommandInteraction.options.getMessage('message', true));
-  expectType<GuildMember | APIInteractionDataResolvedGuildMember | null>(
-    userContextMenuCommandInteraction.options.getMember('useroption'),
-  );
-}
-
 declare const autoModerationRuleManager: AutoModerationRuleManager;
 {
   expectType<Promise<AutoModerationRule>>(autoModerationRuleManager.fetch('1234567890'));

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1508,6 +1508,26 @@ declare const applicationCommandSubGroup: ApplicationCommandSubGroup;
   applicationCommandSubGroup.options = [] as const;
 }
 
+declare const userContextMenuCommandInteraction: UserContextMenuCommandInteraction;
+{
+  expectType<User | null>(userContextMenuCommandInteraction.options.getUser('useroption'));
+  expectType<User>(userContextMenuCommandInteraction.options.getUser('useroption', true));
+  expectType<GuildMember | APIInteractionDataResolvedGuildMember | null>(
+    userContextMenuCommandInteraction.options.getMember('useroption'),
+  );
+  if (userContextMenuCommandInteraction.inCachedGuild()) {
+    expectType<GuildMember | null>(userContextMenuCommandInteraction.options.getMember('useroption'));
+  }
+}
+
+declare const messageContextMenuCommandInteraction: MessageContextMenuCommandInteraction;
+{
+  expectType<Message>(messageContextMenuCommandInteraction.options.getMessage('message', true));
+  expectType<GuildMember | APIInteractionDataResolvedGuildMember | null>(
+    userContextMenuCommandInteraction.options.getMember('useroption'),
+  );
+}
+
 declare const autoModerationRuleManager: AutoModerationRuleManager;
 {
   expectType<Promise<AutoModerationRule>>(autoModerationRuleManager.fetch('1234567890'));
@@ -1803,6 +1823,8 @@ client.on('interactionCreate', async interaction => {
       interaction.commandType === ApplicationCommandType.Message)
   ) {
     expectType<MessageContextMenuCommandInteraction | UserContextMenuCommandInteraction>(interaction);
+    // @ts-expect-error No attachment options on contextmenu commands
+    interaction.options.getAttachment('name');
     if (interaction.inCachedGuild()) {
       expectAssignable<ContextMenuCommandInteraction>(interaction);
       expectAssignable<Guild>(interaction.guild);
@@ -1836,12 +1858,36 @@ client.on('interactionCreate', async interaction => {
     interaction.commandType === ApplicationCommandType.Message
   ) {
     expectType<Message>(interaction.targetMessage);
+    expectType<Message | null>(interaction.options.getMessage('_MESSAGE'));
     if (interaction.inCachedGuild()) {
       expectType<Message<true>>(interaction.targetMessage);
+      expectType<Message<true> | null>(interaction.options.getMessage('_MESSAGE'));
     } else if (interaction.inRawGuild()) {
       expectType<Message<false>>(interaction.targetMessage);
+      expectType<Message<false> | null>(interaction.options.getMessage('_MESSAGE'));
     } else if (interaction.inGuild()) {
       expectType<Message>(interaction.targetMessage);
+      expectType<Message | null>(interaction.options.getMessage('_MESSAGE'));
+    }
+  }
+
+  if (
+    interaction.type === InteractionType.ApplicationCommand &&
+    interaction.commandType === ApplicationCommandType.User
+  ) {
+    expectType<User>(interaction.targetUser);
+    expectType<GuildMember | APIInteractionGuildMember | null>(interaction.targetMember);
+    expectType<User | null>(interaction.options.getUser('user'));
+    expectType<GuildMember | APIInteractionDataResolvedGuildMember | null>(interaction.options.getMember('user'));
+    if (interaction.inCachedGuild()) {
+      expectType<GuildMember | null>(interaction.targetMember);
+      expectType<GuildMember | null>(interaction.options.getMember('user'));
+    } else if (interaction.inRawGuild()) {
+      expectType<APIInteractionGuildMember | null>(interaction.targetMember);
+      expectType<APIInteractionDataResolvedGuildMember | null>(interaction.options.getMember('user'));
+    } else if (interaction.inGuild()) {
+      expectType<GuildMember | APIInteractionGuildMember | null>(interaction.targetMember);
+      expectType<GuildMember | APIInteractionDataResolvedGuildMember | null>(interaction.options.getMember('user'));
     }
   }
 
@@ -1975,6 +2021,9 @@ client.on('interactionCreate', async interaction => {
     expectType<string | null>(interaction.options.getSubcommandGroup());
     expectType<string | null>(interaction.options.getSubcommandGroup(booleanValue));
     expectType<string | null>(interaction.options.getSubcommandGroup(false));
+
+    // @ts-expect-error
+    interaction.options.getMessage('name');
   }
 
   if (interaction.isRepliable()) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Omits the `getUser` and `getMember` methods from the `CommandOptionResolver` on a `MessageContextMenuCommandInteraction` and similar for `getMessage` on `UserContextMenuCommandInteraction`.

Also omits `getAttachment` on both as it seems to not have been omitted when it got added to the resolver.

Supersedes #9606 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- 
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
