### PR TITLE
docs: remove hardcoded locale from links

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Learn how to add code owners here:
-# https://help.github.com/en/articles/about-code-owners
+# https://help.github.com/articles/about-code-owners
 
 * @iCrawl
 

--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -1,4 +1,4 @@
-# https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
+# https://docs.github.com/actions/using-workflows/caching-dependencies-to-speed-up-workflows#force-deleting-cache-entries
 name: Cleanup caches
 on:
   pull_request:

--- a/packages/builders/src/components/ActionRow.ts
+++ b/packages/builders/src/components/ActionRow.ts
@@ -297,7 +297,7 @@ export class ActionRowBuilder extends ComponentBuilder<APIActionRowComponent<API
 	 *
 	 * @remarks
 	 * This method behaves similarly
-	 * to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
+	 * to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
 	 *
 	 * It's useful for modifying and adjusting order of the already-existing components of an action row.
 	 * @example

--- a/packages/builders/src/components/selectMenu/StringSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/StringSelectMenu.ts
@@ -106,7 +106,7 @@ export class StringSelectMenuBuilder extends BaseSelectMenuBuilder<APIStringSele
 	 *
 	 * @remarks
 	 * This method behaves similarly
-	 * to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice | Array.prototype.splice()}.
+	 * to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/slice | Array.prototype.splice()}.
 	 * It's useful for modifying and adjusting the order of existing options.
 	 * @example
 	 * Remove the first option:

--- a/packages/builders/src/interactions/commands/chatInput/mixins/SharedChatInputCommandOptions.ts
+++ b/packages/builders/src/interactions/commands/chatInput/mixins/SharedChatInputCommandOptions.ts
@@ -151,7 +151,7 @@ export class SharedChatInputCommandOptions {
 	 *
 	 * @remarks
 	 * This method behaves similarly
-	 * to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
+	 * to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
 	 *
 	 * It's useful for modifying and adjusting order of the already-existing options for this command.
 	 * @example

--- a/packages/builders/src/interactions/modals/Modal.ts
+++ b/packages/builders/src/interactions/modals/Modal.ts
@@ -108,7 +108,7 @@ export class ModalBuilder implements JSONEncodable<APIModalInteractionResponseCa
 	 *
 	 * @remarks
 	 * This method behaves similarly
-	 * to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
+	 * to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
 	 * The maximum amount of action rows that can be added is 5.
 	 *
 	 * It's useful for modifying and adjusting order of the already-existing action rows of a modal.

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -87,7 +87,7 @@ export class EmbedBuilder implements JSONEncodable<APIEmbed> {
 	 *
 	 * @remarks
 	 * This method behaves similarly
-	 * to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
+	 * to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
 	 * The maximum amount of fields that can be added is 25.
 	 *
 	 * It's useful for modifying and adjusting order of the already-existing fields of an embed.

--- a/packages/builders/src/messages/poll/Poll.ts
+++ b/packages/builders/src/messages/poll/Poll.ts
@@ -82,7 +82,7 @@ export class PollBuilder implements JSONEncodable<RESTAPIPoll> {
 	 *
 	 * @remarks
 	 * This method behaves similarly
-	 * to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
+	 * to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
 	 * The maximum amount of answers that can be added is 10.
 	 *
 	 * It's useful for modifying and adjusting order of the already-existing answers of a poll.

--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -148,7 +148,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	}
 
 	/**
-	 * Identical to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at | Array.at()}.
+	 * Identical to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/at | Array.at()}.
 	 * Returns the item at a given index, allowing for positive and negative integers.
 	 * Negative integers count back from the last item in the collection.
 	 *
@@ -172,7 +172,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	}
 
 	/**
-	 * Identical to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at | Array.at()}.
+	 * Identical to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/at | Array.at()}.
 	 * Returns the key at a given index, allowing for positive and negative integers.
 	 * Negative integers count back from the last item in the collection.
 	 *
@@ -240,7 +240,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	}
 
 	/**
-	 * Identical to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse | Array.reverse()}
+	 * Identical to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse | Array.reverse()}
 	 * but returns a Collection instead of an Array.
 	 */
 	public reverse() {
@@ -252,10 +252,10 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Searches for a single item where the given function returns a truthy value. This behaves like
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find | Array.find()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/find | Array.find()}.
 	 * All collections used in Discord.js are mapped using their `id` property, and if you want to find by id you
 	 * should use the `get` method. See
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get | MDN} for details.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/get | MDN} for details.
 	 *
 	 * @param fn - The function to test with (should return a boolean)
 	 * @param thisArg - Value to use as `this` when executing the function
@@ -288,7 +288,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Searches for the key of a single item where the given function returns a truthy value. This behaves like
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex | Array.findIndex()},
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex | Array.findIndex()},
 	 * but returns the key rather than the positional index.
 	 *
 	 * @param fn - The function to test with (should return a boolean)
@@ -322,7 +322,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Searches for a last item where the given function returns a truthy value. This behaves like
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast | Array.findLast()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLast | Array.findLast()}.
 	 *
 	 * @param fn - The function to test with (should return a boolean)
 	 * @param thisArg - Value to use as `this` when executing the function
@@ -354,7 +354,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Searches for the key of a last item where the given function returns a truthy value. This behaves like
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex | Array.findLastIndex()},
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/findLastIndex | Array.findLastIndex()},
 	 * but returns the key rather than the positional index.
 	 *
 	 * @param fn - The function to test with (should return a boolean)
@@ -407,7 +407,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Identical to
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter | Array.filter()},
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/filter | Array.filter()},
 	 * but returns a Collection instead of an Array.
 	 *
 	 * @param fn - The function to test with (should return a boolean)
