### PR TITLE
feat: allow removing properties from cached objects

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -72,6 +72,13 @@ class Client extends BaseClient {
      * @type {ClientPresence}
      */
     this.presence = new ClientPresence(this, this.options.ws.initialPresence ?? this.options.presence);
+    
+    /**
+     * The presence of the Client
+     * @private
+     * @type {Object}
+     */
+    this.undesiredProperties = this.options.undesiredProperties;
 
     this._validateOptions();
 

--- a/packages/discord.js/src/managers/ChannelManager.js
+++ b/packages/discord.js/src/managers/ChannelManager.js
@@ -6,6 +6,7 @@ const CachedManager = require('./CachedManager');
 const { BaseChannel } = require('../structures/BaseChannel');
 const { createChannel } = require('../util/Channels');
 const { ThreadChannelTypes } = require('../util/Constants');
+const { removeProperties } = require('../util/RemoveProperties');
 const Events = require('../util/Events');
 
 let cacheWarningEmitted = false;
@@ -47,12 +48,15 @@ class ChannelManager extends CachedManager {
       return existing;
     }
 
-    const channel = createChannel(this.client, data, guild, { allowUnknownGuild });
+    let channel = createChannel(this.client, data, guild, { allowUnknownGuild });
 
     if (!channel) {
       this.client.emit(Events.Debug, `Failed to find guild, or unknown type for channel ${data.id} ${data.type}`);
       return null;
     }
+    
+    if (this.client?.undesiredProperties?.ChannelManager)
+      channel = deleteProperties(channel, this.client.undesiredProperties.ChannelManager);
 
     if (cache && !allowUnknownGuild) this.cache.set(channel.id, channel);
 

--- a/packages/discord.js/src/util/RemoveProperties.js
+++ b/packages/discord.js/src/util/RemoveProperties.js
@@ -1,0 +1,15 @@
+'use strict';
+
+function removeProperties(objectsArray, propertiesToRemove) {
+  const propertiesSet = new Set(propertiesToRemove);
+
+  objectsArray.forEach(obj => {
+    for (const prop of propertiesSet) {
+      obj[prop] = undefined;
+    }
+  });
+
+  return objectsArray;
+}
+
+module.exports = { removeProperties };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Cache only the properties you need and remove the undesired one. This greatly improves the memory footprint.

For example, the `channel.topic` property of channels which consumes dozens of bytes. If a bot operates in thousands of servers this can waste unnecessary memory.
```js
const client = new Client({
	undesiredProperties: {
		ChannelManager: ["topic"]
	}
})
```

Goal is to support caching from other managers too.
I am open for what you guys think about it. I am willing to battle test this for a bot with >150k servers.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
-->
