### PR TITLE
fix(website): link tags to events named same as methods

### DIFF
--- a/packages/api-extractor-model/src/model/ModelReferenceResolver.ts
+++ b/packages/api-extractor-model/src/model/ModelReferenceResolver.ts
@@ -115,6 +115,7 @@ export class ModelReferenceResolver {
 			if (memberSelector === undefined) {
 				if (foundMembers.length > 1) {
 					const foundClass: ApiItem | undefined = foundMembers.find((member) => member.kind === ApiItemKind.Class);
+					const foundEvent: ApiItem | undefined = foundMembers.find((member) => member.kind === ApiItemKind.Event);
 					if (
 						foundClass &&
 						foundMembers.filter((member) => member.kind === ApiItemKind.Interface).length === foundMembers.length - 1
@@ -124,6 +125,11 @@ export class ModelReferenceResolver {
 						foundMembers.every((member) => member.kind === ApiItemKind.Method && (member as ApiMethod).overloadIndex)
 					) {
 						currentItem = foundMembers.find((member) => (member as ApiMethod).overloadIndex === 1)!;
+					} else if (
+						foundEvent &&
+						foundMembers.filter((member) => member.kind === ApiItemKind.Method).length === foundMembers.length - 1
+					) {
+						currentItem = foundEvent;
 					} else {
 						result.errorMessage = `The member reference ${JSON.stringify(identifier)} was ambiguous`;
 						return result;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes missing links for cases where we link to an event of a class that has a method of the same name. Realistically only happening for Collectors.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
