### PR TITLE
chore(deps): match requested tslib version with other @discordjs packages

### DIFF
--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -75,7 +75,7 @@
     "discord-api-types": "0.37.90",
     "fast-deep-equal": "3.1.3",
     "lodash.snakecase": "4.1.1",
-    "tslib": "2.6.2",
+    "tslib": "^2.6.2",
     "undici": "6.18.2"
   },
   "devDependencies": {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

@discordjs/builders, @discordjs/rest, @discordjs/ws, and possibly others request a slightly different version of tslib than the main package. This synchronizes them so two different versions of tslib are not installed Discord.js ([2.6.3 was released last month](https://github.com/microsoft/tslib/releases/tag/v2.6.3)).

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
