### PR TITLE
refactor(brokers): re-design API to make groups a constructor option

### DIFF
--- a/packages/brokers/src/brokers/Broker.ts
+++ b/packages/brokers/src/brokers/Broker.ts
@@ -42,7 +42,7 @@ export type ToEventMap<
 
 export interface IBaseBroker<TEvents extends Record<string, any>> {
 	/**
-	 * Subscribes to the given events, grouping them by the given group name
+	 * Subscribes to the given events
 	 */
 	subscribe(events: (keyof TEvents)[]): Promise<void>;
 	/**

--- a/packages/brokers/src/brokers/Broker.ts
+++ b/packages/brokers/src/brokers/Broker.ts
@@ -44,11 +44,11 @@ export interface IBaseBroker<TEvents extends Record<string, any>> {
 	/**
 	 * Subscribes to the given events, grouping them by the given group name
 	 */
-	subscribe(group: string, events: (keyof TEvents)[]): Promise<void>;
+	subscribe(events: (keyof TEvents)[]): Promise<void>;
 	/**
 	 * Unsubscribes from the given events - it's required to pass the same group name as when subscribing for proper cleanup
 	 */
-	unsubscribe(group: string, events: (keyof TEvents)[]): Promise<void>;
+	unsubscribe(events: (keyof TEvents)[]): Promise<void>;
 }
 
 export interface IPubSubBroker<TEvents extends Record<string, any>>

--- a/packages/brokers/src/brokers/Broker.ts
+++ b/packages/brokers/src/brokers/Broker.ts
@@ -46,7 +46,7 @@ export interface IBaseBroker<TEvents extends Record<string, any>> {
 	 */
 	subscribe(events: (keyof TEvents)[]): Promise<void>;
 	/**
-	 * Unsubscribes from the given events - it's required to pass the same group name as when subscribing for proper cleanup
+	 * Unsubscribes from the given events
 	 */
 	unsubscribe(events: (keyof TEvents)[]): Promise<void>;
 }

--- a/packages/brokers/src/brokers/redis/BaseRedis.ts
+++ b/packages/brokers/src/brokers/redis/BaseRedis.ts
@@ -197,7 +197,6 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 		await this.unsubscribe(Array.from(this.subscribedEvents));
 		this.streamReadClient.disconnect();
 		this.redisClient.disconnect();
-		this.removeAllListeners();
 	}
 
 	/**

--- a/packages/brokers/src/brokers/redis/BaseRedis.ts
+++ b/packages/brokers/src/brokers/redis/BaseRedis.ts
@@ -23,10 +23,19 @@ export interface RedisBrokerOptions extends BaseBrokerOptions {
 	 * How long to block for messages when polling
 	 */
 	blockTimeout?: number;
+
+	/**
+	 * Consumer group name to use for this broker
+	 *
+	 * @see {@link https://redis.io/commands/xreadgroup/}
+	 */
+	group: string;
+
 	/**
 	 * Max number of messages to poll at once
 	 */
 	maxChunk?: number;
+
 	/**
 	 * Unique consumer name.
 	 *
@@ -43,7 +52,7 @@ export const DefaultRedisBrokerOptions = {
 	name: randomBytes(20).toString('hex'),
 	maxChunk: 10,
 	blockTimeout: 5_000,
-} as const satisfies Required<RedisBrokerOptions>;
+} as const satisfies Required<Omit<RedisBrokerOptions, 'group'>>;
 
 /**
  * Helper class with shared Redis logic
@@ -93,13 +102,13 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 	/**
 	 * {@inheritDoc IBaseBroker.subscribe}
 	 */
