### PR TITLE
types(ThreadOnlyChannel): remove incorrect `messages` property

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2653,6 +2653,7 @@ export interface ThreadOnlyChannel
     | 'awaitMessages'
     | 'createMessageComponentCollector'
     | 'awaitMessageComponent'
+    | 'messages'
   > {}
 export abstract class ThreadOnlyChannel extends GuildChannel {
   public type: ChannelType.GuildForum | ChannelType.GuildMedia;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -2457,14 +2457,13 @@ declare const forumChannel: ForumChannel;
 declare const mediaChannel: MediaChannel;
 declare const threadOnlyChannel: ThreadOnlyChannel;
 
-// @ts-expect-error
-forumChannel.messages;
+// Threads have messages.
+expectType<GuildMessageManager>(threadChannel.messages);
 
-// @ts-expect-error
-mediaChannel.messages;
-
-// @ts-expect-error
-threadOnlyChannel.messages;
+// Thread-only channels have threads—not messages.
+notPropertyOf(threadOnlyChannel, 'messages');
+notPropertyOf(forumChannel, 'messages');
+notPropertyOf(mediaChannel, 'messages');
 
 await forumChannel.edit({
   availableTags: [...forumChannel.availableTags, { name: 'tag' }],

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -213,6 +213,7 @@ import {
   PollData,
   InteractionCallbackResponse,
   GuildScheduledEventRecurrenceRuleOptions,
+  ThreadOnlyChannel,
 } from '.';
 import { expectAssignable, expectNotAssignable, expectNotType, expectType } from 'tsd';
 import type { ContextMenuCommandBuilder, SlashCommandBuilder } from '@discordjs/builders';
@@ -2453,6 +2454,17 @@ declare const partialGroupDMChannel: PartialGroupDMChannel;
 declare const categoryChannel: CategoryChannel;
 declare const stageChannel: StageChannel;
 declare const forumChannel: ForumChannel;
+declare const mediaChannel: MediaChannel;
+declare const threadOnlyChannel: ThreadOnlyChannel;
+
+// @ts-expect-error
+forumChannel.messages;
+
+// @ts-expect-error
+mediaChannel.messages;
+
+// @ts-expect-error
+threadOnlyChannel.messages;
 
 await forumChannel.edit({
   availableTags: [...forumChannel.availableTags, { name: 'tag' }],


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Resolves #10609 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
