### PR TITLE
feat: print out support for aes-256-gcm in native node:crypto

### DIFF
--- a/packages/voice/src/util/generateDependencyReport.ts
+++ b/packages/voice/src/util/generateDependencyReport.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable @typescript-eslint/no-require-imports */
+import { getCiphers } from 'node:crypto';
 import { resolve, dirname } from 'node:path';
 import prism from 'prism-media';
 
@@ -65,6 +66,7 @@ export function generateDependencyReport() {
 
 	// encryption
 	report.push('Encryption Libraries');
+	report.push(`- native crypto support for aes-256-gcm: ${getCiphers().includes('aes-256-gcm') ? 'yes' : 'no'}`);
 	addVersion('sodium-native');
 	addVersion('sodium');
 	addVersion('libsodium-wrappers');


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Just some extra debug info for voice users to make sure their encryption will work without anything optional installed

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
