### PR TITLE
test: Add `with_response` overload tests

### DIFF
--- a/packages/core/__tests__/types.test.ts
+++ b/packages/core/__tests__/types.test.ts
@@ -1,0 +1,66 @@
+import { REST } from '@discordjs/rest';
+import type {
+	APIActionRowComponent,
+	APIModalActionRowComponent,
+	RESTPostAPIInteractionCallbackWithResponseResult,
+} from 'discord-api-types/v10';
+import { assertType, describe, test } from 'vitest';
+import { API } from '../src/index.js';
+
+const rest = new REST();
+const api = new API(rest);
+const SNOWFLAKE = '123456789012345678' as const;
+const TOKEN = 'token' as const;
+const MODAL_COMPONENTS: APIActionRowComponent<APIModalActionRowComponent>[] = [] as const;
+
+describe('Interaction with_response overloads.', () => {
+	test('Replying returns RESTPostAPIInteractionCallbackWithResponseResult.', () =>
+		assertType<Promise<RESTPostAPIInteractionCallbackWithResponseResult>>(
+			api.interactions.reply(SNOWFLAKE, TOKEN, { with_response: true }),
+		));
+
+	test('Replying returns undefined.', () => assertType<Promise<undefined>>(api.interactions.reply(SNOWFLAKE, TOKEN, {})));
+
+	test('Defer returns RESTPostAPIInteractionCallbackWithResponseResult.', () =>
+		assertType<Promise<RESTPostAPIInteractionCallbackWithResponseResult>>(
+			api.interactions.defer(SNOWFLAKE, TOKEN, { with_response: true }),
+		));
+
+	test('Defer returns undefined.', () => assertType<Promise<undefined>>(api.interactions.defer(SNOWFLAKE, TOKEN, {})));
+
+	test('Defer message update returns RESTPostAPIInteractionCallbackWithResponseResult.', () =>
+		assertType<Promise<RESTPostAPIInteractionCallbackWithResponseResult>>(
+			api.interactions.deferMessageUpdate(SNOWFLAKE, TOKEN, { with_response: true }),
+		));
+
+	test('Defer message update returns undefined.', () => assertType<Promise<undefined>>(api.interactions.deferMessageUpdate(SNOWFLAKE, TOKEN, {})));
+
+	test('Update message returns RESTPostAPIInteractionCallbackWithResponseResult.', () =>
+		assertType<Promise<RESTPostAPIInteractionCallbackWithResponseResult>>(
+			api.interactions.updateMessage(SNOWFLAKE, TOKEN, { with_response: true }),
+		));
+
+	test('Update message returns undefined.', () => assertType<Promise<undefined>>(api.interactions.updateMessage(SNOWFLAKE, TOKEN, {})));
+
+	test('Create autocomplete response returns RESTPostAPIInteractionCallbackWithResponseResult.', () =>
+		assertType<Promise<RESTPostAPIInteractionCallbackWithResponseResult>>(
+			api.interactions.createAutocompleteResponse(SNOWFLAKE, TOKEN, { with_response: true }),
+		));
+
+	test('Create autocomplete response returns undefined.', () => assertType<Promise<undefined>>(api.interactions.createAutocompleteResponse(SNOWFLAKE, TOKEN, {})));
+
+	test('Create modal returns RESTPostAPIInteractionCallbackWithResponseResult.', () =>
+		assertType<Promise<RESTPostAPIInteractionCallbackWithResponseResult>>(
+			api.interactions.createModal(SNOWFLAKE, TOKEN, {
+				title: '',
+				custom_id: '',
+				components: MODAL_COMPONENTS,
+				with_response: true,
+			}),
+		));
+
+	test('Create modal returns undefined.', () =>
+		assertType<Promise<undefined>>(
+			api.interactions.createModal(SNOWFLAKE, TOKEN, { title: '', custom_id: '', components: MODAL_COMPONENTS }),
+		));
+});

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.json",
-	"include": ["src/**/*.ts", "src/**/*.js", "src/**/*.cjs", "src/**/*.mjs", "bin"],
+	"include": ["src/**/*.ts", "src/**/*.js", "src/**/*.cjs", "src/**/*.mjs", "bin", "__tests__", "../../vitest.d.ts"],
 	"exclude": ["node_modules"]
 }

--- a/vitest.d.ts
+++ b/vitest.d.ts
@@ -1,0 +1,8 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+// This file only exists because of https://github.com/vitejs/vite/issues/9813.
+declare interface Worker {}
+declare interface WebSocket {}
+
+declare namespace WebAssembly {
+	interface Module {}
+}


### PR DESCRIPTION
I believe it's a good idea to add type tests for overloads due to the following pull requests:

- #10644
- #10683

Including this to run resulted in global type errors, which is the result of an upstream bug (https://github.com/vitejs/vite/issues/9813). vitest.d.ts has been added to temporarily mitigate this.

#10683 needs to merge for tests on this pull request to pass.