### PR TITLE
chore: Remove "typings" scope from cliff.toml

### DIFF
--- a/packages/brokers/cliff.toml
+++ b/packages/brokers/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/builders/cliff.toml
+++ b/packages/builders/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/collection/cliff.toml
+++ b/packages/collection/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/core/cliff.toml
+++ b/packages/core/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/create-discord-bot/cliff.toml
+++ b/packages/create-discord-bot/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/formatters/cliff.toml
+++ b/packages/formatters/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/next/cliff.toml
+++ b/packages/next/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/proxy/cliff.toml
+++ b/packages/proxy/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/rest/cliff.toml
+++ b/packages/rest/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/scripts/turbo/generators/templates/default/cliff.toml
+++ b/packages/scripts/turbo/generators/templates/default/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/ui/cliff.toml
+++ b/packages/ui/cliff.toml
@@ -50,7 +50,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/util/cliff.toml
+++ b/packages/util/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/voice/cliff.toml
+++ b/packages/voice/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},

--- a/packages/ws/cliff.toml
+++ b/packages/ws/cliff.toml
@@ -57,7 +57,6 @@ commit_parsers = [
 	{ message = "^docs", group = "Documentation"},
 	{ message = "^perf", group = "Performance"},
 	{ message = "^refactor", group = "Refactor"},
-	{ message = "^typings", group = "Typings"},
 	{ message = "^types", group = "Typings"},
 	{ message = ".*deprecated", body = ".*deprecated", group = "Deprecation"},
 	{ message = "^revert", skip = true},


### PR DESCRIPTION
We do not use the "typings" scope any more, so this has been removed from the generator for new packages.

This has also been removed from existing packages where commits to them never had any "typings" scope. The only one that remained was discord.js.