### PR TITLE
fix(website): links to builtin documentation not showing in summary

### DIFF
--- a/apps/website/src/components/DocNode.tsx
+++ b/apps/website/src/components/DocNode.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { BuiltinDocumentationLinks } from '~/util/builtinDocumentationLinks';
 import { OverlayScrollbarsComponent } from './OverlayScrollbars';
 import { SyntaxHighlighter } from './SyntaxHighlighter';
 
@@ -26,6 +27,21 @@ export async function DocNode({ node, version }: { readonly node?: any; readonly
 							key={`${node.text}-${idx}`}
 							className="text-blurple hover:text-blurple-500 dark:hover:text-blurple-300"
 							href={node.uri}
+							rel="external noreferrer noopener"
+							target="_blank"
+						>
+							{node.text}
+						</a>
+					);
+				}
+
+				if (node.text in BuiltinDocumentationLinks) {
+					const href = BuiltinDocumentationLinks[node.text as keyof typeof BuiltinDocumentationLinks];
+					return (
+						<a
+							key={`${node.text}-${idx}`}
+							className="text-blurple hover:text-blurple-500 dark:hover:text-blurple-300"
+							href={href}
 							rel="external noreferrer noopener"
 							target="_blank"
 						>

--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -328,7 +328,7 @@ function itemTsDoc(item: DocNode, apiItem: ApiItem) {
 					if (!foundItem && !resolved) {
 						return {
 							kind: DocNodeKind.LinkTag,
-							text: null,
+							text: codeDestination.memberReferences[0]?.memberIdentifier?.identifier ?? null,
 						};
 					}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Links like the one to `Array` builtin to JS in summary of `BitField#toArray()` didn't resolve correctly.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
