### PR TITLE
docs: Use link tags to render links on the documentation

### DIFF
--- a/packages/discord.js/src/managers/ThreadManager.js
+++ b/packages/discord.js/src/managers/ThreadManager.js
@@ -102,7 +102,7 @@ class ThreadManager extends CachedManager {
    * Data that can be resolved to a Date object. This can be:
    * * A Date object
    * * A number representing a timestamp
-   * * An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) string
+   * * An {@link https://en.wikipedia.org/wiki/ISO_8601 ISO 8601} string
    * @typedef {Date|number|string} DateResolvable
    */
 

--- a/packages/discord.js/src/sharding/ShardClientUtil.js
+++ b/packages/discord.js/src/sharding/ShardClientUtil.js
@@ -202,7 +202,8 @@ class ShardClientUtil {
        * Emitted when the client encounters an error.
        * <warn>Errors thrown within this event do not have a catch handler, it is
        * recommended to not use async functions as `error` event handlers. See the
-       * [Node.js docs](https://nodejs.org/api/events.html#capture-rejections-of-promises) for details.</warn>
+       * {@link https://nodejs.org/api/events.html#capture-rejections-of-promises Node.js documentation}
+       * for details.)</warn>
        * @event Client#error
        * @param {Error} error The error encountered
        */

--- a/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
+++ b/packages/discord.js/src/structures/interfaces/TextBasedChannel.js
@@ -75,7 +75,7 @@ class TextBasedChannel {
    * @property {?string} [content=''] The content for the message. This can only be `null` when editing a message.
    * @property {Array<(EmbedBuilder|Embed|APIEmbed)>} [embeds] The embeds for the message
    * @property {MessageMentionOptions} [allowedMentions] Which mentions should be parsed from the message content
-   * (see [here](https://discord.com/developers/docs/resources/message#allowed-mentions-object) for more details)
+   * (see {@link https://discord.com/developers/docs/resources/message#allowed-mentions-object here} for more details)
    * @property {Array<(AttachmentBuilder|Attachment|AttachmentPayload|BufferResolvable)>} [files]
    * The files to send with the message.
    * @property {Array<(ActionRowBuilder|ActionRow|APIActionRowComponent)>} [components]


### PR DESCRIPTION
Using `@link` will allow the links to be clickable on the documentation. 