### PR TITLE
fix(BaseClient): Fall back to `userAgentAppendix`

### DIFF
--- a/packages/discord.js/src/client/BaseClient.js
+++ b/packages/discord.js/src/client/BaseClient.js
@@ -44,7 +44,7 @@ class BaseClient extends EventEmitter {
         ...options.rest,
         userAgentAppendix: options.rest?.userAgentAppendix
           ? `${Options.userAgentAppendix} ${options.rest.userAgentAppendix}`
-          : undefined,
+          : Options.userAgentAppendix,
       },
     };
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
We're currently getting an `undefined` string in our user agent strings (if an appendix is not specified):

```
Request {
  headersTimeout: undefined,
  bodyTimeout: undefined,
  throwOnError: false,
  method: 'GET',
  abort: null,
  body: null,
  completed: false,
  aborted: false,
  upgrade: null,
  path: '/api/v10/gateway/bot',
  origin: 'https://discord.com',
  idempotent: true,
  blocking: false,
  reset: null,
  host: null,
  contentLength: null,
  contentType: null,
  headers: 'User-Agent: DiscordBot (https://discord.js.org, 2.2.0) undefined\r\n' +
    'Authorization: Bot [REDACTED]\r\n',
  expectContinue: false,
  servername: null,
  [Symbol(handler)]: RequestHandler {
    responseHeaders: null,
    opaque: null,
    callback: [Function (anonymous)],
    res: null,
    abort: null,
    body: null,
    trailers: {},
    context: null,
    onInfo: null,
    throwOnError: undefined,
    highWaterMark: undefined,
    [Symbol(async_id_symbol)]: 92,
    [Symbol(trigger_async_id_symbol)]: 0,
    [Symbol(kSignal)]: AbortSignal { aborted: false },
    [Symbol(kListener)]: [Function (anonymous)]
  }
}
```

This happens because `userAgentAppendix` may be explicitly `undefined` here:

https://github.com/discordjs/discord.js/blob/278396e815add4e028e43034fab586f971a043d4/packages/discord.js/src/client/BaseClient.js#L42-L48

Eventually, it reaches this point:

https://github.com/discordjs/discord.js/blob/278396e815add4e028e43034fab586f971a043d4/packages/rest/src/lib/REST.ts#L79

The explicit `undefined` value is overwriting the default value.

This is a fault of discord.js as it is not possible to do `new REST({ userAgentAppendix: undefined });` due to exact optional property types being set. I've thus opted to fall back to the default value which has been tested even with the past bug #9421 and works fine.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
