### PR TITLE
fix(Message): Ensure channel is defined for clean content

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -563,7 +563,7 @@ class Message extends Base {
    */
   get cleanContent() {
     // eslint-disable-next-line eqeqeq
-    return this.content != null ? cleanContent(this.content, this.channel) : null;
+    return this.content != null && this.channel ? cleanContent(this.content, this.channel) : null;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`channel` may be `null` and thus when passing to `cleanContent()`, a crash will occur on valid types. This is reproducible in 2 (known) ways:

1. Calling `cleanContent` on a forwarded message from a guild one is not in
2. Calling `cleanContent` on a interaction's response message from a guild one is not in

Stack trace:

```
TypeError: Cannot read properties of null (reading 'client')
    at /Users/jiralite/Documents/GitHub/Soulobby/Soulobby/node_modules/.pnpm/discord.js@14.17.2_patch_hash=uqmtazwjzsnpehwi2ldoqezswq/node_modules/discord.js/src/util/Util.js:389:44
    at [Symbol.replace] (<anonymous>)
    at String.replaceAll (<anonymous>)
    at cleanContent (/Users/jiralite/Documents/GitHub/Soulobby/Soulobby/node_modules/.pnpm/discord.js@14.17.2_patch_hash=uqmtazwjzsnpehwi2ldoqezswq/node_modules/discord.js/src/util/Util.js:362:14)
    at get cleanContent (/Users/jiralite/Documents/GitHub/Soulobby/Soulobby/node_modules/.pnpm/discord.js@14.17.2_patch_hash=uqmtazwjzsnpehwi2ldoqezswq/node_modules/discord.js/src/structures/Message.js:594:36)
    at Soulobby.fire (/Users/jiralite/Documents/GitHub/Soulobby/Soulobby/source/events/interaction-create.ts:119:80)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
Emitted 'error' event on Soulobby instance at:
    at emitUnhandledRejectionOrErr (node:events:407:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:92:21)
```

In both cases, a message is constructed with a channel id that is not cached, so that will result in `null` being sent to the `cleanContent()`. This will resolve #10679—seems they're calling `.toJSON()` somewhere to achieve this or `cleanContent` directly.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
