### PR TITLE
refactor(commands): use `Locale`

### DIFF
--- a/packages/builders/src/interactions/commands/SharedName.ts
+++ b/packages/builders/src/interactions/commands/SharedName.ts
@@ -1,4 +1,4 @@
-import type { LocaleString, RESTPostAPIApplicationCommandsJSONBody } from 'discord-api-types/v10';
+import type { Locale, RESTPostAPIApplicationCommandsJSONBody } from 'discord-api-types/v10';
 
 export interface SharedNameData
 	extends Partial<Pick<RESTPostAPIApplicationCommandsJSONBody, 'name_localizations' | 'name'>> {}
@@ -25,7 +25,7 @@ export class SharedName {
 	 * @param locale - The locale to set
 	 * @param localizedName - The localized name for the given `locale`
 	 */
-	public setNameLocalization(locale: LocaleString, localizedName: string) {
+	public setNameLocalization(locale: Locale, localizedName: string) {
 		this.data.name_localizations ??= {};
 		this.data.name_localizations[locale] = localizedName;
 
@@ -37,7 +37,7 @@ export class SharedName {
 	 *
 	 * @param locale - The locale to clear
 	 */
-	public clearNameLocalization(locale: LocaleString) {
+	public clearNameLocalization(locale: Locale) {
 		this.data.name_localizations ??= {};
 		this.data.name_localizations[locale] = undefined;
 
@@ -49,7 +49,7 @@ export class SharedName {
 	 *
 	 * @param localizedNames - The object of localized names to set
 	 */
-	public setNameLocalizations(localizedNames: Partial<Record<LocaleString, string>>) {
+	public setNameLocalizations(localizedNames: Partial<Record<Locale, string>>) {
 		this.data.name_localizations = structuredClone(localizedNames);
 		return this;
 	}

--- a/packages/builders/src/interactions/commands/SharedNameAndDescription.ts
+++ b/packages/builders/src/interactions/commands/SharedNameAndDescription.ts
@@ -1,4 +1,4 @@
-import type { APIApplicationCommand, LocaleString } from 'discord-api-types/v10';
+import type { APIApplicationCommand, Locale } from 'discord-api-types/v10';
 import type { SharedNameData } from './SharedName.js';
 import { SharedName } from './SharedName.js';
 
@@ -28,7 +28,7 @@ export class SharedNameAndDescription extends SharedName {
 	 * @param locale - The locale to set
 	 * @param localizedDescription - The localized description for the given `locale`
 	 */
-	public setDescriptionLocalization(locale: LocaleString, localizedDescription: string) {
+	public setDescriptionLocalization(locale: Locale, localizedDescription: string) {
 		this.data.description_localizations ??= {};
 		this.data.description_localizations[locale] = localizedDescription;
 
@@ -40,7 +40,7 @@ export class SharedNameAndDescription extends SharedName {
 	 *
 	 * @param locale - The locale to clear
 	 */
-	public clearDescriptionLocalization(locale: LocaleString) {
+	public clearDescriptionLocalization(locale: Locale) {
 		this.data.description_localizations ??= {};
 		this.data.description_localizations[locale] = undefined;
 
@@ -52,7 +52,7 @@ export class SharedNameAndDescription extends SharedName {
 	 *
 	 * @param localizedDescriptions - The object of localized descriptions to set
 	 */
-	public setDescriptionLocalizations(localizedDescriptions: Partial<Record<LocaleString, string>>) {
+	public setDescriptionLocalizations(localizedDescriptions: Partial<Record<Locale, string>>) {
 		this.data.description_localizations = structuredClone(localizedDescriptions);
 		return this;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`LocaleString` is deprecated. Switching to `Locale`.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
