### PR TITLE
feat: SlashCommandOption#setType and SharedSlashCommandOptions#addOption

### DIFF
--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -37,6 +37,7 @@ export * from './components/selectMenu/UserSelectMenu.js';
 export * as SlashCommandAssertions from './interactions/slashCommands/Assertions.js';
 export * from './interactions/slashCommands/SlashCommandBuilder.js';
 export * from './interactions/slashCommands/SlashCommandSubcommands.js';
+export * from './interactions/slashCommands/options/all.js';
 export * from './interactions/slashCommands/options/boolean.js';
 export * from './interactions/slashCommands/options/channel.js';
 export * from './interactions/slashCommands/options/integer.js';

--- a/packages/builders/src/interactions/slashCommands/options/all.ts
+++ b/packages/builders/src/interactions/slashCommands/options/all.ts
@@ -28,7 +28,7 @@ export type ApplicationCommandOptionStringType =
  *
  * @typeParam OptionType - The type of option
  */
-export type ApplicationCommandOptionEnumTypeMap<OptionType extends ApplicationCommandOptionType | undefined> =
+export type ApplicationCommandOptionEnumTypeMap<OptionType extends ApplicationCommandOptionType> =
 	OptionType extends ApplicationCommandOptionType.Attachment
 		? SlashCommandAttachmentOption
 		: OptionType extends ApplicationCommandOptionType.Boolean
@@ -54,7 +54,7 @@ export type ApplicationCommandOptionEnumTypeMap<OptionType extends ApplicationCo
  *
  * @typeParam OptionType - The type of option
  */
-export type ApplicationCommandOptionStringTypeMap<OptionType extends ApplicationCommandOptionStringType | undefined> =
+export type ApplicationCommandOptionStringTypeMap<OptionType extends ApplicationCommandOptionStringType> =
 	OptionType extends 'attachment'
 		? SlashCommandAttachmentOption
 		: OptionType extends 'boolean'

--- a/packages/builders/src/interactions/slashCommands/options/all.ts
+++ b/packages/builders/src/interactions/slashCommands/options/all.ts
@@ -30,43 +30,26 @@ export type ApplicationCommandOptionStringType =
  */
 export type ApplicationCommandOptionTypeMap<
 	OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType | undefined,
-> = OptionType extends ApplicationCommandOptionType.Attachment
-	? SlashCommandAttachmentOption
-	: OptionType extends ApplicationCommandOptionType.Boolean
-		? SlashCommandBooleanOption
-		: OptionType extends ApplicationCommandOptionType.Channel
-			? SlashCommandChannelOption
-			: OptionType extends ApplicationCommandOptionType.Integer
-				? SlashCommandIntegerOption
-				: OptionType extends ApplicationCommandOptionType.Mentionable
-					? SlashCommandMentionableOption
-					: OptionType extends ApplicationCommandOptionType.Number
-						? SlashCommandNumberOption
-						: OptionType extends ApplicationCommandOptionType.Role
-							? SlashCommandRoleOption
-							: OptionType extends ApplicationCommandOptionType.String
-								? SlashCommandStringOption
-								: OptionType extends ApplicationCommandOptionType.User
-									? SlashCommandUserOption
-									: OptionType extends 'attachment'
-										? SlashCommandAttachmentOption
-										: OptionType extends 'boolean'
-											? SlashCommandBooleanOption
-											: OptionType extends 'channel'
-												? SlashCommandChannelOption
-												: OptionType extends 'integer'
-													? SlashCommandIntegerOption
-													: OptionType extends 'mentionable'
-														? SlashCommandMentionableOption
-														: OptionType extends 'number'
-															? SlashCommandNumberOption
-															: OptionType extends 'role'
-																? SlashCommandRoleOption
-																: OptionType extends 'string'
-																	? SlashCommandStringOption
-																	: OptionType extends 'user'
-																		? SlashCommandUserOption
-																		: SlashCommandStringOption;
+> = 
+    OptionType extends ApplicationCommandOptionType.Attachment ? SlashCommandAttachmentOption :
+    OptionType extends ApplicationCommandOptionType.Boolean ? SlashCommandBooleanOption :
+    OptionType extends ApplicationCommandOptionType.Channel ? SlashCommandChannelOption :
+    OptionType extends ApplicationCommandOptionType.Integer ? SlashCommandIntegerOption :
+    OptionType extends ApplicationCommandOptionType.Mentionable ? SlashCommandMentionableOption :
+    OptionType extends ApplicationCommandOptionType.Number ? SlashCommandNumberOption :
+    OptionType extends ApplicationCommandOptionType.Role ? SlashCommandRoleOption :
+    OptionType extends ApplicationCommandOptionType.String ? SlashCommandStringOption :
+    OptionType extends ApplicationCommandOptionType.User ? SlashCommandUserOption :
+    OptionType extends 'attachment' ? SlashCommandAttachmentOption :
+    OptionType extends 'boolean' ? SlashCommandBooleanOption :
+    OptionType extends 'channel' ? SlashCommandChannelOption :
+    OptionType extends 'integer' ? SlashCommandIntegerOption :
+    OptionType extends 'mentionable' ? SlashCommandMentionableOption :
+    OptionType extends 'number' ? SlashCommandNumberOption :
+    OptionType extends 'role' ? SlashCommandRoleOption :
+    OptionType extends 'string' ? SlashCommandStringOption :
+    OptionType extends 'user' ? SlashCommandUserOption :
+    SlashCommandStringOption;
 
 /**
  * Helper class to obtain any slash command option type.

--- a/packages/builders/src/interactions/slashCommands/options/all.ts
+++ b/packages/builders/src/interactions/slashCommands/options/all.ts
@@ -89,58 +89,55 @@ export type ApplicationCommandOptionTypeMap<
 		: SlashCommandStringOption;
 
 /**
- * Helper class to obtain any slash command option type.
+ * Creates and returns the slash command option of the specified type.
+ * If no type is specified, it returns {@link SlashCommandStringOption} by default.
+ *
+ * @param type - The type of option to create
  */
