### PR TITLE
fix(ReadonlyCollection): omit `clear` method

### DIFF
--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -15,7 +15,7 @@ export interface CollectionConstructor {
  */
 export type ReadonlyCollection<Key, Value> = Omit<
 	Collection<Key, Value>,
-	'delete' | 'ensure' | 'forEach' | 'get' | 'reverse' | 'set' | 'sort' | 'sweep'
+	'clear' | 'delete' | 'ensure' | 'forEach' | 'get' | 'reverse' | 'set' | 'sort' | 'sweep'
 > &
 	ReadonlyMap<Key, Value>;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Omit the `clear()` method on `ReadonlyCollection`s as it mutates the original array.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
