### PR TITLE
fix(website): links to enum members from excerpts

### DIFF
--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -258,26 +258,35 @@ function itemExcerptText(excerpt: Excerpt, apiPackage: ApiPackage) {
 				};
 			}
 
-			const resolved = token.canonicalReference
-				? resolveCanonicalReference(token.canonicalReference, apiPackage)
-				: null;
+			if (token.canonicalReference) {
+				const resolved = resolveCanonicalReference(token.canonicalReference, apiPackage);
 
-			if (!resolved) {
+				if (!resolved) {
+					return {
+						text: token.text,
+					};
+				}
+
+				const declarationReference = apiPackage
+					.getAssociatedModel()
+					?.resolveDeclarationReference(token.canonicalReference, apiPackage);
+				const foundItem = declarationReference?.resolvedApiItem ?? resolved.item;
+
 				return {
 					text: token.text,
+					resolvedItem: {
+						kind: foundItem.kind,
+						displayName: foundItem.displayName,
+						containerKey: foundItem.containerKey,
+						uri: resolveItemURI(foundItem),
+						packageName: resolved.package?.replace('@discordjs/', ''),
+						version: resolved.version,
+					},
 				};
 			}
 
 			return {
 				text: token.text,
-				resolvedItem: {
-					kind: resolved.item.kind,
-					displayName: resolved.item.displayName,
-					containerKey: resolved.item.containerKey,
-					uri: resolveItemURI(resolved.item),
-					packageName: resolved.package?.replace('@discordjs/', ''),
-					version: resolved.version,
-				},
 			};
 		}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes the links to enum members from excerpt texts like `HeadingLevel.One` on https://discord.js.org/docs/packages/formatters/main/heading:Function and similar.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
