### PR TITLE
fix(Action): Ensure all properties on `getChannel()` are passed

### DIFF
--- a/packages/discord.js/src/client/actions/Action.js
+++ b/packages/discord.js/src/client/actions/Action.js
@@ -31,9 +31,7 @@ class GenericAction {
     const payloadData = {};
     const id = data.channel_id ?? data.id;
 
-    if ('recipients' in data) {
-      payloadData.recipients = data.recipients;
-    } else {
+    if (!('recipients' in data)) {
       // Try to resolve the recipient, but do not add the client user.
       const recipient = data.author ?? data.user ?? { id: data.user_id };
       if (recipient.id !== this.client.user.id) payloadData.recipients = [recipient];

--- a/packages/discord.js/src/client/actions/Action.js
+++ b/packages/discord.js/src/client/actions/Action.js
@@ -40,12 +40,10 @@ class GenericAction {
     }
 
     if (id !== undefined) payloadData.id = id;
-    if ('guild_id' in data) payloadData.guild_id = data.guild_id;
-    if ('last_message_id' in data) payloadData.last_message_id = data.last_message_id;
 
     return (
       data[this.client.actions.injectedChannel] ??
-      this.getPayload(payloadData, this.client.channels, id, Partials.Channel)
+      this.getPayload({ ...data, ...payloadData }, this.client.channels, id, Partials.Channel)
     );
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
User-installable applications are in the wild, and this is one problem I have noticed so far, despite not being exactly relevant.

When a command is invoked in a **group** direct message channel and the channel partial is enabled, discord.js will proceed to create a channel (as direct message channels not initially cached). This is an example payload:

```JavaScript
{
  type: 3,
  owner_id: 'user_id',
  name: '💛💜🖤',
  last_pin_timestamp: '2023-06-26T16:59:39+00:00',
  last_message_id: 'message_id',
  id: 'id',
  icon: null,
  flags: 0
}
```

Notice `type` is `3`. discord.js results in this channel:

```JavaScript
DMChannel {
  type: 1,
  flags: ChannelFlagsBitField { bitfield: 0 },
  id: 'id',
  recipientId: undefined,
  lastMessageId: 'message_id',
  lastPinTimestamp: null,
  messages: DMMessageManager { channel: [Circular *1] }
}
```

`type` has been modified to `1`! It's a `DMChannel` now!

The reason this happens is because of the way `getChannel()` works:

https://github.com/discordjs/discord.js/blob/35207b0b31929558eee69f4bd53a6f9adadb0362/packages/discord.js/src/client/actions/Action.js#L30-L50

We are only extracting properties from `data` and sending them off as `payloadData`. This is an example resulting payload:

```JavaScript
{
  recipients: [ { id: undefined } ],
  id: 'id',
  last_message_id: 'message_id'
}
```
We are losing properties here, most notably, `type`. Merging our overriding properties alongside the original data allows a `PartialGroupDMChannel` to be created.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
