### PR TITLE
chore: Revamp of labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-package_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01-package_bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report an issue with discord.js or another package.
-labels: [bug, need repro]
+labels: [t:bug, t:need reproduction]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/01-package_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01-package_bug_report.yml
@@ -1,6 +1,8 @@
 name: Bug report
 description: Report an issue with discord.js or another package.
-labels: [t:bug, t:need reproduction]
+labels:
+  - t:need reproduction
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-application_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/02-application_bug_report.yml
@@ -1,6 +1,6 @@
 name: Websites bug report
 description: Report an issue with the documentation or guide websites.
-labels: [bug, need repro]
+labels: [t:bug, t:need reproduction]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-application_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/02-application_bug_report.yml
@@ -1,6 +1,8 @@
 name: Websites bug report
 description: Report an issue with the documentation or guide websites.
-labels: [t:bug, t:need reproduction]
+labels:
+  - t:need reproduction
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Request a new feature (discord.js accepts documented features of the official Discord developer API only!)
-labels: [feature request]
+labels: [t:feature request]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/03-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Request a new feature (discord.js accepts documented features of the official Discord developer API only!)
-labels: [t:feature request]
+type: Feature
 body:
   - type: markdown
     attributes:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,104 +1,104 @@
-apps:guide:
-  - changed-files:
-      - any-glob-to-any-file:
-          - apps/guide/*
-          - apps/guide/**/*
-apps:website:
-  - changed-files:
-      - any-glob-to-any-file:
-          - apps/website/*
-          - apps/website/**/*
-packages:api-extractor:
+a:api-extractor:
   - changed-files:
       - any-glob-to-any-file:
           - packages/api-extractor/*
           - packages/api-extractor/**/*
-packages:api-extractor-model:
+a:api-extractor-model:
   - changed-files:
       - any-glob-to-any-file:
           - packages/api-extractor-model/*
           - packages/api-extractor-model/**/*
-packages:brokers:
+a:brokers:
   - changed-files:
       - any-glob-to-any-file:
           - packages/brokers/*
           - packages/brokers/**/*
-packages:builders:
+a:builders:
   - changed-files:
       - any-glob-to-any-file:
           - packages/builders/*
           - packages/builders/**/*
-packages:collection:
+a:collection:
   - changed-files:
       - any-glob-to-any-file:
           - packages/collection/*
           - packages/collection/**/*
-packages:core:
+a:core:
   - changed-files:
       - any-glob-to-any-file:
           - packages/core/*
           - packages/core/**/*
-packages:create-discord-bot:
+a:create-discord-bot:
   - changed-files:
       - any-glob-to-any-file:
           - packages/create-discord-bot/*
           - packages/create-discord-bot/**/*
-packages:discord.js:
+a:discord.js:
   - changed-files:
       - any-glob-to-any-file:
           - packages/discord.js/*
           - packages/discord.js/**/*
-packages:docgen:
+a:docgen:
   - changed-files:
       - any-glob-to-any-file:
           - packages/docgen/*
           - packages/docgen/**/*
-packages:formatters:
+a:formatters:
   - changed-files:
       - any-glob-to-any-file:
           - packages/formatters/*
           - packages/formatters/**/*
-packages:next:
+a:guide:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/guide/*
+          - apps/guide/**/*
+a:next:
   - changed-files:
       - any-glob-to-any-file:
           - packages/next/*
           - packages/next/**/*
-packages:proxy:
+a:proxy:
   - changed-files:
       - any-glob-to-any-file:
           - packages/proxy/*
           - packages/proxy/**/*
-packages:proxy-container:
+a:proxy-container:
   - changed-files:
       - any-glob-to-any-file:
           - packages/proxy-container/*
           - packages/proxy-container/**/*
-packages:rest:
+a:rest:
   - changed-files:
       - any-glob-to-any-file:
           - packages/rest/*
           - packages/rest/**/*
-packages:structures:
+a:structures:
   - changed-files:
       - any-glob-to-any-file:
           - packages/structures/*
           - packages/structures/**/*
-packages:ui:
+a:ui:
   - changed-files:
       - any-glob-to-any-file:
           - packages/ui/*
           - packages/ui/**/*
-packages:util:
+a:util:
   - changed-files:
       - any-glob-to-any-file:
           - packages/util/*
           - packages/util/**/*
-packages:voice:
+a:voice:
   - changed-files:
       - any-glob-to-any-file:
           - packages/voice/*
           - packages/voice/**/*
