### PR TITLE
docs(ApplicationEmojiManager): fix fetch example

### DIFF
--- a/packages/discord.js/src/managers/ApplicationEmojiManager.js
+++ b/packages/discord.js/src/managers/ApplicationEmojiManager.js
@@ -65,12 +65,12 @@ class ApplicationEmojiManager extends CachedManager {
    * @returns {Promise<ApplicationEmoji|Collection<Snowflake, ApplicationEmoji>>}
    * @example
    * // Fetch all emojis from the application
-   * message.application.emojis.fetch()
+   * message.client.application.emojis.fetch()
    *   .then(emojis => console.log(`There are ${emojis.size} emojis.`))
    *   .catch(console.error);
    * @example
    * // Fetch a single emoji
-   * message.application.emojis.fetch('222078108977594368')
+   * message.client.application.emojis.fetch('222078108977594368')
    *   .then(emoji => console.log(`The emoji name is: ${emoji.name}`))
    *   .catch(console.error);
    */

--- a/packages/discord.js/src/managers/ApplicationEmojiManager.js
+++ b/packages/discord.js/src/managers/ApplicationEmojiManager.js
@@ -65,12 +65,12 @@ class ApplicationEmojiManager extends CachedManager {
    * @returns {Promise<ApplicationEmoji|Collection<Snowflake, ApplicationEmoji>>}
    * @example
    * // Fetch all emojis from the application
-   * message.client.application.emojis.fetch()
+   * application.emojis.fetch()
    *   .then(emojis => console.log(`There are ${emojis.size} emojis.`))
    *   .catch(console.error);
    * @example
    * // Fetch a single emoji
-   * message.client.application.emojis.fetch('222078108977594368')
+   * application.emojis.fetch('222078108977594368')
    *   .then(emoji => console.log(`The emoji name is: ${emoji.name}`))
    *   .catch(console.error);
    */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes the `ApplicationEmojiManager#fetch` example, `<Message>.application` doesn't exist

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
