### PR TITLE
refactor: use `cache.get()` for snowflakes, `resolve()` otherwise

### DIFF
--- a/packages/discord.js/src/client/actions/ThreadListSync.js
+++ b/packages/discord.js/src/client/actions/ThreadListSync.js
@@ -13,7 +13,7 @@ class ThreadListSyncAction extends Action {
 
     if (data.channel_ids) {
       for (const id of data.channel_ids) {
-        const channel = client.channels.resolve(id);
+        const channel = client.channels.cache.get(id);
         if (channel) this.removeStale(channel);
       }
     } else {

--- a/packages/discord.js/src/managers/BaseGuildEmojiManager.js
+++ b/packages/discord.js/src/managers/BaseGuildEmojiManager.js
@@ -36,8 +36,8 @@ class BaseGuildEmojiManager extends CachedManager {
    * @returns {?GuildEmoji}
    */
   resolve(emoji) {
-    if (emoji instanceof ReactionEmoji) return super.resolve(emoji.id);
-    if (emoji instanceof ApplicationEmoji) return super.resolve(emoji.id);
+    if (emoji instanceof ReactionEmoji) return super.cache.get(emoji.id) ?? null;
+    if (emoji instanceof ApplicationEmoji) return super.cache.get(emoji.id) ?? null;
     return super.resolve(emoji);
   }
 

--- a/packages/discord.js/src/managers/GuildBanManager.js
+++ b/packages/discord.js/src/managers/GuildBanManager.js
@@ -158,7 +158,7 @@ class GuildBanManager extends CachedManager {
       reason: options.reason,
     });
     if (user instanceof GuildMember) return user;
-    const _user = this.client.users.cache.get(id) ?? null;
+    const _user = this.client.users.cache.get(id);
     if (_user) {
       return this.guild.members.resolve(_user) ?? _user;
     }

--- a/packages/discord.js/src/managers/GuildBanManager.js
+++ b/packages/discord.js/src/managers/GuildBanManager.js
@@ -158,7 +158,7 @@ class GuildBanManager extends CachedManager {
       reason: options.reason,
     });
     if (user instanceof GuildMember) return user;
-    const _user = this.client.users.resolve(id);
+    const _user = this.client.users.cache.get(id) ?? null;
     if (_user) {
       return this.guild.members.resolve(_user) ?? _user;
     }

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -84,7 +84,7 @@ class GuildChannelManager extends CachedManager {
    * @returns {?(GuildChannel|ThreadChannel)}
    */
   resolve(channel) {
-    if (channel instanceof ThreadChannel) return super.resolve(channel.id);
+    if (channel instanceof ThreadChannel) return super.cache.get(channel.id) ?? null;
     return super.resolve(channel);
   }
 
@@ -287,7 +287,7 @@ class GuildChannelManager extends CachedManager {
     const resolvedChannel = this.resolve(channel);
     if (!resolvedChannel) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'channel', 'GuildChannelResolvable');
 
-    const parent = options.parent && this.client.channels.resolveId(options.parent);
+    const parentId = options.parent && this.client.channels.resolveId(options.parent);
 
     if (options.position !== undefined) {
       await this.setPosition(resolvedChannel, options.position, { position: options.position, reason: options.reason });
@@ -298,8 +298,8 @@ class GuildChannelManager extends CachedManager {
     );
 
     if (options.lockPermissions) {
-      if (parent) {
-        const newParent = this.resolve(parent);
+      if (parentId) {
+        const newParent = this.cache.get(parentId);
         if (newParent?.type === ChannelType.GuildCategory) {
           permission_overwrites = newParent.permissionOverwrites.cache.map(overwrite =>
             PermissionOverwrites.resolve(overwrite, this.guild),
@@ -322,7 +322,7 @@ class GuildChannelManager extends CachedManager {
         user_limit: options.userLimit,
         rtc_region: options.rtcRegion,
         video_quality_mode: options.videoQualityMode,
-        parent_id: parent,
+        parent_id: parentId,
         lock_permissions: options.lockPermissions,
         rate_limit_per_user: options.rateLimitPerUser,
         default_auto_archive_duration: options.defaultAutoArchiveDuration,

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -55,7 +55,7 @@ class GuildMemberManager extends CachedManager {
     const memberResolvable = super.resolve(member);
     if (memberResolvable) return memberResolvable;
     const userResolvable = this.client.users.resolveId(member);
-    if (userResolvable) return super.resolve(userResolvable);
+    if (userResolvable) return super.cache.get(userResolvable) ?? null;
     return null;
   }
 
@@ -144,7 +144,7 @@ class GuildMemberManager extends CachedManager {
    */
   get me() {
     return (
-      this.resolve(this.client.user.id) ??
+      this.cache.get(this.client.user.id) ??
       (this.client.options.partials.includes(Partials.GuildMember)
         ? this._add({ user: { id: this.client.user.id } }, true)
         : null)

--- a/packages/discord.js/src/managers/PresenceManager.js
+++ b/packages/discord.js/src/managers/PresenceManager.js
@@ -38,8 +38,8 @@ class PresenceManager extends CachedManager {
   resolve(presence) {
     const presenceResolvable = super.resolve(presence);
     if (presenceResolvable) return presenceResolvable;
-    const userResolvable = this.client.users.resolveId(presence);
-    return super.cache.get(userResolvable) ?? null;
+    const userId = this.client.users.resolveId(presence);
+    return super.cache.get(userId) ?? null;
   }
 
   /**
@@ -50,8 +50,8 @@ class PresenceManager extends CachedManager {
   resolveId(presence) {
     const presenceResolvable = super.resolveId(presence);
     if (presenceResolvable) return presenceResolvable;
-    const userResolvable = this.client.users.resolveId(presence);
-    return this.cache.has(userResolvable) ? userResolvable : null;
+    const userId = this.client.users.resolveId(presence);
+    return this.cache.has(userId) ? userId : null;
   }
 }
 

--- a/packages/discord.js/src/managers/PresenceManager.js
+++ b/packages/discord.js/src/managers/PresenceManager.js
@@ -38,8 +38,8 @@ class PresenceManager extends CachedManager {
   resolve(presence) {
     const presenceResolvable = super.resolve(presence);
     if (presenceResolvable) return presenceResolvable;
-    const UserResolvable = this.client.users.resolveId(presence);
-    return super.resolve(UserResolvable);
+    const userResolvable = this.client.users.resolveId(presence);
+    return super.cache.get(userResolvable) ?? null;
   }
 
   /**

--- a/packages/discord.js/src/managers/ThreadMemberManager.js
+++ b/packages/discord.js/src/managers/ThreadMemberManager.js
@@ -71,8 +71,8 @@ class ThreadMemberManager extends CachedManager {
   resolve(member) {
     const memberResolvable = super.resolve(member);
     if (memberResolvable) return memberResolvable;
-    const userResolvable = this.client.users.resolveId(member);
-    if (userResolvable) return super.cache.get(userResolvable);
+    const userId = this.client.users.resolveId(member);
+    if (userId) return super.cache.get(userId) ?? null;
     return null;
   }
 

--- a/packages/discord.js/src/managers/ThreadMemberManager.js
+++ b/packages/discord.js/src/managers/ThreadMemberManager.js
@@ -53,7 +53,7 @@ class ThreadMemberManager extends CachedManager {
    * @readonly
    */
   get me() {
-    return this.resolve(this.client.user.id);
+    return this.cache.get(this.client.user.id) ?? null;
   }
 
   /**
@@ -72,7 +72,7 @@ class ThreadMemberManager extends CachedManager {
     const memberResolvable = super.resolve(member);
     if (memberResolvable) return memberResolvable;
     const userResolvable = this.client.users.resolveId(member);
-    if (userResolvable) return super.resolve(userResolvable);
+    if (userResolvable) return super.cache.get(userResolvable);
     return null;
   }
 

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -228,7 +228,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get presence() {
-    return this.guild.presences.resolve(this.id);
+    return this.guild.presences.cache.get(this.id) ?? null;
   }
 
   /**

--- a/packages/discord.js/src/structures/GuildOnboardingPromptOption.js
+++ b/packages/discord.js/src/structures/GuildOnboardingPromptOption.js
@@ -79,7 +79,7 @@ class GuildOnboardingPromptOption extends Base {
    */
   get emoji() {
     if (!this._emoji.id && !this._emoji.name) return null;
-    return this.client.emojis.resolve(this._emoji.id) ?? new Emoji(this.client, this._emoji);
+    return this.client.emojis.cache.get(this._emoji.id) ?? new Emoji(this.client, this._emoji);
   }
 }
 

--- a/packages/discord.js/src/structures/Invite.js
+++ b/packages/discord.js/src/structures/Invite.js
@@ -39,7 +39,7 @@ class Invite extends Base {
      */
     this.guild ??= null;
     if (data.guild) {
-      this.guild = this.client.guilds.resolve(data.guild.id) ?? new InviteGuild(this.client, data.guild);
+      this.guild = this.client.guilds.cache.get(data.guild.id) ?? new InviteGuild(this.client, data.guild);
     }
 
     if ('code' in data) {

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -570,7 +570,7 @@ class Message extends Base {
    * @readonly
    */
   get thread() {
-    return this.channel?.threads?.resolve(this.id) ?? null;
+    return this.channel?.threads?.cache.get(this.id) ?? null;
   }
 
   /**

--- a/packages/discord.js/src/structures/PermissionOverwrites.js
+++ b/packages/discord.js/src/structures/PermissionOverwrites.js
@@ -180,7 +180,7 @@ class PermissionOverwrites extends Base {
       };
     }
 
-    const userOrRole = guild.roles.resolve(overwrite.id) ?? guild.client.users.resolve(overwrite.id);
+    const userOrRole = guild.roles.cache.get(overwrite.id) ?? guild.client.users.cache.get(overwrite.id);
     if (!userOrRole) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'parameter', 'User nor a Role');
     const type = userOrRole instanceof Role ? OverwriteType.Role : OverwriteType.Member;
 

--- a/packages/discord.js/src/structures/PollAnswer.js
+++ b/packages/discord.js/src/structures/PollAnswer.js
@@ -61,7 +61,7 @@ class PollAnswer extends Base {
    */
   get emoji() {
     if (!this._emoji || (!this._emoji.id && !this._emoji.name)) return null;
-    return this.client.emojis.resolve(this._emoji.id) ?? new Emoji(this.client, this._emoji);
+    return this.client.emojis.cache.get(this._emoji.id) ?? new Emoji(this.client, this._emoji);
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadMember.js
+++ b/packages/discord.js/src/structures/ThreadMember.js
@@ -87,7 +87,7 @@ class ThreadMember extends Base {
    * @readonly
    */
   get user() {
-    return this.client.users.cache.get(this.id);
+    return this.client.users.cache.get(this.id) ?? null;
   }
 
   /**

--- a/packages/discord.js/src/structures/ThreadMember.js
+++ b/packages/discord.js/src/structures/ThreadMember.js
@@ -69,7 +69,7 @@ class ThreadMember extends Base {
    * @readonly
    */
   get guildMember() {
-    return this.member ?? this.thread.guild.members.resolve(this.id);
+    return this.member ?? this.thread.guild.members.cache.get(this.id) ?? null;
   }
 
   /**
@@ -87,7 +87,7 @@ class ThreadMember extends Base {
    * @readonly
    */
   get user() {
-    return this.client.users.resolve(this.id);
+    return this.client.users.cache.get(this.id);
   }
 
   /**

--- a/packages/discord.js/src/structures/Webhook.js
+++ b/packages/discord.js/src/structures/Webhook.js
@@ -108,7 +108,7 @@ class Webhook {
        * The source guild of the webhook
        * @type {?(Guild|APIGuild)}
        */
-      this.sourceGuild = this.client.guilds?.resolve(data.source_guild.id) ?? data.source_guild;
+      this.sourceGuild = this.client.guilds?.cache.get(data.source_guild.id) ?? data.source_guild;
     } else {
       this.sourceGuild ??= null;
     }
@@ -118,7 +118,7 @@ class Webhook {
        * The source channel of the webhook
        * @type {?(AnnouncementChannel|APIChannel)}
        */
-      this.sourceChannel = this.client.channels?.resolve(data.source_channel?.id) ?? data.source_channel;
+      this.sourceChannel = this.client.channels?.cache.get(data.source_channel?.id) ?? data.source_channel;
     } else {
       this.sourceChannel ??= null;
     }

--- a/packages/discord.js/src/structures/WelcomeChannel.js
+++ b/packages/discord.js/src/structures/WelcomeChannel.js
@@ -53,7 +53,7 @@ class WelcomeChannel extends Base {
    * @type {GuildEmoji|Emoji}
    */
   get emoji() {
-    return this.client.emojis.resolve(this._emoji.id) ?? new Emoji(this.client, this._emoji);
+    return this.client.emojis.cache.get(this._emoji.id) ?? new Emoji(this.client, this._emoji);
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This makes it consistent to use `cache.get()` for snowflakes and `resolve()` for everything else.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
