### PR TITLE
docs(channel): Clarify emoji parameter

### DIFF
--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -92,7 +92,7 @@ export class ChannelsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/message#get-reactions}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to get the reactions for
-	 * @param emoji - The emoji to get the reactions for. Encoding happens internally
+	 * @param emoji - The emoji to get the reactions for. URL encoding happens internally
 	 * @param query - The query options for fetching the reactions
 	 * @param options - The options for fetching the message reactions
 	 * @example
@@ -123,7 +123,7 @@ export class ChannelsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/message#delete-own-reaction}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete the reaction for
-	 * @param emoji - The emoji to delete the reaction for. Encoding happens internally
+	 * @param emoji - The emoji to delete the reaction for. URL encoding happens internally
 	 * @param options - The options for deleting the reaction
 	 * @example
 	 * ```ts
@@ -151,7 +151,7 @@ export class ChannelsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/message#delete-user-reaction}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete the reaction for
-	 * @param emoji - The emoji to delete the reaction for. Encoding happens internally
+	 * @param emoji - The emoji to delete the reaction for. URL encoding happens internally
 	 * @param userId - The id of the user to delete the reaction for
 	 * @param options - The options for deleting the reaction
 	 * @example
@@ -197,7 +197,7 @@ export class ChannelsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/message#delete-all-reactions-for-emoji}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete the reactions for
-	 * @param emoji - The emoji to delete the reactions for. Encoding happens internally
+	 * @param emoji - The emoji to delete the reactions for. URL encoding happens internally
 	 * @param options - The options for deleting the reactions
 	 * @example
 	 * ```ts
@@ -223,7 +223,7 @@ export class ChannelsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/message#create-reaction}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to add the reaction to
-	 * @param emoji - The emoji to add the reaction with. Encoding happens internally
+	 * @param emoji - The emoji to add the reaction with. URL encoding happens internally
 	 * @param options - The options for adding the reaction
 	 * @example
 	 * ```ts

--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -95,6 +95,7 @@ export class ChannelsAPI {
 	 * @param emoji - The emoji to get the reactions for. Encoding happens internally
 	 * @param query - The query options for fetching the reactions
 	 * @param options - The options for fetching the message reactions
+	 * @example
 	 * ```ts
 	 * // Unicode.
 	 * await api.channels.getMessageReactions('1234567890', '1234567890', '👍');
