### PR TITLE
refactor(oauth2): remove unnecessary dependency on 'node:url'

### DIFF
--- a/packages/core/src/api/oauth2.ts
+++ b/packages/core/src/api/oauth2.ts
@@ -1,6 +1,5 @@
 /* eslint-disable jsdoc/check-param-names */
 
-import { URL } from 'node:url';
 import { type RequestData, type REST, makeURLSearchParams } from '@discordjs/rest';
 import {
 	Routes,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This change removes an unnecessary dependency on 'node:url', which fixes a runtime error when using '@discordjs/core/http-only' on Cloudflare Workers.

Related links:
- https://github.com/discordjs/discord.js/discussions/8428#discussioncomment-6955659
- https://developers.cloudflare.com/workers/runtime-apis/nodejs/

**Status and versioning classification:**
- **Code changes have been tested against the Discord API**, ~or there are no code changes~
- ~I know how to update typings and have done so, or~ **typings don't need updating**
