### PR TITLE
fix(EmbedBuilder): allow empty `name` and `value` on fields

### DIFF
--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -324,12 +324,16 @@ describe('Embed', () => {
 		test('GIVEN an embed using Embed#addFields THEN returns valid toJSON data', () => {
 			const embed = new EmbedBuilder();
 			embed.addFields({ name: 'foo', value: 'bar' });
-			embed.addFields([{ name: 'foo', value: 'bar' }]);
+			embed.addFields([
+				{ name: 'foo', value: 'bar' },
+				{ name: '', value: '' },
+			]);
 
 			expect(embed.toJSON()).toStrictEqual({
 				fields: [
 					{ name: 'foo', value: 'bar' },
 					{ name: 'foo', value: 'bar' },
+					{ name: '', value: '' },
 				],
 			});
 		});
@@ -381,38 +385,24 @@ describe('Embed', () => {
 			expect(() => embed.setFields(Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' })))).toThrowError();
 		});
 
-		describe('GIVEN invalid field amount THEN throws error', () => {
-			test('1', () => {
-				const embed = new EmbedBuilder();
+		test('GIVEN invalid field amount THEN throws error', () => {
+			const embed = new EmbedBuilder();
 
-				expect(() =>
-					embed.addFields(...Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' }))),
-				).toThrowError();
-			});
+			expect(() =>
+				embed.addFields(...Array.from({ length: 26 }, () => ({ name: 'foo', value: 'bar' }))),
+			).toThrowError();
 		});
 
-		describe('GIVEN invalid field name THEN throws error', () => {
-			test('2', () => {
-				const embed = new EmbedBuilder();
+		test('GIVEN invalid field name length THEN throws error', () => {
+			const embed = new EmbedBuilder();
 
-				expect(() => embed.addFields({ name: '', value: 'bar' })).toThrowError();
-			});
+			expect(() => embed.addFields({ name: 'a'.repeat(257), value: 'bar' })).toThrowError();
 		});
 
-		describe('GIVEN invalid field name length THEN throws error', () => {
-			test('3', () => {
-				const embed = new EmbedBuilder();
+		test('GIVEN invalid field value length THEN throws error', () => {
+			const embed = new EmbedBuilder();
 
-				expect(() => embed.addFields({ name: 'a'.repeat(257), value: 'bar' })).toThrowError();
-			});
-		});
-
-		describe('GIVEN invalid field value length THEN throws error', () => {
-			test('4', () => {
-				const embed = new EmbedBuilder();
-
-				expect(() => embed.addFields({ name: '', value: 'a'.repeat(1_025) })).toThrowError();
-			});
+			expect(() => embed.addFields({ name: '', value: 'a'.repeat(1_025) })).toThrowError();
 		});
 	});
 });

--- a/packages/builders/src/messages/embed/Assertions.ts
+++ b/packages/builders/src/messages/embed/Assertions.ts
@@ -2,17 +2,9 @@ import { s } from '@sapphire/shapeshift';
 import type { APIEmbedField } from 'discord-api-types/v10';
 import { isValidationEnabled } from '../../util/validation.js';
 
-export const fieldNamePredicate = s
-	.string()
-	.lengthGreaterThanOrEqual(1)
-	.lengthLessThanOrEqual(256)
-	.setValidationEnabled(isValidationEnabled);
+export const fieldNamePredicate = s.string().lengthLessThanOrEqual(256).setValidationEnabled(isValidationEnabled);
 
-export const fieldValuePredicate = s
-	.string()
-	.lengthGreaterThanOrEqual(1)
-	.lengthLessThanOrEqual(1_024)
-	.setValidationEnabled(isValidationEnabled);
+export const fieldValuePredicate = s.string().lengthLessThanOrEqual(1_024).setValidationEnabled(isValidationEnabled);
 
 export const fieldInlinePredicate = s.boolean().optional();
 
@@ -32,7 +24,10 @@ export function validateFieldLength(amountAdding: number, fields?: APIEmbedField
 	fieldLengthPredicate.parse((fields?.length ?? 0) + amountAdding);
 }
 
-export const authorNamePredicate = fieldNamePredicate.nullable().setValidationEnabled(isValidationEnabled);
+export const authorNamePredicate = fieldNamePredicate
+	.lengthGreaterThanOrEqual(1)
+	.nullable()
+	.setValidationEnabled(isValidationEnabled);
 
 export const imageURLPredicate = s
 	.string()
@@ -96,4 +91,7 @@ export const embedFooterPredicate = s
 
 export const timestampPredicate = s.union([s.number(), s.date()]).nullable().setValidationEnabled(isValidationEnabled);
 
-export const titlePredicate = fieldNamePredicate.nullable().setValidationEnabled(isValidationEnabled);
+export const titlePredicate = fieldNamePredicate
+	.lengthGreaterThanOrEqual(1)
+	.nullable()
+	.setValidationEnabled(isValidationEnabled);


### PR DESCRIPTION
Backport of #10745