### PR TITLE
docs(Message): mark `interaction` as deprecated

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -426,6 +426,7 @@ class Message extends Base {
       /**
        * Partial data of the interaction that this message is a reply to
        * @type {?MessageInteraction}
+       * @deprecated Use {@link Message#interactionMetadata} instead.
        */
       this.interaction = {
         id: data.interaction.id,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6416,6 +6416,7 @@ export interface MessageInteractionMetadata {
   triggeringInteractionMetadata: MessageInteractionMetadata | null;
 }
 
+/** @deprecated Use {@link MessageInteractionMetadata} instead. */
 export interface MessageInteraction {
   id: Snowflake;
   type: InteractionType;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
An oversight from #10227. Deprecates `<Message>.interaction` in JSDoc comments and `MessageInteraction` in typings.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
