### PR TITLE
Fix unparsed markdown in ClientOptions documentation

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -66,6 +66,8 @@
 		"react": "19.0.0-rc-f994737d14-20240522",
 		"react-aria-components": "^1.2.1",
 		"react-dom": "19.0.0-rc-f994737d14-20240522",
+		"react-markdown": "^9.0.1",
+		"rehype-raw": "^7.0.0",
 		"sharp": "^0.33.4",
 		"usehooks-ts": "^3.1.0",
 		"vaul": "^0.9.1"

--- a/apps/website/src/components/DocNode.tsx
+++ b/apps/website/src/components/DocNode.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
+import React from 'react';
 import { BuiltinDocumentationLinks } from '~/util/builtinDocumentationLinks';
 import { OverlayScrollbarsComponent } from './OverlayScrollbars';
+import { ParsedText } from './ParsedText';
 import { SyntaxHighlighter } from './SyntaxHighlighter';
 
 export async function DocNode({ node, version }: { readonly node?: any; readonly version: string }) {
@@ -8,6 +10,7 @@ export async function DocNode({ node, version }: { readonly node?: any; readonly
 		switch (node.kind) {
 			case 'PlainText':
 				return <span key={`${node.text}-${idx}`}>{node.text}</span>;
+
 			case 'LinkTag': {
 				if (node.resolvedPackage) {
 					return (
@@ -62,7 +65,6 @@ export async function DocNode({ node, version }: { readonly node?: any; readonly
 
 			case 'FencedCode': {
 				const { language, text } = node;
-
 				return (
 					<OverlayScrollbarsComponent
 						defer
@@ -72,13 +74,17 @@ export async function DocNode({ node, version }: { readonly node?: any; readonly
 						}}
 						className="my-4 rounded-md border border-neutral-300 bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-900"
 					>
-						<SyntaxHighlighter className="py-4 text-sm " lang={language} code={text} />
+						<SyntaxHighlighter className="py-4 text-sm" lang={language} code={text} />
 					</OverlayScrollbarsComponent>
 				);
 			}
 
 			case 'SoftBreak':
 				return null;
+
+			case 'BoldText':
+				return <ParsedText key={`${node.text}-${idx}`} text={node.text} />;
+
 			default:
 				return null;
 		}

--- a/apps/website/src/components/ParsedText.tsx
+++ b/apps/website/src/components/ParsedText.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable react/no-unstable-nested-components */
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
+
+interface ParsedTextProps {
+	readonly text: string;
+}
+
+export const ParsedText: React.FC<ParsedTextProps> = ({ text }) => {
+	return (
+		<ReactMarkdown
+			rehypePlugins={[rehypeRaw]} // Parses raw HTML in markdown
+			components={{
+				strong: ({ children }) => <strong>{children}</strong>, // Renders bold text
+				a: ({ children, href }) => (
+					<a href={href} rel="noopener noreferrer">
+						{children}
+					</a>
+				), // Renders links
+			}}
+		>
+			{text}
+		</ReactMarkdown>
+	);
+};

--- a/packages/discord.js/CHANGELOG.md
+++ b/packages/discord.js/CHANGELOG.md
@@ -2,6 +2,82 @@
 
 All notable changes to this project will be documented in this file.
 
+# [15.0.0](https://github.com/discordjs/discord.js/compare/14.16.3...15.0.0) - (2024-10-25)
+
+## Bug Fixes
+
+- **GuildScheduledEvent:** Handle null recurrence_rule (#10543) ([1925c11](https://github.com/discordjs/discord.js/commit/1925c11a4869a436a77c7e14bfd7af3a4070c95f)) by @Eejit43
+- **Client:** Never pass token in ws constructor (#10544) ([c36728a](https://github.com/discordjs/discord.js/commit/c36728a8144a7522da950b6436d33aa305281a73)) by @didinele
+- **ThreadMember:** Remove audit log reason parameter (#10023) ([b339a7c](https://github.com/discordjs/discord.js/commit/b339a7cb086f22734a27fefd242d7c786fed1fa4)) by @Renegade334
+- **User:** Remove `fetchFlags()` (#8755) ([05541d8](https://github.com/discordjs/discord.js/commit/05541d8288435cd7d5777c54649dd74db2df488c)) by @MrMythicalYT
+
+## Deprecation
+
+- Remove all deprecated features/props (#10421) ([12e5106](https://github.com/discordjs/discord.js/commit/12e510671b67c11e1a659d344bb3f4c939e2d44c)) by @didinele
+  - **BREAKING CHANGE:** Removed `Client#fetchPremiumStickerPacks` method
+  - **BREAKING CHANGE:** Removed `Client#webhookUpdate` event
+  - **BREAKING CHANGE:** Removed various error codes
+  - **BREAKING CHANGE:** Removed `Formatters` namespace
+  - **BREAKING CHANGE:** Removed `InviteStageInstance` class
+  - **BREAKING CHANGE:** Removed `Invite#stageInstance` property
+  - **BREAKING CHANGE:** Removed `StageInstance#discoverable_disabled` property
+  - **BREAKING CHANGE:** Removed `SelectMenuBuilder` alias
+  - **BREAKING CHANGE:** Removed `SelectMenuComponent` alias
+  - **BREAKING CHANGE:** Removed `SelectMenuInteraction` alias
+  - **BREAKING CHANGE:** Removed `SelectMenuOptionBuilder` alias
+  - **BREAKING CHANGE:** Removed `BaseInteraction#isSelectMenu` alias
+  - **BREAKING CHANGE:** Removed `deleteMessageDays` option from `GuildBanManager#create`
+  - **BREAKING CHANGE:** Removed `ActionRow#from` method
+  - **BREAKING CHANGE:** Removed `Emoji#url` getter
+  - **BREAKING CHANGE:** Removed `TeamMember#permissions` property
+  - **BREAKING CHANGE:** Removed `User#avatarDecoration` property
+  - **BREAKING CHANGE:** Removed `InteractionResponses#sendPremiumRequired` method
+  - **BREAKING CHANGE:** Removed `DeletableMessageTypes` constant
+
+## Documentation
+
+- **Client:** Fix incorrect managers descriptions ([960a80d](https://github.com/discordjs/discord.js/commit/960a80dbaeac1d900e82d86539bab3a1fff9b8cd)) by @almeidx
+- **Client:** Fix incorrect managers descriptions (#10519) ([eded459](https://github.com/discordjs/discord.js/commit/eded459335700cd74fba148847d02ec8288427d4)) by @Wolvinny
+- **discord.js:** Remove `utf-8-validate` (#10531) ([c1b849f](https://github.com/discordjs/discord.js/commit/c1b849fa5a6c7b541c4f1a196bca08aae353e867)) by @SuperchupuDev
+
+## Features
+
+- **website:** Type parameters links, builtin doc links, default values (#10515) ([3540c31](https://github.com/discordjs/discord.js/commit/3540c3176caf41c0ee12ac03fb15d1769f146a1c)) by @Qjuh
+- Add ApplicationEmoji to EmojiResolvable and MessageReaction#emoji (#10477) ([c633d5c](https://github.com/discordjs/discord.js/commit/c633d5c7f69a4c4cff98669c596d64bef7a74900)) by @Moebits
+- Recurring scheduled events (#10447) ([9aa3b63](https://github.com/discordjs/discord.js/commit/9aa3b635ef2ed6d6bb17af2422ef1cf7bbe16ab5)) by @almeidx
+- Message forwarding (#10464) ([e1012cc](https://github.com/discordjs/discord.js/commit/e1012cc54a7b28a99c10d11d5ae899bdc7f6b9e9)) by @TAEMBO
+
+## Refactor
+
+- **InteractionResponses:** Remove `ephemeral` response option (#10564) ([48a9c66](https://github.com/discordjs/discord.js/commit/48a9c665dedf9f5085a7992df3a87de3bca2301a)) by @Jiralite
+  - **BREAKING CHANGE:** MessagePayload#isInteraction no longer serves a purpose and has been removed.
+  - **BREAKING CHANGE:** InteractionDeferReplyOptions no longer accepts ephemeral. Use flags instead.
+  - **BREAKING CHANGE:** InteractionReplyOptions no longer accepts ephemeral. Use flags instead.
+- Fix several issues with /ws incorporation (#10556) ([93b84ae](https://github.com/discordjs/discord.js/commit/93b84ae7a6bf2b5521daa8d38998db3fa1eb8aff)) by @Qjuh
+  - **BREAKING CHANGE:** `Client#ping` is nullable now
+- Exclude removed events from their enum (#10547) ([79423c8](https://github.com/discordjs/discord.js/commit/79423c80b41a4e857e9239889e8cfeb7a7fb90cb)) by @imnaiyar
+  - **BREAKING CHANGE:** Removed the following members from `Events` enum: `Raw`, `ShardResume`, `ShardError`, `ShardReady`, `ShardReconnecting`, `ShardResume`, `ShardDisconnect`
+  - **BREAKING CHANGE:** Removed `Reconnecting` from `ShardEvents` enum
+- **NewsChannel:** Rename NewsChannel to AnnouncementChannel (#10532) ([c8ef899](https://github.com/discordjs/discord.js/commit/c8ef899a68d0746709c15d944e4758393e2b3019)) by @imnaiyar
+  - **BREAKING CHANGE:** The `NewsChannel` class was renamed to `AnnouncementChannel`, in line with the type name change
+- Fully integrate /ws into mainlib (#10420) ([a65c762](https://github.com/discordjs/discord.js/commit/a65c76295065df303f42b90d874630248a91cb2a)) by @Qjuh
+  - **BREAKING CHANGE:** `Client#ws` is now a `@discordjs/ws#WebSocketManager`
+  - **BREAKING CHANGE:** `WebSocketManager` and `WebSocketShard` are now re-exports from `@discordjs/ws`
+  - **BREAKING CHANGE:** Removed the `WebSocketShardEvents` enum
+  - **BREAKING CHANGE:** Renamed the `Client#ready` event to `Client#clientReady` event to not confuse it with the gateway `READY` event
+  - **BREAKING CHANGE:** Added `Client#ping` to replace the old `WebSocketManager#ping`
+  - **BREAKING CHANGE:** Removed the `Shard#reconnecting` event which wasn’t emitted anymore since 14.8.0 anyway
+  - **BREAKING CHANGE:** Removed `ShardClientUtil#ids` and `ShardClientUtil#count` in favor of `Client#ws#getShardIds()` and `Client#ws#getShardCount()`
+  - **BREAKING CHANGE:** `ClientUser#setPresence()` and `ClientPresence#set()` now return a Promise which resolves when the gateway call was sent successfully
+  - **BREAKING CHANGE:** Removed `Guild#shard` as `WebSocketShard`s are now handled by `@discordjs/ws`
+  - **BREAKING CHANGE:** Removed the following deprecated `Client` events: `raw`, `shardDisconnect`, `shardError`, `shardReady`, `shardReconnecting`, `shardResume` in favor of events from `@discordjs/ws#WebSocketManager`
+  - **BREAKING CHANGE:** Removed `ClientOptions#shards` and `ClientOptions#shardCount` in favor of `ClientOptions#ws#shardIds` and `ClientOptions#ws#shardCount`
+- **CommandInteractionOptionResolver:** Remove getFull from getFocused() (#9789) ([493a079](https://github.com/discordjs/discord.js/commit/493a079fdf5864ce7e2965025ebe840e61fc988d)) by @ImRodry
+
+## Typings
+
+- Remove newMessage partial on messageUpdate event typing (#10526) ([bb04e09](https://github.com/discordjs/discord.js/commit/bb04e09f8b478bf95d56ed04a7e495bc887ed5f3)) by @Amgelo563
+
 # [14.16.3](https://github.com/discordjs/discord.js/compare/14.16.2...14.16.3) - (2024-09-29)
 
 ## Bug Fixes

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "discord.js",
-  "version": "14.16.3",
+  "version": "15.0.0",
   "description": "A powerful library for interacting with the Discord API",
   "scripts": {
     "test": "pnpm run docs:test && pnpm run test:typescript",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,12 @@ importers:
       react-dom:
         specifier: 19.0.0-rc-f994737d14-20240522
         version: 19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522)
+      react-markdown:
+        specifier: ^9.0.1
+        version: 9.0.1(@types/react@18.3.4)(react@19.0.0-rc-f994737d14-20240522)
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
       sharp:
         specifier: ^0.33.4
         version: 0.33.5
@@ -2589,16 +2595,16 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@definitelytyped/header-parser@0.2.12':
-    resolution: {integrity: sha512-UYtSXiLMhzRFKh7xHMkgiWsscgHxIndmjetaptZMMS0EOvfhUTuEM68GpjiCtz5shXw22Vacs1vDTAkKGDhNmg==}
+  '@definitelytyped/header-parser@0.2.13':
+    resolution: {integrity: sha512-m7YEtGhwAjmQyJQFQ7q8+hTGTiC/WrdRATvw8fyTwgW+RiWUt8MAeehuFj4txnCYXDcLO0ozuW5gNrLoYR4Ubg==}
     engines: {node: '>=18.18.0'}
 
   '@definitelytyped/typescript-versions@0.1.4':
     resolution: {integrity: sha512-4Rz5kCpyxofwXCtBQaNfmWYXZcH0sMJxpbIgJzS+PAxgFCAa9W+2Jil7rrkpzsjx9E7+zOPukbXBXjyXohcyuQ==}
     engines: {node: '>=18.18.0'}
 
-  '@definitelytyped/utils@0.1.7':
-    resolution: {integrity: sha512-t58AeNg6+mvyMnBHyPC6JQqWMW0Iwyb+vlpBz4V0d0iDY9H8gGCnLFg9vtN1nC+JXfTXBlf9efu9unMUeaPCiA==}
+  '@definitelytyped/utils@0.1.8':
+    resolution: {integrity: sha512-4JINx4Rttha29f50PBsJo48xZXx/He5yaIWJRwVarhYAN947+S84YciHl+AIhQNRPAFkg8+5qFngEGtKxQDWXA==}
     engines: {node: '>=18.18.0'}
 
   '@discordjs/builders@1.9.0':
@@ -8185,6 +8191,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@10.1.0:
@@ -8822,6 +8829,9 @@ packages:
   hast-util-from-parse5@7.1.2:
     resolution: {integrity: sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==}
 
+  hast-util-from-parse5@8.0.1:
+    resolution: {integrity: sha512-Er/Iixbc7IEa7r/XLtuG52zoqn/b3Xng/w6aZQ0xGVxzhw5xUFxcRqdPzP6yFi/4HBYRaifaI5fQ1RH8n0ZeOQ==}
+
   hast-util-has-property@2.0.1:
     resolution: {integrity: sha512-X2+RwZIMTMKpXUzlotatPzWj8bspCymtXH3cfG3iQKV+wPF53Vgaqxi/eLqGck0wKq1kS9nvoB1wchbCPEL8sg==}
 
@@ -8846,6 +8856,9 @@ packages:
   hast-util-raw@7.2.3:
     resolution: {integrity: sha512-RujVQfVsOrxzPOPSzZFiwofMArbQke6DJjnFfceiEbFh7S05CbPt0cYN+A5YeD3pso0JQk6O1aHBnx9+Pm2uqg==}
 
+  hast-util-raw@9.0.4:
+    resolution: {integrity: sha512-LHE65TD2YiNsHD3YuXcKPHXPLuYh/gjp12mOfU8jxSrm1f/yJpsb0F/KKljS6U9LJoP0Ux+tCe8iJ2AsPzTdgA==}
+
   hast-util-to-estree@2.3.3:
     resolution: {integrity: sha512-ihhPIUPxN0v0w6M5+IiAZZrn0LH2uZomeWwhn7uP7avZC6TE7lIiEh2yBMPr5+zi1aUCXq6VoYRgs2Bw9xmycQ==}
 
@@ -8860,6 +8873,9 @@ packages:
 
   hast-util-to-parse5@7.1.0:
     resolution: {integrity: sha512-YNRgAJkH2Jky5ySkIqFXTQiaqcAtJyVE+D5lkN6CdtOqrnkLfGYYrEcKuHOJZlp+MwjSwuD3fZuawI+sic/RBw==}
+
+  hast-util-to-parse5@8.0.0:
+    resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
 
   hast-util-to-string@2.0.0:
     resolution: {integrity: sha512-02AQ3vLhuH3FisaMM+i/9sm4OXGSq1UhOOCpTLLQtHdL3tZt7qil69r8M8iDkZYyC0HCFylcYoP+8IO7ddta1A==}
@@ -8919,8 +8935,14 @@ packages:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
 
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
   html-void-elements@2.0.1:
     resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-cache-semantics@4.1.1:
     resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
@@ -11023,6 +11045,9 @@ packages:
   parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
+  parse5@7.2.0:
+    resolution: {integrity: sha512-ZkDsAOcxsUMZ4Lz5fVciOehNcJ+Gb8gTzcA4yl3wnc273BAybYWrQ+Ks/OjCjSEpjvQkDSeZbybK9qj2VHHdGA==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -11596,6 +11621,12 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-markdown@9.0.1:
+    resolution: {integrity: sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -11779,6 +11810,9 @@ packages:
 
   rehype-external-links@3.0.0:
     resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
   rehype-slug@5.1.0:
     resolution: {integrity: sha512-Gf91dJoXneiorNEnn+Phx97CO7oRMrpi+6r155tTxzGuLtm+QrI4cTwCa9e1rtePdL4i9tSO58PeSS6HWfgsiw==}
@@ -12263,6 +12297,7 @@ packages:
   stream-connect@1.0.2:
     resolution: {integrity: sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==}
     engines: {node: '>=0.10.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   stream-to-array@2.3.0:
     resolution: {integrity: sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==}
@@ -13283,6 +13318,9 @@ packages:
 
   vfile-location@4.1.0:
     resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
   vfile-matter@5.0.0:
     resolution: {integrity: sha512-jhPSqlj8hTSkTXOqyxbUeZAFFVq/iwu/jukcApEqc/7DOidaAth6rDc0Zgg0vWpzUnWkwFP7aK28l6nBmxMqdQ==}
@@ -14803,15 +14841,15 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@definitelytyped/header-parser@0.2.12':
+  '@definitelytyped/header-parser@0.2.13':
     dependencies:
       '@definitelytyped/typescript-versions': 0.1.4
-      '@definitelytyped/utils': 0.1.7
+      '@definitelytyped/utils': 0.1.8
       semver: 7.5.4
 
   '@definitelytyped/typescript-versions@0.1.4': {}
 
-  '@definitelytyped/utils@0.1.7':
+  '@definitelytyped/utils@0.1.8':
     dependencies:
       '@qiwi/npm-registry-client': 8.9.1
       '@types/node': 18.19.45
@@ -21515,7 +21553,7 @@ snapshots:
 
   dts-critic@3.3.11(typescript@5.5.4):
     dependencies:
-      '@definitelytyped/header-parser': 0.2.12
+      '@definitelytyped/header-parser': 0.2.13
       command-exists: 1.2.9
       rimraf: 3.0.2
       semver: 6.3.1
@@ -21525,9 +21563,9 @@ snapshots:
 
   dtslint@4.2.1(typescript@5.5.4):
     dependencies:
-      '@definitelytyped/header-parser': 0.2.12
+      '@definitelytyped/header-parser': 0.2.13
       '@definitelytyped/typescript-versions': 0.1.4
-      '@definitelytyped/utils': 0.1.7
+      '@definitelytyped/utils': 0.1.8
       dts-critic: 3.3.11(typescript@5.5.4)
       fs-extra: 6.0.1
       json-stable-stringify: 1.1.1
@@ -22026,7 +22064,7 @@ snapshots:
       debug: 4.3.6
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-i@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       eslint-plugin-import: eslint-plugin-i@2.29.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
@@ -22059,7 +22097,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-i@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -22102,7 +22140,7 @@ snapshots:
       doctrine: 3.0.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-plugin-i@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       get-tsconfig: 4.7.6
       is-glob: 4.0.3
       minimatch: 3.1.2
@@ -23152,6 +23190,17 @@ snapshots:
       vfile-location: 4.1.0
       web-namespaces: 2.0.1
 
+  hast-util-from-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 8.0.0
+      property-information: 6.5.0
+      vfile: 6.0.2
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
   hast-util-has-property@2.0.1: {}
 
   hast-util-heading-rank@2.1.1:
@@ -23190,6 +23239,22 @@ snapshots:
       unist-util-position: 4.0.4
       unist-util-visit: 4.1.2
       vfile: 5.3.7
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-raw@9.0.4:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.2.0
+      hast-util-from-parse5: 8.0.1
+      hast-util-to-parse5: 8.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.0
+      parse5: 7.2.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.0.0
+      vfile: 6.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
@@ -23277,6 +23342,16 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-to-parse5@8.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 6.5.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-to-string@2.0.0:
     dependencies:
       '@types/hast': 2.3.10
@@ -23338,7 +23413,11 @@ snapshots:
 
   html-tags@3.3.1: {}
 
+  html-url-attributes@3.0.1: {}
+
   html-void-elements@2.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.1.1: {}
 
@@ -26366,6 +26445,10 @@ snapshots:
 
   parse5@6.0.1: {}
 
+  parse5@7.2.0:
+    dependencies:
+      entities: 4.5.0
+
   parseurl@1.3.3: {}
 
   pascal-case@2.0.1:
@@ -26906,6 +26989,23 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-markdown@9.0.1(@types/react@18.3.4)(react@19.0.0-rc-f994737d14-20240522):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/react': 18.3.4
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.0
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.0
+      react: 19.0.0-rc-f994737d14-20240522
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.0
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      vfile: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   react-refresh@0.14.2: {}
 
   react-remove-scroll-bar@2.3.6(@types/react@18.3.4)(react@18.3.1):
@@ -27178,6 +27278,12 @@ snapshots:
       is-absolute-url: 4.0.1
       space-separated-tokens: 2.0.2
       unist-util-visit: 5.0.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.0.4
+      vfile: 6.0.2
 
   rehype-slug@5.1.0:
     dependencies:
@@ -29126,6 +29232,11 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
       vfile: 5.3.7
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.2
 
   vfile-matter@5.0.0:
     dependencies:


### PR DESCRIPTION
This PR addresses an issue in the `ClientOptions` documentation where markdown elements such as `**bold**` text and `[links](url)` were not being properly parsed and rendered. The issue was resolved by updating the parsing logic to handle these markdown elements correctly. I refactored the documentation generation code to ensure that elements like **bold** and `[links](url)` are now properly rendered. This improves readability and accuracy of the documentation for users.

### Status and versioning classification:
- Code changes have been tested against the Discord API, or there are no code changes.
- I know how to update typings and have done so, or typings don't need updating.
- This PR only includes non-code changes (documentation).