-packages:ws:
+a:website:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/website/*
+          - apps/website/**/*
+a:ws:
   - changed-files:
       - any-glob-to-any-file:
           - packages/ws/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,105 +1,63 @@
 a:api-extractor:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/api-extractor/*
-          - packages/api-extractor/**/*
+      - any-glob-to-any-file: packages/api-extractor/**/*
 a:api-extractor-model:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/api-extractor-model/*
-          - packages/api-extractor-model/**/*
+      - any-glob-to-any-file: packages/api-extractor-model/**/*
 a:brokers:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/brokers/*
-          - packages/brokers/**/*
+      - any-glob-to-any-file: packages/brokers/**/*
 a:builders:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/builders/*
-          - packages/builders/**/*
+      - any-glob-to-any-file: packages/builders/**/*
 a:collection:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/collection/*
-          - packages/collection/**/*
+      - any-glob-to-any-file: packages/collection/**/*
 a:core:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/core/*
-          - packages/core/**/*
+      - any-glob-to-any-file: packages/core/**/*
 a:create-discord-bot:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/create-discord-bot/*
-          - packages/create-discord-bot/**/*
+      - any-glob-to-any-file: packages/create-discord-bot/**/*
 a:discord.js:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/discord.js/*
-          - packages/discord.js/**/*
+      - any-glob-to-any-file: packages/discord.js/**/*
 a:docgen:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/docgen/*
-          - packages/docgen/**/*
+      - any-glob-to-any-file: packages/docgen/**/*
 a:formatters:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/formatters/*
-          - packages/formatters/**/*
+      - any-glob-to-any-file: packages/formatters/**/*
 a:guide:
   - changed-files:
-      - any-glob-to-any-file:
-          - apps/guide/*
-          - apps/guide/**/*
+      - any-glob-to-any-file: apps/guide/**/*
 a:next:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/next/*
-          - packages/next/**/*
+      - any-glob-to-any-file: packages/next/**/*
 a:proxy:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/proxy/*
-          - packages/proxy/**/*
+      - any-glob-to-any-file: packages/proxy/**/*
 a:proxy-container:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/proxy-container/*
-          - packages/proxy-container/**/*
+      - any-glob-to-any-file: packages/proxy-container/**/*
 a:rest:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/rest/*
-          - packages/rest/**/*
+      - any-glob-to-any-file: packages/rest/**/*
 a:structures:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/structures/*
-          - packages/structures/**/*
+      - any-glob-to-any-file: packages/structures/**/*
 a:ui:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/ui/*
-          - packages/ui/**/*
+      - any-glob-to-any-file: packages/ui/**/*
 a:util:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/util/*
-          - packages/util/**/*
+      - any-glob-to-any-file: packages/util/**/*
 a:voice:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/voice/*
-          - packages/voice/**/*
+      - any-glob-to-any-file: packages/voice/**/*
 a:website:
   - changed-files:
-      - any-glob-to-any-file:
-          - apps/website/*
-          - apps/website/**/*
+      - any-glob-to-any-file: apps/website/**/*
 a:ws:
   - changed-files:
-      - any-glob-to-any-file:
-          - packages/ws/*
-          - packages/ws/**/*
+      - any-glob-to-any-file: packages/ws/**/*

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,126 +1,149 @@
-- name: api changes
-  color: '5663e9'
-- name: api support
-  color: '5663e9'
-- name: apps:guide
+- name: a:api-extractor
+  description: Affects @discordjs/api-extractor.
   color: fbca04
-- name: apps:website
+- name: a:api-extractor-model
+  description: Affects @discordjs/api-extractor-model.
   color: fbca04
