### PR TITLE
feat(OAuth2API): add `revokeToken` method

### DIFF
--- a/packages/core/src/api/oauth2.ts
+++ b/packages/core/src/api/oauth2.ts
@@ -1,5 +1,6 @@
 /* eslint-disable jsdoc/check-param-names */
 
+import { Buffer } from 'node:buffer';
 import { type RequestData, type REST, makeURLSearchParams } from '@discordjs/rest';
 import {
 	Routes,
@@ -13,6 +14,8 @@ import {
 	type RESTGetAPIOAuth2CurrentApplicationResult,
 	type RESTPostOAuth2AccessTokenURLEncodedData,
 	type RESTPostOAuth2AccessTokenResult,
+	type RESTPostOAuth2TokenRevocation,
+	type Snowflake,
 } from 'discord-api-types/v10';
 
 export class OAuth2API {
@@ -120,5 +123,25 @@ export class OAuth2API {
 		return this.rest.get(Routes.oauth2CurrentAuthorization(), {
 			signal,
 		}) as Promise<RESTGetAPIOAuth2CurrentAuthorizationResult>;
+	}
+
+	/**
+	 * Revokes an OAuth2 token
+	 * 
+	 * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-token-revocation-example}
+	 * @param body - The body of the token revocation request
+	 * @param options - The options for the token revocation request
+	 */
+	public async revokeToken(applicationId: Snowflake, applicationSecret: string, body: RESTPostOAuth2TokenRevocation, { signal }: Pick<RequestData, 'signal'> = {}) {
+	 return this.rest.post(Routes.oauth2TokenRevocation(), {
+	  body: makeURLSearchParams(body),
+	  passThroughBody: true,
+	  headers: {
+	   'Content-Type': 'application/x-www-form-urlencoded',
+	   'Authorization': `Basic ${Buffer.from(`${applicationId}:${applicationSecret}`).toString('base64')}`,
+	  },
+	  auth: false,
+	  signal,
+	 }) as Promise<{}>;
 	}
 }

--- a/packages/core/src/api/oauth2.ts
+++ b/packages/core/src/api/oauth2.ts
@@ -142,6 +142,6 @@ export class OAuth2API {
 	  },
 	  auth: false,
 	  signal,
-	 }) as Promise<{}>;
+	 });
 	}
 }

--- a/packages/core/src/api/oauth2.ts
+++ b/packages/core/src/api/oauth2.ts
@@ -1,6 +1,5 @@
 /* eslint-disable jsdoc/check-param-names */
 
-import { Buffer } from 'node:buffer';
 import { type RequestData, type REST, makeURLSearchParams } from '@discordjs/rest';
 import {
 	Routes,
@@ -14,7 +13,7 @@ import {
 	type RESTGetAPIOAuth2CurrentApplicationResult,
 	type RESTPostOAuth2AccessTokenURLEncodedData,
 	type RESTPostOAuth2AccessTokenResult,
-	type RESTPostOAuth2TokenRevocation,
+	type RESTPostOAuth2TokenRevocationQuery,
 	type Snowflake,
 } from 'discord-api-types/v10';
 
@@ -127,21 +126,28 @@ export class OAuth2API {
 
 	/**
 	 * Revokes an OAuth2 token
-	 * 
+	 *
 	 * @see {@link https://discord.com/developers/docs/topics/oauth2#authorization-code-grant-token-revocation-example}
+	 * @param applicationId - The application id
+	 * @param applicationSecret - The application secret
 	 * @param body - The body of the token revocation request
 	 * @param options - The options for the token revocation request
 	 */
-	public async revokeToken(applicationId: Snowflake, applicationSecret: string, body: RESTPostOAuth2TokenRevocation, { signal }: Pick<RequestData, 'signal'> = {}) {
-	 await this.rest.post(Routes.oauth2TokenRevocation(), {
-	  body: makeURLSearchParams(body),
-	  passThroughBody: true,
-	  headers: {
-	   'Content-Type': 'application/x-www-form-urlencoded',
-	   'Authorization': `Basic ${btoa(`${applicationId}:${applicationSecret}`)}`,
-	  },
-	  auth: false,
-	  signal,
-	 });
+	public async revokeToken(
+		applicationId: Snowflake,
+		applicationSecret: string,
+		body: RESTPostOAuth2TokenRevocationQuery,
+		{ signal }: Pick<RequestData, 'signal'> = {},
+	) {
+		await this.rest.post(Routes.oauth2TokenRevocation(), {
+			body: makeURLSearchParams(body),
+			passThroughBody: true,
+			headers: {
+				Authorization: `Basic ${btoa(`${applicationId}:${applicationSecret}`)}`,
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			auth: false,
+			signal,
+		});
 	}
 }

--- a/packages/core/src/api/oauth2.ts
+++ b/packages/core/src/api/oauth2.ts
@@ -138,7 +138,7 @@ export class OAuth2API {
 	  passThroughBody: true,
 	  headers: {
 	   'Content-Type': 'application/x-www-form-urlencoded',
-	   'Authorization': `Basic ${Buffer.from(`${applicationId}:${applicationSecret}`).toString('base64')}`,
+	   'Authorization': `Basic ${btoa(`${applicationId}:${applicationSecret}`)}`,
 	  },
 	  auth: false,
 	  signal,

--- a/packages/core/src/api/oauth2.ts
+++ b/packages/core/src/api/oauth2.ts
@@ -133,7 +133,7 @@ export class OAuth2API {
 	 * @param options - The options for the token revocation request
 	 */
 	public async revokeToken(applicationId: Snowflake, applicationSecret: string, body: RESTPostOAuth2TokenRevocation, { signal }: Pick<RequestData, 'signal'> = {}) {
-	 return this.rest.post(Routes.oauth2TokenRevocation(), {
+	 await this.rest.post(Routes.oauth2TokenRevocation(), {
 	  body: makeURLSearchParams(body),
 	  passThroughBody: true,
 	  headers: {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This change completes the OAuth2 Authorization flow by supporting the [`Token Revocation URL`](https://discord.com/developers/docs/topics/oauth2)

Fixes #10439

This PR relies on:
- https://github.com/discordjs/discord-api-types/pull/1050
- #10446

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
