### PR TITLE
fix(GuildMemberRoleManager): audit-log member role update dont created

### DIFF
--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -128,7 +128,7 @@ class GuildMemberRoleManager extends DataManager {
         );
       }
 
-      await this.client.rest.put(Routes.guildMemberRole(this.guild.id, this.member.id, roleOrRoles), { reason });
+      await this.member.edit({ roles: [...this.cache.keys(), roleOrRoles] }, reason);
 
       const clone = this.member._clone();
       clone._roles = [...this.cache.keys(), roleOrRoles];
@@ -165,7 +165,7 @@ class GuildMemberRoleManager extends DataManager {
         );
       }
 
-      await this.client.rest.delete(Routes.guildMemberRole(this.guild.id, this.member.id, roleOrRoles), { reason });
+      await this.member.edit({ roles: this.cache.filter(role => role.id !== roleOrRoles).keys() }, reason);
 
       const clone = this.member._clone();
       const newRoles = this.cache.filter(role => role.id !== roleOrRoles);


### PR DESCRIPTION
This pull request updates the `GuildMemberRoleManager` class to use the `edit` method to handle audit log sending

### Role management updates:

* [`packages/discord.js/src/managers/GuildMemberRoleManager.js`](diffhunk://#diff-a11dedf8688081af4fca40ff9ba77984570a5d81b98646c5da980d7b5b6a2a4aL131-R131): Replaced the `put` method with the `member.edit` method to trigger audit logging. (`[packages/discord.js/src/managers/GuildMemberRoleManager.jsL131-R131](diffhunk://#diff-a11dedf8688081af4fca40ff9ba77984570a5d81b98646c5da980d7b5b6a2a4aL131-R131)`) `packages/discord.js/src/managers/GuildMemberRoleManager.js`](diffhunk://#diff-a11dedf8688081af4fca40ff9ba77984570a5d81b98646c5da980d7b5b6a2a4aL168-R168): Replaced the `delete` method with the Method `member.edit` to trigger audit logging. (`[packages/discord.js/src/managers/GuildMemberRoleManager.jsL168-R168](diffhunk://#diff-a11dedf8688081af4fca40ff9ba77984570a5d81b98646c5da980d7b5b6a2a4aL168-R168)`)