### PR TITLE
fix(actions): Handle missing poll object

### DIFF
--- a/packages/discord.js/src/client/actions/MessagePollVoteAdd.js
+++ b/packages/discord.js/src/client/actions/MessagePollVoteAdd.js
@@ -13,7 +13,7 @@ class MessagePollVoteAddAction extends Action {
 
     const { poll } = message;
 
-    const answer = poll.answers.get(data.answer_id);
+    const answer = poll?.answers.get(data.answer_id);
     if (!answer) return false;
 
     answer.voteCount++;

--- a/packages/discord.js/src/client/actions/MessagePollVoteRemove.js
+++ b/packages/discord.js/src/client/actions/MessagePollVoteRemove.js
@@ -13,7 +13,7 @@ class MessagePollVoteRemoveAction extends Action {
 
     const { poll } = message;
 
-    const answer = poll.answers.get(data.answer_id);
+    const answer = poll?.answers.get(data.answer_id);
     if (!answer) return false;
 
     answer.voteCount--;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`poll` will be missing if `GUILD_MESSAGE_POLLS` is enabled but `MESSAGE_CONTENT` is not, or if a message containing a poll was uncached but the appropriate partials were enabled. This caused a crash:

```
/Users/jiralite/Documents/code/GitHub/discordjs/discord.js/packages/discord.js/src/client/actions/MessagePollVoteRemove.js:16
    const answer = poll.answers.get(data.answer_id);
                        ^

TypeError: Cannot read properties of null (reading 'answers')
    at MessagePollVoteRemoveAction.handle (/Users/jiralite/Documents/code/GitHub/discordjs/discord.js/packages/discord.js/src/client/actions/MessagePollVoteRemove.js:16:25)
    at module.exports [as MESSAGE_POLL_VOTE_REMOVE] (/Users/jiralite/Documents/code/GitHub/discordjs/discord.js/packages/discord.js/src/client/websocket/handlers/MESSAGE_POLL_VOTE_REMOVE.js:4:40)
    at WebSocketManager.handlePacket (/Users/jiralite/Documents/code/GitHub/discordjs/discord.js/packages/discord.js/src/client/websocket/WebSocketManager.js:355:31)
    at WebSocketManager.<anonymous> (/Users/jiralite/Documents/code/GitHub/discordjs/discord.js/packages/discord.js/src/client/websocket/WebSocketManager.js:239:12)
    at WebSocketManager.emit (/Users/jiralite/Documents/code/GitHub/discordjs/discord.js/node_modules/.pnpm/@vladfrangu+async_event_emitter@2.2.4/node_modules/@vladfrangu/async_event_emitter/src/index.ts:360:28)
    at WebSocketShard.<anonymous> (/Users/jiralite/Documents/code/GitHub/discordjs/discord.js/packages/ws/src/strategies/sharding/SimpleShardingStrategy.ts:32:47)
    at WebSocketShard.emit (/Users/jiralite/Documents/code/GitHub/discordjs/discord.js/node_modules/.pnpm/@vladfrangu+async_event_emitter@2.2.4/node_modules/@vladfrangu/async_event_emitter/src/index.ts:360:28)
    at WebSocketShard.onMessage (/Users/jiralite/Documents/code/GitHub/discordjs/discord.js/packages/ws/src/ws/WebSocketShard.ts:640:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

The optional chaining operator will be enough to cause an exit on the next line with no error.
**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
