### PR TITLE
feat(VoiceState): add methods for fetching voice state

### DIFF
--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -687,11 +687,12 @@ export class GuildsAPI {
 	/**
 	 * Edits a user's voice state in a guild
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/guild#modify-user-voice-state}
+	 * @see {@link https://discord.com/developers/docs/resources/user#modify-user-voice-state}
 	 * @param guildId - The id of the guild to edit the current user's voice state in
 	 * @param userId - The id of the user to edit the voice state for
 	 * @param body - The data for editing the voice state
 	 * @param options - The options for editing the voice state
+	 * @deprecated Use {@link VoiceAPI#editUserVoiceState} instead
 	 */
 	public async editUserVoiceState(
 		guildId: Snowflake,
@@ -1298,9 +1299,10 @@ export class GuildsAPI {
 	/**
 	 * Sets the voice state for the current user
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/guild#modify-current-user-voice-state}
+	 * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
 	 * @param guildId - The id of the guild
 	 * @param body - The options for setting the voice state
+	 * @deprecated Use {@link VoiceAPI#setVoiceState}
 	 */
 	public async setVoiceState(guildId: Snowflake, body: RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = {}) {
 		return this.rest.patch(Routes.guildVoiceState(guildId, '@me'), {

--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -688,7 +688,7 @@ export class GuildsAPI {
 	/**
 	 * Edits a user's voice state in a guild
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/user#modify-user-voice-state}
+	 * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
 	 * @param guildId - The id of the guild to edit the current user's voice state in
 	 * @param userId - The id of the user to edit the voice state for
 	 * @param body - The data for editing the voice state

--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -1303,7 +1303,7 @@ export class GuildsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
 	 * @param guildId - The id of the guild
 	 * @param body - The options for setting the voice state
-	 * @deprecated Use {@link VoiceAPI.setVoiceState}
+	 * @deprecated Use {@link VoiceAPI.editVoiceState} instead
 	 */
 	public async setVoiceState(guildId: Snowflake, body: RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = {}) {
 		return this.rest.patch(Routes.guildVoiceState(guildId, '@me'), {

--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -102,6 +102,7 @@ import {
 	type RESTPutAPIGuildTemplateSyncResult,
 	type Snowflake,
 } from 'discord-api-types/v10';
+import { VoiceAPI } from './voice';
 
 export class GuildsAPI {
 	public constructor(private readonly rest: REST) {}
@@ -692,7 +693,7 @@ export class GuildsAPI {
 	 * @param userId - The id of the user to edit the voice state for
 	 * @param body - The data for editing the voice state
 	 * @param options - The options for editing the voice state
-	 * @deprecated Use {@link VoiceAPI#editUserVoiceState} instead
+	 * @deprecated Use {@link VoiceAPI.editUserVoiceState} instead
 	 */
 	public async editUserVoiceState(
 		guildId: Snowflake,
@@ -1302,7 +1303,7 @@ export class GuildsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
 	 * @param guildId - The id of the guild
 	 * @param body - The options for setting the voice state
-	 * @deprecated Use {@link VoiceAPI#setVoiceState}
+	 * @deprecated Use {@link VoiceAPI.setVoiceState}
 	 */
 	public async setVoiceState(guildId: Snowflake, body: RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = {}) {
 		return this.rest.patch(Routes.guildVoiceState(guildId, '@me'), {

--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -67,9 +67,7 @@ import {
 	type RESTPatchAPIGuildTemplateJSONBody,
 	type RESTPatchAPIGuildTemplateResult,
 	type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody,
-	type RESTPatchAPIGuildVoiceStateCurrentMemberResult,
 	type RESTPatchAPIGuildVoiceStateUserJSONBody,
-	type RESTPatchAPIGuildVoiceStateUserResult,
 	type RESTPatchAPIGuildWelcomeScreenJSONBody,
 	type RESTPatchAPIGuildWelcomeScreenResult,
 	type RESTPatchAPIGuildWidgetSettingsJSONBody,
@@ -702,11 +700,7 @@ export class GuildsAPI {
 		body: RESTPatchAPIGuildVoiceStateUserJSONBody,
 		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
 	) {
-		return this.rest.patch(Routes.guildVoiceState(guildId, userId), {
-			reason,
-			body,
-			signal,
-		}) as Promise<RESTPatchAPIGuildVoiceStateUserResult>;
+		return new VoiceAPI(this.rest).editUserVoiceState(guildId, userId, body, { reason, signal });
 	}
 
 	/**
@@ -1307,13 +1301,16 @@ export class GuildsAPI {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
 	 * @param guildId - The id of the guild
-	 * @param body - The options for setting the voice state
+	 * @param body - The data for setting the voice state
+	 * @param options - The options for setting the voice state
 	 * @deprecated Use {@link VoiceAPI.editVoiceState} instead
 	 */
-	public async setVoiceState(guildId: Snowflake, body: RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = {}) {
-		return this.rest.patch(Routes.guildVoiceState(guildId, '@me'), {
-			body,
-		}) as Promise<RESTPatchAPIGuildVoiceStateCurrentMemberResult>;
+	public async setVoiceState(
+		guildId: Snowflake,
+		body: RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = {},
+		{ signal }: Pick<RequestData, 'signal'> = {},
+	) {
+		return new VoiceAPI(this.rest).editVoiceState(guildId, body, { signal });
 	}
 
 	/**

--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -69,6 +69,7 @@ import {
 	type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody,
 	type RESTPatchAPIGuildVoiceStateCurrentMemberResult,
 	type RESTPatchAPIGuildVoiceStateUserJSONBody,
+	type RESTPatchAPIGuildVoiceStateUserResult,
 	type RESTPatchAPIGuildWelcomeScreenJSONBody,
 	type RESTPatchAPIGuildWelcomeScreenResult,
 	type RESTPatchAPIGuildWidgetSettingsJSONBody,
@@ -701,7 +702,11 @@ export class GuildsAPI {
 		body: RESTPatchAPIGuildVoiceStateUserJSONBody,
 		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
 	) {
-		await this.rest.patch(Routes.guildVoiceState(guildId, userId), { reason, body, signal });
+		return this.rest.patch(Routes.guildVoiceState(guildId, userId), {
+			reason,
+			body,
+			signal,
+		}) as Promise<RESTPatchAPIGuildVoiceStateUserResult>;
 	}
 
 	/**

--- a/packages/core/src/api/voice.ts
+++ b/packages/core/src/api/voice.ts
@@ -52,7 +52,7 @@ export class VoiceAPI {
 	/**
 	 * Edits a user's voice state in a guild
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/user#modify-user-voice-state}
+	 * @see {@link https://discord.com/developers/docs/resources/voice#modify-user-voice-state}
 	 * @param guildId - The id of the guild to edit the current user's voice state in
 	 * @param userId - The id of the user to edit the voice state for
 	 * @param body - The data for editing the voice state
@@ -68,15 +68,21 @@ export class VoiceAPI {
 	}
 
 	/**
-	 * Sets the voice state for the current user
+	 * Edits the voice state for the current user
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
 	 * @param guildId - The id of the guild
-	 * @param body - The options for setting the voice state
+	 * @param body - The data for editing the voice state
+	 * @param options - The options for editing the voice state
 	 */
-	public async setVoiceState(guildId: Snowflake, body: RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = {}) {
+	public async editVoiceState(
+		guildId: Snowflake,
+		body: RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = {},
+		{ signal }: Pick<RequestData, 'signal'> = {},
+	) {
 		return this.rest.patch(Routes.guildVoiceState(guildId, '@me'), {
 			body,
+			signal,
 		}) as Promise<RESTPatchAPIGuildVoiceStateCurrentMemberResult>;
 	}
 }

--- a/packages/core/src/api/voice.ts
+++ b/packages/core/src/api/voice.ts
@@ -10,6 +10,7 @@ import {
 	type RESTPatchAPIGuildVoiceStateUserJSONBody,
 	type RESTPatchAPIGuildVoiceStateCurrentMemberResult,
 	type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody,
+	type RESTPatchAPIGuildVoiceStateUserResult,
 } from 'discord-api-types/v10';
 
 export class VoiceAPI {
@@ -64,7 +65,11 @@ export class VoiceAPI {
 		body: RESTPatchAPIGuildVoiceStateUserJSONBody,
 		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
 	) {
-		await this.rest.patch(Routes.guildVoiceState(guildId, userId), { reason, body, signal });
+		return this.rest.patch(Routes.guildVoiceState(guildId, userId), {
+			reason,
+			body,
+			signal,
+		}) as Promise<RESTPatchAPIGuildVoiceStateUserResult>;
 	}
 
 	/**

--- a/packages/core/src/api/voice.ts
+++ b/packages/core/src/api/voice.ts
@@ -1,7 +1,16 @@
 /* eslint-disable jsdoc/check-param-names */
 
 import type { RequestData, REST } from '@discordjs/rest';
-import { Routes, type RESTGetAPIVoiceRegionsResult } from 'discord-api-types/v10';
+import {
+	Routes,
+	type Snowflake,
+	type RESTGetAPIVoiceRegionsResult,
+	type RESTGetAPIGuildVoiceStateUserResult,
+	type RESTGetAPIGuildVoiceStateCurrentMemberResult,
+	type RESTPatchAPIGuildVoiceStateUserJSONBody,
+	type RESTPatchAPIGuildVoiceStateCurrentMemberResult,
+	type RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody,
+} from 'discord-api-types/v10';
 
 export class VoiceAPI {
 	public constructor(private readonly rest: REST) {}
@@ -14,5 +23,60 @@ export class VoiceAPI {
 	 */
 	public async getVoiceRegions({ signal }: Pick<RequestData, 'signal'> = {}) {
 		return this.rest.get(Routes.voiceRegions(), { signal }) as Promise<RESTGetAPIVoiceRegionsResult>;
+	}
+
+	/**
+	 * Fetches voice state of a user by their id
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/voice#get-user-voice-state}
+	 * @param options - The options for fetching user voice state
+	 */
+	public async getUserVoiceState(guildId: Snowflake, userId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+		return this.rest.get(Routes.guildVoiceState(guildId, userId), {
+			signal,
+		}) as Promise<RESTGetAPIGuildVoiceStateUserResult>;
+	}
+
+	/**
+	 * Fetches the current user's voice state
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/voice#get-current-user-voice-state}
+	 * @param options - The options for fetching user voice state
+	 */
+	public async getVoiceState(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+		return this.rest.get(Routes.guildVoiceState(guildId, '@me'), {
+			signal,
+		}) as Promise<RESTGetAPIGuildVoiceStateCurrentMemberResult>;
+	}
+
+	/**
+	 * Edits a user's voice state in a guild
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/user#modify-user-voice-state}
+	 * @param guildId - The id of the guild to edit the current user's voice state in
+	 * @param userId - The id of the user to edit the voice state for
+	 * @param body - The data for editing the voice state
+	 * @param options - The options for editing the voice state
+	 */
+	public async editUserVoiceState(
+		guildId: Snowflake,
+		userId: Snowflake,
+		body: RESTPatchAPIGuildVoiceStateUserJSONBody,
+		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+	) {
+		await this.rest.patch(Routes.guildVoiceState(guildId, userId), { reason, body, signal });
+	}
+
+	/**
+	 * Sets the voice state for the current user
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/voice#modify-current-user-voice-state}
+	 * @param guildId - The id of the guild
+	 * @param body - The options for setting the voice state
+	 */
+	public async setVoiceState(guildId: Snowflake, body: RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = {}) {
+		return this.rest.patch(Routes.guildVoiceState(guildId, '@me'), {
+			body,
+		}) as Promise<RESTPatchAPIGuildVoiceStateCurrentMemberResult>;
 	}
 }

--- a/packages/discord.js/src/managers/VoiceStateManager.js
+++ b/packages/discord.js/src/managers/VoiceStateManager.js
@@ -41,8 +41,8 @@ class VoiceStateManager extends CachedManager {
    * @returns {Promise<VoiceState>}
    * @example
    * // Fetch a member's voice state
-   * guild.voiceStates.fetch("851588007697580033")
-   *    .then(state => console.log(`Member's voice channel: ${state.channel}`))
+   * guild.voiceStates.fetch("66564597481480192")
+   *    .then(console.log)
    *    .catch(console.error);
    */
   async fetch(member, { cache = true, force = false } = {}) {

--- a/packages/discord.js/src/managers/VoiceStateManager.js
+++ b/packages/discord.js/src/managers/VoiceStateManager.js
@@ -36,7 +36,7 @@ class VoiceStateManager extends CachedManager {
 
   /**
    * Obtains a user's voice state from discord or from the cache if it's already available.
-   * @param {GuildMemberResolvable} member The member whose voice state is to be fetched
+   * @param {GuildMemberResolvable|'@me'} member The member whose voice state is to be fetched
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<VoiceState>}
    * @example
@@ -46,9 +46,9 @@ class VoiceStateManager extends CachedManager {
    *    .catch(console.error);
    */
   async fetch(member, { cache = true, force = false } = {}) {
-    const id = this.guild.members.resolveId(member);
+    const id = member === '@me' ? member : this.guild.members.resolveId(member);
     if (!force) {
-      const existing = this.cache.get(id);
+      const existing = this.cache.get(id === '@me' ? this.client.user.id : id);
       if (existing) return existing;
     }
     const data = await this.client.rest.get(Routes.guildVoiceState(this.guild.id, id));

--- a/packages/discord.js/src/managers/VoiceStateManager.js
+++ b/packages/discord.js/src/managers/VoiceStateManager.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Routes } = require('discord-api-types/v10');
 const CachedManager = require('./CachedManager');
 const VoiceState = require('../structures/VoiceState');
 
@@ -31,6 +32,27 @@ class VoiceStateManager extends CachedManager {
     const entry = new this.holds(this.guild, data);
     if (cache) this.cache.set(data.user_id, entry);
     return entry;
+  }
+
+  /**
+   * Obtains a user's voice state from discord or from the cache if it's already available.
+   * @param {GuildMemberResolvable} member The member whose voice state is to be fetched
+   * @param {BaseFetchOptions} [options] Additional options for this fetch
+   * @returns {Promise<VoiceState>}
+   * @example
+   * // Fetch a member's voice state
+   * guild.voiceStates.fetch("851588007697580033")
+   *    .then(state => console.log(`Member's voice channel: ${state.channel}`))
+   *    .catch(console.error);
+   */
+  async fetch(member, { cache = true, force = false } = {}) {
+    const id = this.guild.members.resolveId(member);
+    if (!force) {
+      const existing = this.cache.get(id);
+      if (existing) return existing;
+    }
+    const data = await this.client.rest.get(Routes.guildVoiceState(this.guild.id, id));
+    return this._add(data, cache);
   }
 }
 

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -251,6 +251,15 @@ class VoiceState extends Base {
   }
 
   /**
+   * Fetches this voice state.
+   * @param {boolean} [force=true] Whether to skip the cache check and request the API
+   * @returns {Promise<VoiceState>}
+   */
+  fetch(force = true) {
+    return this.guild.voiceStates.fetch(this.member, { force });
+  }
+
+  /**
    * Toggles the request to speak in the channel.
    * Only applicable for stage channels and for the client's own voice state.
    * @param {boolean} [requestToSpeak=true] Whether or not the client is requesting to become a speaker.

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -256,7 +256,7 @@ class VoiceState extends Base {
    * @returns {Promise<VoiceState>}
    */
   fetch(force = true) {
-    return this.guild.voiceStates.fetch(this.member, { force });
+    return this.guild.voiceStates.fetch(this.id, { force });
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3589,6 +3589,7 @@ export class VoiceState extends Base {
   public setRequestToSpeak(request?: boolean): Promise<this>;
   public setSuppressed(suppressed?: boolean): Promise<this>;
   public edit(options: VoiceStateEditOptions): Promise<this>;
+  public fetch(force?: boolean): Promise<this>;
 }
 
 // tslint:disable-next-line no-empty-interface
@@ -4591,6 +4592,7 @@ export class UserManager extends CachedManager<Snowflake, User, UserResolvable> 
 export class VoiceStateManager extends CachedManager<Snowflake, VoiceState, typeof VoiceState> {
   private constructor(guild: Guild, iterable?: Iterable<RawVoiceStateData>);
   public guild: Guild;
+  public fetch(member: GuildMemberResolvable, options?: BaseFetchOptions): Promise<VoiceState>;
 }
 
 //#endregion

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3589,7 +3589,7 @@ export class VoiceState extends Base {
   public setRequestToSpeak(request?: boolean): Promise<this>;
   public setSuppressed(suppressed?: boolean): Promise<this>;
   public edit(options: VoiceStateEditOptions): Promise<this>;
-  public fetch(force?: boolean): Promise<this>;
+  public fetch(force?: boolean): Promise<VoiceState>;
 }
 
 // tslint:disable-next-line no-empty-interface

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4592,7 +4592,7 @@ export class UserManager extends CachedManager<Snowflake, User, UserResolvable> 
 export class VoiceStateManager extends CachedManager<Snowflake, VoiceState, typeof VoiceState> {
   private constructor(guild: Guild, iterable?: Iterable<RawVoiceStateData>);
   public guild: Guild;
-  public fetch(member: GuildMemberResolvable, options?: BaseFetchOptions): Promise<VoiceState>;
+  public fetch(member: GuildMemberResolvable | '@me', options?: BaseFetchOptions): Promise<VoiceState>;
 }
 
 //#endregion

--- a/packages/discord.js/typings/rawDataTypes.d.ts
+++ b/packages/discord.js/typings/rawDataTypes.d.ts
@@ -47,6 +47,7 @@ import {
   APIUnavailableGuild,
   APIUser,
   APIVoiceRegion,
+  APIVoiceState,
   APIWebhook,
   GatewayActivity,
   GatewayActivityAssets,
@@ -194,7 +195,7 @@ export type RawUserData =
 
 export type RawVoiceRegionData = APIVoiceRegion;
 
-export type RawVoiceStateData = GatewayVoiceState | Omit<GatewayVoiceState, 'guild_id'>;
+export type RawVoiceStateData = APIVoiceState | Omit<APIVoiceState, 'guild_id'>;
 
 export type RawWebhookData =
   | APIWebhook

--- a/packages/discord.js/typings/rawDataTypes.d.ts
+++ b/packages/discord.js/typings/rawDataTypes.d.ts
@@ -63,7 +63,6 @@ import {
   GatewayPresenceUpdate,
   GatewayReadyDispatchData,
   GatewayTypingStartDispatchData,
-  GatewayVoiceState,
   RESTAPIPartialCurrentUserGuild,
   RESTGetAPIWebhookWithTokenResult,
   RESTPatchAPIChannelMessageJSONBody,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
- Added methods for fetching VoiceState (see https://github.com/discord/discord-api-docs/pull/7061).
- Deprecated and moved `editUserVoiceState` and `setVoiceState` from GuildsAPI to VoiceAPI in core to be more in line with API documentations

Depends on
- https://github.com/discordjs/discord-api-types/pull/1046
- https://github.com/discord/discord-api-docs/pull/7061
- #10452 

**Status and versioning classification:**
 - Code changes have been tested against the Discord API, or there are no code changes
 - I know how to update typings and have done so, or typings don't need updating
 - This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
