### PR TITLE
feat: Add ApplicationEmoji to EmojiResolvable and MessageReaction#emoji

### DIFF
--- a/packages/discord.js/src/managers/BaseGuildEmojiManager.js
+++ b/packages/discord.js/src/managers/BaseGuildEmojiManager.js
@@ -3,6 +3,7 @@
 const CachedManager = require('./CachedManager');
 const GuildEmoji = require('../structures/GuildEmoji');
 const ReactionEmoji = require('../structures/ReactionEmoji');
+const ApplicationEmoji = require('../structures/ApplicationEmoji');
 const { parseEmoji } = require('../util/Util');
 
 /**
@@ -25,7 +26,8 @@ class BaseGuildEmojiManager extends CachedManager {
    * * A Snowflake
    * * A GuildEmoji object
    * * A ReactionEmoji object
-   * @typedef {Snowflake|GuildEmoji|ReactionEmoji} EmojiResolvable
+   * * An ApplicationEmoji object
+   * @typedef {Snowflake|GuildEmoji|ReactionEmoji|ApplicationEmoji} EmojiResolvable
    */
 
   /**
@@ -35,6 +37,7 @@ class BaseGuildEmojiManager extends CachedManager {
    */
   resolve(emoji) {
     if (emoji instanceof ReactionEmoji) return super.resolve(emoji.id);
+    if (emoji instanceof ApplicationEmoji) return super.resolve(emoji.id);
     return super.resolve(emoji);
   }
 
