### PR TITLE
fix: missing tsdocConfig in api.json preventing index generation

### DIFF
--- a/packages/api-extractor-model/src/model/ApiPackage.ts
+++ b/packages/api-extractor-model/src/model/ApiPackage.ts
@@ -294,7 +294,11 @@ export class ApiPackage extends ApiItemContainerMixin(ApiNameMixin(ApiDocumented
 
 		const tsdocConfiguration: TSDocConfiguration = new TSDocConfiguration();
 
-		if (versionToDeserialize >= ApiJsonSchemaVersion.V_1004 && 'tsdocConfig' in jsonObject.metadata) {
+		if (
+			versionToDeserialize >= ApiJsonSchemaVersion.V_1004 &&
+			'tsdocConfig' in jsonObject.metadata &&
+			'$schema' in jsonObject.metadata.tsdocConfig
+		) {
 			const tsdocConfigFile: TSDocConfigFile = TSDocConfigFile.loadFromObject(jsonObject.metadata.tsdocConfig);
 			if (tsdocConfigFile.hasErrors) {
 				throw new Error(`Error loading ${apiJsonFilename}:\n` + tsdocConfigFile.getErrorSummary());


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes failing docs CI because old api.json files omitted the tsdocConfig but newer files have it to support the `@mixes` tag.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
