### PR TITLE
fix(Poll): ensure `this.answers` is set before we reference it

### DIFF
--- a/packages/discord.js/src/structures/Poll.js
+++ b/packages/discord.js/src/structures/Poll.js
@@ -53,6 +53,17 @@ class Poll extends Base {
      */
     this.answers ??= new Collection();
 
+    if (data.answers) {
+      for (const answer of data.answers) {
+        const existing = this.answers.get(answer.answer_id);
+        if (existing) {
+          existing._patch(answer);
+        } else {
+          this.answers.set(answer.answer_id, new PollAnswer(this.client, answer, this));
+        }
+      }
+    }
+
     if (data.results) {
       /**
        * Whether this poll's results have been precisely counted
@@ -116,17 +127,6 @@ class Poll extends Base {
       this.question ??= {
         text: null,
       };
-    }
-
-    if (data.answers) {
-      for (const answer of data.answers) {
-        const existing = this.answers.get(answer.answer_id);
-        if (existing) {
-          existing._patch(answer);
-        } else {
-          this.answers.set(answer.answer_id, new PollAnswer(this.client, answer, this));
-        }
-      }
     }
   }
 

--- a/packages/discord.js/src/structures/Poll.js
+++ b/packages/discord.js/src/structures/Poll.js
@@ -43,16 +43,16 @@ class Poll extends Base {
 
     Object.defineProperty(this, 'message', { value: message });
 
-    this._patch(data);
-  }
-
-  _patch(data) {
     /**
      * The answers of this poll
      * @type {Collection<number, PollAnswer|PartialPollAnswer>}
      */
-    this.answers ??= new Collection();
+    this.answers = new Collection();
 
+    this._patch(data);
+  }
+
+  _patch(data) {
     if (data.answers) {
       for (const answer of data.answers) {
         const existing = this.answers.get(answer.answer_id);

--- a/packages/discord.js/src/structures/Poll.js
+++ b/packages/discord.js/src/structures/Poll.js
@@ -47,6 +47,12 @@ class Poll extends Base {
   }
 
   _patch(data) {
+    /**
+     * The answers of this poll
+     * @type {Collection<number, PollAnswer|PartialPollAnswer>}
+     */
+    this.answers ??= new Collection();
+
     if (data.results) {
       /**
        * Whether this poll's results have been precisely counted
@@ -111,12 +117,6 @@ class Poll extends Base {
         text: null,
       };
     }
-
-    /**
-     * The answers of this poll
-     * @type {Collection<number, PollAnswer|PartialPollAnswer>}
-     */
-    this.answers ??= new Collection();
 
     if (data.answers) {
       for (const answer of data.answers) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
I use polls but I don't subscribe to the `messageUpdate` event, but I've been occassionally seeing this pop up. It doesn't seem to happen for every poll so I'm not 100% sure on reproduce steps. I think it's a minor bug that stems from the overhaul https://github.com/discordjs/discord.js/pull/10328

```ts
[UnhandledPromise] TypeError: Cannot read properties of undefined (reading 'get')

Promise {
<rejected> TypeError: Cannot read properties of undefined (reading 'get')
    at Poll._patch (/app/node_modules/discord.js/src/structures/Poll.js:58:37)
    at new Poll (/app/node_modules/discord.js/src/structures/Poll.js:46:10)
    at Message._patch (/app/node_modules/discord.js/src/structures/Message.js:425:21)
    at Message._update (/app/node_modules/discord.js/src/structures/Base.js:30:10)
    at MessageUpdateAction.handle (/app/node_modules/discord.js/src/client/actions/MessageUpdate.js:14:29)
    at module.exports [as MESSAGE_UPDATE] (/app/node_modules/discord.js/src/client/websocket/handlers/MESSAGE_UPDATE.js:6:57)
    at Client._handlePacket (/app/node_modules/discord.js/src/client/Client.js:355:33)
    at WebSocketManager.emit (/app/node_modules/@vladfrangu/async_event_emitter/src/index.ts:513:28)
    at WebSocketShard.<anonymous> (/app/node_modules/@discordjs/ws/src/strategies/sharding/SimpleShardingStrategy.ts:33:47)
    at WebSocketShard.emit (/app/node_modules/@vladfrangu/async_event_emitter/src/index.ts:513:28) 
```

**Status and versioning classification:**
Patch

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
