### PR TITLE
feat!: create forwards and add `ChannelManager#createMessage()`

### DIFF
--- a/packages/discord.js/src/managers/ChannelManager.js
+++ b/packages/discord.js/src/managers/ChannelManager.js
@@ -141,7 +141,7 @@ class ChannelManager extends CachedManager {
    * @example
    * // Send a remote file
    * client.channels.createMessage(channel, {
-   *   files: ['https://cdn.discordapp.com/icons/222078108977594368/6e1019b3179d71046e463a75915e7244.png?size=2048']
+   *   files: ['https://github.com/discordjs.png']
    * })
    *   .then(console.log)
    *   .catch(console.error);

--- a/packages/discord.js/src/managers/ChannelManager.js
+++ b/packages/discord.js/src/managers/ChannelManager.js
@@ -1,12 +1,16 @@
 'use strict';
 
 const process = require('node:process');
+const { lazy } = require('@discordjs/util');
 const { Routes } = require('discord-api-types/v10');
 const { CachedManager } = require('./CachedManager.js');
 const { BaseChannel } = require('../structures/BaseChannel.js');
+const { MessagePayload } = require('../structures/MessagePayload.js');
 const { createChannel } = require('../util/Channels.js');
 const { ThreadChannelTypes } = require('../util/Constants.js');
 const { Events } = require('../util/Events.js');
+
+const getMessage = lazy(() => require('../structures/Message.js').Message);
 
 let cacheWarningEmitted = false;
 
@@ -122,6 +126,52 @@ class ChannelManager extends CachedManager {
 
     const data = await this.client.rest.get(Routes.channel(id));
     return this._add(data, null, { cache, allowUnknownGuild });
+  }
+
+  /**
+   * Creates a message in a channel.
+   * @param {TextChannelResolvable} channel The channel to send the message to
+   * @param {string|MessagePayload|MessageCreateOptions} options The options to provide
+   * @returns {Promise<Message>}
+   * @example
+   * // Send a basic message
+   * client.channels.createMessage(channel, 'hello!')
+   *   .then(message => console.log(`Sent message: ${message.content}`))
+   *   .catch(console.error);
+   * @example
+   * // Send a remote file
+   * client.channels.createMessage(channel, {
+   *   files: ['https://cdn.discordapp.com/icons/222078108977594368/6e1019b3179d71046e463a75915e7244.png?size=2048']
+   * })
+   *   .then(console.log)
+   *   .catch(console.error);
+   * @example
+   * // Send a local file
+   * client.channels.createMessage(channel, {
+   *   files: [{
+   *     attachment: 'entire/path/to/file.jpg',
+   *     name: 'file.jpg',
+   *     description: 'A description of the file'
+   *   }]
+   * })
+   *   .then(console.log)
+   *   .catch(console.error);
+   */
+  async createMessage(channel, options) {
+    let messagePayload;
+
+    if (options instanceof MessagePayload) {
+      messagePayload = options.resolveBody();
+    } else {
+      messagePayload = MessagePayload.create(this, options).resolveBody();
+    }
+
+    const resolvedChannelId = this.resolveId(channel);
+    const resolvedChannel = this.resolve(channel);
+    const { body, files } = await messagePayload.resolveFiles();
+    const data = await this.client.rest.post(Routes.channelMessages(resolvedChannelId), { body, files });
+
+    return resolvedChannel?.messages._add(data) ?? new (getMessage())(this.client, data);
   }
 }
 

--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -2,9 +2,9 @@
 
 const { Collection } = require('@discordjs/collection');
 const { makeURLSearchParams } = require('@discordjs/rest');
-const { MessageReferenceType, Routes } = require('discord-api-types/v10');
+const { Routes } = require('discord-api-types/v10');
 const { CachedManager } = require('./CachedManager.js');
-const { DiscordjsError, DiscordjsTypeError, ErrorCodes } = require('../errors/index.js');
+const { DiscordjsTypeError, ErrorCodes } = require('../errors/index.js');
 const { Message } = require('../structures/Message.js');
 const { MessagePayload } = require('../structures/MessagePayload.js');
 const { MakeCacheOverrideSymbol } = require('../util/Symbols.js');
@@ -194,46 +194,6 @@ class MessageManager extends CachedManager {
       return clone;
     }
     return this._add(d);