@@ -45,6 +48,7 @@ class BaseGuildEmojiManager extends CachedManager {
    */
   resolveId(emoji) {
     if (emoji instanceof ReactionEmoji) return emoji.id;
+    if (emoji instanceof ApplicationEmoji) return emoji.id;
     return super.resolveId(emoji);
   }
 
@@ -65,6 +69,7 @@ class BaseGuildEmojiManager extends CachedManager {
     const emojiResolvable = this.resolve(emoji);
     if (emojiResolvable) return emojiResolvable.identifier;
     if (emoji instanceof ReactionEmoji) return emoji.identifier;
+    if (emoji instanceof ApplicationEmoji) return emoji.identifier;
     if (typeof emoji === 'string') {
       const res = parseEmoji(emoji);
       if (res?.name.length) {

--- a/packages/discord.js/src/managers/BaseGuildEmojiManager.js
+++ b/packages/discord.js/src/managers/BaseGuildEmojiManager.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const CachedManager = require('./CachedManager');
+const ApplicationEmoji = require('../structures/ApplicationEmoji');
 const GuildEmoji = require('../structures/GuildEmoji');
 const ReactionEmoji = require('../structures/ReactionEmoji');
-const ApplicationEmoji = require('../structures/ApplicationEmoji');
 const { parseEmoji } = require('../util/Util');
 
 /**

--- a/packages/discord.js/src/structures/MessageReaction.js
+++ b/packages/discord.js/src/structures/MessageReaction.js
@@ -121,18 +121,17 @@ class MessageReaction {
     if (this._emoji instanceof ApplicationEmoji) return this._emoji;
     // Check to see if the emoji has become known to the client
     if (this._emoji.id) {
+      const applicationEmojis = this.message.client.application.emojis.cache;
+      if (applicationEmojis.has(this._emoji.id)) {
+        const emoji = applicationEmojis.get(this._emoji.id);
+        this._emoji = emoji;
+        return emoji;
+      }
       const emojis = this.message.client.emojis.cache;
       if (emojis.has(this._emoji.id)) {
         const emoji = emojis.get(this._emoji.id);
         this._emoji = emoji;
         return emoji;
-      } else {
-        const applicationEmojis = this.message.client.application.emojis.cache;
-        if (applicationEmojis.has(this._emoji.id)) {
-          const emoji = applicationEmojis.get(this._emoji.id);
-          this._emoji = emoji;
-          return emoji;
-        }
       }
     }
     return this._emoji;

--- a/packages/discord.js/src/structures/MessageReaction.js
+++ b/packages/discord.js/src/structures/MessageReaction.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Routes } = require('discord-api-types/v10');
+const ApplicationEmoji = require('./ApplicationEmoji');
 const GuildEmoji = require('./GuildEmoji');
 const ReactionEmoji = require('./ReactionEmoji');
 const ReactionUserManager = require('../managers/ReactionUserManager');
@@ -108,14 +109,16 @@ class MessageReaction {
   }
 
   /**
-   * The emoji of this reaction. Either a {@link GuildEmoji} object for known custom emojis, or a {@link ReactionEmoji}
-   * object which has fewer properties. Whatever the prototype of the emoji, it will still have
+   * The emoji of this reaction. Either a {@link GuildEmoji} object for known custom emojis,
+   * {@link ApplicationEmoji} for application emojis, or a {@link ReactionEmoji} object
+   * which has fewer properties. Whatever the prototype of the emoji, it will still have
    * `name`, `id`, `identifier` and `toString()`
-   * @type {GuildEmoji|ReactionEmoji}
+   * @type {GuildEmoji|ReactionEmoji|ApplicationEmoji}
    * @readonly
    */
   get emoji() {
     if (this._emoji instanceof GuildEmoji) return this._emoji;
+    if (this._emoji instanceof ApplicationEmoji) return this._emoji;
     // Check to see if the emoji has become known to the client
     if (this._emoji.id) {
       const emojis = this.message.client.emojis.cache;
@@ -123,6 +126,13 @@ class MessageReaction {
         const emoji = emojis.get(this._emoji.id);
         this._emoji = emoji;
         return emoji;
+      } else {
+        const applicationEmojis = this.message.client.application.emojis.cache;
+        if (applicationEmojis.has(this._emoji.id)) {
+          const emoji = applicationEmojis.get(this._emoji.id);
+          this._emoji = emoji;
+          return emoji;
+        }
       }
     }
     return this._emoji;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5675,7 +5675,7 @@ export type EmojiIdentifierResolvable =
   | `<${'' | 'a'}:${string}:${Snowflake}>`
   | string;
 
-export type EmojiResolvable = Snowflake | GuildEmoji | ReactionEmoji;
+export type EmojiResolvable = Snowflake | GuildEmoji | ReactionEmoji | ApplicationEmoji;
 
 export interface FetchApplicationCommandOptions extends BaseFetchOptions {
   guildId?: Snowflake;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2429,13 +2429,13 @@ export class MessagePayload {
 
 export class MessageReaction {
   private constructor(client: Client<true>, data: RawMessageReactionData, message: Message);
-  private _emoji: GuildEmoji | ReactionEmoji | ApplicationEmoji;
+  private _emoji: GuildEmoji | ReactionEmoji;
 
   public burstColors: string[] | null;
   public readonly client: Client<true>;
   public count: number;
   public countDetails: ReactionCountDetailsData;
-  public get emoji(): GuildEmoji | ReactionEmoji | ApplicationEmoji;
+  public get emoji(): GuildEmoji | ReactionEmoji;
   public me: boolean;
   public meBurst: boolean;
   public message: Message | PartialMessage;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2429,13 +2429,13 @@ export class MessagePayload {
 
 export class MessageReaction {
   private constructor(client: Client<true>, data: RawMessageReactionData, message: Message);
-  private _emoji: GuildEmoji | ReactionEmoji;
+  private _emoji: GuildEmoji | ReactionEmoji | ApplicationEmoji;
 
   public burstColors: string[] | null;
   public readonly client: Client<true>;
   public count: number;
   public countDetails: ReactionCountDetailsData;
-  public get emoji(): GuildEmoji | ReactionEmoji;
+  public get emoji(): GuildEmoji | ReactionEmoji | ApplicationEmoji;
   public me: boolean;
   public meBurst: boolean;
   public message: Message | PartialMessage;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When using typescript you can't react to a message with an `ApplicationEmoji` because `EmojiResolvable` lacks the type.

Edit: I also updated BaseGuildEmojiManager.js and added `ApplicationEmoji` to the `MessageReaction#emoji` getter.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
