### PR TITLE
fix(ChannelUpdateAction): emit client event in handle to not miss change

### DIFF
--- a/packages/discord.js/src/client/actions/ChannelUpdate.js
+++ b/packages/discord.js/src/client/actions/ChannelUpdate.js
@@ -2,6 +2,7 @@
 
 const Action = require('./Action');
 const { createChannel } = require('../../util/Channels');
+const Events = require('../../util/Events');
 
 class ChannelUpdateAction extends Action {
   handle(data) {
@@ -25,6 +26,24 @@ class ChannelUpdateAction extends Action {
 
         channel = newChannel;
         this.client.channels.cache.set(channel.id, channel);
+      }
+
+      if (channel.isThread()) {
+        /**
+         * Emitted whenever a thread is updated - e.g. name change, archive state change, locked state change.
+         * @event Client#threadUpdate
+         * @param {ThreadChannel} oldThread The thread before the update
+         * @param {ThreadChannel} newThread The thread after the update
+         */
+        client.emit(Events.ThreadUpdate, old, channel);
+      } else {
+        /**
+         * Emitted whenever a channel is updated - e.g. name change, topic change, channel type change.
+         * @event Client#channelUpdate
+         * @param {DMChannel|GuildChannel} oldChannel The channel before the update
+         * @param {DMChannel|GuildChannel} newChannel The channel after the update
+         */
+        client.emit(Events.ChannelUpdate, old, channel);
       }
 
       return {

--- a/packages/discord.js/src/client/websocket/handlers/CHANNEL_UPDATE.js
+++ b/packages/discord.js/src/client/websocket/handlers/CHANNEL_UPDATE.js
@@ -1,16 +1,5 @@
 'use strict';
 
-const Events = require('../../../util/Events');
-
 module.exports = (client, packet) => {
-  const { old, updated } = client.actions.ChannelUpdate.handle(packet.d);
-  if (old && updated) {
-    /**
-     * Emitted whenever a channel is updated - e.g. name change, topic change, channel type change.
-     * @event Client#channelUpdate
-     * @param {DMChannel|GuildChannel} oldChannel The channel before the update
-     * @param {DMChannel|GuildChannel} newChannel The channel after the update
-     */
-    client.emit(Events.ChannelUpdate, old, updated);
-  }
+  client.actions.ChannelUpdate.handle(packet.d);
 };

--- a/packages/discord.js/src/client/websocket/handlers/THREAD_UPDATE.js
+++ b/packages/discord.js/src/client/websocket/handlers/THREAD_UPDATE.js
@@ -1,16 +1,5 @@
 'use strict';
 
-const Events = require('../../../util/Events');
-
 module.exports = (client, packet) => {
-  const { old, updated } = client.actions.ChannelUpdate.handle(packet.d);
-  if (old && updated) {
-    /**
-     * Emitted whenever a thread is updated - e.g. name change, archive state change, locked state change.
-     * @event Client#threadUpdate
-     * @param {ThreadChannel} oldThread The thread before the update
-     * @param {ThreadChannel} newThread The thread after the update
-     */
-    client.emit(Events.ThreadUpdate, old, updated);
-  }
+  client.actions.ChannelUpdate.handle(packet.d);
 };

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -343,7 +343,7 @@ class ThreadChannel extends BaseChannel {
   async edit(options) {
     const newData = await this.client.rest.patch(Routes.channel(this.id), {
       body: {
-        name: (options.name ?? this.name).trim(),
+        name: options.name,
         archived: options.archived,
         auto_archive_duration: options.autoArchiveDuration,
         rate_limit_per_user: options.rateLimitPerUser,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR corrects the bug reported in #10658 by moving the emission of events inside the action so that no changes are zapped.
Currently, the `<ChannelUpdateAction>.handle` method is called within the `ThreadChannel` and `GuildChannelManager` classes. This call could result in a modification to the cached instance before the event was received from Discord, causing the event to be lost with the actual modification.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating