### PR TITLE
docs: remove unused `Locale` typedef

### DIFF
--- a/packages/discord.js/src/structures/BaseInteraction.js
+++ b/packages/discord.js/src/structures/BaseInteraction.js
@@ -88,42 +88,6 @@ class BaseInteraction extends Base {
       : null;
 
     /**
-     * A Discord locale string, possible values are:
-     * * en-US (English, US)
-     * * en-GB (English, UK)
-     * * bg (Bulgarian)
-     * * zh-CN (Chinese, China)
-     * * zh-TW (Chinese, Taiwan)
-     * * hr (Croatian)
-     * * cs (Czech)
-     * * da (Danish)
-     * * nl (Dutch)
-     * * fi (Finnish)
-     * * fr (French)
-     * * de (German)
-     * * el (Greek)
-     * * hi (Hindi)
-     * * hu (Hungarian)
-     * * it (Italian)
-     * * ja (Japanese)
-     * * ko (Korean)
-     * * lt (Lithuanian)
-     * * no (Norwegian)
-     * * pl (Polish)
-     * * pt-BR (Portuguese, Brazilian)
-     * * ro (Romanian, Romania)
-     * * ru (Russian)
-     * * es-ES (Spanish)
-     * * sv-SE (Swedish)
-     * * th (Thai)
-     * * tr (Turkish)
-     * * uk (Ukrainian)
-     * * vi (Vietnamese)
-     * @see {@link https://discord.com/developers/docs/reference#locales}
-     * @typedef {string} Locale
-     */
-
-    /**
      * The locale of the user who invoked this interaction
      * @type {Locale}
      */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes the unused typedef, as requested in the reviews

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
