### PR TITLE
fix(InteractionResponses): properly resolve message flags

### DIFF
--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -149,15 +149,12 @@ class MessagePayload {
 
     let flags;
     if (
-      this.options.flags !== undefined ||
+      // eslint-disable-next-line eqeqeq
+      this.options.flags != null ||
       (this.isMessage && this.options.reply === undefined) ||
       this.isMessageManager
     ) {
-      flags =
-        // eslint-disable-next-line eqeqeq
-        this.options.flags != null
-          ? new MessageFlagsBitField(this.options.flags).bitfield
-          : this.target.flags?.bitfield;
+      flags = new MessageFlagsBitField(this.options.flags).bitfield;
     }
 
     let allowedMentions =


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Addressed internally [here](https://canary.discord.com/channels/222078108977594368/1209960895141388389/1316436894766338049).

- `deferReply()` - Passing string message flags would lead to an API error as they were not being resolved.
- `reply()` - `ephemeral` was not being set properly, it was using the flags the user passed and not the resolved bits.
- Also removed some redundant code in `MessagePayload`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
