### PR TITLE
Fix/applicationcommand equals false positive

### DIFF
--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -418,7 +418,8 @@ class ApplicationCommand extends Base {
         command.descriptionLocalizations ?? command.description_localizations ?? {},
         this.descriptionLocalizations ?? {},
       ) ||
-      !isEqual(command.integrationTypes ?? command.integration_types ?? [0], this.integrationTypes ?? []) ||
+      // [0] is the default value sent by Discord
+      !isEqual(command.integrationTypes ?? command.integration_types ?? [0], this.integrationTypes ?? [0]) ||
       !isEqual(command.contexts ?? [], this.contexts ?? [])
     ) {
       return false;

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -418,7 +418,7 @@ class ApplicationCommand extends Base {
         command.descriptionLocalizations ?? command.description_localizations ?? {},
         this.descriptionLocalizations ?? {},
       ) ||
-      !isEqual(command.integrationTypes ?? command.integration_types ?? [], this.integrationTypes ?? []) ||
+      !isEqual(command.integrationTypes ?? command.integration_types ?? [0], this.integrationTypes ?? []) ||
       !isEqual(command.contexts ?? [], this.contexts ?? [])
     ) {
       return false;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes a bug where having a local command that doesn't declare integrationTypes explicitly would cause it to not be equal to the command returned by Discord as they send a default value of `[ 0 ]`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
