### PR TITLE
fix: all shards spawning on shard 0 with sharding manager

### DIFF
--- a/packages/discord.js/src/client/Client.js
+++ b/packages/discord.js/src/client/Client.js
@@ -58,7 +58,8 @@ class Client extends BaseClient {
     const defaults = Options.createDefault();
 
     if (this.options.ws.shardIds === defaults.ws.shardIds && 'SHARDS' in data) {
-      this.options.ws.shardIds = JSON.parse(data.SHARDS);
+      const shards = JSON.parse(data.SHARDS);
+      this.options.ws.shardIds = Array.isArray(shards) ? shards : [shards];
     }
 
     if (this.options.ws.shardCount === defaults.ws.shardCount && 'SHARD_COUNT' in data) {


### PR DESCRIPTION
`process.env.SHARDS` only has the shard id (not an array). This meant that we were passing `shardIds: 0` to WebSocketManager, which fails this the following `if` statement, making /ws fetch get all shards and start them on the current process. 

https://github.com/discordjs/discord.js/blob/4d1942681077c5c49abaf90873cf1cafb21de84f/packages/ws/src/ws/WebSocketManager.ts#L346-L347

![image](https://github.com/user-attachments/assets/5f11cd3a-f396-4ca0-ae60-5a89096887bd)
