### PR TITLE
types: Update accessibility modifiers on constructors

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -311,7 +311,7 @@ export interface ActionRowData<ComponentType extends JSONEncodable<APIActionRowC
 export class ActionRowBuilder<
   ComponentType extends AnyComponentBuilder = AnyComponentBuilder,
 > extends BuilderActionRow<ComponentType> {
-  constructor(
+  public constructor(
     data?: Partial<
       | ActionRowData<ActionRowComponentData | JSONEncodable<APIActionRowComponentTypes>>
       | APIActionRowComponent<APIMessageActionRowComponent | APIModalActionRowComponent>
@@ -2396,7 +2396,7 @@ export interface ActionRowModalData {
 }
 
 export class ModalSubmitFields {
-  constructor(components: readonly (readonly ModalActionRowComponent[])[]);
+  private constructor(components: readonly (readonly ModalActionRowComponent[])[]);
   public components: ActionRowModalData[];
   public fields: Collection<string, ModalActionRowComponent>;
   public getField<Type extends ComponentType>(customId: string, type: Type): { type: Type } & TextInputModalData;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
These two classes had (explicit) accessibility modifiers added to their constructors.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:

- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
