### PR TITLE
fix: Do not omit falsy default values

### DIFF
--- a/apps/website/src/components/ParameterNode.tsx
+++ b/apps/website/src/components/ParameterNode.tsx
@@ -29,7 +29,7 @@ export async function ParameterNode({
 								{description ? <Badges node={parameter} /> : null}
 								{parameter.name}
 								{parameter.isOptional ? '?' : ''}: <ExcerptNode node={parameter.typeExcerpt} version={version} />
-								{parameter.defaultValue !== undefined ? ` = ${parameter.defaultValue}` : ''}
+								{parameter.defaultValue === undefined ? '' : ` = ${parameter.defaultValue}`}
 							</span>
 							{description && parameter.description?.length ? (
 								<div className="mt-4 pl-4">

--- a/apps/website/src/components/ParameterNode.tsx
+++ b/apps/website/src/components/ParameterNode.tsx
@@ -29,7 +29,7 @@ export async function ParameterNode({
 								{description ? <Badges node={parameter} /> : null}
 								{parameter.name}
 								{parameter.isOptional ? '?' : ''}: <ExcerptNode node={parameter.typeExcerpt} version={version} />
-								{parameter.defaultValue ? ` = ${parameter.defaultValue}` : ''}
+								{parameter.defaultValue !== undefined ? ` = ${parameter.defaultValue}` : ''}
 							</span>
 							{description && parameter.description?.length ? (
 								<div className="mt-4 pl-4">

--- a/apps/website/src/components/ParameterNode.tsx
+++ b/apps/website/src/components/ParameterNode.tsx
@@ -29,7 +29,7 @@ export async function ParameterNode({
 								{description ? <Badges node={parameter} /> : null}
 								{parameter.name}
 								{parameter.isOptional ? '?' : ''}: <ExcerptNode node={parameter.typeExcerpt} version={version} />
-								{parameter.defaultValue === undefined ? '' : ` = ${parameter.defaultValue}`}
+								{parameter.defaultValue ? ` = ${parameter.defaultValue}` : ''}
 							</span>
 							{description && parameter.description?.length ? (
 								<div className="mt-4 pl-4">

--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -1270,7 +1270,7 @@ export class ApiModelGenerator {
 				const apiItemMetadata: ApiItemMetadata = this._collector.fetchApiItemMetadata(astDeclaration);
 				const docComment: tsdoc.DocComment | undefined = jsDoc
 					? this._tsDocParser.parseString(
-							`/**\n * ${this._fixLinkTags(jsDoc.description) ?? ''}${jsDoc.default ? ` (default: ${this._escapeSpecialChars(jsDoc.default)})` : ''}\n${
+							`/**\n * ${this._fixLinkTags(jsDoc.description) ?? ''}${jsDoc.default === undefined ? '' : ` (default: ${this._escapeSpecialChars(jsDoc.default)})`}\n${
 								'see' in jsDoc ? jsDoc.see.map((see) => ` * @see ${see}\n`).join('') : ''
 							}${'readonly' in jsDoc && jsDoc.readonly ? ' * @readonly\n' : ''}${
 								'deprecated' in jsDoc && jsDoc.deprecated
@@ -1348,7 +1348,7 @@ export class ApiModelGenerator {
 				const apiItemMetadata: ApiItemMetadata = this._collector.fetchApiItemMetadata(astDeclaration);
 				const docComment: tsdoc.DocComment | undefined = jsDoc
 					? this._tsDocParser.parseString(
-							`/**\n * ${this._fixLinkTags(jsDoc.description) ?? ''}${jsDoc.default ? `\n * @defaultValue ${this._escapeSpecialChars(jsDoc.default)}` : ''}\n${
+							`/**\n * ${this._fixLinkTags(jsDoc.description) ?? ''}${jsDoc.default === undefined ? '' : `\n * @defaultValue ${this._escapeSpecialChars(jsDoc.default)}`}\n${
 								'see' in jsDoc ? jsDoc.see.map((see) => ` * @see ${see}\n`).join('') : ''
 							}${'readonly' in jsDoc && jsDoc.readonly ? ' * @readonly\n' : ''}${
 								'deprecated' in jsDoc && jsDoc.deprecated


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes default falsy values not showing up on docs, like `BaseFetchOptions`' force:
![image](https://github.com/user-attachments/assets/6a5e1459-232c-4b23-8fc4-8fc64e4d3f22)

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
