### PR TITLE
docs: update discord documentation links

### DIFF
--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -45,7 +45,7 @@ export class ChannelsAPI {
 	/**
 	 * Sends a message in a channel
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#create-message}
+	 * @see {@link https://discord.com/developers/docs/resources/message#create-message}
 	 * @param channelId - The id of the channel to send the message in
 	 * @param body - The data for sending the message
 	 * @param options - The options for sending the message
@@ -65,7 +65,7 @@ export class ChannelsAPI {
 	/**
 	 * Edits a message
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#edit-message}
+	 * @see {@link https://discord.com/developers/docs/resources/message#edit-message}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to edit
 	 * @param body - The data for editing the message
@@ -87,7 +87,7 @@ export class ChannelsAPI {
 	/**
 	 * Fetches the reactions for a message
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#get-reactions}
+	 * @see {@link https://discord.com/developers/docs/resources/message#get-reactions}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to get the reactions for
 	 * @param emoji - The emoji to get the reactions for
@@ -110,7 +110,7 @@ export class ChannelsAPI {
 	/**
 	 * Deletes a reaction for the current user
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#delete-own-reaction}
+	 * @see {@link https://discord.com/developers/docs/resources/message#delete-own-reaction}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete the reaction for
 	 * @param emoji - The emoji to delete the reaction for
@@ -130,7 +130,7 @@ export class ChannelsAPI {
 	/**
 	 * Deletes a reaction for a user
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#delete-user-reaction}
+	 * @see {@link https://discord.com/developers/docs/resources/message#delete-user-reaction}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete the reaction for
 	 * @param emoji - The emoji to delete the reaction for
@@ -152,7 +152,7 @@ export class ChannelsAPI {
 	/**
 	 * Deletes all reactions for a message
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions}
+	 * @see {@link https://discord.com/developers/docs/resources/message#delete-all-reactions}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete the reactions for
 	 * @param options - The options for deleting the reactions
@@ -168,7 +168,7 @@ export class ChannelsAPI {
 	/**
 	 * Deletes all reactions of an emoji for a message
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#delete-all-reactions-for-emoji}
+	 * @see {@link https://discord.com/developers/docs/resources/message#delete-all-reactions-for-emoji}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete the reactions for
 	 * @param emoji - The emoji to delete the reactions for
@@ -186,7 +186,7 @@ export class ChannelsAPI {
 	/**
 	 * Adds a reaction to a message
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#create-reaction}
+	 * @see {@link https://discord.com/developers/docs/resources/message#create-reaction}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to add the reaction to
 	 * @param emoji - The emoji to add the reaction with
@@ -242,7 +242,7 @@ export class ChannelsAPI {
 	/**
 	 * Fetches the messages of a channel
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#get-channel-messages}
+	 * @see {@link https://discord.com/developers/docs/resources/message#get-channel-messages}
 	 * @param channelId - The id of the channel to fetch messages from
 	 * @param query - The query options for fetching messages
 	 * @param options - The options for fetching the messages
@@ -299,7 +299,7 @@ export class ChannelsAPI {
 	/**
 	 * Deletes a message
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#delete-message}
+	 * @see {@link https://discord.com/developers/docs/resources/message#delete-message}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete
 	 * @param options - The options for deleting the message
@@ -315,7 +315,7 @@ export class ChannelsAPI {
 	/**
 	 * Bulk deletes messages
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#bulk-delete-messages}
+	 * @see {@link https://discord.com/developers/docs/resources/message#bulk-delete-messages}
 	 * @param channelId - The id of the channel the messages are in
 	 * @param messageIds - The ids of the messages to delete
 	 * @param options - The options for deleting the messages
@@ -331,7 +331,7 @@ export class ChannelsAPI {
 	/**
 	 * Fetches a message
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#get-channel-message}
+	 * @see {@link https://discord.com/developers/docs/resources/message#get-channel-message}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to fetch
 	 * @param options - The options for fetching the message
@@ -345,7 +345,7 @@ export class ChannelsAPI {
 	/**
 	 * Crossposts a message
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#crosspost-message}
+	 * @see {@link https://discord.com/developers/docs/resources/message#crosspost-message}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to crosspost
 	 * @param options - The options for crossposting the message
@@ -452,7 +452,7 @@ export class ChannelsAPI {
 	/**
 	 * Creates a new forum post
 	 *
-	 * @see {@link https://discord.com/developers/docs/resources/channel#start-thread-in-forum-channel}
+	 * @see {@link https://discord.com/developers/docs/resources/channel#start-thread-in-forum-or-media-channel}
 	 * @param channelId - The id of the forum channel to start the thread in
 	 * @param body - The data for starting the thread
 	 * @param options - The options for starting the thread

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -359,7 +359,7 @@ class Message extends Base {
      * * {@link MessageType.ChannelFollowAdd}
      * * {@link MessageType.Reply}
      * * {@link MessageType.ThreadStarterMessage}
-     * @see {@link https://discord.com/developers/docs/resources/channel#message-types}
+     * @see {@link https://discord.com/developers/docs/resources/message#message-object-message-types}
      * @typedef {Object} MessageReference
      * @property {Snowflake} channelId The channel id that was referenced
      * @property {Snowflake|undefined} guildId The guild id that was referenced

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -75,7 +75,7 @@ class TextBasedChannel {
    * @property {?string} [content=''] The content for the message. This can only be `null` when editing a message.
    * @property {Array<(EmbedBuilder|Embed|APIEmbed)>} [embeds] The embeds for the message
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
-   * (see [here](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) for more details)
+   * (see [here](https://discord.com/developers/docs/resources/message#allowed-mentions-object) for more details)
    * @property {Array<(AttachmentBuilder|Attachment|AttachmentPayload|BufferResolvable)>} [files]
    * The files to send with the message.
    * @property {Array<(ActionRowBuilder|ActionRow|APIActionRowComponent)>} [components]


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Updates Discord documentation links after https://github.com/discord/discord-api-docs/pull/7034 and also some broken/outdated links.

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
