### PR TITLE
fix: use `resolve()` for `PermissionOverwrites`

### DIFF
--- a/packages/discord.js/src/managers/BaseGuildEmojiManager.js
+++ b/packages/discord.js/src/managers/BaseGuildEmojiManager.js
@@ -36,8 +36,8 @@ class BaseGuildEmojiManager extends CachedManager {
    * @returns {?GuildEmoji}
    */
   resolve(emoji) {
-    if (emoji instanceof ReactionEmoji) return super.cache.get(emoji.id) ?? null;
-    if (emoji instanceof ApplicationEmoji) return super.cache.get(emoji.id) ?? null;
+    if (emoji instanceof ReactionEmoji) return this.cache.get(emoji.id) ?? null;
+    if (emoji instanceof ApplicationEmoji) return this.cache.get(emoji.id) ?? null;
     return super.resolve(emoji);
   }
 

--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -84,7 +84,7 @@ class GuildChannelManager extends CachedManager {
    * @returns {?(GuildChannel|ThreadChannel)}
    */
   resolve(channel) {
-    if (channel instanceof ThreadChannel) return super.cache.get(channel.id) ?? null;
+    if (channel instanceof ThreadChannel) return this.cache.get(channel.id) ?? null;
     return super.resolve(channel);
   }
 

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -54,8 +54,8 @@ class GuildMemberManager extends CachedManager {
   resolve(member) {
     const memberResolvable = super.resolve(member);
     if (memberResolvable) return memberResolvable;
-    const userResolvable = this.client.users.resolveId(member);
-    if (userResolvable) return super.cache.get(userResolvable) ?? null;
+    const userId = this.client.users.resolveId(member);
+    if (userId) return this.cache.get(userId) ?? null;
     return null;
   }
 
@@ -67,8 +67,8 @@ class GuildMemberManager extends CachedManager {
   resolveId(member) {
     const memberResolvable = super.resolveId(member);
     if (memberResolvable) return memberResolvable;
-    const userResolvable = this.client.users.resolveId(member);
-    return this.cache.has(userResolvable) ? userResolvable : null;
+    const userId = this.client.users.resolveId(member);
+    return this.cache.has(userId) ? userId : null;
   }
 
   /**

--- a/packages/discord.js/src/structures/PermissionOverwrites.js
+++ b/packages/discord.js/src/structures/PermissionOverwrites.js
@@ -180,7 +180,7 @@ class PermissionOverwrites extends Base {
       };
     }
 
-    const userOrRole = guild.roles.cache.get(overwrite.id) ?? guild.client.users.cache.get(overwrite.id);
+    const userOrRole = guild.roles.cache.resolve(overwrite.id) ?? guild.client.users.resolve(overwrite.id);
     if (!userOrRole) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'parameter', 'User nor a Role');
     const type = userOrRole instanceof Role ? OverwriteType.Role : OverwriteType.Member;
 

--- a/packages/discord.js/src/structures/PermissionOverwrites.js
+++ b/packages/discord.js/src/structures/PermissionOverwrites.js
@@ -180,7 +180,7 @@ class PermissionOverwrites extends Base {
       };
     }
 
-    const userOrRole = guild.roles.cache.resolve(overwrite.id) ?? guild.client.users.resolve(overwrite.id);
+    const userOrRole = guild.roles.resolve(overwrite.id) ?? guild.client.users.resolve(overwrite.id);
     if (!userOrRole) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'parameter', 'User nor a Role');
     const type = userOrRole instanceof Role ? OverwriteType.Role : OverwriteType.Member;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This fixes an issue where `cache.get()` was used because of #10626, causing `PermissionOverwrites#resolve` to return undefined when `overwrite.id` may be a Role or User instance. Also updated `super.cache.get()` to `this.cache.get()` for clarity.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
