### PR TITLE
fix(docs): remove spaces in type parameter brackets

### DIFF
--- a/packages/api-extractor/src/generators/ExcerptBuilder.ts
+++ b/packages/api-extractor/src/generators/ExcerptBuilder.ts
@@ -325,11 +325,11 @@ export class ExcerptBuilder {
 					// Remove BarTokens from excerpts if they immediately follow a LessThanToken, e.g. `Promise< | Something>`
 					// would become `Promise<Something>`
 					if (/<(?:\s*\||\s+)/.test(prevToken.text)) {
-						prevToken.text = prevToken.text.replace(/<\s*\|?\s*/, '<');
+						prevToken.text = prevToken.text.replaceAll(/<\s*\|?\s*/, '<');
 					}
 
 					if (/\s+>/.test(prevToken.text)) {
-						prevToken.text = prevToken.text.replace(/\s*>/, '>');
+						prevToken.text = prevToken.text.replaceAll(/\s*>/, '>');
 					}
 
 					mergeCount = 1;

--- a/packages/api-extractor/src/generators/ExcerptBuilder.ts
+++ b/packages/api-extractor/src/generators/ExcerptBuilder.ts
@@ -325,11 +325,11 @@ export class ExcerptBuilder {
 					// Remove BarTokens from excerpts if they immediately follow a LessThanToken, e.g. `Promise< | Something>`
 					// would become `Promise<Something>`
 					if (/<(?:\s*\||\s+)/.test(prevToken.text)) {
-						prevToken.text = prevToken.text.replaceAll(/<\s*\|?\s*/, '<');
+						prevToken.text = prevToken.text.replaceAll(/<\s*\|?\s*/g, '<');
 					}
 
 					if (/\s+>/.test(prevToken.text)) {
-						prevToken.text = prevToken.text.replaceAll(/\s*>/, '>');
+						prevToken.text = prevToken.text.replaceAll(/\s*>/g, '>');
 					}
 
 					mergeCount = 1;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Types with nested type parameters still had unneccessary spaces like `Type<Type<Type | Type> >`

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
