### PR TITLE
fix(ThreadChannel): Address parameter type on `fetchOwner()`

### DIFF
--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -288,10 +288,16 @@ class ThreadChannel extends BaseChannel {
   }
 
   /**
+   * Options used to fetch a thread member owner.
+   * @typedef {BaseFetchOptions} FetchThreadOwnerOptions
+   * @property {boolean} [withMember] Whether to also return the guild member associated with this thread member
+   */
+
+  /**
    * Fetches the owner of this thread. If the thread member object isn't needed,
    * use {@link ThreadChannel#ownerId} instead.
-   * @param {BaseFetchOptions} [options] The options for fetching the member
-   * @returns {Promise<?ThreadMember>}
+   * @param {FetchThreadOwnerOptions} [options] Options for fetching the owner
+   * @returns {Promise<ThreadMember>}
    */
   async fetchOwner(options) {
     if (!this.ownerId) {

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -288,7 +288,7 @@ class ThreadChannel extends BaseChannel {
   }
 
   /**
-   * Options used to fetch a thread member owner.
+   * Options used to fetch a thread owner.
    * @typedef {BaseFetchOptions} FetchThreadOwnerOptions
    * @property {boolean} [withMember] Whether to also return the guild member associated with this thread member
    */

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3315,7 +3315,7 @@ export class ThreadChannel<ThreadOnly extends boolean = boolean> extends BaseCha
     memberOrRole: GuildMemberResolvable | RoleResolvable,
     checkAdmin?: boolean,
   ): Readonly<PermissionsBitField> | null;
-  public fetchOwner(options?: BaseFetchOptions): Promise<ThreadMember | null>;
+  public fetchOwner(options?: FetchThreadOwnerOptions): Promise<ThreadMember>;
   public fetchStarterMessage(options?: BaseFetchOptions): Promise<Message<true> | null>;
   public setArchived(archived?: boolean, reason?: string): Promise<this>;
   public setAutoArchiveDuration(autoArchiveDuration: ThreadAutoArchiveDuration, reason?: string): Promise<this>;
@@ -5557,6 +5557,10 @@ export interface FetchReactionUsersOptions {
 
 export interface FetchThreadMemberOptions extends BaseFetchOptions {
   member: ThreadMemberResolvable;
+  withMember?: boolean;
+}
+
+export interface FetchThreadOwnerOptions extends BaseFetchOptions {
   withMember?: boolean;
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #10578.

In addition, this method cannot return `null`, so the typings and documentation had `null` removed (remnant of #10421).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
