### PR TITLE
fix: deprecate `underscore` in favor of `underline`

### DIFF
--- a/packages/formatters/__tests__/formatters.test.ts
+++ b/packages/formatters/__tests__/formatters.test.ts
@@ -24,7 +24,7 @@ import {
 	strikethrough,
 	time,
 	TimestampStyles,
-	underscore,
+	underline,
 	unorderedList,
 	userMention,
 } from '../src/index.js';
@@ -58,9 +58,9 @@ describe('Message formatters', () => {
 		});
 	});
 
-	describe('underscore', () => {
+	describe('underline', () => {
 		test('GIVEN "discord.js" THEN returns "__discord.js__"', () => {
-			expect<'__discord.js__'>(underscore('discord.js')).toEqual('__discord.js__');
+			expect<'__discord.js__'>(underline('discord.js')).toEqual('__discord.js__');
 		});
 	});
 

--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -64,7 +64,7 @@ export function bold<Content extends string>(content: Content): `**${Content}**`
  * @deprecated Use {@link underline} instead.
  */
 export function underscore<Content extends string>(content: Content): `__${Content}__` {
-	return `__${content}__`;
+	return underline(content);
 }
 
 /**

--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -61,8 +61,19 @@ export function bold<Content extends string>(content: Content): `**${Content}**`
  *
  * @typeParam Content - This is inferred by the supplied content
  * @param content - The content to wrap
+ * @deprecated Use {@link underline} instead.
  */
 export function underscore<Content extends string>(content: Content): `__${Content}__` {
+	return `__${content}__`;
+}
+
+/**
+ * Formats the content into underlined text.
+ *
+ * @typeParam Content - This is inferred by the supplied content
+ * @param content - The content to wrap
+ */
+export function underline<Content extends string>(content: Content): `__${Content}__` {
 	return `__${content}__`;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This addresses the issue where the formatter is named `underscore` and its escaper is named `escapeUnderline` as pointed out in [Discord server](https://discord.com/channels/222078108977594368/937420598383108167/1185666172792868914). I went with underline because that's what Discord refers it as in [Markdown Text 101](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline-).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
