### PR TITLE
refactor(Emoji)!: make imageURL() change extension dynamically

### DIFF
--- a/packages/discord.js/src/structures/BaseGuildEmoji.js
+++ b/packages/discord.js/src/structures/BaseGuildEmoji.js
@@ -58,7 +58,7 @@ class BaseGuildEmoji extends Emoji {
  * @method imageURL
  * @memberof BaseGuildEmoji
  * @instance
- * @param {BaseImageURLOptions} [options] Options for the image URL
+ * @param {ImageURLOptions} [options={}] Options for the image URL
  * @returns {string}
  */
 

--- a/packages/discord.js/src/structures/Emoji.js
+++ b/packages/discord.js/src/structures/Emoji.js
@@ -46,7 +46,7 @@ class Emoji extends Base {
    * @returns {?string}
    */
   imageURL(options) {
-    return this.id && this.client.rest.cdn.emoji(this.id, options);
+    return this.id && this.client.rest.cdn.emoji(this.id, this.animated ? { ...options, extension: 'gif' } : options);
   }
 
   /**

--- a/packages/discord.js/src/structures/Emoji.js
+++ b/packages/discord.js/src/structures/Emoji.js
@@ -42,11 +42,11 @@ class Emoji extends Base {
 
   /**
    * Returns a URL for the emoji or `null` if this is not a custom emoji.
-   * @param {BaseImageURLOptions} [options] Options for the image URL
+   * @param {ImageURLOptions} [options={}] Options for the image URL
    * @returns {?string}
    */
-  imageURL(options) {
-    return this.id && this.client.rest.cdn.emoji(this.id, this.animated ? { extension: 'gif', ...options } : options);
+  imageURL(options = {}) {
+    return this.id && this.client.rest.cdn.emoji(this.id, this.animated, options);
   }
 
   /**

--- a/packages/discord.js/src/structures/Emoji.js
+++ b/packages/discord.js/src/structures/Emoji.js
@@ -46,7 +46,7 @@ class Emoji extends Base {
    * @returns {?string}
    */
   imageURL(options) {
-    return this.id && this.client.rest.cdn.emoji(this.id, this.animated ? { ...options, extension: 'gif' } : options);
+    return this.id && this.client.rest.cdn.emoji(this.id, this.animated ? { extension: 'gif', ...options } : options);
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -634,7 +634,7 @@ export abstract class BaseGuild extends Base {
 
 export class BaseGuildEmoji extends Emoji {
   protected constructor(client: Client<true>, data: RawGuildEmojiData, guild: Guild | GuildPreview);
-  public imageURL(options?: BaseImageURLOptions): string;
+  public imageURL(options?: ImageURLOptions): string;
   public get url(): string;
   public available: boolean | null;
   public get createdAt(): Date;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1333,7 +1333,7 @@ export class Emoji extends Base {
   public id: Snowflake | null;
   public name: string | null;
   public get identifier(): string;
-  public imageURL(options?: BaseImageURLOptions): string | null;
+  public imageURL(options?: ImageURLOptions): string | null;
   public get url(): string | null;
   public toJSON(): unknown;
   public toString(): string;

--- a/packages/rest/__tests__/CDN.test.ts
+++ b/packages/rest/__tests__/CDN.test.ts
@@ -51,11 +51,11 @@ test('discoverySplash default', () => {
 });
 
 test('emoji default', () => {
-	expect(cdn.emoji(id)).toEqual(`${baseCDN}/emojis/${id}.webp`);
+	expect(cdn.emoji(id, false)).toEqual(`${baseCDN}/emojis/${id}.webp`);
 });
 
 test('emoji gif', () => {
-	expect(cdn.emoji(id, { extension: 'gif' })).toEqual(`${baseCDN}/emojis/${id}.gif`);
+	expect(cdn.emoji(id, true)).toEqual(`${baseCDN}/emojis/${id}.gif`);
 });
 
 test('guildMemberAvatar default', () => {

--- a/packages/rest/__tests__/CDN.test.ts
+++ b/packages/rest/__tests__/CDN.test.ts
@@ -50,12 +50,28 @@ test('discoverySplash default', () => {
 	expect(cdn.discoverySplash(id, hash)).toEqual(`${baseCDN}/discovery-splashes/${id}/${hash}.webp`);
 });
 
-test('emoji default', () => {
+test('emoji static', () => {
 	expect(cdn.emoji(id, false)).toEqual(`${baseCDN}/emojis/${id}.webp`);
 });
 
-test('emoji gif', () => {
+test('emoji static with JPG extension', () => {
+	expect(cdn.emoji(id, false, { extension: 'jpg' })).toEqual(`${baseCDN}/emojis/${id}.jpg`);
+});
+
+test('emoji static with JPG extension with force static', () => {
+	expect(cdn.emoji(id, false, { extension: 'jpg', forceStatic: true })).toEqual(`${baseCDN}/emojis/${id}.jpg`);
+});
+
+test('emoji animated', () => {
 	expect(cdn.emoji(id, true)).toEqual(`${baseCDN}/emojis/${id}.gif`);
+});
+
+test('emoji animated with JPG extension', () => {
+	expect(cdn.emoji(id, true, { extension: 'jpg' })).toEqual(`${baseCDN}/emojis/${id}.gif`);
+});
+
+test('emoji animated with JPG extension with force static', () => {
+	expect(cdn.emoji(id, true, { extension: 'jpg', forceStatic: true })).toEqual(`${baseCDN}/emojis/${id}.jpg`);
 });
 
 test('guildMemberAvatar default', () => {

--- a/packages/rest/src/lib/CDN.ts
+++ b/packages/rest/src/lib/CDN.ts
@@ -161,6 +161,7 @@ export class CDN {
 	 * Generates an emoji's URL.
 	 *
 	 * @param emojiId - The emoji id
+  	 * @param animated - Indicates whether the emoji is animated or not
 	 * @param options - Optional options for the emoji
 	 */
 	public emoji(emojiId: string, animated: boolean, options?: Readonly<ImageURLOptions>): string {

--- a/packages/rest/src/lib/CDN.ts
+++ b/packages/rest/src/lib/CDN.ts
@@ -161,7 +161,7 @@ export class CDN {
 	 * Generates an emoji's URL.
 	 *
 	 * @param emojiId - The emoji id
-  	 * @param animated - Indicates whether the emoji is animated or not
+	 * @param animated - Whether the emoji is animated
 	 * @param options - Optional options for the emoji
 	 */
 	public emoji(emojiId: string, animated: boolean, options?: Readonly<ImageURLOptions>): string {

--- a/packages/rest/src/lib/CDN.ts
+++ b/packages/rest/src/lib/CDN.ts
@@ -163,8 +163,8 @@ export class CDN {
 	 * @param emojiId - The emoji id
 	 * @param options - Optional options for the emoji
 	 */
-	public emoji(emojiId: string, options?: Readonly<BaseImageURLOptions>): string {
-		return this.makeURL(`/emojis/${emojiId}`, options);
+	public emoji(emojiId: string, animated: boolean, options?: Readonly<ImageURLOptions>): string {
+		return this.dynamicMakeURL(`/emojis/${emojiId}`, animated ? 'a_' : '', options);
 	}
 
 	/**


### PR DESCRIPTION
BREAKING CHANGE: The `REST#emoji` method now has a `animated` required parameter.

**Please describe the changes this PR makes and why it should be merged:**

I think it'd be better if `Emoji#imageURL()` changes the extension dynamically as others `...URL()` functions.

**Status and versioning classification:**

- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)