### PR TITLE
fix: `query` is optional for some endpoints

### DIFF
--- a/packages/core/src/api/monetization.ts
+++ b/packages/core/src/api/monetization.ts
@@ -38,7 +38,7 @@ export class MonetizationAPI {
 	 */
 	public async getSKUSubscriptions(
 		skuId: Snowflake,
-		query: RESTGetAPISKUSubscriptionsQuery,
+		query: RESTGetAPISKUSubscriptionsQuery = {},
 		{ signal }: Pick<RequestData, 'signal'> = {},
 	) {
 		return this.rest.get(Routes.skuSubscriptions(skuId), {

--- a/packages/core/src/api/monetization.ts
+++ b/packages/core/src/api/monetization.ts
@@ -75,7 +75,7 @@ export class MonetizationAPI {
 	 */
 	public async getEntitlements(
 		applicationId: Snowflake,
-		query: RESTGetAPIEntitlementsQuery,
+		query: RESTGetAPIEntitlementsQuery = {},
 		{ signal }: Pick<RequestData, 'signal'> = {},
 	) {
 		return this.rest.get(Routes.entitlements(applicationId), {

--- a/packages/core/src/api/poll.ts
+++ b/packages/core/src/api/poll.ts
@@ -26,7 +26,7 @@ export class PollAPI {
 		channelId: Snowflake,
 		messageId: Snowflake,
 		answerId: number,
-		query: RESTGetAPIPollAnswerVotersQuery,
+		query: RESTGetAPIPollAnswerVotersQuery = {},
 		{ signal }: Pick<RequestData, 'signal'> = {},
 	) {
 		return this.rest.get(Routes.pollAnswerVoters(channelId, messageId, answerId), {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Nothing in these query options are required, so they have been defaulted to `{}`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
