### PR TITLE
fix(website): use correct version for cross-package links

### DIFF
--- a/apps/website/src/components/DocNode.tsx
+++ b/apps/website/src/components/DocNode.tsx
@@ -13,7 +13,7 @@ export async function DocNode({ node, version }: { readonly node?: any; readonly
 						<Link
 							key={`${node.text}-${idx}`}
 							className="font-mono text-blurple hover:text-blurple-500 dark:hover:text-blurple-300"
-							href={`/docs/packages/${node.resolvedPackage.packageName}/${version}/${node.uri}`}
+							href={`/docs/packages/${node.resolvedPackage.packageName}/${node.resolvedPackage.version ?? version}/${node.uri}`}
 						>
 							{node.text}
 						</Link>

--- a/apps/website/src/components/ExcerptNode.tsx
+++ b/apps/website/src/components/ExcerptNode.tsx
@@ -20,7 +20,7 @@ export async function ExcerptNode({ node, version }: { readonly node?: any; read
 							<Link
 								key={`${excerpt.resolvedItem.displayName}-${idx}`}
 								className="text-blurple hover:text-blurple-500 dark:hover:text-blurple-300"
-								href={`/docs/packages/${excerpt.resolvedItem.packageName}/${version}/${excerpt.resolvedItem.uri}`}
+								href={`/docs/packages/${excerpt.resolvedItem.packageName}/${excerpt.resolvedItem.version ?? version}/${excerpt.resolvedItem.uri}`}
 							>
 								{excerpt.text}
 							</Link>

--- a/apps/website/src/util/fetchNode.ts
+++ b/apps/website/src/util/fetchNode.ts
@@ -17,7 +17,10 @@ export async function fetchNode({
 	if (ENV.IS_LOCAL_DEV) {
 		try {
 			const fileContent = await readFile(
-				join(process.cwd(), `../../packages/${packageName}/docs/split/${version}.${normalizeItem}.api.json`),
+				join(
+					process.cwd(),
+					`../../packages/${packageName}/docs/${packageName}/split/${version}.${normalizeItem}.api.json`,
+				),
 				'utf8',
 			);
 

--- a/apps/website/src/util/fetchSitemap.ts
+++ b/apps/website/src/util/fetchSitemap.ts
@@ -13,7 +13,7 @@ export async function fetchSitemap({
 	if (ENV.IS_LOCAL_DEV) {
 		try {
 			const fileContent = await readFile(
-				join(process.cwd(), `../../packages/${packageName}/docs/split/${version}.sitemap.api.json`),
+				join(process.cwd(), `../../packages/${packageName}/docs/${packageName}/split/${version}.sitemap.api.json`),
 				'utf8',
 			);
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Links to types in other subpackages use the correct version of that subpackage now, instead of the version of the current package.

Fixes for example https://discord.js.org/docs/packages/discord.js/14.14.1/Client:Class#rest

Also fixed two small issues for local testing of the docs website

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