-export class SlashCommandOption {
-	/**
-	 * Creates and returns the slash command option of the specified type.
-	 * If no type is specified, it returns {@link SlashCommandStringOption} by default.
-	 *
-	 * @param type - The type of option to create
-	 */
-	public static createOption<
-		OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType | undefined = 'string',
-	>(type?: OptionType) {
-		const typeParam = type ?? ApplicationCommandOptionType.String;
-		switch (typeParam) {
-			case ApplicationCommandOptionType.Attachment:
-				return new SlashCommandAttachmentOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case ApplicationCommandOptionType.Boolean:
-				return new SlashCommandBooleanOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case ApplicationCommandOptionType.Channel:
-				return new SlashCommandChannelOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case ApplicationCommandOptionType.Integer:
-				return new SlashCommandIntegerOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case ApplicationCommandOptionType.Mentionable:
-				return new SlashCommandMentionableOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case ApplicationCommandOptionType.Number:
-				return new SlashCommandNumberOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case ApplicationCommandOptionType.Role:
-				return new SlashCommandRoleOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case ApplicationCommandOptionType.String:
-				return new SlashCommandStringOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case ApplicationCommandOptionType.User:
-				return new SlashCommandUserOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case 'attachment':
-				return new SlashCommandAttachmentOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case 'boolean':
-				return new SlashCommandBooleanOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case 'channel':
-				return new SlashCommandChannelOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case 'integer':
-				return new SlashCommandIntegerOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case 'mentionable':
-				return new SlashCommandMentionableOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case 'number':
-				return new SlashCommandNumberOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case 'role':
-				return new SlashCommandRoleOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case 'string':
-				return new SlashCommandStringOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			case 'user':
-				return new SlashCommandUserOption() as ApplicationCommandOptionTypeMap<OptionType>;
-			default:
-				throw new Error(`Unsupported option type: ${typeParam}`);
-		}
+export const SlashCommandOption = <
+	OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType | undefined = 'string',
+>(
+	type?: OptionType,
+) => {
+	const typeParam = type ?? ApplicationCommandOptionType.String;
+	switch (typeParam) {
+		case ApplicationCommandOptionType.Attachment:
+			return new SlashCommandAttachmentOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case ApplicationCommandOptionType.Boolean:
+			return new SlashCommandBooleanOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case ApplicationCommandOptionType.Channel:
+			return new SlashCommandChannelOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case ApplicationCommandOptionType.Integer:
+			return new SlashCommandIntegerOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case ApplicationCommandOptionType.Mentionable:
+			return new SlashCommandMentionableOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case ApplicationCommandOptionType.Number:
+			return new SlashCommandNumberOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case ApplicationCommandOptionType.Role:
+			return new SlashCommandRoleOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case ApplicationCommandOptionType.String:
+			return new SlashCommandStringOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case ApplicationCommandOptionType.User:
+			return new SlashCommandUserOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case 'attachment':
+			return new SlashCommandAttachmentOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case 'boolean':
+			return new SlashCommandBooleanOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case 'channel':
+			return new SlashCommandChannelOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case 'integer':
+			return new SlashCommandIntegerOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case 'mentionable':
+			return new SlashCommandMentionableOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case 'number':
+			return new SlashCommandNumberOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case 'role':
+			return new SlashCommandRoleOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case 'string':
+			return new SlashCommandStringOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		case 'user':
+			return new SlashCommandUserOption() as ApplicationCommandOptionTypeMap<OptionType>;
+		default:
+			throw new Error(`Unsupported option type: ${typeParam}`);
 	}
-}
+};

--- a/packages/builders/src/interactions/slashCommands/options/all.ts
+++ b/packages/builders/src/interactions/slashCommands/options/all.ts
@@ -24,32 +24,69 @@ export type ApplicationCommandOptionStringType =
 	| 'user';
 
 /**
+ * Returns the corresponding slash command option based on the {@link ApplicationCommandOptionType}.
+ *
+ * @typeParam OptionType - The type of option
+ */
+export type ApplicationCommandOptionEnumTypeMap<OptionType extends ApplicationCommandOptionType | undefined> =
+	OptionType extends ApplicationCommandOptionType.Attachment
+		? SlashCommandAttachmentOption
+		: OptionType extends ApplicationCommandOptionType.Boolean
+			? SlashCommandBooleanOption
+			: OptionType extends ApplicationCommandOptionType.Channel
+				? SlashCommandChannelOption
+				: OptionType extends ApplicationCommandOptionType.Integer
+					? SlashCommandIntegerOption
+					: OptionType extends ApplicationCommandOptionType.Mentionable
+						? SlashCommandMentionableOption
+						: OptionType extends ApplicationCommandOptionType.Number
+							? SlashCommandNumberOption
+							: OptionType extends ApplicationCommandOptionType.Role
+								? SlashCommandRoleOption
+								: OptionType extends ApplicationCommandOptionType.String
+									? SlashCommandStringOption
+									: OptionType extends ApplicationCommandOptionType.User
+										? SlashCommandUserOption
+										: never;
+
+/**
+ * Returns the corresponding slash command option based on the string type.
+ *
+ * @typeParam OptionType - The type of option
+ */
+export type ApplicationCommandOptionStringTypeMap<OptionType extends ApplicationCommandOptionStringType | undefined> =
+	OptionType extends 'attachment'
+		? SlashCommandAttachmentOption
+		: OptionType extends 'boolean'
+			? SlashCommandBooleanOption
+			: OptionType extends 'channel'
+				? SlashCommandChannelOption
+				: OptionType extends 'integer'
+					? SlashCommandIntegerOption
+					: OptionType extends 'mentionable'
+						? SlashCommandMentionableOption
+						: OptionType extends 'number'
+							? SlashCommandNumberOption
+							: OptionType extends 'role'
+								? SlashCommandRoleOption
+								: OptionType extends 'string'
+									? SlashCommandStringOption
+									: OptionType extends 'user'
+										? SlashCommandUserOption
+										: never;
+
+/**
  * Returns the corresponding slash command option based on the type.
  *
- * @typeParam type - The type of option
+ * @typeParam OptionType - The type of option
  */
 export type ApplicationCommandOptionTypeMap<
 	OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType | undefined,
-> = 
-    OptionType extends ApplicationCommandOptionType.Attachment ? SlashCommandAttachmentOption :
-    OptionType extends ApplicationCommandOptionType.Boolean ? SlashCommandBooleanOption :
-    OptionType extends ApplicationCommandOptionType.Channel ? SlashCommandChannelOption :
-    OptionType extends ApplicationCommandOptionType.Integer ? SlashCommandIntegerOption :
-    OptionType extends ApplicationCommandOptionType.Mentionable ? SlashCommandMentionableOption :
-    OptionType extends ApplicationCommandOptionType.Number ? SlashCommandNumberOption :
-    OptionType extends ApplicationCommandOptionType.Role ? SlashCommandRoleOption :
-    OptionType extends ApplicationCommandOptionType.String ? SlashCommandStringOption :
-    OptionType extends ApplicationCommandOptionType.User ? SlashCommandUserOption :
-    OptionType extends 'attachment' ? SlashCommandAttachmentOption :
-    OptionType extends 'boolean' ? SlashCommandBooleanOption :
-    OptionType extends 'channel' ? SlashCommandChannelOption :
-    OptionType extends 'integer' ? SlashCommandIntegerOption :
-    OptionType extends 'mentionable' ? SlashCommandMentionableOption :
-    OptionType extends 'number' ? SlashCommandNumberOption :
-    OptionType extends 'role' ? SlashCommandRoleOption :
-    OptionType extends 'string' ? SlashCommandStringOption :
-    OptionType extends 'user' ? SlashCommandUserOption :
-    SlashCommandStringOption;
+> = OptionType extends ApplicationCommandOptionType
+	? ApplicationCommandOptionEnumTypeMap<OptionType>
+	: OptionType extends ApplicationCommandOptionStringType
+		? ApplicationCommandOptionStringTypeMap<OptionType>
+		: SlashCommandStringOption;
 
 /**
  * Helper class to obtain any slash command option type.

--- a/packages/builders/src/interactions/slashCommands/options/all.ts
+++ b/packages/builders/src/interactions/slashCommands/options/all.ts
@@ -94,7 +94,7 @@ export type ApplicationCommandOptionTypeMap<
  *
  * @param type - The type of option to create
  */
-export const SlashCommandOption = <
+export const createSlashCommandOption = <
 	OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType | undefined = 'string',
 >(
 	type?: OptionType,

--- a/packages/builders/src/interactions/slashCommands/options/all.ts
+++ b/packages/builders/src/interactions/slashCommands/options/all.ts
@@ -1,0 +1,126 @@
+import { ApplicationCommandOptionType } from 'discord-api-types/v10';
+import { SlashCommandAttachmentOption } from './attachment.js';
+import { SlashCommandBooleanOption } from './boolean.js';
+import { SlashCommandChannelOption } from './channel.js';
+import { SlashCommandIntegerOption } from './integer.js';
+import { SlashCommandMentionableOption } from './mentionable.js';
+import { SlashCommandNumberOption } from './number.js';
+import { SlashCommandRoleOption } from './role.js';
+import { SlashCommandStringOption } from './string.js';
+import { SlashCommandUserOption } from './user.js';
+
+/**
+ * The slash command option types as strings.
+ */
+export type ApplicationCommandOptionStringType =
+	| 'attachment'
+	| 'boolean'
+	| 'channel'
+	| 'integer'
+	| 'mentionable'
+	| 'number'
+	| 'role'
+	| 'string'
+	| 'user';
+
+/**
+ * Returns the corresponding slash command option based on the type.
+ *
+ * @typeParam type - The type of option
+ */
+export type ApplicationCommandOptionTypeMap<
+	OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType | undefined,
+> = OptionType extends ApplicationCommandOptionType.Attachment
+	? SlashCommandAttachmentOption
+	: OptionType extends ApplicationCommandOptionType.Boolean
+		? SlashCommandBooleanOption
+		: OptionType extends ApplicationCommandOptionType.Channel
+			? SlashCommandChannelOption
+			: OptionType extends ApplicationCommandOptionType.Integer
+				? SlashCommandIntegerOption
+				: OptionType extends ApplicationCommandOptionType.Mentionable
+					? SlashCommandMentionableOption
+					: OptionType extends ApplicationCommandOptionType.Number
+						? SlashCommandNumberOption
+						: OptionType extends ApplicationCommandOptionType.Role
+							? SlashCommandRoleOption
+							: OptionType extends ApplicationCommandOptionType.String
+								? SlashCommandStringOption
+								: OptionType extends ApplicationCommandOptionType.User
+									? SlashCommandUserOption
+									: OptionType extends 'attachment'
+										? SlashCommandAttachmentOption
+										: OptionType extends 'boolean'
+											? SlashCommandBooleanOption
+											: OptionType extends 'channel'
+												? SlashCommandChannelOption
+												: OptionType extends 'integer'
+													? SlashCommandIntegerOption
+													: OptionType extends 'mentionable'
+														? SlashCommandMentionableOption
+														: OptionType extends 'number'
+															? SlashCommandNumberOption
+															: OptionType extends 'role'
+																? SlashCommandRoleOption
+																: OptionType extends 'string'
+																	? SlashCommandStringOption
+																	: OptionType extends 'user'
+																		? SlashCommandUserOption
+																		: SlashCommandStringOption;
+
+/**
+ * Helper class to obtain any slash command option type.
+ */
+export class SlashCommandOption {
+	/**
+	 * Creates and returns the slash command option of the specified type.
+	 * If no type is specified, it returns {@link SlashCommandStringOption} by default.
+	 *
+	 * @param type - The type of option to create
+	 */
+	public static createOption<
+		OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType | undefined = 'string',
+	>(type?: OptionType) {
+		const typeParam = type ?? ApplicationCommandOptionType.String;
+		switch (typeParam) {
+			case ApplicationCommandOptionType.Attachment:
+				return new SlashCommandAttachmentOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Boolean:
+				return new SlashCommandBooleanOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Channel:
+				return new SlashCommandChannelOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Integer:
+				return new SlashCommandIntegerOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Mentionable:
+				return new SlashCommandMentionableOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Number:
+				return new SlashCommandNumberOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Role:
+				return new SlashCommandRoleOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.String:
+				return new SlashCommandStringOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.User:
+				return new SlashCommandUserOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'attachment':
+				return new SlashCommandAttachmentOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'boolean':
+				return new SlashCommandBooleanOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'channel':
+				return new SlashCommandChannelOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'integer':
+				return new SlashCommandIntegerOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'mentionable':
+				return new SlashCommandMentionableOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'number':
+				return new SlashCommandNumberOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'role':
+				return new SlashCommandRoleOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'string':
+				return new SlashCommandStringOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'user':
+				return new SlashCommandUserOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			default:
+				throw new Error(`Unsupported option type: ${typeParam}`);
+		}
+	}
+}

--- a/packages/builders/src/interactions/slashCommands/options/all.ts
+++ b/packages/builders/src/interactions/slashCommands/options/all.ts
@@ -81,63 +81,68 @@ export type ApplicationCommandOptionStringTypeMap<OptionType extends Application
  * @typeParam OptionType - The type of option
  */
 export type ApplicationCommandOptionTypeMap<
-	OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType | undefined,
+	OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType,
 > = OptionType extends ApplicationCommandOptionType
 	? ApplicationCommandOptionEnumTypeMap<OptionType>
 	: OptionType extends ApplicationCommandOptionStringType
 		? ApplicationCommandOptionStringTypeMap<OptionType>
-		: SlashCommandStringOption;
+		: never;
 
 /**
- * Creates and returns the slash command option of the specified type.
- * If no type is specified, it returns {@link SlashCommandStringOption} by default.
- *
- * @param type - The type of option to create
+ * A base slash command option that can have its type specified.
  */
-export const createSlashCommandOption = <
-	OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType | undefined = 'string',
->(
-	type?: OptionType,
-) => {
-	const typeParam = type ?? ApplicationCommandOptionType.String;
-	switch (typeParam) {
-		case ApplicationCommandOptionType.Attachment:
-			return new SlashCommandAttachmentOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case ApplicationCommandOptionType.Boolean:
-			return new SlashCommandBooleanOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case ApplicationCommandOptionType.Channel:
-			return new SlashCommandChannelOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case ApplicationCommandOptionType.Integer:
-			return new SlashCommandIntegerOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case ApplicationCommandOptionType.Mentionable:
-			return new SlashCommandMentionableOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case ApplicationCommandOptionType.Number:
-			return new SlashCommandNumberOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case ApplicationCommandOptionType.Role:
-			return new SlashCommandRoleOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case ApplicationCommandOptionType.String:
-			return new SlashCommandStringOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case ApplicationCommandOptionType.User:
-			return new SlashCommandUserOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case 'attachment':
-			return new SlashCommandAttachmentOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case 'boolean':
-			return new SlashCommandBooleanOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case 'channel':
-			return new SlashCommandChannelOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case 'integer':
-			return new SlashCommandIntegerOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case 'mentionable':
-			return new SlashCommandMentionableOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case 'number':
-			return new SlashCommandNumberOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case 'role':
-			return new SlashCommandRoleOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case 'string':
-			return new SlashCommandStringOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		case 'user':
-			return new SlashCommandUserOption() as ApplicationCommandOptionTypeMap<OptionType>;
-		default:
-			throw new Error(`Unsupported option type: ${typeParam}`);
-	}
-};
+export class SlashCommandOption {
+	/* eslint-disable-next-line @typescript-eslint/no-useless-constructor */
+	public constructor() {}
+
+	/**
+	 * Creates and returns the slash command option of the specified type.
+	 * If no type is specified, it returns {@link SlashCommandStringOption} by default.
+	 *
+	 * @param type - The type of option to create
+	 */
+	public setType = <OptionType extends ApplicationCommandOptionStringType | ApplicationCommandOptionType>(
+		type: OptionType,
+	) => {
+		switch (type) {
+			case ApplicationCommandOptionType.Attachment:
+				return new SlashCommandAttachmentOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Boolean:
+				return new SlashCommandBooleanOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Channel:
+				return new SlashCommandChannelOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Integer:
+				return new SlashCommandIntegerOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Mentionable:
+				return new SlashCommandMentionableOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Number:
+				return new SlashCommandNumberOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.Role:
+				return new SlashCommandRoleOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.String:
+				return new SlashCommandStringOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case ApplicationCommandOptionType.User:
+				return new SlashCommandUserOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'attachment':
+				return new SlashCommandAttachmentOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'boolean':
+				return new SlashCommandBooleanOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'channel':
+				return new SlashCommandChannelOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'integer':
+				return new SlashCommandIntegerOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'mentionable':
+				return new SlashCommandMentionableOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'number':
+				return new SlashCommandNumberOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'role':
+				return new SlashCommandRoleOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'string':
+				return new SlashCommandStringOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			case 'user':
+				return new SlashCommandUserOption() as ApplicationCommandOptionTypeMap<OptionType>;
+			default:
+				throw new Error(`Unsupported option type: ${type}`);
+		}
+	};
+}

--- a/packages/builders/src/interactions/slashCommands/options/all.ts
+++ b/packages/builders/src/interactions/slashCommands/options/all.ts
@@ -97,7 +97,6 @@ export class SlashCommandOption {
 
 	/**
 	 * Creates and returns the slash command option of the specified type.
-	 * If no type is specified, it returns {@link SlashCommandStringOption} by default.
 	 *
 	 * @param type - The type of option to create
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**The problem:**

It has been tedious for me to add SlashCommandOption's with every type being it's own class. This usually results in bloated imports that must be changed between commands

```ts
import { SlashCommandStringOption, SlashCommandChannelOption, 
SlashCommandBooleanOption, SlashCommandNumberOption, 
SlashCommandMentionableOption, SlashCommandRoleOption, 
SlashCommandAttachmentOption } from "discord.js" // imports are tedious

const userOption = new SlashCommandMentionableOption()
    .setName("user")
    .setDescription("User")
            
const subcommand = new SlashCommandSubcommandBuilder()
    .setName("subcommand")
    .setDescription("description")
    .addMentionableOption(userOption) // different method for each type
```

To improve ease of use, I propose adding two changes: 
- A `SlashCommandOption` helper class that can be set to any type in `.setType()`
- Addition of `SharedSlashCommandOptions#addOption` that supports adding option of any type

Now with my proposed changes, the code will look like this:
```ts
import { SlashCommandOption } from "discord.js" // cleaner imports

const userOption = new SlashCommandOption()
    .setType("mentionable")
    .setName("user")
    .setDescription("User")
            
const subcommand = new SlashCommandSubcommandBuilder()
    .setName("subcommand")
    .setDescription("description")
    .addOption(userOption) // supports any type
```

`SlashCommandOption#setType` supports passing a string or `ApplicationCommandOptionType`.

This also works: 
```ts
const userOption = new SlashCommandOption()
    .setType(ApplicationCommandOptionType.Mentionable)
```

**No breaking changes**

This PR does not rename or remove any old methods so it doesn't have breaking changes. If people prefer the old method they can continue to use it. 

**Use cases**

I believe this makes it easier for me to create SlashCommandOptions and quickly copy code over to a different command without having to deal with changing imports and methods.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->