### PR TITLE
docs: add note about idempotence to role add/remove routes

### DIFF
--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -101,7 +101,7 @@ class GuildMemberRoleManager extends DataManager {
 
   /**
    * Adds a role (or multiple roles) to the member.
-   * 
+   *
    * <info>Uses the idempotent PUT route for singular roles, otherwise PATCHes the underlying guild member</info>
    * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to add
    * @param {string} [reason] Reason for adding the role(s)
@@ -140,7 +140,7 @@ class GuildMemberRoleManager extends DataManager {
 
   /**
    * Removes a role (or multiple roles) from the member.
-   * 
+   *
    * <info>Uses the idempotent DELETE route for singular roles, otherwise PATCHes the underlying guild member</info>
    * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to remove
    * @param {string} [reason] Reason for removing the role(s)

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -101,6 +101,8 @@ class GuildMemberRoleManager extends DataManager {
 
   /**
    * Adds a role (or multiple roles) to the member.
+   * 
+   * <info>Uses the idempotent PUT route for singular roles, otherwise PATCHes the underlying guild member</info>
    * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to add
    * @param {string} [reason] Reason for adding the role(s)
    * @returns {Promise<GuildMember>}
@@ -138,6 +140,8 @@ class GuildMemberRoleManager extends DataManager {
 
   /**
    * Removes a role (or multiple roles) from the member.
+   * 
+   * <info>Uses the idempotent DELETE route for singular roles, otherwise PATCHes the underlying guild member</info>
    * @param {RoleResolvable|RoleResolvable[]|Collection<Snowflake, Role>} roleOrRoles The role or roles to remove
    * @param {string} [reason] Reason for removing the role(s)
    * @returns {Promise<GuildMember>}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

It's not clear to users that the behaviour of #add and #remove calls changes based on if a singular or multiple roles are supplied. We should explicitly note that, as it can lead to issues (for example when multiple role-state bots interact and use patch calls).

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
