### PR TITLE
fix(InteractionResponses): throw error on deleting response of unacknowledged interaction

### DIFF
--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -174,6 +174,8 @@ class InteractionResponses {
    *   .catch(console.error);
    */
   async deleteReply(message = '@original') {
+    if (!this.deferred && !this.replied) throw new DiscordjsError(ErrorCodes.InteractionNotReplied);
+
     await this.webhook.deleteMessage(message);
   }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Currently no check is done when calling `deleteReply()`, similar to `editReply()`, `followUp()`, you cannot delete an interaction response if the interaction is not acknowledged first, this leads to getting `Unknown Webhook` error.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
