### PR TITLE
docs(guild): Remove "all" for listing guild members

### DIFF
--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -206,7 +206,7 @@ export class GuildsAPI {
 	}
 
 	/**
-	 * Fetches all the members of a guild
+	 * Fetches members of a guild.
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/guild#list-guild-members}
 	 * @param guildId - The id of the guild


### PR DESCRIPTION
This endpoint does not fetch all the members. It's bound by a limit of a maximum of 1,000.