### PR TITLE
refactor: Deprecate fetching user flags

### DIFF
--- a/packages/discord.js/src/managers/UserManager.js
+++ b/packages/discord.js/src/managers/UserManager.js
@@ -105,7 +105,7 @@ class UserManager extends CachedManager {
    * Flags may still be retrieved via {@link UserManager#fetch}.</warn>
    */
   async fetchFlags(user, options) {
-    emitDeprecationWarningForUserFetchFlags(true);
+    emitDeprecationWarningForUserFetchFlags(this.constructor.name);
     return (await this.fetch(user, options)).flags;
   }
 

--- a/packages/discord.js/src/managers/UserManager.js
+++ b/packages/discord.js/src/managers/UserManager.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { deprecate } = require('node:util');
 const { ChannelType, Routes } = require('discord-api-types/v10');
 const CachedManager = require('./CachedManager');
 const { DiscordjsError, ErrorCodes } = require('../errors');
@@ -8,6 +7,7 @@ const { GuildMember } = require('../structures/GuildMember');
 const { Message } = require('../structures/Message');
 const ThreadMember = require('../structures/ThreadMember');
 const User = require('../structures/User');
+const { emitDeprecationWarningForUserFetchFlags } = require('../util/Util');
 
 /**
  * Manages API methods for users and stores their cache.
@@ -105,6 +105,7 @@ class UserManager extends CachedManager {
    * Flags may still be retrieved via {@link UserManager#fetch}.</warn>
    */
   async fetchFlags(user, options) {
+    emitDeprecationWarningForUserFetchFlags(true);
     return (await this.fetch(user, options)).flags;
   }
 
@@ -141,10 +142,5 @@ class UserManager extends CachedManager {
     return super.resolveId(user);
   }
 }
-
-UserManager.prototype.fetchFlags = deprecate(
-  UserManager.prototype.fetchFlags,
-  'UserManager#fetchFlags() is deprecated. Use UserManager#fetch() instead.',
-);
 
 module.exports = UserManager;

--- a/packages/discord.js/src/managers/UserManager.js
+++ b/packages/discord.js/src/managers/UserManager.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { deprecate } = require('node:util');
 const { ChannelType, Routes } = require('discord-api-types/v10');
 const CachedManager = require('./CachedManager');
 const { DiscordjsError, ErrorCodes } = require('../errors');
@@ -100,6 +101,8 @@ class UserManager extends CachedManager {
    * @param {UserResolvable} user The UserResolvable to identify
    * @param {BaseFetchOptions} [options] Additional options for this fetch
    * @returns {Promise<UserFlagsBitField>}
+   * @deprecated <warn>This method is deprecated and will be removed in the next major version.
+   * Flags may still be retrieved via {@link UserManager#fetch}.</warn>
    */
   async fetchFlags(user, options) {
     return (await this.fetch(user, options)).flags;
@@ -138,5 +141,10 @@ class UserManager extends CachedManager {
     return super.resolveId(user);
   }
 }
+
+UserManager.prototype.fetchFlags = deprecate(
+  UserManager.prototype.fetchFlags,
+  'UserManager#fetchFlags() is deprecated. Use UserManager#fetch() instead.',
+);
 
 module.exports = UserManager;

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -346,6 +346,8 @@ class User extends Base {
    * Fetches this user's flags.
    * @param {boolean} [force=false] Whether to skip the cache check and request the API
    * @returns {Promise<UserFlagsBitField>}
+   * @deprecated <warn>This method is deprecated and will be removed in the next major version.
+   * Flags may still be retrieved via {@link User#fetch}.</warn>
    */
   fetchFlags(force = false) {
     return this.client.users.fetchFlags(this.id, { force });

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -351,7 +351,7 @@ class User extends Base {
    * Flags may still be retrieved via {@link User#fetch}.</warn>
    */
   fetchFlags(force = false) {
-    emitDeprecationWarningForUserFetchFlags(false);
+    emitDeprecationWarningForUserFetchFlags(this.constructor.name);
     return this.client.users.fetchFlags(this.id, { force });
   }
 

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -6,6 +6,7 @@ const { DiscordSnowflake } = require('@sapphire/snowflake');
 const Base = require('./Base');
 const TextBasedChannel = require('./interfaces/TextBasedChannel');
 const UserFlagsBitField = require('../util/UserFlagsBitField');
+const { emitDeprecationWarningForUserFetchFlags } = require('../util/Util');
 
 /**
  * Represents a user on Discord.
@@ -350,6 +351,7 @@ class User extends Base {
    * Flags may still be retrieved via {@link User#fetch}.</warn>
    */
   fetchFlags(force = false) {
+    emitDeprecationWarningForUserFetchFlags(false);
     return this.client.users.fetchFlags(this.id, { force });
   }
 

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -504,12 +504,11 @@ function resolveSKUId(resolvable) {
 
 /**
  * Deprecation function for fetching user flags.
- * @param {boolean} userManager Whether the class name is the user manager
+ * @param {string} name Name of the class
  * @private
  */
-function emitDeprecationWarningForUserFetchFlags(userManager) {
+function emitDeprecationWarningForUserFetchFlags(name) {
   if (deprecationEmittedForUserFetchFlags) return;
-  const name = userManager ? 'UserManager' : 'User';
   process.emitWarning(`${name}#fetchFlags() is deprecated. Use ${name}#fetch() instead.`);
   deprecationEmittedForUserFetchFlags = true;
 }

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -1,12 +1,15 @@
 'use strict';
 
 const { parse } = require('node:path');
+const process = require('node:process');
 const { Collection } = require('@discordjs/collection');
 const { ChannelType, RouteBases, Routes } = require('discord-api-types/v10');
 const { fetch } = require('undici');
 const Colors = require('./Colors');
 const { DiscordjsError, DiscordjsRangeError, DiscordjsTypeError, ErrorCodes } = require('../errors');
 const isObject = d => typeof d === 'object' && d !== null;
+
+let deprecationEmittedForUserFetchFlags = false;
 
 /**
  * Flatten an object. Any properties that are collections will get converted to an array of keys.
@@ -499,6 +502,18 @@ function resolveSKUId(resolvable) {
   return null;
 }
 
+/**
+ * Deprecation function for fetching user flags.
+ * @param {boolean} userManager Whether the class name is the user manager
+ * @private
+ */
+function emitDeprecationWarningForUserFetchFlags(userManager) {
+  if (deprecationEmittedForUserFetchFlags) return;
+  const name = userManager ? 'UserManager' : 'User';
+  process.emitWarning(`${name}#fetchFlags() is deprecated. Use ${name}#fetch() instead.`);
+  deprecationEmittedForUserFetchFlags = true;
+}
+
 module.exports = {
   flatten,
   fetchRecommendedShardCount,
@@ -518,6 +533,7 @@ module.exports = {
   parseWebhookURL,
   transformResolved,
   resolveSKUId,
+  emitDeprecationWarningForUserFetchFlags,
 };
 
 // Fixes Circular

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3461,6 +3461,7 @@ export class User extends Base {
   public displayAvatarURL(options?: ImageURLOptions): string;
   public equals(user: User): boolean;
   public fetch(force?: boolean): Promise<User>;
+  /** @deprecated This method is deprecated and will be removed in the next major version. Flags may still be retrieved via {@link User.fetch} */
   public fetchFlags(force?: boolean): Promise<UserFlagsBitField>;
   public toString(): UserMention;
 }
@@ -4693,6 +4694,7 @@ export class UserManager extends CachedManager<Snowflake, User, UserResolvable> 
   public createDM(user: UserResolvable, options?: BaseFetchOptions): Promise<DMChannel>;
   public deleteDM(user: UserResolvable): Promise<DMChannel>;
   public fetch(user: UserResolvable, options?: BaseFetchOptions): Promise<User>;
+  /** @deprecated This method is deprecated and will be removed in the next major version. Flags may still be retrieved via {@link User.fetch} */
   public fetchFlags(user: UserResolvable, options?: BaseFetchOptions): Promise<UserFlagsBitField>;
   public send(user: UserResolvable, options: string | MessagePayload | MessageCreateOptions): Promise<Message>;
 }

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4694,7 +4694,7 @@ export class UserManager extends CachedManager<Snowflake, User, UserResolvable> 
   public createDM(user: UserResolvable, options?: BaseFetchOptions): Promise<DMChannel>;
   public deleteDM(user: UserResolvable): Promise<DMChannel>;
   public fetch(user: UserResolvable, options?: BaseFetchOptions): Promise<User>;
-  /** @deprecated This method is deprecated and will be removed in the next major version. Flags may still be retrieved via {@link User.fetch} */
+  /** @deprecated This method is deprecated and will be removed in the next major version. Flags may still be retrieved via {@link UserManager.fetch} */
   public fetchFlags(user: UserResolvable, options?: BaseFetchOptions): Promise<UserFlagsBitField>;
   public send(user: UserResolvable, options: string | MessagePayload | MessageCreateOptions): Promise<Message>;
 }

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -212,6 +212,7 @@ import {
   GuildScheduledEventManager,
   SendableChannels,
   PollData,
+  UserManager,
 } from '.';
 import { expectAssignable, expectDeprecated, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import type { ContextMenuCommandBuilder, SlashCommandBuilder } from '@discordjs/builders';
@@ -1751,6 +1752,12 @@ declare const threadMemberManager: ThreadMemberManager;
   threadMemberManager.fetch({ cache: true, force: false });
   // @ts-expect-error `withMember` needs to be `true` to receive paginated results.
   threadMemberManager.fetch({ withMember: false, limit: 5, after: '12345678901234567' });
+}
+
+declare const userManager: UserManager;
+{
+  expectDeprecated(userManager.fetchFlags('1234567890'));
+  expectDeprecated(user.fetchFlags());
 }
 
 declare const typing: Typing;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Deprecates the fetching of user flags that were removed with #8755.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->