### PR TITLE
refactor!: fix several issues with /ws incorporation

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -106,14 +106,6 @@ class Client extends BaseClient {
     this.actions = new ActionsManager(this);
 
     /**
-     * Shard helpers for the client (only if the process was spawned from a {@link ShardingManager})
-     * @type {?ShardClientUtil}
-     */
-    this.shard = process.env.SHARDING_MANAGER
-      ? ShardClientUtil.singleton(this, process.env.SHARDING_MANAGER_MODE)
-      : null;
-
-    /**
      * The user manager of this client
      * @type {UserManager}
      */
@@ -169,6 +161,14 @@ class Client extends BaseClient {
      * @type {WebSocketManager}
      */
     this.ws = new WebSocketManager(wsOptions);
+
+    /**
+     * Shard helpers for the client (only if the process was spawned from a {@link ShardingManager})
+     * @type {?ShardClientUtil}
+     */
+    this.shard = process.env.SHARDING_MANAGER
+      ? ShardClientUtil.singleton(this, process.env.SHARDING_MANAGER_MODE)
+      : null;
 
     /**
      * The voice manager of the client
@@ -414,12 +414,11 @@ class Client extends BaseClient {
 
   /**
    * The average ping of all WebSocketShards
-   * @type {number}
+   * @type {?number}
    * @readonly
    */
   get ping() {
-    const sum = this.pings.reduce((a, b) => a + b, 0);
-    return sum / this.pings.size;
+    return this.pings.size ? this.pings.reduce((a, b) => a + b, 0) / this.pings.size : null;
   }
 
   /**

--- a/packages/discord.js/src/errors/ErrorCodes.js
+++ b/packages/discord.js/src/errors/ErrorCodes.js
@@ -12,25 +12,8 @@
  * @property {'TokenMissing'} TokenMissing
  * @property {'ApplicationCommandPermissionsTokenMissing'} ApplicationCommandPermissionsTokenMissing
 
- * @property {'WSCloseRequested'} WSCloseRequested
- * <warn>This property is deprecated.</warn>
- * @property {'WSConnectionExists'} WSConnectionExists
- * <warn>This property is deprecated.</warn>
- * @property {'WSNotOpen'} WSNotOpen
- * <warn>This property is deprecated.</warn>
- * @property {'ManagerDestroyed'} ManagerDestroyed
- * <warn>This property is deprecated.</warn>
-
  * @property {'BitFieldInvalid'} BitFieldInvalid
 
- * @property {'ShardingInvalid'} ShardingInvalid
- * <warn>This property is deprecated.</warn>
- * @property {'ShardingRequired'} ShardingRequired
- * <warn>This property is deprecated.</warn>
- * @property {'InvalidIntents'} InvalidIntents
- * <warn>This property is deprecated.</warn>
- * @property {'DisallowedIntents'} DisallowedIntents
- * <warn>This property is deprecated.</warn>
  * @property {'ShardingNoShards'} ShardingNoShards
  * @property {'ShardingInProcess'} ShardingInProcess
  * @property {'ShardingInvalidEvalBroadcast'} ShardingInvalidEvalBroadcast
@@ -49,30 +32,10 @@
 
  * @property {'InviteOptionsMissingChannel'} InviteOptionsMissingChannel
 
- * @property {'ButtonLabel'} ButtonLabel
- * <warn>This property is deprecated.</warn>
- * @property {'ButtonURL'} ButtonURL
- * <warn>This property is deprecated.</warn>
- * @property {'ButtonCustomId'} ButtonCustomId
- * <warn>This property is deprecated.</warn>
-
- * @property {'SelectMenuCustomId'} SelectMenuCustomId
- * <warn>This property is deprecated.</warn>
- * @property {'SelectMenuPlaceholder'} SelectMenuPlaceholder
- * <warn>This property is deprecated.</warn>
- * @property {'SelectOptionLabel'} SelectOptionLabel
- * <warn>This property is deprecated.</warn>
- * @property {'SelectOptionValue'} SelectOptionValue
- * <warn>This property is deprecated.</warn>
- * @property {'SelectOptionDescription'} SelectOptionDescription
- * <warn>This property is deprecated.</warn>
-
  * @property {'InteractionCollectorError'} InteractionCollectorError
 
  * @property {'FileNotFound'} FileNotFound
 
- * @property {'UserBannerNotFetched'} UserBannerNotFetched
- * <warn>This property is deprecated.</warn>
  * @property {'UserNoDMChannel'} UserNoDMChannel
 
  * @property {'VoiceNotStageChannel'} VoiceNotStageChannel
@@ -82,18 +45,10 @@
 
  * @property {'ReqResourceType'} ReqResourceType
 
- * @property {'ImageFormat'} ImageFormat
- * <warn>This property is deprecated.</warn>
- * @property {'ImageSize'} ImageSize
- * <warn>This property is deprecated.</warn>
-
  * @property {'MessageBulkDeleteType'} MessageBulkDeleteType
  * @property {'MessageContentType'} MessageContentType
  * @property {'MessageNonceRequired'} MessageNonceRequired
  * @property {'MessageNonceType'} MessageNonceType
-
- * @property {'SplitMaxLen'} SplitMaxLen
- * <warn>This property is deprecated.</warn>
 
  * @property {'BanResolveId'} BanResolveId
  * @property {'FetchBanResolveId'} FetchBanResolveId
@@ -128,15 +83,10 @@
  * @property {'EmojiType'} EmojiType
  * @property {'EmojiManaged'} EmojiManaged
  * @property {'MissingManageGuildExpressionsPermission'} MissingManageGuildExpressionsPermission
- * @property {'MissingManageEmojisAndStickersPermission'} MissingManageEmojisAndStickersPermission
- * <warn>This property is deprecated. Use `MissingManageGuildExpressionsPermission` instead.</warn>
  *
  * @property {'NotGuildSticker'} NotGuildSticker
 
  * @property {'ReactionResolveUser'} ReactionResolveUser
-
- * @property {'VanityURL'} VanityURL
- * <warn>This property is deprecated.</warn>
 
  * @property {'InviteResolveCode'} InviteResolveCode
 
@@ -152,8 +102,6 @@
 
  * @property {'InteractionAlreadyReplied'} InteractionAlreadyReplied
  * @property {'InteractionNotReplied'} InteractionNotReplied
- * @property {'InteractionEphemeralReplied'} InteractionEphemeralReplied
- * <warn>This property is deprecated.</warn>
 
  * @property {'CommandInteractionOptionNotFound'} CommandInteractionOptionNotFound
  * @property {'CommandInteractionOptionType'} CommandInteractionOptionType
@@ -192,17 +140,8 @@ const keys = [
   'TokenMissing',
   'ApplicationCommandPermissionsTokenMissing',
 
-  'WSCloseRequested',
-  'WSConnectionExists',
-  'WSNotOpen',
-  'ManagerDestroyed',
-
   'BitFieldInvalid',
 
-  'ShardingInvalid',
-  'ShardingRequired',
-  'InvalidIntents',
-  'DisallowedIntents',
   'ShardingNoShards',
   'ShardingInProcess',
   'ShardingInvalidEvalBroadcast',
@@ -221,21 +160,10 @@ const keys = [
 
   'InviteOptionsMissingChannel',
 
-  'ButtonLabel',
-  'ButtonURL',
-  'ButtonCustomId',
-
-  'SelectMenuCustomId',
-  'SelectMenuPlaceholder',
-  'SelectOptionLabel',
-  'SelectOptionValue',
-  'SelectOptionDescription',
-
   'InteractionCollectorError',
 
   'FileNotFound',
 
-  'UserBannerNotFetched',
   'UserNoDMChannel',
 
   'VoiceNotStageChannel',
@@ -245,15 +173,10 @@ const keys = [
 
   'ReqResourceType',
 
-  'ImageFormat',
-  'ImageSize',
-
   'MessageBulkDeleteType',
   'MessageContentType',
   'MessageNonceRequired',
   'MessageNonceType',
-
-  'SplitMaxLen',
 
   'BanResolveId',
   'FetchBanResolveId',
@@ -288,13 +211,10 @@ const keys = [
   'EmojiType',
   'EmojiManaged',
   'MissingManageGuildExpressionsPermission',
-  'MissingManageEmojisAndStickersPermission',
 
   'NotGuildSticker',
 
   'ReactionResolveUser',
-
-  'VanityURL',
 
   'InviteResolveCode',
 
@@ -310,7 +230,6 @@ const keys = [
 
   'InteractionAlreadyReplied',
   'InteractionNotReplied',
-  'InteractionEphemeralReplied',
 
   'CommandInteractionOptionNotFound',
   'CommandInteractionOptionType',

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -985,7 +985,7 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
   public guilds: GuildManager;
   public lastPingTimestamp: number;
   public options: Omit<ClientOptions, 'intents'> & { intents: IntentsBitField };
-  public get ping(): number;
+  public get ping(): number | null;
   public get readyAt(): If<Ready, Date>;
   public readyTimestamp: If<Ready, number>;
   public sweepers: Sweepers;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

#10420 introduced some bugs that get fixed with this:
- `Client#shard` registers listeners on `Client#ws` so it needs to be initialized after `Client#ws`
- `Client#ping` was `NaN` before the first heartbeat from the gateway was received, now it'll return `null` instead
- erroneous rebase of #10420 caused deprecated DiscordjsErrorCodes to reappear in `src/errors/ErrorCodes.js`

Fixes #10555.

BREAKING CHANGE: `Client#ping` is nullable now

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
