### PR TITLE
fix: use Message#interactionMetadata

### DIFF
--- a/packages/discord.js/src/structures/InteractionCollector.js
+++ b/packages/discord.js/src/structures/InteractionCollector.js
@@ -153,8 +153,8 @@ class InteractionCollector extends Collector {
     if (this.messageId && interaction.message?.id !== this.messageId) return null;
     if (
       this.messageInteractionId &&
-      interaction.message?.interaction?.id &&
-      interaction.message.interaction.id !== this.messageInteractionId
+      interaction.message?.interactionMetadata?.id &&
+      interaction.message.interactionMetadata.id !== this.messageInteractionId
     ) {
       return null;
     }
@@ -180,8 +180,8 @@ class InteractionCollector extends Collector {
     if (this.messageId && interaction.message?.id !== this.messageId) return null;
     if (
       this.messageInteractionId &&
-      interaction.message?.interaction?.id &&
-      interaction.message.interaction.id !== this.messageInteractionId
+      interaction.message?.interactionMetadata?.id &&
+      interaction.message.interactionMetadata.id !== this.messageInteractionId
     ) {
       return null;
     }
@@ -224,7 +224,7 @@ class InteractionCollector extends Collector {
       this.stop('messageDelete');
     }
 
-    if (message.interaction?.id === this.messageInteractionId) {
+    if (message.interactionMetadata?.id === this.messageInteractionId) {
       this.stop('messageDelete');
     }
   }

--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -228,7 +228,7 @@ class InteractionResponses {
 
     return options.withResponse
       ? new InteractionCallbackResponse(this.client, response)
-      : new InteractionResponse(this, this.message?.interaction?.id);
+      : new InteractionResponse(this, this.message?.interactionMetadata?.id);
   }
 
   /**
@@ -266,7 +266,7 @@ class InteractionResponses {
 
     return options.withResponse
       ? new InteractionCallbackResponse(this.client, response)
-      : new InteractionResponse(this, this.message.interaction?.id);
+      : new InteractionResponse(this, this.message.interactionMetadata?.id);
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`Message#interaction` has been removed since #10647  but was still being used internally in some places

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
