### PR TITLE
docs(BaseInteraction): correct return type of `member`

### DIFF
--- a/packages/discord.js/src/structures/BaseInteraction.js
+++ b/packages/discord.js/src/structures/BaseInteraction.js
@@ -63,7 +63,7 @@ class BaseInteraction extends Base {
 
     /**
      * If this interaction was sent in a guild, the member which sent it
-     * @type {?(GuildMember|APIGuildMember)}
+     * @type {?(GuildMember|APIInteractionGuildMember)}
      */
     this.member = data.member ? this.guild?.members._add(data.member) ?? data.member : null;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The return type should be `APIInteractionGuildMember` instead of `APIGuildMember`, the typings are correct, just the documentation seems to be incorrect here.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
