### PR TITLE
build: bump discord-api-types to 0.37.78

### DIFF
--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -67,7 +67,7 @@
 		"@discordjs/formatters": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"@sapphire/shapeshift": "^3.9.6",
-		"discord-api-types": "0.37.61",
+		"discord-api-types": "0.37.78",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.4",
 		"tslib": "^2.6.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,7 @@
 		"@discordjs/ws": "workspace:^",
 		"@sapphire/snowflake": "^3.5.3",
 		"@vladfrangu/async_event_emitter": "^2.2.4",
-		"discord-api-types": "0.37.61"
+		"discord-api-types": "0.37.78"
 	},
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -71,7 +71,7 @@
     "@discordjs/util": "workspace:^",
     "@discordjs/ws": "workspace:^",
     "@sapphire/snowflake": "3.5.3",
-    "discord-api-types": "0.37.61",
+    "discord-api-types": "0.37.78",
     "fast-deep-equal": "3.1.3",
     "lodash.snakecase": "4.1.1",
     "tslib": "2.6.2",

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -54,7 +54,7 @@
 	},
 	"homepage": "https://discord.js.org",
 	"dependencies": {
-		"discord-api-types": "0.37.61"
+		"discord-api-types": "0.37.78"
 	},
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -71,7 +71,7 @@
 		"@discordjs/rest": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"@discordjs/ws": "workspace:^",
-		"discord-api-types": "0.37.61"
+		"discord-api-types": "0.37.78"
 	},
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -87,7 +87,7 @@
 		"@sapphire/async-queue": "^1.5.2",
 		"@sapphire/snowflake": "^3.5.3",
 		"@vladfrangu/async_event_emitter": "^2.2.4",
-		"discord-api-types": "0.37.61",
+		"discord-api-types": "0.37.78",
 		"magic-bytes.js": "^1.10.0",
 		"tslib": "^2.6.2",
 		"undici": "6.7.1"

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -63,7 +63,7 @@
 	"homepage": "https://discord.js.org",
 	"dependencies": {
 		"@types/ws": "^8.5.10",
-		"discord-api-types": "0.37.61",
+		"discord-api-types": "0.37.78",
 		"prism-media": "^1.3.5",
 		"tslib": "^2.6.2",
 		"ws": "^8.16.0"

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -78,7 +78,7 @@
 		"@sapphire/async-queue": "^1.5.2",
 		"@types/ws": "^8.5.10",
 		"@vladfrangu/async_event_emitter": "^2.2.4",
-		"discord-api-types": "0.37.61",
+		"discord-api-types": "0.37.78",
 		"tslib": "^2.6.2",
 		"ws": "^8.16.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,8 +686,8 @@ importers:
         specifier: ^3.9.6
         version: 3.9.6
       discord-api-types:
-        specifier: 0.37.61
-        version: 0.37.61
+        specifier: 0.37.78
+        version: 0.37.78
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -813,8 +813,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       discord-api-types:
-        specifier: 0.37.61
-        version: 0.37.61
+        specifier: 0.37.78
+        version: 0.37.78
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -950,8 +950,8 @@ importers:
         specifier: 3.5.3
         version: 3.5.3
       discord-api-types:
-        specifier: 0.37.61
-        version: 0.37.61
+        specifier: 0.37.78
+        version: 0.37.78
       fast-deep-equal:
         specifier: 3.1.3
         version: 3.1.3
@@ -1069,8 +1069,8 @@ importers:
   packages/formatters:
     dependencies:
       discord-api-types:
-        specifier: 0.37.61
-        version: 0.37.61
+        specifier: 0.37.78
+        version: 0.37.78
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -1142,8 +1142,8 @@ importers:
         specifier: workspace:^
         version: link:../ws
       discord-api-types:
-        specifier: 0.37.61
-        version: 0.37.61
+        specifier: 0.37.78
+        version: 0.37.78
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -1316,8 +1316,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       discord-api-types:
-        specifier: 0.37.61
-        version: 0.37.61
+        specifier: 0.37.78
+        version: 0.37.78
       magic-bytes.js:
         specifier: ^1.10.0
         version: 1.10.0
@@ -1613,8 +1613,8 @@ importers:
         specifier: ^8.5.10
         version: 8.5.10
       discord-api-types:
-        specifier: 0.37.61
-        version: 0.37.61
+        specifier: 0.37.78
+        version: 0.37.78
       prism-media:
         specifier: ^1.3.5
         version: 1.3.5
@@ -1710,8 +1710,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       discord-api-types:
-        specifier: 0.37.61
-        version: 0.37.61
+        specifier: 0.37.78
+        version: 0.37.78
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -14520,8 +14520,8 @@ packages:
       path-type: 4.0.0
     dev: true
 
-  /discord-api-types@0.37.61:
-    resolution: {integrity: sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw==}
+  /discord-api-types@0.37.78:
+    resolution: {integrity: sha512-IJdyOPhq7r9Gw5/4X9u4vG8rX7+AwOtX7flUSQyQ1vAZzlnN452GGElUPmjQJIo8gB5VwMesbA9eMW+f0NMWVA==}
     dev: false
 
   /dlv@1.1.3:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Unblocks:
- #10182

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
