### PR TITLE
feat(SlashCommandBuilder): Add explicit command type when building

### DIFF
--- a/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/packages/builders/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -1,4 +1,5 @@
 import {
+	ApplicationCommandType,
 	ApplicationIntegrationType,
 	ChannelType,
 	InteractionContextType,
@@ -133,6 +134,10 @@ describe('Slash Commands', () => {
 		});
 
 		describe('Builder with simple options', () => {
+			test('GIVEN valid builder THEN returns type included', () => {
+				expect(getNamedBuilder().toJSON()).includes({ type: ApplicationCommandType.ChatInput });
+			});
+
 			test('GIVEN valid builder with options THEN does not throw error', () => {
 				expect(() =>
 					getBuilder()

--- a/packages/builders/src/interactions/slashCommands/mixins/SharedSlashCommand.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/SharedSlashCommand.ts
@@ -5,6 +5,7 @@ import type {
 	Permissions,
 	RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord-api-types/v10';
+import { ApplicationCommandType } from 'discord-api-types/v10';
 import type { RestOrArray } from '../../../util/normalizeArray.js';
 import { normalizeArray } from '../../../util/normalizeArray.js';
 import {
@@ -149,6 +150,7 @@ export class SharedSlashCommand {
 
 		return {
 			...this,
+			type: ApplicationCommandType.ChatInput,
 			options: this.options.map((option) => option.toJSON()),
 		};
 	}

--- a/packages/builders/src/interactions/slashCommands/mixins/SharedSlashCommand.ts
+++ b/packages/builders/src/interactions/slashCommands/mixins/SharedSlashCommand.ts
@@ -1,11 +1,11 @@
-import type {
-	ApplicationIntegrationType,
-	InteractionContextType,
-	LocalizationMap,
-	Permissions,
-	RESTPostAPIChatInputApplicationCommandsJSONBody,
+import {
+	ApplicationCommandType,
+	type ApplicationIntegrationType,
+	type InteractionContextType,
+	type LocalizationMap,
+	type Permissions,
+	type RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from 'discord-api-types/v10';
-import { ApplicationCommandType } from 'discord-api-types/v10';
 import type { RestOrArray } from '../../../util/normalizeArray.js';
 import { normalizeArray } from '../../../util/normalizeArray.js';
 import {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR makes the `SlashCommandBuilder` explicitly specify its type (`ApplicationCommandType.ChatInput`) when building, by modifying the `SharedSlashCommand` mixin.

One useful scenario for this is when mapping data received from the API (which always contains the type) to a builder's generated data (which currently doesn't contain the type for chat inputs), without relying on a fallback or assuming Discord's default.

I also asked about the issue on the developing-djs channel and a maintainer suggested I should open a PR for it.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
