### PR TITLE
build: bump discord-api-types to 0.37.82

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
 	"engines": {
 		"node": ">=18"
 	},
-	"packageManager": "pnpm@8.10.2"
+	"packageManager": "pnpm@8.15.7+sha256.50783dd0fa303852de2dd1557cd4b9f07cb5b018154a6e76d0f40635d6cee019"
 }

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -67,7 +67,7 @@
 		"@discordjs/formatters": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"@sapphire/shapeshift": "^3.9.7",
-		"discord-api-types": "0.37.79",
+		"discord-api-types": "0.37.82",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.4",
 		"tslib": "^2.6.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,7 +69,7 @@
 		"@discordjs/ws": "workspace:^",
 		"@sapphire/snowflake": "^3.5.3",
 		"@vladfrangu/async_event_emitter": "^2.2.4",
-		"discord-api-types": "0.37.79"
+		"discord-api-types": "0.37.82"
 	},
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -198,8 +198,9 @@ export class Client extends AsyncEventEmitter<MappedEvents> {
 
 		this.gateway.on(WebSocketShardEvents.Dispatch, ({ data: dispatch, shardId }) => {
 			this.emit(
-				dispatch.t,
+				// TODO: This comment will have to be moved down once the new Poll events are added to the `ManagerShardEventsMap`
 				// @ts-expect-error event props can't be resolved properly, but they are correct
+				dispatch.t,
 				this.wrapIntrinsicProps(dispatch.d, shardId),
 			);
 		});

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -71,7 +71,7 @@
     "@discordjs/util": "workspace:^",
     "@discordjs/ws": "workspace:^",
     "@sapphire/snowflake": "3.5.3",
-    "discord-api-types": "0.37.79",
+    "discord-api-types": "0.37.82",
     "fast-deep-equal": "3.1.3",
     "lodash.snakecase": "4.1.1",
     "tslib": "2.6.2",

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -54,7 +54,7 @@
 	},
 	"homepage": "https://discord.js.org",
 	"dependencies": {
-		"discord-api-types": "0.37.79"
+		"discord-api-types": "0.37.82"
 	},
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -71,7 +71,7 @@
 		"@discordjs/rest": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"@discordjs/ws": "workspace:^",
-		"discord-api-types": "0.37.79"
+		"discord-api-types": "0.37.82"
 	},
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -87,7 +87,7 @@
 		"@sapphire/async-queue": "^1.5.2",
 		"@sapphire/snowflake": "^3.5.3",
 		"@vladfrangu/async_event_emitter": "^2.2.4",
-		"discord-api-types": "0.37.79",
+		"discord-api-types": "0.37.82",
 		"magic-bytes.js": "^1.10.0",
 		"tslib": "^2.6.2",
 		"undici": "6.13.0"

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -63,7 +63,7 @@
 	"homepage": "https://discord.js.org",
 	"dependencies": {
 		"@types/ws": "^8.5.10",
-		"discord-api-types": "0.37.79",
+		"discord-api-types": "0.37.82",
 		"prism-media": "^1.3.5",
 		"tslib": "^2.6.2",
 		"ws": "^8.16.0"

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -78,7 +78,7 @@
 		"@sapphire/async-queue": "^1.5.2",
 		"@types/ws": "^8.5.10",
 		"@vladfrangu/async_event_emitter": "^2.2.4",
-		"discord-api-types": "0.37.79",
+		"discord-api-types": "0.37.82",
 		"tslib": "^2.6.2",
 		"ws": "^8.16.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,8 +686,8 @@ importers:
         specifier: ^3.9.7
         version: 3.9.7
       discord-api-types:
-        specifier: 0.37.79
-        version: 0.37.79
+        specifier: 0.37.82
+        version: 0.37.82
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -810,8 +810,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       discord-api-types:
-        specifier: 0.37.79
-        version: 0.37.79
+        specifier: 0.37.82
+        version: 0.37.82
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -947,8 +947,8 @@ importers:
         specifier: 3.5.3
         version: 3.5.3
       discord-api-types:
-        specifier: 0.37.79
-        version: 0.37.79
+        specifier: 0.37.82
+        version: 0.37.82
       fast-deep-equal:
         specifier: 3.1.3
         version: 3.1.3
@@ -1066,8 +1066,8 @@ importers:
   packages/formatters:
     dependencies:
       discord-api-types:
-        specifier: 0.37.79
-        version: 0.37.79
+        specifier: 0.37.82
+        version: 0.37.82
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -1139,8 +1139,8 @@ importers:
         specifier: workspace:^
         version: link:../ws
       discord-api-types:
-        specifier: 0.37.79
-        version: 0.37.79
+        specifier: 0.37.82
+        version: 0.37.82
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -1313,8 +1313,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       discord-api-types:
-        specifier: 0.37.79
-        version: 0.37.79
+        specifier: 0.37.82
+        version: 0.37.82
       magic-bytes.js:
         specifier: ^1.10.0
         version: 1.10.0
@@ -1610,8 +1610,8 @@ importers:
         specifier: ^8.5.10
         version: 8.5.10
       discord-api-types:
-        specifier: 0.37.79
-        version: 0.37.79
+        specifier: 0.37.82
+        version: 0.37.82
       prism-media:
         specifier: ^1.3.5
         version: 1.3.5
@@ -1707,8 +1707,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       discord-api-types:
-        specifier: 0.37.79
-        version: 0.37.79
+        specifier: 0.37.82
+        version: 0.37.82
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -14562,8 +14562,8 @@ packages:
       path-type: 4.0.0
     dev: true
 
-  /discord-api-types@0.37.79:
-    resolution: {integrity: sha512-jblKMZL5f9t/pfUyhHNey8Lb9yVCcBVIPxz/JTY0raAmfj7CuFXdl9m5o/+iiB7E0vv1Kz9V7Ao5HtLRc2gH1Q==}
+  /discord-api-types@0.37.82:
+    resolution: {integrity: sha512-qye+lpqYz7USEWW2GGPqlC565NtWNNSzImQHO1WiPQOtvDnbyMjXWInHsa7LmRtXW8Etu2EbTIwD6PuOmhwiqA==}
     dev: false
 
   /dlv@1.1.3:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Bumped discord-api-types to the latest version in order to unblock:
- #10185

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
