### PR TITLE
fix(website): always link in TypeAlias

### DIFF
--- a/apps/website/src/components/documentation/section/UnionMembersSection.tsx
+++ b/apps/website/src/components/documentation/section/UnionMembersSection.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { ExcerptText } from '~/components/ExcerptText';
 import { DocumentationSection } from './DocumentationSection';
 
-export type UnionMember = ExcerptToken[];
+export type UnionMember = readonly ExcerptToken[];
 
 export function UnionMembersSection({
 	item,

--- a/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
+++ b/apps/website/src/components/documentation/tsdoc/TSDoc.tsx
@@ -25,9 +25,9 @@ export function TSDoc({ item, tsdoc }: { readonly item: ApiItem; readonly tsdoc:
 				case DocNodeKind.Section:
 				case DocNodeKind.Paragraph:
 					return (
-						<span className="break-words leading-relaxed" key={idx}>
+						<div className="break-words leading-relaxed" key={idx}>
 							{(tsdoc as DocNodeContainer).nodes.map((node, idx) => createNode(node, idx))}
-						</span>
+						</div>
 					);
 				case DocNodeKind.SoftBreak:
 					return <Fragment key={idx} />;

--- a/apps/website/src/components/model/TypeAlias.tsx
+++ b/apps/website/src/components/model/TypeAlias.tsx
@@ -13,16 +13,10 @@ export function TypeAlias({ item }: { readonly item: ApiTypeAlias }) {
 		let depth = 0;
 		for (const token of item.typeExcerpt.spannedTokens) {
 			if (token.text.includes('?')) {
-				return [];
+				return [item.typeExcerpt.spannedTokens];
 			}
 
-			if (token.text.includes('<')) {
-				depth++;
-			}
-
-			if (token.text.includes('>')) {
-				depth--;
-			}
+			depth += token.text.split('<').length - token.text.split('>').length;
 
 			if (token.text.trim() === '|' && depth === 0) {
 				if (currentUnionMember.length) {
@@ -47,7 +41,7 @@ export function TypeAlias({ item }: { readonly item: ApiTypeAlias }) {
 			}
 		}
 
-		if (currentUnionMember.length && union.length) {
+		if (currentUnionMember.length) {
 			union.push(currentUnionMember);
 		}
 

--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -1690,20 +1690,22 @@ export class ApiModelGenerator {
 	}
 
 	private _fixLinkTags(input?: string): string | undefined {
-		return input?.replaceAll(linkRegEx, (_match, _p1, _p2, _p3, _p4, _p5, _offset, _string, groups) => {
-			let target = groups.class ?? groups.url;
-			const external = this._jsDocJson?.externals.find((external) => groups.class && external.name === groups.class);
-			const match = /discord-api-types-(?<type>[^#]*?)(?:#|\/(?<kind>[^#/]*)\/)(?<name>[^/}]*)}$/.exec(
-				external?.see?.[0] ?? '',
-			);
-			if (match) {
-				target = `discord-api-types#(${match.groups!.name}:${
-					/^v\d+$/.test(match.groups!.type!) ? match.groups!.kind : 'type'
-				})`;
-			}
+		return input
+			?.replaceAll(linkRegEx, (_match, _p1, _p2, _p3, _p4, _p5, _offset, _string, groups) => {
+				let target = groups.class ?? groups.url;
+				const external = this._jsDocJson?.externals.find((external) => groups.class && external.name === groups.class);
+				const match = /discord-api-types-(?<type>[^#]*?)(?:#|\/(?<kind>[^#/]*)\/)(?<name>[^/}]*)}$/.exec(
+					external?.see?.[0] ?? '',
+				);
+				if (match) {
+					target = `discord-api-types#(${match.groups!.name}:${
+						/^v\d+$/.test(match.groups!.type!) ? match.groups!.kind : 'type'
+					})`;
+				}
 
-			return `{@link ${target}${groups.prop ? `.${groups.prop}` : ''}${groups.name ? ` |${groups.name}` : ''}}`;
-		});
+				return `{@link ${target}${groups.prop ? `.${groups.prop}` : ''}${groups.name ? ` |${groups.name}` : ''}}`;
+			})
+			.replaceAll('* ', '\n * * ');
 	}
 
 	private _mapVarType(typey: DocgenVarTypeJson): IExcerptToken[] {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously only (most) Union types had links to their members. This now adds linked Excerpts for all `TypeAlias`es.

Also fixes an issue with markdown lists in JSDoc not being shown in the generated TSDoc in `api-extractor`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
