### PR TITLE
types: Forum starter messages do not support polls

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6331,7 +6331,7 @@ export interface MessageCreateOptions extends BaseMessageOptions {
 }
 
 export interface GuildForumThreadMessageCreateOptions
-  extends BaseMessageOptions,
+  extends Omit<BaseMessageOptions, 'poll'>,
     Pick<MessageCreateOptions, 'flags' | 'stickers'> {}
 
 export interface MessageEditAttachmentData {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Bring the types in line with what is [documented
![image](https://github.com/discordjs/discord.js/assets/61329810/4254e248-f6a0-4e05-a504-7e407bc64c70)](https://discord.com/developers/docs/resources/channel#start-thread-in-forum-or-media-channel-forum-and-media-thread-message-params-object)

Manually confirmed that forum starter messages do not support polls as well.


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
