### PR TITLE
chore: use string values in vs code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,9 +9,9 @@
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"editor.formatOnSave": true,
 	"editor.codeActionsOnSave": {
-		"source.organizeImports": false,
-		"source.fixAll.eslint": true,
-		"source.fixAll": true
+		"source.organizeImports": "never",
+		"source.fixAll.eslint": "explicit",
+		"source.fixAll": "explicit"
 	},
 	"editor.trimAutoWhitespace": false,
 	"files.associations": {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Boolean values will soon be deprecated, and these values are automatically changed whenever you launch Visual Studio Code (only Insiders for now as far as I know).

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
