### PR TITLE
refactor(website): search index name of members includes class now

### DIFF
--- a/packages/scripts/src/generateIndex.ts
+++ b/packages/scripts/src/generateIndex.ts
@@ -129,7 +129,7 @@ export function visitNodes(item: ApiItem, tag: string) {
 
 		members.push({
 			id: idx++,
-			name: member.displayName,
+			name: member.getScopedNameWithinPackage(),
 			kind: member.kind,
 			summary: tryResolveSummaryText(member) ?? '',
 			path: generatePath(inherited ? [...item.getHierarchy(), member] : member.getHierarchy(), tag),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously the search index for e.g. `GuildMember#guild` had just `guild` as name for the entry and only the path it links to and maybe the description told you what class it belongs to.

With this small change the name now includes the Classname too and also distinguishes methods from properties. I.e. `fetch` is now `GuildMember.fetch()`.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
