### PR TITLE
feat: install button with dropdown for npm, pnpm, yarn and bun

### DIFF
--- a/apps/website/src/components/ui/InstallButton.tsx
+++ b/apps/website/src/components/ui/InstallButton.tsx
@@ -1,15 +1,30 @@
 'use client';
 
-import { ChevronDown, Copy, CopyCheck } from 'lucide-react';
+import { Copy, CopyCheck } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useCopyToClipboard } from 'usehooks-ts';
+
+const getCommand = (manager: string) => {
+	switch (manager) {
+		case 'pnpm':
+			return 'pnpm install discord.js';
+		case 'yarn':
+			return 'yarn add discord.js';
+		case 'bun':
+			return 'bun add discord.js';
+		default:
+			return 'npm install discord.js';
+	}
+};
 
 export function InstallButton({ className = '' }: { readonly className?: string }) {
 	const [interacted, setInteracted] = useState(false);
 	const [copiedText, copyToClipboard] = useCopyToClipboard();
 	const [showDropdown, setShowDropdown] = useState(false);
+	const [selectedPackageManager, setSelectedPackageManager] = useState('npm');
 
-	const handleCopy = async (command: string) => {
+	const handleCopy = async (manager: string) => {
+		const command = getCommand(manager);
 		setInteracted(true);
 		await copyToClipboard(command);
 		setShowDropdown(false);
@@ -27,50 +42,65 @@ export function InstallButton({ className = '' }: { readonly className?: string 
 				onClick={() => setShowDropdown(!showDropdown)}
 				type="button"
 			>
-				<span className="font-semibold text-blurple">{'>'}</span> npm install discord.js
-				<ChevronDown aria-hidden size={20} className="ml-2 inline-block" />
+				<span className="font-semibold text-blurple">{'>'}</span> {getCommand(selectedPackageManager)}
+				{copiedText && interacted ? (
+					<CopyCheck aria-hidden size={20} className="ml-2 inline-block text-green-500" />
+				) : (
+					<Copy aria-hidden size={20} className="ml-2 inline-block" />
+				)}
 			</button>
-			{copiedText && interacted ? (
-				<CopyCheck aria-hidden size={20} className="ml-2 inline-block text-green-500" />
-			) : (
-				<Copy aria-hidden size={20} className="ml-2 inline-block" />
-			)}
 
 			{showDropdown && (
 				<div className="absolute left-0 mt-2 w-full rounded-md border border-neutral-300 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
 					<ul className="py-1">
 						<li>
 							<button
-								type="button"
 								className="block w-full px-4 py-2 text-left hover:bg-neutral-200 dark:hover:bg-neutral-700"
-								onClick={async () => handleCopy('npm install discord.js')}
+								onClick={async () => {
+									setSelectedPackageManager('npm');
+									await handleCopy('npm');
+								}}
+								role="button"
+								type="button"
 							>
 								npm
 							</button>
 						</li>
 						<li>
 							<button
-								type="button"
 								className="block w-full px-4 py-2 text-left hover:bg-neutral-200 dark:hover:bg-neutral-700"
-								onClick={async () => handleCopy('pnpm install discord.js')}
+								onClick={async () => {
+									setSelectedPackageManager('pnpm');
+									await handleCopy('pnpm');
+								}}
+								role="button"
+								type="button"
 							>
 								pnpm
 							</button>
 						</li>
 						<li>
 							<button
-								type="button"
 								className="block w-full px-4 py-2 text-left hover:bg-neutral-200 dark:hover:bg-neutral-700"
-								onClick={async () => handleCopy('yarn add discord.js')}
+								onClick={async () => {
+									setSelectedPackageManager('yarn');
+									await handleCopy('yarn');
+								}}
+								role="button"
+								type="button"
 							>
 								yarn
 							</button>
 						</li>
 						<li>
 							<button
-								type="button"
 								className="block w-full px-4 py-2 text-left hover:bg-neutral-200 dark:hover:bg-neutral-700"
-								onClick={async () => handleCopy('bun add discord.js')}
+								onClick={async () => {
+									setSelectedPackageManager('bun');
+									await handleCopy('bun');
+								}}
+								role="button"
+								type="button"
 							>
 								bun
 							</button>

--- a/apps/website/src/components/ui/InstallButton.tsx
+++ b/apps/website/src/components/ui/InstallButton.tsx
@@ -1,12 +1,19 @@
 'use client';
 
-import { Copy, CopyCheck } from 'lucide-react';
+import { ChevronDown, Copy, CopyCheck } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useCopyToClipboard } from 'usehooks-ts';
 
 export function InstallButton({ className = '' }: { readonly className?: string }) {
 	const [interacted, setInteracted] = useState(false);
 	const [copiedText, copyToClipboard] = useCopyToClipboard();
+	const [showDropdown, setShowDropdown] = useState(false);
+
+	const handleCopy = async (command: string) => {
+		setInteracted(true);
+		await copyToClipboard(command);
+		setShowDropdown(false);
+	};
 
 	useEffect(() => {
 		const timer = setTimeout(() => setInteracted(false), 2_000);
@@ -14,20 +21,63 @@ export function InstallButton({ className = '' }: { readonly className?: string 
 	}, [interacted]);
 
 	return (
-		<button
-			className={`cursor-copy rounded-md border border-neutral-300 bg-white px-4 py-2 font-mono hover:bg-neutral-200 dark:border-neutral-700 dark:bg-transparent dark:hover:bg-neutral-800 ${className}`}
-			onClick={async () => {
-				setInteracted(true);
-				await copyToClipboard('npm install discord.js');
-			}}
-			type="button"
-		>
-			<span className="font-semibold text-blurple">{'>'}</span> npm install discord.js{' '}
+		<div className={`relative inline-block ${className}`}>
+			<button
+				className="cursor-pointer rounded-md border border-neutral-300 bg-white px-4 py-2 font-mono hover:bg-neutral-200 dark:border-neutral-700 dark:bg-transparent dark:hover:bg-neutral-800"
+				onClick={() => setShowDropdown(!showDropdown)}
+				type="button"
+			>
+				<span className="font-semibold text-blurple">{'>'}</span> npm install discord.js
+				<ChevronDown aria-hidden size={20} className="ml-2 inline-block" />
+			</button>
 			{copiedText && interacted ? (
-				<CopyCheck aria-hidden size={20} className="ml-1 inline-block text-green-500" />
+				<CopyCheck aria-hidden size={20} className="ml-2 inline-block text-green-500" />
 			) : (
-				<Copy aria-hidden size={20} className="ml-1 inline-block" />
+				<Copy aria-hidden size={20} className="ml-2 inline-block" />
 			)}
-		</button>
+
+			{showDropdown && (
+				<div className="absolute left-0 mt-2 w-full rounded-md border border-neutral-300 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
+					<ul className="py-1">
+						<li>
+							<button
+								type="button"
+								className="block w-full px-4 py-2 text-left hover:bg-neutral-200 dark:hover:bg-neutral-700"
+								onClick={async () => handleCopy('npm install discord.js')}
+							>
+								npm
+							</button>
+						</li>
+						<li>
+							<button
+								type="button"
+								className="block w-full px-4 py-2 text-left hover:bg-neutral-200 dark:hover:bg-neutral-700"
+								onClick={async () => handleCopy('pnpm install discord.js')}
+							>
+								pnpm
+							</button>
+						</li>
+						<li>
+							<button
+								type="button"
+								className="block w-full px-4 py-2 text-left hover:bg-neutral-200 dark:hover:bg-neutral-700"
+								onClick={async () => handleCopy('yarn add discord.js')}
+							>
+								yarn
+							</button>
+						</li>
+						<li>
+							<button
+								type="button"
+								className="block w-full px-4 py-2 text-left hover:bg-neutral-200 dark:hover:bg-neutral-700"
+								onClick={async () => handleCopy('bun add discord.js')}
+							>
+								bun
+							</button>
+						</li>
+					</ul>
+				</div>
+			)}
+		</div>
 	);
 }


### PR DESCRIPTION
This PR modifies a documentation component to enhance the install button functionality. The dropdown now includes `npm`, `pnpm`, `yarn`, and `bun`, allowing users to easily copy the installation command for their preferred package manager. This update improves the flexibility and user experience for developers consulting the documentation.

**Status and versioning classification:**

<!--
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->