### PR TITLE
refactor(resolveColor): Prioritise number type check

### DIFF
--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -289,7 +289,7 @@ function resolveColor(color) {
     resolvedColor = (color[0] << 16) + (color[1] << 8) + color[2];
   }
 
-  if (typeof resolvedColor !== 'number' || Number.isNaN(resolvedColor)) {
+  if (!Number.isInteger(resolvedColor)) {
     throw new DiscordjsTypeError(ErrorCodes.ColorConvert, color);
   }
 

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -289,12 +289,12 @@ function resolveColor(color) {
     resolvedColor = (color[0] << 16) + (color[1] << 8) + color[2];
   }
 
-  if (resolvedColor < 0 || resolvedColor > 0xffffff) {
-    throw new DiscordjsRangeError(ErrorCodes.ColorRange);
-  }
-
   if (typeof resolvedColor !== 'number' || Number.isNaN(resolvedColor)) {
     throw new DiscordjsTypeError(ErrorCodes.ColorConvert, color);
+  }
+
+  if (resolvedColor < 0 || resolvedColor > 0xffffff) {
+    throw new DiscordjsRangeError(ErrorCodes.ColorRange);
   }
 
   return resolvedColor;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
It's more logical to check for a number first before doing `resolvedColor < 0 || resolvedColor > 0xffffff`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