@@ -124,6 +125,7 @@ export class ChannelsAPI {
 	 * @param messageId - The id of the message to delete the reaction for
 	 * @param emoji - The emoji to delete the reaction for. Encoding happens internally
 	 * @param options - The options for deleting the reaction
+	 * @example
 	 * ```ts
 	 * // Unicode.
 	 * await api.channels.deleteOwnMessageReaction('1234567890', '1234567890', '👍');
@@ -152,6 +154,7 @@ export class ChannelsAPI {
 	 * @param emoji - The emoji to delete the reaction for. Encoding happens internally
 	 * @param userId - The id of the user to delete the reaction for
 	 * @param options - The options for deleting the reaction
+	 * @example
 	 * ```ts
 	 * // Unicode.
 	 * await api.channels.deleteUserMessageReaction('1234567890', '1234567890', '👍', '1234567890');
@@ -196,6 +199,7 @@ export class ChannelsAPI {
 	 * @param messageId - The id of the message to delete the reactions for
 	 * @param emoji - The emoji to delete the reactions for. Encoding happens internally
 	 * @param options - The options for deleting the reactions
+	 * @example
 	 * ```ts
 	 * // Unicode.
 	 * await api.channels.deleteAllMessageReactionsForEmoji('1234567890', '1234567890', '👍');

--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -92,9 +92,16 @@ export class ChannelsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/message#get-reactions}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to get the reactions for
-	 * @param emoji - The emoji to get the reactions for
+	 * @param emoji - The emoji to get the reactions for. Encoding happens internally
 	 * @param query - The query options for fetching the reactions
 	 * @param options - The options for fetching the message reactions
+	 * ```ts
+	 * // Unicode.
+	 * await api.channels.getMessageReactions('1234567890', '1234567890', '👍');
+	 *
+	 * // Custom emoji.
+	 * await api.channels.getMessageReactions('1234567890', '1234567890', 'emoji_name:1234567890');
+	 * ```
 	 */
 	public async getMessageReactions(
 		channelId: Snowflake,
@@ -115,8 +122,15 @@ export class ChannelsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/message#delete-own-reaction}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete the reaction for
-	 * @param emoji - The emoji to delete the reaction for
+	 * @param emoji - The emoji to delete the reaction for. Encoding happens internally
 	 * @param options - The options for deleting the reaction
+	 * ```ts
+	 * // Unicode.
+	 * await api.channels.deleteOwnMessageReaction('1234567890', '1234567890', '👍');
+	 *
+	 * // Custom emoji.
+	 * await api.channels.deleteOwnMessageReaction('1234567890', '1234567890', 'emoji_name:1234567890');
+	 * ```
 	 */
 	public async deleteOwnMessageReaction(
 		channelId: Snowflake,
@@ -135,9 +149,16 @@ export class ChannelsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/message#delete-user-reaction}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete the reaction for
-	 * @param emoji - The emoji to delete the reaction for
+	 * @param emoji - The emoji to delete the reaction for. Encoding happens internally
 	 * @param userId - The id of the user to delete the reaction for
 	 * @param options - The options for deleting the reaction
+	 * ```ts
+	 * // Unicode.
+	 * await api.channels.deleteUserMessageReaction('1234567890', '1234567890', '👍', '1234567890');
+	 *
+	 * // Custom emoji.
+	 * await api.channels.deleteUserMessageReaction('1234567890', '1234567890', 'emoji_name:1234567890', '1234567890');
+	 * ```
 	 */
 	public async deleteUserMessageReaction(
 		channelId: Snowflake,
@@ -173,8 +194,15 @@ export class ChannelsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/message#delete-all-reactions-for-emoji}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to delete the reactions for
-	 * @param emoji - The emoji to delete the reactions for
+	 * @param emoji - The emoji to delete the reactions for. Encoding happens internally
 	 * @param options - The options for deleting the reactions
+	 * ```ts
+	 * // Unicode.
+	 * await api.channels.deleteAllMessageReactionsForEmoji('1234567890', '1234567890', '👍');
+	 *
+	 * // Custom emoji.
+	 * await api.channels.deleteAllMessageReactionsForEmoji('1234567890', '1234567890', 'emoji_name:1234567890');
+	 * ```
 	 */
 	public async deleteAllMessageReactionsForEmoji(
 		channelId: Snowflake,
@@ -191,8 +219,16 @@ export class ChannelsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/message#create-reaction}
 	 * @param channelId - The id of the channel the message is in
 	 * @param messageId - The id of the message to add the reaction to
-	 * @param emoji - The emoji to add the reaction with
+	 * @param emoji - The emoji to add the reaction with. Encoding happens internally
 	 * @param options - The options for adding the reaction
+	 * @example
+	 * ```ts
+	 * // Unicode.
+	 * await api.channels.addMessageReaction('1234567890', '1234567890', '👍');
+	 *
+	 * // Custom emoji.
+	 * await api.channels.addMessageReaction('1234567890', '1234567890', 'emoji_name:1234567890');
+	 * ```
 	 */
 	public async addMessageReaction(
 		channelId: Snowflake,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
For these methods, the emoji must be encoded which is done via `encodeURIComponent()`. However, there is no indication that discord.js handles this internally without checking the source code. Therefore, it is plausible to assume that one must encode their emoji before passing it into the method, resulting in a double encoding. This pull request clarifies the internal behaviour and provides examples.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->