### PR TITLE
fix: add inherited properties to search index

### DIFF
--- a/packages/scripts/src/generateIndex.ts
+++ b/packages/scripts/src/generateIndex.ts
@@ -12,6 +12,7 @@ import {
 import { generatePath } from '@discordjs/api-extractor-utils';
 import { DocNodeKind } from '@microsoft/tsdoc';
 import type { DocLinkTag, DocCodeSpan, DocNode, DocParagraph, DocPlainText } from '@microsoft/tsdoc';
+import { resolveMembers } from './generateSplitDocumentation.js';
 import { PACKAGES, fetchVersionDocs, fetchVersions } from './shared.js';
 
 export interface MemberJSON {
@@ -117,25 +118,21 @@ export enum SearchOrderType {
 export function visitNodes(item: ApiItem, tag: string) {
 	const members: (MemberJSON & { id: number })[] = [];
 
-	for (const member of item.members) {
-		if (!(member instanceof ApiDeclaredItem)) {
-			continue;
-		}
-
+	for (const { item: member, inherited } of ApiItemContainerMixin.isBaseClassOf(item)
+		? resolveMembers(item, (child): child is ApiDeclaredItem => child instanceof ApiDeclaredItem)
+		: []) {
 		if (member.kind === ApiItemKind.Constructor || member.kind === ApiItemKind.Namespace) {
 			continue;
 		}
 
-		if (ApiItemContainerMixin.isBaseClassOf(member)) {
-			members.push(...visitNodes(member, tag));
-		}
+		members.push(...visitNodes(member, tag));
 
 		members.push({
 			id: idx++,
 			name: member.displayName,
 			kind: member.kind,
 			summary: tryResolveSummaryText(member) ?? '',
-			path: generatePath(member.getHierarchy(), tag),
+			path: generatePath(inherited ? [...item.getHierarchy(), member] : member.getHierarchy(), tag),
 			type: SearchOrderType[member.kind as keyof typeof SearchOrderType],
 		});
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Inherited members now show up in generated search indices for docs. 

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
