### PR TITLE
fix(SlashCommandBuilder): add missing shared properties

### DIFF
--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -1,5 +1,5 @@
 import { ChannelType, PermissionFlagsBits, type APIApplicationCommandOptionChoice } from 'discord-api-types/v10';
-import { describe, test, expect, expectTypeOf } from 'vitest';
+import { describe, test, expect } from 'vitest';
 import {
 	SlashCommandAssertions,
 	SlashCommandBooleanOption,
@@ -332,19 +332,6 @@ describe('Slash Commands', () => {
 				expect(() => getBuilder().addBooleanOption(() => SlashCommandStringOption)).toThrowError();
 				// @ts-expect-error: Checking if not providing anything, or an invalid return type causes an error
 				expect(() => getBuilder().addBooleanOption(() => new Collection())).toThrowError();
-			});
-
-			test('GIVEN valid builder with consistent method return types to builder, THEN does not throw error', () => {
-				type BuilderPropsOnly<Type = SlashCommandBuilder> = Pick<
-					Type,
-					keyof {
-						[Key in keyof Type as Type[Key] extends (...args: any) => any ? never : Key]: any;
-					}
-				>;
-
-				expectTypeOf(getBuilder().addStringOption(getStringOption())).toMatchTypeOf<BuilderPropsOnly>();
-
-				expectTypeOf(getBuilder().addSubcommand(getSubcommand())).toMatchTypeOf<BuilderPropsOnly>();
 			});
 
 			test('GIVEN valid builder with defaultPermission false THEN does not throw error', () => {

--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -1,5 +1,5 @@
 import { ChannelType, PermissionFlagsBits, type APIApplicationCommandOptionChoice } from 'discord-api-types/v10';
-import { describe, test, expect } from 'vitest';
+import { describe, test, expect, expectTypeOf } from 'vitest';
 import {
 	SlashCommandAssertions,
 	SlashCommandBooleanOption,
@@ -332,6 +332,16 @@ describe('Slash Commands', () => {
 				expect(() => getBuilder().addBooleanOption(() => SlashCommandStringOption)).toThrowError();
 				// @ts-expect-error: Checking if not providing anything, or an invalid return type causes an error
 				expect(() => getBuilder().addBooleanOption(() => new Collection())).toThrowError();
+			});
+            
+            test("GIVEN valid builder with consistent method return types to builder, THEN does not throw error", () => {
+                type BuilderPropsOnly<Type = SlashCommandBuilder> = Pick<Type, keyof {
+                    [Key in keyof Type as Type[Key] extends (...args: any) => any ? never : Key]: any;
+                }>;
+                
+                expectTypeOf(getBuilder().addStringOption(getStringOption())).toMatchTypeOf<BuilderPropsOnly>();
+                
+                expectTypeOf(getBuilder().addSubcommand(getSubcommand())).toMatchTypeOf<BuilderPropsOnly>();
 			});
 
 			test('GIVEN valid builder with defaultPermission false THEN does not throw error', () => {

--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -333,15 +333,18 @@ describe('Slash Commands', () => {
 				// @ts-expect-error: Checking if not providing anything, or an invalid return type causes an error
 				expect(() => getBuilder().addBooleanOption(() => new Collection())).toThrowError();
 			});
-            
-            test("GIVEN valid builder with consistent method return types to builder, THEN does not throw error", () => {
-                type BuilderPropsOnly<Type = SlashCommandBuilder> = Pick<Type, keyof {
-                    [Key in keyof Type as Type[Key] extends (...args: any) => any ? never : Key]: any;
-                }>;
-                
-                expectTypeOf(getBuilder().addStringOption(getStringOption())).toMatchTypeOf<BuilderPropsOnly>();
-                
-                expectTypeOf(getBuilder().addSubcommand(getSubcommand())).toMatchTypeOf<BuilderPropsOnly>();
+
+			test('GIVEN valid builder with consistent method return types to builder, THEN does not throw error', () => {
+				type BuilderPropsOnly<Type = SlashCommandBuilder> = Pick<
+					Type,
+					keyof {
+						[Key in keyof Type as Type[Key] extends (...args: any) => any ? never : Key]: any;
+					}
+				>;
+
+				expectTypeOf(getBuilder().addStringOption(getStringOption())).toMatchTypeOf<BuilderPropsOnly>();
+
+				expectTypeOf(getBuilder().addSubcommand(getSubcommand())).toMatchTypeOf<BuilderPropsOnly>();
 			});
 
 			test('GIVEN valid builder with defaultPermission false THEN does not throw error', () => {

--- a/packages/builders/__tests__/types.test.ts
+++ b/packages/builders/__tests__/types.test.ts
@@ -1,0 +1,17 @@
+import { expectTypeOf } from 'vitest';
+import { SlashCommandBuilder, SlashCommandStringOption, SlashCommandSubcommandBuilder } from '../src/index.js';
+
+const getBuilder = () => new SlashCommandBuilder();
+const getStringOption = () => new SlashCommandStringOption().setName('owo').setDescription('Testing 123');
+const getSubcommand = () => new SlashCommandSubcommandBuilder().setName('owo').setDescription('Testing 123');
+
+type BuilderPropsOnly<Type = SlashCommandBuilder> = Pick<
+	Type,
+	keyof {
+		[Key in keyof Type as Type[Key] extends (...args: any) => any ? never : Key]: any;
+	}
+>;
+
+expectTypeOf(getBuilder().addStringOption(getStringOption())).toMatchTypeOf<BuilderPropsOnly>();
+
+expectTypeOf(getBuilder().addSubcommand(getSubcommand())).toMatchTypeOf<BuilderPropsOnly>();

--- a/packages/builders/src/interactions/slashCommands/mixins/SharedSlashCommand.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/SharedSlashCommand.ts
@@ -28,6 +28,17 @@ export class SharedSlashCommand {
 	public readonly options: ToAPIApplicationCommandOptions[] = [];
 
 	/**
+	 * @deprecated Use {@link SharedSlashCommand.setDefaultMemberPermissions} or {@link SharedSlashCommand.setDMPermission} instead.
+	 */
+	public readonly default_permission: boolean | undefined = undefined;
+
+	public readonly default_member_permissions: Permissions | null | undefined = undefined;
+
+	public readonly dm_permission: boolean | undefined = undefined;
+
+	public readonly nsfw: boolean | undefined = undefined;
+
+	/**
 	 * Sets whether the command is enabled by default when the application is added to a guild.
 	 *
 	 * @remarks

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,10 @@ export default defineConfig({
 	test: {
 		exclude: ['**/node_modules', '**/dist', '.idea', '.git', '.cache'],
 		passWithNoTests: true,
+        typecheck: {
+            enabled: true,
+            include: ["**/__tests__/types.test.ts"]
+        },
 		coverage: {
 			enabled: true,
 			all: true,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Following #10253, other properties were observed to also not be present when using options or subcommands. This PR adds those properties on the type level where they are present during runtime.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
