### PR TITLE
perf(collection): optimisations

### DIFF
--- a/packages/collection/__tests__/collection.test.ts
+++ b/packages/collection/__tests__/collection.test.ts
@@ -70,12 +70,20 @@ describe('at() tests', () => {
 		expect(coll.at(0)).toStrictEqual(1);
 	});
 
+	test('positive non-integer index', () => {
+		expect(coll.at(1.5)).toStrictEqual(2);
+	});
+
 	test('negative index', () => {
 		expect(coll.at(-1)).toStrictEqual(3);
 	});
 
+	test('negative non-integer index', () => {
+		expect(coll.at(-2.5)).toStrictEqual(2);
+	});
+
 	test('invalid positive index', () => {
-		expect(coll.at(4)).toBeUndefined();
+		expect(coll.at(3)).toBeUndefined();
 	});
 
 	test('invalid negative index', () => {
@@ -432,12 +440,20 @@ describe('keyAt() tests', () => {
 		expect(coll.keyAt(0)).toStrictEqual('a');
 	});
 
+	test('positive non-integer index', () => {
+		expect(coll.keyAt(1.5)).toStrictEqual('b');
+	});
+
 	test('negative index', () => {
 		expect(coll.keyAt(-1)).toStrictEqual('c');
 	});
 
+	test('negative non-integer index', () => {
+		expect(coll.keyAt(-2.5)).toStrictEqual('b');
+	});
+
 	test('invalid positive index', () => {
-		expect(coll.keyAt(4)).toBeUndefined();
+		expect(coll.keyAt(3)).toBeUndefined();
 	});
 
 	test('invalid negative index', () => {

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -154,10 +154,19 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	 *
 	 * @param index - The index of the element to obtain
 	 */
-	public at(index: number) {
-		index = Math.floor(index);
-		const arr = [...this.values()];
-		return arr.at(index);
+	public at(index: number): Value | undefined {
+		index = Math.trunc(index);
+		if (index >= 0) {
+			if (index >= this.size) return undefined;
+		} else {
+			if (index < this.size * -1) return undefined;
+			index += this.size;
+		}
+		const iter = this.values();
+		for (let skip = 0; skip < index; skip++) {
+			iter.next();
+		}
+		return iter.next().value!;
 	}
 
 	/**
@@ -167,10 +176,19 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	 *
 	 * @param index - The index of the key to obtain
 	 */
-	public keyAt(index: number) {
-		index = Math.floor(index);
-		const arr = [...this.keys()];
-		return arr.at(index);
+	public keyAt(index: number): Key | undefined {
+		index = Math.trunc(index);
+		if (index >= 0) {
+			if (index >= this.size) return undefined;
+		} else {
+			if (index < this.size * -1) return undefined;
+			index += this.size;
+		}
+		const iter = this.keys();
+		for (let skip = 0; skip < index; skip++) {
+			iter.next();
+		}
+		return iter.next().value!;
 	}
 
 	/**

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -117,11 +117,14 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	public last(): Value | undefined;
 	public last(amount: number): Value[];
 	public last(amount?: number): Value | Value[] | undefined {
-		const arr = [...this.values()];
-		if (amount === undefined) return arr[arr.length - 1];
-		if (amount < 0) return this.first(amount * -1);
+		if (amount === undefined) {
+			const arr = [...this.values()];
+			return arr[arr.length - 1];
+		}
 		if (!amount) return [];
-		return arr.slice(-amount);
+		if (amount < 0) return this.first(amount * -1);
+		const arr = [...this.values()];
+		return arr.slice(amount * -1);
 	}
 
 	/**
@@ -134,11 +137,14 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	public lastKey(): Key | undefined;
 	public lastKey(amount: number): Key[];
 	public lastKey(amount?: number): Key | Key[] | undefined {
-		const arr = [...this.keys()];
-		if (amount === undefined) return arr[arr.length - 1];
-		if (amount < 0) return this.firstKey(amount * -1);
+		if (amount === undefined) {
+			const arr = [...this.keys()];
+			return arr[arr.length - 1];
+		}
 		if (!amount) return [];
-		return arr.slice(-amount);
+		if (amount < 0) return this.firstKey(amount * -1);
+		const arr = [...this.keys()];
+		return arr.slice(amount * -1);
 	}
 
 	/**

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -87,7 +87,13 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		if (amount < 0) return this.last(amount * -1);
 		amount = Math.min(this.size, amount);
 		const iter = this.values();
-		return Array.from({ length: amount }, (): Value => iter.next().value!);
+		// eslint-disable-next-line unicorn/no-new-array
+		const results: Value[] = new Array(amount);
+		for (let index = 0; index < amount; index++) {
+			results[index] = iter.next().value!;
+		}
+
+		return results;
 	}
 
 	/**
@@ -104,7 +110,13 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		if (amount < 0) return this.lastKey(amount * -1);
 		amount = Math.min(this.size, amount);
 		const iter = this.keys();
-		return Array.from({ length: amount }, (): Key => iter.next().value!);
+		// eslint-disable-next-line unicorn/no-new-array
+		const results: Key[] = new Array(amount);
+		for (let index = 0; index < amount; index++) {
+			results[index] = iter.next().value!;
+		}
+
+		return results;
 	}
 
 	/**
@@ -121,6 +133,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 			const arr = [...this.values()];
 			return arr[arr.length - 1];
 		}
+
 		if (!amount) return [];
 		if (amount < 0) return this.first(amount * -1);
 		const arr = [...this.values()];
@@ -141,6 +154,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 			const arr = [...this.keys()];
 			return arr[arr.length - 1];
 		}
+
 		if (!amount) return [];
 		if (amount < 0) return this.firstKey(amount * -1);
 		const arr = [...this.keys()];
@@ -162,10 +176,12 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 			if (index < this.size * -1) return undefined;
 			index += this.size;
 		}
+
 		const iter = this.values();
 		for (let skip = 0; skip < index; skip++) {
 			iter.next();
 		}
+
 		return iter.next().value!;
 	}
 
@@ -184,10 +200,12 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 			if (index < this.size * -1) return undefined;
 			index += this.size;
 		}
+
 		const iter = this.keys();
 		for (let skip = 0; skip < index; skip++) {
 			iter.next();
 		}
+
 		return iter.next().value!;
 	}
 

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -218,13 +218,17 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	public random(): Value | undefined;
 	public random(amount: number): Value[];
 	public random(amount?: number): Value | Value[] | undefined {
+		if (amount === 0) return [];
 		const arr = [...this.values()];
 		if (amount === undefined) return arr[Math.floor(Math.random() * arr.length)];
-		if (!arr.length || !amount) return [];
-		return Array.from(
-			{ length: Math.min(amount, arr.length) },
-			(): Value => arr.splice(Math.floor(Math.random() * arr.length), 1)[0]!,
-		);
+		amount = Math.min(this.size, amount);
+		// eslint-disable-next-line unicorn/no-new-array
+		const results: Value[] = new Array(amount);
+		for (let index = 0; index < amount; index++) {
+			results[index] = arr.splice(Math.floor(Math.random() * arr.length), 1)[0]!;
+		}
+
+		return results;
 	}
 
 	/**
@@ -236,13 +240,17 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	public randomKey(): Key | undefined;
 	public randomKey(amount: number): Key[];
 	public randomKey(amount?: number): Key | Key[] | undefined {
+		if (amount === 0) return [];
 		const arr = [...this.keys()];
 		if (amount === undefined) return arr[Math.floor(Math.random() * arr.length)];
-		if (!arr.length || !amount) return [];
-		return Array.from(
-			{ length: Math.min(amount, arr.length) },
-			(): Key => arr.splice(Math.floor(Math.random() * arr.length), 1)[0]!,
-		);
+		amount = Math.min(this.size, amount);
+		// eslint-disable-next-line unicorn/no-new-array
+		const results: Key[] = new Array(amount);
+		for (let index = 0; index < amount; index++) {
+			results[index] = arr.splice(Math.floor(Math.random() * arr.length), 1)[0]!;
+		}
+
+		return results;
 	}
 
 	/**

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -997,8 +997,8 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	 * collection.sorted((userA, userB) => userA.createdTimestamp - userB.createdTimestamp);
 	 * ```
 	 */
-	public toSorted(compareFunction: Comparator<Key, Value> = Collection.defaultSort) {
-		return new this.constructor[Symbol.species](this).sort((av, bv, ak, bk) => compareFunction(av, bv, ak, bk));
+	public toSorted(compareFunction: Comparator<Key, Value> = Collection.defaultSort): Collection<Key, Value> {
+		return new this.constructor[Symbol.species](this).sort(compareFunction);
 	}
 
 	public toJSON() {

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -959,12 +959,14 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 			const hasInSelf = this.has(key);
 			const hasInOther = other.has(key);
 
-			if (hasInSelf && hasInOther) {
-				const result = whenInBoth(this.get(key)!, other.get(key)!, key);
-				if (result.keep) coll.set(key, result.value);
-			} else if (hasInSelf) {
-				const result = whenInSelf(this.get(key)!, key);
-				if (result.keep) coll.set(key, result.value);
+			if (hasInSelf) {
+				if (hasInOther) {
+					const result = whenInBoth(this.get(key)!, other.get(key)!, key);
+					if (result.keep) coll.set(key, result.value);
+				} else {
+					const result = whenInSelf(this.get(key)!, key);
+					if (result.keep) coll.set(key, result.value);
+				}
 			} else if (hasInOther) {
 				const result = whenInOther(other.get(key)!, key);
 				if (result.keep) coll.set(key, result.value);

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -553,10 +553,14 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		if (typeof fn !== 'function') throw new TypeError(`${fn} is not a function`);
 		if (thisArg !== undefined) fn = fn.bind(thisArg);
 		const iter = this.entries();
-		return Array.from({ length: this.size }, (): NewValue => {
+		// eslint-disable-next-line unicorn/no-new-array
+		const results: NewValue[] = new Array(this.size);
+		for (let index = 0; index < this.size; index++) {
 			const [key, value] = iter.next().value!;
-			return fn(value, key, this);
-		});
+			results[index] = fn(value, key, this);
+		}
+
+		return results;
 	}
 
 	/**

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -85,7 +85,8 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	public first(amount?: number): Value | Value[] | undefined {
 		if (amount === undefined) return this.values().next().value;
 		if (amount < 0) return this.last(amount * -1);
-		amount = Math.min(this.size, amount);
+		if (amount >= this.size) return [...this.values()];
+
 		const iter = this.values();
 		// eslint-disable-next-line unicorn/no-new-array
 		const results: Value[] = new Array(amount);
@@ -108,7 +109,8 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	public firstKey(amount?: number): Key | Key[] | undefined {
 		if (amount === undefined) return this.keys().next().value;
 		if (amount < 0) return this.lastKey(amount * -1);
-		amount = Math.min(this.size, amount);
+		if (amount >= this.size) return [...this.keys()];
+
 		const iter = this.keys();
 		// eslint-disable-next-line unicorn/no-new-array
 		const results: Key[] = new Array(amount);

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -214,14 +214,15 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	public random(): Value | undefined;
 	public random(amount: number): Value[];
 	public random(amount?: number): Value | Value[] | undefined {
-		if (amount === 0) return [];
-		const arr = [...this.values()];
-		if (amount === undefined) return arr[Math.floor(Math.random() * arr.length)];
+		if (amount === undefined) return this.at(Math.floor(Math.random() * this.size));
 		amount = Math.min(this.size, amount);
+		if (!amount) return [];
+
+		const values = [...this.values()];
 		// eslint-disable-next-line unicorn/no-new-array
 		const results: Value[] = new Array(amount);
 		for (let index = 0; index < amount; index++) {
-			results[index] = arr.splice(Math.floor(Math.random() * arr.length), 1)[0]!;
+			results[index] = values.splice(Math.floor(Math.random() * values.length), 1)[0]!;
 		}
 
 		return results;
@@ -236,14 +237,15 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	public randomKey(): Key | undefined;
 	public randomKey(amount: number): Key[];
 	public randomKey(amount?: number): Key | Key[] | undefined {
-		if (amount === 0) return [];
-		const arr = [...this.keys()];
-		if (amount === undefined) return arr[Math.floor(Math.random() * arr.length)];
+		if (amount === undefined) return this.keyAt(Math.floor(Math.random() * this.size));
 		amount = Math.min(this.size, amount);
+		if (!amount) return [];
+
+		const keys = [...this.keys()];
 		// eslint-disable-next-line unicorn/no-new-array
 		const results: Key[] = new Array(amount);
 		for (let index = 0; index < amount; index++) {
-			results[index] = arr.splice(Math.floor(Math.random() * arr.length), 1)[0]!;
+			results[index] = keys.splice(Math.floor(Math.random() * keys.length), 1)[0]!;
 		}
 
 		return results;

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -169,8 +169,8 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		if (index >= 0) {
 			if (index >= this.size) return undefined;
 		} else {
-			if (index < this.size * -1) return undefined;
 			index += this.size;
+			if (index < 0) return undefined;
 		}
 
 		const iter = this.values();
@@ -193,8 +193,8 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		if (index >= 0) {
 			if (index >= this.size) return undefined;
 		} else {
-			if (index < this.size * -1) return undefined;
 			index += this.size;
+			if (index < 0) return undefined;
 		}
 
 		const iter = this.keys();

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -219,13 +219,12 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		if (!amount) return [];
 
 		const values = [...this.values()];
-		// eslint-disable-next-line unicorn/no-new-array
-		const results: Value[] = new Array(amount);
-		for (let index = 0; index < amount; index++) {
-			results[index] = values.splice(Math.floor(Math.random() * values.length), 1)[0]!;
+		for (let sourceIndex = 0; sourceIndex < amount; sourceIndex++) {
+			const targetIndex = sourceIndex + Math.floor(Math.random() * (values.length - sourceIndex));
+			[values[sourceIndex], values[targetIndex]] = [values[targetIndex]!, values[sourceIndex]!];
 		}
 
-		return results;
+		return values.slice(0, amount);
 	}
 
 	/**
@@ -242,13 +241,12 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		if (!amount) return [];
 
 		const keys = [...this.keys()];
-		// eslint-disable-next-line unicorn/no-new-array
-		const results: Key[] = new Array(amount);
-		for (let index = 0; index < amount; index++) {
-			results[index] = keys.splice(Math.floor(Math.random() * keys.length), 1)[0]!;
+		for (let sourceIndex = 0; sourceIndex < amount; sourceIndex++) {
+			const targetIndex = sourceIndex + Math.floor(Math.random() * (keys.length - sourceIndex));
+			[keys[sourceIndex], keys[targetIndex]] = [keys[targetIndex]!, keys[sourceIndex]!];
 		}
 
-		return results;
+		return keys.slice(0, amount);
 	}
 
 	/**

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -129,13 +129,10 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	public last(): Value | undefined;
 	public last(amount: number): Value[];
 	public last(amount?: number): Value | Value[] | undefined {
-		if (amount === undefined) {
-			const arr = [...this.values()];
-			return arr[arr.length - 1];
-		}
-
+		if (amount === undefined) return this.at(-1);
 		if (!amount) return [];
 		if (amount < 0) return this.first(amount * -1);
+
 		const arr = [...this.values()];
 		return arr.slice(amount * -1);
 	}
@@ -150,13 +147,10 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	public lastKey(): Key | undefined;
 	public lastKey(amount: number): Key[];
 	public lastKey(amount?: number): Key | Key[] | undefined {
-		if (amount === undefined) {
-			const arr = [...this.keys()];
-			return arr[arr.length - 1];
-		}
-
+		if (amount === undefined) return this.keyAt(-1);
 		if (!amount) return [];
 		if (amount < 0) return this.firstKey(amount * -1);
+
 		const arr = [...this.keys()];
 		return arr.slice(amount * -1);
 	}


### PR DESCRIPTION
#### `.first()`, `.firstKey()`
The callback variant of `Array.from()` is slow in V8. Changing the method of array generation from:
```js
Array.from({ length: amount }, () => ...)
```
to
```js
const results = new Array(amount)
for (let index = 0; index < amount; index++) results[index] = ...
```
produces a ~90-95% reduction in execution time, when tested with all current LTS versions of Node.

Note that this is deliberately `new Array(n)` and not `Array.from({ length: n })`:
- The first of these just creates an empty array with a length property of `n`, and is an O(1) operation.
- The second of these is an O(n) operation: it creates an empty array of length `n`, then for all `i` in `0 <= i < n`, it reads the property `obj[i]` from the object parameter (which in this case will always be undefined), and sets `array[i]` to that value. This is significantly slower for large arrays, and not what we want here.

Additionally, switches to just using iterable-to-array in the case where `amount >= this.size`, which is a fast operation for builtin iterables. This further halves the execution time when compared with the above method.

#### `.last()`, `.lastKey()`
Only carry out the memory-expensive `[...this.<iterable>()]` if needed.

Previously, passing `amount <= 0` would still copy the entire collection into a temporary array, even though it's never referenced. This significantly speeds up execution in those cases.

Uses the new `.at()` or `.keyAt()` (as below) to fetch the last element in the collection in the case where `amount === undefined`. This is around 10-20% faster than the previous method of copying into a temporary array and selecting the last element.

#### `.at()`, `.keyAt()`
Manually iterate to the target index, instead of generating a full array copy of the collection to call `Array.prototype.at()`.

The performance of the previous implementation was essentially linear on the size of the collection, and independent of the index being fetched, as the whole collection was copied into a temporary array regardless.

The performance of the new implementation is linear on the index being fetched, and results in a performance improvement of >90% when the target index is close to the start of the collection. In the worst case when the target index is close to the end of the collection, it still performs well (around 10-20% faster in Node v22, and around 50% faster in Node v18). It also avoids the memory cost of copying the collection into a temporary array.

**This contains a small off-by-one fix which represents a technical breaking change.** Previously, the implementations of `.at()` and `.keyAt()` were not compliant with the standard for `Array.prototype.at()` specifically when passing a negative non-integer index: the standard dictates that these are truncated (ie. rounded _towards_ zero), whereas the previous implementation used `Math.floor()` (ie. rounded these _away from_ zero).

#### `.random()`, `.randomKey()`
The previous implementation used repeated calls to `Array.prototype.splice()` to extract individual random elements from a temporary array copy of the collection. This is a very slow process for larger arrays, since each splice necessitates a memory move of all elements above the extracted element, so performing repeated splices for each random element becomes very inefficient.

The new implementation uses an in-place Durstenfeld shuffle, stopping after enough elements have been randomised, and then returns the shuffled elements using `Array.prototype.slice()`. This is about 40% faster for small collections, and >90% faster for large ones.

Additionally, skips copying the collection into a temporary array if `amount === 0`, and uses the new `.at()` or `.keyAt()` (as above) to fetch a single element in the case where `amount === undefined`.

#### `.map()`
Changes the method of array generation to pushing to a new array, instead of passing a callback to `Array.from()`.

Same rationale as `.first()` above. This change produces a ~80% reduction in execution time when tested with all current LTS versions of Node.

#### `.merge()`
Adjusts the logic for checking `hasInSelf` and `hasInOther`. Previously, each of these boolean conditions was evaluated twice; this makes a small change to the control flow to deduplicate the checks.

#### `.toSorted()`
Removes the redundant closure wrapping `compareFunction` and just passes it directly, eliminating a needless call from the stack.

### Status and versioning classification:

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
