### PR TITLE
refactor(IContextFetchingStrategy): explicitly name forwarded properties

### DIFF
--- a/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
@@ -3,15 +3,20 @@ import type { APIGatewayBotInfo } from 'discord-api-types/v10';
 import type { SessionInfo, WebSocketManager, WebSocketManagerOptions } from '../../ws/WebSocketManager.js';
 
 export interface FetchingStrategyOptions
-	extends Omit<
+	extends Pick<
 		WebSocketManagerOptions,
-		| 'buildIdentifyThrottler'
-		| 'buildStrategy'
-		| 'rest'
-		| 'retrieveSessionInfo'
-		| 'shardCount'
-		| 'shardIds'
-		| 'updateSessionInfo'
+		| 'compression'
+		| 'encoding'
+		| 'handshakeTimeout'
+		| 'helloTimeout'
+		| 'identifyProperties'
+		| 'initialPresence'
+		| 'intents'
+		| 'largeThreshold'
+		| 'readyTimeout'
+		| 'token'
+		| 'useIdentifyCompression'
+		| 'version'
 	> {
 	readonly gatewayInformation: APIGatewayBotInfo;
 	readonly shardCount: number;
@@ -33,20 +38,20 @@ export interface IContextFetchingStrategy {
 }
 
 export async function managerToFetchingStrategyOptions(manager: WebSocketManager): Promise<FetchingStrategyOptions> {
-	const {
-		buildIdentifyThrottler,
-		buildStrategy,
-		retrieveSessionInfo,
-		updateSessionInfo,
-		shardCount,
-		shardIds,
-		rest,
-		...managerOptions
-	} = manager.options;
-
 	return {
-		...managerOptions,
+		compression: manager.options.compression,
+		encoding: manager.options.encoding,
+		handshakeTimeout: manager.options.handshakeTimeout,
+		helloTimeout: manager.options.helloTimeout,
+		identifyProperties: manager.options.identifyProperties,
+		initialPresence: manager.options.initialPresence,
+		intents: manager.options.intents,
+		largeThreshold: manager.options.largeThreshold,
+		readyTimeout: manager.options.readyTimeout,
 		token: manager.token,
+		useIdentifyCompression: manager.options.useIdentifyCompression,
+		version: manager.options.version,
+
 		gatewayInformation: await manager.fetchGatewayInformation(),
 		shardCount: await manager.getShardCount(),
 	};


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This has been a pain on multiple occasions. It's worth to just name the properties explicitly.