### PR TITLE
build!: Bump Node.js to 22.12.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-package_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01-package_bug_report.yml
@@ -62,7 +62,7 @@ body:
       description: List necessary versions here. This includes your package version, runtime version, operating system etc.
       placeholder: |
         - discord.js 14.12.1 (`npm ls discord.js` or another package)
-        - Node.js 16.11.0 (`node --version`)
+        - Node.js 22.12.0 (`node --version`)
         - TypeScript 5.1.6 (`npm ls typescript` if you use it)
         - macOS Ventura 13.3.1
     validations:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Node.js v20
+      - name: Install Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/.github/workflows/deprecate-version.yml
+++ b/.github/workflows/deprecate-version.yml
@@ -36,10 +36,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Node.js v20
+      - name: Install Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -40,10 +40,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || '' }}
 
-      - name: Install Node.js v20
+      - name: Install Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache
@@ -215,10 +215,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Node.js v20
+      - name: Install Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/.github/workflows/publish-dev-docker.yml
+++ b/.github/workflows/publish-dev-docker.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Node.js v20
+      - name: Install Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -47,10 +47,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Node.js v20
+      - name: Install Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
 
       - name: Check the current development version

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -9,10 +9,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Node.js v20
+      - name: Install Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install Node.js v20
+      - name: Install Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Node.js v20
+      - name: Install Node.js v22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -72,7 +72,9 @@
 	"devDependencies": {
 		"@shikijs/rehype": "^1.24.4",
 		"@tailwindcss/typography": "^0.5.15",
-		"@types/node": "^20.17.10",
+		"@testing-library/react": "^15.0.7",
+		"@testing-library/user-event": "^14.5.2",
+		"@types/node": "^22.10.10",
 		"@types/react": "^18.3.18",
 		"@types/react-dom": "^18.3.5",
 		"@vitejs/plugin-react": "^4.3.4",
@@ -96,6 +98,6 @@
 		"vercel": "^37.14.0"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
 		}
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
-	"packageManager": "pnpm@9.15.2"
+	"packageManager": "pnpm@9.15.4"
 }

--- a/packages/actions/package.json
+++ b/packages/actions/package.json
@@ -53,7 +53,7 @@
 		"undici": "6.21.0"
 	},
 	"devDependencies": {
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.57.1",
@@ -66,6 +66,6 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	}
 }

--- a/packages/api-extractor-model/package.json
+++ b/packages/api-extractor-model/package.json
@@ -37,7 +37,7 @@
 	},
 	"devDependencies": {
 		"@types/jest": "^29.5.14",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.57.1",
 		"eslint-config-neon": "^0.1.62",

--- a/packages/api-extractor-utils/package.json
+++ b/packages/api-extractor-utils/package.json
@@ -50,7 +50,7 @@
 		"@microsoft/tsdoc": "0.14.2"
 	},
 	"devDependencies": {
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.57.1",
 		"eslint-config-neon": "^0.1.62",
@@ -61,6 +61,6 @@
 		"typescript": "~5.5.4"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	}
 }

--- a/packages/api-extractor/package.json
+++ b/packages/api-extractor/package.json
@@ -54,7 +54,7 @@
 		"@microsoft/tsdoc": "0.14.2",
 		"@microsoft/tsdoc-config": "0.16.2",
 		"@rushstack/node-core-library": "4.1.0",
-		"@rushstack/rig-package": "0.5.1",
+		"@rushstack/rig-package": "0.5.3",
 		"@rushstack/ts-command-line": "4.17.1",
 		"colors": "~1.4.0",
 		"lodash": "~4.17.21",
@@ -66,7 +66,7 @@
 	"devDependencies": {
 		"@types/jest": "^29.5.14",
 		"@types/lodash": "^4.17.13",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@types/resolve": "^1.20.6",
 		"@types/semver": "^7.5.8",
 		"cpy-cli": "^5.0.0",

--- a/packages/brokers/README.md
+++ b/packages/brokers/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/brokers

--- a/packages/brokers/package.json
+++ b/packages/brokers/package.json
@@ -75,7 +75,7 @@
 		"@discordjs/api-extractor": "workspace:^",
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",
@@ -89,7 +89,7 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/builders/README.md
+++ b/packages/builders/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/builders

--- a/packages/builders/package.json
+++ b/packages/builders/package.json
@@ -76,7 +76,7 @@
 		"@discordjs/api-extractor": "workspace:^",
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",
@@ -90,7 +90,7 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/collection/README.md
+++ b/packages/collection/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/collection

--- a/packages/collection/package.json
+++ b/packages/collection/package.json
@@ -64,7 +64,7 @@
 		"@discordjs/api-extractor": "workspace:^",
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",
@@ -78,7 +78,7 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,7 @@
 		"@discordjs/api-extractor": "workspace:^",
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",
@@ -90,7 +90,7 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/create-discord-bot/package.json
+++ b/packages/create-discord-bot/package.json
@@ -58,7 +58,7 @@
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@types/prompts": "^2.4.9",
 		"@types/validate-npm-package-name": "^4.0.2",
 		"cross-env": "^7.0.3",
@@ -71,7 +71,7 @@
 		"typescript": "~5.5.4"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/create-discord-bot/template/JavaScript/package.json
+++ b/packages/create-discord-bot/template/JavaScript/package.json
@@ -21,5 +21,8 @@
 		"eslint-formatter-pretty": "^6.0.1",
 		"prettier": "^3.4.2",
 		"zod": "^3.24.1"
+	},
+	"engines": {
+		"node": ">=22.12.0"
 	}
 }

--- a/packages/create-discord-bot/template/TypeScript/package.json
+++ b/packages/create-discord-bot/template/TypeScript/package.json
@@ -18,12 +18,15 @@
 	},
 	"devDependencies": {
 		"@sapphire/ts-config": "^5.0.1",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"eslint": "^8.57.1",
 		"eslint-config-neon": "^0.1.62",
 		"eslint-formatter-pretty": "^6.0.1",
 		"prettier": "^3.4.2",
 		"typescript": "~5.5.4",
 		"zod": "^3.24.1"
+	},
+	"engines": {
+		"node": ">=22.12.0"
 	}
 }

