### PR TITLE
feat(Managers): update cache when use edit method

### DIFF
--- a/packages/discord.js/src/managers/GuildEmojiManager.js
+++ b/packages/discord.js/src/managers/GuildEmojiManager.js
@@ -140,9 +140,8 @@ class GuildEmojiManager extends BaseGuildEmojiManager {
     });
     const existing = this.cache.get(id);
     if (existing) {
-      const clone = existing._clone();
-      clone._patch(newData);
-      return clone;
+      existing._patch(newData);
+      return existing; 
     }
     return this._add(newData);
   }

--- a/packages/discord.js/src/managers/GuildStickerManager.js
+++ b/packages/discord.js/src/managers/GuildStickerManager.js
@@ -115,9 +115,8 @@ class GuildStickerManager extends CachedManager {
 
     const existing = this.cache.get(stickerId);
     if (existing) {
-      const clone = existing._clone();
-      clone._patch(d);
-      return clone;
+      existing._patch(d);
+      return existing; 
     }
     return this._add(d);
   }

--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -189,9 +189,8 @@ class MessageManager extends CachedManager {
 
     const existing = this.cache.get(messageId);
     if (existing) {
-      const clone = existing._clone();
-      clone._patch(d);
-      return clone;
+      existing._patch(d);
+      return existing; 
     }
     return this._add(d);
   }

--- a/packages/discord.js/src/managers/RoleManager.js
+++ b/packages/discord.js/src/managers/RoleManager.js
@@ -208,9 +208,8 @@ class RoleManager extends CachedManager {
 
     const d = await this.client.rest.patch(Routes.guildRole(this.guild.id, role.id), { body, reason: options.reason });
 
-    const clone = role._clone();
-    clone._patch(d);
-    return clone;
+    role._patch(d);
+    return role; 
   }
 
   /**

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -359,9 +359,8 @@ class Webhook {
     const existing = messageManager.cache.get(d.id);
     if (!existing) return messageManager._add(d);
 
-    const clone = existing._clone();
-    clone._patch(d);
-    return clone;
+    existing._patch(d);
+    return existing; 
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
After updating something, you have to get information from Discord again, since using the information in the cache becomes impossible due to its irrelevance. I think this is wrong and suggest updating the cache with every valid change to something like in GuildChannelManager, instead of cloning.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--- I know how to update typings and have done so, or typings don't need updating
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