-  }
-
-  /**
-   * Publishes a message in an announcement channel to all channels following it, even if it's not cached.
-   * @param {MessageResolvable} message The message to publish
-   * @returns {Promise<Message>}
-   */
-  async crosspost(message) {
-    message = this.resolveId(message);
-    if (!message) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'message', 'MessageResolvable');
-
-    const data = await this.client.rest.post(Routes.channelMessageCrosspost(this.channel.id, message));
-    return this.cache.get(data.id) ?? this._add(data);
-  }
-
-  /**
-   * Forwards a message to this manager's channel.
-   * @param {Message|MessageReference} reference The message to forward
-   * @returns {Promise<Message>}
-   */
-  async forward(reference) {
-    if (!reference) throw new DiscordjsError(ErrorCodes.MessageReferenceMissing);
-    const message_id = this.resolveId(reference.messageId);
-    if (!message_id) throw new DiscordjsError(ErrorCodes.MessageReferenceMissing);
-    const channel_id = this.client.channels.resolveId(reference.channelId);
-    if (!channel_id) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'channel', 'ChannelResolvable');
-    const guild_id = this.client.guilds.resolveId(reference.guildId);
-
-    const data = await this.client.rest.post(Routes.channelMessages(this.channel.id), {
-      body: {
-        message_reference: {
-          message_id,
-          channel_id,
-          guild_id,
-          type: MessageReferenceType.Forward,
-        },
-      },
-    });
-
-    return this.cache.get(data.id) ?? this._add(data);
   }
 
   /**

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -191,6 +191,6 @@ class BaseGuildTextChannel extends GuildChannel {
   setNSFW() {}
 }
 
-TextBasedChannel.applyToClass(BaseGuildTextChannel, true);
+TextBasedChannel.applyToClass(BaseGuildTextChannel);
 
 exports.BaseGuildTextChannel = BaseGuildTextChannel;

--- a/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
@@ -229,6 +229,6 @@ class BaseGuildVoiceChannel extends GuildChannel {
   setNSFW() {}
 }
 
-TextBasedChannel.applyToClass(BaseGuildVoiceChannel, true, ['lastPinAt']);
+TextBasedChannel.applyToClass(BaseGuildVoiceChannel, ['lastPinAt']);
 
 exports.BaseGuildVoiceChannel = BaseGuildVoiceChannel;

--- a/packages/discord.js/src/structures/DMChannel.js
+++ b/packages/discord.js/src/structures/DMChannel.js
@@ -118,7 +118,7 @@ class DMChannel extends BaseChannel {
   // Doesn't work on DM channels; setNSFW() {}
 }
 
-TextBasedChannel.applyToClass(DMChannel, true, [
+TextBasedChannel.applyToClass(DMChannel, [
   'bulkDelete',
   'fetchWebhooks',
   'createWebhook',

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -3,7 +3,6 @@
 const { PermissionFlagsBits } = require('discord-api-types/v10');
 const { Base } = require('./Base.js');
 const { VoiceState } = require('./VoiceState.js');
-const { TextBasedChannel } = require('./interfaces/TextBasedChannel.js');
 const { DiscordjsError, ErrorCodes } = require('../errors/index.js');
 const { GuildMemberRoleManager } = require('../managers/GuildMemberRoleManager.js');
 const { GuildMemberFlagsBitField } = require('../util/GuildMemberFlagsBitField.js');
@@ -11,7 +10,6 @@ const { PermissionsBitField } = require('../util/PermissionsBitField.js');
 
 /**
  * Represents a member of a guild on Discord.
- * @implements {TextBasedChannel}
  * @extends {Base}
  */
 class GuildMember extends Base {
@@ -477,6 +475,22 @@ class GuildMember extends Base {
   }
 
   /**
+   * Sends a message to this user.
+   * @param {string|MessagePayload|MessageCreateOptions} options The options to provide
+   * @returns {Promise<Message>}
+   * @example
+   * // Send a direct message
+   * guildMember.send('Hello!')
+   *   .then(message => console.log(`Sent message: ${message.content} to ${guildMember.displayName}`))
+   *   .catch(console.error);
+   */
+  async send(options) {
+    const dmChannel = await this.createDM();
+
+    return this.client.channels.createMessage(dmChannel, options);
+  }
+
+  /**
    * Whether this guild member equals another guild member. It compares all properties, so for most
    * comparison it is advisable to just compare `member.id === member2.id` as it is significantly faster
    * and is often what most users need.
@@ -526,21 +540,5 @@ class GuildMember extends Base {
     return json;
   }
 }
-
-/**
- * Sends a message to this user.
- * @method send
- * @memberof GuildMember
- * @instance
- * @param {string|MessagePayload|MessageCreateOptions} options The options to provide
- * @returns {Promise<Message>}
- * @example
- * // Send a direct message
- * guildMember.send('Hello!')
- *   .then(message => console.log(`Sent message: ${message.content} to ${guildMember.displayName}`))
- *   .catch(console.error);
- */
-
-TextBasedChannel.applyToClass(GuildMember);
 
 exports.GuildMember = GuildMember;

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -930,7 +930,7 @@ class Message extends Base {
         messageReference: {
           messageId: this.id,
           channelId: this.channelId,
-          guildId: this.guildId,
+          guildId: this.guildId ?? undefined,
           type: MessageReferenceType.Default,
           failIfNotExists: options?.failIfNotExists ?? this.client.options.failIfNotExists,
         },
@@ -949,7 +949,7 @@ class Message extends Base {
       messageReference: {
         messageId: this.id,
         channelId: this.channelId,
-        guildId: this.guildId,
+        guildId: this.guildId ?? undefined,
         type: MessageReferenceType.Forward,
       },
     });

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -8,6 +8,7 @@ const {
   ChannelType,
   MessageType,
   MessageFlags,
+  MessageReferenceType,
   PermissionFlagsBits,
 } = require('discord-api-types/v10');
 const { Attachment } = require('./Attachment.js');
@@ -20,7 +21,7 @@ const { MessagePayload } = require('./MessagePayload.js');
 const { Poll } = require('./Poll.js');
 const { ReactionCollector } = require('./ReactionCollector.js');
 const { Sticker } = require('./Sticker.js');
-const { DiscordjsError, ErrorCodes } = require('../errors/index.js');
+const { DiscordjsError, DiscordjsTypeError, ErrorCodes } = require('../errors/index.js');
 const { ReactionManager } = require('../managers/ReactionManager.js');
 const { createComponent } = require('../util/Components.js');
 const { NonSystemMessageTypes, MaxBulkDeletableMessageAge, UndeletableMessageTypes } = require('../util/Constants.js');
@@ -771,6 +772,20 @@ class Message extends Base {
   }
 
   /**
+   * Forwards this message.
+   * @param {ChannelResolvable} channel The channel to forward this message to
+   * @returns {Promise<Message>}
+   */
+  async forward(channel) {
+    const resolvedChannel = this.client.channels.resolve(channel);
+
+    if (!resolvedChannel) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'channel', 'ChannelResolvable');
+
+    const message = await resolvedChannel.messages.forward(this);
+    return message;
+  }
+
+  /**
    * Whether the message is crosspostable by the client user
    * @type {boolean}
    * @readonly
@@ -923,8 +938,11 @@ class Message extends Base {
       data = options;
     } else {
       data = MessagePayload.create(this, options, {
-        reply: {
-          messageReference: this,
+        messageReference: {
+          messageId: this.id,
+          channelId: this.channelId,
+          guildId: this.guildId,
+          type: MessageReferenceType.Default,
           failIfNotExists: options?.failIfNotExists ?? this.client.options.failIfNotExists,
         },
       });

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -168,13 +168,19 @@ class MessagePayload {
     }
 
     let message_reference;
-    if (typeof this.options.reply === 'object') {
-      const reference = this.options.reply.messageReference;
-      const message_id = this.isMessage ? (reference.id ?? reference) : this.target.messages.resolveId(reference);
+    if (this.options.messageReference) {
+      const reference = this.options.messageReference;
+      const message_id = this.target.messages.resolveId(reference.messageId);
+      const channel_id = this.target.client.channels.resolveId(reference.channelId);
+      const guild_id = this.target.client.guilds.resolveId(reference.guildId);
+
       if (message_id) {
         message_reference = {
           message_id,
-          fail_if_not_exists: this.options.reply.failIfNotExists ?? this.target.client.options.failIfNotExists,
+          channel_id,
+          guild_id,
+          type: reference.type,
+          fail_if_not_exists: reference.failIfNotExists ?? this.target.client.options.failIfNotExists,
         };
       }
     }

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -151,7 +151,7 @@ class MessagePayload {
     if (
       // eslint-disable-next-line eqeqeq
       this.options.flags != null ||
-      (this.isMessage && this.options.reply === undefined) ||
+      (this.isMessage && this.options.messageReference === undefined) ||
       this.isMessageManager
     ) {
       flags = new MessageFlagsBitField(this.options.flags).bitfield;
@@ -170,15 +170,12 @@ class MessagePayload {
     let message_reference;
     if (this.options.messageReference) {
       const reference = this.options.messageReference;
-      const message_id = this.target.messages.resolveId(reference.messageId);
-      const channel_id = this.target.client.channels.resolveId(reference.channelId);
-      const guild_id = this.target.client.guilds.resolveId(reference.guildId);
 
-      if (message_id) {
+      if (reference.messageId) {
         message_reference = {
-          message_id,
-          channel_id,
-          guild_id,
+          message_id: reference.messageId,
+          channel_id: reference.channelId,
+          guild_id: reference.guildId,
           type: reference.type,
           fail_if_not_exists: reference.failIfNotExists ?? this.target.client.options.failIfNotExists,
         };
@@ -298,7 +295,7 @@ exports.MessagePayload = MessagePayload;
 
 /**
  * A target for a message.
- * @typedef {TextBasedChannels|User|GuildMember|Webhook|WebhookClient|BaseInteraction|InteractionWebhook|
+ * @typedef {TextBasedChannels|ChannelManager|Webhook|WebhookClient|BaseInteraction|InteractionWebhook|
  * Message|MessageManager} MessageTarget
  */
 

