### PR TITLE
fix: invalid token wrong recognition

### DIFF
--- a/packages/rest/src/lib/handlers/Shared.ts
+++ b/packages/rest/src/lib/handlers/Shared.ts
@@ -140,9 +140,10 @@ export async function handleErrors(
 			// The request will not succeed for some reason, parse the error returned from the api
 			const data = (await parseResponse(res)) as DiscordErrorData | OAuthErrorData;
 			const isDiscordError = 'code' in data;
+			const isOauthError = 'error' in data;
 
 			// If we receive the 401 status with 0 code, it means the token we had is no longer valid.
-			if (status === 401 && requestData.auth === true && isDiscordError && data.code === 0) {
+			if (status === 401 && requestData.auth === true && (isOauthError || isDiscordError && data.code === 0)) {
 				manager.setToken(null!);
 			}
 


### PR DESCRIPTION
The following code does not correctly handle cases where the bot token is invalid: https://github.com/discordjs/discord.js/blob/ab6a69401e7de81a7c619d82b9f00741dfae3af4/packages/rest/src/lib/handlers/Shared.ts#L141-L143

Other requests may return a 401 status, which does not mean that the token is actually invalid. The following request is an example, where the webhook token is invalid, not the bot's token:

```js
DiscordAPIError[50027]: Invalid Webhook Token
    at handleErrors (/application/node_modules/@discordjs/rest/dist/index.js:727:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async SequentialHandler.runRequest (/application/node_modules/@discordjs/rest/dist/index.js:1128:23)
    at async SequentialHandler.queueRequest (/application/node_modules/@discordjs/rest/dist/index.js:959:14)
    at async _REST.request (/application/node_modules/@discordjs/rest/dist/index.js:1272:22)
    at async Object.f (/application/dist/util/tasks/carrinhos/treatments/cancelled/cancelled.js:4:320)
    at async C (/application/dist/util/tasks/carrinhos/main.js:1:2251) {
  requestBody: { files: undefined, json: { embeds: [Array], components: [] } },
  rawError: { message: 'Invalid Webhook Token', code: 50027 },
  code: 50027,
  status: 401,
  method: 'PATCH',
  url: 'https://discord.com/api/v10/webhooks/1332931122040143913/aW50ZXJhY3Rpb246MTM0ODY5NDU4MTYyNTIyOTQyNDozODF5NlBJTHYxZ09XWWtjdTl5ZlhCNU5qU2E0djI5SXhWV3psUUk0SFlKaXY4cmh0VXRoY1NKQjRKdmxIcmVEMDhEeG5WZ2pXUmNKaUc5Y1dXaW03WnlKYVJOU1RhaHJsSXZmdExJbTRxMjE1V1JBY2t5NE4yYTF0UDRBdU12YQ/messages/@original'
}
```

Remembering that you don't necessarily need to have a webhook to receive this error, it just takes a long time to respond to an interaction, so this wrong condition ends up affecting several bots, especially in Discord API instabilities.

This commit fixes invalid token wrong detection cases like these, only handling the case where the token is actually invalid, which is when receiving code 0 from the Discord API:

```json
{ "message": "401: Unauthorized", "code": 0 }
```

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
