### PR TITLE
docs: remove utf-8-validate

### DIFF
--- a/packages/ws/README.md
+++ b/packages/ws/README.md
@@ -36,7 +36,6 @@ bun add @discordjs/ws
 
 - [zlib-sync](https://www.npmjs.com/package/zlib-sync) for WebSocket data compression and inflation (`npm install zlib-sync`)
 - [bufferutil](https://www.npmjs.com/package/bufferutil) for a much faster WebSocket connection (`npm install bufferutil`)
-- [utf-8-validate](https://www.npmjs.com/package/utf-8-validate) in combination with `bufferutil` for much faster WebSocket processing (`npm install utf-8-validate`)
 
 ## Example usage
 


### PR DESCRIPTION
utf-8-validate is only for legacy versions of Node.js, so having it in the readme like this is a footgun and will cause the ecosystem to install useless dependencies.