### PR TITLE
refactor(Messages): Improve `ColorConvert` error

### DIFF
--- a/packages/discord.js/src/errors/Messages.js
+++ b/packages/discord.js/src/errors/Messages.js
@@ -39,7 +39,7 @@ const Messages = {
     `Calculated invalid shard ${shard} for guild ${guild} with ${count} shards.`,
 
   [DjsErrorCodes.ColorRange]: 'Color must be within the range 0 - 16777215 (0xFFFFFF).',
-  [DjsErrorCodes.ColorConvert]: 'Unable to convert color to a number.',
+  [DjsErrorCodes.ColorConvert]: color => `Unable to convert "${color}" to a number.`,
 
   [DjsErrorCodes.InviteOptionsMissingChannel]:
     'A valid guild channel must be provided when GuildScheduledEvent is EXTERNAL.',

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -278,19 +278,24 @@ function verifyString(
  * @returns {number} A color
  */
 function resolveColor(color) {
+  let resolvedColor;
+
   if (typeof color === 'string') {
     if (color === 'Random') return Math.floor(Math.random() * (0xffffff + 1));
     if (color === 'Default') return 0;
     if (/^#?[\da-f]{6}$/i.test(color)) return parseInt(color.replace('#', ''), 16);
-    color = Colors[color];
+    resolvedColor = Colors[color];
   } else if (Array.isArray(color)) {
-    color = (color[0] << 16) + (color[1] << 8) + color[2];
+    resolvedColor = (color[0] << 16) + (color[1] << 8) + color[2];
   }
 
-  if (color < 0 || color > 0xffffff) throw new DiscordjsRangeError(ErrorCodes.ColorRange);
-  if (typeof color !== 'number' || Number.isNaN(color)) throw new DiscordjsTypeError(ErrorCodes.ColorConvert);
+  if (resolvedColor < 0 || resolvedColor > 0xffffff) throw new DiscordjsRangeError(ErrorCodes.ColorRange);
 
-  return color;
+  if (typeof resolvedColor !== 'number' || Number.isNaN(resolvedColor)) {
+    throw new DiscordjsTypeError(ErrorCodes.ColorConvert, color);
+  }
+
+  return resolvedColor;
 }
 
 /**

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -289,7 +289,9 @@ function resolveColor(color) {
     resolvedColor = (color[0] << 16) + (color[1] << 8) + color[2];
   }
 
-  if (resolvedColor < 0 || resolvedColor > 0xffffff) throw new DiscordjsRangeError(ErrorCodes.ColorRange);
+  if (resolvedColor < 0 || resolvedColor > 0xffffff) {
+    throw new DiscordjsRangeError(ErrorCodes.ColorRange);
+  }
 
   if (typeof resolvedColor !== 'number' || Number.isNaN(resolvedColor)) {
     throw new DiscordjsTypeError(ErrorCodes.ColorConvert, color);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Improves the error by specifying what was unable to be converted. This may resolve in quicker debugging. Also resolves a possible mutation in `resolveColor()`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
