### PR TITLE
refactor(PermissionOverwrites)!: cache-independent resolve

### DIFF
--- a/packages/discord.js/src/errors/ErrorCodes.js
+++ b/packages/discord.js/src/errors/ErrorCodes.js
@@ -129,6 +129,8 @@
  * @property {'BulkBanUsersOptionEmpty'} BulkBanUsersOptionEmpty
 
  * @property {'PollAlreadyExpired'} PollAlreadyExpired
+
+ * @property {'PermissionOverwritesTypeMismatch'} PermissionOverwritesTypeMismatch
  */
 
 const keys = [
@@ -258,6 +260,8 @@ const keys = [
   'BulkBanUsersOptionEmpty',
 
   'PollAlreadyExpired',
+
+  'PermissionOverwritesTypeMismatch',
 ];
 
 // JSDoc for IntelliSense purposes

--- a/packages/discord.js/src/errors/ErrorCodes.js
+++ b/packages/discord.js/src/errors/ErrorCodes.js
@@ -130,6 +130,7 @@
 
  * @property {'PollAlreadyExpired'} PollAlreadyExpired
 
+ * @property {'PermissionOverwritesTypeMandatory'} PermissionOverwritesTypeMandatory
  * @property {'PermissionOverwritesTypeMismatch'} PermissionOverwritesTypeMismatch
  */
 
@@ -261,6 +262,7 @@ const keys = [
 
   'PollAlreadyExpired',
 
+  'PermissionOverwritesTypeMandatory',
   'PermissionOverwritesTypeMismatch',
 ];
 

--- a/packages/discord.js/src/errors/Messages.js
+++ b/packages/discord.js/src/errors/Messages.js
@@ -144,6 +144,10 @@ const Messages = {
   [DjsErrorCodes.BulkBanUsersOptionEmpty]: 'Option "users" array or collection is empty',
 
   [DjsErrorCodes.PollAlreadyExpired]: 'This poll has already expired.',
+
+  [DjsErrorCodes.PermissionOverwritesTypeMismatch]: expected =>
+    `"overwrite.id" is a ${expected.toLowerCase()} object, ` +
+    `but "overwrite.type" is not equal to OverwriteType.${expected}.`,
 };
 
 module.exports = Messages;

--- a/packages/discord.js/src/errors/Messages.js
+++ b/packages/discord.js/src/errors/Messages.js
@@ -145,9 +145,10 @@ const Messages = {
 
   [DjsErrorCodes.PollAlreadyExpired]: 'This poll has already expired.',
 
+  [DjsErrorCodes.PermissionOverwritesTypeMandatory]: '"overwrite.type" is mandatory if "overwrite.id" is a Snowflake',
   [DjsErrorCodes.PermissionOverwritesTypeMismatch]: expected =>
     `"overwrite.id" is a ${expected.toLowerCase()} object, ` +
-    `but "overwrite.type" is not equal to OverwriteType.${expected}.`,
+    `but "overwrite.type" is defined and not equal to OverwriteType.${expected}`,
 };
 
 module.exports = Messages;

--- a/packages/discord.js/src/structures/PermissionOverwrites.js
+++ b/packages/discord.js/src/structures/PermissionOverwrites.js
@@ -177,18 +177,20 @@ class PermissionOverwrites extends Base {
       throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'overwrite.id', 'GuildMemberResolvable or RoleResolvable');
     }
 
+    if (overwrite.type !== undefined && (typeof overwrite.type !== 'number' || !(overwrite.type in OverwriteType))) {
+      throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'overwrite.type', 'OverwriteType', true);
+    }
+
     let type;
     if (typeof overwrite.id === 'string') {
-      if (typeof overwrite.type === 'number' && overwrite.type in OverwriteType) {
-        type = overwrite.type;
-      } else {
-        throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'overwrite.type', 'OverwriteType', true);
+      if (overwrite.type === undefined) {
+        throw new DiscordjsTypeError(ErrorCodes.PermissionOverwritesTypeMandatory);
       }
+      type = overwrite.type;
     } else {
       type = overwrite.id instanceof Role ? OverwriteType.Role : OverwriteType.Member;
-      // eslint-disable-next-line eqeqeq
-      if (overwrite.type != null && type !== overwrite.type) {
-        throw new DiscordjsTypeError(ErrorCodes.PermissionOverwriteTypeMismatch, OverwriteType[type]);
+      if (overwrite.type !== undefined && type !== overwrite.type) {
+        throw new DiscordjsTypeError(ErrorCodes.PermissionOverwritesTypeMismatch, OverwriteType[type]);
       }
     }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6519,12 +6519,22 @@ export interface MultipleShardSpawnOptions {
   timeout?: number;
 }
 
-export interface OverwriteData {
+export interface BaseOverwriteData {
   allow?: PermissionResolvable;
   deny?: PermissionResolvable;
   id: GuildMemberResolvable | RoleResolvable;
   type?: OverwriteType;
 }
+
+export interface OverwriteDataWithMandatoryType extends BaseOverwriteData {
+  type: OverwriteType;
+}
+
+export interface OverwriteDataWithOptionalType extends BaseOverwriteData {
+  id: Exclude<GuildMemberResolvable | RoleResolvable, Snowflake>;
+}
+
+export type OverwriteData = OverwriteDataWithMandatoryType | OverwriteDataWithOptionalType;
 
 export type OverwriteResolvable = PermissionOverwrites | OverwriteData;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #10450.

The linked issue relates to the current cache-dependent behaviour of `PermissionOverwrites.resolve()`, specifically that passing identical parameters to `.resolve()` can conditionally pass or fail validation depending on the state of the cache.

This isn't ideal, and the function would be better placed resolving the target via `.resolveId()` in a cache-independent manner.

This approach doesn't allow for `overwrite.type` to be optional if `overwrite.id` is a Snowflake, since it would no longer attempt to seek the respective member/role object from the cache to identify it as one or the other. There are two options for how to handle this:
1. always enforce `overwrite.type` as mandatory, even if `overwrite.id` is a member object or role object;
2. keep `overwrite.type` as optional if `overwrite.id` is a member object or role object (current behaviour), but enforce it as mandatory if `overwrite.id` is a Snowflake.

This PR implements the latter approach. It validates `overwrite.id` and `overwrite.type` as `GuildMemberResolvable|RoleResolvable` and `OverwriteType|undefined` respectively, then:
- if `overwrite.id` is a Snowflake, it sets the type of the result to `overwrite.type`, throwing an error if it's not defined;
- if `overwrite.id` is a member/role object, it sets the type of the result to the OverwriteType corresponding to that object.
  - There's then the question of what to do if `overwrite.type` is provided, but doesn't match the type of `overwrite.id`. This changeset plumps for throwing a validation error if that occurs, since silently overruling the type provided to the function without warning the user could lead to some hard-to-debug quirks.

The same cache-dependent `type` behaviour is also present on `PermissionOverwriteManager#upsert()`, and the behaviour of `PermissionOverwriteManager#edit()` is also seemingly unnecessarily cache-dependent. Think these should also be updated, but will wait for feedback on the PR so far.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
