### PR TITLE
fix(textInput): Value must be at least 1 character in length

### DIFF
--- a/packages/builders/src/components/textInput/Assertions.ts
+++ b/packages/builders/src/components/textInput/Assertions.ts
@@ -10,6 +10,6 @@ export const textInputPredicate = z.object({
 	min_length: z.number().min(0).max(4_000).optional(),
 	max_length: z.number().min(1).max(4_000).optional(),
 	placeholder: z.string().max(100).optional(),
-	value: z.string().max(4_000).optional(),
+	value: z.string().min(1).max(4_000).optional(),
 	required: z.boolean().optional(),
 });


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Will throw this error otherwise: `data.components[1].components[0].value[BASE_TYPE_MIN_LENGTH]: Must be 1 or more in length.`

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
