### PR TITLE
feat(GuildMember): Expose `serverMute` and `serverDeaf` fields

### DIFF
--- a/packages/discord.js/src/client/actions/VoiceStateUpdate.js
+++ b/packages/discord.js/src/client/actions/VoiceStateUpdate.js
@@ -9,12 +9,6 @@ class VoiceStateUpdate extends Action {
     const client = this.client;
     const guild = client.guilds.cache.get(data.guild_id);
     if (guild) {
-      // Update the state
-      const oldState =
-        guild.voiceStates.cache.get(data.user_id)?._clone() ?? new VoiceState(guild, { user_id: data.user_id });
-
-      const newState = guild.voiceStates._add(data);
-
       // Get the member
       let member = guild.members.cache.get(data.user_id);
       if (member && data.member) {
@@ -22,6 +16,15 @@ class VoiceStateUpdate extends Action {
       } else if (data.member?.user && data.member.joined_at) {
         member = guild.members._add(data.member);
       }
+
+      // Update the state
+      const oldState = guild.voiceStates.cache.get(data.user_id)?._clone() ?? new VoiceState(guild, {
+        user_id: data.user_id,
+        mute: member._mute,
+        deaf: member._deaf,
+      });
+
+      const newState = guild.voiceStates._add(data);
 
       // Emit event
       if (member?.user.id === client.user.id) {

--- a/packages/discord.js/src/client/actions/VoiceStateUpdate.js
+++ b/packages/discord.js/src/client/actions/VoiceStateUpdate.js
@@ -20,8 +20,8 @@ class VoiceStateUpdate extends Action {
       // Update the state
       const oldState = guild.voiceStates.cache.get(data.user_id)?._clone() ?? new VoiceState(guild, {
         user_id: data.user_id,
-        mute: member._mute,
-        deaf: member._deaf,
+        mute: member._serverMute,
+        deaf: member._serverDeaf,
       });
 
       const newState = guild.voiceStates._add(data);

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -62,7 +62,7 @@ class GuildMember extends Base {
      */
     Object.defineProperty(this, '_roles', { value: [], writable: true });
 
-     /**
+    /**
      * The voice mute state of the member
      * @name GuildMember#_mute
      * @type {boolean}
@@ -70,7 +70,7 @@ class GuildMember extends Base {
      */
     Object.defineProperty(this, '_mute', { value: false, writable: true });
 
-     /**
+    /**
      * The voice deaf state of the member
      * @name GuildMember#_deaf
      * @type {boolean}

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -62,6 +62,22 @@ class GuildMember extends Base {
      */
     Object.defineProperty(this, '_roles', { value: [], writable: true });
 
+     /**
+     * The voice mute state of the member
+     * @name GuildMember#_mute
+     * @type {boolean}
+     * @private
+     */
+    Object.defineProperty(this, '_mute', { value: false, writable: true });
+
+     /**
+     * The voice deaf state of the member
+     * @name GuildMember#_deaf
+     * @type {boolean}
+     * @private
+     */
+    Object.defineProperty(this, '_deaf', { value: false, writable: true });
+
     if (data) this._patch(data);
   }
 
@@ -89,6 +105,8 @@ class GuildMember extends Base {
       this.premiumSinceTimestamp = data.premium_since ? Date.parse(data.premium_since) : null;
     }
     if ('roles' in data) this._roles = data.roles;
+    if ('mute' in data) this._mute = data.mute;
+    if ('deaf' in data) this._deaf = data.deaf;
 
     if ('pending' in data) {
       this.pending = data.pending;
@@ -143,7 +161,11 @@ class GuildMember extends Base {
    * @readonly
    */
   get voice() {
-    return this.guild.voiceStates.cache.get(this.id) ?? new VoiceState(this.guild, { user_id: this.id });
+    return this.guild.voiceStates.cache.get(this.id) ?? new VoiceState(this.guild, {
+      user_id: this.id,
+      mute: this._mute,
+      deaf: this._deaf,
+    });
   }
 
   /**

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -63,20 +63,20 @@ class GuildMember extends Base {
     Object.defineProperty(this, '_roles', { value: [], writable: true });
 
     /**
-     * The voice mute state of the member
-     * @name GuildMember#_mute
+     * The server mute state of the member
+     * @name GuildMember#_serverMute
      * @type {boolean}
      * @private
      */
-    Object.defineProperty(this, '_mute', { value: false, writable: true });
+    Object.defineProperty(this, '_serverMute', { value: null, writable: true });
 
     /**
-     * The voice deaf state of the member
-     * @name GuildMember#_deaf
+     * The server deaf state of the member
+     * @name GuildMember#_serverDeaf
      * @type {boolean}
      * @private
      */
-    Object.defineProperty(this, '_deaf', { value: false, writable: true });
+    Object.defineProperty(this, '_serverDeaf', { value: null, writable: true });
 
     if (data) this._patch(data);
   }
@@ -105,8 +105,8 @@ class GuildMember extends Base {
       this.premiumSinceTimestamp = data.premium_since ? Date.parse(data.premium_since) : null;
     }
     if ('roles' in data) this._roles = data.roles;
-    if ('mute' in data) this._mute = data.mute;
-    if ('deaf' in data) this._deaf = data.deaf;
+    if ('mute' in data) this._serverMute = data.mute;
+    if ('deaf' in data) this._serverDeaf = data.deaf;
 
     if ('pending' in data) {
       this.pending = data.pending;
@@ -163,8 +163,8 @@ class GuildMember extends Base {
   get voice() {
     return this.guild.voiceStates.cache.get(this.id) ?? new VoiceState(this.guild, {
       user_id: this.id,
-      mute: this._mute,
-      deaf: this._deaf,
+      mute: this._serverMute,
+      deaf: this._serverDeaf,
     });
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
According to the developer documentation, it is possible to find out whether a member has been muted or deafen by right-clicking. Even if the member is not connected in a voice call.

This is documented by the presence of the two fields in the `GuildMember` structure.

**Additional information:** Unfortunately it's still not possible to mute or unmute a member if the member is not present in a voice channel. I intend to create an issue on `discord-api-docs` about this.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
