### PR TITLE
fix(OAuth2API): enable token exchange without token

### DIFF
--- a/packages/core/src/api/oauth2.ts
+++ b/packages/core/src/api/oauth2.ts
@@ -47,6 +47,7 @@ export class OAuth2API {
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},
+			auth: false,
 			signal,
 		}) as Promise<RESTPostOAuth2AccessTokenResult>;
 	}
@@ -68,6 +69,7 @@ export class OAuth2API {
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},
+			auth: false,
 			signal,
 		}) as Promise<RESTPostOAuth2RefreshTokenResult>;
 	}
@@ -91,6 +93,7 @@ export class OAuth2API {
 			headers: {
 				'Content-Type': 'application/x-www-form-urlencoded',
 			},
+			auth: false,
 			signal,
 		}) as Promise<RESTPostOAuth2ClientCredentialsResult>;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:** Currently, requests made by the [OAuth2API](https://discord.js.org/docs/packages/core/main/OAuth2API:Class) class require the `Authorization` header by default. If no token is set on the underlying REST client, this produces an error:
```
Error: Expected token to be set for this request, but none was present
```
However, for requests such as exchanging an authorization code for a token or refreshing using a refresh token, an existing token isn't required by the Discord API and doesn't really make sense; if the client already has a valid token, there's no need to exchange a code for a new token. (See [here](https://stackblitz.com/edit/node-vaut2g?file=index.js) for a simple StackBlitz reproduction.) This PR disables the `Authorization` header for these requests.



**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
