### PR TITLE
types: Reintroduction of the PartialGroupDMChannel within the exclude of TextBasedChannel

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6876,7 +6876,7 @@ export type Channel =
   | ForumChannel
   | MediaChannel;
 
-export type TextBasedChannel = Exclude<Extract<Channel, { type: TextChannelType }>, ForumChannel | MediaChannel>;
+export type TextBasedChannel = Exclude<Extract<Channel, { type: TextChannelType }>, ForumChannel | MediaChannel | PartialGroupDMChannel>;
 
 export type TextBasedChannels = TextBasedChannel;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I believe that during [this merge](https://github.com/discordjs/discord.js/pull/10227), "PartialGroupDMChannel" was incorrectly removed from the excluded definition of "TextBasedChannel." This leads to the inability to use the 'send' function on any "TextBasedChannel"
**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
