### PR TITLE
feat: allow RestOrArray for command option builders

### DIFF
--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -144,23 +144,22 @@ describe('Slash Commands', () => {
 							integer
 								.setName('iscool')
 								.setDescription('Are we cool or what?')
-								.addChoices({ name: 'Very cool', value: 1_000 }),
+								.addChoices({ name: 'Very cool', value: 1_000 })
+								.addChoices([{ name: 'Even cooler', value: 2_000 }]),
 						)
 						.addNumberOption((number) =>
 							number
 								.setName('iscool')
 								.setDescription('Are we cool or what?')
-								.addChoices({ name: 'Very cool', value: 1.5 }),
+								.addChoices({ name: 'Very cool', value: 1.5 })
+								.addChoices([{ name: 'Even cooler', value: 2.5 }]),
 						)
 						.addStringOption((string) =>
 							string
 								.setName('iscool')
 								.setDescription('Are we cool or what?')
-								.addChoices(
-									{ name: 'Fancy Pants', value: 'fp_1' },
-									{ name: 'Fancy Shoes', value: 'fs_1' },
-									{ name: 'The Whole shebang', value: 'all' },
-								),
+								.addChoices({ name: 'Fancy Pants', value: 'fp_1' }, { name: 'Fancy Shoes', value: 'fs_1' })
+								.addChoices([{ name: 'The Whole shebang', value: 'all' }]),
 						)
 						.addIntegerOption((integer) =>
 							integer.setName('iscool').setDescription('Are we cool or what?').setAutocomplete(true),
@@ -229,7 +228,9 @@ describe('Slash Commands', () => {
 
 			test('GIVEN a builder with valid channel options and channel_types THEN does not throw an error', () => {
 				expect(() =>
-					getBuilder().addChannelOption(getChannelOption().addChannelTypes(ChannelType.GuildText)),
+					getBuilder().addChannelOption(
+						getChannelOption().addChannelTypes(ChannelType.GuildText).addChannelTypes([ChannelType.GuildVoice]),
+					),
 				).not.toThrowError();
 
 				expect(() => {

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionChannelTypesMixin.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionChannelTypesMixin.ts
@@ -1,7 +1,6 @@
 import { s } from '@sapphire/shapeshift';
 import { ChannelType } from 'discord-api-types/v10';
-import type { RestOrArray } from '../../../util/normalizeArray';
-import { normalizeArray } from '../../../util/normalizeArray';
+import { normalizeArray, type RestOrArray } from '../../../util/normalizeArray';
 
 /**
  * The allowed channel types used for a channel option in a slash command builder.

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionChannelTypesMixin.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionChannelTypesMixin.ts
@@ -1,5 +1,7 @@
 import { s } from '@sapphire/shapeshift';
 import { ChannelType } from 'discord-api-types/v10';
+import type { RestOrArray } from '../../../util/normalizeArray';
+import { normalizeArray } from '../../../util/normalizeArray';
 
 /**
  * The allowed channel types used for a channel option in a slash command builder.
@@ -41,12 +43,12 @@ export class ApplicationCommandOptionChannelTypesMixin {
 	 *
 	 * @param channelTypes - The channel types
 	 */
-	public addChannelTypes(...channelTypes: ApplicationCommandOptionAllowedChannelTypes[]) {
+	public addChannelTypes(...channelTypes: RestOrArray<ApplicationCommandOptionAllowedChannelTypes>) {
 		if (this.channel_types === undefined) {
 			Reflect.set(this, 'channel_types', []);
 		}
 
-		this.channel_types!.push(...channelTypesPredicate.parse(channelTypes));
+		this.channel_types!.push(...channelTypesPredicate.parse(normalizeArray(channelTypes)));
 
 		return this;
 	}

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionWithChoicesMixin.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionWithChoicesMixin.ts
@@ -1,7 +1,6 @@
 import { s } from '@sapphire/shapeshift';
 import { ApplicationCommandOptionType, type APIApplicationCommandOptionChoice } from 'discord-api-types/v10';
-import type { RestOrArray } from '../../../util/normalizeArray.js';
-import { normalizeArray } from '../../../util/normalizeArray.js';
+import { normalizeArray, type RestOrArray } from '../../../util/normalizeArray.js';
 import { localizationMapPredicate, validateChoicesLength } from '../Assertions.js';
 
 const stringPredicate = s.string.lengthGreaterThanOrEqual(1).lengthLessThanOrEqual(100);

--- a/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionWithChoicesMixin.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/ApplicationCommandOptionWithChoicesMixin.ts
@@ -1,5 +1,7 @@
 import { s } from '@sapphire/shapeshift';
 import { ApplicationCommandOptionType, type APIApplicationCommandOptionChoice } from 'discord-api-types/v10';
+import type { RestOrArray } from '../../../util/normalizeArray.js';
+import { normalizeArray } from '../../../util/normalizeArray.js';
 import { localizationMapPredicate, validateChoicesLength } from '../Assertions.js';
 
 const stringPredicate = s.string.lengthGreaterThanOrEqual(1).lengthLessThanOrEqual(100);
@@ -31,20 +33,21 @@ export class ApplicationCommandOptionWithChoicesMixin<ChoiceType extends number 
 	 *
 	 * @param choices - The choices to add
 	 */
-	public addChoices(...choices: APIApplicationCommandOptionChoice<ChoiceType>[]): this {
-		if (choices.length > 0 && 'autocomplete' in this && this.autocomplete) {
+	public addChoices(...choices: RestOrArray<APIApplicationCommandOptionChoice<ChoiceType>>): this {
+		const normalizedChoices = normalizeArray(choices);
+		if (normalizedChoices.length > 0 && 'autocomplete' in this && this.autocomplete) {
 			throw new RangeError('Autocomplete and choices are mutually exclusive to each other.');
 		}
 
-		choicesPredicate.parse(choices);
+		choicesPredicate.parse(normalizedChoices);
 
 		if (this.choices === undefined) {
 			Reflect.set(this, 'choices', []);
 		}
 
-		validateChoicesLength(choices.length, this.choices);
+		validateChoicesLength(normalizedChoices.length, this.choices);
 
-		for (const { name, name_localizations, value } of choices) {
+		for (const { name, name_localizations, value } of normalizedChoices) {
 			// Validate the value
 			if (this.type === ApplicationCommandOptionType.String) {
 				stringPredicate.parse(value);
@@ -63,15 +66,16 @@ export class ApplicationCommandOptionWithChoicesMixin<ChoiceType extends number 
 	 *
 	 * @param choices - The choices to set
 	 */
-	public setChoices<Input extends APIApplicationCommandOptionChoice<ChoiceType>[]>(...choices: Input): this {
-		if (choices.length > 0 && 'autocomplete' in this && this.autocomplete) {
+	public setChoices<Input extends APIApplicationCommandOptionChoice<ChoiceType>>(...choices: RestOrArray<Input>): this {
+		const normalizedChoices = normalizeArray(choices);
+		if (normalizedChoices.length > 0 && 'autocomplete' in this && this.autocomplete) {
 			throw new RangeError('Autocomplete and choices are mutually exclusive to each other.');
 		}
 
-		choicesPredicate.parse(choices);
+		choicesPredicate.parse(normalizedChoices);
 
 		Reflect.set(this, 'choices', []);
-		this.addChoices(...choices);
+		this.addChoices(normalizedChoices);
 
 		return this;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR changes ApplicationCommandOption methods to allow both rest and array params, which previously wasn't consistent with other builders. This was done by widening the parameter from `...T[]` to `RestOrArray<T>` and normalizing it inside the method. Since arrays are still allowed, this is not a breaking change. The test file has been modified to test both rest and array parameters.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->