### PR TITLE
feat: Add modify function to the GuildMemberRoleManager for adding/removing roles at once.

### DIFF
--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -162,17 +162,18 @@ class GuildMemberRoleManager extends DataManager {
 
   /**
    * @typedef {Object} ModifyGuildMemberRolesOptions
-   * @property {readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>} [rolesToAdd] The roles to add
-   * @property {readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>} [rolesToRemove] The roles to remove
-   * @property {readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>} [reason] Reason for modifying the roles
+   * @property {Readonly<RoleResolvable[]> | ReadonlyCollection<Snowflake, Role>} [rolesToAdd] The roles to add
+   * @property {Readonly<RoleResolvable[]> | ReadonlyCollection<Snowflake, Role>} [rolesToRemove] The roles to remove
+   * @property {Readonly<RoleResolvable[]> | ReadonlyCollection<Snowflake, Role>} [reason] Reason for modifying
+   * the roles
    */
 
   /**
    * Modifies the roles of the member.
    * @param {ModifyGuildMemberRolesOptions} [options] Options for modifying the roles
-   * @returns {Promise<GuildMember>}
+   * @returns {GuildMember}
    */
-  async modify(options) {
+  modify(options) {
     const resolvedRolesToAdd = this.resolveRoles(options.rolesToAdd);
     const resolvedRolesToRemove = this.resolveRoles(options.rolesToRemove);
 

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -162,14 +162,14 @@ class GuildMemberRoleManager extends DataManager {
   
   /**
    * Modifies the roles of the member.
-   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleIdsToAdd The roles to add
-   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleIdsToRemove The roles to remove
+   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} rolesToAdd The roles to add
+   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} rolesToRemove The roles to remove
    * @param {string} [reason] Reason for modifying the roles
    * @returns {Promise<GuildMember>}
    */
-  public static async modify(roleIdsToAdd, roleIdsToRemove, reason) {
-    const resolvedRolesToAdd = this.resolveRoles(roleIdsToAdd)
-    const resolvedRolesToRemove = this.resolveRoles(roleIdsToRemove);
+  public static async modify(rolesToAdd, rolesToRemove, reason) {
+    const resolvedRolesToAdd = this.resolveRoles(rolesToAdd)
+    const resolvedRolesToRemove = this.resolveRoles(rolesToRemove);
 
     const currentRoles = new Set(this.member.roles.cache.keys());
     for (const role of resolvedRolesToAdd) {

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -162,8 +162,8 @@ class GuildMemberRoleManager extends DataManager {
 
   /**
    * Modifies the roles of the member.
-   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} rolesToAdd The roles to add
-   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} rolesToRemove The roles to remove
+   * @param {RoleResolvable[]|Collection<Snowflake, Role>} rolesToAdd The roles to add
+   * @param {RoleResolvable[]|Collection<Snowflake, Role>} rolesToRemove The roles to remove
    * @param {string} [reason] Reason for modifying the roles
    * @returns {Promise<GuildMember>}
    */
@@ -186,6 +186,7 @@ class GuildMemberRoleManager extends DataManager {
    * Resolves roles from the input.
    * @param {RoleResolvable[] | Collection<Snowflake, Role>} rolesToResolve The roles to resolve
    * @returns {Array} The resolved roles
+   * @private
    */
   resolveRoles(rolesToResolve) {
     const resolvedRoles = [];

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -167,7 +167,7 @@ class GuildMemberRoleManager extends DataManager {
    * @param {string} [reason] Reason for modifying the roles
    * @returns {Promise<GuildMember>}
    */
-  public static async modify(rolesToAdd, rolesToRemove, reason) {
+  async modify(rolesToAdd, rolesToRemove, reason) {
     const resolvedRolesToAdd = this.resolveRoles(rolesToAdd)
     const resolvedRolesToRemove = this.resolveRoles(rolesToRemove);
 
@@ -182,12 +182,12 @@ class GuildMemberRoleManager extends DataManager {
     return await this.member.roles.set([...currentRoles], reason);
 }
 
-/**
- * Resolves roles from the input.
- * @param {RoleResolvable[] | Collection<Snowflake, Role>} rolesToResolve The roles to resolve
- * @returns {Array} The resolved roles
- */
-private static resolveRoles(rolesToResolve, guild) {
+  /**
+   * Resolves roles from the input.
+   * @param {RoleResolvable[] | Collection<Snowflake, Role>} rolesToResolve The roles to resolve
+   * @returns {Array} The resolved roles
+   */
+  resolveRoles(rolesToResolve, guild) {
     const resolvedRoles = [];
     for (const role of rolesToResolve.values()) {
         const resolvedRole = this.guild.roles.resolveId(role);

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -161,6 +161,13 @@ class GuildMemberRoleManager extends DataManager {
   }
 
   /**
+   * @typedef {Object} ModifyGuildMemberRolesOptions
+   * @property {readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>} [rolesToAdd] The roles to add
+   * @property {readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>} [rolesToRemove] The roles to remove
+   * @property {readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>} [reason] Reason for modifying the roles
+   */
+
+  /**
    * Modifies the roles of the member.
    * @param {ModifyGuildMemberRolesOptions} [options] Options for modifying the roles
    * @returns {Promise<GuildMember>}

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -159,7 +159,7 @@ class GuildMemberRoleManager extends DataManager {
       return clone;
     }
   }
-  
+
   /**
    * Modifies the roles of the member.
    * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} rolesToAdd The roles to add
@@ -168,36 +168,36 @@ class GuildMemberRoleManager extends DataManager {
    * @returns {Promise<GuildMember>}
    */
   async modify(rolesToAdd, rolesToRemove, reason) {
-    const resolvedRolesToAdd = this.resolveRoles(rolesToAdd)
+    const resolvedRolesToAdd = this.resolveRoles(rolesToAdd);
     const resolvedRolesToRemove = this.resolveRoles(rolesToRemove);
 
     const currentRoles = new Set(this.member.roles.cache.keys());
     for (const role of resolvedRolesToAdd) {
-        currentRoles.add(role.id);
+      currentRoles.add(role.id);
     }
     for (const role of resolvedRolesToRemove) {
-        currentRoles.delete(role.id);
+      currentRoles.delete(role.id);
     }
 
-    return await this.member.roles.set([...currentRoles], reason);
-}
+    return this.member.roles.set([...currentRoles], reason);
+  }
 
   /**
    * Resolves roles from the input.
    * @param {RoleResolvable[] | Collection<Snowflake, Role>} rolesToResolve The roles to resolve
    * @returns {Array} The resolved roles
    */
-  resolveRoles(rolesToResolve, guild) {
+  resolveRoles(rolesToResolve) {
     const resolvedRoles = [];
     for (const role of rolesToResolve.values()) {
-        const resolvedRole = this.guild.roles.resolveId(role);
-        if (!resolvedRole) {
-          throw new DiscordjsTypeError(ErrorCodes.InvalidElement, 'Array or Collection', 'roles', role);
-        }
-        resolvedRoles.push(resolvedRole);
+      const resolvedRole = this.guild.roles.resolveId(role);
+      if (!resolvedRole) {
+        throw new DiscordjsTypeError(ErrorCodes.InvalidElement, 'Array or Collection', 'roles', role);
+      }
+      resolvedRoles.push(resolvedRole);
     }
     return resolvedRoles;
-}
+  }
 
   /**
    * Sets the roles applied to the member.

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -167,11 +167,11 @@ class GuildMemberRoleManager extends DataManager {
    * @param {string} [reason] Reason for modifying the roles
    * @returns {Promise<GuildMember>}
    */
-  public static async modify(roleIdsToAdd, roleIdsToRemove, member, reason) {
+  public static async modify(roleIdsToAdd, roleIdsToRemove, reason) {
     const resolvedRolesToAdd = this.resolveRoles(roleIdsToAdd)
     const resolvedRolesToRemove = this.resolveRoles(roleIdsToRemove);
 
-    const currentRoles = new Set(member.roles.cache.keys());
+    const currentRoles = new Set(this.member.roles.cache.keys());
     for (const role of resolvedRolesToAdd) {
         currentRoles.add(role.id);
     }
@@ -179,7 +179,7 @@ class GuildMemberRoleManager extends DataManager {
         currentRoles.delete(role.id);
     }
 
-    return await member.roles.set([...currentRoles], reason);
+    return await this.member.roles.set([...currentRoles], reason);
 }
 
 /**

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -107,10 +107,7 @@ class GuildMemberRoleManager extends DataManager {
    */
   async add(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
-      const resolvedRoles = this.resolveRoles(roleOrRoles);
-
-      const newRoles = [...new Set(resolvedRoles.concat(...this.cache.keys()))];
-      return this.set(newRoles, reason);
+      return this.modify({ rolesToAdd: roleOrRoles, reason });
     } else {
       roleOrRoles = this.guild.roles.resolveId(roleOrRoles);
       if (roleOrRoles === null) {
@@ -137,10 +134,7 @@ class GuildMemberRoleManager extends DataManager {
    */
   async remove(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
-      const resolvedRoles = this.resolveRoles(roleOrRoles);
-
-      const newRoles = this.cache.filter(role => !resolvedRoles.includes(role.id));
-      return this.set(newRoles, reason);
+      return this.modify({ rolesToRemove: roleOrRoles, reason });
     } else {
       roleOrRoles = this.guild.roles.resolveId(roleOrRoles);
       if (roleOrRoles === null) {
@@ -190,11 +184,12 @@ class GuildMemberRoleManager extends DataManager {
 
   /**
    * Resolves roles from the input.
-   * @param {RoleResolvable[] | Collection<Snowflake, Role>} rolesToResolve The roles to resolve
-   * @returns {Array} The resolved roles
+   * @param {Readonly<RoleResolvable[]> | ReadonlyCollection<Snowflake, Role>} rolesToResolve The roles to resolve
+   * @returns {Role[]} The resolved roles
    * @private
    */
   resolveRoles(rolesToResolve) {
+    if (!rolesToResolve) return [];
     const resolvedRoles = [];
     for (const role of rolesToResolve.values()) {
       const resolvedRole = this.guild.roles.resolveId(role);

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -107,7 +107,7 @@ class GuildMemberRoleManager extends DataManager {
    */
   async add(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
-      const resolvedRoles = this.resolveRoles(roleOrRoles, this.guild);
+      const resolvedRoles = this.resolveRoles(roleOrRoles);
 
       const newRoles = [...new Set(resolvedRoles.concat(...this.cache.keys()))];
       return this.set(newRoles, reason);
@@ -137,7 +137,7 @@ class GuildMemberRoleManager extends DataManager {
    */
   async remove(roleOrRoles, reason) {
     if (roleOrRoles instanceof Collection || Array.isArray(roleOrRoles)) {
-      const resolvedRoles = this.resolveRoles(roleOrRoles, this.guild);
+      const resolvedRoles = this.resolveRoles(roleOrRoles);
 
       const newRoles = this.cache.filter(role => !resolvedRoles.includes(role.id));
       return this.set(newRoles, reason);
@@ -162,19 +162,14 @@ class GuildMemberRoleManager extends DataManager {
   
   /**
    * Modifies the roles of the member.
-   * @param {RoleResolvable[]} roleIdsToAdd The role ids to add
-   * @param {RoleResolvable[]} roleIdsToRemove The role ids to remove
+   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleIdsToAdd The roles to add
+   * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleIdsToRemove The roles to remove
    * @param {string} [reason] Reason for modifying the roles
    * @returns {Promise<GuildMember>}
    */
-  public static async modify(
-    roleIdsToAdd: RoleResolvable[],
-    roleIdsToRemove: RoleResolvable[],
-    member: GuildMember,
-    reason?: any
-): Promise<GuildMember> {
-    const resolvedRolesToAdd = this.resolveRoles(roleIdsToAdd, member.guild)
-    const resolvedRolesToRemove = this.resolveRoles(roleIdsToRemove, member.guild);
+  public static async modify(roleIdsToAdd, roleIdsToRemove, member, reason) {
+    const resolvedRolesToAdd = this.resolveRoles(roleIdsToAdd)
+    const resolvedRolesToRemove = this.resolveRoles(roleIdsToRemove);
 
     const currentRoles = new Set(member.roles.cache.keys());
     for (const role of resolvedRolesToAdd) {
@@ -189,14 +184,13 @@ class GuildMemberRoleManager extends DataManager {
 
 /**
  * Resolves roles from the input.
- * @param {RoleResolvable[]} rolesToResolve The roles to resolve
- * @param {Guild} guild The guild to resolve the roles in
+ * @param {RoleResolvable[] | Collection<Snowflake, Role>} rolesToResolve The roles to resolve
  * @returns {Array} The resolved roles
  */
-private static resolveRoles(rolesToResolve: RoleResolvable[], guild: Guild): Role[] {
+private static resolveRoles(rolesToResolve, guild) {
     const resolvedRoles = [];
-    for (const role of rolesToResolve) {
-        const resolvedRole = guild.roles.resolve(role);
+    for (const role of rolesToResolve.values()) {
+        const resolvedRole = this.guild.roles.resolveId(role);
         if (!resolvedRole) {
           throw new DiscordjsTypeError(ErrorCodes.InvalidElement, 'Array or Collection', 'roles', role);
         }

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -162,14 +162,12 @@ class GuildMemberRoleManager extends DataManager {
 
   /**
    * Modifies the roles of the member.
-   * @param {RoleResolvable[]|Collection<Snowflake, Role>} rolesToAdd The roles to add
-   * @param {RoleResolvable[]|Collection<Snowflake, Role>} rolesToRemove The roles to remove
-   * @param {string} [reason] Reason for modifying the roles
+   * @param {ModifyGuildMemberRolesOptions} [options] Options for modifying the roles
    * @returns {Promise<GuildMember>}
    */
-  async modify(rolesToAdd, rolesToRemove, reason) {
-    const resolvedRolesToAdd = this.resolveRoles(rolesToAdd);
-    const resolvedRolesToRemove = this.resolveRoles(rolesToRemove);
+  async modify(options) {
+    const resolvedRolesToAdd = this.resolveRoles(options.rolesToAdd);
+    const resolvedRolesToRemove = this.resolveRoles(options.rolesToRemove);
 
     const currentRoles = new Set(this.member.roles.cache.keys());
     for (const role of resolvedRolesToAdd) {
@@ -179,7 +177,7 @@ class GuildMemberRoleManager extends DataManager {
       currentRoles.delete(role.id);
     }
 
-    return this.member.roles.set([...currentRoles], reason);
+    return this.member.roles.set([...currentRoles], options.reason);
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4409,8 +4409,8 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
     reason?: string,
   ): Promise<GuildMember>;
   public modify(
-    roleIdsToAdd: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
-    roleIdsToRemove: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
+    rolesToAdd: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
+    rolesToRemove: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     reason?: any
   ): Promise<GuildMember>;
   public set(

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4414,7 +4414,7 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
     roleOrRoles: RoleResolvable | readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     reason?: string,
   ): Promise<GuildMember>;
-  public modify(options: ModifyGuildMemberRolesOptions): Promise<GuildMember>;
+  public modify(options: ModifyGuildMemberRolesOptions): GuildMember;
   public set(
     roles: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     reason?: string,
@@ -4423,6 +4423,7 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
     roleOrRoles: RoleResolvable | readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     reason?: string,
   ): Promise<GuildMember>;
+  private resolveRoles(rolesToResolve: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>): Role[];
 }
 
 export interface FetchPollAnswerVotersOptions extends BaseFetchPollAnswerVotersOptions {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4411,7 +4411,7 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
   public modify(
     rolesToAdd: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     rolesToRemove: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
-    reason?: any
+    reason?: any,
   ): Promise<GuildMember>;
   public set(
     roles: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4408,7 +4408,7 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
     roleOrRoles: RoleResolvable | readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     reason?: string,
   ): Promise<GuildMember>;
-  public remove(
+  public modify(
     roleIdsToAdd: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     roleIdsToRemove: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     member: GuildMember,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4393,6 +4393,12 @@ export class GuildStickerManager extends CachedManager<Snowflake, Sticker, Stick
   public fetchUser(sticker: StickerResolvable): Promise<User | null>;
 }
 
+export interface ModifyGuildMemberRolesOptions {
+  rolesToAdd?: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>;
+  rolesToRemove?: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>;
+  reason?: string;
+}
+
 export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleResolvable> {
   private constructor(member: GuildMember);
   public get hoist(): Role | null;
@@ -4408,11 +4414,7 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
     roleOrRoles: RoleResolvable | readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     reason?: string,
   ): Promise<GuildMember>;
-  public modify(
-    rolesToAdd: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
-    rolesToRemove: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
-    reason?: any,
-  ): Promise<GuildMember>;
+  public modify(options: ModifyGuildMemberRolesOptions): Promise<GuildMember>;
   public set(
     roles: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     reason?: string,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4411,7 +4411,6 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
   public modify(
     roleIdsToAdd: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     roleIdsToRemove: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
-    member: GuildMember,
     reason?: any
   ): Promise<GuildMember>;
   public set(

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4408,6 +4408,12 @@ export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleRes
     roleOrRoles: RoleResolvable | readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     reason?: string,
   ): Promise<GuildMember>;
+  public remove(
+    roleIdsToAdd: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
+    roleIdsToRemove: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
+    member: GuildMember,
+    reason?: any
+  ): Promise<GuildMember>;
   public set(
     roles: readonly RoleResolvable[] | ReadonlyCollection<Snowflake, Role>,
     reason?: string,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The GuildMemberRoleManager class has an add & remove function which, when given multiple roles, use the GuildMemberManager.edit function which utilizes Modify Guild Member endpoint allowing discord.js to add/remove multiple roles in a single api call. However, there is no function for adding and removing multiple roles at once, this PR adds one.

Additionally, the add/remove functions in the GuildMemberRoleManager both used the same logic for resolving a list of roles. This PR moves that logic into a shared function both can use, as well as the new modify function.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
