### PR TITLE
fix(ModalSubmitInteraction): add missing `update()` types

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2398,6 +2398,10 @@ export class ModalSubmitInteraction<Cached extends CacheType = CacheType> extend
   public reply(
     options: string | MessagePayload | InteractionReplyOptions,
   ): Promise<InteractionResponse<BooleanCache<Cached>>>;
+  public update(options: InteractionUpdateOptions & { fetchReply: true }): Promise<Message<BooleanCache<Cached>>>;
+  public update(
+    options: string | MessagePayload | InteractionUpdateOptions,
+  ): Promise<InteractionResponse<BooleanCache<Cached>>>;
   public deleteReply(message?: MessageResolvable | '@original'): Promise<void>;
   public editReply(
     options: string | MessagePayload | InteractionEditReplyOptions,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

ModalSubmitInteraction implements InteractionResponses, which means that `update()` is a valid method that can be used on an instance of a ModalSubmitInteraction. This is also reflected via [the docs](https://old.discordjs.dev/#/docs/discord.js/main/class/ModalSubmitInteraction?scrollTo=update), as well as runtime usage. This PR adds the missing types which reflect the presence and usage of this method.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
