### PR TITLE
fix: message reaction crash

### DIFF
--- a/packages/discord.js/src/structures/MessageReaction.js
+++ b/packages/discord.js/src/structures/MessageReaction.js
@@ -83,6 +83,8 @@ class MessageReaction {
         burst: data.count_details.burst,
         normal: data.count_details.normal,
       };
+    } else {
+      this.countDetails ??= { burst: 0, normal: 0 };
     }
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR fixes an edge case where MessageReaction#countDetails was not initialized before a new reaction has been added.
Fixes https://github.com/discordjs/discord.js/issues/10468

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
