### PR TITLE
types(Message): correctly mark `system` as nullable

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2165,7 +2165,7 @@ export class Message<InGuild extends boolean = boolean> extends Base {
   public position: number | null;
   public roleSubscriptionData: RoleSubscriptionData | null;
   public resolved: CommandInteractionResolvedData | null;
-  public system: boolean;
+  public system: boolean | null;
   public get thread(): AnyThreadChannel | null;
   public tts: boolean;
   public poll: Poll | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Message#system` was marked nullable in JSDoc and implementation but not in typings, this PR fixes that

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
