### PR TITLE
revert: chore: deprecate client options presence

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -32,7 +32,6 @@ const Status = require('../util/Status');
 const Sweepers = require('../util/Sweepers');
 
 let deprecationEmittedForPremiumStickerPacks = false;
-let deprecationEmittedForClientPresence = false;
 
 /**
  * The main hub for interacting with the Discord API, and the starting point for any bot.
@@ -140,7 +139,7 @@ class Client extends BaseClient {
      * @private
      * @type {ClientPresence}
      */
-    this.presence = new ClientPresence(this, this.options.ws.presence ?? this.options.presence);
+    this.presence = new ClientPresence(this, this.options.presence);
 
     Object.defineProperty(this, 'token', { writable: true });
     if (!this.token && 'DISCORD_TOKEN' in process.env) {
@@ -220,15 +219,6 @@ class Client extends BaseClient {
     this.emit(Events.Debug, `Provided token: ${this._censoredToken}`);
 
     if (this.options.presence) {
-      if (!deprecationEmittedForClientPresence) {
-        process.emitWarning(
-          'ClientOptions#presence is deprecated and will be removed. Use ClientOptions#ws#presence instead.',
-          'DeprecationWarning',
-        );
-
-        deprecationEmittedForClientPresence = true;
-      }
-
       this.options.ws.presence = this.presence._parse(this.options.presence);
     }
 
@@ -556,9 +546,6 @@ class Client extends BaseClient {
     }
     if (typeof options.ws !== 'object' || options.ws === null) {
       throw new DiscordjsTypeError(ErrorCodes.ClientInvalidOption, 'ws', 'an object');
-    }
-    if (typeof options.ws.presence !== 'object' || options.ws.presence === null) {
-      throw new DiscordjsTypeError(ErrorCodes.ClientInvalidOption, 'ws.presence', 'an object');
     }
     if (typeof options.rest !== 'object' || options.rest === null) {
       throw new DiscordjsTypeError(ErrorCodes.ClientInvalidOption, 'rest', 'an object');

--- a/packages/discord.js/src/util/Options.js
+++ b/packages/discord.js/src/util/Options.js
@@ -91,7 +91,6 @@ const { version } = require('../../package.json');
  * only set this if you know what you are doing</warn>
  * @property {BuildStrategyFunction} [buildStrategy] Builds the strategy to use for sharding
  * @property {IdentifyThrottlerFunction} [buildIdentifyThrottler] Builds the identify throttler to use for sharding
- * @property {PresenceData} [presence={}] Presence data to use upon login
  */
 
 /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -181,7 +181,6 @@ import {
   APISelectMenuDefaultValue,
   SelectMenuDefaultValueType,
   InviteType,
-  GatewayPresenceUpdateData,
 } from 'discord-api-types/v10';
 import { ChildProcess } from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -5305,7 +5304,6 @@ export interface ClientOptions {
   allowedMentions?: MessageMentionOptions;
   partials?: readonly Partials[];
   failIfNotExists?: boolean;
-  /** @deprecated Use {@link ClientOptions.ws.presence} instead */
   presence?: PresenceData;
   intents: BitFieldResolvable<GatewayIntentsString, number>;
   waitGuildTimeout?: number;
@@ -6878,7 +6876,6 @@ export interface WebhookMessageCreateOptions extends Omit<MessageCreateOptions, 
 export interface WebSocketOptions {
   large_threshold?: number;
   version?: number;
-  presence?: GatewayPresenceUpdateData;
   buildStrategy?(manager: WSWebSocketManager): IShardingStrategy;
   buildIdentifyThrottler?(manager: WSWebSocketManager): Awaitable<IIdentifyThrottler>;
 }


### PR DESCRIPTION
This reverts commit 8f97d2bacf78544e60935405316024a6bc4a4a50.

After internal discussion, we decided to revert this change. See https://github.com/discordjs/discord.js/pull/10426#discussion_r1703174908 for more info
