### PR TITLE
fix(GuildMemberManager): Ensure empty object for fetching many guild members

### DIFF
--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -223,7 +223,7 @@ class GuildMemberManager extends CachedManager {
     query: initialQuery,
     time = 120e3,
     nonce = DiscordSnowflake.generate().toString(),
-  }) {
+  } = {}) {
     if (nonce.length > 32) throw new DiscordjsRangeError(ErrorCodes.MemberFetchNonceLength);
 
     const query = initialQuery || (!users ? '' : undefined);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
A regression from #10715: when doing `fetch()`, an error is thrown:

```
/Users/jiralite/Documents/GitHub/discord.js/discord.js/packages/discord.js/src/managers/GuildMemberManager.js:220
    limit = 0,
    ^

TypeError: Cannot read properties of undefined (reading 'limit')
    at GuildMemberManager._fetchMany (/Users/jiralite/Documents/GitHub/discord.js/discord.js/packages/discord.js/src/managers/GuildMemberManager.js:220:5)
    at GuildMemberManager.fetch (/Users/jiralite/Documents/GitHub/discord.js/discord.js/packages/discord.js/src/managers/GuildMemberManager.js:201:31)
    at Client.<anonymous> (/Users/jiralite/Documents/GitHub/Soulobby/Soulobby/source/test.ts:11:58)
    at Client.emit (/Users/jiralite/Documents/GitHub/discord.js/discord.js/node_modules/.pnpm/@vladfrangu+async_event_emitter@2.4.6/node_modules/@vladfrangu/async_event_emitter/src/index.ts:513:28)
    at Client._triggerClientReady (/Users/jiralite/Documents/GitHub/discord.js/discord.js/packages/discord.js/src/client/Client.js:389:10)
    at Client._checkReady (/Users/jiralite/Documents/GitHub/discord.js/discord.js/packages/discord.js/src/client/Client.js:283:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

This is because the empty object default was removed, and as such, properties were attempted to be extracted from `undefined`.

This pull request adds the empty object back in.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
