### PR TITLE
fix(GuildMember): cache based on partials options

### DIFF
--- a/packages/discord.js/src/client/websocket/handlers/PRESENCE_UPDATE.js
+++ b/packages/discord.js/src/client/websocket/handlers/PRESENCE_UPDATE.js
@@ -21,11 +21,14 @@ module.exports = (client, { d: data }) => {
 
   let member = guild.members.cache.get(user.id);
   if (!member && data.status !== 'offline') {
-    member = guild.members._add({
-      user,
-      deaf: false,
-      mute: false,
-    });
+    member = guild.members._add(
+      {
+        user,
+        deaf: false,
+        mute: false,
+      },
+      client.options.partials.includes(Partials.GuildMember),
+    );
 
     client.emit(Events.GuildMemberAvailable, member);
   }

--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -31,7 +31,7 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * The cache of this Manager
-   * @type {Collection<Snowflake, GuildMember>}
+   * @type {Collection<Snowflake, GuildMember | PartialGuildMember>}
    * @name GuildMemberManager#cache
    */
 
@@ -42,7 +42,7 @@ class GuildMemberManager extends CachedManager {
   /**
    * Resolves a {@link UserResolvable} to a {@link GuildMember} object.
    * @param {UserResolvable} member The user that is part of the guild
-   * @returns {?GuildMember}
+   * @returns {?(GuildMember | PartialGuildMember)}
    */
   resolve(member) {
     const memberResolvable = super.resolve(member);
@@ -132,7 +132,7 @@ class GuildMemberManager extends CachedManager {
 
   /**
    * The client user as a GuildMember of this guild
-   * @type {?GuildMember}
+   * @type {?(GuildMember | PartialGuildMember)}
    * @readonly
    */
   get me() {

--- a/packages/discord.js/src/managers/GuildMemberRoleManager.js
+++ b/packages/discord.js/src/managers/GuildMemberRoleManager.js
@@ -16,7 +16,7 @@ class GuildMemberRoleManager extends DataManager {
 
     /**
      * The GuildMember this manager belongs to
-     * @type {GuildMember}
+     * @type {GuildMember | PartialGuildMember}
      */
     this.member = member;
 

--- a/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
@@ -93,7 +93,7 @@ class BaseGuildVoiceChannel extends GuildChannel {
 
   /**
    * The members in this voice-based channel
-   * @type {Collection<Snowflake, GuildMember>}
+   * @type {Collection<Snowflake, GuildMember | PartialGuildMember>}
    * @readonly
    */
   get members() {

--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -275,7 +275,7 @@ class GuildChannel extends BaseChannel {
    * A collection of cached members of this channel, mapped by their ids.
    * Members that can view this channel, if the channel is text-based.
    * Members in the channel, if the channel is voice-based.
-   * @type {Collection<Snowflake, GuildMember>}
+   * @type {Collection<Snowflake, GuildMember | PartialGuildMember>}
    * @readonly
    */
   get members() {

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -497,7 +497,7 @@ class Message extends Base {
   /**
    * Represents the author of the message as a guild member.
    * Only available if the message comes from a guild where the author is still a member
-   * @type {?GuildMember}
+   * @type {?(GuildMember | PartialGuildMember)}
    * @readonly
    */
   get member() {

--- a/packages/discord.js/src/structures/MessageMentions.js
+++ b/packages/discord.js/src/structures/MessageMentions.js
@@ -129,7 +129,7 @@ class MessageMentions {
 
     /**
      * Cached members for {@link MessageMentions#members}
-     * @type {?Collection<Snowflake, GuildMember>}
+     * @type {?Collection<Snowflake, GuildMember | PartialGuildMember>}
      * @private
      */
     this._members = null;
@@ -190,7 +190,7 @@ class MessageMentions {
   /**
    * Any members that were mentioned (only in {@link Guild}s)
    * <info>Order as received from the API, not as they appear in the message content</info>
-   * @type {?Collection<Snowflake, GuildMember>}
+   * @type {?Collection<Snowflake, GuildMember | PartialGuildMember>}
    * @readonly
    */
   get members() {

--- a/packages/discord.js/src/structures/Presence.js
+++ b/packages/discord.js/src/structures/Presence.js
@@ -63,7 +63,7 @@ class Presence extends Base {
 
   /**
    * The member of this presence
-   * @type {?GuildMember}
+   * @type {?(GuildMember | PartialGuildMember)}
    * @readonly
    */
   get member() {

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -175,7 +175,7 @@ class Role extends Base {
 
   /**
    * The cached guild members that have this role
-   * @type {Collection<Snowflake, GuildMember>}
+   * @type {Collection<Snowflake, GuildMember | PartialGuildMember>}
    * @readonly
    */
   get members() {

--- a/packages/discord.js/src/structures/Typing.js
+++ b/packages/discord.js/src/structures/Typing.js
@@ -63,7 +63,7 @@ class Typing extends Base {
 
   /**
    * The member who is typing
-   * @type {?GuildMember}
+   * @type {?(GuildMember | PartialGuildMember)}
    * @readonly
    */
   get member() {

--- a/packages/discord.js/src/structures/VoiceState.js
+++ b/packages/discord.js/src/structures/VoiceState.js
@@ -132,7 +132,7 @@ class VoiceState extends Base {
 
   /**
    * The member that this voice state belongs to
-   * @type {?GuildMember}
+   * @type {?(GuildMember | PartialGuildMember)}
    * @readonly
    */
   get member() {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -677,7 +677,7 @@ export class BaseGuildVoiceChannel extends GuildChannel {
   public bitrate: number;
   public get full(): boolean;
   public get joinable(): boolean;
-  public get members(): Collection<Snowflake, GuildMember>;
+  public get members(): Collection<Snowflake, GuildMember | PartialGuildMember>;
   public nsfw: boolean;
   public rateLimitPerUser: number | null;
   public rtcRegion: string | null;
@@ -1541,7 +1541,10 @@ export class GuildBan extends Base {
 
 export abstract class GuildChannel extends BaseChannel {
   public constructor(guild: Guild, data?: RawGuildChannelData, client?: Client<true>, immediatePatch?: boolean);
-  private memberPermissions(member: GuildMember, checkAdmin: boolean): Readonly<PermissionsBitField>;
+  private memberPermissions(
+    member: GuildMember | PartialGuildMember,
+    checkAdmin: boolean,
+  ): Readonly<PermissionsBitField>;
   private rolePermissions(role: Role, checkAdmin: boolean): Readonly<PermissionsBitField>;
   public get createdAt(): Date;
   public get createdTimestamp(): number;
@@ -1550,7 +1553,7 @@ export abstract class GuildChannel extends BaseChannel {
   public guild: Guild;
   public guildId: Snowflake;
   public get manageable(): boolean;
-  public get members(): Collection<Snowflake, GuildMember>;
+  public get members(): Collection<Snowflake, GuildMember | PartialGuildMember>;
   public name: string;
   public get parent(): CategoryChannel | null;
   public parentId: Snowflake | null;
@@ -1565,7 +1568,10 @@ export abstract class GuildChannel extends BaseChannel {
   public edit(options: GuildChannelEditOptions): Promise<this>;
   public equals(channel: GuildChannel): boolean;
   public lockPermissions(): Promise<this>;
-  public permissionsFor(memberOrRole: GuildMember | Role, checkAdmin?: boolean): Readonly<PermissionsBitField>;
+  public permissionsFor(
+    memberOrRole: GuildMember | PartialGuildMember | Role,
+    checkAdmin?: boolean,
+  ): Readonly<PermissionsBitField>;
   public permissionsFor(
     memberOrRole: UserResolvable | RoleResolvable,
     checkAdmin?: boolean,
@@ -1618,8 +1624,8 @@ export class GuildMember extends Base {
   public get communicationDisabledUntil(): Date | null;
   public communicationDisabledUntilTimestamp: number | null;
   public flags: Readonly<GuildMemberFlagsBitField>;
-  public get joinedAt(): Date | null;
-  public joinedTimestamp: number | null;
+  public get joinedAt(): Date;
+  public joinedTimestamp: number;
   public get kickable(): boolean;
   public get manageable(): boolean;
   public get moderatable(): boolean;
@@ -2135,7 +2141,7 @@ export class Message<InGuild extends boolean = boolean> extends Base {
   public get hasThread(): boolean;
   public id: Snowflake;
   public interactionMetadata: MessageInteractionMetadata | null;
-  public get member(): GuildMember | null;
+  public get member(): GuildMember | PartialGuildMember | null;
   public mentions: MessageMentions<InGuild>;
   public nonce: string | number | null;
   public get partial(): false;
@@ -2370,7 +2376,7 @@ export class MessageMentions<InGuild extends boolean = boolean> {
   );
   private _channels: Collection<Snowflake, Channel> | null;
   private readonly _content: string;
-  private _members: Collection<Snowflake, GuildMember> | null;
+  private _members: Collection<Snowflake, GuildMember | PartialGuildMember> | null;
   private _parsedUsers: Collection<Snowflake, User> | null;
 
   public get channels(): Collection<Snowflake, Channel>;
@@ -2378,7 +2384,7 @@ export class MessageMentions<InGuild extends boolean = boolean> {
   public everyone: boolean;
   public readonly guild: If<InGuild, Guild>;
   public has(data: UserResolvable | RoleResolvable | ChannelResolvable, options?: MessageMentionsHasOptions): boolean;
-  public get members(): If<InGuild, Collection<Snowflake, GuildMember>>;
+  public get members(): If<InGuild, Collection<Snowflake, GuildMember | PartialGuildMember>>;
   public get parsedUsers(): Collection<Snowflake, User>;
   public repliedUser: User | null;
   public roles: Collection<Snowflake, Role>;
@@ -2693,7 +2699,7 @@ export class Presence extends Base {
   public activities: Activity[];
   public clientStatus: ClientPresenceStatusData | null;
   public guild: Guild | null;
-  public get member(): GuildMember | null;
+  public get member(): GuildMember | PartialGuildMember | null;
   public status: PresenceStatus;
   public get user(): User | null;
   public userId: Snowflake;
@@ -2803,7 +2809,7 @@ export class Role extends Base {
   public hoist: boolean;
   public id: Snowflake;
   public managed: boolean;
-  public get members(): Collection<Snowflake, GuildMember>;
+  public get members(): Collection<Snowflake, GuildMember | PartialGuildMember>;
   public mentionable: boolean;
   public name: string;
   public permissions: Readonly<PermissionsBitField>;
@@ -3355,7 +3361,10 @@ export class ThreadChannel<ThreadOnly extends boolean = boolean> extends BaseCha
   public edit(options: ThreadEditOptions): Promise<this>;
   public join(): Promise<this>;
   public leave(): Promise<this>;
-  public permissionsFor(memberOrRole: GuildMember | Role, checkAdmin?: boolean): Readonly<PermissionsBitField>;
+  public permissionsFor(
+    memberOrRole: GuildMember | PartialGuildMember | Role,
+    checkAdmin?: boolean,
+  ): Readonly<PermissionsBitField>;
   public permissionsFor(
     memberOrRole: UserResolvable | RoleResolvable,
     checkAdmin?: boolean,
@@ -3403,7 +3412,7 @@ export class Typing extends Base {
   public startedTimestamp: number;
   public get startedAt(): Date;
   public get guild(): Guild | null;
-  public get member(): GuildMember | null;
+  public get member(): GuildMember | PartialGuildMember | null;
   public inGuild(): this is this & {
     channel: TextChannel | AnnouncementChannel | ThreadChannel;
     get guild(): Guild;
@@ -3586,7 +3595,7 @@ export class VoiceState extends Base {
   public get deaf(): boolean | null;
   public guild: Guild;
   public id: Snowflake;
-  public get member(): GuildMember | null;
+  public get member(): GuildMember | PartialGuildMember | null;
   public get mute(): boolean | null;
   public selfDeaf: boolean | null;
   public selfMute: boolean | null;
@@ -4224,10 +4233,10 @@ export interface AddOrRemoveGuildMemberRoleOptions {
   reason?: string;
 }
 
-export class GuildMemberManager extends CachedManager<Snowflake, GuildMember, UserResolvable> {
+export class GuildMemberManager extends CachedManager<Snowflake, GuildMember | PartialGuildMember, UserResolvable> {
   private constructor(guild: Guild, iterable?: Iterable<RawGuildMemberData>);
   public guild: Guild;
-  public get me(): GuildMember | null;
+  public get me(): GuildMember | PartialGuildMember | null;
   public add(
     user: UserResolvable,
     options: AddGuildMemberOptions & { fetchWhenExisting: false },
@@ -4314,14 +4323,14 @@ export class GuildStickerManager extends CachedManager<Snowflake, Sticker, Stick
 }
 
 export class GuildMemberRoleManager extends DataManager<Snowflake, Role, RoleResolvable> {
-  private constructor(member: GuildMember);
+  private constructor(member: GuildMember | PartialGuildMember);
   public get hoist(): Role | null;
   public get icon(): Role | null;
   public get color(): Role | null;
   public get highest(): Role;
   public get premiumSubscriberRole(): Role | null;
   public get botRole(): Role | null;
-  public member: GuildMember;
+  public member: GuildMember | PartialGuildMember;
   public guild: Guild;
 
   public add(
@@ -5959,7 +5968,15 @@ export interface GuildMemberEditOptions {
   reason?: string;
 }
 
-export type GuildResolvable = Guild | NonThreadGuildBasedChannel | GuildMember | GuildEmoji | Invite | Role | Snowflake;
+export type GuildResolvable =
+  | Guild
+  | NonThreadGuildBasedChannel
+  | GuildMember
+  | PartialGuildMember
+  | GuildEmoji
+  | Invite
+  | Role
+  | Snowflake;
 
 export interface GuildPruneMembersOptions {
   count?: boolean;
@@ -6864,7 +6881,7 @@ export type ThreadMemberResolvable = ThreadMember | UserResolvable;
 
 export type UserMention = `<@${Snowflake}>`;
 
-export type UserResolvable = User | Snowflake | Message | GuildMember | ThreadMember;
+export type UserResolvable = User | Snowflake | Message | GuildMember | PartialGuildMember | ThreadMember;
 
 export interface Vanity {
   code: string | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR based on [previous PR's](https://github.com/discordjs/discord.js/pull/10784) conversation.

[Discord API's Guild Member object](https://discord.com/developers/docs/resources/guild#guild-member-object) has isn't nullable `joinedAt` property.
This also confirms the [partial property set to false](https://github.com/discordjs/discord.js/blob/main/packages/discord.js/typings/index.d.ts#L1627), which depends on the [nullability of `joinedAt`](https://github.com/discordjs/discord.js/blob/88bfeaab224b896147483e59013874c0de2dfbac/packages/discord.js/src/structures/GuildMember.js#L136) and the [use of `Partialize`](https://github.com/discordjs/discord.js/blob/88bfeaab224b896147483e59013874c0de2dfbac/packages/discord.js/typings/index.d.ts#L6579) for this property to create the `PartialGuildMember` interface.
It's also incorrect that caching of a partial member is performed despite the provided partials options.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