@@ -502,7 +502,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Maps each item into a Collection, then joins the results into a single Collection. Identical in behavior to
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap | Array.flatMap()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap | Array.flatMap()}.
 	 *
 	 * @param fn - Function that produces a new Collection
 	 * @param thisArg - Value to use as `this` when executing the function
@@ -529,7 +529,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Maps each item to another value into an array. Identical in behavior to
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map | Array.map()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/map | Array.map()}.
 	 *
 	 * @param fn - Function that produces an element of the new array, taking three arguments
 	 * @param thisArg - Value to use as `this` when executing the function
@@ -559,7 +559,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Maps each item to another value into a collection. Identical in behavior to
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map | Array.map()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/map | Array.map()}.
 	 *
 	 * @param fn - Function that produces an element of the new collection, taking three arguments
 	 * @param thisArg - Value to use as `this` when executing the function
@@ -586,7 +586,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Checks if there exists an item that passes a test. Identical in behavior to
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some | Array.some()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/some | Array.some()}.
 	 *
 	 * @param fn - Function used to test (should return a boolean)
 	 * @param thisArg - Value to use as `this` when executing the function
@@ -609,7 +609,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Checks if all items passes a test. Identical in behavior to
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every | Array.every()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/every | Array.every()}.
 	 *
 	 * @param fn - Function used to test (should return a boolean)
 	 * @param thisArg - Value to use as `this` when executing the function
@@ -646,7 +646,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Applies a function to produce a single value. Identical in behavior to
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce | Array.reduce()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce | Array.reduce()}.
 	 *
 	 * @param fn - Function used to reduce, taking four arguments; `accumulator`, `currentValue`, `currentKey`,
 	 * and `collection`
@@ -688,7 +688,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Applies a function to produce a single value. Identical in behavior to
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight | Array.reduceRight()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight | Array.reduceRight()}.
 	 *
 	 * @param fn - Function used to reduce, taking four arguments; `accumulator`, `value`, `key`, and `collection`
 	 * @param initialValue - Starting value for the accumulator
@@ -730,7 +730,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 
 	/**
 	 * Identical to
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach | Map.forEach()},
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach | Map.forEach()},
 	 * but returns the collection instead of undefined.
 	 *
 	 * @param fn - Function to execute for each element
@@ -832,7 +832,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	/**
 	 * The sort method sorts the items of a collection in place and returns it.
 	 * If a comparison function is not provided, the function sorts by element values, using the same stringwise comparison algorithm as
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort | Array.sort()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort | Array.sort()}.
 	 *
 	 * @param compareFunction - Specifies a function that defines the sort order. The return value of this function should be negative if
 	 * `a` comes before `b`, positive if `b` comes before `a`, or zero if `a` and `b` are considered equal.
@@ -1017,7 +1017,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	}
 
 	/**
-	 * Identical to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed | Array.toReversed()}
+	 * Identical to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/toReversed | Array.toReversed()}
 	 * but returns a Collection instead of an Array.
 	 */
 	public toReversed() {
@@ -1027,7 +1027,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	/**
 	 * The toSorted method returns a shallow copy of the collection with the items sorted.
 	 * If a comparison function is not provided, the function sorts by element values, using the same stringwise comparison algorithm as
-	 * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort | Array.sort()}.
+	 * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/sort | Array.sort()}.
 	 *
 	 * @param compareFunction - Specifies a function that defines the sort order. The return value of this function should be negative if
 	 * `a` comes before `b`, positive if `b` comes before `a`, or zero if `a` and `b` are considered equal.
@@ -1089,7 +1089,7 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	}
 
 	/**
-	 * Identical to {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy | Map.groupBy()}
+	 * Identical to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map/groupBy | Map.groupBy()}
 	 * but returns a Collection instead of a Map.
 	 */
 	public static override groupBy<Key, Item>(

--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -656,7 +656,7 @@ class Client extends BaseClient {
   }
 
   /**
-   * Calls {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval} on a script
+   * Calls {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/eval} on a script
    * with the client as `this`.
    * @param {string} script Script to eval
    * @returns {*}
@@ -733,7 +733,7 @@ exports.Client = Client;
  */
 
 /**
- * A {@link https://developer.twitter.com/en/docs/twitter-ids Twitter snowflake},
+ * A {@link https://docs.x.com/resources/fundamentals/x-ids Twitter snowflake},
  * except the epoch is 2015-01-01T00:00:00.000Z.
  *
  * If we have a snowflake '266241948824764416' we can represent it as binary:

--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -267,7 +267,7 @@ class Collector extends AsyncEventEmitter {
 
   /**
    * Allows collectors to be consumed with for-await-of loops
-   * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of}
+   * @see {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/for-await...of}
    */
   async *[Symbol.asyncIterator]() {
     const queue = [];

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -345,9 +345,9 @@ export class REST extends AsyncEventEmitter<RestEvents> {
 			for (const [index, file] of request.files.entries()) {
 				const fileKey = file.key ?? `files[${index}]`;
 
-				// https://developer.mozilla.org/en-US/docs/Web/API/FormData/append#parameters
+				// https://developer.mozilla.org/docs/Web/API/FormData/append#parameters
 				// FormData.append only accepts a string or Blob.
-				// https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob#parameters
+				// https://developer.mozilla.org/docs/Web/API/Blob/Blob#parameters
 				// The Blob constructor accepts TypedArray/ArrayBuffer, strings, and Blobs.
 				if (isBufferLike(file.data)) {
 					// Try to infer the content type from the buffer if one isn't passed


### PR DESCRIPTION
Removed hardcoded locale links from external links, so each user can open the page directly in their preferred locale