--- a/packages/discord.js/README.md
+++ b/packages/discord.js/README.md
@@ -29,7 +29,7 @@ discord.js is a powerful [Node.js](https://nodejs.org) module that allows you to
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install discord.js

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -84,7 +84,7 @@
     "@discordjs/docgen": "workspace:^",
     "@discordjs/scripts": "workspace:^",
     "@favware/cliff-jumper": "^4.1.0",
-    "@types/node": "^20.17.10",
+    "@types/node": "^22.10.10",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "@typescript-eslint/parser": "^8.19.0",
     "cross-env": "^7.0.3",
@@ -99,7 +99,7 @@
     "typescript": "~5.5.4"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.12.0"
   },
   "publishConfig": {
     "provenance": true

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -68,7 +68,7 @@
 	"devDependencies": {
 		"@favware/cliff-jumper": "^4.1.0",
 		"@types/jsdoc-to-markdown": "^7.0.6",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.57.1",
 		"eslint-config-neon": "^0.1.62",
@@ -79,7 +79,7 @@
 		"typescript": "~5.5.4"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/formatters/README.md
+++ b/packages/formatters/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/formatters

--- a/packages/formatters/package.json
+++ b/packages/formatters/package.json
@@ -61,7 +61,7 @@
 		"@discordjs/api-extractor": "workspace:^",
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",
@@ -75,7 +75,7 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -16,7 +16,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/next

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -78,7 +78,7 @@
 		"@discordjs/api-extractor": "workspace:^",
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",
@@ -92,7 +92,7 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/proxy-container/package.json
+++ b/packages/proxy-container/package.json
@@ -50,7 +50,7 @@
 		"tslib": "^2.8.1"
 	},
 	"devDependencies": {
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.57.1",
 		"eslint-config-neon": "^0.1.62",
@@ -61,7 +61,7 @@
 		"typescript": "~5.5.4"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/proxy

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -74,7 +74,7 @@
 		"@discordjs/api-extractor": "workspace:^",
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@types/supertest": "^6.0.2",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
@@ -90,7 +90,7 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/rest

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -112,7 +112,7 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -74,7 +74,8 @@
 	},
 	"devDependencies": {
 		"@turbo/gen": "^2.3.3",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
+		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"env-cmd": "^10.1.0",
 		"eslint": "^8.57.1",
@@ -86,6 +87,6 @@
 		"typescript": "~5.5.4"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	}
 }

