### PR TITLE
feat: add `auth` option in api methods

### DIFF
--- a/packages/core/src/api/applicationCommands.ts
+++ b/packages/core/src/api/applicationCommands.ts
@@ -42,9 +42,10 @@ export class ApplicationCommandsAPI {
 	public async getGlobalCommands(
 		applicationId: Snowflake,
 		query: RESTGetAPIApplicationCommandsQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.applicationCommands(applicationId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIApplicationCommandsResult>;
@@ -61,9 +62,10 @@ export class ApplicationCommandsAPI {
 	public async createGlobalCommand(
 		applicationId: Snowflake,
 		body: RESTPostAPIApplicationCommandsJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.applicationCommands(applicationId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPostAPIApplicationCommandsResult>;
@@ -80,9 +82,10 @@ export class ApplicationCommandsAPI {
 	public async getGlobalCommand(
 		applicationId: Snowflake,
 		commandId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.applicationCommand(applicationId, commandId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIApplicationCommandResult>;
 	}
@@ -100,9 +103,10 @@ export class ApplicationCommandsAPI {
 		applicationId: Snowflake,
 		commandId: Snowflake,
 		body: RESTPatchAPIApplicationCommandJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.applicationCommand(applicationId, commandId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPatchAPIApplicationCommandResult>;
@@ -119,9 +123,9 @@ export class ApplicationCommandsAPI {
 	public async deleteGlobalCommand(
 		applicationId: Snowflake,
 		commandId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.applicationCommand(applicationId, commandId), { signal });
+		await this.rest.delete(Routes.applicationCommand(applicationId, commandId), { auth, signal });
 	}
 
 	/**
@@ -135,9 +139,10 @@ export class ApplicationCommandsAPI {
 	public async bulkOverwriteGlobalCommands(
 		applicationId: Snowflake,
 		body: RESTPutAPIApplicationCommandsJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.put(Routes.applicationCommands(applicationId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPutAPIApplicationCommandsResult>;
@@ -156,9 +161,10 @@ export class ApplicationCommandsAPI {
 		applicationId: Snowflake,
 		guildId: Snowflake,
 		query: RESTGetAPIApplicationGuildCommandsQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.applicationGuildCommands(applicationId, guildId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIApplicationGuildCommandsResult>;
@@ -177,9 +183,10 @@ export class ApplicationCommandsAPI {
 		applicationId: Snowflake,
 		guildId: Snowflake,
 		body: RESTPostAPIApplicationGuildCommandsJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.applicationGuildCommands(applicationId, guildId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPostAPIApplicationGuildCommandsResult>;
@@ -198,9 +205,10 @@ export class ApplicationCommandsAPI {
 		applicationId: Snowflake,
 		guildId: Snowflake,
 		commandId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.applicationGuildCommand(applicationId, guildId, commandId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIApplicationGuildCommandResult>;
 	}
@@ -220,9 +228,10 @@ export class ApplicationCommandsAPI {
 		guildId: Snowflake,
 		commandId: Snowflake,
 		body: RESTPatchAPIApplicationGuildCommandJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.applicationGuildCommand(applicationId, guildId, commandId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPatchAPIApplicationGuildCommandResult>;
@@ -241,9 +250,9 @@ export class ApplicationCommandsAPI {
 		applicationId: Snowflake,
 		guildId: Snowflake,
 		commandId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.applicationGuildCommand(applicationId, guildId, commandId), { signal });
+		await this.rest.delete(Routes.applicationGuildCommand(applicationId, guildId, commandId), { auth, signal });
 	}
 
 	/**
@@ -259,9 +268,10 @@ export class ApplicationCommandsAPI {
 		applicationId: Snowflake,
 		guildId: Snowflake,
 		body: RESTPutAPIApplicationGuildCommandsJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.put(Routes.applicationGuildCommands(applicationId, guildId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPutAPIApplicationGuildCommandsResult>;
@@ -280,9 +290,10 @@ export class ApplicationCommandsAPI {
 		applicationId: Snowflake,
 		guildId: Snowflake,
 		commandId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.applicationCommandPermissions(applicationId, guildId, commandId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIApplicationCommandPermissionsResult>;
 	}
@@ -298,9 +309,10 @@ export class ApplicationCommandsAPI {
 	public async getGuildCommandsPermissions(
 		applicationId: Snowflake,
 		guildId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildApplicationCommandsPermissions(applicationId, guildId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIGuildApplicationCommandsPermissionsResult>;
 	}

--- a/packages/core/src/api/applications.ts
+++ b/packages/core/src/api/applications.ts
@@ -24,8 +24,8 @@ export class ApplicationsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/application#get-current-application}
 	 * @param options - The options for fetching the application
 	 */
-	public async getCurrent({ signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.currentApplication(), { signal }) as Promise<RESTGetCurrentApplicationResult>;
+	public async getCurrent({ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.currentApplication(), { auth, signal }) as Promise<RESTGetCurrentApplicationResult>;
 	}
 
 	/**
@@ -35,8 +35,12 @@ export class ApplicationsAPI {
 	 * @param body - The new application data
 	 * @param options - The options for editing the application
 	 */
-	public async editCurrent(body: RESTPatchCurrentApplicationJSONBody, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async editCurrent(
+		body: RESTPatchCurrentApplicationJSONBody,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.patch(Routes.currentApplication(), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPatchCurrentApplicationResult>;
@@ -49,8 +53,9 @@ export class ApplicationsAPI {
 	 * @param applicationId - The id of the application to fetch the emojis of
 	 * @param options - The options for fetching the emojis
 	 */
-	public async getEmojis(applicationId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getEmojis(applicationId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.get(Routes.applicationEmojis(applicationId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIApplicationEmojisResult>;
 	}
@@ -63,8 +68,13 @@ export class ApplicationsAPI {
 	 * @param emojiId - The id of the emoji to fetch
 	 * @param options - The options for fetching the emoji
 	 */
-	public async getEmoji(applicationId: Snowflake, emojiId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getEmoji(
+		applicationId: Snowflake,
+		emojiId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.get(Routes.applicationEmoji(applicationId, emojiId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIApplicationEmojiResult>;
 	}
@@ -80,9 +90,10 @@ export class ApplicationsAPI {
 	public async createEmoji(
 		applicationId: Snowflake,
 		body: RESTPostAPIApplicationEmojiJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.applicationEmojis(applicationId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPostAPIApplicationEmojiResult>;
@@ -101,9 +112,10 @@ export class ApplicationsAPI {
 		applicationId: Snowflake,
 		emojiId: Snowflake,
 		body: RESTPatchAPIApplicationEmojiJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.applicationEmoji(applicationId, emojiId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPatchAPIApplicationEmojiResult>;
@@ -117,7 +129,11 @@ export class ApplicationsAPI {
 	 * @param emojiId - The id of the emoji to delete
 	 * @param options - The options for deleting the emoji
 	 */
-	public async deleteEmoji(applicationId: Snowflake, emojiId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		await this.rest.delete(Routes.applicationEmoji(applicationId, emojiId), { signal });
+	public async deleteEmoji(
+		applicationId: Snowflake,
+		emojiId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		await this.rest.delete(Routes.applicationEmoji(applicationId, emojiId), { auth, signal });
 	}
 }

--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -63,9 +63,10 @@ export class ChannelsAPI {
 	public async createMessage(
 		channelId: Snowflake,
 		{ files, ...body }: CreateMessageOptions,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.channelMessages(channelId), {
+			auth,
 			files,
 			body,
 			signal,
@@ -85,9 +86,10 @@ export class ChannelsAPI {
 		channelId: Snowflake,
 		messageId: Snowflake,
 		{ files, ...body }: EditMessageOptions,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.channelMessage(channelId, messageId), {
+			auth,
 			files,
 			body,
 			signal,
@@ -117,9 +119,10 @@ export class ChannelsAPI {
 		messageId: Snowflake,
 		emoji: string,
 		query: RESTGetAPIChannelMessageReactionUsersQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.channelMessageReaction(channelId, messageId, encodeURIComponent(emoji)), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIChannelMessageReactionUsersResult>;
@@ -146,9 +149,10 @@ export class ChannelsAPI {
 		channelId: Snowflake,
 		messageId: Snowflake,
 		emoji: string,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		await this.rest.delete(Routes.channelMessageOwnReaction(channelId, messageId, encodeURIComponent(emoji)), {
+			auth,
 			signal,
 		});
 	}
@@ -176,9 +180,10 @@ export class ChannelsAPI {
 		messageId: Snowflake,
 		emoji: string,
 		userId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		await this.rest.delete(Routes.channelMessageUserReaction(channelId, messageId, encodeURIComponent(emoji), userId), {
+			auth,
 			signal,
 		});
 	}
@@ -194,9 +199,9 @@ export class ChannelsAPI {
 	public async deleteAllMessageReactions(
 		channelId: Snowflake,
 		messageId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.channelMessageAllReactions(channelId, messageId), { signal });
+		await this.rest.delete(Routes.channelMessageAllReactions(channelId, messageId), { auth, signal });
 	}
 
 	/**
@@ -220,9 +225,12 @@ export class ChannelsAPI {
 		channelId: Snowflake,
 		messageId: Snowflake,
 		emoji: string,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.channelMessageReaction(channelId, messageId, encodeURIComponent(emoji)), { signal });
+		await this.rest.delete(Routes.channelMessageReaction(channelId, messageId, encodeURIComponent(emoji)), {
+			auth,
+			signal,
+		});
 	}
 
 	/**
@@ -246,9 +254,12 @@ export class ChannelsAPI {
 		channelId: Snowflake,
 		messageId: Snowflake,
 		emoji: string,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
-		await this.rest.put(Routes.channelMessageOwnReaction(channelId, messageId, encodeURIComponent(emoji)), { signal });
+		await this.rest.put(Routes.channelMessageOwnReaction(channelId, messageId, encodeURIComponent(emoji)), {
+			auth,
+			signal,
+		});
 	}
 
 	/**
@@ -258,8 +269,8 @@ export class ChannelsAPI {
 	 * @param channelId - The id of the channel
 	 * @param options - The options for fetching the channel
 	 */
-	public async get(channelId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.channel(channelId), { signal }) as Promise<RESTGetAPIChannelResult>;
+	public async get(channelId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.channel(channelId), { auth, signal }) as Promise<RESTGetAPIChannelResult>;
 	}
 
 	/**
@@ -273,9 +284,9 @@ export class ChannelsAPI {
 	public async edit(
 		channelId: Snowflake,
 		body: RESTPatchAPIChannelJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
-		return this.rest.patch(Routes.channel(channelId), { body, signal }) as Promise<RESTPatchAPIChannelResult>;
+		return this.rest.patch(Routes.channel(channelId), { auth, body, signal }) as Promise<RESTPatchAPIChannelResult>;
 	}
 
 	/**
@@ -285,8 +296,8 @@ export class ChannelsAPI {
 	 * @param channelId - The id of the channel to delete
 	 * @param options - The options for deleting the channel
 	 */
-	public async delete(channelId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.delete(Routes.channel(channelId), { signal }) as Promise<RESTDeleteAPIChannelResult>;
+	public async delete(channelId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.delete(Routes.channel(channelId), { auth, signal }) as Promise<RESTDeleteAPIChannelResult>;
 	}
 
 	/**
@@ -300,9 +311,10 @@ export class ChannelsAPI {
 	public async getMessages(
 		channelId: Snowflake,
 		query: RESTGetAPIChannelMessagesQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.channelMessages(channelId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIChannelMessagesResult>;
@@ -315,8 +327,8 @@ export class ChannelsAPI {
 	 * @param channelId - The id of the channel to show the typing indicator in
 	 * @param options - The options for showing the typing indicator
 	 */
-	public async showTyping(channelId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		await this.rest.post(Routes.channelTyping(channelId), { signal });
+	public async showTyping(channelId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		await this.rest.post(Routes.channelTyping(channelId), { auth, signal });
 	}
 
 	/**
@@ -326,8 +338,8 @@ export class ChannelsAPI {
 	 * @param channelId - The id of the channel to fetch pinned messages from
 	 * @param options - The options for fetching the pinned messages
 	 */
-	public async getPins(channelId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.channelPins(channelId), { signal }) as Promise<RESTGetAPIChannelPinsResult>;
+	public async getPins(channelId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.channelPins(channelId), { auth, signal }) as Promise<RESTGetAPIChannelPinsResult>;
 	}
 
 	/**
@@ -341,9 +353,9 @@ export class ChannelsAPI {
 	public async pinMessage(
 		channelId: Snowflake,
 		messageId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.put(Routes.channelPin(channelId, messageId), { reason, signal });
+		await this.rest.put(Routes.channelPin(channelId, messageId), { auth, reason, signal });
 	}
 
 	/**
@@ -357,9 +369,9 @@ export class ChannelsAPI {
 	public async deleteMessage(
 		channelId: Snowflake,
 		messageId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.channelMessage(channelId, messageId), { reason, signal });
+		await this.rest.delete(Routes.channelMessage(channelId, messageId), { auth, reason, signal });
 	}
 
 	/**
@@ -373,9 +385,9 @@ export class ChannelsAPI {
 	public async bulkDeleteMessages(
 		channelId: Snowflake,
 		messageIds: Snowflake[],
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	): Promise<void> {
-		await this.rest.post(Routes.channelBulkDelete(channelId), { reason, body: { messages: messageIds }, signal });
+		await this.rest.post(Routes.channelBulkDelete(channelId), { auth, reason, body: { messages: messageIds }, signal });
 	}
 
 	/**
@@ -386,8 +398,13 @@ export class ChannelsAPI {
 	 * @param messageId - The id of the message to fetch
 	 * @param options - The options for fetching the message
 	 */
-	public async getMessage(channelId: Snowflake, messageId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getMessage(
+		channelId: Snowflake,
+		messageId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.get(Routes.channelMessage(channelId, messageId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIChannelMessageResult>;
 	}
@@ -403,9 +420,10 @@ export class ChannelsAPI {
 	public async crosspostMessage(
 		channelId: Snowflake,
 		messageId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.channelMessageCrosspost(channelId, messageId), {
+			auth,
 			signal,
 		}) as Promise<RESTPostAPIChannelMessageCrosspostResult>;
 	}
@@ -421,9 +439,9 @@ export class ChannelsAPI {
 	public async unpinMessage(
 		channelId: Snowflake,
 		messageId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.channelPin(channelId, messageId), { reason, signal });
+		await this.rest.delete(Routes.channelPin(channelId, messageId), { auth, reason, signal });
 	}
 
 	/**
@@ -437,9 +455,10 @@ export class ChannelsAPI {
 	public async followAnnouncements(
 		channelId: Snowflake,
 		webhookChannelId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.channelFollowers(channelId), {
+			auth,
 			body: { webhook_channel_id: webhookChannelId },
 			reason,
 			signal,
@@ -457,9 +476,10 @@ export class ChannelsAPI {
 	public async createInvite(
 		channelId: Snowflake,
 		body: RESTPostAPIChannelInviteJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.channelInvites(channelId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -473,8 +493,8 @@ export class ChannelsAPI {
 	 * @param channelId - The id of the channel to fetch invites from
 	 * @param options - The options for fetching the invites
 	 */
-	public async getInvites(channelId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.channelInvites(channelId), { signal }) as Promise<RESTGetAPIChannelInvitesResult>;
+	public async getInvites(channelId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.channelInvites(channelId), { auth, signal }) as Promise<RESTGetAPIChannelInvitesResult>;
 	}
 
 	/**
@@ -491,9 +511,10 @@ export class ChannelsAPI {
 		channelId: Snowflake,
 		body: RESTPostAPIChannelThreadsJSONBody,
 		messageId?: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.threads(channelId, messageId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPostAPIChannelThreadsResult>;
@@ -510,7 +531,7 @@ export class ChannelsAPI {
 	public async createForumThread(
 		channelId: Snowflake,
 		{ message, ...optionsBody }: StartForumThreadOptions,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		const { files, ...messageBody } = message;
 
@@ -519,7 +540,7 @@ export class ChannelsAPI {
 			message: messageBody,
 		};
 
-		return this.rest.post(Routes.threads(channelId), { files, body, signal }) as Promise<APIThreadChannel>;
+		return this.rest.post(Routes.threads(channelId), { auth, files, body, signal }) as Promise<APIThreadChannel>;
 	}
 
 	/**
@@ -536,9 +557,10 @@ export class ChannelsAPI {
 		channelId: Snowflake,
 		archivedStatus: 'private' | 'public',
 		query: RESTGetAPIChannelThreadsArchivedQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.channelThreads(channelId, archivedStatus), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIChannelUsersThreadsArchivedResult>;
@@ -555,9 +577,10 @@ export class ChannelsAPI {
 	public async getJoinedPrivateArchivedThreads(
 		channelId: Snowflake,
 		query: RESTGetAPIChannelThreadsArchivedQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.channelJoinedArchivedThreads(channelId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIChannelUsersThreadsArchivedResult>;
@@ -574,9 +597,10 @@ export class ChannelsAPI {
 	public async createWebhook(
 		channelId: Snowflake,
 		body: RESTPostAPIChannelWebhookJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.channelWebhooks(channelId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -588,9 +612,13 @@ export class ChannelsAPI {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/webhook#get-channel-webhooks}
 	 * @param channelId - The id of the channel
+	 * @param options - The options for fetching the webhooks
 	 */
-	public async getWebhooks(channelId: Snowflake) {
-		return this.rest.get(Routes.channelWebhooks(channelId)) as Promise<RESTGetAPIChannelWebhooksResult>;
+	public async getWebhooks(channelId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.channelWebhooks(channelId), {
+			auth,
+			signal,
+		}) as Promise<RESTGetAPIChannelWebhooksResult>;
 	}
 
 	/**
@@ -606,9 +634,10 @@ export class ChannelsAPI {
 		channelId: Snowflake,
 		overwriteId: Snowflake,
 		body: RESTPutAPIChannelPermissionJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		await this.rest.put(Routes.channelPermission(channelId, overwriteId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -626,9 +655,10 @@ export class ChannelsAPI {
 	public async deletePermissionOverwrite(
 		channelId: Snowflake,
 		overwriteId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		await this.rest.delete(Routes.channelPermission(channelId, overwriteId), {
+			auth,
 			reason,
 			signal,
 		});
@@ -645,9 +675,10 @@ export class ChannelsAPI {
 	public async sendSoundboardSound(
 		channelId: Snowflake,
 		body: RESTPostAPISoundboardSendSoundJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.sendSoundboardSound(channelId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPostAPISendSoundboardSoundResult>;

--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -122,8 +122,13 @@ export class GuildsAPI {
 	 * @param query - The query options for fetching the guild
 	 * @param options - The options for fetching the guild
 	 */
-	public async get(guildId: Snowflake, query: RESTGetAPIGuildQuery = {}, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async get(
+		guildId: Snowflake,
+		query: RESTGetAPIGuildQuery = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.get(Routes.guild(guildId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIGuildResult>;
@@ -136,8 +141,9 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the preview from
 	 * @param options - The options for fetching the guild preview
 	 */
-	public async getPreview(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getPreview(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.get(Routes.guildPreview(guildId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIGuildPreviewResult>;
 	}
@@ -149,8 +155,8 @@ export class GuildsAPI {
 	 * @param body - The guild to create
 	 * @param options - The options for creating the guild
 	 */
-	public async create(body: RESTPostAPIGuildsJSONBody, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.post(Routes.guilds(), { body, signal }) as Promise<RESTPostAPIGuildsResult>;
+	public async create(body: RESTPostAPIGuildsJSONBody, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.post(Routes.guilds(), { auth, body, signal }) as Promise<RESTPostAPIGuildsResult>;
 	}
 
 	/**
@@ -164,9 +170,10 @@ export class GuildsAPI {
 	public async edit(
 		guildId: Snowflake,
 		body: RESTPatchAPIGuildJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guild(guildId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -180,8 +187,11 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to delete
 	 * @param options - The options for deleting this guild
 	 */
-	public async delete(guildId: Snowflake, { signal, reason }: Pick<RequestData, 'reason' | 'signal'> = {}) {
-		await this.rest.delete(Routes.guild(guildId), { reason, signal });
+	public async delete(
+		guildId: Snowflake,
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
+	) {
+		await this.rest.delete(Routes.guild(guildId), { auth, reason, signal });
 	}
 
 	/**
@@ -197,9 +207,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		userId: Snowflake,
 		body: RESTPutAPIGuildMemberJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.put(Routes.guildMember(guildId, userId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPutAPIGuildMemberResult>;
@@ -216,9 +227,10 @@ export class GuildsAPI {
 	public async getMembers(
 		guildId: Snowflake,
 		query: RESTGetAPIGuildMembersQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildMembers(guildId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIGuildMembersResult>;
@@ -231,8 +243,9 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the channels from
 	 * @param options - The options for fetching the guild channels
 	 */
-	public async getChannels(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getChannels(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.get(Routes.guildChannels(guildId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIGuildChannelsResult>;
 	}
@@ -248,9 +261,10 @@ export class GuildsAPI {
 	public async createChannel(
 		guildId: Snowflake,
 		body: RESTPostAPIGuildChannelJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.guildChannels(guildId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -268,9 +282,9 @@ export class GuildsAPI {
 	public async setChannelPositions(
 		guildId: Snowflake,
 		body: RESTPatchAPIGuildChannelPositionsJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.patch(Routes.guildChannels(guildId), { reason, body, signal });
+		await this.rest.patch(Routes.guildChannels(guildId), { auth, reason, body, signal });
 	}
 
 	/**
@@ -280,8 +294,8 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the active threads from
 	 * @param options - The options for fetching the active threads
 	 */
-	public async getActiveThreads(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildActiveThreads(guildId), { signal }) as Promise<RESTGetAPIGuildThreadsResult>;
+	public async getActiveThreads(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildActiveThreads(guildId), { auth, signal }) as Promise<RESTGetAPIGuildThreadsResult>;
 	}
 
 	/**
@@ -292,8 +306,12 @@ export class GuildsAPI {
 	 * @param userId - The id of the user to fetch the ban
 	 * @param options - The options for fetching the ban
 	 */
-	public async getMemberBan(guildId: Snowflake, userId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildBan(guildId, userId), { signal }) as Promise<RESTGetAPIGuildBanResult>;
+	public async getMemberBan(
+		guildId: Snowflake,
+		userId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		return this.rest.get(Routes.guildBan(guildId, userId), { auth, signal }) as Promise<RESTGetAPIGuildBanResult>;
 	}
 
 	/**
@@ -307,9 +325,10 @@ export class GuildsAPI {
 	public async getMemberBans(
 		guildId: Snowflake,
 		query: RESTGetAPIGuildBansQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildBans(guildId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIGuildBansResult>;
@@ -328,9 +347,9 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		userId: Snowflake,
 		body: RESTPutAPIGuildBanJSONBody = {},
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.put(Routes.guildBan(guildId, userId), { reason, body, signal });
+		await this.rest.put(Routes.guildBan(guildId, userId), { auth, reason, body, signal });
 	}
 
 	/**
@@ -344,9 +363,9 @@ export class GuildsAPI {
 	public async unbanUser(
 		guildId: Snowflake,
 		userId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.guildBan(guildId, userId), { reason, signal });
+		await this.rest.delete(Routes.guildBan(guildId, userId), { auth, reason, signal });
 	}
 
 	/**
@@ -360,9 +379,10 @@ export class GuildsAPI {
 	public async bulkBanUsers(
 		guildId: Snowflake,
 		body: RESTPostAPIGuildBulkBanJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.guildBulkBan(guildId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -376,8 +396,8 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the roles from
 	 * @param options - The options for fetching the guild roles
 	 */
-	public async getRoles(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildRoles(guildId), { signal }) as Promise<RESTGetAPIGuildRolesResult>;
+	public async getRoles(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildRoles(guildId), { auth, signal }) as Promise<RESTGetAPIGuildRolesResult>;
 	}
 
 	/**
@@ -388,8 +408,12 @@ export class GuildsAPI {
 	 * @param roleId - The id of the role to fetch
 	 * @param options - The options for fetching the guild role
 	 */
-	public async getRole(guildId: Snowflake, roleId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildRole(guildId, roleId), { signal }) as Promise<RESTGetAPIGuildRoleResult>;
+	public async getRole(
+		guildId: Snowflake,
+		roleId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		return this.rest.get(Routes.guildRole(guildId, roleId), { auth, signal }) as Promise<RESTGetAPIGuildRoleResult>;
 	}
 
 	/**
@@ -403,9 +427,14 @@ export class GuildsAPI {
 	public async createRole(
 		guildId: Snowflake,
 		body: RESTPostAPIGuildRoleJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		return this.rest.post(Routes.guildRoles(guildId), { reason, body, signal }) as Promise<RESTPostAPIGuildRoleResult>;
+		return this.rest.post(Routes.guildRoles(guildId), {
+			auth,
+			reason,
+			body,
+			signal,
+		}) as Promise<RESTPostAPIGuildRoleResult>;
 	}
 
 	/**
@@ -419,9 +448,10 @@ export class GuildsAPI {
 	public async setRolePositions(
 		guildId: Snowflake,
 		body: RESTPatchAPIGuildRolePositionsJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildRoles(guildId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -441,9 +471,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		roleId: Snowflake,
 		body: RESTPatchAPIGuildRoleJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildRole(guildId, roleId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -461,9 +492,9 @@ export class GuildsAPI {
 	public async deleteRole(
 		guildId: Snowflake,
 		roleId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.guildRole(guildId, roleId), { reason, signal });
+		await this.rest.delete(Routes.guildRole(guildId, roleId), { auth, reason, signal });
 	}
 
 	/**
@@ -477,9 +508,10 @@ export class GuildsAPI {
 	public async editMFALevel(
 		guildId: Snowflake,
 		level: GuildMFALevel,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.guildMFA(guildId), {
+			auth,
 			reason,
 			signal,
 			body: { level },
@@ -497,9 +529,10 @@ export class GuildsAPI {
 	public async getPruneCount(
 		guildId: Snowflake,
 		query: RESTGetAPIGuildPruneCountQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildPrune(guildId), {
+			auth,
 			signal,
 			query: makeURLSearchParams(query),
 		}) as Promise<RESTGetAPIGuildPruneCountResult>;
@@ -516,9 +549,10 @@ export class GuildsAPI {
 	public async beginPrune(
 		guildId: Snowflake,
 		body: RESTPostAPIGuildPruneJSONBody = {},
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.guildPrune(guildId), {
+			auth,
 			body,
 			reason,
 			signal,
@@ -532,8 +566,11 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the voice regions from
 	 * @param options - The options for fetching the voice regions
 	 */
-	public async getVoiceRegions(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildVoiceRegions(guildId), { signal }) as Promise<RESTGetAPIGuildVoiceRegionsResult>;
+	public async getVoiceRegions(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildVoiceRegions(guildId), {
+			auth,
+			signal,
+		}) as Promise<RESTGetAPIGuildVoiceRegionsResult>;
 	}
 
 	/**
@@ -543,8 +580,8 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the invites from
 	 * @param options - The options for fetching the invites
 	 */
-	public async getInvites(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildInvites(guildId), { signal }) as Promise<RESTGetAPIGuildInvitesResult>;
+	public async getInvites(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildInvites(guildId), { auth, signal }) as Promise<RESTGetAPIGuildInvitesResult>;
 	}
 
 	/**
@@ -554,8 +591,11 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the integrations from
 	 * @param options - The options for fetching the integrations
 	 */
-	public async getIntegrations(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildIntegrations(guildId), { signal }) as Promise<RESTGetAPIGuildIntegrationsResult>;
+	public async getIntegrations(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildIntegrations(guildId), {
+			auth,
+			signal,
+		}) as Promise<RESTGetAPIGuildIntegrationsResult>;
 	}
 
 	/**
@@ -569,9 +609,9 @@ export class GuildsAPI {
 	public async deleteIntegration(
 		guildId: Snowflake,
 		integrationId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.guildIntegration(guildId, integrationId), { reason, signal });
+		await this.rest.delete(Routes.guildIntegration(guildId, integrationId), { auth, reason, signal });
 	}
 
 	/**
@@ -581,8 +621,9 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the widget settings from
 	 * @param options - The options for fetching the widget settings
 	 */
-	public async getWidgetSettings(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getWidgetSettings(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.get(Routes.guildWidgetSettings(guildId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIGuildWidgetSettingsResult>;
 	}
@@ -598,9 +639,10 @@ export class GuildsAPI {
 	public async editWidgetSettings(
 		guildId: Snowflake,
 		body: RESTPatchAPIGuildWidgetSettingsJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildWidgetSettings(guildId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -614,8 +656,8 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the widget from
 	 * @param options - The options for fetching the widget
 	 */
-	public async getWidget(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildWidgetJSON(guildId), { signal }) as Promise<RESTGetAPIGuildWidgetJSONResult>;
+	public async getWidget(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildWidgetJSON(guildId), { auth, signal }) as Promise<RESTGetAPIGuildWidgetJSONResult>;
 	}
 
 	/**
@@ -625,8 +667,8 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the vanity url from
 	 * @param options - The options for fetching the vanity url
 	 */
-	public async getVanityURL(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildVanityUrl(guildId), { signal }) as Promise<RESTGetAPIGuildVanityUrlResult>;
+	public async getVanityURL(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildVanityUrl(guildId), { auth, signal }) as Promise<RESTGetAPIGuildVanityUrlResult>;
 	}
 
 	/**
@@ -640,9 +682,10 @@ export class GuildsAPI {
 	public async getWidgetImage(
 		guildId: Snowflake,
 		style?: GuildWidgetStyle,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildWidgetImage(guildId), {
+			auth,
 			query: makeURLSearchParams({ style }),
 			signal,
 		}) as Promise<RESTGetAPIGuildWidgetImageResult>;
@@ -655,8 +698,11 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the welcome screen from
 	 * @param options - The options for fetching the welcome screen
 	 */
-	public async getWelcomeScreen(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildWelcomeScreen(guildId), { signal }) as Promise<RESTGetAPIGuildWelcomeScreenResult>;
+	public async getWelcomeScreen(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildWelcomeScreen(guildId), {
+			auth,
+			signal,
+		}) as Promise<RESTGetAPIGuildWelcomeScreenResult>;
 	}
 
 	/**
@@ -670,9 +716,10 @@ export class GuildsAPI {
 	public async editWelcomeScreen(
 		guildId: Snowflake,
 		body?: RESTPatchAPIGuildWelcomeScreenJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildWelcomeScreen(guildId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -686,8 +733,8 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the emojis from
 	 * @param options - The options for fetching the emojis
 	 */
-	public async getEmojis(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildEmojis(guildId), { signal }) as Promise<RESTGetAPIGuildEmojisResult>;
+	public async getEmojis(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildEmojis(guildId), { auth, signal }) as Promise<RESTGetAPIGuildEmojisResult>;
 	}
 
 	/**
@@ -698,8 +745,12 @@ export class GuildsAPI {
 	 * @param emojiId - The id of the emoji to fetch
 	 * @param options - The options for fetching the emoji
 	 */
-	public async getEmoji(guildId: Snowflake, emojiId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildEmoji(guildId, emojiId), { signal }) as Promise<RESTGetAPIGuildEmojiResult>;
+	public async getEmoji(
+		guildId: Snowflake,
+		emojiId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		return this.rest.get(Routes.guildEmoji(guildId, emojiId), { auth, signal }) as Promise<RESTGetAPIGuildEmojiResult>;
 	}
 
 	/**
@@ -713,9 +764,10 @@ export class GuildsAPI {
 	public async createEmoji(
 		guildId: Snowflake,
 		body: RESTPostAPIGuildEmojiJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.guildEmojis(guildId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -735,9 +787,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		emojiId: Snowflake,
 		body: RESTPatchAPIGuildEmojiJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildEmoji(guildId, emojiId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -755,9 +808,9 @@ export class GuildsAPI {
 	public async deleteEmoji(
 		guildId: Snowflake,
 		emojiId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.guildEmoji(guildId, emojiId), { reason, signal });
+		await this.rest.delete(Routes.guildEmoji(guildId, emojiId), { auth, reason, signal });
 	}
 
 	/**
@@ -771,9 +824,10 @@ export class GuildsAPI {
 	public async getScheduledEvents(
 		guildId: Snowflake,
 		query: RESTGetAPIGuildScheduledEventsQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildScheduledEvents(guildId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIGuildScheduledEventsResult>;
@@ -790,9 +844,10 @@ export class GuildsAPI {
 	public async createScheduledEvent(
 		guildId: Snowflake,
 		body: RESTPostAPIGuildScheduledEventJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.guildScheduledEvents(guildId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -812,9 +867,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		eventId: Snowflake,
 		query: RESTGetAPIGuildScheduledEventQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildScheduledEvent(guildId, eventId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIGuildScheduledEventResult>;
@@ -833,9 +889,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		eventId: Snowflake,
 		body: RESTPatchAPIGuildScheduledEventJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildScheduledEvent(guildId, eventId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -853,9 +910,9 @@ export class GuildsAPI {
 	public async deleteScheduledEvent(
 		guildId: Snowflake,
 		eventId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.guildScheduledEvent(guildId, eventId), { reason, signal });
+		await this.rest.delete(Routes.guildScheduledEvent(guildId, eventId), { auth, reason, signal });
 	}
 
 	/**
@@ -871,9 +928,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		eventId: Snowflake,
 		query: RESTGetAPIGuildScheduledEventUsersQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildScheduledEventUsers(guildId, eventId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIGuildScheduledEventUsersResult>;
@@ -886,8 +944,8 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the templates from
 	 * @param options - The options for fetching the templates
 	 */
-	public async getTemplates(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildTemplates(guildId), { signal }) as Promise<RESTGetAPIGuildTemplatesResult>;
+	public async getTemplates(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildTemplates(guildId), { auth, signal }) as Promise<RESTGetAPIGuildTemplatesResult>;
 	}
 
 	/**
@@ -898,8 +956,13 @@ export class GuildsAPI {
 	 * @param templateCode - The code of the template to sync
 	 * @param options - The options for syncing the template
 	 */
-	public async syncTemplate(guildId: Snowflake, templateCode: string, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async syncTemplate(
+		guildId: Snowflake,
+		templateCode: string,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.put(Routes.guildTemplate(guildId, templateCode), {
+			auth,
 			signal,
 		}) as Promise<RESTPutAPIGuildTemplateSyncResult>;
 	}
@@ -917,9 +980,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		templateCode: string,
 		body: RESTPatchAPIGuildTemplateJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildTemplate(guildId, templateCode), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPatchAPIGuildTemplateResult>;
@@ -933,8 +997,12 @@ export class GuildsAPI {
 	 * @param templateCode - The code of the template to delete
 	 * @param options - The options for deleting the template
 	 */
-	public async deleteTemplate(guildId: Snowflake, templateCode: string, { signal }: Pick<RequestData, 'signal'> = {}) {
-		await this.rest.delete(Routes.guildTemplate(guildId, templateCode), { signal });
+	public async deleteTemplate(
+		guildId: Snowflake,
+		templateCode: string,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		await this.rest.delete(Routes.guildTemplate(guildId, templateCode), { auth, signal });
 	}
 
 	/**
@@ -944,8 +1012,8 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the stickers from
 	 * @param options - The options for fetching the stickers
 	 */
-	public async getStickers(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildStickers(guildId), { signal }) as Promise<RESTGetAPIGuildStickersResult>;
+	public async getStickers(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildStickers(guildId), { auth, signal }) as Promise<RESTGetAPIGuildStickersResult>;
 	}
 
 	/**
@@ -956,8 +1024,15 @@ export class GuildsAPI {
 	 * @param stickerId - The id of the sticker to fetch
 	 * @param options - The options for fetching the sticker
 	 */
-	public async getSticker(guildId: Snowflake, stickerId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildSticker(guildId, stickerId), { signal }) as Promise<RESTGetAPIGuildStickerResult>;
+	public async getSticker(
+		guildId: Snowflake,
+		stickerId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		return this.rest.get(Routes.guildSticker(guildId, stickerId), {
+			auth,
+			signal,
+		}) as Promise<RESTGetAPIGuildStickerResult>;
 	}
 
 	/**
@@ -971,11 +1046,12 @@ export class GuildsAPI {
 	public async createSticker(
 		guildId: Snowflake,
 		{ file, ...body }: CreateStickerOptions,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		const fileData = { ...file, key: 'file' };
 
 		return this.rest.post(Routes.guildStickers(guildId), {
+			auth,
 			appendToFormData: true,
 			body,
 			files: [fileData],
@@ -997,9 +1073,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		stickerId: Snowflake,
 		body: RESTPatchAPIGuildStickerJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildSticker(guildId, stickerId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -1017,9 +1094,9 @@ export class GuildsAPI {
 	public async deleteSticker(
 		guildId: Snowflake,
 		stickerId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.guildSticker(guildId, stickerId), { reason, signal });
+		await this.rest.delete(Routes.guildSticker(guildId, stickerId), { auth, reason, signal });
 	}
 
 	/**
@@ -1033,9 +1110,10 @@ export class GuildsAPI {
 	public async getAuditLogs(
 		guildId: Snowflake,
 		query: RESTGetAPIAuditLogQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildAuditLog(guildId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIAuditLogResult>;
@@ -1048,8 +1126,9 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the auto moderation rules from
 	 * @param options - The options for fetching the auto moderation rules
 	 */
-	public async getAutoModerationRules(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getAutoModerationRules(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.get(Routes.guildAutoModerationRules(guildId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIAutoModerationRulesResult>;
 	}
@@ -1065,9 +1144,10 @@ export class GuildsAPI {
 	public async getAutoModerationRule(
 		guildId: Snowflake,
 		ruleId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildAutoModerationRule(guildId, ruleId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIAutoModerationRuleResult>;
 	}
@@ -1083,9 +1163,10 @@ export class GuildsAPI {
 	public async createAutoModerationRule(
 		guildId: Snowflake,
 		body: RESTPostAPIAutoModerationRuleJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.guildAutoModerationRules(guildId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -1105,9 +1186,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		ruleId: Snowflake,
 		body: RESTPatchAPIAutoModerationRuleJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildAutoModerationRule(guildId, ruleId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -1125,9 +1207,9 @@ export class GuildsAPI {
 	public async deleteAutoModerationRule(
 		guildId: Snowflake,
 		ruleId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.guildAutoModerationRule(guildId, ruleId), { reason, signal });
+		await this.rest.delete(Routes.guildAutoModerationRule(guildId, ruleId), { auth, reason, signal });
 	}
 
 	/**
@@ -1138,8 +1220,12 @@ export class GuildsAPI {
 	 * @param userId - The id of the user
 	 * @param options - The options for fetching the guild member
 	 */
-	public async getMember(guildId: Snowflake, userId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildMember(guildId, userId), { signal }) as Promise<RESTGetAPIGuildMemberResult>;
+	public async getMember(
+		guildId: Snowflake,
+		userId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		return this.rest.get(Routes.guildMember(guildId, userId), { auth, signal }) as Promise<RESTGetAPIGuildMemberResult>;
 	}
 
 	/**
@@ -1153,9 +1239,10 @@ export class GuildsAPI {
 	public async searchForMembers(
 		guildId: Snowflake,
 		query: RESTGetAPIGuildMembersSearchQuery,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildMembersSearch(guildId), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIGuildMembersSearchResult>;
@@ -1174,9 +1261,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		userId: Snowflake,
 		body: RESTPatchAPIGuildMemberJSONBody = {},
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildMember(guildId, userId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -1194,9 +1282,9 @@ export class GuildsAPI {
 	public async removeMember(
 		guildId: Snowflake,
 		userId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		return this.rest.delete(Routes.guildMember(guildId, userId), { reason, signal });
+		return this.rest.delete(Routes.guildMember(guildId, userId), { auth, reason, signal });
 	}
 
 	/**
@@ -1212,9 +1300,9 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		userId: Snowflake,
 		roleId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.put(Routes.guildMemberRole(guildId, userId, roleId), { reason, signal });
+		await this.rest.put(Routes.guildMemberRole(guildId, userId, roleId), { auth, reason, signal });
 	}
 
 	/**
@@ -1230,9 +1318,9 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		userId: Snowflake,
 		roleId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.guildMemberRole(guildId, userId, roleId), { reason, signal });
+		await this.rest.delete(Routes.guildMemberRole(guildId, userId, roleId), { auth, reason, signal });
 	}
 
 	/**
@@ -1242,8 +1330,8 @@ export class GuildsAPI {
 	 * @param templateCode - The code of the template
 	 * @param options - The options for fetching the guild template
 	 */
-	public async getTemplate(templateCode: string, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.template(templateCode), { signal }) as Promise<RESTGetAPITemplateResult>;
+	public async getTemplate(templateCode: string, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.template(templateCode), { auth, signal }) as Promise<RESTGetAPITemplateResult>;
 	}
 
 	/**
@@ -1257,9 +1345,13 @@ export class GuildsAPI {
 	public async createTemplate(
 		templateCode: string,
 		body: RESTPostAPIGuildTemplatesJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
-		return this.rest.post(Routes.template(templateCode), { body, signal }) as Promise<RESTPostAPIGuildTemplatesResult>;
+		return this.rest.post(Routes.template(templateCode), {
+			auth,
+			body,
+			signal,
+		}) as Promise<RESTPostAPIGuildTemplatesResult>;
 	}
 
 	/**
@@ -1267,9 +1359,10 @@ export class GuildsAPI {
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/webhook#get-guild-webhooks}
 	 * @param id - The id of the guild
+	 * @param options - The options for fetching the webhooks
 	 */
-	public async getWebhooks(id: Snowflake) {
-		return this.rest.get(Routes.guildWebhooks(id)) as Promise<RESTGetAPIGuildWebhooksResult>;
+	public async getWebhooks(id: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildWebhooks(id), { auth, signal }) as Promise<RESTGetAPIGuildWebhooksResult>;
 	}
 
 	/**
@@ -1279,8 +1372,8 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild
 	 * @param options - The options for fetching the guild onboarding
 	 */
-	public async getOnboarding(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.guildOnboarding(guildId), { signal }) as Promise<RESTGetAPIGuildOnboardingResult>;
+	public async getOnboarding(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.guildOnboarding(guildId), { auth, signal }) as Promise<RESTGetAPIGuildOnboardingResult>;
 	}
 
 	/**
@@ -1294,9 +1387,10 @@ export class GuildsAPI {
 	public async editOnboarding(
 		guildId: Snowflake,
 		body: RESTPutAPIGuildOnboardingJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.put(Routes.guildOnboarding(guildId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -1310,8 +1404,9 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to fetch the soundboard sounds for
 	 * @param options - The options for fetching the soundboard sounds
 	 */
-	public async getSoundboardSounds(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getSoundboardSounds(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.get(Routes.guildSoundboardSounds(guildId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIGuildSoundboardSoundsResult>;
 	}
@@ -1327,9 +1422,10 @@ export class GuildsAPI {
 	public async getSoundboardSound(
 		guildId: Snowflake,
 		soundId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.guildSoundboardSound(guildId, soundId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIGuildSoundboardSoundResult>;
 	}
@@ -1345,9 +1441,10 @@ export class GuildsAPI {
 	public async createSoundboardSound(
 		guildId: Snowflake,
 		body: RESTPostAPIGuildSoundboardSoundJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.guildSoundboardSounds(guildId), {
+			auth,
 			body,
 			reason,
 			signal,
@@ -1367,9 +1464,10 @@ export class GuildsAPI {
 		guildId: Snowflake,
 		soundId: Snowflake,
 		body: RESTPatchAPIGuildSoundboardSoundJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildSoundboardSound(guildId, soundId), {
+			auth,
 			body,
 			reason,
 			signal,
@@ -1387,8 +1485,8 @@ export class GuildsAPI {
 	public async deleteSoundboardSound(
 		guildId: Snowflake,
 		soundId: Snowflake,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.guildSoundboardSound(guildId, soundId), { reason, signal });
+		await this.rest.delete(Routes.guildSoundboardSound(guildId, soundId), { auth, reason, signal });
 	}
 }

--- a/packages/core/src/api/invite.ts
+++ b/packages/core/src/api/invite.ts
@@ -14,8 +14,13 @@ export class InvitesAPI {
 	 * @param query - The options for fetching the invite
 	 * @param options - The options for fetching the invite
 	 */
-	public async get(code: string, query: RESTGetAPIInviteQuery = {}, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async get(
+		code: string,
+		query: RESTGetAPIInviteQuery = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.get(Routes.invite(code), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPIInviteResult>;
@@ -28,7 +33,7 @@ export class InvitesAPI {
 	 * @param code - The invite code
 	 * @param options - The options for deleting the invite
 	 */
-	public async delete(code: string, { reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {}) {
-		await this.rest.delete(Routes.invite(code), { reason, signal });
+	public async delete(code: string, { auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {}) {
+		await this.rest.delete(Routes.invite(code), { auth, reason, signal });
 	}
 }

--- a/packages/core/src/api/monetization.ts
+++ b/packages/core/src/api/monetization.ts
@@ -25,8 +25,8 @@ export class MonetizationAPI {
 	 * @param applicationId - The application id to fetch SKUs for
 	 * @param options - The options for fetching the SKUs.
 	 */
-	public async getSKUs(applicationId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.skus(applicationId), { signal }) as Promise<RESTGetAPISKUsResult>;
+	public async getSKUs(applicationId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.skus(applicationId), { auth, signal }) as Promise<RESTGetAPISKUsResult>;
 	}
 
 	/**
@@ -40,9 +40,10 @@ export class MonetizationAPI {
 	public async getSKUSubscriptions(
 		skuId: Snowflake,
 		query: RESTGetAPISKUSubscriptionsQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.skuSubscriptions(skuId), {
+			auth,
 			signal,
 			query: makeURLSearchParams(query),
 		}) as Promise<RESTGetAPISKUSubscriptionsResult>;
@@ -59,9 +60,10 @@ export class MonetizationAPI {
 	public async getSKUSubscription(
 		skuId: Snowflake,
 		subscriptionId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.skuSubscription(skuId, subscriptionId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPISKUSubscriptionResult>;
 	}
@@ -77,9 +79,10 @@ export class MonetizationAPI {
 	public async getEntitlements(
 		applicationId: Snowflake,
 		query: RESTGetAPIEntitlementsQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.entitlements(applicationId), {
+			auth,
 			signal,
 			query: makeURLSearchParams(query),
 		}) as Promise<RESTGetAPIEntitlementsResult>;
@@ -96,9 +99,10 @@ export class MonetizationAPI {
 	public async getEntitlement(
 		applicationId: Snowflake,
 		entitlementId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.entitlement(applicationId, entitlementId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIEntitlementResult>;
 	}
@@ -114,9 +118,10 @@ export class MonetizationAPI {
 	public async createTestEntitlement(
 		applicationId: Snowflake,
 		body: RESTPostAPIEntitlementJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.entitlements(applicationId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPostAPIEntitlementResult>;
@@ -133,9 +138,9 @@ export class MonetizationAPI {
 	public async deleteTestEntitlement(
 		applicationId: Snowflake,
 		entitlementId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
-		await this.rest.delete(Routes.entitlement(applicationId, entitlementId), { signal });
+		await this.rest.delete(Routes.entitlement(applicationId, entitlementId), { auth, signal });
 	}
 
 	/**
@@ -149,8 +154,8 @@ export class MonetizationAPI {
 	public async consumeEntitlement(
 		applicationId: Snowflake,
 		entitlementId: Snowflake,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
-		await this.rest.post(Routes.consumeEntitlement(applicationId, entitlementId), { signal });
+		await this.rest.post(Routes.consumeEntitlement(applicationId, entitlementId), { auth, signal });
 	}
 }

--- a/packages/core/src/api/oauth2.ts
+++ b/packages/core/src/api/oauth2.ts
@@ -106,8 +106,9 @@ export class OAuth2API {
 	 * @see {@link https://discord.com/developers/docs/topics/oauth2#get-current-bot-application-information}
 	 * @param options - The options for the current bot application information request
 	 */
-	public async getCurrentBotApplicationInformation({ signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getCurrentBotApplicationInformation({ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.get(Routes.oauth2CurrentApplication(), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIOAuth2CurrentApplicationResult>;
 	}
@@ -118,8 +119,9 @@ export class OAuth2API {
 	 * @see {@link https://discord.com/developers/docs/topics/oauth2#get-current-authorization-information}
 	 * @param options - The options for the current authorization information request
 	 */
-	public async getCurrentAuthorizationInformation({ signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getCurrentAuthorizationInformation({ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.get(Routes.oauth2CurrentAuthorization(), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIOAuth2CurrentAuthorizationResult>;
 	}

--- a/packages/core/src/api/poll.ts
+++ b/packages/core/src/api/poll.ts
@@ -27,9 +27,10 @@ export class PollAPI {
 		messageId: Snowflake,
 		answerId: number,
 		query: RESTGetAPIPollAnswerVotersQuery = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.get(Routes.pollAnswerVoters(channelId, messageId, answerId), {
+			auth,
 			signal,
 			query: makeURLSearchParams(query),
 		}) as Promise<RESTGetAPIPollAnswerVotersResult>;
@@ -43,8 +44,13 @@ export class PollAPI {
 	 * @param messageId - The id of the message containing the poll
 	 * @param options - The options for expiring the poll
 	 */
-	public async expirePoll(channelId: Snowflake, messageId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async expirePoll(
+		channelId: Snowflake,
+		messageId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.post(Routes.expirePoll(channelId, messageId), {
+			auth,
 			signal,
 		}) as Promise<RESTPostAPIPollExpireResult>;
 	}

--- a/packages/core/src/api/roleConnections.ts
+++ b/packages/core/src/api/roleConnections.ts
@@ -19,8 +19,12 @@ export class RoleConnectionsAPI {
 	 * @param applicationId - The id of the application to get role connection metadata records for
 	 * @param options - The options for fetching the role connection metadata records
 	 */
-	public async getMetadataRecords(applicationId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getMetadataRecords(
+		applicationId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.get(Routes.applicationRoleConnectionMetadata(applicationId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIApplicationRoleConnectionMetadataResult>;
 	}
@@ -36,9 +40,10 @@ export class RoleConnectionsAPI {
 	public async updateMetadataRecords(
 		applicationId: Snowflake,
 		body: RESTPutAPIApplicationRoleConnectionMetadataJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.put(Routes.applicationRoleConnectionMetadata(applicationId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPutAPIApplicationRoleConnectionMetadataResult>;

--- a/packages/core/src/api/soundboardSounds.ts
+++ b/packages/core/src/api/soundboardSounds.ts
@@ -12,8 +12,9 @@ export class SoundboardSoundsAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/soundboard#list-default-soundboard-sounds}
 	 * @param options - The options for fetching the soundboard default sounds.
 	 */
-	public async getSoundboardDefaultSounds({ signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getSoundboardDefaultSounds({ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.get(Routes.soundboardDefaultSounds(), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPISoundboardDefaultSoundsResult>;
 	}

--- a/packages/core/src/api/stageInstances.ts
+++ b/packages/core/src/api/stageInstances.ts
@@ -23,9 +23,10 @@ export class StageInstancesAPI {
 	 */
 	public async create(
 		body: RESTPostAPIStageInstanceJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.stageInstances(), {
+			auth,
 			body,
 			reason,
 			signal,
@@ -39,8 +40,8 @@ export class StageInstancesAPI {
 	 * @param channelId - The id of the channel
 	 * @param options - The options for fetching the stage instance
 	 */
-	public async get(channelId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.stageInstance(channelId), { signal }) as Promise<RESTGetAPIStageInstanceResult>;
+	public async get(channelId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.stageInstance(channelId), { auth, signal }) as Promise<RESTGetAPIStageInstanceResult>;
 	}
 
 	/**
@@ -54,9 +55,10 @@ export class StageInstancesAPI {
 	public async edit(
 		channelId: Snowflake,
 		body: RESTPatchAPIStageInstanceJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.stageInstance(channelId), {
+			auth,
 			body,
 			reason,
 			signal,
@@ -70,7 +72,10 @@ export class StageInstancesAPI {
 	 * @param channelId - The id of the channel
 	 * @param options - The options for deleting the stage instance
 	 */
-	public async delete(channelId: Snowflake, { reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {}) {
-		await this.rest.delete(Routes.stageInstance(channelId), { reason, signal });
+	public async delete(
+		channelId: Snowflake,
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
+	) {
+		await this.rest.delete(Routes.stageInstance(channelId), { auth, reason, signal });
 	}
 }

--- a/packages/core/src/api/sticker.ts
+++ b/packages/core/src/api/sticker.ts
@@ -19,8 +19,8 @@ export class StickersAPI {
 	 * @param packId - The id of the sticker pack
 	 * @param options - The options for fetching the sticker pack
 	 */
-	public async getStickerPack(packId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.stickerPack(packId), { signal }) as Promise<RESTGetAPIStickerPackResult>;
+	public async getStickerPack(packId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.stickerPack(packId), { auth, signal }) as Promise<RESTGetAPIStickerPackResult>;
 	}
 
 	/**
@@ -29,8 +29,8 @@ export class StickersAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/sticker#list-sticker-packs}
 	 * @param options - The options for fetching the sticker packs
 	 */
-	public async getStickers({ signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.stickerPacks(), { signal }) as Promise<RESTGetStickerPacksResult>;
+	public async getStickers({ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.stickerPacks(), { auth, signal }) as Promise<RESTGetStickerPacksResult>;
 	}
 
 	/**
@@ -40,7 +40,7 @@ export class StickersAPI {
 	 * @param stickerId - The id of the sticker
 	 * @param options - The options for fetching the sticker
 	 */
-	public async get(stickerId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.sticker(stickerId), { signal }) as Promise<RESTGetAPIStickerResult>;
+	public async get(stickerId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.sticker(stickerId), { auth, signal }) as Promise<RESTGetAPIStickerResult>;
 	}
 }

--- a/packages/core/src/api/thread.ts
+++ b/packages/core/src/api/thread.ts
@@ -18,8 +18,8 @@ export class ThreadsAPI {
 	 * @param threadId - The id of the thread to join
 	 * @param options - The options for joining the thread
 	 */
-	public async join(threadId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		await this.rest.put(Routes.threadMembers(threadId, '@me'), { signal });
+	public async join(threadId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		await this.rest.put(Routes.threadMembers(threadId, '@me'), { auth, signal });
 	}
 
 	/**
@@ -30,8 +30,12 @@ export class ThreadsAPI {
 	 * @param userId - The id of the user to add to the thread
 	 * @param options - The options for adding the member to the thread
 	 */
-	public async addMember(threadId: Snowflake, userId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		await this.rest.put(Routes.threadMembers(threadId, userId), { signal });
+	public async addMember(
+		threadId: Snowflake,
+		userId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		await this.rest.put(Routes.threadMembers(threadId, userId), { auth, signal });
 	}
 
 	/**
@@ -41,8 +45,8 @@ export class ThreadsAPI {
 	 * @param threadId - The id of the thread to leave
 	 * @param options - The options for leaving the thread
 	 */
-	public async leave(threadId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		await this.rest.delete(Routes.threadMembers(threadId, '@me'), { signal });
+	public async leave(threadId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		await this.rest.delete(Routes.threadMembers(threadId, '@me'), { auth, signal });
 	}
 
 	/**
@@ -53,8 +57,12 @@ export class ThreadsAPI {
 	 * @param userId - The id of the user to remove from the thread
 	 * @param options - The options for removing the member from the thread
 	 */
-	public async removeMember(threadId: Snowflake, userId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		await this.rest.delete(Routes.threadMembers(threadId, userId), { signal });
+	public async removeMember(
+		threadId: Snowflake,
+		userId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		await this.rest.delete(Routes.threadMembers(threadId, userId), { auth, signal });
 	}
 
 	/**
@@ -65,8 +73,12 @@ export class ThreadsAPI {
 	 * @param userId - The id of the user
 	 * @param options - The options for fetching the member
 	 */
-	public async getMember(threadId: Snowflake, userId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.threadMembers(threadId, userId), { signal }) as Promise<APIThreadMember>;
+	public async getMember(
+		threadId: Snowflake,
+		userId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		return this.rest.get(Routes.threadMembers(threadId, userId), { auth, signal }) as Promise<APIThreadMember>;
 	}
 
 	/**
@@ -76,7 +88,10 @@ export class ThreadsAPI {
 	 * @param threadId - The id of the thread to fetch the members from
 	 * @param options - The options for fetching the members
 	 */
-	public async getAllMembers(threadId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.threadMembers(threadId), { signal }) as Promise<RESTGetAPIChannelThreadMembersResult>;
+	public async getAllMembers(threadId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.threadMembers(threadId), {
+			auth,
+			signal,
+		}) as Promise<RESTGetAPIChannelThreadMembersResult>;
 	}
 }

--- a/packages/core/src/api/user.ts
+++ b/packages/core/src/api/user.ts
@@ -30,8 +30,8 @@ export class UsersAPI {
 	 * @param userId - The id of the user to fetch
 	 * @param options - The options for fetching the user
 	 */
-	public async get(userId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.user(userId), { signal }) as Promise<RESTGetAPIUserResult>;
+	public async get(userId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.user(userId), { auth, signal }) as Promise<RESTGetAPIUserResult>;
 	}
 
 	/**
@@ -40,8 +40,8 @@ export class UsersAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/user#get-current-user}
 	 * @param options - The options for fetching the current user
 	 */
-	public async getCurrent({ signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.user('@me'), { signal }) as Promise<RESTGetAPICurrentUserResult>;
+	public async getCurrent({ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.user('@me'), { auth, signal }) as Promise<RESTGetAPICurrentUserResult>;
 	}
 
 	/**
@@ -51,8 +51,12 @@ export class UsersAPI {
 	 * @param query - The query options for fetching the current user's guilds
 	 * @param options - The options for fetching the guilds
 	 */
-	public async getGuilds(query: RESTGetAPICurrentUserGuildsQuery = {}, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getGuilds(
+		query: RESTGetAPICurrentUserGuildsQuery = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.get(Routes.userGuilds(), {
+			auth,
 			query: makeURLSearchParams(query),
 			signal,
 		}) as Promise<RESTGetAPICurrentUserGuildsResult>;
@@ -65,8 +69,8 @@ export class UsersAPI {
 	 * @param guildId - The id of the guild
 	 * @param options - The options for leaving the guild
 	 */
-	public async leaveGuild(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		await this.rest.delete(Routes.userGuild(guildId), { signal });
+	public async leaveGuild(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		await this.rest.delete(Routes.userGuild(guildId), { auth, signal });
 	}
 
 	/**
@@ -76,8 +80,11 @@ export class UsersAPI {
 	 * @param body - The new data for the current user
 	 * @param options - The options for editing the user
 	 */
-	public async edit(body: RESTPatchAPICurrentUserJSONBody, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.patch(Routes.user('@me'), { body, signal }) as Promise<RESTPatchAPICurrentUserResult>;
+	public async edit(
+		body: RESTPatchAPICurrentUserJSONBody,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
+		return this.rest.patch(Routes.user('@me'), { auth, body, signal }) as Promise<RESTPatchAPICurrentUserResult>;
 	}
 
 	/**
@@ -87,8 +94,11 @@ export class UsersAPI {
 	 * @param guildId - The id of the guild
 	 * @param options - The options for fetching the guild member
 	 */
-	public async getGuildMember(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.userGuildMember(guildId), { signal }) as Promise<RESTGetCurrentUserGuildMemberResult>;
+	public async getGuildMember(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.userGuildMember(guildId), {
+			auth,
+			signal,
+		}) as Promise<RESTGetCurrentUserGuildMemberResult>;
 	}
 
 	/**
@@ -102,9 +112,10 @@ export class UsersAPI {
 	public async editCurrentGuildMember(
 		guildId: Snowflake,
 		body: RESTPatchAPIGuildMemberJSONBody = {},
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildMember(guildId, '@me'), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -118,8 +129,9 @@ export class UsersAPI {
 	 * @param userId - The id of the user to open a DM channel with
 	 * @param options - The options for opening the DM
 	 */
-	public async createDM(userId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async createDM(userId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.post(Routes.userChannels(), {
+			auth,
 			body: { recipient_id: userId },
 			signal,
 		}) as Promise<RESTPostAPICurrentUserCreateDMChannelResult>;
@@ -131,8 +143,8 @@ export class UsersAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/user#get-user-connections}
 	 * @param options - The options for fetching the user's connections
 	 */
-	public async getConnections({ signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.userConnections(), { signal }) as Promise<RESTGetAPICurrentUserConnectionsResult>;
+	public async getConnections({ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.userConnections(), { auth, signal }) as Promise<RESTGetAPICurrentUserConnectionsResult>;
 	}
 
 	/**
@@ -142,8 +154,12 @@ export class UsersAPI {
 	 * @param applicationId - The id of the application
 	 * @param options - The options for fetching the role connections
 	 */
-	public async getApplicationRoleConnection(applicationId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getApplicationRoleConnection(
+		applicationId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.get(Routes.userApplicationRoleConnection(applicationId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPICurrentUserApplicationRoleConnectionResult>;
 	}
@@ -159,9 +175,10 @@ export class UsersAPI {
 	public async updateApplicationRoleConnection(
 		applicationId: Snowflake,
 		body: RESTPutAPICurrentUserApplicationRoleConnectionJSONBody,
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.put(Routes.userApplicationRoleConnection(applicationId), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPutAPICurrentUserApplicationRoleConnectionResult>;

--- a/packages/core/src/api/voice.ts
+++ b/packages/core/src/api/voice.ts
@@ -22,8 +22,8 @@ export class VoiceAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/voice#list-voice-regions}
 	 * @param options - The options for fetching the voice regions
 	 */
-	public async getVoiceRegions({ signal }: Pick<RequestData, 'signal'> = {}) {
-		return this.rest.get(Routes.voiceRegions(), { signal }) as Promise<RESTGetAPIVoiceRegionsResult>;
+	public async getVoiceRegions({ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		return this.rest.get(Routes.voiceRegions(), { auth, signal }) as Promise<RESTGetAPIVoiceRegionsResult>;
 	}
 
 	/**
@@ -32,8 +32,13 @@ export class VoiceAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/voice#get-user-voice-state}
 	 * @param options - The options for fetching user voice state
 	 */
-	public async getUserVoiceState(guildId: Snowflake, userId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getUserVoiceState(
+		guildId: Snowflake,
+		userId: Snowflake,
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.get(Routes.guildVoiceState(guildId, userId), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIGuildVoiceStateUserResult>;
 	}
@@ -44,8 +49,9 @@ export class VoiceAPI {
 	 * @see {@link https://discord.com/developers/docs/resources/voice#get-current-user-voice-state}
 	 * @param options - The options for fetching user voice state
 	 */
-	public async getVoiceState(guildId: Snowflake, { signal }: Pick<RequestData, 'signal'> = {}) {
+	public async getVoiceState(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
 		return this.rest.get(Routes.guildVoiceState(guildId, '@me'), {
+			auth,
 			signal,
 		}) as Promise<RESTGetAPIGuildVoiceStateCurrentMemberResult>;
 	}
@@ -63,9 +69,10 @@ export class VoiceAPI {
 		guildId: Snowflake,
 		userId: Snowflake,
 		body: RESTPatchAPIGuildVoiceStateUserJSONBody,
-		{ reason, signal }: Pick<RequestData, 'reason' | 'signal'> = {},
+		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildVoiceState(guildId, userId), {
+			auth,
 			reason,
 			body,
 			signal,
@@ -83,9 +90,10 @@ export class VoiceAPI {
 	public async editVoiceState(
 		guildId: Snowflake,
 		body: RESTPatchAPIGuildVoiceStateCurrentMemberJSONBody = {},
-		{ signal }: Pick<RequestData, 'signal'> = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
 		return this.rest.patch(Routes.guildVoiceState(guildId, '@me'), {
+			auth,
 			body,
 			signal,
 		}) as Promise<RESTPatchAPIGuildVoiceStateCurrentMemberResult>;

--- a/packages/rest/src/lib/utils/types.ts
+++ b/packages/rest/src/lib/utils/types.ts
@@ -295,7 +295,7 @@ export interface RequestData {
 	 *
 	 * @defaultValue `true`
 	 */
-	auth?: AuthData | boolean;
+	auth?: AuthData | boolean | undefined;
 	/**
 	 * The body to send to this request.
 	 * If providing as BodyInit, set `passThroughBody: true`


### PR DESCRIPTION
With #10682, we can now support configuring `auth` per request in /core.

Resolves DJS-42

