### PR TITLE
fix(GuildChannelManager): properly resolve avatar for createWebhook

### DIFF
--- a/packages/discord.js/src/managers/GuildChannelManager.js
+++ b/packages/discord.js/src/managers/GuildChannelManager.js
@@ -237,13 +237,13 @@ class GuildChannelManager extends CachedManager {
   async createWebhook({ channel, name, avatar, reason }) {
     const id = this.resolveId(channel);
     if (!id) throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'channel', 'GuildChannelResolvable');
-    if (typeof avatar === 'string' && !avatar.startsWith('data:')) {
-      avatar = await resolveImage(avatar);
-    }
+
+    const resolvedImage = await resolveImage(avatar);
+
     const data = await this.client.rest.post(Routes.channelWebhooks(id), {
       body: {
         name,
-        avatar,
+        avatar: resolvedImage,
       },
       reason,
     });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
 It was only resolving when avatar was a string, but it is also typed to accept `BufferResolvable` and by extension a `Buffer`.
 Fixes #10770 
 
**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