--- a/packages/discord.js/src/structures/PartialGroupDMChannel.js
+++ b/packages/discord.js/src/structures/PartialGroupDMChannel.js
@@ -116,7 +116,7 @@ class PartialGroupDMChannel extends BaseChannel {
   awaitMessageComponent() {}
 }
 
-TextBasedChannel.applyToClass(PartialGroupDMChannel, true, [
+TextBasedChannel.applyToClass(PartialGroupDMChannel, [
   'bulkDelete',
   'send',
   'sendTyping',

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -598,6 +598,6 @@ class ThreadChannel extends BaseChannel {
   // Doesn't work on Thread channels; setNSFW() {}
 }
 
-TextBasedChannel.applyToClass(ThreadChannel, true, ['fetchWebhooks', 'setRateLimitPerUser', 'setNSFW']);
+TextBasedChannel.applyToClass(ThreadChannel, ['fetchWebhooks', 'setRateLimitPerUser', 'setNSFW']);
 
 exports.ThreadChannel = ThreadChannel;

--- a/packages/discord.js/src/structures/ThreadOnlyChannel.js
+++ b/packages/discord.js/src/structures/ThreadOnlyChannel.js
@@ -234,7 +234,7 @@ class ThreadOnlyChannel extends GuildChannel {
   setRateLimitPerUser() {}
 }
 
-TextBasedChannel.applyToClass(ThreadOnlyChannel, true, [
+TextBasedChannel.applyToClass(ThreadOnlyChannel, [
   'send',
   'lastMessage',
   'lastPinAt',

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -4,12 +4,10 @@ const { userMention } = require('@discordjs/formatters');
 const { calculateUserDefaultAvatarIndex } = require('@discordjs/rest');
 const { DiscordSnowflake } = require('@sapphire/snowflake');
 const { Base } = require('./Base.js');
-const { TextBasedChannel } = require('./interfaces/TextBasedChannel.js');
 const { UserFlagsBitField } = require('../util/UserFlagsBitField.js');
 
 /**
  * Represents a user on Discord.
- * @implements {TextBasedChannel}
  * @extends {Base}
  */
 class User extends Base {
@@ -278,6 +276,22 @@ class User extends Base {
   }
 
   /**
+   * Sends a message to this user.
+   * @param {string|MessagePayload|MessageCreateOptions} options The options to provide
+   * @returns {Promise<Message>}
+   * @example
+   * // Send a direct message
+   * user.send('Hello!')
+   *   .then(message => console.log(`Sent message: ${message.content} to ${user.tag}`))
+   *   .catch(console.error);
+   */
+  async send(options) {
+    const dmChannel = await this.createDM();
+
+    return this.client.channels.createMessage(dmChannel, options);
+  }
+
+  /**
    * Checks if the user is equal to another.
    * It compares id, username, discriminator, avatar, banner, accent color, and bot flags.
    * It is recommended to compare equality by using `user.id === user2.id` unless you want to compare all properties.
@@ -360,21 +374,5 @@ class User extends Base {
     return json;
   }
 }
-
-/**
- * Sends a message to this user.
- * @method send
- * @memberof User
- * @instance
- * @param {string|MessagePayload|MessageCreateOptions} options The options to provide
- * @returns {Promise<Message>}
- * @example
- * // Send a direct message
- * user.send('Hello!')
- *   .then(message => console.log(`Sent message: ${message.content} to ${user.tag}`))
- *   .catch(console.error);
- */
-
-TextBasedChannel.applyToClass(User);
 
 exports.User = User;

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -172,7 +172,7 @@ class Webhook {
    * @example
    * // Send a remote file
    * webhook.send({
-   *   files: ['https://cdn.discordapp.com/icons/222078108977594368/6e1019b3179d71046e463a75915e7244.png?size=2048']
+   *   files: ['https://github.com/discordjs.png']
    * })
    *   .then(console.log)
    *   .catch(console.error);

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -113,7 +113,7 @@ class TextBasedChannel {
   /**
    * The options for sending a message.
    * @typedef {BaseMessageCreateOptions} MessageCreateOptions
-   * @property {ReplyOptions} [reply] The options for replying to a message
+   * @property {MessageReference|MessageResolvable} [messageReference] The options for a reference to a message
    */
 
   /**

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -88,14 +88,6 @@ class TextBasedChannel {
    */
 
   /**
-   * Options for sending a message with a reply.
-   * @typedef {Object} ReplyOptions
-   * @property {MessageResolvable} messageReference The message to reply to (must be in the same channel and not system)
-   * @property {boolean} [failIfNotExists=this.client.options.failIfNotExists] Whether to error if the referenced
-   * message does not exist (creates a standard message in this case when false)
-   */
-
-  /**
    * The options for sending a message.
    * @typedef {BaseMessageOptionsWithPoll} BaseMessageCreateOptions
    * @property {boolean} [tts=false] Whether the message should be spoken aloud
@@ -110,9 +102,15 @@ class TextBasedChannel {
    */
 
   /**
+   * @typedef {MessageReference} MessageReferenceOptions
+   * @property {boolean} [failIfNotExists=this.client.options.failIfNotExists] Whether to error if the
+   * referenced message doesn't exist instead of sending as a normal (non-reply) message
+   */
+
+  /**
    * The options for sending a message.
    * @typedef {BaseMessageCreateOptions} MessageCreateOptions
-   * @property {MessageReference|MessageResolvable} [messageReference] The options for a reference to a message
+   * @property {MessageReferenceOptions} [messageReference] The options for a reference to a message
    */
 
   /**
@@ -144,7 +142,7 @@ class TextBasedChannel {
    * @example
    * // Send a remote file
    * channel.send({
-   *   files: ['https://cdn.discordapp.com/icons/222078108977594368/6e1019b3179d71046e463a75915e7244.png?size=2048']
+   *   files: ['https://github.com/discordjs.png']
    * })
    *   .then(console.log)
    *   .catch(console.error);
@@ -366,24 +364,22 @@ class TextBasedChannel {
     return this.edit({ nsfw, reason });
   }
 
-  static applyToClass(structure, full = false, ignore = []) {
-    const props = ['send'];
-    if (full) {
-      props.push(
-        'lastMessage',
-        'lastPinAt',
-        'bulkDelete',
-        'sendTyping',
-        'createMessageCollector',
-        'awaitMessages',
-        'createMessageComponentCollector',
-        'awaitMessageComponent',
-        'fetchWebhooks',
-        'createWebhook',
-        'setRateLimitPerUser',
-        'setNSFW',
-      );
-    }
+  static applyToClass(structure, ignore = []) {
+    const props = [
+      'lastMessage',
+      'lastPinAt',
+      'bulkDelete',
+      'sendTyping',
+      'createMessageCollector',
+      'awaitMessages',
+      'createMessageComponentCollector',
+      'awaitMessageComponent',
+      'fetchWebhooks',
+      'createWebhook',
+      'setRateLimitPerUser',
+      'setNSFW',
+      'send',
+    ];
 
     for (const prop of props) {
       if (ignore.includes(prop)) continue;

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -7,7 +7,6 @@ const { DiscordjsTypeError, DiscordjsError, ErrorCodes } = require('../../errors
 const { MaxBulkDeletableMessageAge } = require('../../util/Constants.js');
 const { InteractionCollector } = require('../InteractionCollector.js');
 const { MessageCollector } = require('../MessageCollector.js');
-const { MessagePayload } = require('../MessagePayload.js');
 
 /**
  * Interface for classes that have text-channel-like features.
@@ -161,27 +160,8 @@ class TextBasedChannel {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async send(options) {
-    const { User } = require('../User.js');
-    const { GuildMember } = require('../GuildMember.js');
-
-    if (this instanceof User || this instanceof GuildMember) {
-      const dm = await this.createDM();
-      return dm.send(options);
-    }
-
-    let messagePayload;
-
-    if (options instanceof MessagePayload) {
-      messagePayload = options.resolveBody();
-    } else {
-      messagePayload = MessagePayload.create(this, options).resolveBody();
-    }
-
-    const { body, files } = await messagePayload.resolveFiles();
-    const d = await this.client.rest.post(Routes.channelMessages(this.id), { body, files });
-
-    return this.messages.cache.get(d.id) ?? this.messages._add(d);
+  send(options) {
+    return this.client.channels.createMessage(this, options);
   }
 
   /**
@@ -404,6 +384,7 @@ class TextBasedChannel {
         'setNSFW',
       );
     }
+
     for (const prop of props) {
       if (ignore.includes(prop)) continue;
       Object.defineProperty(

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2167,7 +2167,6 @@ export class Message<InGuild extends boolean = boolean> extends Base {
   public equals(message: Message, rawData: unknown): boolean;
   public fetchReference(): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
   public fetchWebhook(): Promise<Webhook>;
-  public forward(channel: TextBasedChannelResolvable): Promise<Message>;
   public crosspost(): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
   public fetch(force?: boolean): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
   public pin(reason?: string): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
@@ -2176,6 +2175,7 @@ export class Message<InGuild extends boolean = boolean> extends Base {
   public reply(
     options: string | MessagePayload | MessageReplyOptions,
   ): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
+  public forward(channel: TextBasedChannelResolvable): Promise<OmitPartialGroupDMChannel<Message>>;
   public resolveComponent(customId: string): MessageActionRowComponent | null;
   public startThread(options: StartThreadOptions): Promise<PublicThreadChannel<false>>;
   public suppressEmbeds(suppress?: boolean): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
@@ -4027,6 +4027,10 @@ export class CategoryChannelChildManager extends DataManager<Snowflake, Category
 
 export class ChannelManager extends CachedManager<Snowflake, Channel, ChannelResolvable> {
   private constructor(client: Client<true>, iterable: Iterable<RawChannelData>);
+  public createMessage(
+    channel: Omit<TextBasedChannelResolvable, 'PartialGroupDMChannel'>,
+    options: string | MessagePayload | MessageCreateOptions,
+  ): Promise<Message>;
   public fetch(id: Snowflake, options?: FetchChannelOptions): Promise<Channel | null>;
 }
 
@@ -4331,7 +4335,6 @@ export abstract class MessageManager<InGuild extends boolean = boolean> extends 
   public fetch(options: MessageResolvable | FetchMessageOptions): Promise<Message<InGuild>>;
   public fetch(options?: FetchMessagesOptions): Promise<Collection<Snowflake, Message<InGuild>>>;
   public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message<InGuild>>>;
-  public forward(reference: Omit<MessageReference, 'type'>): Promise<Message<InGuild>>;
   public react(message: MessageResolvable, emoji: EmojiIdentifierResolvable): Promise<void>;
   public pin(message: MessageResolvable, reason?: string): Promise<void>;
   public unpin(message: MessageResolvable, reason?: string): Promise<void>;
@@ -6439,15 +6442,14 @@ export interface TextInputComponentData extends BaseComponentData {
 }
 
 export type MessageTarget =
+  | ChannelManager
   | Interaction
   | InteractionWebhook
-  | TextBasedChannel
-  | User
-  | GuildMember
-  | Webhook<WebhookType.Incoming>
-  | WebhookClient
   | Message
-  | MessageManager;
+  | MessageManager
+  | TextBasedChannel
+  | Webhook<WebhookType.Incoming>
+  | WebhookClient;
 
 export interface MultipleShardRespawnOptions {
   shardDelay?: number;
@@ -6780,25 +6782,25 @@ export type Channel =
 
 export type TextBasedChannel = Exclude<Extract<Channel, { type: TextChannelType }>, ForumChannel | MediaChannel>;
 
-export type SendableChannels = Extract<Channel, { send: (...args: any[]) => any }>;
-
 export type TextBasedChannels = TextBasedChannel;
 
 export type TextBasedChannelTypes = TextBasedChannel['type'];
 
 export type GuildTextBasedChannelTypes = Exclude<TextBasedChannelTypes, ChannelType.DM | ChannelType.GroupDM>;
 
-export type SendableChannelTypes = SendableChannels['type'];
-
 export type VoiceBasedChannel = Extract<Channel, { bitrate: number }>;
 
 export type GuildBasedChannel = Extract<Channel, { guild: Guild }>;
+
+export type SendableChannels = Extract<Channel, { send: (...args: any[]) => any }>;
 
 export type CategoryChildChannel = Exclude<Extract<Channel, { parent: CategoryChannel | null }>, CategoryChannel>;
 
 export type NonThreadGuildBasedChannel = Exclude<GuildBasedChannel, AnyThreadChannel>;
 
 export type GuildTextBasedChannel = Extract<GuildBasedChannel, TextBasedChannel>;
+
+export type SendableChannelTypes = SendableChannels['type'];
 
 export type TextChannelResolvable = Snowflake | TextChannel;
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2167,6 +2167,7 @@ export class Message<InGuild extends boolean = boolean> extends Base {
   public equals(message: Message, rawData: unknown): boolean;
   public fetchReference(): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
   public fetchWebhook(): Promise<Webhook>;
+  public forward(channel: TextBasedChannelResolvable): Promise<Message>;
   public crosspost(): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
   public fetch(force?: boolean): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
   public pin(reason?: string): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
@@ -4330,6 +4331,7 @@ export abstract class MessageManager<InGuild extends boolean = boolean> extends 
   public fetch(options: MessageResolvable | FetchMessageOptions): Promise<Message<InGuild>>;
   public fetch(options?: FetchMessagesOptions): Promise<Collection<Snowflake, Message<InGuild>>>;
   public fetchPinned(cache?: boolean): Promise<Collection<Snowflake, Message<InGuild>>>;
+  public forward(reference: Omit<MessageReference, 'type'>): Promise<Message<InGuild>>;
   public react(message: MessageResolvable, emoji: EmojiIdentifierResolvable): Promise<void>;
   public pin(message: MessageResolvable, reason?: string): Promise<void>;
   public unpin(message: MessageResolvable, reason?: string): Promise<void>;
@@ -6332,7 +6334,7 @@ export interface MessageCreateOptions extends BaseMessageOptionsWithPoll {
   tts?: boolean;
   nonce?: string | number;
   enforceNonce?: boolean;
-  reply?: ReplyOptions;
+  messageReference?: MessageReference & { failIfNotExists?: boolean };
   stickers?: readonly StickerResolvable[];
   flags?:
     | BitFieldResolvable<
@@ -6609,12 +6611,7 @@ export interface ReactionCollectorOptions extends CollectorOptions<[MessageReact
   maxUsers?: number;
 }
 
-export interface ReplyOptions {
-  messageReference: MessageResolvable;
-  failIfNotExists?: boolean;
-}
-
-export interface MessageReplyOptions extends Omit<MessageCreateOptions, 'reply'> {
+export interface MessageReplyOptions extends Omit<MessageCreateOptions, 'messageReference'> {
   failIfNotExists?: boolean;
 }
 
@@ -6893,7 +6890,8 @@ export interface WebhookFetchMessageOptions {
   threadId?: Snowflake;
 }
 
-export interface WebhookMessageCreateOptions extends Omit<MessageCreateOptions, 'nonce' | 'reply' | 'stickers'> {
+export interface WebhookMessageCreateOptions
+  extends Omit<MessageCreateOptions, 'nonce' | 'messageReference' | 'stickers'> {
   username?: string;
   avatarURL?: string;
   threadId?: Snowflake;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2175,7 +2175,9 @@ export class Message<InGuild extends boolean = boolean> extends Base {
   public reply(
     options: string | MessagePayload | MessageReplyOptions,
   ): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
-  public forward(channel: TextBasedChannelResolvable): Promise<OmitPartialGroupDMChannel<Message>>;
+  public forward(
+    channel: Exclude<TextBasedChannelResolvable, PartialGroupDMChannel>,
+  ): Promise<OmitPartialGroupDMChannel<Message>>;
   public resolveComponent(customId: string): MessageActionRowComponent | null;
   public startThread(options: StartThreadOptions): Promise<PublicThreadChannel<false>>;
   public suppressEmbeds(suppress?: boolean): Promise<OmitPartialGroupDMChannel<Message<InGuild>>>;
@@ -4028,9 +4030,9 @@ export class CategoryChannelChildManager extends DataManager<Snowflake, Category
 export class ChannelManager extends CachedManager<Snowflake, Channel, ChannelResolvable> {
   private constructor(client: Client<true>, iterable: Iterable<RawChannelData>);
   public createMessage(
-    channel: Omit<TextBasedChannelResolvable, 'PartialGroupDMChannel'>,
+    channel: Exclude<TextBasedChannelResolvable, PartialGroupDMChannel>,
     options: string | MessagePayload | MessageCreateOptions,
-  ): Promise<Message>;
+  ): Promise<OmitPartialGroupDMChannel<Message>>;
   public fetch(id: Snowflake, options?: FetchChannelOptions): Promise<Channel | null>;
 }
 
@@ -6337,7 +6339,7 @@ export interface MessageCreateOptions extends BaseMessageOptionsWithPoll {
   tts?: boolean;
   nonce?: string | number;
   enforceNonce?: boolean;
-  messageReference?: MessageReference & { failIfNotExists?: boolean };
+  messageReference?: MessageReferenceOptions;
   stickers?: readonly StickerResolvable[];
   flags?:
     | BitFieldResolvable<
@@ -6368,6 +6370,10 @@ export interface MessageReference {
   guildId: Snowflake | undefined;
   messageId: Snowflake | undefined;
   type: MessageReferenceType;
+}
+
+export interface MessageReferenceOptions extends MessageReference {
+  failIfNotExists?: boolean;
 }
 
 export type MessageResolvable = Message | Snowflake;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -432,11 +432,19 @@ client.on('messageCreate', async message => {
   assertIsMessage(channel.send({}));
   assertIsMessage(channel.send({ embeds: [] }));
 
+  assertIsMessage(client.channels.createMessage(channel, 'string'));
+  assertIsMessage(client.channels.createMessage(channel, {}));
+  assertIsMessage(client.channels.createMessage(channel, { embeds: [] }));
+
   const attachment = new AttachmentBuilder('file.png');
   const embed = new EmbedBuilder();
   assertIsMessage(channel.send({ files: [attachment] }));
   assertIsMessage(channel.send({ embeds: [embed] }));
   assertIsMessage(channel.send({ embeds: [embed], files: [attachment] }));
+
+  assertIsMessage(client.channels.createMessage(channel, { files: [attachment] }));
+  assertIsMessage(client.channels.createMessage(channel, { embeds: [embed] }));
+  assertIsMessage(client.channels.createMessage(channel, { embeds: [embed], files: [attachment] }));
 
   if (message.inGuild()) {
     expectAssignable<Message<true>>(message);
@@ -467,8 +475,13 @@ client.on('messageCreate', async message => {
   // @ts-expect-error
   channel.send();
   // @ts-expect-error
+  client.channels.createMessage();
+  // @ts-expect-error
   channel.send({ another: 'property' });
-
+  // @ts-expect-error
+  client.channels.createMessage({ another: 'property' });
+  // @ts-expect-error
+  client.channels.createMessage('string');
   // Check collector creations.
 
   // Verify that buttons interactions are inferred.
@@ -647,7 +660,7 @@ client.on('messageCreate', async message => {
 
   const embedData = { description: 'test', color: 0xff0000 };
 
-  channel.send({
+  client.channels.createMessage(channel, {
     components: [row, rawButtonsRow, buttonsRow, rawStringSelectMenuRow, stringSelectRow],
     embeds: [embed, embedData],
   });
@@ -1334,7 +1347,7 @@ client.on('guildCreate', async g => {
       ],
     });
 
-    channel.send({ components: [row, row2] });
+    client.channels.createMessage(channel, { components: [row, row2] });
   }
 
   channel.setName('foo').then(updatedChannel => {
@@ -2704,7 +2717,7 @@ declare const sku: SKU;
   });
 }
 
-await textChannel.send({
+await client.channels.createMessage('123', {
   poll: {
     question: {
       text: 'Question',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds a centralized spot where the creation of messages go through.

BREAKING CHANGE: `MessageCreateOptions` no longer accepts `forward` or `reply`. Use `messageReference` instead.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
