### PR TITLE
types(DirectoryChannel): Ensure directory channels cannot contain user mentions when stringified

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2888,6 +2888,7 @@ export class DirectoryChannel extends BaseChannel {
   public guild: InviteGuild;
   public guildId: Snowflake;
   public name: string;
+  public toString(): ChannelMention;
 }
 
 export class StageInstance extends Base {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -186,6 +186,7 @@ import {
   Emoji,
   PartialEmoji,
   Awaitable,
+  DirectoryChannel,
 } from '.';
 import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import type { ContextMenuCommandBuilder, SlashCommandBuilder } from '@discordjs/builders';
@@ -2282,16 +2283,22 @@ declare const anyComponentsActionRowComp: ActionRow<ActionRowComponent>;
 expectType<ActionRowBuilder>(ActionRowBuilder.from(anyComponentsActionRowData));
 expectType<ActionRowBuilder>(ActionRowBuilder.from(anyComponentsActionRowComp));
 
-declare const stageChannel: StageChannel;
 declare const partialGroupDMChannel: PartialGroupDMChannel;
+declare const stageChannel: StageChannel;
+declare const directoryChannel: DirectoryChannel;
+declare const mediaChannel: MediaChannel;
 
 expectType<ChannelMention>(textChannel.toString());
+expectType<UserMention>(dmChannel.toString());
 expectType<ChannelMention>(voiceChannel.toString());
+expectType<ChannelMention>(partialGroupDMChannel.toString());
+expectType<ChannelMention>(categoryChannel.toString());
 expectType<ChannelMention>(newsChannel.toString());
 expectType<ChannelMention>(threadChannel.toString());
 expectType<ChannelMention>(stageChannel.toString());
-expectType<ChannelMention>(partialGroupDMChannel.toString());
-expectType<UserMention>(dmChannel.toString());
+expectType<ChannelMention>(directoryChannel.toString());
+expectType<ChannelMention>(forumChannel.toString());
+expectType<ChannelMention>(mediaChannel.toString());
 expectType<UserMention>(user.toString());
 expectType<UserMention>(guildMember.toString());
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -186,6 +186,7 @@ import {
   Emoji,
   PartialEmoji,
   Awaitable,
+  Channel,
   DirectoryChannel,
 } from '.';
 import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd';
@@ -2283,22 +2284,12 @@ declare const anyComponentsActionRowComp: ActionRow<ActionRowComponent>;
 expectType<ActionRowBuilder>(ActionRowBuilder.from(anyComponentsActionRowData));
 expectType<ActionRowBuilder>(ActionRowBuilder.from(anyComponentsActionRowComp));
 
-declare const partialGroupDMChannel: PartialGroupDMChannel;
-declare const stageChannel: StageChannel;
-declare const directoryChannel: DirectoryChannel;
-declare const mediaChannel: MediaChannel;
+type UserMentionChannels = DMChannel | PartialDMChannel;
+declare const channelMentionChannels: Exclude<Channel | DirectoryChannel, UserMentionChannels>;
+declare const userMentionChannels: UserMentionChannels;
 
-expectType<ChannelMention>(textChannel.toString());
-expectType<UserMention>(dmChannel.toString());
-expectType<ChannelMention>(voiceChannel.toString());
-expectType<ChannelMention>(partialGroupDMChannel.toString());
-expectType<ChannelMention>(categoryChannel.toString());
-expectType<ChannelMention>(newsChannel.toString());
-expectType<ChannelMention>(threadChannel.toString());
-expectType<ChannelMention>(stageChannel.toString());
-expectType<ChannelMention>(directoryChannel.toString());
-expectType<ChannelMention>(forumChannel.toString());
-expectType<ChannelMention>(mediaChannel.toString());
+expectType<ChannelMention>(channelMentionChannels.toString());
+expectType<UserMention>(userMentionChannels.toString());
 expectType<UserMention>(user.toString());
 expectType<UserMention>(guildMember.toString());
 
@@ -2320,7 +2311,9 @@ expectType<Promise<Message>>(interactionWebhook.send('content'));
 expectType<Promise<Message>>(interactionWebhook.editMessage(snowflake, 'content'));
 expectType<Promise<Message>>(interactionWebhook.fetchMessage(snowflake));
 
+declare const partialGroupDMChannel: PartialGroupDMChannel;
 declare const categoryChannel: CategoryChannel;
+declare const stageChannel: StageChannel;
 declare const forumChannel: ForumChannel;
 
 await forumChannel.edit({


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Directory channels when stringified cannot possibly be a user mention (which is typed through the inheritance chain):

https://github.com/discordjs/discord.js/blob/1f5d71e087f3e86f092634f798c33bd63029977f/packages/discord.js/typings/index.d.ts#L2901

https://github.com/discordjs/discord.js/blob/1f5d71e087f3e86f092634f798c33bd63029977f/packages/discord.js/typings/index.d.ts#L938-L955

Also added tests for the remaining channels.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
