### PR TITLE
fix(website): correctly link type parameters in docs

### DIFF
--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -295,15 +295,15 @@ function itemExcerptText(excerpt: Excerpt, apiPackage: ApiPackage, parent?: ApiT
 			}
 
 			if (parent?.typeParameters.some((type) => type.name === token.text)) {
-				const [packageName, parentItem] = parent.canonicalReference.toString().split('!');
+				const resolvedParent = resolveCanonicalReference(parent.canonicalReference, apiPackage);
 				return {
 					text: token.text,
 					resolvedItem: {
 						kind: 'TypeParameter',
 						displayName: token.text,
 						containerKey: `${parent.containerKey}|${token.text}`,
-						uri: `${parentItem}#${token.text}`,
-						packageName: packageName?.replace('@discordjs/', ''),
+						uri: `${resolveItemURI(parent)}#${token.text}`,
+						packageName: resolvedParent?.package?.replace('@discordjs/', ''),
 					},
 				};
 			}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Links to Type Parameters in docs were using the wrong suffix so they 404d.

For example the link to CachedType or RawType on https://discord.js.org/docs/packages/discord.js/14.18.0/CacheTypeReducer:TypeAlias

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
