### PR TITLE
fix(website): nullable parameters on events

### DIFF
--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -1510,15 +1510,17 @@ export class ApiModelGenerator {
 			const excerptTokens: IExcerptToken[] = [
 				{
 					kind: ExcerptTokenKind.Content,
-					text: `on('${name}', (${
-						jsDoc.params?.length ? `${jsDoc.params[0]?.name}${jsDoc.params[0]?.nullable ? '?' : ''}: ` : ') => {})'
+					text: `public on(eventName: '${name}', listener: (${
+						jsDoc.params?.length
+							? `${jsDoc.params[0]?.name}${jsDoc.params[0]?.optional ? '?' : ''}: `
+							: ') => void): this;'
 					}`,
 				},
 			];
 			const parameters: IApiParameterOptions[] = [];
 			for (let index = 0; index < (jsDoc.params?.length ?? 0) - 1; index++) {
 				const parameter = jsDoc.params![index]!;
-				const newTokens = this._mapVarType(parameter.type);
+				const newTokens = this._mapVarType(parameter.type, parameter.nullable);
 				parameters.push({
 					parameterName: parameter.name,
 					parameterTypeTokenRange: {
@@ -1537,7 +1539,7 @@ export class ApiModelGenerator {
 
 			if (jsDoc.params?.length) {
 				const parameter = jsDoc.params![jsDoc.params.length - 1]!;
-				const newTokens = this._mapVarType(parameter.type);
+				const newTokens = this._mapVarType(parameter.type, parameter.nullable);
 				parameters.push({
 					parameterName: parameter.name,
 					parameterTypeTokenRange: {
@@ -1550,7 +1552,7 @@ export class ApiModelGenerator {
 				excerptTokens.push(...newTokens);
 				excerptTokens.push({
 					kind: ExcerptTokenKind.Content,
-					text: `) => {})`,
+					text: `) => void): this;`,
 				});
 			}
 
@@ -1773,7 +1775,7 @@ export class ApiModelGenerator {
 			.replaceAll('* ', '\n * * ');
 	}
 
-	private _mapVarType(typey: DocgenVarTypeJson): IExcerptToken[] {
+	private _mapVarType(typey: DocgenVarTypeJson, nullable?: boolean): IExcerptToken[] {
 		const mapper = Array.isArray(typey) ? typey : (typey.types ?? []);
 		const lookup: { [K in ts.SyntaxKind]?: string } = {
 			[ts.SyntaxKind.ClassDeclaration]: 'class',
@@ -1816,7 +1818,22 @@ export class ApiModelGenerator {
 						{ kind: ExcerptTokenKind.Content, text: symbol ?? '' },
 					];
 				}, []);
-				return index === 0 ? result : [{ kind: ExcerptTokenKind.Content, text: ' | ' }, ...result];
+				return index === 0
+					? mapper.length === 1 && (nullable || ('nullable' in typey && typey.nullable))
+						? [
+								...result,
+								{ kind: ExcerptTokenKind.Content, text: ' | ' },
+								{ kind: ExcerptTokenKind.Reference, text: 'null' },
+							]
+						: result
+					: index === mapper.length - 1 && (nullable || ('nullable' in typey && typey.nullable))
+						? [
+								{ kind: ExcerptTokenKind.Content, text: ' | ' },
+								...result,
+								{ kind: ExcerptTokenKind.Content, text: ' | ' },
+								{ kind: ExcerptTokenKind.Reference, text: 'null' },
+							]
+						: [{ kind: ExcerptTokenKind.Content, text: ' | ' }, ...result];
 			})
 			.filter((excerpt) => excerpt.text.length);
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds `| null` to the types on website for parameter of events that are nullable. This was a regression ever since js events were parsed into api-extractor generated docs.

See https://discord.js.org/docs/packages/discord.js/main/Client:Class#presenceUpdate for an example, oldPresence here is nullable but not shown as such. This PR fixes that.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
