### PR TITLE
fix(Transformers): pass client to recursive call

### DIFF
--- a/packages/discord.js/src/util/Transformers.js
+++ b/packages/discord.js/src/util/Transformers.js
@@ -49,7 +49,7 @@ function _transformAPIMessageInteractionMetadata(client, messageInteractionMetad
     originalResponseMessageId: messageInteractionMetadata.original_response_message_id ?? null,
     interactedMessageId: messageInteractionMetadata.interacted_message_id ?? null,
     triggeringInteractionMetadata: messageInteractionMetadata.triggering_interaction_metadata
-      ? _transformAPIMessageInteractionMetadata(messageInteractionMetadata.triggering_interaction_metadata)
+      ? _transformAPIMessageInteractionMetadata(client, messageInteractionMetadata.triggering_interaction_metadata)
       : null,
   };
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`_transformAPIMessageInteractionMetadata`'s recursive call wasn't passing the first parameter (`client`) along.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

