### PR TITLE
chore: bump license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2021 Noel Buechler
+   Copyright 2024 Noel Buechler
    Copyright 2015 Amish Shah
 
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Bumps year of Apache license to 2024.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