--- a/packages/scripts/turbo/generators/templates/default/package.json.hbs
+++ b/packages/scripts/turbo/generators/templates/default/package.json.hbs
@@ -59,7 +59,7 @@
 	"devDependencies": {
 		"@discordjs/api-extractor": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",
@@ -73,7 +73,7 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -66,7 +66,8 @@
 		"@storybook/blocks": "^8.4.7",
 		"@storybook/react": "^8.4.7",
 		"@storybook/react-vite": "^8.4.7",
-		"@types/node": "^20.17.10",
+		"@storybook/testing-library": "^0.2.2",
+		"@types/node": "^22.10.10",
 		"@types/react": "^18.3.18",
 		"@types/react-dom": "^18.3.5",
 		"@unocss/eslint-plugin": "^0.60.4",
@@ -87,7 +88,7 @@
 		"vite-plugin-dts": "^3.9.1"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -20,7 +20,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/util

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -65,7 +65,7 @@
 		"@discordjs/api-extractor": "workspace:^",
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",
@@ -79,7 +79,7 @@
 		"vitest": "^2.1.8"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -32,7 +32,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/voice

--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -75,7 +75,7 @@
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
 		"@noble/ciphers": "^1.1.3",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",
@@ -90,7 +90,7 @@
 		"vitest-websocket-mock": "^0.3.0"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/packages/ws/README.md
+++ b/packages/ws/README.md
@@ -23,7 +23,7 @@
 
 ## Installation
 
-**Node.js 20 or newer is required.**
+**Node.js 22.12.0 or newer is required.**
 
 ```sh
 npm install @discordjs/ws

--- a/packages/ws/package.json
+++ b/packages/ws/package.json
@@ -87,7 +87,7 @@
 		"@discordjs/api-extractor": "workspace:^",
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "^20.17.10",
+		"@types/node": "^22.10.10",
 		"@vitest/coverage-v8": "^2.1.8",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",
@@ -104,7 +104,7 @@
 		"zlib-sync": "^0.1.9"
 	},
 	"engines": {
-		"node": ">=20"
+		"node": ">=22.12.0"
 	},
 	"publishConfig": {
 		"access": "public",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.6.1
-        version: 19.6.1(@types/node@22.10.2)(typescript@5.5.4)
+        version: 19.6.1(@types/node@22.10.10)(typescript@5.5.4)
       '@commitlint/config-angular':
         specifier: ^19.6.0
         version: 19.6.0
@@ -41,7 +41,7 @@ importers:
         version: 0.65.3(eslint@8.57.1)(typescript@5.5.4)
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.2)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       conventional-changelog-cli:
         specifier: ^4.1.0
         version: 4.1.0
@@ -68,7 +68,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.2))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -80,13 +80,13 @@ importers:
         version: 8.19.0(eslint@8.57.1)(typescript@5.5.4)
       unocss:
         specifier: ^0.65.3
-        version: 0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))
+        version: 0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
       vercel:
         specifier: ^39.2.2
         version: 39.2.2(encoding@0.1.13)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.2)(happy-dom@14.12.3)(terser@5.37.0)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   apps/guide:
     dependencies:
@@ -289,10 +289,16 @@ importers:
         version: 1.24.4
       '@tailwindcss/typography':
         specifier: ^0.5.15
-        version: 0.5.15(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)))
+        version: 0.5.15(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4)))
+      '@testing-library/react':
+        specifier: ^15.0.7
+        version: 15.0.7(@types/react@18.3.18)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.5.2(@testing-library/dom@10.4.0)
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@types/react':
         specifier: ^18.3.18
         version: 18.3.18
@@ -301,7 +307,7 @@ importers:
         version: 18.3.5(@types/react@18.3.18)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))
+        version: 4.3.4(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.20(postcss@8.4.49)
@@ -346,7 +352,7 @@ importers:
         version: 1.24.4
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.17(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+        version: 3.4.17(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -391,11 +397,11 @@ importers:
         version: 6.21.0
     devDependencies:
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -413,7 +419,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -422,7 +428,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   packages/api-extractor:
     dependencies:
@@ -437,10 +443,10 @@ importers:
         version: 0.16.2(patch_hash=35av6rrndvjtr2u2jso66jatbu)
       '@rushstack/node-core-library':
         specifier: 4.1.0
-        version: 4.1.0(@types/node@20.17.10)
+        version: 4.1.0(@types/node@22.10.10)
       '@rushstack/rig-package':
-        specifier: 0.5.1
-        version: 0.5.1
+        specifier: 0.5.3
+        version: 0.5.3
       '@rushstack/ts-command-line':
         specifier: 4.17.1
         version: 4.17.1
@@ -470,8 +476,8 @@ importers:
         specifier: ^4.17.13
         version: 4.17.13
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@types/resolve':
         specifier: ^1.20.6
         version: 1.20.6
@@ -495,13 +501,13 @@ importers:
         version: 6.0.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+        version: 29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -516,14 +522,14 @@ importers:
         version: 0.16.2(patch_hash=35av6rrndvjtr2u2jso66jatbu)
       '@rushstack/node-core-library':
         specifier: 4.1.0
-        version: 4.1.0(@types/node@20.17.10)
+        version: 4.1.0(@types/node@22.10.10)
     devDependencies:
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -538,13 +544,13 @@ importers:
         version: 6.0.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+        version: 29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -562,8 +568,8 @@ importers:
         version: 0.14.2
     devDependencies:
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -581,7 +587,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -611,11 +617,11 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -636,7 +642,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -645,7 +651,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   packages/builders:
     dependencies:
@@ -678,11 +684,11 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -703,7 +709,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -712,7 +718,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   packages/collection:
     devDependencies:
@@ -726,11 +732,11 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -751,7 +757,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -760,7 +766,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   packages/core:
     dependencies:
@@ -793,11 +799,11 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -818,7 +824,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -827,7 +833,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   packages/create-discord-bot:
     dependencies:
@@ -854,8 +860,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
@@ -882,7 +888,7 @@ importers:
         version: 5.37.0
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       typescript:
         specifier: ~5.5.4
         version: 5.5.4
@@ -942,8 +948,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.19.0
         version: 8.19.0(@typescript-eslint/parser@8.19.0(eslint@8.57.1)(typescript@5.5.4))(eslint@8.57.1)(typescript@5.5.4)
@@ -964,7 +970,7 @@ importers:
         version: 5.0.0
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+        version: 29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -1003,8 +1009,8 @@ importers:
         specifier: ^7.0.6
         version: 7.0.6
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1022,7 +1028,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -1046,11 +1052,11 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1071,7 +1077,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -1080,7 +1086,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   packages/next:
     dependencies:
@@ -1119,11 +1125,11 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1144,7 +1150,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -1153,7 +1159,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   packages/proxy:
     dependencies:
@@ -1180,14 +1186,14 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.2
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1211,7 +1217,7 @@ importers:
         version: 7.0.0
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -1220,7 +1226,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   packages/proxy-container:
     dependencies:
@@ -1235,8 +1241,8 @@ importers:
         version: 2.8.1
     devDependencies:
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1254,7 +1260,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -1379,10 +1385,13 @@ importers:
     devDependencies:
       '@turbo/gen':
         specifier: ^2.3.3
-        version: 2.3.3(@types/node@20.17.10)(typescript@5.5.4)
+        version: 2.3.3(@types/node@22.10.10)(typescript@5.5.4)
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
+      '@vitest/coverage-v8':
+        specifier: ^2.1.8
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1403,7 +1412,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -1449,10 +1458,13 @@ importers:
         version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(typescript@5.5.4)
       '@storybook/react-vite':
         specifier: ^8.4.7
-        version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(typescript@5.5.4)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))
+        version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(typescript@5.5.4)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
+      '@storybook/testing-library':
+        specifier: ^0.2.2
+        version: 0.2.2
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@types/react':
         specifier: ^18.3.18
         version: 18.3.18
@@ -1467,7 +1479,7 @@ importers:
         version: 0.60.4
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.3.4(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))
+        version: 4.3.4(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
       chromatic:
         specifier: ^11.20.2
         version: 11.20.2
@@ -1500,13 +1512,13 @@ importers:
         version: 5.5.4
       unocss:
         specifier: ^0.60.4
-        version: 0.60.4(postcss@8.4.49)(rollup@4.29.1)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))
+        version: 0.60.4(postcss@8.4.49)(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
       vite:
         specifier: ^5.4.11
-        version: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
+        version: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
       vite-plugin-dts:
         specifier: ^3.9.1
-        version: 3.9.1(@types/node@20.17.10)(rollup@4.29.1)(typescript@5.5.4)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))
+        version: 3.9.1(@types/node@22.10.10)(rollup@4.29.1)(typescript@5.5.4)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
 
   packages/util:
     devDependencies:
@@ -1520,11 +1532,11 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@types/node@20.17.10))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1545,7 +1557,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(postcss@8.4.49)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -1554,7 +1566,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.10)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   packages/voice:
     dependencies:
@@ -1590,11 +1602,11 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1615,7 +1627,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -1624,10 +1636,10 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
       vitest-websocket-mock:
         specifier: ^0.3.0
-        version: 0.3.0(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))
+        version: 0.3.0(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
 
   packages/ws:
     dependencies:
@@ -1657,7 +1669,7 @@ importers:
         version: 2.8.1
       ws:
         specifier: ^8.18.0
-        version: 8.18.0
+        version: 8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5)
     devDependencies:
       '@discordjs/api-extractor':
         specifier: workspace:^
@@ -1669,11 +1681,11 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: ^20.17.10
-        version: 20.17.10
+        specifier: ^22.10.10
+        version: 22.10.10
       '@vitest/coverage-v8':
         specifier: ^2.1.8
-        version: 2.1.8(vitest@2.1.8(@types/node@20.17.10))
+        version: 2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1697,7 +1709,7 @@ importers:
         version: 3.4.2
       tsup:
         specifier: ^8.3.5
-        version: 8.3.5(postcss@8.4.49)(typescript@5.5.4)(yaml@2.7.0)
+        version: 8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0)
       turbo:
         specifier: ^2.3.3
         version: 2.3.3
@@ -1709,7 +1721,7 @@ importers:
         version: 6.21.0
       vitest:
         specifier: ^2.1.8
-        version: 2.1.8(@types/node@20.17.10)
+        version: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
       zlib-sync:
         specifier: ^0.1.9
         version: 0.1.9
@@ -4729,11 +4741,11 @@ packages:
       '@types/node':
         optional: true
 
-  '@rushstack/rig-package@0.5.1':
-    resolution: {integrity: sha512-pXRYSe29TjRw7rqxD4WS3HN/sRSbfr+tJs4a9uuaSIBAITbUggygdhuG0VrO0EO+QqH91GhYMN4S6KRtOEmGVA==}
-
   '@rushstack/rig-package@0.5.2':
     resolution: {integrity: sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==}
+
+  '@rushstack/rig-package@0.5.3':
+    resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
 
   '@rushstack/terminal@0.10.0':
     resolution: {integrity: sha512-UbELbXnUdc7EKwfH2sb8ChqNgapUOdqcCIdQP4NGxBpTZV2sQyeekuK3zmfQSa/MN+/7b4kBogl2wq0vpkpYGw==}
@@ -5053,6 +5065,10 @@ packages:
     peerDependencies:
       storybook: ^8.4.7
 
+  '@storybook/testing-library@0.2.2':
+    resolution: {integrity: sha512-L8sXFJUHmrlyU2BsWWZGuAjv39Jl1uAqUHdxmN42JY15M4+XCMjGlArdCCjDe1wpTSW6USYISA9axjZojgtvnw==}
+    deprecated: In Storybook 8, this package functionality has been integrated to a new package called @storybook/test, which uses Vitest APIs for an improved experience. When upgrading to Storybook 8 with 'npx storybook@latest upgrade', you will get prompted and will get an automigration for the new package. Please migrate when you can.
+
   '@storybook/theming@7.6.17':
     resolution: {integrity: sha512-ZbaBt3KAbmBtfjNqgMY7wPMBshhSJlhodyMNQypv+95xLD/R+Az6aBYbpVAOygLaUQaQk4ar7H/Ww6lFIoiFbA==}
     peerDependencies:
@@ -5097,9 +5113,24 @@ packages:
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
     engines: {node: '>=18'}
 
+  '@testing-library/dom@9.3.4':
+    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
+    engines: {node: '>=14'}
+
   '@testing-library/jest-dom@6.5.0':
     resolution: {integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@15.0.7':
+    resolution: {integrity: sha512-cg0RvEdD1TIhhkm1IeYMQxrzy0MtUNfa3minv4MjbgcYzJAZ7yD0i0lwoPOTPr+INtiXFezt2o8xMSnyHhEn2Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': ^18.0.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@testing-library/user-event@14.5.2':
     resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
@@ -5303,11 +5334,8 @@ packages:
   '@types/node@18.19.69':
     resolution: {integrity: sha512-ECPdY1nlaiO/Y6GUnwgtAAhLNaQ53AyIVz+eILxpEo5OvuqE6yWkqWBIb5dU0DqhKQtMeny+FBD3PK6lm7L5xQ==}
 
-  '@types/node@20.17.10':
-    resolution: {integrity: sha512-/jrvh5h6NXhEauFFexRin69nA0uHJ5gwk4iDivp/DeoEua3uwCUto6PC86IpRITBOs4+6i2I56K5x5b6WYGXHA==}
-
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
+  '@types/node@22.10.10':
+    resolution: {integrity: sha512-X47y/mPNzxviAGY5TcYPtYL8JsY3kAq2n8fMmKoRCxq/c4v4pyGNCzM2R6+M5/umG4ZfHuT+sgqDYqWc9rJ6ww==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -6135,6 +6163,9 @@ packages:
   aria-hidden@1.2.4:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
+
+  aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -7186,6 +7217,10 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deep-equal@2.2.3:
+    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
+    engines: {node: '>= 0.4'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -7432,6 +7467,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
   es-iterator-helpers@1.2.1:
     resolution: {integrity: sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==}
@@ -10423,6 +10461,10 @@ packages:
     resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
     engines: {node: '>= 0.4'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
   object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
@@ -11826,6 +11868,10 @@ packages:
   std-env@3.8.0:
     resolution: {integrity: sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
   store2@2.14.4:
     resolution: {integrity: sha512-srTItn1GOvyvOycgxjAnPA63FZNwy0PTyUBFMHRM+hVFltAeoh0LmNBz9SZqUS9mMqGk8rfyWyXn3GH5ReJ8Zw==}
 
@@ -12565,9 +12611,6 @@ packages:
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
@@ -13599,11 +13642,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@commitlint/cli@19.6.1(@types/node@22.10.2)(typescript@5.5.4)':
+  '@commitlint/cli@19.6.1(@types/node@22.10.10)(typescript@5.5.4)':
     dependencies:
       '@commitlint/format': 19.5.0
       '@commitlint/lint': 19.6.0
-      '@commitlint/load': 19.6.1(@types/node@22.10.2)(typescript@5.5.4)
+      '@commitlint/load': 19.6.1(@types/node@22.10.10)(typescript@5.5.4)
       '@commitlint/read': 19.5.0
       '@commitlint/types': 19.5.0
       tinyexec: 0.3.2
@@ -13651,7 +13694,7 @@ snapshots:
       '@commitlint/rules': 19.6.0
       '@commitlint/types': 19.5.0
 
-  '@commitlint/load@19.6.1(@types/node@22.10.2)(typescript@5.5.4)':
+  '@commitlint/load@19.6.1(@types/node@22.10.10)(typescript@5.5.4)':
     dependencies:
       '@commitlint/config-validator': 19.5.0
       '@commitlint/execute-rule': 19.5.0
@@ -13659,7 +13702,7 @@ snapshots:
       '@commitlint/types': 19.5.0
       chalk: 5.4.1
       cosmiconfig: 9.0.0(typescript@5.5.4)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.10.2)(cosmiconfig@9.0.0(typescript@5.5.4))(typescript@5.5.4)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.10.10)(cosmiconfig@9.0.0(typescript@5.5.4))(typescript@5.5.4)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -14483,27 +14526,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      jest-config: 29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -14528,7 +14571,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -14546,7 +14589,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -14568,7 +14611,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -14644,15 +14687,15 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.4.2(typescript@5.5.4)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.4.2(typescript@5.5.4)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))':
     dependencies:
       magic-string: 0.27.0
       react-docgen-typescript: 2.2.2(typescript@5.5.4)
-      vite: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     optionalDependencies:
       typescript: 5.5.4
 
@@ -14793,22 +14836,13 @@ snapshots:
       - '@types/node'
     optional: true
 
-  '@microsoft/api-extractor-model@7.28.13(@types/node@20.17.10)':
+  '@microsoft/api-extractor-model@7.28.13(@types/node@22.10.10)':
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2(patch_hash=35av6rrndvjtr2u2jso66jatbu)
-      '@rushstack/node-core-library': 4.0.2(@types/node@20.17.10)
+      '@rushstack/node-core-library': 4.0.2(@types/node@22.10.10)
     transitivePeerDependencies:
       - '@types/node'
-
-  '@microsoft/api-extractor-model@7.28.13(@types/node@22.10.2)':
-    dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2(patch_hash=35av6rrndvjtr2u2jso66jatbu)
-      '@rushstack/node-core-library': 4.0.2(@types/node@22.10.2)
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor@7.43.0(@types/node@18.17.9)':
     dependencies:
@@ -14829,15 +14863,15 @@ snapshots:
       - '@types/node'
     optional: true
 
-  '@microsoft/api-extractor@7.43.0(@types/node@20.17.10)':
+  '@microsoft/api-extractor@7.43.0(@types/node@22.10.10)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.13(@types/node@20.17.10)
+      '@microsoft/api-extractor-model': 7.28.13(@types/node@22.10.10)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2(patch_hash=35av6rrndvjtr2u2jso66jatbu)
-      '@rushstack/node-core-library': 4.0.2(@types/node@20.17.10)
+      '@rushstack/node-core-library': 4.0.2(@types/node@22.10.10)
       '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.10.0(@types/node@20.17.10)
-      '@rushstack/ts-command-line': 4.19.1(@types/node@20.17.10)
+      '@rushstack/terminal': 0.10.0(@types/node@22.10.10)
+      '@rushstack/ts-command-line': 4.19.1(@types/node@22.10.10)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -14846,25 +14880,6 @@ snapshots:
       typescript: 5.4.2
     transitivePeerDependencies:
       - '@types/node'
-
-  '@microsoft/api-extractor@7.43.0(@types/node@22.10.2)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.28.13(@types/node@22.10.2)
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2(patch_hash=35av6rrndvjtr2u2jso66jatbu)
-      '@rushstack/node-core-library': 4.0.2(@types/node@22.10.2)
-      '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.10.0(@types/node@22.10.2)
-      '@rushstack/ts-command-line': 4.19.1(@types/node@22.10.2)
-      lodash: 4.17.21
-      minimatch: 3.0.8
-      resolve: 1.22.10
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@microsoft/tsdoc-config@0.16.2(patch_hash=35av6rrndvjtr2u2jso66jatbu)':
     dependencies:
@@ -16898,7 +16913,7 @@ snapshots:
       '@types/node': 18.17.9
     optional: true
 
-  '@rushstack/node-core-library@4.0.2(@types/node@20.17.10)':
+  '@rushstack/node-core-library@4.0.2(@types/node@22.10.10)':
     dependencies:
       fs-extra: 7.0.1
       import-lazy: 4.0.0
@@ -16907,9 +16922,9 @@ snapshots:
       semver: 7.5.4
       z-schema: 5.0.5
     optionalDependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
 
-  '@rushstack/node-core-library@4.0.2(@types/node@22.10.2)':
+  '@rushstack/node-core-library@4.1.0(@types/node@22.10.10)':
     dependencies:
       fs-extra: 7.0.1
       import-lazy: 4.0.0
@@ -16918,26 +16933,14 @@ snapshots:
       semver: 7.5.4
       z-schema: 5.0.5
     optionalDependencies:
-      '@types/node': 22.10.2
-    optional: true
+      '@types/node': 22.10.10
 
-  '@rushstack/node-core-library@4.1.0(@types/node@20.17.10)':
-    dependencies:
-      fs-extra: 7.0.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.10
-      semver: 7.5.4
-      z-schema: 5.0.5
-    optionalDependencies:
-      '@types/node': 20.17.10
-
-  '@rushstack/rig-package@0.5.1':
+  '@rushstack/rig-package@0.5.2':
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/rig-package@0.5.2':
+  '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
@@ -16950,20 +16953,12 @@ snapshots:
       '@types/node': 18.17.9
     optional: true
 
-  '@rushstack/terminal@0.10.0(@types/node@20.17.10)':
+  '@rushstack/terminal@0.10.0(@types/node@22.10.10)':
     dependencies:
-      '@rushstack/node-core-library': 4.0.2(@types/node@20.17.10)
+      '@rushstack/node-core-library': 4.0.2(@types/node@22.10.10)
       supports-color: 8.1.1
     optionalDependencies:
-      '@types/node': 20.17.10
-
-  '@rushstack/terminal@0.10.0(@types/node@22.10.2)':
-    dependencies:
-      '@rushstack/node-core-library': 4.0.2(@types/node@22.10.2)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 22.10.2
-    optional: true
+      '@types/node': 22.10.10
 
   '@rushstack/ts-command-line@4.17.1':
     dependencies:
@@ -16982,24 +16977,14 @@ snapshots:
       - '@types/node'
     optional: true
 
-  '@rushstack/ts-command-line@4.19.1(@types/node@20.17.10)':
+  '@rushstack/ts-command-line@4.19.1(@types/node@22.10.10)':
     dependencies:
-      '@rushstack/terminal': 0.10.0(@types/node@20.17.10)
+      '@rushstack/terminal': 0.10.0(@types/node@22.10.10)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
     transitivePeerDependencies:
       - '@types/node'
-
-  '@rushstack/ts-command-line@4.19.1(@types/node@22.10.2)':
-    dependencies:
-      '@rushstack/terminal': 0.10.0(@types/node@22.10.2)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@sapphire/async-queue@1.5.5': {}
 
@@ -17225,13 +17210,13 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))':
+  '@storybook/builder-vite@8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))':
     dependencies:
       '@storybook/csf-plugin': 8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))
       browser-assert: 1.2.1
       storybook: 8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)
       ts-dedent: 2.2.0
-      vite: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
 
   '@storybook/channels@7.6.17':
     dependencies:
@@ -17287,7 +17272,7 @@ snapshots:
       '@storybook/node-logger': 7.6.20
       '@storybook/types': 7.6.20
       '@types/find-cache-dir': 3.2.1
-      '@types/node': 18.19.68
+      '@types/node': 18.19.69
       '@types/node-fetch': 2.6.12
       '@types/pretty-hrtime': 1.0.3
       chalk: 4.1.2
@@ -17433,11 +17418,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)
 
-  '@storybook/react-vite@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(typescript@5.5.4)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))':
+  '@storybook/react-vite@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.29.1)(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(typescript@5.5.4)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.4.2(typescript@5.5.4)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.4.2(typescript@5.5.4)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
       '@rollup/pluginutils': 5.1.4(rollup@4.29.1)
-      '@storybook/builder-vite': 8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))
+      '@storybook/builder-vite': 8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
       '@storybook/react': 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5))(typescript@5.5.4)
       find-up: 5.0.0
       magic-string: 0.30.17
@@ -17447,7 +17432,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)
       tsconfig-paths: 4.2.0
-      vite: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     transitivePeerDependencies:
       - '@storybook/test'
       - rollup
@@ -17492,6 +17477,12 @@ snapshots:
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
       storybook: 8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5)
+
+  '@storybook/testing-library@0.2.2':
+    dependencies:
+      '@testing-library/dom': 9.3.4
+      '@testing-library/user-event': 14.5.2(@testing-library/dom@9.3.4)
+      ts-dedent: 2.2.0
 
   '@storybook/theming@7.6.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -17544,13 +17535,13 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
 
-  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)))':
+  '@tailwindcss/typography@0.5.15(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4)))':
     dependencies:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -17558,6 +17549,17 @@ snapshots:
       '@babel/runtime': 7.26.0
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/dom@9.3.4':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/runtime': 7.26.0
+      '@types/aria-query': 5.0.4
+      aria-query: 5.1.3
       chalk: 4.1.2
       dom-accessibility-api: 0.5.16
       lz-string: 1.5.0
@@ -17573,9 +17575,23 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
+  '@testing-library/react@15.0.7(@types/react@18.3.18)(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@testing-library/dom': 10.4.0
+      '@types/react-dom': 18.3.5(@types/react@18.3.18)
+      react: 19.0.0-rc-f994737d14-20240522
+      react-dom: 19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522)
+    optionalDependencies:
+      '@types/react': 18.3.18
+
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
+
+  '@testing-library/user-event@14.5.2(@testing-library/dom@9.3.4)':
+    dependencies:
+      '@testing-library/dom': 9.3.4
 
   '@tootallnate/once@2.0.0': {}
 
@@ -17598,7 +17614,7 @@ snapshots:
 
   '@tsd/typescript@5.4.5': {}
 
-  '@turbo/gen@2.3.3(@types/node@20.17.10)(typescript@5.5.4)':
+  '@turbo/gen@2.3.3(@types/node@22.10.10)(typescript@5.5.4)':
     dependencies:
       '@turbo/workspaces': 2.3.3
       commander: 10.0.1
@@ -17608,7 +17624,7 @@ snapshots:
       node-plop: 0.26.3
       picocolors: 1.0.1
       proxy-agent: 6.5.0
-      ts-node: 10.9.2(@types/node@20.17.10)(typescript@5.5.4)
+      ts-node: 10.9.2(@types/node@22.10.10)(typescript@5.5.4)
       update-check: 1.5.4
       validate-npm-package-name: 5.0.1
     transitivePeerDependencies:
@@ -17664,19 +17680,19 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
 
   '@types/concat-stream@2.0.3':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
 
   '@types/conventional-commits-parser@5.0.1':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 18.19.69
 
   '@types/cookiejar@2.1.5': {}
 
@@ -17704,7 +17720,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       '@types/qs': 6.9.17
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -17721,11 +17737,11 @@ snapshots:
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
 
   '@types/hast@2.3.10':
     dependencies:
@@ -17807,7 +17823,7 @@ snapshots:
 
   '@types/node-fetch@2.6.12':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       form-data: 4.0.1
 
   '@types/node@16.18.11': {}
@@ -17822,11 +17838,7 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@20.17.10':
-    dependencies:
-      undici-types: 6.19.8
-
-  '@types/node@22.10.2':
+  '@types/node@22.10.10':
     dependencies:
       undici-types: 6.20.0
 
@@ -17836,7 +17848,7 @@ snapshots:
 
   '@types/pg@8.11.6':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       pg-protocol: 1.7.0
       pg-types: 4.0.2
 
@@ -17844,7 +17856,7 @@ snapshots:
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       kleur: 3.0.3
 
   '@types/prop-types@15.7.14': {}
@@ -17869,12 +17881,12 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       '@types/send': 0.17.4
 
   '@types/stack-utils@2.0.3': {}
@@ -17883,7 +17895,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       form-data: 4.0.1
 
   '@types/supertest@6.0.2':
@@ -17895,7 +17907,7 @@ snapshots:
 
   '@types/through@0.0.33':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
 
   '@types/tinycolor2@1.4.6': {}
 
@@ -17909,7 +17921,7 @@ snapshots:
 
   '@types/ws@8.5.13':
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -18190,23 +18202,23 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@unocss/astro@0.60.4(rollup@4.29.1)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))':
+  '@unocss/astro@0.60.4(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))':
     dependencies:
       '@unocss/core': 0.60.4
       '@unocss/reset': 0.60.4
-      '@unocss/vite': 0.60.4(rollup@4.29.1)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))
+      '@unocss/vite': 0.60.4(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
     optionalDependencies:
-      vite: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     transitivePeerDependencies:
       - rollup
 
-  '@unocss/astro@0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))':
+  '@unocss/astro@0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))':
     dependencies:
       '@unocss/core': 0.65.3
       '@unocss/reset': 0.65.3
-      '@unocss/vite': 0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))
+      '@unocss/vite': 0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.2)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -18502,7 +18514,7 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  '@unocss/vite@0.60.4(rollup@4.29.1)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))':
+  '@unocss/vite@0.60.4(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.4(rollup@4.29.1)
@@ -18514,11 +18526,11 @@ snapshots:
       chokidar: 3.6.0
       fast-glob: 3.3.2
       magic-string: 0.30.17
-      vite: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     transitivePeerDependencies:
       - rollup
 
-  '@unocss/vite@0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))':
+  '@unocss/vite@0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@rollup/pluginutils': 5.1.4(rollup@4.29.1)
@@ -18528,7 +18540,7 @@ snapshots:
       chokidar: 3.6.0
       magic-string: 0.30.17
       tinyglobby: 0.2.10
-      vite: 5.4.11(@types/node@22.10.2)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -18817,14 +18829,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))':
+  '@vitejs/plugin-react@4.3.4(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.0)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.0)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18846,7 +18858,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0))':
+  '@vitest/coverage-v8@2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -18860,43 +18872,7 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitest/coverage-v8@2.1.8(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.2)(happy-dom@14.12.3)(terser@5.37.0))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 0.2.3
-      debug: 4.4.0
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.17
-      magicast: 0.3.5
-      std-env: 3.8.0
-      test-exclude: 7.0.1
-      tinyrainbow: 1.2.0
-      vitest: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.2)(happy-dom@14.12.3)(terser@5.37.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitest/coverage-v8@2.1.8(vitest@2.1.8(@types/node@20.17.10))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 0.2.3
-      debug: 4.4.0
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.17
-      magicast: 0.3.5
-      std-env: 3.8.0
-      test-exclude: 7.0.1
-      tinyrainbow: 1.2.0
-      vitest: 2.1.8(@types/node@20.17.10)
+      vitest: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18914,21 +18890,13 @@ snapshots:
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@20.17.10))':
+  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))':
     dependencies:
       '@vitest/spy': 2.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.11(@types/node@20.17.10)
-
-  '@vitest/mocker@2.1.8(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))':
-    dependencies:
-      '@vitest/spy': 2.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.2)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -19165,6 +19133,10 @@ snapshots:
   aria-hidden@1.2.4:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.1.3:
+    dependencies:
+      deep-equal: 2.2.3
 
   aria-query@5.3.0:
     dependencies:
@@ -20081,9 +20053,9 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@22.10.2)(cosmiconfig@9.0.0(typescript@5.5.4))(typescript@5.5.4):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@22.10.10)(cosmiconfig@9.0.0(typescript@5.5.4))(typescript@5.5.4):
     dependencies:
-      '@types/node': 22.10.2
+      '@types/node': 22.10.10
       cosmiconfig: 9.0.0(typescript@5.5.4)
       jiti: 2.4.2
       typescript: 5.5.4
@@ -20128,13 +20100,13 @@ snapshots:
       p-filter: 3.0.0
       p-map: 6.0.0
 
-  create-jest@29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)):
+  create-jest@29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      jest-config: 29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -20264,6 +20236,27 @@ snapshots:
   dedent@1.5.3: {}
 
   deep-eql@5.0.2: {}
+
+  deep-equal@2.2.3:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.8
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.2.6
+      is-arguments: 1.2.0
+      is-array-buffer: 3.0.5
+      is-date-object: 1.1.0
+      is-regex: 1.2.1
+      is-shared-array-buffer: 1.0.4
+      isarray: 2.0.5
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      regexp.prototype.flags: 1.5.3
+      side-channel: 1.1.0
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.18
 
   deep-extend@0.6.0: {}
 
@@ -20555,6 +20548,18 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-get-iterator@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      get-intrinsic: 1.2.6
+      has-symbols: 1.1.0
+      is-arguments: 1.2.0
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-string: 1.1.1
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.1.0
 
   es-iterator-helpers@1.2.1:
     dependencies:
@@ -22704,7 +22709,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -22724,16 +22729,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)):
+  jest-cli@29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      create-jest: 29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      jest-config: 29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -22743,7 +22748,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)):
+  jest-config@29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
@@ -22768,8 +22773,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.17.10
-      ts-node: 10.9.2(@types/node@20.17.10)(typescript@5.5.4)
+      '@types/node': 22.10.10
+      ts-node: 10.9.2(@types/node@22.10.10)(typescript@5.5.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -22798,7 +22803,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -22808,7 +22813,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -22847,7 +22852,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -22882,7 +22887,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -22910,7 +22915,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       chalk: 4.1.2
       cjs-module-lexer: 1.4.1
       collect-v8-coverage: 1.0.2
@@ -22956,7 +22961,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -22975,7 +22980,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -22984,17 +22989,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)):
+  jest@29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.17.10)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      jest-cli: 29.7.0(@types/node@22.10.10)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -24815,6 +24820,11 @@ snapshots:
 
   object-inspect@1.13.3: {}
 
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+
   object-keys@1.1.1: {}
 
   object-to-spawn-args@2.0.1: {}
@@ -25220,13 +25230,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.49
 
-  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)):
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.7.0
     optionalDependencies:
       postcss: 8.4.49
-      ts-node: 10.9.2(@types/node@20.17.10)(typescript@5.5.4)
+      ts-node: 10.9.2(@types/node@22.10.10)(typescript@5.5.4)
 
   postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(yaml@2.7.0):
     dependencies:
@@ -25235,13 +25245,6 @@ snapshots:
       jiti: 2.4.2
       postcss: 8.4.49
       tsx: 4.19.2
-      yaml: 2.7.0
-
-  postcss-load-config@6.0.1(postcss@8.4.49)(yaml@2.7.0):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      postcss: 8.4.49
       yaml: 2.7.0
 
   postcss-loader@7.3.4(postcss@8.4.49)(typescript@5.5.4):
@@ -25408,7 +25411,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 20.17.10
+      '@types/node': 18.19.69
       long: 5.2.3
 
   proxy-agent@6.5.0:
@@ -26483,6 +26486,11 @@ snapshots:
 
   std-env@3.8.0: {}
 
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
   store2@2.14.4: {}
 
   storybook@8.4.7(bufferutil@4.0.9)(prettier@3.4.2)(utf-8-validate@6.0.5):
@@ -26760,7 +26768,7 @@ snapshots:
       typical: 2.6.1
       wordwrapjs: 3.0.0
 
-  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4)):
+  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -26779,7 +26787,7 @@ snapshots:
       postcss: 8.4.49
       postcss-import: 15.1.0(postcss@8.4.49)
       postcss-js: 4.0.1(postcss@8.4.49)
-      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4))
       postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -26999,14 +27007,14 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@20.17.10)(typescript@5.5.4):
+  ts-node@10.9.2(@types/node@22.10.10)(typescript@5.5.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -27103,7 +27111,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.3.5(@microsoft/api-extractor@7.43.0(@types/node@20.17.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0):
+  tsup@8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.10))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.24.2)
       cac: 6.7.14
@@ -27122,62 +27130,7 @@ snapshots:
       tinyglobby: 0.2.10
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.43.0(@types/node@20.17.10)
-      postcss: 8.4.49
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.3.5(@microsoft/api-extractor@7.43.0(@types/node@22.10.2))(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.7.0):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.24.2)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.3.3
-      debug: 4.4.0
-      esbuild: 0.24.2
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.4.49)(tsx@4.19.2)(yaml@2.7.0)
-      resolve-from: 5.0.0
-      rollup: 4.29.1
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.10
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.43.0(@types/node@22.10.2)
-      postcss: 8.4.49
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
-  tsup@8.3.5(postcss@8.4.49)(typescript@5.5.4)(yaml@2.7.0):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.24.2)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.3.3
-      debug: 4.4.0
-      esbuild: 0.24.2
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.4.49)(yaml@2.7.0)
-      resolve-from: 5.0.0
-      rollup: 4.29.1
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.10
-      tree-kill: 1.2.2
-    optionalDependencies:
+      '@microsoft/api-extractor': 7.43.0(@types/node@22.10.10)
       postcss: 8.4.49
       typescript: 5.5.4
     transitivePeerDependencies:
@@ -27379,8 +27332,6 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici-types@6.19.8: {}
-
   undici-types@6.20.0: {}
 
   undici@5.28.4:
@@ -27403,7 +27354,7 @@ snapshots:
       '@types/concat-stream': 2.0.3
       '@types/debug': 4.1.12
       '@types/is-empty': 1.2.3
-      '@types/node': 22.10.2
+      '@types/node': 22.10.10
       '@types/unist': 3.0.3
       concat-stream: 2.0.0
       debug: 4.4.0
@@ -27563,9 +27514,9 @@ snapshots:
       - rollup
       - supports-color
 
-  unocss@0.60.4(postcss@8.4.49)(rollup@4.29.1)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0)):
+  unocss@0.60.4(postcss@8.4.49)(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0)):
     dependencies:
-      '@unocss/astro': 0.60.4(rollup@4.29.1)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))
+      '@unocss/astro': 0.60.4(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
       '@unocss/cli': 0.60.4(rollup@4.29.1)
       '@unocss/core': 0.60.4
       '@unocss/extractor-arbitrary-variants': 0.60.4
@@ -27584,17 +27535,17 @@ snapshots:
       '@unocss/transformer-compile-class': 0.60.4
       '@unocss/transformer-directives': 0.60.4
       '@unocss/transformer-variant-group': 0.60.4
-      '@unocss/vite': 0.60.4(rollup@4.29.1)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0))
+      '@unocss/vite': 0.60.4(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
     optionalDependencies:
-      vite: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     transitivePeerDependencies:
       - postcss
       - rollup
       - supports-color
 
-  unocss@0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0)):
+  unocss@0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0)):
     dependencies:
-      '@unocss/astro': 0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))
+      '@unocss/astro': 0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
       '@unocss/cli': 0.65.3(rollup@4.29.1)
       '@unocss/core': 0.65.3
       '@unocss/postcss': 0.65.3
@@ -27610,9 +27561,9 @@ snapshots:
       '@unocss/transformer-compile-class': 0.65.3
       '@unocss/transformer-directives': 0.65.3
       '@unocss/transformer-variant-group': 0.65.3
-      '@unocss/vite': 0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))
+      '@unocss/vite': 0.65.3(rollup@4.29.1)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
     optionalDependencies:
-      vite: 5.4.11(@types/node@22.10.2)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -27875,13 +27826,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.8(@types/node@20.17.10):
+  vite-node@2.1.8(@types/node@22.10.10)(terser@5.37.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 1.1.2
-      vite: 5.4.11(@types/node@20.17.10)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -27893,45 +27844,9 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.8(@types/node@20.17.10)(terser@5.37.0):
+  vite-plugin-dts@3.9.1(@types/node@22.10.10)(rollup@4.29.1)(typescript@5.5.4)(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0)):
     dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      es-module-lexer: 1.6.0
-      pathe: 1.1.2
-      vite: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-node@2.1.8(@types/node@22.10.2)(terser@5.37.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.0
-      es-module-lexer: 1.6.0
-      pathe: 1.1.2
-      vite: 5.4.11(@types/node@22.10.2)(terser@5.37.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite-plugin-dts@3.9.1(@types/node@20.17.10)(rollup@4.29.1)(typescript@5.5.4)(vite@5.4.11(@types/node@20.17.10)(terser@5.37.0)):
-    dependencies:
-      '@microsoft/api-extractor': 7.43.0(@types/node@20.17.10)
+      '@microsoft/api-extractor': 7.43.0(@types/node@22.10.10)
       '@rollup/pluginutils': 5.1.4(rollup@4.29.1)
       '@vue/language-core': 1.8.27(typescript@5.5.4)
       debug: 4.4.0
@@ -27940,7 +27855,7 @@ snapshots:
       typescript: 5.5.4
       vue-tsc: 1.8.27(typescript@5.5.4)
     optionalDependencies:
-      vite: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
@@ -27966,45 +27881,26 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.37.0
 
-  vite@5.4.11(@types/node@20.17.10):
+  vite@5.4.11(@types/node@22.10.10)(terser@5.37.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.49
       rollup: 4.29.1
     optionalDependencies:
-      '@types/node': 20.17.10
-      fsevents: 2.3.3
-
-  vite@5.4.11(@types/node@20.17.10)(terser@5.37.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.29.1
-    optionalDependencies:
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       fsevents: 2.3.3
       terser: 5.37.0
 
-  vite@5.4.11(@types/node@22.10.2)(terser@5.37.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.49
-      rollup: 4.29.1
-    optionalDependencies:
-      '@types/node': 22.10.2
-      fsevents: 2.3.3
-      terser: 5.37.0
-
-  vitest-websocket-mock@0.3.0(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)):
+  vitest-websocket-mock@0.3.0(vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)):
     dependencies:
       jest-diff: 29.7.0
       mock-socket: 9.3.1
-      vitest: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0)
+      vitest: 2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0)
 
   vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@18.17.9)(happy-dom@14.12.3)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -28038,10 +27934,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.17.10)(happy-dom@14.12.3)(terser@5.37.0):
+  vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.10)(happy-dom@14.12.3)(terser@5.37.0):
     dependencies:
       '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))
+      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.10)(terser@5.37.0))
       '@vitest/pretty-format': 2.1.8
       '@vitest/runner': 2.1.8
       '@vitest/snapshot': 2.1.8
@@ -28057,85 +27953,13 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@20.17.10)(terser@5.37.0)
-      vite-node: 2.1.8(@types/node@20.17.10)(terser@5.37.0)
+      vite: 5.4.11(@types/node@22.10.10)(terser@5.37.0)
+      vite-node: 2.1.8(@types/node@22.10.10)(terser@5.37.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@edge-runtime/vm': 3.2.0
-      '@types/node': 20.17.10
+      '@types/node': 22.10.10
       happy-dom: 14.12.3
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@2.1.8(@edge-runtime/vm@3.2.0)(@types/node@22.10.2)(happy-dom@14.12.3)(terser@5.37.0):
-    dependencies:
-      '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@22.10.2)(terser@5.37.0))
-      '@vitest/pretty-format': 2.1.8
-      '@vitest/runner': 2.1.8
-      '@vitest/snapshot': 2.1.8
-      '@vitest/spy': 2.1.8
-      '@vitest/utils': 2.1.8
-      chai: 5.1.2
-      debug: 4.4.0
-      expect-type: 1.1.0
-      magic-string: 0.30.17
-      pathe: 1.1.2
-      std-env: 3.8.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.0.2
-      tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@22.10.2)(terser@5.37.0)
-      vite-node: 2.1.8(@types/node@22.10.2)(terser@5.37.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@edge-runtime/vm': 3.2.0
-      '@types/node': 22.10.2
-      happy-dom: 14.12.3
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@2.1.8(@types/node@20.17.10):
-    dependencies:
-      '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.11(@types/node@20.17.10))
-      '@vitest/pretty-format': 2.1.8
-      '@vitest/runner': 2.1.8
-      '@vitest/snapshot': 2.1.8
-      '@vitest/spy': 2.1.8
-      '@vitest/utils': 2.1.8
-      chai: 5.1.2
-      debug: 4.4.0
-      expect-type: 1.1.0
-      magic-string: 0.30.17
-      pathe: 1.1.2
-      std-env: 3.8.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.0.2
-      tinyrainbow: 1.2.0
-      vite: 5.4.11(@types/node@20.17.10)
-      vite-node: 2.1.8(@types/node@20.17.10)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 20.17.10
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -28317,8 +28141,6 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
-
-  ws@8.18.0: {}
 
   ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@6.0.5):
     optionalDependencies:


### PR DESCRIPTION
All packages will now require Node.js 22.12.0 or above.