### PR TITLE
feat(MessageManager): poll methods

### DIFF
--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -266,6 +266,38 @@ class MessageManager extends CachedManager {
 
     await this.client.rest.delete(Routes.channelMessage(this.channel.id, message));
   }
+
+  /**
+   * Ends a poll.
+   * @param {Snowflake} channelId The id of the channel
+   * @param {Snowflake} messageId The id of the message
+   * @returns {Promise<Message>}
+   */
+  async endPoll(channelId, messageId) {
+    const message = await this.client.rest.post(Routes.expirePoll(channelId, messageId));
+    return this._add(message, false);
+  }
+
+  /**
+   * Options used for fetching voters of an answer in an uncached poll.
+   * @typedef {BaseFetchPollAnswerVotersOptions} FetchPollAnswerVotersOptions
+   * @param {Snowflake} channelId The id of the channel
+   * @param {Snowflake} messageId The id of the message
+   * @param {number} answerId The id of the answer
+   */
+
+  /**
+   * Fetches the users that voted for a poll answer.
+   * @param {FetchPollAnswerVotersOptions} options The options for fetching the poll answer voters
+   * @returns {Promise<Collection<Snowflake, User>>}
+   */
+  async fetchPollAnswerVoters({ channelId, messageId, answerId, after, limit }) {
+    const voters = await this.client.rest.get(Routes.pollAnswerVoters(channelId, messageId, answerId), {
+      query: makeURLSearchParams({ limit, after }),
+    });
+
+    return voters.users.reduce((acc, user) => acc.set(user.id, this.client.users._add(user, false)), new Collection());
+  }
 }
 
 module.exports = MessageManager;

--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -279,7 +279,7 @@ class MessageManager extends CachedManager {
   }
 
   /**
-   * Options used for fetching voters of an answer in an uncached poll.
+   * Options used for fetching voters of an answer in a poll.
    * @typedef {BaseFetchPollAnswerVotersOptions} FetchPollAnswerVotersOptions
    * @param {Snowflake} channelId The id of the channel
    * @param {Snowflake} messageId The id of the message

--- a/packages/discord.js/src/structures/Poll.js
+++ b/packages/discord.js/src/structures/Poll.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { Collection } = require('@discordjs/collection');
-const { Routes } = require('discord-api-types/v10');
 const Base = require('./Base');
 const { PollAnswer } = require('./PollAnswer');
 const { DiscordjsError } = require('../errors/DJSError');
@@ -95,19 +94,15 @@ class Poll extends Base {
   }
 
   /**
-   * End this poll
+   * Ends this poll.
    * @returns {Promise<Message>}
    */
-  async end() {
+  end() {
     if (Date.now() > this.expiresTimestamp) {
-      throw new DiscordjsError(ErrorCodes.PollAlreadyExpired);
+      return Promise.reject(new DiscordjsError(ErrorCodes.PollAlreadyExpired));
     }
 
-    const message = await this.client.rest.post(Routes.expirePoll(this.message.channel.id, this.message.id));
-
-    const clone = this.message._clone();
-    clone._patch(message);
-    return clone;
+    return this.message.channel.messages.endPoll(this.message.channel.id, this.message.id);
   }
 }
 

--- a/packages/discord.js/src/structures/PollAnswer.js
+++ b/packages/discord.js/src/structures/PollAnswer.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const { Collection } = require('@discordjs/collection');
-const { makeURLSearchParams } = require('@discordjs/rest');
-const { Routes } = require('discord-api-types/v10');
 const Base = require('./Base');
 const { Emoji } = require('./Emoji');
 
@@ -68,24 +65,25 @@ class PollAnswer extends Base {
   }
 
   /**
-   * @typedef {Object} FetchPollVotersOptions
+   * Options used for fetching voters of a poll answer.
+   * @typedef {Object} BaseFetchPollAnswerVotersOptions
    * @property {number} [limit] The maximum number of voters to fetch
    * @property {Snowflake} [after] The user id to fetch voters after
    */
 
   /**
-   * Fetches the users that voted for this answer
-   * @param {FetchPollVotersOptions} [options={}] The options for fetching voters
+   * Fetches the users that voted for this answer.
+   * @param {BaseFetchPollAnswerVotersOptions} [options={}] The options for fetching voters
    * @returns {Promise<Collection<Snowflake, User>>}
    */
-  async fetchVoters({ after, limit } = {}) {
-    const { message } = this.poll;
-
-    const voters = await this.client.rest.get(Routes.pollAnswerVoters(message.channel.id, message.id, this.id), {
-      query: makeURLSearchParams({ limit, after }),
+  fetchVoters({ after, limit } = {}) {
+    return this.poll.message.channel.fetchPollAnswerVoters({
+      channelId: this.poll.message.channel.id,
+      messageId: this.poll.message.id,
+      answerId: this.id,
+      after,
+      limit,
     });
-
-    return voters.users.reduce((acc, user) => acc.set(user.id, this.client.users._add(user, false)), new Collection());
   }
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2608,7 +2608,7 @@ export class Poll extends Base {
   public end(): Promise<Message>;
 }
 
-export interface FetchPollVotersOptions {
+export interface BaseFetchPollAnswerVotersOptions {
   after?: Snowflake;
   limit?: number;
 }
@@ -2621,7 +2621,7 @@ export class PollAnswer extends Base {
   public text: string | null;
   public voteCount: number;
   public get emoji(): GuildEmoji | Emoji | null;
-  public fetchVoters(options?: FetchPollVotersOptions): Promise<Collection<Snowflake, User>>;
+  public fetchVoters(options?: BaseFetchPollAnswerVotersOptions): Promise<Collection<Snowflake, User>>;
 }
 
 export class ReactionCollector extends Collector<Snowflake | string, MessageReaction, [User]> {
@@ -4397,6 +4397,12 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
   ): Promise<GuildMember>;
 }
 
+export interface FetchPollAnswerVotersOptions extends BaseFetchPollAnswerVotersOptions {
+  channelId: Snowflake;
+  messageId: Snowflake;
+  answerId: number;
+}
+
 export abstract class MessageManager<InGuild extends boolean = boolean> extends CachedManager<
   Snowflake,
   Message<InGuild>,
@@ -4415,6 +4421,8 @@ export abstract class MessageManager<InGuild extends boolean = boolean> extends 
   public react(message: MessageResolvable, emoji: EmojiIdentifierResolvable): Promise<void>;
   public pin(message: MessageResolvable, reason?: string): Promise<void>;
   public unpin(message: MessageResolvable, reason?: string): Promise<void>;
+  public endPoll(channelId: Snowflake, messageId: Snowflake): Promise<Message>;
+  public fetchPollAnswerVoters(options: FetchPollAnswerVotersOptions): Promise<Collection<Snowflake, User>>;
 }
 
 export class DMMessageManager extends MessageManager {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -2548,4 +2548,11 @@ declare const poll: Poll;
   expectType<number>(answer.voteCount);
 
   expectType<Collection<Snowflake, User>>(await answer.fetchVoters({ after: snowflake, limit: 10 }));
+
+  await messageManager.endPoll(snowflake, snowflake);
+  await messageManager.fetchPollAnswerVoters({
+    channelId: snowflake,
+    messageId: snowflake,
+    answerId: 1,
+  });
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add `endPoll` and `fetchPollAnswerVoters`  methods to the `MessageManager` class to allow interacting with polls without them being cached.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
