### PR TITLE
test: Include type checks on builders

### DIFF
--- a/packages/builders/__tests__/components/textInput.test.ts
+++ b/packages/builders/__tests__/components/textInput.test.ts
@@ -2,8 +2,6 @@ import { ComponentType, TextInputStyle, type APITextInputComponent } from 'disco
 import { describe, test, expect } from 'vitest';
 import { TextInputBuilder } from '../../src/components/textInput/TextInput.js';
 
-const superLongStr = 'a'.repeat(5_000);
-
 const textInputComponent = () => new TextInputBuilder();
 
 describe('Text Input Components', () => {

--- a/packages/builders/__tests__/interactions/ContextMenuCommands.test.ts
+++ b/packages/builders/__tests__/interactions/ContextMenuCommands.test.ts
@@ -1,10 +1,4 @@
-import {
-	ApplicationCommandType,
-	ApplicationIntegrationType,
-	InteractionContextType,
-	Locale,
-	PermissionFlagsBits,
-} from 'discord-api-types/v10';
+import { ApplicationIntegrationType, InteractionContextType, Locale, PermissionFlagsBits } from 'discord-api-types/v10';
 import { describe, test, expect } from 'vitest';
 import { MessageContextCommandBuilder } from '../../src/index.js';
 

--- a/packages/builders/tsconfig.json
+++ b/packages/builders/tsconfig.json
@@ -5,6 +5,6 @@
 		"emitDecoratorMetadata": true,
 		"exactOptionalPropertyTypes": false
 	},
-	"include": ["src/**/*.ts", "src/**/*.js", "src/**/*.cjs", "src/**/*.mjs", "bin"],
+	"include": ["src/**/*.ts", "src/**/*.js", "src/**/*.cjs", "src/**/*.mjs", "bin", "__tests__", "../../vitest.d.ts"],
 	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
Turns out builders had type checks too, but they were not doing anything as they were not being type checked. You can test this: change some types in the file and run the test script prior to this pull request. Tests will pass.

Now that types are checked in the directory, it picked up some undeclared variables, which I've removed.