### PR TITLE
fix(Faces): Escape backslash in `Shrug`

### DIFF
--- a/packages/formatters/__tests__/formatters.test.ts
+++ b/packages/formatters/__tests__/formatters.test.ts
@@ -314,12 +314,9 @@ describe('Message formatters', () => {
 	});
 
 	describe('Faces', () => {
-		// prettier-ignore
-		/* eslint-disable no-useless-escape */
-		test('GIVEN Faces.Shrug THEN returns "¯\_(ツ)_/¯"', () => {
-			expect<'¯\_(ツ)_/¯'>(Faces.Shrug).toEqual('¯\_(ツ)_/¯');
+		test('GIVEN Faces.Shrug THEN returns "¯\\_(ツ)_/¯"', () => {
+			expect<'¯\\_(ツ)_/¯'>(Faces.Shrug).toEqual('¯\\_(ツ)_/¯');
 		});
-		/* eslint-enable no-useless-escape */
 
 		test('GIVEN Faces.Tableflip THEN returns "(╯°□°)╯︵ ┻━┻"', () => {
 			expect<'(╯°□°)╯︵ ┻━┻'>(Faces.Tableflip).toEqual('(╯°□°)╯︵ ┻━┻');

--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -684,7 +684,7 @@ export enum Faces {
 	 * `¯\_(ツ)_/¯`
 	 */
 	// eslint-disable-next-line no-useless-escape
-	Shrug = '¯\_(ツ)_/¯',
+	Shrug = '¯\\_(ツ)_/¯',
 
 	/**
 	 * `(╯°□°)╯︵ ┻━┻`

--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -683,7 +683,6 @@ export enum Faces {
 	/**
 	 * `¯\_(ツ)_/¯`
 	 */
-	// eslint-disable-next-line no-useless-escape
 	Shrug = '¯\\_(ツ)_/¯',
 
 	/**

--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -675,7 +675,6 @@ export const TimestampStyles = {
  */
 export type TimestampStylesString = (typeof TimestampStyles)[keyof typeof TimestampStyles];
 
-// prettier-ignore
 /**
  * All the available faces from Discord's native slash commands.
  */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

On stable, the value of `Shrug` is `¯_(ツ)_/¯`, which is incorrect. This PR fixes the error by escaping the backslash.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
