### PR TITLE
ci: always generate docs with latest main ae

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -51,8 +51,33 @@ jobs:
       - name: Build dependencies
         run: pnpm run build
 
+      - name: Checkout main repository
+        if: ${{ inputs.ref && inputs.ref != 'main' }}
+        uses: actions/checkout@v3
+        with:
+          path: 'main'
+
+      - name: Build main
+        if: ${{ inputs.ref && inputs.ref != 'main' }}
+        shell: bash
+        run: |
+          cd main
+          pnpm install --frozen-lockfile --prefer-offline --loglevel error
+          pnpm run build
+          cd ..
+
       - name: Build docs
         run: pnpm run docs
+
+      - name: Build docs with main api-extractor
+        if: ${{ inputs.ref && inputs.ref != 'main' }}
+        run: |
+          declare -a PACKAGES=("brokers" "builders" "collection" "core" "discord.js" "formatters" "next" "proxy" "rest" "util" "voice" "ws")
+          for PACKAGE in "${PACKAGES[@]}"; do
+            cd "packages/${PACKAGE}"
+            ../../main/packages/api-extractor/bin/api-extractor run --local --minify
+            cd ../..
+          done
 
       - name: Checkout docs repository
         uses: actions/checkout@v3


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

On manual runs of documentation.yml workflow additionally checks out main branch if targeting another tag/branch. Before uploading runs api-extractor from main branch on the packages in target branch.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
