### PR TITLE
fix: Correct testing local changes in `CONTRIBUTING.md`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,9 +23,8 @@ If you want to test changes you've made locally, you can do so by using `pnpm li
 
 1. Create a new directory `mkdir discordjs-test` and move into it `cd discordjs-test`
 2. Initialize a new pnpm project `pnpm init`
-3. Now link the local discord.js project you cloned earlier `pnpm link {PATH_TO_DISCORDJS_REPO}`
-4. Install packages you'd like to test locally `pnpm add discord.js@latest`, `pnpm add @discordjs/rest@latest`, etc. **Note: Make sure you use `latest` tag or else pnpm will try to install the remote package from npm**
-5. Import the package in your source code and test them out!
+3. Now link the discord.js package from the directory you cloned earlier `pnpm link {PATH_TO_DISCORDJS_REPO}/packages/<package>`. (e.g. `pnpm link ~/discord.js/packages/rest`)
+4. Import the package in your source code and test them out!
 
 ### Working with TypeScript packages
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously with yarn you needed to link the entire workspace and then manually install each local package to test. With pnpm all we need to do is just run `link` against the individual packages we want to test.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
