### PR TITLE
fix(scripts): show name of inheriting class on search index

### DIFF
--- a/packages/scripts/src/generateIndex.ts
+++ b/packages/scripts/src/generateIndex.ts
@@ -129,7 +129,7 @@ export function visitNodes(item: ApiItem, tag: string) {
 
 		members.push({
 			id: idx++,
-			name: (inherited
+			name: (inherited && member.parent
 				? member.getScopedNameWithinPackage().replace(new RegExp(`^${member.parent?.displayName}`), item.displayName)
 				: member.getScopedNameWithinPackage()
 			).replaceAll('.', '#'),

--- a/packages/scripts/src/generateIndex.ts
+++ b/packages/scripts/src/generateIndex.ts
@@ -129,7 +129,10 @@ export function visitNodes(item: ApiItem, tag: string) {
 
 		members.push({
 			id: idx++,
-			name: member.getScopedNameWithinPackage(),
+			name: (inherited
+				? member.getScopedNameWithinPackage().replace(new RegExp(`^${member.parent?.displayName}`), item.displayName)
+				: member.getScopedNameWithinPackage()
+			).replaceAll('.', '#'),
 			kind: member.kind,
 			summary: tryResolveSummaryText(member) ?? '',
 			path: generatePath(inherited ? [...item.getHierarchy(), member] : member.getHierarchy(), tag),


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

With #10415 the name on search index includes the name of the class now, but for inherited properties it's the name of the defining class instead of the one the entry links to.

This PR fixes this and also changes the delimiter so the name for https://discord.js.org/docs/packages/discord.js/14.15.3/ClientUser:Class#bot would be `ClientUser#bot` instead of `User.bot`now.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
