### PR TITLE
fix(interactions): wrong return type and missing implementation of with_response in core

### DIFF
--- a/packages/core/src/api/interactions.ts
+++ b/packages/core/src/api/interactions.ts
@@ -316,6 +316,7 @@ export class InteractionsAPI {
 		{ signal }: Pick<RequestData, 'signal'> = {},
 	) {
 		const response = await this.rest.post(Routes.interactionCallback(interactionId, interactionToken), {
+			query: makeURLSearchParams({ with_response }),
 			files,
 			auth: false,
 			body: {
@@ -342,7 +343,7 @@ export class InteractionsAPI {
 		interactionToken: string,
 		callbackData: CreateAutocompleteResponseOptions & { with_response: true },
 		options?: Pick<RequestData, 'signal'>,
-	): Promise<APICommandAutocompleteInteractionResponseCallbackData>;
+	): Promise<RESTPostAPIInteractionCallbackWithResponseResult>;
 
 	/**
 	 * Sends an autocomplete response to an interaction
@@ -367,6 +368,7 @@ export class InteractionsAPI {
 		{ signal }: Pick<RequestData, 'signal'> = {},
 	) {
 		const response = await this.rest.post(Routes.interactionCallback(interactionId, interactionToken), {
+			query: makeURLSearchParams({ with_response }),
 			auth: false,
 			body: {
 				type: InteractionResponseType.ApplicationCommandAutocompleteResult,
@@ -417,6 +419,7 @@ export class InteractionsAPI {
 		{ signal }: Pick<RequestData, 'signal'> = {},
 	) {
 		const response = await this.rest.post(Routes.interactionCallback(interactionId, interactionToken), {
+			query: makeURLSearchParams({ with_response }),
 			auth: false,
 			body: {
 				type: InteractionResponseType.Modal,

--- a/packages/core/src/api/interactions.ts
+++ b/packages/core/src/api/interactions.ts
@@ -159,7 +159,7 @@ export class InteractionsAPI {
 		interactionToken: string,
 		body: RESTPostAPIInteractionCallbackQuery & { with_response: true },
 		options?: Pick<RequestData, 'signal'>,
-	): Promise<undefined>;
+	): Promise<RESTPostAPIInteractionCallbackWithResponseResult>;
 
 	/**
 	 * Defers an update from a message component interaction
@@ -175,7 +175,7 @@ export class InteractionsAPI {
 		interactionToken: string,
 		body?: RESTPostAPIInteractionCallbackQuery & { with_response?: false },
 		options?: Pick<RequestData, 'signal'>,
-	): Promise<RESTPostAPIInteractionCallbackWithResponseResult>;
+	): Promise<undefined>;
 
 	public async deferMessageUpdate(
 		interactionId: Snowflake,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`with_response` was missing implementations in some methods as well as some had wrong return types

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
