### PR TITLE
fix: export "ESM" types when discord.js is imported in ESM land

### DIFF
--- a/packages/discord.js/.eslintrc.json
+++ b/packages/discord.js/.eslintrc.json
@@ -202,7 +202,7 @@
       }
     },
     {
-      "files": ["typings/*.ts"],
+      "files": ["typings/*.ts", "scripts/*.mjs"],
       "parser": "@typescript-eslint/parser",
       "plugins": ["@typescript-eslint"],
       "rules": {

--- a/packages/discord.js/.gitignore
+++ b/packages/discord.js/.gitignore
@@ -25,3 +25,7 @@ docs/**/*
 # Miscellaneous
 .turbo
 .tmp
+
+# Generated files
+typings/index.d.mts
+typings/rawDataTypes.d.mts

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -12,12 +12,24 @@
     "docs": "docgen -i './src/*.js' './src/**/*.js' -c ./docs/index.json -r ../../ -o ./docs/docs.json && pnpm run docs:new",
     "docs:test": "docgen -i './src/*.js' './src/**/*.js' -c ./docs/index.json -r ../../",
     "docs:new": "api-extractor run --local --minify",
-    "prepack": "pnpm run lint && pnpm run test",
+    "prepack": "pnpm run lint && pnpm run test && node ./scripts/esmDts.mjs",
     "changelog": "git cliff --prepend ./CHANGELOG.md -u -c ./cliff.toml -r ../../ --include-path 'packages/discord.js/*'",
     "release": "cliff-jumper"
   },
   "main": "./src/index.js",
   "types": "./typings/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./typings/index.d.mts",
+        "default": "./src/index.js"
+      },
+      "require": {
+        "types": "./typings/index.d.ts",
+        "default": "./src/index.js"
+      }
+    }
+  },
   "directories": {
     "lib": "src",
     "test": "test"

--- a/packages/discord.js/scripts/esmDts.mjs
+++ b/packages/discord.js/scripts/esmDts.mjs
@@ -1,0 +1,38 @@
+import { readFile, writeFile } from 'node:fs/promises';
+
+const rawTypesDTS = new URL('../typings/rawDataTypes.d.ts', import.meta.url);
+const rawIndexDTS = new URL('../typings/index.d.ts', import.meta.url);
+
+const rawTypesMDTS = new URL('../typings/rawDataTypes.d.mts', import.meta.url);
+const rawIndexMTS = new URL('../typings/index.d.mts', import.meta.url);
+
+const [rawTypesString, rawIndexString] = await Promise.all([
+  readFile(rawTypesDTS, 'utf8'),
+  readFile(rawIndexDTS, 'utf8'),
+]);
+
+/**
+ *
+ * @param {string} source
+ * @param {[from: string, to: string][]} imports
+ */
+function updateImports(source, imports) {
+  return imports.reduce((code, [from, to]) => {
+    return code.replaceAll(from, to);
+  }, source);
+}
+
+/** @type {[string, string][]} */
+const rawTypesImports = [
+  ['./index.js', './index.mjs'], //
+];
+
+/** @type {[string, string][]} */
+const rawIndexImports = [
+  ['./rawDataTypes.js', './rawDataTypes.mjs'], //
+];
+
+const rawTypesMDTSString = updateImports(rawTypesString, rawTypesImports);
+const rawIndexMTSString = updateImports(rawIndexString, rawIndexImports);
+
+await Promise.all([writeFile(rawTypesMDTS, rawTypesMDTSString), writeFile(rawIndexMTS, rawIndexMTSString)]);

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -231,7 +231,7 @@ import {
   RawWelcomeScreenData,
   RawWidgetData,
   RawWidgetMemberData,
-} from './rawDataTypes';
+} from './rawDataTypes.js';
 
 declare module 'node:events' {
   class EventEmitter {

--- a/packages/discord.js/typings/rawDataTypes.d.ts
+++ b/packages/discord.js/typings/rawDataTypes.d.ts
@@ -77,7 +77,7 @@ import {
   Snowflake,
   APIGuildScheduledEvent,
 } from 'discord-api-types/v10';
-import { GuildChannel, Guild, PermissionOverwrites } from '.';
+import { GuildChannel, Guild, PermissionOverwrites } from './index.js';
 
 export type RawActivityData = GatewayActivity;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Closes https://github.com/discordjs/discord.js/issues/9985

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.