### PR TITLE
fix: remove potentially erroneous check

### DIFF
--- a/packages/discord.js/src/structures/InteractionCollector.js
+++ b/packages/discord.js/src/structures/InteractionCollector.js
@@ -40,7 +40,7 @@ class InteractionCollector extends Collector {
      * The message from which to collect interactions, if provided
      * @type {?Snowflake}
      */
-    this.messageId = options.message?.id ?? options.interactionResponse?.interaction.message?.id ?? null;
+    this.messageId = options.message?.id ?? null;
 
     /**
      * The message interaction id from which to collect interactions, if provided


### PR DESCRIPTION
In fixing a bug, #8598 seems to have introduced a different bug in which the `InteractionCollector`s checks would incorrectly reject interactions coming from `MessageComponent`s in a reply to other `MessageComponentInteraction`s.

Removing this check seems to resolve the issue, and I believe I've tested the original scenario too. However, I'm not certain so would appreciate feedback from @RedGuy12 and @ImRodry who fixed/raised the original issue.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
