### PR TITLE
fix: 🔧 don't error out if no options are provided

### DIFF
--- a/packages/discord.js/src/structures/interfaces/InteractionResponses.js
+++ b/packages/discord.js/src/structures/interfaces/InteractionResponses.js
@@ -242,7 +242,7 @@ class InteractionResponses {
    *   .then(console.log)
    *   .catch(console.error);
    */
-  async update(options) {
+  async update(options = {}) {
     if (this.deferred || this.replied) throw new DiscordjsError(ErrorCodes.InteractionAlreadyReplied);
 
     let messagePayload;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This commit stops calls to `options.withResponse`, etc erroring out when `interaction.update();` is called alone with no params.

This allows users to do `await interaction.update()` on something like a `StringSelectMenuInteraction` where the goal isn't to update the message in any way, just to send a blank object to refresh the message state and reset the Select Menu so it shows the placeholder again and not the last-selected `StringSelectMenuOption`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
