### PR TITLE
docs: allow `@mixes` TSDoc tag for documenting mixins

### DIFF
--- a/packages/api-extractor-model/src/model/ApiPackage.ts
+++ b/packages/api-extractor-model/src/model/ApiPackage.ts
@@ -293,7 +293,7 @@ export class ApiPackage extends ApiItemContainerMixin(ApiNameMixin(ApiDocumented
 
 		const tsdocConfiguration: TSDocConfiguration = new TSDocConfiguration();
 
-		if (versionToDeserialize >= ApiJsonSchemaVersion.V_1004 && 'tsdocConfiguration' in jsonObject) {
+		if (versionToDeserialize >= ApiJsonSchemaVersion.V_1004 && 'tsdocConfig' in jsonObject.metadata) {
 			const tsdocConfigFile: TSDocConfigFile = TSDocConfigFile.loadFromObject(jsonObject.metadata.tsdocConfig);
 			if (tsdocConfigFile.hasErrors) {
 				throw new Error(`Error loading ${apiJsonFilename}:\n` + tsdocConfigFile.getErrorSummary());
@@ -420,6 +420,8 @@ export class ApiPackage extends ApiItemContainerMixin(ApiNameMixin(ApiDocumented
 				for (const key of Object.keys(item)) {
 					if (key === 'dependencies') {
 						result[MinifyJSONMapping.dependencies] = item.dependencies;
+					} else if (key === 'tsdocConfig') {
+						result[MinifyJSONMapping.tsdocConfig] = item.tsdocConfig;
 					} else
 						result[MinifyJSONMapping[key as keyof typeof MinifyJSONMapping]] =
 							typeof item[key] === 'object' ? mapper(item[key]) : item[key];
@@ -440,6 +442,8 @@ export class ApiPackage extends ApiItemContainerMixin(ApiNameMixin(ApiDocumented
 				for (const key of Object.keys(item)) {
 					if (key === MinifyJSONMapping.dependencies) {
 						result.dependencies = item[MinifyJSONMapping.dependencies];
+					} else if (key === MinifyJSONMapping.tsdocConfig) {
+						result.tsdocConfig = item[MinifyJSONMapping.tsdocConfig];
 					} else
 						result[
 							Object.keys(MinifyJSONMapping).find(

--- a/packages/api-extractor/extends/tsdoc-base.json
+++ b/packages/api-extractor/extends/tsdoc-base.json
@@ -32,6 +32,10 @@
 		{
 			"tagName": "@preapproved",
 			"syntaxKind": "modifier"
+		},
+		{
+			"tagName": "@mixes",
+			"syntaxKind": "block"
 		}
 	],
 

--- a/packages/builders/src/interactions/commands/chatInput/ChatInputCommand.ts
+++ b/packages/builders/src/interactions/commands/chatInput/ChatInputCommand.ts
@@ -9,6 +9,11 @@ import { SharedChatInputCommandSubcommands } from './mixins/SharedSubcommands.js
 
 /**
  * A builder that creates API-compatible JSON data for chat input commands.
+ *
+ * @mixes CommandBuilder<RESTPostAPIChatInputApplicationCommandsJSONBody>
+ * @mixes SharedChatInputCommandOptions
+ * @mixes SharedNameAndDescription
+ * @mixes SharedChatInputCommandSubcommands
  */
 export class ChatInputCommandBuilder extends Mixin(
 	CommandBuilder<RESTPostAPIChatInputApplicationCommandsJSONBody>,

--- a/packages/builders/tsdoc.json
+++ b/packages/builders/tsdoc.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"tagDefinitions": [
+		{
+			"tagName": "@mixes",
+			"syntaxKind": "block"
+		}
+	]
+}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

For documenting members of mixins that are merged into a class definition `api-extractor` now supports the `@mixes` TSDoc tag.

Before: https://discord.js.org/docs/packages/builders/main/ChatInputCommandBuilder:Class

After:
<img width="1287" alt="Bildschirmfoto 2024-10-09 um 13 28 55" src="https://github.com/user-attachments/assets/3201cd2d-f405-4218-ba4f-e7ab272c0cff">

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
