### PR TITLE
types: make `Client.on()` compatible with esnext.disposable in TS5.6+

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1029,6 +1029,16 @@ export type If<Value extends boolean, TrueResult, FalseResult = null> = Value ex
     ? FalseResult
     : TrueResult | FalseResult;
 
+/** @internal */
+type AsyncEventIteratorDisposability =
+  ReturnType<typeof EventEmitter.on> extends AsyncDisposable ? AsyncDisposable : {};
+/** @internal */
+interface AsyncEventIterator<Params extends any[]>
+  extends AsyncIterableIterator<Params>,
+    AsyncEventIteratorDisposability {
+  [Symbol.asyncIterator](): AsyncEventIterator<Params>;
+}
+
 export class Client<Ready extends boolean = boolean> extends BaseClient {
   public constructor(options: ClientOptions);
   private actions: unknown;
@@ -1049,7 +1059,7 @@ export class Client<Ready extends boolean = boolean> extends BaseClient {
     eventEmitter: Emitter,
     eventName: Emitter extends Client ? Event : string | symbol,
     options?: { signal?: AbortSignal | undefined },
-  ): AsyncIterableIterator<Emitter extends Client ? ClientEvents[Event] : any[]>;
+  ): AsyncEventIterator<Emitter extends Client ? ClientEvents[Event] : any[]>;
 
   public application: If<Ready, ClientApplication>;
   public channels: ChannelManager;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1322,7 +1322,7 @@ client.on('guildCreate', async g => {
 
 // EventEmitter static method overrides
 expectType<Promise<[Client<true>]>>(Client.once(client, 'ready'));
-expectType<AsyncIterableIterator<[Client<true>]>>(Client.on(client, 'ready'));
+expectAssignable<AsyncIterableIterator<[Client<true>]>>(Client.on(client, 'ready'));
 
 client.login('absolutely-valid-token');
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Resolves #10577.

A sticking plaster for v14 to cover this issue, which causes compiler errors when using TS 5.6 or higher under [specific conditions](https://github.com/discordjs/discord.js/issues/10577#issuecomment-2434353380). The underlying problem is that the `EventEmitter.on()` iterator now extends AsyncIteratorObject in TS 5.6+, which becomes an AsyncDisposable if lib.esnext.disposable is loaded, whereas the override signature in the v14 types uses the older AsyncIterableIterator, which isn't AsyncDisposable and so causes an assignability mismatch.

AsyncIteratorObject doesn't exist in TypeScript 5.5 and earlier, so this change provides a custom AsyncIterableIterator interface that matches whether the return type of the parent `EventEmitter.on()` is AsyncDisposable or not.

This isn't future-proof against any further changes to the TS iterator types, but this only really needs to hold until v15 ships, and this seems like the least invasive fix.

It's not possible to test this fix within the tsd tests, as the package dependencies use neither an affected version of TypeScript nor an affected version of @types/node; however, manual tests confirm it to be working as intended.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
