### PR TITLE
docs(MappedComponentTypes): fix "inpiut" typo

### DIFF
--- a/packages/builders/src/components/Components.ts
+++ b/packages/builders/src/components/Components.ts
@@ -23,31 +23,31 @@ export interface MappedComponentTypes {
 	 */
 	[ComponentType.ActionRow]: ActionRowBuilder<AnyComponentBuilder>;
 	/**
-	 * The button component type is associated with an {@link ButtonBuilder}.
+	 * The button component type is associated with a {@link ButtonBuilder}.
 	 */
 	[ComponentType.Button]: ButtonBuilder;
 	/**
-	 * The string select component type is associated with an {@link StringSelectMenuBuilder}.
+	 * The string select component type is associated with a {@link StringSelectMenuBuilder}.
 	 */
 	[ComponentType.StringSelect]: StringSelectMenuBuilder;
 	/**
-	 * The text input component type is associated with an {@link TextInputBuilder}.
+	 * The text input component type is associated with a {@link TextInputBuilder}.
 	 */
 	[ComponentType.TextInput]: TextInputBuilder;
 	/**
-	 * The user select component type is associated with an {@link UserSelectMenuBuilder}.
+	 * The user select component type is associated with a {@link UserSelectMenuBuilder}.
 	 */
 	[ComponentType.UserSelect]: UserSelectMenuBuilder;
 	/**
-	 * The role select component type is associated with an {@link RoleSelectMenuBuilder}.
+	 * The role select component type is associated with a {@link RoleSelectMenuBuilder}.
 	 */
 	[ComponentType.RoleSelect]: RoleSelectMenuBuilder;
 	/**
-	 * The mentionable select component type is associated with an {@link MentionableSelectMenuBuilder}.
+	 * The mentionable select component type is associated with a {@link MentionableSelectMenuBuilder}.
 	 */
 	[ComponentType.MentionableSelect]: MentionableSelectMenuBuilder;
 	/**
-	 * The channel select component type is associated with an {@link ChannelSelectMenuBuilder}.
+	 * The channel select component type is associated with a {@link ChannelSelectMenuBuilder}.
 	 */
 	[ComponentType.ChannelSelect]: ChannelSelectMenuBuilder;
 }

--- a/packages/builders/src/components/Components.ts
+++ b/packages/builders/src/components/Components.ts
@@ -31,7 +31,7 @@ export interface MappedComponentTypes {
 	 */
 	[ComponentType.StringSelect]: StringSelectMenuBuilder;
 	/**
-	 * The text inpiut component type is associated with an {@link TextInputBuilder}.
+	 * The text input component type is associated with an {@link TextInputBuilder}.
 	 */
 	[ComponentType.TextInput]: TextInputBuilder;
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a typo in the docs for text input components.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
