### PR TITLE
feat(GuildForumThreadManager): add pinned getter

### DIFF
--- a/packages/discord.js/src/managers/GuildForumThreadManager.js
+++ b/packages/discord.js/src/managers/GuildForumThreadManager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Routes } = require('discord-api-types/v10');
+const { Routes, ChannelFlags } = require('discord-api-types/v10');
 const ThreadManager = require('./ThreadManager');
 const { DiscordjsTypeError, ErrorCodes } = require('../errors');
 const MessagePayload = require('../structures/MessagePayload');
@@ -77,6 +77,14 @@ class GuildForumThreadManager extends ThreadManager {
     });
 
     return this.client.actions.ThreadCreate.handle(data).thread;
+  }
+
+  /**
+   * Returns the pinned thread in the channel if it exists. Otherwise, returns `undefined`.
+   * @returns {ForumThreadChannel|undefined}
+   */
+  get pinned() {
+    return this.cache.find(thread => thread.flags.has(ChannelFlags.Pinned));
   }
 }
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Given that there can only be one pinned thread per guild forum, a helper getter is added to provide an easier way to retrieve it.

**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)


<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
