### PR TITLE
refactor(GuildChannelManager): Remove redundant edit code

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -284,13 +284,13 @@ class GuildChannelManager extends CachedManager {
    *   .catch(console.error);
    */
   async edit(channel, options) {
-    channel = this.resolve(channel);
-    if (!channel) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'channel', 'GuildChannelResolvable');
+    const resolvedChannel = this.resolve(channel);
+    if (!resolvedChannel) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'channel', 'GuildChannelResolvable');
 
     const parent = options.parent && this.client.channels.resolveId(options.parent);
 
     if (options.position !== undefined) {
-      await this.setPosition(channel, options.position, { position: options.position, reason: options.reason });
+      await this.setPosition(resolvedChannel, options.position, { position: options.position, reason: options.reason });
     }
 
     let permission_overwrites = options.permissionOverwrites?.map(overwrite =>
@@ -305,22 +305,22 @@ class GuildChannelManager extends CachedManager {
             PermissionOverwrites.resolve(overwrite, this.guild),
           );
         }
-      } else if (channel.parent) {
-        permission_overwrites = channel.parent.permissionOverwrites.cache.map(overwrite =>
+      } else if (resolvedChannel.parent) {
+        permission_overwrites = resolvedChannel.parent.permissionOverwrites.cache.map(overwrite =>
           PermissionOverwrites.resolve(overwrite, this.guild),
         );
       }
     }
 
-    const newData = await this.client.rest.patch(Routes.channel(channel.id), {
+    const newData = await this.client.rest.patch(Routes.channel(resolvedChannel.id), {
       body: {
-        name: (options.name ?? channel.name).trim(),
+        name: options.name,
         type: options.type,
         topic: options.topic,
         nsfw: options.nsfw,
-        bitrate: options.bitrate ?? channel.bitrate,
-        user_limit: options.userLimit ?? channel.userLimit,
-        rtc_region: 'rtcRegion' in options ? options.rtcRegion : channel.rtcRegion,
+        bitrate: options.bitrate,
+        user_limit: options.userLimit,
+        rtc_region: options.rtcRegion,
         video_quality_mode: options.videoQualityMode,
         parent_id: parent,
         lock_permissions: options.lockPermissions,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes redundant code, such as this:

```diff
- (options.name ?? channel.name).trim(),
+ options.name,
```

In this example, `.trim()` is redundant as the API performs trimming. The `??` is also redundant (here and later in the code) as the properties are optional. Methods like these work just fine still:

```TypeScript
await channel.setRTCRegion(null);

// " hello " is trimmed API-side.
await channel.edit({ name: " hello ", bitrate: 96000, userLimit: 13, rtcRegion: null });
```

Also avoided reassigning the parameter.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