-- name: backlog
-  color: 7ef7ef
-- name: backport
-  color: 88aabb
-- name: backport-candidate
-  color: 0075ca
-- name: blocked
-  color: fc1423
-- name: bug
-  color: d73a4a
-- name: caching
-  color: 80c042
-- name: chore
-  color: ffffff
-- name: ci
-  color: 0075ca
-- name: dependencies
-  color: 276bd1
-- name: discord
-  color: '5663e9'
-- name: discussion
+- name: a:brokers
+  description: Affects @discordjs/brokers.
+  color: fbca04
+- name: a:builders
+  description: Affects @discordjs/builders.
+  color: fbca04
+- name: a:collection
+  description: Affects @discordjs/collection.
+  color: fbca04
+- name: a:core
+  description: Affects @discordjs/core.
+  color: fbca04
+- name: a:create-discord-bot
+  description: Affects create-discord-bot.
+  color: fbca04
+- name: a:discord.js
+  description: Affects discord.js.
+  color: fbca04
+- name: a:docgen
+  description: Affects @discordjs/docgen.
+  color: fbca04
+- name: a:formatters
+  description: Affects @discordjs/formatters.
+  color: fbca04
+- name: a:guide
+  description: Affects @discordjs/guide.
+  color: fbca04
+- name: a:next
+  description: Affects @discordjs/next.
+  color: fbca04
+- name: a:proxy
+  description: Affects @discordjs/proxy.
+  color: fbca04
+- name: a:proxy-container
+  description: Affects @discordjs/proxy-container.
+  color: fbca04
+- name: a:rest
+  description: Affects @discordjs/rest.
+  color: fbca04
+- name: a:structures
+  description: Affects @discordjs/structures.
+  color: fbca04
+- name: a:ui
+  description: Affects @discordjs/ui.
+  color: fbca04
+- name: a:util
+  description: Affects @discordjs/util.
+  color: fbca04
+- name: a:voice
+  description: Affects @discordjs/voice.
+  color: fbca04
+- name: a:website
+  description: Affects @discordjs/website.
+  color: fbca04
+- name: a:ws
+  description: Affects @discordjs/ws.
+  color: fbca04
+- name: f:application commands
+  description: Related to the application commands feature.
   color: b6b1f9
-- name: documentation
+- name: f:applications
+  description: Related to the applications feature.
+  color: b6b1f9
+- name: f:channel
+  description: Related to the channel feature.
+  color: b6b1f9
+- name: f:guild
+  description: Related to the guild feature.
+  color: b6b1f9
+- name: f:interactions
+  description: Related to the interactions feature.
+  color: b6b1f9
+- name: f:invite
+  description: Related to the invite feature.
+  color: b6b1f9
+- name: f:monetization
+  description: Related to the monetization feature.
+  color: b6b1f9
+- name: f:poll
+  description: Related to the poll feature.
+  color: b6b1f9
+- name: f:role connections
+  description: Related to the role connections feature.
+  color: b6b1f9
+- name: f:stage instances
+  description: Related to the stage instances feature.
+  color: b6b1f9
+- name: f:stickers
+  description: Related to the stickers feature.
+  color: b6b1f9
+- name: f:threads
+  description: Related to the threads feature.
+  color: b6b1f9
+- name: f:user
+  description: Related to the user feature.
+  color: b6b1f9
+- name: f:voice
+  description: Related to the voice feature.
+  color: b6b1f9
+- name: f:webhook
+  description: Related to the webhook feature.
+  color: b6b1f9
+- name: s:major
+  description: This is a major change.
+  color: c10f47
+- name: s:minor
+  description: This is a minor change.
+  color: e4f486
+- name: s:patch
+  description: This is a patch change.
+  color: e8be8b
+- name: t:backport
+  color: 88aabb
+- name: t:backport-candidate
   color: 0075ca
-- name: duplicate
+- name: t:bug
+  description: Something is not working as expected.
+  color: '870808'
+- name: t:duplicate
   color: cfd3d7
-- name: error handling
-  color: 80c042
-- name: feature request
+- name: t:feature request
   color: fcf95a
-- name: gateway
-  color: 80c042
+- name: t:invalid
+  description: This is not related to discord.js.
+  color: e4e669
+- name: t:need reproduction
+  color: c66037
+- name: t:won't fix
+  description: No work will be done towards this issue.
+  color: cfd3d7
+- name: blocked
+  description: Generic label to stop Kodiak from merging a pull request.
+  color: fc1423
+- name: discord
+  description: This is a Discord-related issue.
+  color: 5865f2
 - name: good first issue
   color: 7057ff
 - name: help wanted
   color: '008672'
-- name: in progress
-  color: ffccd7
 - name: in review
+  description: This pull request is currently in review; halts Kodiak.
   color: aed5fc
