### PR TITLE
fix: docs search

### DIFF
--- a/apps/website/src/util/fetchDependencies.ts
+++ b/apps/website/src/util/fetchDependencies.ts
@@ -20,7 +20,7 @@ export async function fetchDependencies({
 
 			return Object.entries<string>(parsedDependencies)
 				.filter(([key]) => key.startsWith('@discordjs/') && !key.includes('api-extractor'))
-				.map(([key, value]) => `${key.replace('@discordjs/', '').replaceAll('.', '-')}-${value.replaceAll('.', '-')}`);
+				.map(([key, value]) => `${key.replace('@discordjs/', '').replaceAll('.', '-')}-${sanitizeVersion(value)}`);
 		} catch {
 			return [];
 		}
@@ -36,8 +36,12 @@ export async function fetchDependencies({
 
 		return Object.entries<string>(parsedDependencies)
 			.filter(([key]) => key.startsWith('@discordjs/') && !key.includes('api-extractor'))
-			.map(([key, value]) => `${key.replace('@discordjs/', '').replaceAll('.', '-')}-${value.replaceAll('.', '-')}`);
+			.map(([key, value]) => `${key.replace('@discordjs/', '').replaceAll('.', '-')}-${sanitizeVersion(value)}`);
 	} catch {
 		return [];
 	}
+}
+
+function sanitizeVersion(version: string) {
+	return version.replaceAll('.', '-').replace(/^[\^~]/, '');
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`discord.js` now depends on `@discordjs/builders` `^1.9.0` which includes an invalid character (`^`) for the search index

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
