### PR TITLE
fix(ApplicationCommand): incorrect comparison in equals method

### DIFF
--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -418,7 +418,7 @@ class ApplicationCommand extends Base {
         command.descriptionLocalizations ?? command.description_localizations ?? {},
         this.descriptionLocalizations ?? {},
       ) ||
-      !isEqual(command.integrationTypes ?? command.integration_types ?? [], this.integrationTypes ?? {}) ||
+      !isEqual(command.integrationTypes ?? command.integration_types ?? [], this.integrationTypes ?? []) ||
       !isEqual(command.contexts ?? [], this.contexts ?? [])
     ) {
       return false;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Raised in support: https://discord.com/channels/222078108977594368/824411059443204127/1283275617667780628

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
