### PR TITLE
fix(build): update to support strictBuiltinIteratorReturn

### DIFF
--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -87,7 +87,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		if (amount < 0) return this.last(amount * -1);
 		amount = Math.min(this.size, amount);
 		const iter = this.values();
-		return Array.from({ length: amount }, (): Value => iter.next().value);
+		return Array.from({ length: amount }, (): Value => iter.next().value!);
 	}
 
 	/**
@@ -104,7 +104,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		if (amount < 0) return this.lastKey(amount * -1);
 		amount = Math.min(this.size, amount);
 		const iter = this.keys();
-		return Array.from({ length: amount }, (): Key => iter.next().value);
+		return Array.from({ length: amount }, (): Key => iter.next().value!);
 	}
 
 	/**
@@ -512,7 +512,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		const iter = this.entries();
 		return Array.from({ length: this.size }, (): NewValue => {
-			const [key, value] = iter.next().value;
+			const [key, value] = iter.next().value!;
 			return fn(value, key, this);
 		});
 	}
@@ -626,7 +626,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		const iterator = this.entries();
 		if (initialValue === undefined) {
 			if (this.size === 0) throw new TypeError('Reduce of empty collection with no initial value');
-			accumulator = iterator.next().value[1];
+			accumulator = iterator.next().value![1];
 		} else {
 			accumulator = initialValue;
 		}

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -626,7 +626,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		const iterator = this.entries();
 		if (initialValue === undefined) {
 			if (this.size === 0) throw new TypeError('Reduce of empty collection with no initial value');
-			accumulator = iterator.next().value![1];
+			accumulator = iterator.next().value![1] as unknown as InitialValue;
 		} else {
 			accumulator = initialValue;
 		}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This updates the build to be forwards compatible with https://github.com/microsoft/TypeScript/pull/58243, which uses a stricter return type for built-in iterators under the new `strictBuiltinIteratorReturn` option, which is enabled by default when building with `strict`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
