### PR TITLE
docs(discord.js): remove `utf-8-validate`

### DIFF
--- a/packages/discord.js/README.md
+++ b/packages/discord.js/README.md
@@ -42,7 +42,6 @@ bun add discord.js
 
 - [zlib-sync](https://www.npmjs.com/package/zlib-sync) for WebSocket data compression and inflation (`npm install zlib-sync`)
 - [bufferutil](https://www.npmjs.com/package/bufferutil) for a much faster WebSocket connection (`npm install bufferutil`)
-- [utf-8-validate](https://www.npmjs.com/package/utf-8-validate) in combination with `bufferutil` for much faster WebSocket processing (`npm install utf-8-validate`)
 - [@discordjs/voice](https://www.npmjs.com/package/@discordjs/voice) for interacting with the Discord Voice API (`npm install @discordjs/voice`)
 
 ## Example usage


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Like #10059 but for mainlib

Closes #10530

**Status and versioning classification:**
- This PR **only** includes non-code changes, like changes to documentation, README, etc.