### PR TITLE
refactor(GuildChannelManager): improve addFollower errors

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -99,16 +99,28 @@ class GuildChannelManager extends CachedManager {
   }
 
   /**
+   * Data that can be resolved to a News Channel object. This can be:
+   * * A NewsChannel object
+   * * A Snowflake
+   * @typedef {NewsChannel|Snowflake} NewsChannelResolvable
+   */
+
+  /**
    * Adds the target channel to a channel's followers.
-   * @param {NewsChannel|Snowflake} channel The channel to follow
+   * @param {NewsChannelResolvable} channel The channel to follow
    * @param {TextChannelResolvable} targetChannel The channel where published announcements will be posted at
    * @param {string} [reason] Reason for creating the webhook
    * @returns {Promise<Snowflake>} Returns created target webhook id.
    */
   async addFollower(channel, targetChannel, reason) {
     const channelId = this.resolveId(channel);
+    if (!channelId) {
+      throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'channel', 'NewsChannelResolvable');
+    }
     const targetChannelId = this.resolveId(targetChannel);
-    if (!channelId || !targetChannelId) throw new Error(ErrorCodes.GuildChannelResolve);
+    if (!targetChannelId) {
+      throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'targetChannel', 'TextChannelResolvable');
+    }
     const { webhook_id } = await this.client.rest.post(Routes.channelFollowers(channelId), {
       body: { webhook_channel_id: targetChannelId },
       reason,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2464,6 +2464,8 @@ export class NewsChannel extends BaseGuildTextChannel {
   public addFollower(channel: TextChannelResolvable, reason?: string): Promise<NewsChannel>;
 }
 
+export type NewsChannelResolvable = NewsChannel | Snowflake;
+
 export class OAuth2Guild extends BaseGuild {
   private constructor(client: Client<true>, data: RawOAuth2GuildData);
   public owner: boolean;
@@ -4219,7 +4221,7 @@ export class GuildChannelManager extends CachedManager<Snowflake, GuildBasedChan
   public guild: Guild;
 
   public addFollower(
-    channel: NewsChannel | Snowflake,
+    channel: NewsChannelResolvable,
     targetChannel: TextChannelResolvable,
     reason?: string,
   ): Promise<Snowflake>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This appears to be the last incidence of a naked `Error` being thrown within the d.js library. Changed to throw `DiscordjsTypeError` on failed resolution, along with individualising the parameter checks for easier debugging.

Adds a `NewsChannelResolvable` type for semantic purposes. This is a non-breaking type change.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
