### PR TITLE
fix(website): serialize methods with overload index

### DIFF
--- a/apps/website/src/components/documentation/util.ts
+++ b/apps/website/src/components/documentation/util.ts
@@ -146,6 +146,7 @@ export function serializeMembers(clazz: ApiItemContainerMixin): TableOfContentsS
 			return {
 				kind: member.kind as 'Method' | 'MethodSignature',
 				name: member.displayName,
+				overloadIndex: (member as ApiMethod | ApiMethodSignature).overloadIndex,
 			};
 		} else if (member.kind === 'Event') {
 			return {
@@ -156,7 +157,6 @@ export function serializeMembers(clazz: ApiItemContainerMixin): TableOfContentsS
 			return {
 				kind: member.kind as 'Property' | 'PropertySignature',
 				name: member.displayName,
-				overloadIndex: (member as ApiMethod | ApiMethodSignature).overloadIndex,
 			};
 		}
 	});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds overloads prop to methods when serializing.

Fixes some overloads from appearing more than once in the outline.
https://discordjs.dev/docs/packages/voice/main/AudioPlayer:Class

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
