### PR TITLE
fix(EmbedFieldBuilder): allow empty `name` and `value`

### DIFF
--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -341,13 +341,17 @@ describe('Embed', () => {
 		test('GIVEN an embed using Embed#addFields THEN returns valid toJSON data', () => {
 			const embed = new EmbedBuilder();
 			embed.addFields({ name: 'foo', value: 'bar' });
-			embed.addFields([{ name: 'foo', value: 'bar' }]);
+			embed.addFields([
+				{ name: 'foo', value: 'bar' },
+				{ name: '', value: '' },
+			]);
 
 			expect(embed.toJSON()).toStrictEqual({
 				...base,
 				fields: [
 					{ name: 'foo', value: 'bar' },
 					{ name: 'foo', value: 'bar' },
+					{ name: '', value: '' },
 				],
 			});
 		});
@@ -395,40 +399,25 @@ describe('Embed', () => {
 			expect(() => embed.toJSON()).toThrowError();
 		});
 
-		describe('GIVEN invalid field amount THEN throws error', () => {
-			test('1', () => {
-				const embed = new EmbedBuilder();
+		test('GIVEN invalid field amount THEN throws error', () => {
+			const embed = new EmbedBuilder();
 
-				embed.addFields(...Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' })));
-				expect(() => embed.toJSON()).toThrowError();
-			});
+			embed.addFields(...Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' })));
+			expect(() => embed.toJSON()).toThrowError();
 		});
 
-		describe('GIVEN invalid field name THEN throws error', () => {
-			test('2', () => {
-				const embed = new EmbedBuilder();
+		test('GIVEN invalid field name length THEN throws error', () => {
+			const embed = new EmbedBuilder();
 
-				embed.addFields({ name: '', value: 'bar' });
-				expect(() => embed.toJSON()).toThrowError();
-			});
+			embed.addFields({ name: 'a'.repeat(257), value: 'bar' });
+			expect(() => embed.toJSON()).toThrowError();
 		});
 
-		describe('GIVEN invalid field name length THEN throws error', () => {
-			test('3', () => {
-				const embed = new EmbedBuilder();
+		test('GIVEN invalid field value length THEN throws error', () => {
+			const embed = new EmbedBuilder();
 
-				embed.addFields({ name: 'a'.repeat(257), value: 'bar' });
-				expect(() => embed.toJSON()).toThrowError();
-			});
-		});
-
-		describe('GIVEN invalid field value length THEN throws error', () => {
-			test('4', () => {
-				const embed = new EmbedBuilder();
-
-				embed.addFields({ name: '', value: 'a'.repeat(1_025) });
-				expect(() => embed.toJSON()).toThrowError();
-			});
+			embed.addFields({ name: '', value: 'a'.repeat(1_025) });
+			expect(() => embed.toJSON()).toThrowError();
 		});
 	});
 });

--- a/packages/builders/src/messages/embed/Assertions.ts
+++ b/packages/builders/src/messages/embed/Assertions.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { refineURLPredicate } from '../../Assertions.js';
 import { embedLength } from '../../util/componentUtil.js';
 
-const namePredicate = z.string().min(1).max(256);
+const namePredicate = z.string().max(256);
 
 const iconURLPredicate = z
 	.string()
@@ -18,12 +18,12 @@ const URLPredicate = z
 
 export const embedFieldPredicate = z.object({
 	name: namePredicate,
-	value: z.string().min(1).max(1_024),
+	value: z.string().max(1_024),
 	inline: z.boolean().optional(),
 });
 
 export const embedAuthorPredicate = z.object({
-	name: namePredicate,
+	name: namePredicate.min(1),
 	icon_url: iconURLPredicate.optional(),
 	url: URLPredicate.optional(),
 });
@@ -35,7 +35,7 @@ export const embedFooterPredicate = z.object({
 
 export const embedPredicate = z
 	.object({
-		title: namePredicate.optional(),
+		title: namePredicate.min(1).optional(),
 		description: z.string().min(1).max(4_096).optional(),
 		url: URLPredicate.optional(),
 		timestamp: z.string().optional(),


### PR DESCRIPTION
Fixes #10744
