### PR TITLE
Skip sweeping if the guild is not available

### DIFF
--- a/packages/discord.js/src/util/Sweepers.js
+++ b/packages/discord.js/src/util/Sweepers.js
@@ -425,8 +425,8 @@ class Sweepers {
     let items = 0;
 
     for (const guild of this.client.guilds.cache.values()) {
-      // We may be unable to sweep the cache if the guild is unavailable
-      if (!guild.available) continue;
+      // We may be unable to sweep the cache if the guild is unavailable and was never patched
+      if (!(key in guild)) continue;
 
       const { cache } = guild[key];
 

--- a/packages/discord.js/src/util/Sweepers.js
+++ b/packages/discord.js/src/util/Sweepers.js
@@ -425,7 +425,7 @@ class Sweepers {
     let items = 0;
 
     for (const guild of this.client.guilds.cache.values()) {
-      // we may be unable to sweep the cache if the guild is unavailable
+      // We may be unable to sweep the cache if the guild is unavailable
       if (!guild.available) continue;
 
       const { cache } = guild[key];

--- a/packages/discord.js/src/util/Sweepers.js
+++ b/packages/discord.js/src/util/Sweepers.js
@@ -426,7 +426,7 @@ class Sweepers {
 
     for (const guild of this.client.guilds.cache.values()) {
       // We may be unable to sweep the cache if the guild is unavailable and was never patched
-      if (!(key in guild)) continue;
+      if (!guild.available) continue;
 
       const { cache } = guild[key];
 

--- a/packages/discord.js/src/util/Sweepers.js
+++ b/packages/discord.js/src/util/Sweepers.js
@@ -427,7 +427,7 @@ class Sweepers {
     for (const guild of this.client.guilds.cache.values()) {
       // we may be unable to sweep the cache if the guild is unavailable
       if (!guild.available) continue;
-      
+
       const { cache } = guild[key];
 
       guilds++;

--- a/packages/discord.js/src/util/Sweepers.js
+++ b/packages/discord.js/src/util/Sweepers.js
@@ -425,7 +425,7 @@ class Sweepers {
     let items = 0;
 
     for (const guild of this.client.guilds.cache.values()) {
-      // we may be unable to sweeep the cache if the guild is unavailable
+      // we may be unable to sweep the cache if the guild is unavailable
       if (!guild.available) continue;
       
       const { cache } = guild[key];

--- a/packages/discord.js/src/util/Sweepers.js
+++ b/packages/discord.js/src/util/Sweepers.js
@@ -425,6 +425,9 @@ class Sweepers {
     let items = 0;
 
     for (const guild of this.client.guilds.cache.values()) {
+      // we may be unable to sweeep the cache if the guild is unavailable
+      if (!guild.available) continue;
+      
       const { cache } = guild[key];
 
       guilds++;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes #10069. It would seem that certain properties do not get set properly if the guild is not available, so when we go to sweep them, the property is undefined (.stickers, .emojis etc). Skipping unavailable guilds on a sweep pass should resolve the issue.

**Status and versioning classification:**
Patch

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
