### PR TITLE
fix: invert deletable message types list

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -22,7 +22,7 @@ const { Sticker } = require('./Sticker');
 const { DiscordjsError, ErrorCodes } = require('../errors');
 const ReactionManager = require('../managers/ReactionManager');
 const { createComponent } = require('../util/Components');
-const { NonSystemMessageTypes, MaxBulkDeletableMessageAge, DeletableMessageTypes } = require('../util/Constants');
+const { NonSystemMessageTypes, MaxBulkDeletableMessageAge, UndeletableMessageTypes } = require('../util/Constants');
 const MessageFlagsBitField = require('../util/MessageFlagsBitField');
 const PermissionsBitField = require('../util/PermissionsBitField');
 const { cleanContent, resolvePartialEmoji, transformResolved } = require('../util/Util');
@@ -635,7 +635,7 @@ class Message extends Base {
    * @readonly
    */
   get deletable() {
-    if (!DeletableMessageTypes.includes(this.type)) return false;
+    if (UndeletableMessageTypes.includes(this.type)) return false;
 
     if (!this.guild) {
       return this.author.id === this.client.user.id;

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -156,6 +156,25 @@ exports.SelectMenuTypes = [
 ];
 
 /**
+ * The types of messages that cannot be deleted. The available types are:
+ * * {@link MessageType.RecipientAdd}
+ * * {@link MessageType.RecipientRemove}
+ * * {@link MessageType.Call}
+ * * {@link MessageType.ChannelNameChange}
+ * * {@link MessageType.ChannelIconChange}
+ * * {@link MessageType.ThreadStarterMessage}
+ * @typedef {MessageType[]} UndeletableMessageTypes
+ */
+exports.UndeletableMessageTypes = [
+  MessageType.RecipientAdd,
+  MessageType.RecipientRemove,
+  MessageType.Call,
+  MessageType.ChannelNameChange,
+  MessageType.ChannelIconChange,
+  MessageType.ThreadStarterMessage,
+];
+
+/**
  * The types of messages that can be deleted. The available types are:
  * * {@link MessageType.AutoModerationAction}
  * * {@link MessageType.ChannelFollowAdd}
@@ -179,6 +198,7 @@ exports.SelectMenuTypes = [
  * * {@link MessageType.ThreadCreated}
  * * {@link MessageType.UserJoin}
  * @typedef {MessageType[]} DeletableMessageTypes
+ * @deprecated This list will no longer be updated. Use {@link UndeletableMessageTypes} instead.
  */
 exports.DeletableMessageTypes = [
   MessageType.AutoModerationAction,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3666,6 +3666,15 @@ export type NonSystemMessageType =
   | MessageType.ChatInputCommand
   | MessageType.ContextMenuCommand;
 
+export type UndeletableMessageType =
+  | MessageType.RecipientAdd
+  | MessageType.RecipientRemove
+  | MessageType.Call
+  | MessageType.ChannelNameChange
+  | MessageType.ChannelIconChange
+  | MessageType.ThreadStarterMessage;
+
+/** @deprecated This type will no longer be updated. Use {@link UndeletableMessageType} instead. */
 export type DeletableMessageType =
   | MessageType.AutoModerationAction
   | MessageType.ChannelFollowAdd
@@ -3698,6 +3707,8 @@ export const Constants: {
   ThreadChannelTypes: ThreadChannelType[];
   VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
   SelectMenuTypes: SelectMenuType[];
+  UndeletableMessageTypes: UndeletableMessageType[];
+  /** @deprecated This list will no longer be updated. Use {@link Constants.UndeletableMessageTypes} */
   DeletableMessageTypes: DeletableMessageType[];
   StickerFormatExtensionMap: Record<StickerFormatType, ImageFormat>;
 };

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3708,7 +3708,7 @@ export const Constants: {
   VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
   SelectMenuTypes: SelectMenuType[];
   UndeletableMessageTypes: UndeletableMessageType[];
-  /** @deprecated This list will no longer be updated. Use {@link Constants.UndeletableMessageTypes} */
+  /** @deprecated This list will no longer be updated. Use {@link Constants.UndeletableMessageTypes} instead. */
   DeletableMessageTypes: DeletableMessageType[];
   StickerFormatExtensionMap: Record<StickerFormatType, ImageFormat>;
 };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Discord has inverted their deletable message types list to be an undeletable message types list instead:
- https://github.com/discord/discord-api-docs/issues/6551#issuecomment-1894758069

Replicated this on our side and deprecated the previous `DeletableMessageTypes` array.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
