### PR TITLE
refactor(InteractionResponses): Deprecate ephemeral response option

### DIFF
--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -92,6 +92,7 @@ class MessagePayload {
    * Whether or not the target is an {@link BaseInteraction} or an {@link InteractionWebhook}
    * @type {boolean}
    * @readonly
+   * @deprecated This will no longer serve a purpose in the next major version.
    */
   get isInteraction() {
     const BaseInteraction = getBaseInteraction();

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const process = require('node:process');
 const { deprecate } = require('node:util');
 const { isJSONEncodable } = require('@discordjs/util');
 const { InteractionResponseType, MessageFlags, Routes, InteractionType } = require('discord-api-types/v10');
@@ -7,6 +8,8 @@ const { DiscordjsError, ErrorCodes } = require('../../errors');
 const InteractionCollector = require('../InteractionCollector');
 const InteractionResponse = require('../InteractionResponse');
 const MessagePayload = require('../MessagePayload');
+
+let deprecationEmittedForEphemeralOption = false;
 
 /**
  * @typedef {Object} ModalComponentData
@@ -71,6 +74,17 @@ class InteractionResponses {
    */
   async deferReply(options = {}) {
     if (this.deferred || this.replied) throw new DiscordjsError(ErrorCodes.InteractionAlreadyReplied);
+
+    if ('ephemeral' in options) {
+      if (!deprecationEmittedForEphemeralOption) {
+        process.emitWarning(
+          `Supplying "ephemeral" for interaction response options is deprecated. Utilize flags instead.`,
+        );
+
+        deprecationEmittedForEphemeralOption = true;
+      }
+    }
+
     let { flags } = options;
 
     if (options.ephemeral) {
@@ -112,6 +126,16 @@ class InteractionResponses {
    */
   async reply(options) {
     if (this.deferred || this.replied) throw new DiscordjsError(ErrorCodes.InteractionAlreadyReplied);
+
+    if ('ephemeral' in options) {
+      if (!deprecationEmittedForEphemeralOption) {
+        process.emitWarning(
+          `Supplying "ephemeral" for interaction response options is deprecated. Utilize flags instead.`,
+        );
+
+        deprecationEmittedForEphemeralOption = true;
+      }
+    }
 
     let messagePayload;
     if (options instanceof MessagePayload) messagePayload = options;

--- a/packages/discord.js/src/util/MessageFlagsBitField.js
+++ b/packages/discord.js/src/util/MessageFlagsBitField.js
@@ -24,6 +24,15 @@ class MessageFlagsBitField extends BitField {
  */
 
 /**
+ * Data that can be resolved to give a message flags bit field. This can be:
+ * * A string (see {@link MessageFlagsBitField.Flags})
+ * * A message flag
+ * * An instance of {@link MessageFlagsBitField}
+ * * An array of `MessageFlagsResolvable`
+ * @typedef {string|number|MessageFlagsBitField|MessageFlagsResolvable[]} MessageFlagsResolvable
+ */
+
+/**
  * Bitfield of the packed bits
  * @type {number}
  * @name MessageFlagsBitField#bitfield

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2389,8 +2389,10 @@ export type MessageFlagsString = keyof typeof MessageFlags;
 
 export class MessageFlagsBitField extends BitField<MessageFlagsString> {
   public static Flags: typeof MessageFlags;
-  public static resolve(bit?: BitFieldResolvable<MessageFlagsString, number>): number;
+  public static resolve(bit?: MessageFlagsResolvable): number;
 }
+
+export type MessageFlagsResolvable = BitFieldResolvable<MessageFlagsString, number>;
 
 export class MessageMentions<InGuild extends boolean = boolean> {
   private constructor(

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2441,6 +2441,7 @@ export class MessagePayload {
   public get isWebhook(): boolean;
   public get isMessage(): boolean;
   public get isMessageManager(): boolean;
+  /** @deprecated This will no longer serve a purpose in the next major version. */
   public get isInteraction(): boolean;
   public files: RawFile[] | null;
   public options: MessagePayloadOption;
@@ -6351,15 +6352,23 @@ export interface InteractionCollectorOptions<
 }
 
 export interface InteractionDeferReplyOptions {
+  /** @deprecated Use {@link InteractionDeferReplyOptions.flags} instead. */
   ephemeral?: boolean;
+  flags?: BitFieldResolvable<
+    Extract<MessageFlagsString, 'Ephemeral' | 'SuppressEmbeds' | 'SuppressNotifications'>,
+    MessageFlags.Ephemeral | MessageFlags.SuppressEmbeds | MessageFlags.SuppressNotifications
+  >;
   fetchReply?: boolean;
 }
 
-export interface InteractionDeferUpdateOptions extends Omit<InteractionDeferReplyOptions, 'ephemeral'> {}
+export interface InteractionDeferUpdateOptions {
+  fetchReply?: boolean;
+}
 
 export interface InteractionReplyOptions extends BaseMessageOptionsWithPoll {
-  tts?: boolean;
+  /** @deprecated Use {@link InteractionDeferReplyOptions.flags} instead. */
   ephemeral?: boolean;
+  tts?: boolean;
   fetchReply?: boolean;
   flags?: BitFieldResolvable<
     Extract<MessageFlagsString, 'Ephemeral' | 'SuppressEmbeds' | 'SuppressNotifications'>,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6366,7 +6366,7 @@ export interface InteractionDeferUpdateOptions {
 }
 
 export interface InteractionReplyOptions extends BaseMessageOptionsWithPoll {
-  /** @deprecated Use {@link InteractionDeferReplyOptions.flags} instead. */
+  /** @deprecated Use {@link InteractionReplyOptions.flags} instead. */
   ephemeral?: boolean;
   tts?: boolean;
   fetchReply?: boolean;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Deprecates the `ephemeral` option due to #10564.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
