### PR TITLE
fix: `GuildChannel#guildId` not being patched to `undefined`

### DIFF
--- a/packages/discord.js/src/client/actions/MessageCreate.js
+++ b/packages/discord.js/src/client/actions/MessageCreate.js
@@ -6,7 +6,11 @@ const Events = require('../../util/Events');
 class MessageCreateAction extends Action {
   handle(data) {
     const client = this.client;
-    const channel = this.getChannel({ id: data.channel_id, guild_id: data.guild_id, author: data.author });
+    const channel = this.getChannel({
+      id: data.channel_id,
+      author: data.author,
+      ...(data.guildId && { guild_id: data.guild_id }),
+    });
     if (channel) {
       if (!channel.isTextBased()) return {};
 

--- a/packages/discord.js/src/client/actions/MessageCreate.js
+++ b/packages/discord.js/src/client/actions/MessageCreate.js
@@ -9,7 +9,7 @@ class MessageCreateAction extends Action {
     const channel = this.getChannel({
       id: data.channel_id,
       author: data.author,
-      ...(data.guildId && { guild_id: data.guild_id }),
+      ...('guild_id' in data && { guild_id: data.guild_id }),
     });
     if (channel) {
       if (!channel.isTextBased()) return {};

--- a/packages/discord.js/src/client/actions/MessageDelete.js
+++ b/packages/discord.js/src/client/actions/MessageDelete.js
@@ -6,7 +6,7 @@ const Events = require('../../util/Events');
 class MessageDeleteAction extends Action {
   handle(data) {
     const client = this.client;
-    const channel = this.getChannel({ id: data.channel_id, guild_id: data.guild_id });
+    const channel = this.getChannel({ id: data.channel_id, ...('guild_id' in data && { guild_id: data.guild_id }) });
     let message;
     if (channel) {
       if (!channel.isTextBased()) return {};

--- a/packages/discord.js/src/client/actions/MessagePollVoteAdd.js
+++ b/packages/discord.js/src/client/actions/MessagePollVoteAdd.js
@@ -5,7 +5,7 @@ const Events = require('../../util/Events');
 
 class MessagePollVoteAddAction extends Action {
   handle(data) {
-    const channel = this.getChannel({ id: data.channel_id, guild_id: data.guild_id });
+    const channel = this.getChannel({ id: data.channel_id, ...('guild_id' in data && { guild_id: data.guild_id }) });
     if (!channel?.isTextBased()) return false;
 
     const message = this.getMessage(data, channel);

--- a/packages/discord.js/src/client/actions/MessagePollVoteRemove.js
+++ b/packages/discord.js/src/client/actions/MessagePollVoteRemove.js
@@ -5,7 +5,7 @@ const Events = require('../../util/Events');
 
 class MessagePollVoteRemoveAction extends Action {
   handle(data) {
-    const channel = this.getChannel({ id: data.channel_id, guild_id: data.guild_id });
+    const channel = this.getChannel({ id: data.channel_id, ...('guild_id' in data && { guild_id: data.guild_id }) });
     if (!channel?.isTextBased()) return false;
 
     const message = this.getMessage(data, channel);

--- a/packages/discord.js/src/client/actions/MessageReactionAdd.js
+++ b/packages/discord.js/src/client/actions/MessageReactionAdd.js
@@ -25,7 +25,7 @@ class MessageReactionAdd extends Action {
     // Verify channel
     const channel = this.getChannel({
       id: data.channel_id,
-      guild_id: data.guild_id,
+      ...('guild_id' in data && { guild_id: data.guild_id }),
       user_id: data.user_id,
       ...this.spreadInjectedData(data),
     });

--- a/packages/discord.js/src/client/actions/MessageReactionRemove.js
+++ b/packages/discord.js/src/client/actions/MessageReactionRemove.js
@@ -19,7 +19,11 @@ class MessageReactionRemove extends Action {
     if (!user) return false;
 
     // Verify channel
-    const channel = this.getChannel({ id: data.channel_id, guild_id: data.guild_id, user_id: data.user_id });
+    const channel = this.getChannel({
+      id: data.channel_id,
+      ...('guild_id' in data && { guild_id: data.guild_id }),
+      user_id: data.user_id,
+    });
     if (!channel?.isTextBased()) return false;
 
     // Verify message

--- a/packages/discord.js/src/client/actions/MessageReactionRemoveAll.js
+++ b/packages/discord.js/src/client/actions/MessageReactionRemoveAll.js
@@ -6,7 +6,7 @@ const Events = require('../../util/Events');
 class MessageReactionRemoveAll extends Action {
   handle(data) {
     // Verify channel
-    const channel = this.getChannel({ id: data.channel_id, guild_id: data.guild_id });
+    const channel = this.getChannel({ id: data.channel_id, ...('guild_id' in data && { guild_id: data.guild_id }) });
     if (!channel?.isTextBased()) return false;
 
     // Verify message

--- a/packages/discord.js/src/client/actions/MessageReactionRemoveEmoji.js
+++ b/packages/discord.js/src/client/actions/MessageReactionRemoveEmoji.js
@@ -5,7 +5,7 @@ const Events = require('../../util/Events');
 
 class MessageReactionRemoveEmoji extends Action {
   handle(data) {
-    const channel = this.getChannel({ id: data.channel_id, guild_id: data.guild_id });
+    const channel = this.getChannel({ id: data.channel_id, ...('guild_id' in data && { guild_id: data.guild_id }) });
     if (!channel?.isTextBased()) return false;
 
     const message = this.getMessage(data, channel);

--- a/packages/discord.js/src/client/actions/MessageUpdate.js
+++ b/packages/discord.js/src/client/actions/MessageUpdate.js
@@ -4,7 +4,7 @@ const Action = require('./Action');
 
 class MessageUpdateAction extends Action {
   handle(data) {
-    const channel = this.getChannel({ id: data.channel_id, guild_id: data.guild_id });
+    const channel = this.getChannel({ id: data.channel_id, ...('guild_id' in data && { guild_id: data.guild_id }) });
     if (channel) {
       if (!channel.isTextBased()) return {};
 

--- a/packages/discord.js/src/client/actions/TypingStart.js
+++ b/packages/discord.js/src/client/actions/TypingStart.js
@@ -6,7 +6,7 @@ const Events = require('../../util/Events');
 
 class TypingStart extends Action {
   handle(data) {
-    const channel = this.getChannel({ id: data.channel_id, guild_id: data.guild_id });
+    const channel = this.getChannel({ id: data.channel_id, ...('guild_id' in data && { guild_id: data.guild_id }) });
     if (!channel) return;
 
     if (!channel.isTextBased()) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes #10495.

`guild_id` only gets passed to `Action#getChannel()` if it exists in the payload as key.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