-	public async subscribe(group: string, events: (keyof TEvents)[]): Promise<void> {
+	public async subscribe(events: (keyof TEvents)[]): Promise<void> {
 		await Promise.all(
 			// @ts-expect-error: Intended
 			events.map(async (event) => {
 				this.subscribedEvents.add(event as string);
 				try {
-					return await this.redisClient.xgroup('CREATE', event as string, group, 0, 'MKSTREAM');
+					return await this.redisClient.xgroup('CREATE', event as string, this.options.group, 0, 'MKSTREAM');
 				} catch (error) {
 					if (!(error instanceof ReplyError)) {
 						throw error;
@@ -107,18 +116,18 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 				}
 			}),
 		);
-		void this.listen(group);
+		void this.listen();
 	}
 
 	/**
 	 * {@inheritDoc IBaseBroker.unsubscribe}
 	 */
-	public async unsubscribe(group: string, events: (keyof TEvents)[]): Promise<void> {
+	public async unsubscribe(events: (keyof TEvents)[]): Promise<void> {
 		const commands: unknown[][] = Array.from({ length: events.length * 2 });
 		for (let idx = 0; idx < commands.length; idx += 2) {
 			const event = events[idx / 2];
-			commands[idx] = ['xgroup', 'delconsumer', event as string, group, this.options.name];
-			commands[idx + 1] = ['xcleangroup', event as string, group];
+			commands[idx] = ['xgroup', 'delconsumer', event as string, this.options.group, this.options.name];
+			commands[idx + 1] = ['xcleangroup', event as string, this.options.group];
 		}
 
 		await this.redisClient.pipeline(commands).exec();
@@ -131,7 +140,7 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 	/**
 	 * Begins polling for events, firing them to {@link BaseRedisBroker.listen}
 	 */
-	protected async listen(group: string): Promise<void> {
+	protected async listen(): Promise<void> {
 		if (this.listening) {
 			return;
 		}
@@ -142,7 +151,7 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 			try {
 				const data = await this.streamReadClient.xreadgroupBuffer(
 					'GROUP',
-					group,
+					this.options.group,
 					this.options.name,
 					'COUNT',
 					String(this.options.maxChunk),
@@ -169,7 +178,7 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 							continue;
 						}
 
-						this.emitEvent(id, group, event.toString('utf8'), this.options.decode(data));
+						this.emitEvent(id, this.options.group, event.toString('utf8'), this.options.decode(data));
 					}
 				}
 			} catch (error) {
@@ -185,6 +194,7 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 	 * Destroys the broker, closing all connections
 	 */
 	public async destroy() {
+		await this.unsubscribe(Array.from(this.subscribedEvents));
 		this.streamReadClient.disconnect();
 		this.redisClient.disconnect();
 		this.removeAllListeners();

--- a/packages/brokers/src/brokers/redis/BaseRedis.ts
+++ b/packages/brokers/src/brokers/redis/BaseRedis.ts
@@ -194,7 +194,7 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 	 * Destroys the broker, closing all connections
 	 */
 	public async destroy() {
-		await this.unsubscribe(Array.from(this.subscribedEvents));
+		await this.unsubscribe([...this.subscribedEvents]);
 		this.streamReadClient.disconnect();
 		this.redisClient.disconnect();
 	}

--- a/packages/brokers/src/brokers/redis/BaseRedis.ts
+++ b/packages/brokers/src/brokers/redis/BaseRedis.ts
@@ -138,7 +138,7 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 
 		this.listening = true;
 
-		while (true) {
+		while (this.subscribedEvents.size > 0) {
 			try {
 				const data = await this.streamReadClient.xreadgroupBuffer(
 					'GROUP',
@@ -187,6 +187,7 @@ export abstract class BaseRedisBroker<TEvents extends Record<string, any>>
 	public async destroy() {
 		this.streamReadClient.disconnect();
 		this.redisClient.disconnect();
+		this.removeAllListeners();
 	}
 
 	/**

--- a/packages/brokers/src/brokers/redis/RPCRedis.ts
+++ b/packages/brokers/src/brokers/redis/RPCRedis.ts
@@ -24,7 +24,7 @@ export interface RPCRedisBrokerOptions extends RedisBrokerOptions {
 export const DefaultRPCRedisBrokerOptions = {
 	...DefaultRedisBrokerOptions,
 	timeout: 5_000,
-} as const satisfies Required<RPCRedisBrokerOptions>;
+} as const satisfies Required<Omit<RPCRedisBrokerOptions, 'group'>>;
 
 /**
  * RPC broker powered by Redis
@@ -114,11 +114,11 @@ export class RPCRedisBroker<TEvents extends Record<string, any>, TResponses exte
 		});
 	}
 
-	protected emitEvent(id: Buffer, group: string, event: string, data: unknown) {
+	protected emitEvent(id: Buffer, event: string, data: unknown) {
 		const payload: { ack(): Promise<void>; data: unknown; reply(data: unknown): Promise<void> } = {
 			data,
 			ack: async () => {
-				await this.redisClient.xack(event, group, id);
+				await this.redisClient.xack(event, this.options.group, id);
 			},
 			reply: async (data) => {
 				await this.redisClient.publish(`${event}:${id.toString()}`, this.options.encode(data));

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -354,15 +354,15 @@ class Message extends Base {
      * Reference data sent in a message that contains ids identifying the referenced message.
      * This can be present in the following types of message:
      * * Crossposted messages (`MessageFlags.Crossposted`)
-     * * {@link MessageType.ChannelFollowAdd}
      * * {@link MessageType.ChannelPinnedMessage}
+     * * {@link MessageType.ChannelFollowAdd}
      * * {@link MessageType.Reply}
      * * {@link MessageType.ThreadStarterMessage}
      * @see {@link https://discord.com/developers/docs/resources/channel#message-types}
      * @typedef {Object} MessageReference
-     * @property {Snowflake} channelId The channel's id the message was referenced
-     * @property {?Snowflake} guildId The guild's id the message was referenced
-     * @property {?Snowflake} messageId The message's id that was referenced
+     * @property {Snowflake} channelId The channel id that was referenced
+     * @property {Snowflake|undefined} guildId The guild id that was referenced
+     * @property {Snowflake|undefined} messageId The message id that was referenced
      */
 
     if ('message_reference' in data) {
@@ -708,6 +708,7 @@ class Message extends Base {
   async fetchReference() {
     if (!this.reference) throw new DiscordjsError(ErrorCodes.MessageReferenceMissing);
     const { channelId, messageId } = this.reference;
+    if (!messageId) throw new DiscordjsError(ErrorCodes.MessageReferenceMissing);
     const channel = this.client.channels.resolve(channelId);
     if (!channel) throw new DiscordjsError(ErrorCodes.GuildChannelResolve);
     const message = await channel.messages.fetch(messageId);

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -973,10 +973,12 @@ class Message extends Base {
       this.id === message.id &&
       this.author.id === message.author.id &&
       this.content === message.content &&
-      this.tts === message.tts &&
       this.nonce === message.nonce &&
+      this.tts === message.tts &&
+      this.attachments.size === message.attachments.size &&
       this.embeds.length === message.embeds.length &&
-      this.attachments.length === message.attachments.length;
+      this.attachments.every(attachment => message.attachments.has(attachment.id)) &&
+      this.embeds.every((embed, index) => embed.equals(message.embeds[index]));
 
     if (equal && rawData) {
       equal =


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
~~A small fix~~ A complete refactor to address the issue described in https://github.com/discordjs/discord.js/issues/10273 where the broker keeps pooling even when there's no subscribed events causing a `Redis` `ReplyError`.

This PR fixes this by stop pooling when there's no subscriptions and adds a cleanup to the event emitter listeners on the destroy as discussed in https://github.com/discordjs/discord.js/issues/10273 

Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
