### PR TITLE
feat(Typing): cache member object

### DIFF
--- a/packages/discord.js/src/structures/Typing.js
+++ b/packages/discord.js/src/structures/Typing.js
@@ -33,6 +33,14 @@ class Typing extends Base {
        */
       this.startedTimestamp = data.timestamp * 1_000;
     }
+
+    if ('member' in data) {
+      /**
+       * The member that this guild typing instance represents
+       * @type {?GuildMember}
+       */
+      this.member = this.channel.guild.members._add(data.member, true);
+    }
   }
 
   /**
@@ -59,15 +67,6 @@ class Typing extends Base {
    */
   get guild() {
     return this.channel.guild ?? null;
-  }
-
-  /**
-   * The member who is typing
-   * @type {?GuildMember}
-   * @readonly
-   */
-  get member() {
-    return this.guild?.members.resolve(this.user) ?? null;
   }
 }
 

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3403,7 +3403,7 @@ export class Typing extends Base {
   public startedTimestamp: number;
   public get startedAt(): Date;
   public get guild(): Guild | null;
-  public get member(): GuildMember | null;
+  public member: GuildMember | null;
   public inGuild(): this is this & {
     channel: TextChannel | AnnouncementChannel | ThreadChannel;
     get guild(): Guild;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Discord API [provides member object](https://discord.com/developers/docs/events/gateway-events#typing-start) with `TYPING_START` event in guild. We can use this for cache update and getting value without getter

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
