### PR TITLE
ci: enable npm provenance

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -35,6 +35,8 @@ jobs:
           - package: '@discordjs/ws'
             folder: 'ws'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
@@ -71,7 +73,7 @@ jobs:
         if: steps.release-check.outputs.release == '1'
         run: |
           pnpm --filter=${{ matrix.package }} run release --preid "dev.$(date +%s)-$(git rev-parse --short HEAD)"
-          pnpm --filter=${{ matrix.package }} publish --no-git-checks --tag dev || true
+          pnpm --filter=${{ matrix.package }} publish --provenance --no-git-checks --tag dev || true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -36,6 +36,6 @@ jobs:
 
       - name: Publish package
         run: |
-          pnpm --filter=${{ steps.extract-tag.outputs.subpackage == 'true' && '@discordjs/' || '' }}${{ steps.extract-tag.outputs.package }} publish --no-git-checks
+          pnpm --filter=${{ steps.extract-tag.outputs.subpackage == 'true' && '@discordjs/' || '' }}${{ steps.extract-tag.outputs.package }} publish --provenance --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -6,6 +6,8 @@ jobs:
   npm-publish:
     name: npm publish
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/packages/api-extractor-utils/package.json
+++ b/packages/api-extractor-utils/package.json
@@ -63,6 +63,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/api-extractor-utils/package.json
+++ b/packages/api-extractor-utils/package.json
@@ -61,9 +61,5 @@
 	},
 	"engines": {
 		"node": ">=18"
-	},
-	"publishConfig": {
-		"access": "public",
-		"provenance": true
 	}
 }

--- a/packages/brokers/package.json
+++ b/packages/brokers/package.json
@@ -91,6 +91,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -94,6 +94,7 @@
 		"node": ">=16.11.0"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -80,6 +80,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -92,6 +92,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/create-discord-bot/package.json
+++ b/packages/create-discord-bot/package.json
@@ -75,6 +75,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -100,5 +100,8 @@
   },
   "engines": {
     "node": ">=16.11.0"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -81,6 +81,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -77,6 +77,7 @@
 		"node": ">=16.11.0"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -94,6 +94,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/proxy-container/package.json
+++ b/packages/proxy-container/package.json
@@ -63,6 +63,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -92,6 +92,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -113,6 +113,7 @@
 		"node": ">=16.11.0"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/scripts/turbo/generators/templates/package.json.hbs
+++ b/packages/scripts/turbo/generators/templates/package.json.hbs
@@ -70,6 +70,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -93,6 +93,7 @@
 		"node": ">=18"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -82,7 +82,8 @@
 		"node": ">=16.11.0"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	},
 	"tsd": {
 		"directory": "__tests__/types"

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -95,6 +95,7 @@
 		"node": ">=16.11.0"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -107,6 +107,7 @@
 		"node": ">=16.11.0"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"provenance": true
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
See https://github.blog/2023-04-19-introducing-npm-package-provenance/ and https://docs.npmjs.com/generating-provenance-statements

pnpm has supported the `--provenance` option since [8.4.0](https://github.com/pnpm/pnpm/releases/tag/v8.4.0)

Also enabled it in every (public) package.json to error out if someone tries to publish it in an environment where provenance is not supported (i.e. their own computer)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
