### PR TITLE
fix: type guard for sendable text-based channels

### DIFF
--- a/packages/discord.js/src/structures/BaseChannel.js
+++ b/packages/discord.js/src/structures/BaseChannel.js
@@ -156,11 +156,11 @@ class BaseChannel extends Base {
   }
 
   /**
-   * Indicates whether this channel is {@link TextBasedChannels text-based} and can have messages sent in it.
+   * Indicates whether this channel is sendable.
    * @returns {boolean}
    */
   isSendable() {
-    return this.isTextBased() && 'send' in this;
+    return 'send' in this;
   }
 
   toJSON(...props) {

--- a/packages/discord.js/src/structures/BaseChannel.js
+++ b/packages/discord.js/src/structures/BaseChannel.js
@@ -155,6 +155,14 @@ class BaseChannel extends Base {
     return 'availableTags' in this;
   }
 
+  /**
+   * Indicates whether this channel is {@link TextBasedChannels text-based} and can have messages sent in it.
+   * @returns {boolean}
+   */
+  isSendable() {
+    return this.isTextBased() && 'send' in this;
+  }
+
   toJSON(...props) {
     return super.toJSON({ createdTimestamp: true }, ...props);
   }

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -117,9 +117,24 @@ exports.GuildTextBasedChannelTypes = [
  * * {@link ChannelType.PrivateThread}
  * * {@link ChannelType.GuildVoice}
  * * {@link ChannelType.GuildStageVoice}
+ * * {@link ChannelType.GroupDM}
  * @typedef {ChannelType[]} TextBasedChannelTypes
  */
-exports.TextBasedChannelTypes = [...exports.GuildTextBasedChannelTypes, ChannelType.DM];
+exports.TextBasedChannelTypes = [...exports.GuildTextBasedChannelTypes, ChannelType.DM, ChannelType.GroupDM];
+
+/**
+ * The types of channels that are text-based and can have messages sent into. The available types are:
+ * * {@link ChannelType.DM}
+ * * {@link ChannelType.GuildText}
+ * * {@link ChannelType.GuildAnnouncement}
+ * * {@link ChannelType.AnnouncementThread}
+ * * {@link ChannelType.PublicThread}
+ * * {@link ChannelType.PrivateThread}
+ * * {@link ChannelType.GuildVoice}
+ * * {@link ChannelType.GuildStageVoice}
+ * @typedef {ChannelType[]} SendableTextBasedChannelTypes
+ */
+exports.SendableTextBasedChannelTypes = [...exports.GuildTextBasedChannelTypes, ChannelType.DM];
 
 /**
  * The types of channels that are threads. The available types are:

--- a/packages/discord.js/src/util/Constants.js
+++ b/packages/discord.js/src/util/Constants.js
@@ -132,9 +132,9 @@ exports.TextBasedChannelTypes = [...exports.GuildTextBasedChannelTypes, ChannelT
  * * {@link ChannelType.PrivateThread}
  * * {@link ChannelType.GuildVoice}
  * * {@link ChannelType.GuildStageVoice}
- * @typedef {ChannelType[]} SendableTextBasedChannelTypes
+ * @typedef {ChannelType[]} SendableChannels
  */
-exports.SendableTextBasedChannelTypes = [...exports.GuildTextBasedChannelTypes, ChannelType.DM];
+exports.SendableChannels = [...exports.GuildTextBasedChannelTypes, ChannelType.DM];
 
 /**
  * The types of channels that are threads. The available types are:

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -975,7 +975,7 @@ export abstract class BaseChannel extends Base {
   public isDMBased(): this is PartialGroupDMChannel | DMChannel | PartialDMChannel;
   public isVoiceBased(): this is VoiceBasedChannel;
   public isThreadOnly(): this is ThreadOnlyChannel;
-  public isSendable(): this is SendableTextBasedChannels;
+  public isSendable(): this is SendableChannels;
   public toString(): ChannelMention | UserMention;
 }
 
@@ -3868,7 +3868,7 @@ export const Constants: {
   SweeperKeys: SweeperKey[];
   NonSystemMessageTypes: NonSystemMessageType[];
   TextBasedChannelTypes: TextBasedChannelTypes[];
-  SendableTextBasedChannelTypes: SendableTextBasedChannelTypes[];
+  SendableChannels: SendableChannelTypes[];
   GuildTextBasedChannelTypes: GuildTextBasedChannelTypes[];
   ThreadChannelTypes: ThreadChannelType[];
   VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
@@ -6880,7 +6880,7 @@ export type Channel =
 
 export type TextBasedChannel = Exclude<Extract<Channel, { type: TextChannelType }>, ForumChannel | MediaChannel>;
 
-export type SendableTextBasedChannels = Exclude<TextBasedChannel, PartialGroupDMChannel>;
+export type SendableChannels = Extract<Channel, { send: (...args: any[]) => any }>;
 
 export type TextBasedChannels = TextBasedChannel;
 
@@ -6888,7 +6888,7 @@ export type TextBasedChannelTypes = TextBasedChannel['type'];
 
 export type GuildTextBasedChannelTypes = Exclude<TextBasedChannelTypes, ChannelType.DM | ChannelType.GroupDM>;
 
-export type SendableTextBasedChannelTypes = SendableTextBasedChannels['type'];
+export type SendableChannelTypes = SendableChannels['type'];
 
 export type VoiceBasedChannel = Extract<Channel, { bitrate: number }>;
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3868,6 +3868,7 @@ export const Constants: {
   SweeperKeys: SweeperKey[];
   NonSystemMessageTypes: NonSystemMessageType[];
   TextBasedChannelTypes: TextBasedChannelTypes[];
+  SendableTextBasedChannelTypes: SendableTextBasedChannelTypes[];
   GuildTextBasedChannelTypes: GuildTextBasedChannelTypes[];
   ThreadChannelTypes: ThreadChannelType[];
   VoiceBasedChannelTypes: VoiceBasedChannelTypes[];
@@ -6885,7 +6886,9 @@ export type TextBasedChannels = TextBasedChannel;
 
 export type TextBasedChannelTypes = TextBasedChannel['type'];
 
-export type GuildTextBasedChannelTypes = Exclude<TextBasedChannelTypes, ChannelType.DM>;
+export type GuildTextBasedChannelTypes = Exclude<TextBasedChannelTypes, ChannelType.DM | ChannelType.GroupDM>;
+
+export type SendableTextBasedChannelTypes = SendableTextBasedChannels['type'];
 
 export type VoiceBasedChannel = Extract<Channel, { bitrate: number }>;
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -975,6 +975,7 @@ export abstract class BaseChannel extends Base {
   public isDMBased(): this is PartialGroupDMChannel | DMChannel | PartialDMChannel;
   public isVoiceBased(): this is VoiceBasedChannel;
   public isThreadOnly(): this is ThreadOnlyChannel;
+  public isSendable(): this is SendableTextBasedChannels;
   public toString(): ChannelMention | UserMention;
 }
 
@@ -6877,6 +6878,8 @@ export type Channel =
   | MediaChannel;
 
 export type TextBasedChannel = Exclude<Extract<Channel, { type: TextChannelType }>, ForumChannel | MediaChannel>;
+
+export type SendableTextBasedChannels = Exclude<TextBasedChannel, PartialGroupDMChannel>;
 
 export type TextBasedChannels = TextBasedChannel;
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -209,7 +209,7 @@ import {
   ApplicationEmoji,
   ApplicationEmojiManager,
   StickerPack,
-  SendableTextBasedChannels,
+  SendableChannels,
 } from '.';
 import { expectAssignable, expectDeprecated, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import type { ContextMenuCommandBuilder, SlashCommandBuilder } from '@discordjs/builders';
@@ -2604,7 +2604,7 @@ client.on('interactionCreate', interaction => {
   interaction.channel.send();
 
   if (interaction.channel.isSendable()) {
-    expectType<SendableTextBasedChannels>(interaction.channel);
-    interaction.channel.send();
+    expectType<SendableChannels>(interaction.channel);
+    interaction.channel.send({ embeds: [] });
   }
 });

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -209,6 +209,7 @@ import {
   ApplicationEmoji,
   ApplicationEmojiManager,
   StickerPack,
+  SendableTextBasedChannels,
 } from '.';
 import { expectAssignable, expectDeprecated, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import type { ContextMenuCommandBuilder, SlashCommandBuilder } from '@discordjs/builders';
@@ -2593,3 +2594,16 @@ declare const poll: Poll;
 expectType<Collection<Snowflake, StickerPack>>(await client.fetchStickerPacks());
 expectType<Collection<Snowflake, StickerPack>>(await client.fetchStickerPacks({}));
 expectType<StickerPack>(await client.fetchStickerPacks({ packId: snowflake }));
+
+client.on('interactionCreate', interaction => {
+  if (!interaction.channel) {
+    return;
+  }
+
+  // @ts-expect-error
+  interaction.channel.send();
+
+  if (interaction.channel.isSendable()) {
+    expectType<SendableTextBasedChannels>(interaction.channel);
+  }
+});

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -2605,5 +2605,6 @@ client.on('interactionCreate', interaction => {
 
   if (interaction.channel.isSendable()) {
     expectType<SendableTextBasedChannels>(interaction.channel);
+    interaction.channel.send();
   }
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds in `BaseChannel#isSendable`, which is a mix of `isTextBased()` and checking if you can actually send messages in the channel. This way, we can have the correct types for interaction.channel, and you can assert whether you got the interaction from a Group DM Channel or not

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
