### PR TITLE
feat(ws): zstd streaming support

### DIFF
--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -20,6 +20,7 @@ export enum Encoding {
 export enum CompressionMethod {
 	ZlibNative,
 	ZlibSync,
+	ZstdStream,
 }
 
 export const DefaultDeviceProperty = `@discordjs/ws [VI]{{inject}}[/VI]` as `@discordjs/ws ${string}`;
@@ -29,6 +30,7 @@ const getDefaultSessionStore = lazy(() => new Collection<number, SessionInfo | n
 export const CompressionParameterMap = {
 	[CompressionMethod.ZlibNative]: 'zlib-stream',
 	[CompressionMethod.ZlibSync]: 'zlib-stream',
+	[CompressionMethod.ZstdStream]: 'zstd-stream',
 } as const satisfies Record<CompressionMethod, string>;
 
 /**

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -222,7 +222,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 
 						this.nativeInflate = inflate;
 					} else {
-						console.warn('WebSocketShard: Compression is set to native but node:zlib is not available.');
+						console.warn('WebSocketShard: Compression is set to native zlib but node:zlib is not available.');
 						params.delete('compress');
 					}
 
@@ -238,6 +238,35 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 						});
 					} else {
 						console.warn('WebSocketShard: Compression is set to zlib-sync, but it is not installed.');
+						params.delete('compress');
+					}
+
+					break;
+				}
+
+				case CompressionMethod.ZstdStream: {
+					const zlib = await getNativeZlib();
+					if (zlib && 'createZstdDecompress' in zlib) {
+						this.inflateBuffer = [];
+
+						// @ts-expect-error node 23 called, it wants its code back
+						const inflate = zlib.createZstdDecompress({
+							chunkSize: 65_535,
+						}) as nativeZlib.Inflate;
+
+						inflate.on('data', (chunk) => {
+							this.inflateBuffer.push(chunk);
+						});
+
+						inflate.on('error', (error) => {
+							this.emit(WebSocketShardEvents.Error, error);
+						});
+
+						this.nativeInflate = inflate;
+					} else {
+						console.warn(
+							'WebSocketShard: Compression is set to native zstd but node:zlib is not available or your node version does not support zstd decompression.',
+						);
 						params.delete('compress');
 					}
 
@@ -632,12 +661,14 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 
 		// Deal with transport compression
 		if (this.transportCompressionEnabled) {
+			// Each WS message received is a full gateway message for zstd streaming, but for zlib it's chunked
 			const flush =
-				decompressable.length >= 4 &&
-				decompressable.at(-4) === 0x00 &&
-				decompressable.at(-3) === 0x00 &&
-				decompressable.at(-2) === 0xff &&
-				decompressable.at(-1) === 0xff;
+				this.strategy.options.compression === CompressionMethod.ZstdStream ||
+				(decompressable.length >= 4 &&
+					decompressable.at(-4) === 0x00 &&
+					decompressable.at(-3) === 0x00 &&
+					decompressable.at(-2) === 0xff &&
+					decompressable.at(-1) === 0xff);
 
 			if (this.nativeInflate) {
 				const doneWriting = new Promise<void>((resolve) => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Brings in native zstd streaming support for gateway decompression in environments that have it

That said, I'm leaving this as a draft for now, and seeing how zstd support progresses in node (specifically the backporting)

If someone wants to test it locally with their bots that have bigger payloads, you can use a script like this, after cloning this PR and building the repo

```js
import { REST } from '@discordjs/rest';
import { CompressionMethod, WebSocketManager } from '@discordjs/ws';

const token = '';

const rest = new REST({}).setToken(token);

const manager = new WebSocketManager({
	intents: 0,
	rest,
	token,
	shardCount: 16,
	shardIds: [0],
	helloTimeout: 10_000,
	compression: CompressionMethod.ZstdNative,
});

manager.on('debug', console.log);
manager.on('error', console.error);

await manager.connect();
console.log('Connected');
```

Runnable with `volta run --node 23 node script.mjs` or whichever tool floats your boat.

Ideally we'd have some non native zstd module too but there doesn't seem to be any that exist right now 🙃

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
