### PR TITLE
types(collection): reduce* method signatures

### DIFF
--- a/packages/collection/__tests__/collection.test.ts
+++ b/packages/collection/__tests__/collection.test.ts
@@ -715,7 +715,7 @@ describe('reduce() tests', () => {
 
 	test('reduce empty collection with initial value', () => {
 		const coll = createCollection();
-		expect(coll.reduce((a, x) => a + x, 0)).toStrictEqual(0);
+		expect<number>(coll.reduce((a, x) => a + x, 0)).toStrictEqual(0);
 	});
 
 	test('reduce empty collection without initial value', () => {
@@ -738,17 +738,17 @@ describe('reduceRight() tests', () => {
 
 	test('reduce collection into a single value with initial value', () => {
 		const sum = coll.reduceRight((a, x) => a + x, 0);
-		expect(sum).toStrictEqual(6);
+		expect<number>(sum).toStrictEqual(6);
 	});
 
 	test('reduce collection into a single value without initial value', () => {
 		const sum = coll.reduceRight((a, x) => a + x);
-		expect(sum).toStrictEqual(6);
+		expect<number>(sum).toStrictEqual(6);
 	});
 
 	test('reduce empty collection with initial value', () => {
 		const coll = createCollection();
-		expect(coll.reduceRight((a, x) => a + x, 0)).toStrictEqual(0);
+		expect<number>(coll.reduceRight((a, x) => a + x, 0)).toStrictEqual(0);
 	});
 
 	test('reduce empty collection without initial value', () => {

--- a/packages/collection/__tests__/collection.test.ts
+++ b/packages/collection/__tests__/collection.test.ts
@@ -713,6 +713,11 @@ describe('reduce() tests', () => {
 		expect<number>(sum).toStrictEqual(6);
 	});
 
+	test('reduce collection into a single value with different accumulator type', () => {
+		const str = coll.reduce((a, x) => a.concat(x.toString()), '');
+		expect<string>(str).toStrictEqual('123');
+	});
+
 	test('reduce empty collection with initial value', () => {
 		const coll = createCollection();
 		expect<number>(coll.reduce((a, x) => a + x, 0)).toStrictEqual(0);
@@ -744,6 +749,11 @@ describe('reduceRight() tests', () => {
 	test('reduce collection into a single value without initial value', () => {
 		const sum = coll.reduceRight((a, x) => a + x);
 		expect<number>(sum).toStrictEqual(6);
+	});
+
+	test('reduce collection into a single value with different accumulator type', () => {
+		const str = coll.reduceRight((a, x) => a.concat(x.toString()), '');
+		expect<string>(str).toStrictEqual('321');
 	});
 
 	test('reduce empty collection with initial value', () => {

--- a/packages/collection/__tests__/collection.test.ts
+++ b/packages/collection/__tests__/collection.test.ts
@@ -720,7 +720,40 @@ describe('reduce() tests', () => {
 
 	test('reduce empty collection without initial value', () => {
 		const coll = createCollection();
-		expect(() => coll.reduce((a: number, x) => a + x)).toThrowError(
+		expect(() => coll.reduce((a, x) => a + x)).toThrowError(
+			new TypeError('Reduce of empty collection with no initial value'),
+		);
+	});
+});
+
+describe('reduceRight() tests', () => {
+	const coll = createTestCollection();
+
+	test('throws if fn is not a function', () => {
+		// @ts-expect-error: Invalid function
+		expectInvalidFunctionError(() => coll.reduceRight());
+		// @ts-expect-error: Invalid function
+		expectInvalidFunctionError(() => coll.reduceRight(123), 123);
+	});
+
+	test('reduce collection into a single value with initial value', () => {
+		const sum = coll.reduceRight((a, x) => a + x, 0);
+		expect(sum).toStrictEqual(6);
+	});
+
+	test('reduce collection into a single value without initial value', () => {
+		const sum = coll.reduceRight((a, x) => a + x);
+		expect(sum).toStrictEqual(6);
+	});
+
+	test('reduce empty collection with initial value', () => {
+		const coll = createCollection();
+		expect(coll.reduceRight((a, x) => a + x, 0)).toStrictEqual(0);
+	});
+
+	test('reduce empty collection without initial value', () => {
+		const coll = createCollection();
+		expect(() => coll.reduceRight((a, x) => a + x)).toThrowError(
 			new TypeError('Reduce of empty collection with no initial value'),
 		);
 	});
@@ -1011,33 +1044,5 @@ describe('findLastKey() tests', () => {
 			expect(this).toBeNull();
 			return true;
 		}, null);
-	});
-});
-
-describe('reduceRight() tests', () => {
-	const coll = createTestCollection();
-
-	test('throws if fn is not a function', () => {
-		// @ts-expect-error: Invalid function
-		expectInvalidFunctionError(() => coll.reduceRight());
-		// @ts-expect-error: Invalid function
-		expectInvalidFunctionError(() => coll.reduceRight(123), 123);
-	});
-
-	test('reduce collection into a single value with initial value', () => {
-		const sum = coll.reduceRight((a, x) => a + x, 0);
-		expect(sum).toStrictEqual(6);
-	});
-
-	test('reduce collection into a single value without initial value', () => {
-		const sum = coll.reduceRight<number>((a, x) => a + x);
-		expect(sum).toStrictEqual(6);
-	});
-
-	test('reduce empty collection without initial value', () => {
-		const coll = createCollection();
-		expect(() => coll.reduceRight((a: number, x) => a + x)).toThrowError(
-			new TypeError('Reduce of empty collection with no initial value'),
-		);
 	});
 });

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -616,7 +616,15 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	 * collection.reduce((acc, guild) => acc + guild.memberCount, 0);
 	 * ```
 	 */
-	public reduce<InitialValue = Value>(
+	public reduce(
+		fn: (accumulator: Value, value: Value, key: Key, collection: this) => Value,
+		initialValue?: Value,
+	): Value;
+	public reduce<InitialValue>(
+		fn: (accumulator: InitialValue, value: Value, key: Key, collection: this) => InitialValue,
+		initialValue: InitialValue,
+	): InitialValue;
+	public reduce<InitialValue>(
 		fn: (accumulator: InitialValue, value: Value, key: Key, collection: this) => InitialValue,
 		initialValue?: InitialValue,
 	): InitialValue {
@@ -645,6 +653,14 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	 * @param fn - Function used to reduce, taking four arguments; `accumulator`, `value`, `key`, and `collection`
 	 * @param initialValue - Starting value for the accumulator
 	 */
+	public reduceRight(
+		fn: (accumulator: Value, value: Value, key: Key, collection: this) => Value,
+		initialValue?: Value,
+	): Value;
+	public reduceRight<InitialValue>(
+		fn: (accumulator: InitialValue, value: Value, key: Key, collection: this) => InitialValue,
+		initialValue: InitialValue,
+	): InitialValue;
 	public reduceRight<InitialValue>(
 		fn: (accumulator: InitialValue, value: Value, key: Key, collection: this) => InitialValue,
 		initialValue?: InitialValue,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Small changes relating to the typed method definitions for `reduce()` and `reduceRight()`:
- Fix the "without-initial-value" signature of `reduceRight()`.
  - When `initialValue` was not provided, this method would previously accept a callback with any arbitrary type for `previousValue`, or infer the type as `unknown` without explicit type annotation:
    ```ts
    declare const coll: Collection<string, number>;
    coll.reduceRight((a, x) => a + x); // error: 'a' is of type 'unknown'
    coll.reduceRight((a: string, x) => a.repeat(x)); // compiles OK, but will raise a TypeError at runtime
    ```
  - With this change, if an initial value for the accumulator is not provided, the callback's `previousValue` type is always the collection value type, and will raise an error otherwise.
- Separate out "accumulator type = collection value type" and "accumulator type = arbitrary type" overload signatures, à la TypeScript's library definitions for `Array.prototype.reduce`.
  - This changes the type behaviour in one specific set of cases, which is where a value for `initialValue` is provided with a type that is assignable to, but not equal to, the collection value type:
    ```ts
    declare const coll: Collection<string, number>;
    declare const initial: 1 | 2 | 3;
    
    coll.reduce((a, x) => a + x, initial); // Type 'number' is not assignable to type '1 | 2 | 3'
    ```
  - Previously, `InitialValue` would be inferred as `1 | 2 | 3`, leading to compilation errors.
  - With this change, if `initialValue` is assignable to the collection value type, the method signature will preferentially use the collection value type for the callback, rather than narrowing to the type of `initialValue`. This matches the behaviour of `Array.prototype.reduce` in TypeScript.

Also adds one missing `reduceRight()` test (reduce empty collection with initial value).