### PR TITLE
chore: remove ws dependency

### DIFF
--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -71,13 +71,11 @@
     "@discordjs/util": "workspace:^",
     "@discordjs/ws": "workspace:^",
     "@sapphire/snowflake": "3.5.3",
-    "@types/ws": "8.5.10",
     "discord-api-types": "0.37.61",
     "fast-deep-equal": "3.1.3",
     "lodash.snakecase": "4.1.1",
     "tslib": "2.6.2",
-    "undici": "6.7.1",
-    "ws": "8.16.0"
+    "undici": "6.7.1"
   },
   "devDependencies": {
     "@discordjs/api-extractor": "workspace:^",

--- a/packages/discord.js/tsconfig.json
+++ b/packages/discord.js/tsconfig.json
@@ -16,7 +16,6 @@
       "@discordjs/ws",
       "discord-api-types/v10",
       "node",
-      "ws",
       "tsd",
       "jest",
       "undici",

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -180,7 +180,6 @@ import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
 import { Stream } from 'node:stream';
 import { MessagePort, Worker } from 'node:worker_threads';
-import { Data as WebSocketData, WebSocket } from 'ws';
 import {
   RawActivityData,
   RawAnonymousGuildData,
@@ -5484,13 +5483,6 @@ export type EmojiIdentifierResolvable =
 
 export type EmojiResolvable = Snowflake | GuildEmoji | ReactionEmoji;
 
-export interface ErrorEvent {
-  error: unknown;
-  message: string;
-  type: string;
-  target: WebSocket;
-}
-
 export interface FetchApplicationCommandOptions extends BaseFetchOptions {
   guildId?: Snowflake;
   locale?: LocaleString;
@@ -6202,12 +6194,6 @@ export interface MessageComponentCollectorOptions<Interaction extends CollectedM
 
 export interface MessageChannelComponentCollectorOptions<Interaction extends CollectedMessageInteraction>
   extends Omit<InteractionCollectorOptions<Interaction>, 'channel' | 'guild' | 'interactionType'> {}
-
-export interface MessageEvent {
-  data: WebSocketData;
-  type: string;
-  target: WebSocket;
-}
 
 export interface MessageInteraction {
   id: Snowflake;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,9 +949,6 @@ importers:
       '@sapphire/snowflake':
         specifier: 3.5.3
         version: 3.5.3
-      '@types/ws':
-        specifier: 8.5.10
-        version: 8.5.10
       discord-api-types:
         specifier: 0.37.61
         version: 0.37.61
@@ -967,9 +964,6 @@ importers:
       undici:
         specifier: 6.7.1
         version: 6.7.1
-      ws:
-        specifier: 8.16.0
-        version: 8.16.0
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -4067,7 +4061,7 @@ packages:
     dependencies:
       '@definitelytyped/typescript-versions': 0.1.1
       '@definitelytyped/utils': 0.1.5
-      semver: 7.5.4
+      semver: 7.6.0
     dev: true
 
   /@definitelytyped/typescript-versions@0.1.1:
@@ -6398,7 +6392,7 @@ packages:
       request: 2.88.2
       retry: 0.12.0
       safe-buffer: 5.2.1
-      semver: 7.5.4
+      semver: 7.6.0
       slide: 1.1.6
       ssri: 8.0.1
     optionalDependencies:
@@ -21336,7 +21330,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      semver: 7.5.4
+      semver: 7.6.0
       validate-npm-package-name: 3.0.0
     dev: true
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Remove the `ws` dependency of `discord.js`main library which is not used anymore since incorporating `@discordjs/ws` into main library.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
