### PR TITLE
fix!: move `crosspost()` to `GuildMessageManager`

### DIFF
--- a/packages/discord.js/src/managers/GuildMessageManager.js
+++ b/packages/discord.js/src/managers/GuildMessageManager.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const { Routes } = require('discord-api-types/v10');
 const MessageManager = require('./MessageManager');
+const { DiscordjsTypeError, ErrorCodes } = require('../errors');
 
 /**
  * Manages API methods for messages in a guild and holds their cache.
@@ -12,6 +14,19 @@ class GuildMessageManager extends MessageManager {
    * @name GuildMessageManager#channel
    * @type {GuildTextBasedChannel}
    */
+
+  /**
+   * Publishes a message in an announcement channel to all channels following it, even if it's not cached.
+   * @param {MessageResolvable} message The message to publish
+   * @returns {Promise<Message>}
+   */
+  async crosspost(message) {
+    const messageId = this.resolveId(message);
+    if (!messageId) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'message', 'MessageResolvable');
+
+    const data = await this.client.rest.post(Routes.channelMessageCrosspost(this.channel.id, messageId));
+    return this.cache.get(data.id) ?? this._add(data);
+  }
 }
 
 module.exports = GuildMessageManager;

--- a/packages/discord.js/src/managers/MessageManager.js
+++ b/packages/discord.js/src/managers/MessageManager.js
@@ -197,19 +197,6 @@ class MessageManager extends CachedManager {
   }
 
   /**
-   * Publishes a message in an announcement channel to all channels following it, even if it's not cached.
-   * @param {MessageResolvable} message The message to publish
-   * @returns {Promise<Message>}
-   */
-  async crosspost(message) {
-    message = this.resolveId(message);
-    if (!message) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'message', 'MessageResolvable');
-
-    const data = await this.client.rest.post(Routes.channelMessageCrosspost(this.channel.id, message));
-    return this.cache.get(data.id) ?? this._add(data);
-  }
-
-  /**
    * Pins a message to the channel's pinned messages, even if it's not cached.
    * @param {MessageResolvable} message The message to pin
    * @param {string} [reason] Reason for pinning


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Moved `MessageManager#crosspost()` to `GuildMessageManager` as messages can't be crossposted to DMs. The typings already had the `crosspost` method under `GuildMessageManager` and didn't need updating.

BREAKING CHANGE: The `crosspost()` method from `MessageManager` has been moved to `GuildMessageManager`. 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
