### PR TITLE
fix(website): search hanging on complex types

### DIFF
--- a/apps/website/src/components/CmdK.tsx
+++ b/apps/website/src/components/CmdK.tsx
@@ -58,6 +58,7 @@ export function CmdKDialog() {
 						router.push(item.path);
 						dialog!.setOpen(false);
 					}}
+					value={item.path}
 				>
 					<div className="flex grow flex-row place-content-between place-items-center gap-4">
 						<div className="flex flex-row place-items-center gap-4">


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`cmdk` package builds the list based on `value`, which gets inferred from the content if not explicitly set. This caused the render to majorly lag for things with long descriptions because it was using a recursive function to build information for the value from `command-score` on that long string.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
