### PR TITLE
feat(collection): honour subclassing via `@@species` in static methods

### DIFF
--- a/packages/collection/__tests__/collection.test.ts
+++ b/packages/collection/__tests__/collection.test.ts
@@ -1099,3 +1099,58 @@ describe('findLastKey() tests', () => {
 		}, null);
 	});
 });
+
+describe('subclassing tests', () => {
+	class DerivedCollection<Key, Value> extends Collection<Key, Value> {}
+
+	test('constructor[Symbol.species]', () => {
+		expect(DerivedCollection[Symbol.species]).toStrictEqual(DerivedCollection);
+	});
+
+	describe('methods that construct new collections return subclassed objects', () => {
+		const coll = new DerivedCollection();
+
+		test('filter()', () => {
+			expect(coll.filter(Boolean)).toBeInstanceOf(DerivedCollection);
+		});
+		test('partition()', () => {
+			for (const partition of coll.partition(Boolean)) {
+				expect(partition).toBeInstanceOf(DerivedCollection);
+			}
+		});
+		test('flatMap()', () => {
+			expect(coll.flatMap(() => new Collection())).toBeInstanceOf(DerivedCollection);
+		});
+		test('mapValues()', () => {
+			expect(coll.mapValues(Object)).toBeInstanceOf(DerivedCollection);
+		});
+		test('clone()', () => {
+			expect(coll.clone()).toBeInstanceOf(DerivedCollection);
+		});
+		test('intersection()', () => {
+			expect(coll.intersection(new Collection())).toBeInstanceOf(DerivedCollection);
+		});
+		test('union()', () => {
+			expect(coll.union(new Collection())).toBeInstanceOf(DerivedCollection);
+		});
+		test('difference()', () => {
+			expect(coll.difference(new Collection())).toBeInstanceOf(DerivedCollection);
+		});
+		test('symmetricDifference()', () => {
+			expect(coll.symmetricDifference(new Collection())).toBeInstanceOf(DerivedCollection);
+		});
+		test('merge()', () => {
+			const fn = () => ({ keep: false }) as const; // eslint-disable-line unicorn/consistent-function-scoping
+			expect(coll.merge(new Collection(), fn, fn, fn)).toBeInstanceOf(DerivedCollection);
+		});
+		test('toReversed()', () => {
+			expect(coll.toReversed()).toBeInstanceOf(DerivedCollection);
+		});
+		test('toSorted()', () => {
+			expect(coll.toSorted()).toBeInstanceOf(DerivedCollection);
+		});
+		test('Collection.combineEntries()', () => {
+			expect(DerivedCollection.combineEntries([], Object)).toBeInstanceOf(DerivedCollection);
+		});
+	});
+});

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -11,11 +11,11 @@ export type ReadonlyCollection<Key, Value> = Omit<
 
 export interface Collection<Key, Value> {
 	/**
-	 * Ambient declaration to allow `this.constructor[@@species]` in class methods.
+	 * Ambient declaration to allow references to `this.constructor` in class methods.
 	 *
 	 * @internal
 	 */
-	constructor: typeof Collection & { readonly [Symbol.species]: typeof Collection };
+	constructor: typeof Collection;
 }
 
 /**
@@ -1076,7 +1076,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 		entries: Iterable<[Key, Value]>,
 		combine: (firstValue: Value, secondValue: Value, key: Key) => Value,
 	): Collection<Key, Value> {
-		const coll = new Collection<Key, Value>();
+		const coll = new this[Symbol.species]<Key, Value>();
 		for (const [key, value] of entries) {
 			if (coll.has(key)) {
 				coll.set(key, combine(coll.get(key)!, value, key));
@@ -1087,6 +1087,11 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 		return coll;
 	}
+
+	/**
+	 * @internal
+	 */
+	declare public static readonly [Symbol.species]: typeof Collection;
 }
 
 /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Collection methods feature subclassing support via `Symbol.species`. This currently doesn't apply to the one static method, which calls the Collection constructor specifically.

This change brings the behaviour of static methods in line with instance methods, such that `DerivedCollection.combineEntries(...)` returns a DerivedCollection, not a Collection.
