### PR TITLE
feat: Prettier way to send a single embed/file/component

### DIFF
--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -147,9 +147,13 @@ class MessagePayload {
       }
     }
 
-    const components = this.options.components?.map(component =>
-      (isJSONEncodable(component) ? component : new ActionRowBuilder(component)).toJSON(),
-    );
+    let components;
+    if (this.options.components) {
+      if (!Array.isArray(this.options.components)) this.options.components = [this.options.components];
+      components = this.options.components.map(component =>
+        (isJSONEncodable(component) ? component : new ActionRowBuilder(component)).toJSON(),
+      );
+    }
 
     let username;
     let avatarURL;
@@ -272,6 +276,9 @@ class MessagePayload {
   async resolveFiles() {
     if (this.files) return this;
 
+    if (this.options.files) {
+      if (!Array.isArray(this.options.files)) this.options.files = [this.options.files];
+    }
     this.files = await Promise.all(this.options.files?.map(file => this.constructor.resolveFile(file)) ?? []);
     return this;
   }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6451,16 +6451,17 @@ export type FileResolvable =
   | AttachmentBuilder
   | AttachmentPayload;
 
+export type MessageActionRow =
+  | JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>
+  | ActionRowData<MessageActionRowComponentData | MessageActionRowComponentBuilder>
+  | APIActionRowComponent<APIMessageActionRowComponent>;
+
 export interface BaseMessageOptions {
   content?: string;
   embeds?: readonly MessageEmbed[] | MessageEmbed;
   allowedMentions?: MessageMentionOptions;
   files?: readonly FileResolvable[] | FileResolvable;
-  components?: readonly (
-    | JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>
-    | ActionRowData<MessageActionRowComponentData | MessageActionRowComponentBuilder>
-    | APIActionRowComponent<APIMessageActionRowComponent>
-  )[];
+  components?: readonly MessageActionRow[] | MessageActionRow;
   poll?: PollData;
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6442,18 +6442,20 @@ export interface MessageMentionOptions {
 
 export type MessageMentionTypes = 'roles' | 'users' | 'everyone';
 
+export type MessageEmbed = JSONEncodable<APIEmbed> | APIEmbed;
+export type FileResolvable =
+  | BufferResolvable
+  | Stream
+  | JSONEncodable<APIAttachment>
+  | Attachment
+  | AttachmentBuilder
+  | AttachmentPayload;
+
 export interface BaseMessageOptions {
   content?: string;
-  embeds?: readonly (JSONEncodable<APIEmbed> | APIEmbed)[];
+  embeds?: readonly MessageEmbed[] | MessageEmbed;
   allowedMentions?: MessageMentionOptions;
-  files?: readonly (
-    | BufferResolvable
-    | Stream
-    | JSONEncodable<APIAttachment>
-    | Attachment
-    | AttachmentBuilder
-    | AttachmentPayload
-  )[];
+  files?: readonly FileResolvable[] | FileResolvable;
   components?: readonly (
     | JSONEncodable<APIActionRowComponent<APIMessageActionRowComponent>>
     | ActionRowData<MessageActionRowComponentData | MessageActionRowComponentBuilder>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**The problem:**
I know this comes down to stylistic preference, but I don't like the way you have to send a single embed/file/component, making me having to use `[x]` everywhere in my code:
```ts
await interaction.reply({embeds: [embed], files: [file], components: [actionRow]})
```
This is such a simple check to make with `Array.isArray`. I also added the types `MessageEmbed`, `FileResolvable`, and `MessageActionRow` to aid in the typings.

New method:
```ts
await interaction.reply({embeds: embed, files: file, components: actionRow})
```

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
