### PR TITLE
fix(PollAnswer): fetchVoters route changed to MessageManager

### DIFF
--- a/packages/discord.js/src/structures/PollAnswer.js
+++ b/packages/discord.js/src/structures/PollAnswer.js
@@ -77,7 +77,7 @@ class PollAnswer extends Base {
    * @returns {Promise<Collection<Snowflake, User>>}
    */
   fetchVoters({ after, limit } = {}) {
-    return this.poll.message.channel.fetchPollAnswerVoters({
+    return this.poll.message.channel.messages.fetchPollAnswerVoters({
       messageId: this.poll.message.id,
       answerId: this.id,
       after,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Poll.fetchVoters() function was throwing error cause it used the Channel Internally, so i changed to use the MessageManager Instead.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating