### PR TITLE
feat: use get sticker pack endpoint

### DIFF
--- a/packages/core/src/api/sticker.ts
+++ b/packages/core/src/api/sticker.ts
@@ -3,6 +3,7 @@
 import type { RequestData, REST } from '@discordjs/rest';
 import {
 	Routes,
+	type RESTGetAPIStickerPack,
 	type RESTGetAPIStickerResult,
 	type RESTGetStickerPacksResult,
 	type Snowflake,
@@ -10,6 +11,17 @@ import {
 
 export class StickersAPI {
 	public constructor(private readonly rest: REST) {}
+
+	/**
+	 * Fetches a sticker pack
+	 *
+	 * @see {@link https://discord.com/developers/docs/resources/sticker#get-sticker-pack}
+	 * @param packId - The id of the sticker pack
+	 * @param options - The options for fetching the sticker pack
+	 */
+	public async getStickerPack(packId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+		return this.rest.get(Routes.stickerPack(packId), { signal }) as Promise<RESTGetAPIStickerPack>;
+	}
 
 	/**
 	 * Fetches all of the sticker packs

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -343,14 +343,31 @@ class Client extends BaseClient {
   }
 
   /**
+   * Options for fetching sticker packs.
+   * @typedef {Object} StickerPackFetchOptions
+   * @property {Snowflake} [packId] The id of the sticker pack to fetch
+   */
+
+  /**
    * Obtains the list of available sticker packs.
-   * @returns {Promise<Collection<Snowflake, StickerPack>>}
+   * @param {StickerPackFetchOptions} [options={}] Options for fetching sticker packs
+   * @returns {Promise<Collection<Snowflake, StickerPack>|StickerPack>}
+   * A collection of sticker packs, or a single sticker pack if a packId was provided
    * @example
    * client.fetchStickerPacks()
    *   .then(packs => console.log(`Available sticker packs are: ${packs.map(pack => pack.name).join(', ')}`))
    *   .catch(console.error);
+   * @example
+   * client.fetchStickerPacks({ packId: '751604115435421716' })
+   *   .then(pack => console.log(`Sticker pack name: ${pack.name}`))
+   *   .catch(console.error);
    */
-  async fetchStickerPacks() {
+  async fetchStickerPacks({ packId } = {}) {
+    if (packId) {
+      const data = await this.rest.get(Routes.stickerPack(packId));
+      return new StickerPack(this, data);
+    }
+
     const data = await this.rest.get(Routes.stickerPacks());
     return new Collection(data.sticker_packs.map(stickerPack => [stickerPack.id, new StickerPack(this, stickerPack)]));
   }

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -182,8 +182,9 @@ class Sticker extends Base {
    * Fetches the pack that contains this sticker.
    * @returns {Promise<?StickerPack>} The sticker pack or `null` if this sticker does not belong to one.
    */
-  async fetchPack() {
-    return (this.packId && (await this.client.fetchStickerPacks()).get(this.packId)) ?? null;
+  fetchPack() {
+    if (!this.packId) return null;
+    return this.client.fetchStickerPacks({ packId: this.packId });
   }
 
   /**

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -182,8 +182,8 @@ class Sticker extends Base {
    * Fetches the pack that contains this sticker.
    * @returns {Promise<?StickerPack>} The sticker pack or `null` if this sticker does not belong to one.
    */
-  async fetchPack() {
-    if (!this.packId) return null;
+  fetchPack() {
+    if (!this.packId) return Promise.resolve(null);
     return this.client.fetchStickerPacks({ packId: this.packId });
   }
 

--- a/packages/discord.js/src/structures/Sticker.js
+++ b/packages/discord.js/src/structures/Sticker.js
@@ -182,7 +182,7 @@ class Sticker extends Base {
    * Fetches the pack that contains this sticker.
    * @returns {Promise<?StickerPack>} The sticker pack or `null` if this sticker does not belong to one.
    */
-  fetchPack() {
+  async fetchPack() {
     if (!this.packId) return null;
     return this.client.fetchStickerPacks({ packId: this.packId });
   }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1020,7 +1020,8 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
   public fetchGuildTemplate(template: GuildTemplateResolvable): Promise<GuildTemplate>;
   public fetchVoiceRegions(): Promise<Collection<string, VoiceRegion>>;
   public fetchSticker(id: Snowflake): Promise<Sticker>;
-  public fetchStickerPacks(): Promise<Collection<Snowflake, StickerPack>>;
+  public fetchStickerPacks(options: { packId: Snowflake }): Promise<StickerPack>;
+  public fetchStickerPacks(options?: StickerPackFetchOptions): Promise<Collection<Snowflake, StickerPack>>;
   /** @deprecated Use {@link Client.fetchStickerPacks} instead. */
   public fetchPremiumStickerPacks(): ReturnType<Client['fetchStickerPacks']>;
   public fetchWebhook(id: Snowflake, token?: string): Promise<Webhook>;
@@ -1053,6 +1054,10 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
 
   public removeAllListeners<Event extends keyof ClientEvents>(event?: Event): this;
   public removeAllListeners<Event extends string | symbol>(event?: Exclude<Event, keyof ClientEvents>): this;
+}
+
+export interface StickerPackFetchOptions {
+  packId?: Snowflake;
 }
 
 export class ClientApplication extends Application {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -205,6 +205,7 @@ import {
   ChannelSelectMenuComponent,
   MentionableSelectMenuComponent,
   Poll,
+  StickerPack,
 } from '.';
 import { expectAssignable, expectDeprecated, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import type { ContextMenuCommandBuilder, SlashCommandBuilder } from '@discordjs/builders';
@@ -2561,3 +2562,7 @@ declare const poll: Poll;
     answerId: 1,
   });
 }
+
+expectType<Collection<Snowflake, StickerPack>>(await client.fetchStickerPacks());
+expectType<Collection<Snowflake, StickerPack>>(await client.fetchStickerPacks({}));
+expectType<StickerPack>(await client.fetchStickerPacks({ packId: snowflake }));


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Add the ability to fetch a single sticker pack

Upstream:
- https://github.com/discord/discord-api-docs/pull/7065

Depends on:
- https://github.com/discordjs/discord-api-types/pull/1053

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
