### PR TITLE
ci: fix call to generateSplitDocumentation if run on tag

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -88,7 +88,7 @@ jobs:
             cd "packages/${PACKAGE}"
             sed -i 's!https://github.com/discordjs/discord.js/tree/main!https://github.com/discordjs/discord.js/tree/${{ inputs.ref }}!' api-extractor.json
             ../../main/packages/api-extractor/bin/api-extractor run --local --minify
-            ../../main/packages/scripts/bin/generateSplitDocumentation
+            ../../main/packages/scripts/bin/generateSplitDocumentation.js
             cd ../..
           done
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes documentation.yml CI to run the correct generateSplitDocumentation**.js** when run against a tag or branch.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
