### PR TITLE
fix(ThreadManager): match parent ID when fetching a single thread

### DIFF
--- a/packages/discord.js/src/errors/ErrorCodes.js
+++ b/packages/discord.js/src/errors/ErrorCodes.js
@@ -118,7 +118,7 @@
  * @property {'MessageThreadParent'} MessageThreadParent
  * @property {'MessageExistingThread'} MessageExistingThread
  * @property {'ThreadInvitableType'} ThreadInvitableType
- * @property {'InvalidThreadChannel'} InvalidThreadChannel
+ * @property {'NotAThreadOfParent'} NotAThreadOfParent
 
  * @property {'WebhookMessage'} WebhookMessage
  * @property {'WebhookTokenUnavailable'} WebhookTokenUnavailable
@@ -279,7 +279,7 @@ const keys = [
   'MessageThreadParent',
   'MessageExistingThread',
   'ThreadInvitableType',
-  'InvalidThreadChannel',
+  'NotAThreadOfParent',
 
   'WebhookMessage',
   'WebhookTokenUnavailable',

--- a/packages/discord.js/src/errors/ErrorCodes.js
+++ b/packages/discord.js/src/errors/ErrorCodes.js
@@ -118,6 +118,7 @@
  * @property {'MessageThreadParent'} MessageThreadParent
  * @property {'MessageExistingThread'} MessageExistingThread
  * @property {'ThreadInvitableType'} ThreadInvitableType
+ * @property {'InvalidThreadChannel'} InvalidThreadChannel
 
  * @property {'WebhookMessage'} WebhookMessage
  * @property {'WebhookTokenUnavailable'} WebhookTokenUnavailable
@@ -278,6 +279,7 @@ const keys = [
   'MessageThreadParent',
   'MessageExistingThread',
   'ThreadInvitableType',
+  'InvalidThreadChannel',
 
   'WebhookMessage',
   'WebhookTokenUnavailable',

--- a/packages/discord.js/src/errors/Messages.js
+++ b/packages/discord.js/src/errors/Messages.js
@@ -78,7 +78,7 @@ const Messages = {
   [DjsErrorCodes.MessageThreadParent]: 'The message was not sent in a guild text or announcement channel',
   [DjsErrorCodes.MessageExistingThread]: 'The message already has a thread',
   [DjsErrorCodes.ThreadInvitableType]: type => `Invitable cannot be edited on ${type}`,
-  [DjsErrorCodes.InvalidThreadChannel]: 'Provided ThreadChannelResolvable is not a thread of the parent channel.',
+  [DjsErrorCodes.NotAThreadOfParent]: 'Provided ThreadChannelResolvable is not a thread of the parent channel.',
 
   [DjsErrorCodes.WebhookMessage]: 'The message was not sent by a webhook.',
   [DjsErrorCodes.WebhookTokenUnavailable]: 'This action requires a webhook token, but none is available.',

--- a/packages/discord.js/src/errors/Messages.js
+++ b/packages/discord.js/src/errors/Messages.js
@@ -78,6 +78,7 @@ const Messages = {
   [DjsErrorCodes.MessageThreadParent]: 'The message was not sent in a guild text or announcement channel',
   [DjsErrorCodes.MessageExistingThread]: 'The message already has a thread',
   [DjsErrorCodes.ThreadInvitableType]: type => `Invitable cannot be edited on ${type}`,
+  [DjsErrorCodes.InvalidThreadChannel]: 'Provided ThreadChannelResolvable is not a thread of the parent channel.',
 
   [DjsErrorCodes.WebhookMessage]: 'The message was not sent by a webhook.',
   [DjsErrorCodes.WebhookTokenUnavailable]: 'This action requires a webhook token, but none is available.',

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -83,10 +83,15 @@ class ThreadManager extends CachedManager {
    *   .then(channel => console.log(channel.name))
    *   .catch(console.error);
    */
-  fetch(options, { cache, force } = {}) {
+  async fetch(options, { cache, force } = {}) {
     if (!options) return this.fetchActive(cache);
     const channel = this.client.channels.resolveId(options);
-    if (channel) return this.client.channels.fetch(channel, { cache, force });
+    if (channel) {
+      const threadChannel = await this.client.channels.fetch(channel, { cache, force });
+      if (threadChannel.parentId !== this.channel.id) throw new DiscordjsTypeError(ErrorCodes.InvalidThreadChannel);
+      return threadChannel;
+    }
+
     if (options.archived) {
       return this.fetchArchived(options.archived, cache);
     }

--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -88,7 +88,7 @@ class ThreadManager extends CachedManager {
     const channel = this.client.channels.resolveId(options);
     if (channel) {
       const threadChannel = await this.client.channels.fetch(channel, { cache, force });
-      if (threadChannel.parentId !== this.channel.id) throw new DiscordjsTypeError(ErrorCodes.InvalidThreadChannel);
+      if (threadChannel.parentId !== this.channel.id) throw new DiscordjsTypeError(ErrorCodes.NotAThreadOfParent);
       return threadChannel;
     }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently as it stands, when fetching a single thread, discord.js simply returns `ChannelManager#fetch`, so ideally, one can fetch any channel of a guild, not just a thread in the channel of the manager, this is misleading as the docs state the return type to be a `ThreadChannel` (or equivalent). This pr adds in a check to match the parent id of the returned channel with the id of manager's channel and throws an error if it doesn't match. It also makes sense to have it this way, as one would expect to get a thread of the channel the manager is of, similar to how `fetchActive` (and others) do.

I don't think it's breaking in any way as it doesn't change the return type or anything, just adds in a way to ensure it returns a thread of the parent channel.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
