### PR TITLE
fix(website): duplicate method in docs when interface merging

### DIFF
--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -1788,18 +1788,20 @@ export class ApiModelGenerator {
 						{
 							kind: type?.includes("'") ? ExcerptTokenKind.Content : ExcerptTokenKind.Reference,
 							text: fixPrimitiveTypes(type ?? 'unknown', symbol),
-							canonicalReference: type?.includes("'")
-								? undefined
-								: DeclarationReference.package(pkg)
-										.addNavigationStep(
-											Navigation.Members as any,
-											DeclarationReference.parseComponent(type ?? 'unknown'),
-										)
-										.withMeaning(
-											(lookup[astSymbol?.astDeclarations.at(-1)?.declaration.kind ?? ts.SyntaxKind.ClassDeclaration] ??
-												'class') as Meaning,
-										)
-										.toString(),
+							canonicalReference:
+								type?.includes("'") || !astEntity
+									? undefined
+									: DeclarationReference.package(pkg)
+											.addNavigationStep(
+												Navigation.Members as any,
+												DeclarationReference.parseComponent(type ?? 'unknown'),
+											)
+											.withMeaning(
+												(lookup[
+													astSymbol?.astDeclarations.at(-1)?.declaration.kind ?? ts.SyntaxKind.ClassDeclaration
+												] ?? 'class') as Meaning,
+											)
+											.toString(),
 						},
 						{ kind: ExcerptTokenKind.Content, text: symbol ?? '' },
 					];
@@ -1867,7 +1869,7 @@ export class ApiModelGenerator {
 					: `${method.access ? `${method.access} ` : ''}${method.scope === 'static' ? 'static ' : ''}${method.name}(`
 			}${
 				method.params?.length
-					? `${method.params[0]!.name}${method.params[0]!.nullable || method.params[0]!.optional ? '?' : ''}`
+					? `${method.params[0]!.name}${method.params[0]!.nullable || method.params[0]!.optional ? '?' : ''}: `
 					: '): '
 			}`,
 		});

--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -99,7 +99,7 @@ export function resolveMembers<WantedItem extends ApiItem>(
 		.getMergedSiblings()
 		.filter((sibling) => sibling.containerKey !== parent.containerKey)
 		.flatMap((sibling) => (sibling as ApiItemContainerMixin).findMembersWithInheritance().items)
-		.filter((item) => predicate(item) && !seenItems.has(item.containerKey))
+		.filter((item) => predicate(item) && !seenItems.has(item.displayName))
 		.map((item) => ({
 			item: item as WantedItem,
 			inherited: item.parent ? (item.parent as ApiItemContainerMixin) : undefined,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes an issue where `User#send()` shows twice on documentation website, one of them with invalid links and missing JSDoc.

See https://discord.js.org/docs/packages/discord.js/main/User:Class#send

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
