### PR TITLE
Support at least a bit the interaction endpoint API feature

### DIFF
--- a/packages/discord.js/src/structures/AutocompleteInteraction.js
+++ b/packages/discord.js/src/structures/AutocompleteInteraction.js
@@ -83,7 +83,7 @@ class AutocompleteInteraction extends BaseInteraction {
   async respond(options) {
     if (this.responded) throw new DiscordjsError(ErrorCodes.InteractionAlreadyReplied);
 
-    await this.client.rest.post(Routes.interactionCallback(this.id, this.token), {
+    let response = {
       body: {
         type: InteractionResponseType.ApplicationCommandAutocompleteResult,
         data: {
@@ -93,8 +93,14 @@ class AutocompleteInteraction extends BaseInteraction {
           })),
         },
       },
-      auth: false,
-    });
+    }
+    if(this.respondFunction) {
+      this.respondFunction(response);
+      this.respondFunction = null;
+    }else{
+      response.auth = false;
+      await this.client.rest.post(Routes.interactionCallback(this.id, this.token), response);
+    }
     this.responded = true;
   }
 }

--- a/packages/discord.js/src/structures/BaseInteraction.js
+++ b/packages/discord.js/src/structures/BaseInteraction.js
@@ -65,6 +65,12 @@ class BaseInteraction extends Base {
      * @type {?(GuildMember|APIGuildMember)}
      */
     this.member = data.member ? this.guild?.members._add(data.member) ?? data.member : null;
+    
+    /**
+     * A function that will be run with the response.
+     * @type {function}
+     */
+    this.respondFunction = data.respondFunction ?? null;
 
     /**
      * The version


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
These changes adds support to a new property to the BaseInteraction that I've called respondFunction. Instead of making the scripts respond to interactions by making a request to the Discord API, the scripts will use that respondFunction once.

**Status and versioning classification:**
The scripts that I've edited were up-to-date with the main branch of the original scripts.

- Code changes have been tested against the Discord API, and I am going to use them for my own bot;
- I don't know really how to update typings and have not done so;
- This PR changes the library's interface (one parameter is being added).

**Example:**
This script can be called whenever a request is made to a specific page of your website:
```
      if(!nacl.sign.detached.verify(
        Buffer.from(req.headers["x-signature-timestamp"] + body),
        Buffer.from(req.headers["x-signature-ed25519"], 'hex'),
        Buffer.from("Client public key", 'hex')
      )){
        res.statusCode = 401
        return res.end("invalid request signature")
      }
      res.setHeader("content-type","application/json")
      let obj = JSON.parse(body) // Get the body variable with your own scripts
      if(obj.type==1){ // ACK the pings
        res.statusCode = 200
        return res.end(JSON.stringify({type:1}))
      }
      const r = await new Promise(ok=>{
        obj.respondFunction = ok
        client.actions.InteractionCreate.handle(obj) // Emits the interactionCreate event with a valid interaction
      })
      return res.end(JSON.stringify(r.body)) // Respond to Discord.
```

*Some of my changes probably aren't formatted like the other code.*