### PR TITLE
fix: update `clientReady` event name references

### DIFF
--- a/packages/discord.js/.eslintrc.json
+++ b/packages/discord.js/.eslintrc.json
@@ -3,7 +3,7 @@
   "root": true,
   "overrides": [
     {
-      "files": ["src/**/*.js"],
+      "files": ["src/**/*.js", "test/**/*.js"],
       "extends": ["eslint:recommended"],
       "plugins": ["import"],
       "parserOptions": {

--- a/packages/discord.js/README.md
+++ b/packages/discord.js/README.md
@@ -83,14 +83,15 @@ try {
 Afterwards we can create a quite simple example bot:
 
 ```js
-import { Client, GatewayIntentBits } from 'discord.js';
+import { Client, Events, GatewayIntentBits } from 'discord.js';
+
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-client.on('ready', () => {
-  console.log(`Logged in as ${client.user.tag}!`);
+client.on(Events.ClientReady, readyClient => {
+  console.log(`Logged in as ${readyClient.user.tag}!`);
 });
 
-client.on('interactionCreate', async interaction => {
+client.on(Events.InteractionCreate, async interaction => {
   if (!interaction.isChatInputCommand()) return;
 
   if (interaction.commandName === 'ping') {

--- a/packages/discord.js/src/util/Events.js
+++ b/packages/discord.js/src/util/Events.js
@@ -12,7 +12,7 @@
  * @property {string} ChannelDelete channelDelete
  * @property {string} ChannelPinsUpdate channelPinsUpdate
  * @property {string} ChannelUpdate channelUpdate
- * @property {string} ClientReady ready
+ * @property {string} ClientReady clientReady
  * @property {string} Debug debug
  * @property {string} EntitlementCreate entitlementCreate
  * @property {string} EntitlementUpdate entitlementUpdate

--- a/packages/discord.js/test/createGuild.js
+++ b/packages/discord.js/test/createGuild.js
@@ -3,13 +3,13 @@
 const assert = require('node:assert');
 const { ChannelType, GatewayIntentBits } = require('discord-api-types/v10');
 const { token } = require('./auth');
-const { Client } = require('../src');
+const { Client, Events } = require('../src');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
 
-client.on('ready', async () => {
+client.on(Events.ClientReady, async readyClient => {
   try {
-    const guild = await client.guilds.create('testing', {
+    const guild = await readyClient.guilds.create('testing', {
       channels: [
         { name: 'afk channel', type: ChannelType.GuildVoice, id: 0 },
         { name: 'system-channel', id: 1 },
@@ -26,7 +26,7 @@ client.on('ready', async () => {
   } catch (error) {
     console.error(error);
   } finally {
-    await client.destroy();
+    await readyClient.destroy();
   }
 });
 

--- a/packages/discord.js/test/random.js
+++ b/packages/discord.js/test/random.js
@@ -3,7 +3,7 @@
 'use strict';
 
 const { token, owner } = require('./auth.js');
-const { Client } = require('../src');
+const { Client, Events } = require('../src');
 const { ChannelType, GatewayIntentBits } = require('discord-api-types/v10');
 
 console.time('magic');
@@ -24,18 +24,18 @@ client
   .catch(console.error);
 
 // Fetch all members in a new guild
-client.on('guildCreate', guild =>
+client.on(Events.GuildCreate, guild =>
   guild.members.fetch().catch(err => console.log(`Failed to fetch all members: ${err}\n${err.stack}`)),
 );
 
 // Fetch all members in a newly available guild
-client.on('guildUpdate', (oldGuild, newGuild) =>
+client.on(Events.GuildUpdate, (oldGuild, newGuild) =>
   !oldGuild.available && newGuild.available
     ? newGuild.members.fetch().catch(err => console.log(`Failed to fetch all members: ${err}\n${err.stack}`))
     : Promise.resolve(),
 );
 
-client.on('ready', async () => {
+client.on(Events.ClientReady, async () => {
   // Fetch all members for initially available guilds
   try {
     const promises = client.guilds.cache.map(guild => (guild.available ? guild.members.fetch() : Promise.resolve()));
@@ -48,12 +48,11 @@ client.on('ready', async () => {
   console.timeEnd('magic');
 });
 
-client.on('debug', console.log);
+client.on(Events.Debug, console.log);
 
-client.on('error', m => console.log('debug', new Error(m).stack));
-client.on('reconnecting', m => console.log('reconnecting', m));
+client.on(Events.Error, m => console.log('debug', new Error(m).stack));
 
-client.on('messageCreate', message => {
+client.on(Events.MessageCreate, message => {
   if (true) {
     if (message.content === 'makechann') {
       if (message.channel.guild) {
@@ -182,7 +181,7 @@ function chanLoop(channel) {
   channel.setName(`${channel.name}a`).then(chanLoop).catch(console.error);
 }
 
-client.on('messageCreate', msg => {
+client.on(Events.MessageCreate, msg => {
   if (msg.content.startsWith('?raw')) {
     msg.channel.send(`\`\`\`${msg.content}\`\`\``);
   }
@@ -197,17 +196,17 @@ client.on('messageCreate', msg => {
   }
 });
 
-client.on('messageReactionAdd', (reaction, user) => {
+client.on(Events.MessageReactionAdd, (reaction, user) => {
   if (reaction.message.channelId !== '222086648706498562') return;
   reaction.message.channel.send(`${user.username} added reaction ${reaction.emoji}, count is now ${reaction.count}`);
 });
 
-client.on('messageReactionRemove', (reaction, user) => {
+client.on(Events.MessageReactionRemove, (reaction, user) => {
   if (reaction.message.channelId !== '222086648706498562') return;
   reaction.message.channel.send(`${user.username} removed reaction ${reaction.emoji}, count is now ${reaction.count}`);
 });
 
-client.on('messageCreate', m => {
+client.on(Events.MessageCreate, m => {
   if (m.content.startsWith('#reactions')) {
     const mId = m.content.split(' ')[1];
     m.channel.messages.fetch(mId).then(rM => {

--- a/packages/discord.js/test/reactionCollectorCreated.test.js
+++ b/packages/discord.js/test/reactionCollectorCreated.test.js
@@ -2,14 +2,14 @@
 
 const { GatewayIntentBits } = require('discord-api-types/v10');
 const { token, guildId, channelId, messageId } = require('./auth.js');
-const { Client, ReactionCollector } = require('../src');
+const { Client, Events, ReactionCollector } = require('../src');
 
 const client = new Client({
   intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.GuildMessageReactions],
 });
 
-client.on('ready', async () => {
-  const guild = client.guilds.cache.get(guildId);
+client.on(Events.ClientReady, async readyClient => {
+  const guild = readyClient.guilds.cache.get(guildId);
 
   const channel = guild.channels.cache.get(channelId);
 

--- a/packages/discord.js/test/sendtest.js
+++ b/packages/discord.js/test/sendtest.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { Buffer } = require('node:buffer');
 const fs = require('node:fs');
 const path = require('node:path');
 const process = require('node:process');
@@ -8,7 +9,7 @@ const util = require('node:util');
 const { GatewayIntentBits } = require('discord-api-types/v10');
 const { fetch } = require('undici');
 const { owner, token } = require('./auth.js');
-const { Client, MessageAttachment, Embed } = require('../src');
+const { Client, MessageAttachment, Embed, Events } = require('../src');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
 
@@ -88,7 +89,7 @@ const tests = [
   m => m.channel.send('Done!'),
 ];
 
-client.on('messageCreate', async message => {
+client.on(Events.MessageCreate, async message => {
   if (message.author.id !== owner) return;
   const match = message.content.match(/^do (.+)$/);
   if (match?.[1] === 'it') {

--- a/packages/discord.js/test/shard.js
+++ b/packages/discord.js/test/shard.js
@@ -4,7 +4,7 @@ const process = require('node:process');
 const { setTimeout } = require('node:timers');
 const { GatewayIntentBits } = require('discord-api-types/v10');
 const { token } = require('./auth.json');
-const { Client } = require('../src');
+const { Client, Events } = require('../src');
 
 const client = new Client({
   intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages],
@@ -12,7 +12,7 @@ const client = new Client({
   shardCount: process.argv[3],
 });
 
-client.on('messageCreate', msg => {
+client.on(Events.ClientReady, msg => {
   if (msg.content.startsWith('?eval') && msg.author.id === '66564597481480192') {
     try {
       const com = eval(msg.content.split(' ').slice(1).join(' '));
@@ -25,9 +25,9 @@ client.on('messageCreate', msg => {
 
 process.send(123);
 
-client.on('ready', () => {
-  console.log('Ready', client.options.shards);
-  if (client.options.shards === 0) {
+client.on(Events.ClientReady, readyClient => {
+  console.log('Ready', readyClient.options.shards);
+  if (readyClient.options.shards === 0) {
     setTimeout(async () => {
       console.log('kek dying');
       await client.destroy();

--- a/packages/discord.js/test/templateCreateGuild.js
+++ b/packages/discord.js/test/templateCreateGuild.js
@@ -1,12 +1,13 @@
 'use strict';
 
 const { token } = require('./auth');
-const { Client, GatewayIntentBits } = require('../src');
+const { Client, Events, GatewayIntentBits } = require('../src');
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
+
 client
-  .on('ready', () => console.log('ready'))
-  .on('messageCreate', async message => {
+  .on(Events.ClientReady, () => console.log('ready'))
+  .on(Events.MessageCreate, async message => {
     try {
       const templates = await message.guild.fetchTemplates();
       if (!templates.size) {

--- a/packages/discord.js/test/tester1000.js
+++ b/packages/discord.js/test/tester1000.js
@@ -3,7 +3,7 @@
 const process = require('node:process');
 const { GatewayIntentBits } = require('discord-api-types/v10');
 const { token, prefix, owner } = require('./auth.js');
-const { Client } = require('../src');
+const { Client, Events, RESTEvents } = require('../src');
 
 // eslint-disable-next-line no-console
 const log = (...args) => console.log(process.uptime().toFixed(3), ...args);
@@ -13,12 +13,12 @@ const client = new Client({
   shardCount: 2,
 });
 
-client.on('debug', log);
-client.on('ready', () => {
+client.on(Events.Debug, log);
+client.on(Events.ClientReady, () => {
   log('READY', client.user.tag, client.user.id);
 });
-client.on('rateLimit', log);
-client.on('error', console.error);
+client.rest.on(RESTEvents.RateLimited, log);
+client.on(Events.Error, console.error);
 
 const commands = {
   eval: message => {
@@ -37,7 +37,7 @@ const commands = {
   ping: message => message.channel.send('pong'),
 };
 
-client.on('messageCreate', message => {
+client.on(Events.MessageCreate, message => {
   if (!message.content.startsWith(prefix) || message.author.bot) return;
 
   message.content = message.content.replace(prefix, '').trim().split(' ');

--- a/packages/discord.js/test/tester2000.js
+++ b/packages/discord.js/test/tester2000.js
@@ -3,7 +3,7 @@
 const process = require('node:process');
 const { GatewayIntentBits } = require('discord-api-types/v10');
 const { token, prefix, owner } = require('./auth.js');
-const { Client, Options, codeBlock } = require('../src');
+const { Client, Events, Options, RESTEvents, codeBlock } = require('../src');
 
 // eslint-disable-next-line no-console
 const log = (...args) => console.log(process.uptime().toFixed(3), ...args);
@@ -25,12 +25,12 @@ const client = new Client({
   }),
 });
 
-client.on('debug', log);
-client.on('ready', () => {
+client.on(Events.Debug, log);
+client.on(Events.ClientReady, () => {
   log('READY', client.user.tag, client.user.id);
 });
-client.on('rateLimit', log);
-client.on('error', console.error);
+client.rest.on(RESTEvents.RateLimited, log);
+client.on(Events.Error, console.error);
 
 const commands = {
   eval: message => {
@@ -49,7 +49,7 @@ const commands = {
   ping: message => message.channel.send('pong'),
 };
 
-client.on('messageCreate', message => {
+client.on(Events.MessageCreate, message => {
   if (!message.content.startsWith(prefix) || message.author.bot) return;
 
   message.content = message.content.replace(prefix, '').trim().split(' ');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This updates the JSDoc reference for `clientReady` which was missed in https://github.com/discordjs/discord.js/commit/a65c76295065df303f42b90d874630248a91cb2a, it was pointed out [here](https://canary.discord.com/channels/222078108977594368/937420598383108167/1313591770252185681). Also updated the readme and tests references as well.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
