### PR TITLE
feat: add subtext formatter

### DIFF
--- a/packages/formatters/__tests__/formatters.test.ts
+++ b/packages/formatters/__tests__/formatters.test.ts
@@ -23,6 +23,7 @@ import {
 	roleMention,
 	spoiler,
 	strikethrough,
+	subtext,
 	time,
 	TimestampStyles,
 	underline,
@@ -274,6 +275,12 @@ describe('Message formatters', () => {
 			expect(unorderedList(['discord.js', 'discord.js 2', ['discord.js 3']])).toEqual(
 				'- discord.js\n- discord.js 2\n  - discord.js 3',
 			);
+		});
+	});
+
+	describe('subtext', () => {
+		test('GIVEN "discord.js" THEN returns "-# discord.js"', () => {
+			expect<'-# discord.js'>(subtext('discord.js')).toEqual('-# discord.js');
 		});
 	});
 

--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -570,6 +570,16 @@ export function unorderedList(list: RecursiveArray<string>): string {
 }
 
 /**
+ * Formats the content into a subtext.
+ *
+ * @typeParam Content - This is inferred by the supplied content
+ * @param content - The content to wrap
+ */
+export function subtext<Content extends string>(content: Content): `-# ${Content}` {
+	return `-# ${content}`;
+}
+
+/**
  * Formats a date into a short date-time string.
  *
  * @param date - The date to format. Defaults to the current time


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds a formatter for the new subtext markdown feature which can be found [here](https://support.discord.com/hc/en-us/articles/210298617-Markdown-Text-101-Chat-Formatting-Bold-Italic-Underline) under "Organizational Text Formatting"

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
