### PR TITLE
refactor!: consolidate parameters into a single `options` object

### DIFF
--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -118,7 +118,7 @@ class ApplicationCommandManager extends CachedManager {
     const { cache, force, guildId, id, locale, withLocalizations } = options;
 
     if (typeof options === 'string' || typeof id === 'string') {
-      return this._fetchSingle({ cache, force, guildId, id: options.id ?? options });
+      return this._fetchSingle({ cache, force, guildId, id: id ?? options });
     }
 
     return this._fetchMany({ cache, guildId, locale, withLocalizations });

--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -115,11 +115,11 @@ class ApplicationCommandManager extends CachedManager {
   async fetch(options) {
     if (!options) return this._fetchMany();
 
+    if (typeof options === 'string') return this._fetchSingle({ id: options });
+
     const { cache, force, guildId, id, locale, withLocalizations } = options;
 
-    if (typeof options === 'string' || typeof id === 'string') {
-      return this._fetchSingle({ cache, force, guildId, id: id ?? options });
-    }
+    if (id) return this._fetchSingle({ cache, force, guildId, id });
 
     return this._fetchMany({ cache, guildId, locale, withLocalizations });
   }

--- a/packages/discord.js/src/managers/ApplicationCommandManager.js
+++ b/packages/discord.js/src/managers/ApplicationCommandManager.js
@@ -81,6 +81,7 @@ class ApplicationCommandManager extends CachedManager {
   /**
    * Options used to fetch Application Commands from Discord
    * @typedef {BaseFetchOptions} FetchApplicationCommandOptions
+   * @property {Snowflake} [id] The command's id to fetch
    * @property {Snowflake} [guildId] The guild's id to fetch commands for, for when the guild is not cached
    * @property {Locale} [locale] The locale to use when fetching this command
    * @property {boolean} [withLocalizations] Whether to fetch all localization data
@@ -88,12 +89,11 @@ class ApplicationCommandManager extends CachedManager {
 
   /**
    * Obtains one or multiple application commands from Discord, or the cache if it's already available.
-   * @param {Snowflake|FetchApplicationCommandOptions} [id] Options for fetching application command(s)
-   * @param {FetchApplicationCommandOptions} [options] Additional options for this fetch
+   * @param {FetchApplicationCommandOptions} [options] Options for fetching application command(s)
    * @returns {Promise<ApplicationCommand|Collection<Snowflake, ApplicationCommand>>}
    * @example
    * // Fetch a single command
-   * client.application.commands.fetch('123456789012345678')
+   * client.application.commands.fetch({ id: '123456789012345678' })
    *   .then(command => console.log(`Fetched command ${command.name}`))
    *   .catch(console.error);
    * @example
@@ -102,10 +102,12 @@ class ApplicationCommandManager extends CachedManager {
    *   .then(commands => console.log(`Fetched ${commands.size} commands`))
    *   .catch(console.error);
    */
-  async fetch(id, { guildId, cache = true, force = false, locale, withLocalizations } = {}) {
-    if (typeof id === 'object') {
-      ({ guildId, cache = true, locale, withLocalizations } = id);
-    } else if (id) {
+  async fetch(options = {}) {
+    if (typeof options !== 'object') throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'options', 'object', true);
+
+    const { cache = true, force = false, guildId, id, locale, withLocalizations } = options;
+
+    if (id) {
       if (!force) {
         const existing = this.cache.get(id);
         if (existing) return existing;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3913,7 +3913,7 @@ export class ApplicationCommandManager<
     guildId: Snowflake,
   ): Promise<ApplicationCommand>;
   public fetch(
-    options: Omit<FetchApplicationCommandOptions, 'guildId'> & { id: Snowflake },
+    options: Snowflake | (Omit<FetchApplicationCommandOptions, 'guildId'> & { id: Snowflake }),
   ): Promise<ApplicationCommandScope>;
   public fetch(
     options: FetchApplicationCommandOptions & { id: Snowflake; guildId: Snowflake },
@@ -4091,7 +4091,9 @@ export class GuildApplicationCommandManager extends ApplicationCommandManager<Ap
     command: ApplicationCommandResolvable,
     data: Partial<ApplicationCommandDataResolvable>,
   ): Promise<ApplicationCommand>;
-  public fetch(options: FetchGuildApplicationCommandFetchOptions & { id: Snowflake }): Promise<ApplicationCommand>;
+  public fetch(
+    options: Snowflake | (FetchGuildApplicationCommandFetchOptions & { id: Snowflake }),
+  ): Promise<ApplicationCommand>;
   public fetch(
     options?: Omit<FetchGuildApplicationCommandFetchOptions, 'id'>,
   ): Promise<Collection<Snowflake, ApplicationCommand>>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3919,10 +3919,7 @@ export class ApplicationCommandManager<
     options: FetchApplicationCommandOptions & { id: Snowflake; guildId: Snowflake },
   ): Promise<ApplicationCommand>;
   public fetch(
-    options: Omit<FetchApplicationCommandOptions, 'id'> & { guildId: Snowflake },
-  ): Promise<Collection<Snowflake, ApplicationCommandScope>>;
-  public fetch(
-    options?: Omit<FetchApplicationCommandOptions, 'id' | 'guildId'>,
+    options?: Omit<FetchApplicationCommandOptions, 'id'>,
   ): Promise<Collection<Snowflake, ApplicationCommandScope>>;
   public set(
     commands: readonly ApplicationCommandDataResolvable[],

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3913,14 +3913,16 @@ export class ApplicationCommandManager<
     guildId: Snowflake,
   ): Promise<ApplicationCommand>;
   public fetch(
-    id: Snowflake,
-    options: FetchApplicationCommandOptions & { guildId: Snowflake },
-  ): Promise<ApplicationCommand>;
-  public fetch(options: FetchApplicationCommandOptions): Promise<Collection<Snowflake, ApplicationCommandScope>>;
-  public fetch(id: Snowflake, options?: FetchApplicationCommandOptions): Promise<ApplicationCommandScope>;
+    options: Omit<FetchApplicationCommandOptions, 'guildId'> & { id: Snowflake },
+  ): Promise<ApplicationCommandScope>;
   public fetch(
-    id?: Snowflake,
-    options?: FetchApplicationCommandOptions,
+    options: FetchApplicationCommandOptions & { id: Snowflake; guildId: Snowflake },
+  ): Promise<ApplicationCommand>;
+  public fetch(
+    options: Omit<FetchApplicationCommandOptions, 'id'> & { guildId: Snowflake },
+  ): Promise<Collection<Snowflake, ApplicationCommandScope>>;
+  public fetch(
+    options?: Omit<FetchApplicationCommandOptions, 'id' | 'guildId'>,
   ): Promise<Collection<Snowflake, ApplicationCommandScope>>;
   public set(
     commands: readonly ApplicationCommandDataResolvable[],
@@ -4089,11 +4091,9 @@ export class GuildApplicationCommandManager extends ApplicationCommandManager<Ap
     command: ApplicationCommandResolvable,
     data: Partial<ApplicationCommandDataResolvable>,
   ): Promise<ApplicationCommand>;
-  public fetch(id: Snowflake, options?: FetchGuildApplicationCommandFetchOptions): Promise<ApplicationCommand>;
-  public fetch(options: FetchGuildApplicationCommandFetchOptions): Promise<Collection<Snowflake, ApplicationCommand>>;
+  public fetch(options: FetchGuildApplicationCommandFetchOptions & { id: Snowflake }): Promise<ApplicationCommand>;
   public fetch(
-    id?: undefined,
-    options?: FetchGuildApplicationCommandFetchOptions,
+    options?: Omit<FetchGuildApplicationCommandFetchOptions, 'id'>,
   ): Promise<Collection<Snowflake, ApplicationCommand>>;
   public set(commands: readonly ApplicationCommandDataResolvable[]): Promise<Collection<Snowflake, ApplicationCommand>>;
 }
@@ -5461,6 +5461,7 @@ export type EmojiIdentifierResolvable =
 export type EmojiResolvable = Snowflake | GuildEmoji | ReactionEmoji | ApplicationEmoji;
 
 export interface FetchApplicationCommandOptions extends BaseFetchOptions {
+  id?: Snowflake;
   guildId?: Snowflake;
   locale?: Locale;
   withLocalizations?: boolean;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -711,9 +711,9 @@ client.on('clientReady', async client => {
   );
 
   // Test command manager methods
-  const globalCommand = await client.application?.commands.fetch(globalCommandId);
-  const guildCommandFromGlobal = await client.application?.commands.fetch(guildCommandId, { guildId: testGuildId });
-  const guildCommandFromGuild = await client.guilds.cache.get(testGuildId)?.commands.fetch(guildCommandId);
+  const globalCommand = await client.application?.commands.fetch({ id: globalCommandId });
+  const guildCommandFromGlobal = await client.application?.commands.fetch({ id: guildCommandId, guildId: testGuildId });
+  const guildCommandFromGuild = await client.guilds.cache.get(testGuildId)?.commands.fetch({ id: guildCommandId });
 
   await client.application?.commands.create(slashCommandBuilder);
   await client.application?.commands.create(contextMenuCommandBuilder);
@@ -1589,9 +1589,8 @@ declare const autoModerationRuleManager: AutoModerationRuleManager;
 }
 
 declare const guildApplicationCommandManager: GuildApplicationCommandManager;
+expectType<Promise<ApplicationCommand>>(guildApplicationCommandManager.fetch({ id: '0' }));
 expectType<Promise<Collection<Snowflake, ApplicationCommand>>>(guildApplicationCommandManager.fetch());
-expectType<Promise<Collection<Snowflake, ApplicationCommand>>>(guildApplicationCommandManager.fetch(undefined, {}));
-expectType<Promise<ApplicationCommand>>(guildApplicationCommandManager.fetch('0'));
 
 declare const categoryChannelChildManager: CategoryChannelChildManager;
 {

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -711,7 +711,7 @@ client.on('clientReady', async client => {
   );
 
   // Test command manager methods
-  const globalCommand = await client.application?.commands.fetch({ id: globalCommandId });
+  const globalCommand = await client.application?.commands.fetch(globalCommandId);
   const guildCommandFromGlobal = await client.application?.commands.fetch({ id: guildCommandId, guildId: testGuildId });
   const guildCommandFromGuild = await client.guilds.cache.get(testGuildId)?.commands.fetch({ id: guildCommandId });
 
@@ -1589,6 +1589,7 @@ declare const autoModerationRuleManager: AutoModerationRuleManager;
 }
 
 declare const guildApplicationCommandManager: GuildApplicationCommandManager;
+expectType<Promise<ApplicationCommand>>(guildApplicationCommandManager.fetch('0'));
 expectType<Promise<ApplicationCommand>>(guildApplicationCommandManager.fetch({ id: '0' }));
 expectType<Promise<Collection<Snowflake, ApplicationCommand>>>(guildApplicationCommandManager.fetch());
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Removes `options` as the second parameter. The first parameter now accepts `id` or `options` which can also have the `id` property. Internal discussion [here](https://canary.discord.com/channels/222078108977594368/1209960895141388389/1330584992564379648)

BREAKING CHANGE: `ApplicationCommandManager#fetch` and `GuildApplicationCommandManager#fetch` no longer accept 2 parameters. Instead, the first parameter accepts `id` or `options` which can now also have the `id` property.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
