### PR TITLE
build: bump discord-api-types to 0.37.82

### DIFF
--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -68,7 +68,7 @@
 		"@discordjs/formatters": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"@sapphire/shapeshift": "^3.9.7",
-		"discord-api-types": "0.37.82",
+		"discord-api-types": "0.37.83",
 		"fast-deep-equal": "^3.1.3",
 		"ts-mixer": "^6.0.4",
 		"tslib": "^2.6.2"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,7 +70,7 @@
 		"@discordjs/ws": "workspace:^",
 		"@sapphire/snowflake": "^3.5.3",
 		"@vladfrangu/async_event_emitter": "^2.2.4",
-		"discord-api-types": "0.37.82"
+		"discord-api-types": "0.37.83"
 	},
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -72,7 +72,7 @@
     "@discordjs/util": "workspace:^",
     "@discordjs/ws": "workspace:^",
     "@sapphire/snowflake": "3.5.3",
-    "discord-api-types": "0.37.82",
+    "discord-api-types": "0.37.83",
     "fast-deep-equal": "3.1.3",
     "lodash.snakecase": "4.1.1",
     "tslib": "2.6.2",

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -55,7 +55,7 @@
 	"homepage": "https://discord.js.org",
 	"funding": "https://github.com/discordjs/discord.js?sponsor",
 	"dependencies": {
-		"discord-api-types": "0.37.82"
+		"discord-api-types": "0.37.83"
 	},
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -72,7 +72,7 @@
 		"@discordjs/rest": "workspace:^",
 		"@discordjs/util": "workspace:^",
 		"@discordjs/ws": "workspace:^",
-		"discord-api-types": "0.37.82"
+		"discord-api-types": "0.37.83"
 	},
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -88,7 +88,7 @@
 		"@sapphire/async-queue": "^1.5.2",
 		"@sapphire/snowflake": "^3.5.3",
 		"@vladfrangu/async_event_emitter": "^2.2.4",
-		"discord-api-types": "0.37.82",
+		"discord-api-types": "0.37.83",
 		"magic-bytes.js": "^1.10.0",
 		"tslib": "^2.6.2",
 		"undici": "6.13.0"

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -64,7 +64,7 @@
 	"funding": "https://github.com/discordjs/discord.js?sponsor",
 	"dependencies": {
 		"@types/ws": "^8.5.10",
-		"discord-api-types": "0.37.82",
+		"discord-api-types": "0.37.83",
 		"prism-media": "^1.3.5",
 		"tslib": "^2.6.2",
 		"ws": "^8.16.0"

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -79,7 +79,7 @@
 		"@sapphire/async-queue": "^1.5.2",
 		"@types/ws": "^8.5.10",
 		"@vladfrangu/async_event_emitter": "^2.2.4",
-		"discord-api-types": "0.37.82",
+		"discord-api-types": "0.37.83",
 		"tslib": "^2.6.2",
 		"ws": "^8.16.0"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,8 +686,8 @@ importers:
         specifier: ^3.9.7
         version: 3.9.7
       discord-api-types:
-        specifier: 0.37.82
-        version: 0.37.82
+        specifier: 0.37.83
+        version: 0.37.83
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -810,8 +810,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       discord-api-types:
-        specifier: 0.37.82
-        version: 0.37.82
+        specifier: 0.37.83
+        version: 0.37.83
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -947,8 +947,8 @@ importers:
         specifier: 3.5.3
         version: 3.5.3
       discord-api-types:
-        specifier: 0.37.82
-        version: 0.37.82
+        specifier: 0.37.83
+        version: 0.37.83
       fast-deep-equal:
         specifier: 3.1.3
         version: 3.1.3
@@ -1066,8 +1066,8 @@ importers:
   packages/formatters:
     dependencies:
       discord-api-types:
-        specifier: 0.37.82
-        version: 0.37.82
+        specifier: 0.37.83
+        version: 0.37.83
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -1139,8 +1139,8 @@ importers:
         specifier: workspace:^
         version: link:../ws
       discord-api-types:
-        specifier: 0.37.82
-        version: 0.37.82
+        specifier: 0.37.83
+        version: 0.37.83
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -1313,8 +1313,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       discord-api-types:
-        specifier: 0.37.82
-        version: 0.37.82
+        specifier: 0.37.83
+        version: 0.37.83
       magic-bytes.js:
         specifier: ^1.10.0
         version: 1.10.0
@@ -1610,8 +1610,8 @@ importers:
         specifier: ^8.5.10
         version: 8.5.10
       discord-api-types:
-        specifier: 0.37.82
-        version: 0.37.82
+        specifier: 0.37.83
+        version: 0.37.83
       prism-media:
         specifier: ^1.3.5
         version: 1.3.5
@@ -1707,8 +1707,8 @@ importers:
         specifier: ^2.2.4
         version: 2.2.4
       discord-api-types:
-        specifier: 0.37.82
-        version: 0.37.82
+        specifier: 0.37.83
+        version: 0.37.83
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -14562,8 +14562,8 @@ packages:
       path-type: 4.0.0
     dev: true
 
-  /discord-api-types@0.37.82:
-    resolution: {integrity: sha512-qye+lpqYz7USEWW2GGPqlC565NtWNNSzImQHO1WiPQOtvDnbyMjXWInHsa7LmRtXW8Etu2EbTIwD6PuOmhwiqA==}
+  /discord-api-types@0.37.83:
+    resolution: {integrity: sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA==}
     dev: false
 
   /dlv@1.1.3:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I am, once again, bumping discord-api-types in this repository.

Unblocks:
- #10235

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
