### PR TITLE
docs: Fix reference for BaseChannel#isTextBased

### DIFF
--- a/packages/discord.js/src/structures/BaseChannel.js
+++ b/packages/discord.js/src/structures/BaseChannel.js
@@ -124,7 +124,7 @@ class BaseChannel extends Base {
   }
 
   /**
-   * Indicates whether this channel is {@link TextBasedChannels text-based}.
+   * Indicates whether this channel is {@link TextBasedChannel text-based}.
    * @returns {boolean}
    */
   isTextBased() {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

<img width="420" alt="image" src="https://github.com/discordjs/discord.js/assets/10330923/326d7318-e16d-4418-9535-35b547f0d22a">

Noticed that docs for this method weren't rendering properly.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
