### PR TITLE
feat: use globally available WebSocket client in runtimes that have it

### DIFF
--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -7,7 +7,7 @@ import { URLSearchParams } from 'node:url';
 import { TextDecoder } from 'node:util';
 import { inflate } from 'node:zlib';
 import { Collection } from '@discordjs/collection';
-import { lazy } from '@discordjs/util';
+import { lazy, shouldUseGlobalFetchAndWebSocket } from '@discordjs/util';
 import { AsyncQueue } from '@sapphire/async-queue';
 import { AsyncEventEmitter } from '@vladfrangu/async_event_emitter';
 import {
@@ -80,11 +80,9 @@ export interface SendRateLimitState {
 	resetAt: number;
 }
 
-// TODO(vladfrangu): enable this once https://github.com/oven-sh/bun/issues/3392 is solved
-// const WebSocketConstructor: typeof WebSocket = shouldUseGlobalFetchAndWebSocket()
-// 	? (globalThis as any).WebSocket
-// 	: WebSocket;
-const WebSocketConstructor: typeof WebSocket = WebSocket;
+const WebSocketConstructor: typeof WebSocket = shouldUseGlobalFetchAndWebSocket()
+	? (globalThis as any).WebSocket
+	: WebSocket;
 
 export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 	private connection: WebSocket | null = null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Bun fixed the WebSocket issue (https://github.com/oven-sh/bun/issues/3392). WS now reports correct close codes and everything! Now, fingers crossed their WebSocket client doesn't have some hidden bugs 🤞 

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
