### PR TITLE
fix(website): move function header into switcher

### DIFF
--- a/apps/website/src/components/model/function/Function.tsx
+++ b/apps/website/src/components/model/function/Function.tsx
@@ -8,16 +8,14 @@ const OverloadSwitcher = dynamic(async () => import('../../OverloadSwitcher'));
 
 export function Function({ item }: { readonly item: ApiFunction }) {
 	if (item.getMergedSiblings().length > 1) {
-		const overloads = item
-			.getMergedSiblings()
-			.map((sibling, idx) => <FunctionBody item={sibling as ApiFunction} key={`${sibling.displayName}-${idx}`} />);
-
-		return (
-			<Documentation>
-				<ObjectHeader item={item} />
-				<OverloadSwitcher methodName={item.displayName} overloads={overloads} />
+		const overloads = item.getMergedSiblings().map((sibling, idx) => (
+			<Documentation key={`${sibling.displayName}-${idx}`}>
+				<ObjectHeader item={sibling as ApiFunction} />
+				<FunctionBody item={sibling as ApiFunction} />
 			</Documentation>
-		);
+		));
+
+		return <OverloadSwitcher methodName={item.displayName} overloads={overloads} />;
 	}
 
 	return (


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This moves top level function headers into the overload switcher in order to sync the exerpt text to the overload.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
