### PR TITLE
docs(PermissionOverwriteManager): `PermissionsFlagsBit` typo

### DIFF
--- a/packages/discord.js/src/managers/PermissionOverwriteManager.js
+++ b/packages/discord.js/src/managers/PermissionOverwriteManager.js
@@ -58,7 +58,7 @@ class PermissionOverwriteManager extends CachedManager {
    * message.channel.permissionOverwrites.set([
    *   {
    *      id: message.author.id,
-   *      deny: [PermissionsFlagsBit.ViewChannel],
+   *      deny: [PermissionFlagsBits.ViewChannel],
    *   },
    * ], 'Needed to change permissions');
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes a typo in the example of [PermissionOverwriteManager#set()](https://old.discordjs.dev/#/docs/discord.js/14.14.1/class/PermissionOverwriteManager?scrollTo=set).

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
