### PR TITLE
docs(InteractionDeferReplyOptions): Associate `flags` with its `<info>`

### DIFF
--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -24,8 +24,8 @@ class InteractionResponses {
   /**
    * Options for deferring the reply to an {@link BaseInteraction}.
    * @typedef {Object} InteractionDeferReplyOptions
-   * @property {MessageFlagsResolvable} [flags] Flags for the reply.
    * @property {boolean} [withResponse] Whether to return an {@link InteractionCallbackResponse} as the response
+   * @property {MessageFlagsResolvable} [flags] Flags for the reply.
    * <info>Only `MessageFlags.Ephemeral` can be set.</info>
    */
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Moves `flags` down beneath `withResponse` so `<info>` is associated to the correct property.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
