### PR TITLE
fix: make version and package select openable on mobile

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -68,7 +68,7 @@
 		"react-dom": "19.0.0-rc-f994737d14-20240522",
 		"sharp": "^0.33.5",
 		"usehooks-ts": "^3.1.0",
-		"vaul": "^0.9.9"
+		"vaul": "^1.1.2"
 	},
 	"devDependencies": {
 		"@shikijs/rehype": "^1.24.4",

--- a/apps/website/src/components/ui/PackageSelect.tsx
+++ b/apps/website/src/components/ui/PackageSelect.tsx
@@ -52,7 +52,7 @@ export function PackageSelect({ packageName }: { readonly packageName: string })
 				</Popover>
 			</Select>
 
-			<Vaul.NestedRoot open={open} onOpenChange={setOpen} dismissible={false}>
+			<Vaul.NestedRoot open={open} onOpenChange={setOpen}>
 				<Vaul.Trigger
 					aria-label="Open package select"
 					className="flex w-full place-content-between place-items-center rounded-md bg-neutral-200 p-2 dark:bg-neutral-800 md:hidden"

--- a/apps/website/src/components/ui/VersionSelect.tsx
+++ b/apps/website/src/components/ui/VersionSelect.tsx
@@ -59,7 +59,7 @@ export function VersionSelect({
 				</Popover>
 			</Select>
 
-			<Vaul.NestedRoot open={open} onOpenChange={setOpen} dismissible={false}>
+			<Vaul.NestedRoot open={open} onOpenChange={setOpen}>
 				<Vaul.Trigger
 					aria-label="Open version select"
 					className="flex w-full place-content-between place-items-center rounded-md bg-neutral-200 p-2 dark:bg-neutral-800 md:hidden"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,8 +293,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(react@19.0.0-rc-f994737d14-20240522)
       vaul:
-        specifier: ^0.9.9
-        version: 0.9.9(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522)
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522)
     devDependencies:
       '@shikijs/rehype':
         specifier: ^1.24.4
@@ -5364,6 +5364,9 @@ packages:
 
   '@types/node@18.19.68':
     resolution: {integrity: sha512-QGtpFH1vB99ZmTa63K4/FU8twThj4fuVSBkGddTp7uIL/cuoLWIUSL2RcOaigBhfR+hg5pgGkBnkoOxrTVBMKw==}
+
+  '@types/node@18.19.69':
+    resolution: {integrity: sha512-ECPdY1nlaiO/Y6GUnwgtAAhLNaQ53AyIVz+eILxpEo5OvuqE6yWkqWBIb5dU0DqhKQtMeny+FBD3PK6lm7L5xQ==}
 
   '@types/node@20.17.10':
     resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
@@ -12887,11 +12890,11 @@ packages:
     resolution: {integrity: sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==}
     engines: {node: '>= 0.10'}
 
-  vaul@0.9.9:
-    resolution: {integrity: sha512-7afKg48srluhZwIkaU+lgGtFCUsYBSGOl8vcc8N/M3YQlZFlynHD15AE+pwrYdc826o7nrIND4lL9Y6b9WWZZQ==}
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
     peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0
-      react-dom: ^16.8 || ^17.0 || ^18.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vercel@37.14.0:
     resolution: {integrity: sha512-ZSEvhARyJBn4YnEVZULsvti8/OHd5txRCgJqEhNIyo/XXSvBJSvlCjA+SE1zraqn0rqyEOG3+56N3kh1Enk8Tg==}
@@ -13889,7 +13892,7 @@ snapshots:
   '@definitelytyped/utils@0.1.8':
     dependencies:
       '@qiwi/npm-registry-client': 8.9.1
-      '@types/node': 18.19.68
+      '@types/node': 18.19.69
       cachedir: 2.4.0
       charm: 1.0.2
       minimatch: 9.0.5
@@ -17779,7 +17782,7 @@ snapshots:
 
   '@types/concat-stream@2.0.3':
     dependencies:
-      '@types/node': 18.19.68
+      '@types/node': 20.17.10
 
   '@types/connect@3.4.38':
     dependencies:
@@ -17926,6 +17929,10 @@ snapshots:
   '@types/node@18.17.9': {}
 
   '@types/node@18.19.68':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/node@18.19.69':
     dependencies:
       undici-types: 5.26.5
 
@@ -25551,7 +25558,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 18.19.68
+      '@types/node': 20.17.10
       long: 5.2.3
 
   proxy-agent@6.5.0:
@@ -27868,7 +27875,7 @@ snapshots:
 
   validator@13.12.0: {}
 
-  vaul@0.9.9(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522):
+  vaul@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522):
     dependencies:
       '@radix-ui/react-dialog': 1.1.4(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522)
       react: 19.0.0-rc-f994737d14-20240522


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Opening the version select and package select drawers on the mobile documentation site was broken due to an issue in the vaul package after a version bump from 0.9.2 in https://github.com/discordjs/discord.js/commit/a6685a319efbb8892d65dbda9a9c1db1f64f1fc9.

- https://github.com/emilkowalski/vaul/issues/457

This PR bumps vaul to 1.1.2 and removes `dismissible={false}` from the drawers. (I'm not exactly sure why that was added? It doesn't allow me to stay on the current package/version on mobile by clicking on the current package/version (so I have to refresh the page), and this behaviour isn't present on the desktop select menu.)

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
