### PR TITLE
fix: Handle unknown versions

### DIFF
--- a/apps/website/src/util/fetchSitemap.ts
+++ b/apps/website/src/util/fetchSitemap.ts
@@ -24,5 +24,9 @@ export async function fetchSitemap({
 		{ next: isMainVersion ? { revalidate: 0 } : { revalidate: 604_800 } },
 	);
 
+	if (!fileContent.ok) {
+		return null;
+	}
+
 	return fileContent.json();
 }


### PR DESCRIPTION
Visiting a page with an unknown version causes a 500. Example: https://discordjs.dev/docs/packages/discord.js/mainn/Client:Class

This was caused by `fetchSiteMap()`:

https://github.com/discordjs/discord.js/blob/fd1958bd67b35faa0222b3c125c9265596f054de/apps/website/src/util/fetchSitemap.ts#L21-L27

The version doesn't exist. We do not check `ok`, so this eventually bubbles up to here and causes a 500 (the `if` statement is not reached):

https://github.com/discordjs/discord.js/blob/fd1958bd67b35faa0222b3c125c9265596f054de/apps/website/src/components/Navigation.tsx#L31-L35

Checking if `fileContent` is `ok` resolves this.