### PR TITLE
refactor(formatters): Change `:_:` emoji name placeholder

### DIFF
--- a/packages/formatters/__tests__/formatters.test.ts
+++ b/packages/formatters/__tests__/formatters.test.ts
@@ -179,15 +179,21 @@ describe('Message formatters', () => {
 		});
 
 		test('GIVEN static emojiId WITH animated explicitly false THEN returns "<:emoji:[emojiId]>"', () => {
-			expect<`<:emoji:851461487498493952>`>(formatEmoji('851461487498493952', false)).toEqual('<:emoji:851461487498493952>');
+			expect<`<:emoji:851461487498493952>`>(formatEmoji('851461487498493952', false)).toEqual(
+				'<:emoji:851461487498493952>',
+			);
 		});
 
 		test('GIVEN animated emojiId THEN returns "<a:emoji:${emojiId}>"', () => {
-			expect<`<a:emoji:827220205352255549>`>(formatEmoji('827220205352255549', true)).toEqual('<a:emoji:827220205352255549>');
+			expect<`<a:emoji:827220205352255549>`>(formatEmoji('827220205352255549', true)).toEqual(
+				'<a:emoji:827220205352255549>',
+			);
 		});
 
 		test('GIVEN static id in options object THEN returns "<:emoji:${id}>"', () => {
-			expect<`<:emoji:851461487498493952>`>(formatEmoji({ id: '851461487498493952' })).toEqual('<:emoji:851461487498493952>');
+			expect<`<:emoji:851461487498493952>`>(formatEmoji({ id: '851461487498493952' })).toEqual(
+				'<:emoji:851461487498493952>',
+			);
 		});
 
 		test('GIVEN static id in options object WITH animated explicitly false THEN returns "<:emoji:${id}>"', () => {

--- a/packages/formatters/__tests__/formatters.test.ts
+++ b/packages/formatters/__tests__/formatters.test.ts
@@ -174,31 +174,31 @@ describe('Message formatters', () => {
 	});
 
 	describe('formatEmoji', () => {
-		test('GIVEN static emojiId THEN returns "<:_:${emojiId}>"', () => {
-			expect<`<:_:851461487498493952>`>(formatEmoji('851461487498493952')).toEqual('<:_:851461487498493952>');
+		test('GIVEN static emojiId THEN returns "<:emoji:${emojiId}>"', () => {
+			expect<`<:emoji:851461487498493952>`>(formatEmoji('851461487498493952')).toEqual('<:emoji:851461487498493952>');
 		});
 
-		test('GIVEN static emojiId WITH animated explicitly false THEN returns "<:_:[emojiId]>"', () => {
-			expect<`<:_:851461487498493952>`>(formatEmoji('851461487498493952', false)).toEqual('<:_:851461487498493952>');
+		test('GIVEN static emojiId WITH animated explicitly false THEN returns "<:emoji:[emojiId]>"', () => {
+			expect<`<:emoji:851461487498493952>`>(formatEmoji('851461487498493952', false)).toEqual('<:emoji:851461487498493952>');
 		});
 
-		test('GIVEN animated emojiId THEN returns "<a:_:${emojiId}>"', () => {
-			expect<`<a:_:827220205352255549>`>(formatEmoji('827220205352255549', true)).toEqual('<a:_:827220205352255549>');
+		test('GIVEN animated emojiId THEN returns "<a:emoji:${emojiId}>"', () => {
+			expect<`<a:emoji:827220205352255549>`>(formatEmoji('827220205352255549', true)).toEqual('<a:emoji:827220205352255549>');
 		});
 
-		test('GIVEN static id in options object THEN returns "<:_:${id}>"', () => {
-			expect<`<:_:851461487498493952>`>(formatEmoji({ id: '851461487498493952' })).toEqual('<:_:851461487498493952>');
+		test('GIVEN static id in options object THEN returns "<:emoji:${id}>"', () => {
+			expect<`<:emoji:851461487498493952>`>(formatEmoji({ id: '851461487498493952' })).toEqual('<:emoji:851461487498493952>');
 		});
 
-		test('GIVEN static id in options object WITH animated explicitly false THEN returns "<:_:${id}>"', () => {
-			expect<`<:_:851461487498493952>`>(formatEmoji({ animated: false, id: '851461487498493952' })).toEqual(
-				'<:_:851461487498493952>',
+		test('GIVEN static id in options object WITH animated explicitly false THEN returns "<:emoji:${id}>"', () => {
+			expect<`<:emoji:851461487498493952>`>(formatEmoji({ animated: false, id: '851461487498493952' })).toEqual(
+				'<:emoji:851461487498493952>',
 			);
 		});
 
-		test('GIVEN animated id in options object THEN returns "<a:_:${id}>"', () => {
-			expect<`<a:_:827220205352255549>`>(formatEmoji({ animated: true, id: '827220205352255549' })).toEqual(
-				'<a:_:827220205352255549>',
+		test('GIVEN animated id in options object THEN returns "<a:emoji:${id}>"', () => {
+			expect<`<a:emoji:827220205352255549>`>(formatEmoji({ animated: true, id: '827220205352255549' })).toEqual(
+				'<a:emoji:827220205352255549>',
 			);
 		});
 

--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -323,7 +323,7 @@ export function chatInputApplicationCommandMention<
  * @typeParam EmojiId - This is inferred by the supplied emoji id
  * @param emojiId - The emoji id to format
  */
-export function formatEmoji<EmojiId extends Snowflake>(emojiId: EmojiId, animated?: false): `<:_:${EmojiId}>`;
+export function formatEmoji<EmojiId extends Snowflake>(emojiId: EmojiId, animated?: false): `<:emoji:${EmojiId}>`;
 
 /**
  * Formats an animated emoji id into a fully qualified emoji identifier.
@@ -332,7 +332,7 @@ export function formatEmoji<EmojiId extends Snowflake>(emojiId: EmojiId, animate
  * @param emojiId - The emoji id to format
  * @param animated - Whether the emoji is animated
  */
-export function formatEmoji<EmojiId extends Snowflake>(emojiId: EmojiId, animated?: true): `<a:_:${EmojiId}>`;
+export function formatEmoji<EmojiId extends Snowflake>(emojiId: EmojiId, animated?: true): `<a:emoji:${EmojiId}>`;
 
 /**
  * Formats an emoji id into a fully qualified emoji identifier.
@@ -344,7 +344,7 @@ export function formatEmoji<EmojiId extends Snowflake>(emojiId: EmojiId, animate
 export function formatEmoji<EmojiId extends Snowflake>(
 	emojiId: EmojiId,
 	animated?: boolean,
-): `<:_:${EmojiId}>` | `<a:_:${EmojiId}>`;
+): `<:emoji:${EmojiId}>` | `<a:emoji:${EmojiId}>`;
 
 /**
  * Formats a non-animated emoji id and name into a fully qualified emoji identifier.
@@ -393,7 +393,7 @@ export function formatEmoji<EmojiId extends Snowflake, EmojiName extends string>
 
 	const { id, animated: isAnimated, name: emojiName } = options;
 
-	return `<${isAnimated ? 'a' : ''}:${emojiName ?? '_'}:${id}>`;
+	return `<${isAnimated ? 'a' : ''}:${emojiName ?? 'emoji'}:${id}>`;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Discord doesn't verify emoji names, meaning you only actually need to include a valid ID for an emoji to display properly. Discord.js uses `_` as a fallback name when formatting emojis with just an ID. However, since `_` is not a valid emoji name, if you were to parse that emoji, it would fail, which could be unexpected behavior.
![image](https://github.com/user-attachments/assets/ab7afbc8-323e-408e-8db7-b7ff2c62b70c)
![image](https://github.com/user-attachments/assets/219d589b-5d8f-432f-8a7e-3864398b70c9)

Additionally, if you were to have multiple emojis with the `_` name placeholder and invalid IDs (or if the bot doesn't have access to the emoji), they fail to render in Discord and the text between them becomes unintentionally italicized. For example, `<:_:123678901234578> foobar <:_:123678901234578>`
![image](https://github.com/user-attachments/assets/7664f4ca-9bb7-4137-be44-2b47eaeb4d28)
This is another unintentional side-effect of using `:_:` as a placeholder emoji name that end-users currently have to look out for.


To fix this, I changed the `:_:` placeholder to `:emoji:`. This way it is a valid emoji name that parses correctly and doesn't interfere with any other Markdown features. Originally, I was going to change it to `:__:`, which would parse correctly, but causes text between invalid emojis to be underlined.

In my opinion, `parseEmoji` should also be changed to properly support emojis that used `:_:` in the past, because even though it's not a valid emoji name, it does still render correctly, but people in the support server disagreed
![image](https://github.com/user-attachments/assets/a51ed592-7d56-4f86-b6c2-8295980e6ca3)

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
