### PR TITLE
feat(website): add type field to search index to sort by

### DIFF
--- a/apps/website/src/components/ui/CmdK.tsx
+++ b/apps/website/src/components/ui/CmdK.tsx
@@ -95,6 +95,7 @@ export function CmdK({ dependencies }: { readonly dependencies: string[] }) {
 					q: searchString,
 					limit: 25,
 					attributesToSearchOn: ['name'],
+					sort: ['type:asc'],
 				})),
 			});
 			setSearchResults(result.results.flatMap((res) => res.hits));

--- a/packages/actions/src/uploadSearchIndices/index.ts
+++ b/packages/actions/src/uploadSearchIndices/index.ts
@@ -66,7 +66,10 @@ try {
 					await client.waitForTask(task.taskUid);
 				}
 
-				await client.index(index.index).addDocuments(index.data);
+				const searchIndex = client.index(index.index);
+				await searchIndex.updateSettings({ sortableAttributes: ['type'] });
+
+				await searchIndex.addDocuments(index.data);
 			}),
 		);
 	} catch {}

--- a/packages/scripts/src/generateIndex.ts
+++ b/packages/scripts/src/generateIndex.ts
@@ -19,6 +19,7 @@ export interface MemberJSON {
 	name: string;
 	path: string;
 	summary: string | null;
+	type: number;
 }
 
 let idx = 0;
@@ -89,6 +90,30 @@ export function tryResolveSummaryText(item: ApiDeclaredItem): string | null {
 	return retVal;
 }
 
+export enum SearchOrderType {
+	Class,
+	Interface,
+	TypeAlias,
+	Function,
+	Enum,
+	Variable,
+	Event,
+	Method,
+	Property,
+	MethodSignature,
+	PropertySignature,
+	EnumMember,
+	Package,
+	Namespace,
+	IndexSignature,
+	CallSignature,
+	Constructor,
+	ConstructSignature,
+	EntryPoint,
+	Model,
+	None,
+}
+
 export function visitNodes(item: ApiItem, tag: string) {
 	const members: (MemberJSON & { id: number })[] = [];
 
@@ -111,6 +136,7 @@ export function visitNodes(item: ApiItem, tag: string) {
 			kind: member.kind,
 			summary: tryResolveSummaryText(member) ?? '',
 			path: generatePath(member.getHierarchy(), tag),
+			type: SearchOrderType[member.kind as keyof typeof SearchOrderType],
 		});
 	}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds a `type` property to the meilisearch documents, which then is used in CmdK search to sort the results in the following order:

- Class,
- Interface,
- TypeAlias,
- Function,
- Enum,
- Variable,
- Event,
- Method,
- Property,
- MethodSignature,
- PropertySignature,
- EnumMember,

The following `ApiItemKind` are added at the end of the enum used for sorting, although they should never appear in the index:
Package, Namespace, IndexSignature, CallSignature, Constructor, ConstructSignature, EntryPoint, Model, None

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
