### PR TITLE
docs(ActionRow): fix deprecated message

### DIFF
--- a/packages/discord.js/src/structures/ActionRow.js
+++ b/packages/discord.js/src/structures/ActionRow.js
@@ -27,7 +27,7 @@ class ActionRow extends Component {
    * @memberof ActionRow
    * @param {ActionRowBuilder|ActionRow|APIActionRowComponent} other The other data
    * @returns {ActionRowBuilder}
-   * @deprecated Use {@link ActionRowBuilder.from} instead.
+   * @deprecated Use {@link ActionRowBuilder.from | ActionRowBuilder#from} instead.
    */
   static from = deprecate(
     other => new this(isJSONEncodable(other) ? other.toJSON() : other),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Updated the deprecated message for clarity; now suggests "ActionRowBuilder#from" instead of just "from."

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
