### PR TITLE
ci(pr-triage): Split job up

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -7,19 +7,22 @@ on:
       - reopened
       - synchronize
 jobs:
-  pr-triage:
-    name: PR Triage
+  label:
+    name: Label
+    if: github.event.action != 'edited'
     runs-on: ubuntu-latest
     steps:
-      - name: Automatically label PR
+      - name: Label pull request
         uses: actions/labeler@v5
-        if: github.event.action != 'edited'
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           sync-labels: true
-
-      - name: Validate commit convention
-        if: github.event.action != 'synchronize'
+  validate-title:
+    name: Validate title
+    if: github.event.action != 'synchronize'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate pull request title
         run: |
           TITLE="${{ github.event.pull_request.title }}"
           REGEX="^(revert: )?(feat|fix|docs|style|refactor|perf|test|workflow|build|ci|chore|types|wip)(\\(.+\\))?: .{1,72}$"


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Splits the job up as it semantically makes sense.

Also looks better when observing the workflows:

![image](https://github.com/discordjs/discord.js/assets/33201955/52656207-158c-4e68-87df-8ef8e1bd4b02)

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