-- name: interactions
-  color: 80c042
-- name: invalid
-  color: e4e669
-- name: need repro
-  color: c66037
-- name: packages:api-extractor
-  color: fbca04
-- name: packages:api-extractor-model
-  color: fbca04
-- name: packages:brokers
-  color: fbca04
-- name: packages:builders
-  color: fbca04
-- name: packages:collection
-  color: fbca04
-- name: packages:core
-  color: fbca04
-- name: packages:create-discord-bot
-  color: fbca04
-- name: packages:discord.js
-  color: fbca04
-- name: packages:docgen
-  color: fbca04
-- name: packages:formatters
-  color: fbca04
-- name: packages:next
-  color: fbca04
-- name: packages:proxy
-  color: fbca04
-- name: packages:proxy-container
-  color: fbca04
-- name: packages:rest
-  color: fbca04
-- name: packages:structures
-  color: fbca04
-- name: packages:ui
-  color: fbca04
-- name: packages:util
-  color: fbca04
-- name: packages:voice
-  color: fbca04
-- name: packages:ws
-  color: fbca04
-- name: performance
-  color: 80c042
-- name: permissions
-  color: 80c042
-- name: priority:high
-  color: fc1423
-- name: question (please use Discord instead)
-  color: d876e3
-- name: ratelimits
-  color: 80c042
-- name: refactor
-  color: 1d637f
-- name: regression
-  color: ea8785
-- name: REST
-  color: 80c042
-- name: semver:major
-  color: c10f47
-- name: semver:minor
-  color: e4f486
-- name: semver:patch
-  color: e8be8b
-- name: sharding
-  color: 80c042
-- name: tests
-  color: f06dff
-- name: threads
-  color: 80c042
-- name: typings
-  color: 80c042
-- name: utility
-  color: 80c042
-- name: wontfix
-  color: ffffff

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -119,13 +119,8 @@
   color: 88aabb
 - name: t:backport-candidate
   color: 0075ca
-- name: t:bug
-  description: Something is not working as expected.
-  color: '870808'
 - name: t:duplicate
   color: cfd3d7
-- name: t:feature request
-  color: fcf95a
 - name: t:invalid
   description: This is not related to discord.js.
   color: e4e669

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -119,11 +119,6 @@
   color: 88aabb
 - name: t:backport-candidate
   color: 0075ca
-- name: t:duplicate
-  color: cfd3d7
-- name: t:invalid
-  description: This is not related to discord.js.
-  color: e4e669
 - name: t:need reproduction
   color: c66037
 - name: t:won't fix

--- a/packages/scripts/turbo/generators/config.ts
+++ b/packages/scripts/turbo/generators/config.ts
@@ -71,12 +71,12 @@ export default function generator(plop: PlopTypes.NodePlopAPI): void {
 				type: 'modify',
 				path: `${plop.getDestBasePath()}/../../.github/labeler.yml`,
 				transform(content, answers) {
-					const labelerYAML = parseYAML(content) as Record<string, Record<string, Record<string, string[]>[]>[]>;
+					const labelerYAML = parseYAML(content) as Record<string, Record<string, Record<string, string>[]>[]>;
 
 					labelerYAML[`packages:${answers.name}`] = [
 						{
 							'changed-files': [
-								{ 'any-glob-to-any-file': [`packages/${answers.name}/*`, `packages/${answers.name}/**/*`] },
+								{ 'any-glob-to-any-file': `packages/${answers.name}/**/*` },
 							],
 						},
 					];


### PR DESCRIPTION
> [!Important]  
> The label synchronisation workflow must be temporarily disabled for this to merge.

- Rather than the "interactions" and "threads" labels which were the only kind of feature-related labels we had, they are now a "feature" label. Added as organised from the core package with a few others
  - "api changes" and "api support" have been deduplicated to "t:discord" (an update to the Discord API may require a change or a new feature to support)
- Added descriptions to some labels
- We will use issue types!

Some labels were removed. Examples:
- "discussion" was removed as GitHub Discussions exist
- "question (please use Discord instead)" was removed as GitHub Discussions exist
  - If a discussion is not required, then this should be labelled as invalid
- "bug" and "feature request" have been replaced with organisation-wide issue types
- Etc.

<hr>

### If `interactions` was renamed to `f:interactions`, wouldn't that remove all the labels from previous issues and pull requests?

Yes. However, that can be avoided with the following steps:

1. Disable the label synchronisation workflow before this pull request is merged (this is harmless)
2. Rename the label
3. Enable the workflow
4. Optionally run the workflow

crazy-max/ghaction-github-labeler will then identify that `f:interactions` exists and will not delete any labels, but make amendments, if any.

### How will the deduplication of "api changes" and "api support" work?

Similarily to the above question, we can rename "api changes" to "t:discord" and those with that label will be updated. However, we cannot rename "api support" to "t:discord" as label names must be unique.

We can automatically modify all those issues and pull requests. For example, with issues:

```
gh issue list --json number --label "api support" --limit 1000 --state all | jq --raw-output '.[].number' | while read -r issue_number; do
  gh issue edit $issue_number --add-label "t:discord"
  gh issue edit $issue_number --remove-label "api support"
done
```

Or, we could do nothing. Both are effortless.

<hr>

I'll be doing the manual work once this merges. No pressure on anyone else!

This is a time to make any other label changes! Open to suggestions.