### PR TITLE
ci: make docs run succeed for old tags

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -60,6 +60,8 @@ jobs:
       - name: Build main
         if: ${{ inputs.ref && inputs.ref != 'main' }}
         shell: bash
+        env:
+          COREPACK_ENABLE_STRICT: 0
         run: |
           cd main
           pnpm install --frozen-lockfile --prefer-offline --loglevel error


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Prevents CI failing on pnpm version mismatch between main branch and version tag.

**Status and versioning classification:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
