### PR TITLE
fix(api-extractor): link class in docs if interface merging happened

### DIFF
--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -41,7 +41,7 @@ import {
 	Navigation,
 } from '@discordjs/api-extractor-model';
 import type * as tsdoc from '@microsoft/tsdoc';
-import { DeclarationReference } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference.js';
+import { DeclarationReference, type Meaning } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference.js';
 import { JsonFile, Path } from '@rushstack/node-core-library';
 import * as ts from 'typescript';
 import type { AstDeclaration } from '../analyzer/AstDeclaration.js';
@@ -1796,8 +1796,8 @@ export class ApiModelGenerator {
 											DeclarationReference.parseComponent(type ?? 'unknown'),
 										)
 										.withMeaning(
-											lookup[astSymbol?.astDeclarations[0]?.declaration.kind ?? ts.SyntaxKind.ClassDeclaration] ??
-												('class' as any),
+											(lookup[astSymbol?.astDeclarations.at(-1)?.declaration.kind ?? ts.SyntaxKind.ClassDeclaration] ??
+												'class') as Meaning,
 										)
 										.toString(),
 						},


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes parameter types linking to the the class instead of the (merged) interface for cases where interface merging happened. (e.g. GuildMember, User, DMChannel, TextChannel, Webhook, ...)

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
