### PR TITLE
feat: re-emit REST debug logs

### DIFF
--- a/packages/discord.js/src/client/BaseClient.js
+++ b/packages/discord.js/src/client/BaseClient.js
@@ -1,9 +1,10 @@
 'use strict';
 
-const { REST } = require('@discordjs/rest');
+const { REST, RESTEvents } = require('@discordjs/rest');
 const { AsyncEventEmitter } = require('@vladfrangu/async_event_emitter');
 const { Routes } = require('discord-api-types/v10');
 const { DiscordjsTypeError, ErrorCodes } = require('../errors/index.js');
+const { Events } = require('../util/Events.js');
 const { Options } = require('../util/Options.js');
 const { flatten } = require('../util/Util.js');
 
@@ -53,6 +54,8 @@ class BaseClient extends AsyncEventEmitter {
      * @type {REST}
      */
     this.rest = new REST(this.options.rest);
+
+    this.rest.on(RESTEvents.Debug, message => this.emit(Events.Debug, message));
   }
 
   /**

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -115,7 +115,7 @@ export class REST extends AsyncEventEmitter<RestEvents> {
 						sweptHashes.set(key, val);
 
 						// Emit debug information
-						this.emit(RESTEvents.Debug, `Hash ${val.value} for ${key} swept due to lifetime being exceeded`);
+						this.emit(RESTEvents.Debug, `[REST] Hash ${val.value} for ${key} swept due to lifetime being exceeded`);
 					}
 
 					return shouldSweep;
@@ -140,7 +140,7 @@ export class REST extends AsyncEventEmitter<RestEvents> {
 					// Collect inactive handlers
 					if (inactive) {
 						sweptHandlers.set(key, val);
-						this.emit(RESTEvents.Debug, `Handler ${val.id} for ${key} swept due to being inactive`);
+						this.emit(RESTEvents.Debug, `[REST] Handler ${val.id} for ${key} swept due to being inactive`);
 					}
 
 					return inactive;


### PR DESCRIPTION
Re-emit /rest debug event on discord.js' debug event, just like the debug event from /ws

To provide better context, added a seemingly missing prefix from REST's class debug logs, which is already present on the individual handlers, like
https://github.com/discordjs/discord.js/blob/1054f4abce14969429e6c84e095f9f0f0b10fa85/packages/rest/src/lib/handlers/SequentialHandler.ts#L118 