### PR TITLE
fix: update undici's version

### DIFF
--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -91,7 +91,7 @@
 		"discord-api-types": "^0.37.114",
 		"magic-bytes.js": "^1.10.0",
 		"tslib": "^2.8.1",
-		"undici": "6.21.0",
+		"undici": "^6.21.1",
 		"uuid": "^11.0.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Because of a non-vulnerable version.

**Status and versioning classification:**
> Use of Insufficiently Random Values in undici

I have updated it is version from `6.20.0` to `^6.20.1`.

- This PR **only** includes non-code changes, like changes to documentation, README, etc.
