### PR TITLE
ci: fix docs source url on tag push

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Apply tag to api-extractor config
         if: ${{ env.REF_TYPE == 'tag' && !inputs.ref }}
-        run: sed -i 's!https://github.com/discordjs/discord.js/tree/main!https://github.com/discordjs/discord.js/tree/${{ steps.extract-tag.outputs.semver }}!' "packages/${{ steps.extract-tag.outputs.package}}/api-extractor.json"
+        run: sed -i 's!https://github.com/discordjs/discord.js/tree/main!https://github.com/discordjs/discord.js/tree/${{ github.ref_name }}!' "packages/${{ steps.extract-tag.outputs.package}}/api-extractor.json"
 
       - name: Build docs
         run: pnpm run docs


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes sourcecode links for tagged versions of subpackages like `@discordjs/builders@1.8.2` using full tag name instead of just the semver part.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
