### PR TITLE
fix(LimitedCollection): fix keepOverLimit behavior  #10062

### DIFF
--- a/packages/discord.js/src/util/LimitedCollection.js
+++ b/packages/discord.js/src/util/LimitedCollection.js
@@ -47,14 +47,10 @@ class LimitedCollection extends Collection {
   }
 
   set(key, value) {
-    if (this.maxSize === 0 && !this.keepOverLimit?.(value, key, this)) return this;
     if (this.size >= this.maxSize && !this.has(key)) {
-      for (const [k, v] of this.entries()) {
-        const keep = this.keepOverLimit?.(v, k, this) ?? false;
-        if (!keep) {
-          this.delete(k);
-          break;
-        }
+      const keep = this.keepOverLimit?.(value, key, this) ?? false;
+      if (!keep) {
+        return this;
       }
     }
     return super.set(key, value);


### PR DESCRIPTION
Original Issue: https://github.com/discordjs/discord.js/issues/10062

* always allow updating of elements even when maxSize is 0
* keep elements in the collection and disallow adding new ones if non matching the keepOverLimit expression
* do not remove any non-matching element from the collection when a new one is tried to add

**Please describe the changes this PR makes and why it should be merged:**
The behavior of the set function of this class was inconistent depending on the maxSize and keepOverLimit attributes. Also the documentation is misleading any may need an update.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes (Tests can be found here: https://github.com/p4bes/discordjs-bot/blob/main/test/LimitedCollection.test.js )
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
