### PR TITLE
types: Add `defaultValues` to respective select menu components data

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -178,6 +178,8 @@ import {
   APIPoll,
   PollLayoutType,
   APIPollAnswer,
+  APISelectMenuDefaultValue,
+  SelectMenuDefaultValueType,
 } from 'discord-api-types/v10';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -6364,10 +6366,12 @@ export interface StringSelectMenuComponentData extends BaseSelectMenuComponentDa
 
 export interface UserSelectMenuComponentData extends BaseSelectMenuComponentData {
   type: ComponentType.UserSelect;
+  defaultValues?: readonly APISelectMenuDefaultValue<SelectMenuDefaultValueType.User>[];
 }
 
 export interface RoleSelectMenuComponentData extends BaseSelectMenuComponentData {
   type: ComponentType.RoleSelect;
+  defaultValues?: readonly APISelectMenuDefaultValue<SelectMenuDefaultValueType.Role>[];
 }
 
 export interface MentionableSelectMenuComponentData extends BaseSelectMenuComponentData {
@@ -6377,6 +6381,7 @@ export interface MentionableSelectMenuComponentData extends BaseSelectMenuCompon
 export interface ChannelSelectMenuComponentData extends BaseSelectMenuComponentData {
   type: ComponentType.ChannelSelect;
   channelTypes?: readonly ChannelType[];
+  defaultValues?: readonly APISelectMenuDefaultValue<SelectMenuDefaultValueType.Channel>[];
 }
 
 export interface MessageSelectOption {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6376,6 +6376,7 @@ export interface RoleSelectMenuComponentData extends BaseSelectMenuComponentData
 
 export interface MentionableSelectMenuComponentData extends BaseSelectMenuComponentData {
   type: ComponentType.MentionableSelect;
+  defaultValues?: readonly APISelectMenuDefaultValue<SelectMenuDefaultValueType.Role | SelectMenuDefaultValueType.User>[];
 }
 
 export interface ChannelSelectMenuComponentData extends BaseSelectMenuComponentData {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6376,7 +6376,9 @@ export interface RoleSelectMenuComponentData extends BaseSelectMenuComponentData
 
 export interface MentionableSelectMenuComponentData extends BaseSelectMenuComponentData {
   type: ComponentType.MentionableSelect;
-  defaultValues?: readonly APISelectMenuDefaultValue<SelectMenuDefaultValueType.Role | SelectMenuDefaultValueType.User>[];
+  defaultValues?: readonly APISelectMenuDefaultValue<
+    SelectMenuDefaultValueType.Role | SelectMenuDefaultValueType.User
+  >[];
 }
 
 export interface ChannelSelectMenuComponentData extends BaseSelectMenuComponentData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Added 'defaultValues' typings on ChannelSelectMenuComponentData, RoleSelectMenuComponentData, and UserSelectMenuComponentData.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating