### PR TITLE
fix: missing displayName property for json data.

### DIFF
--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -365,6 +365,7 @@ class User extends Base {
         defaultAvatarURL: true,
         hexAccentColor: true,
         tag: true,
+        displayName: true,
       },
       ...props,
     );


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Since json data of `GuildMember` has `displayName` but `User` doesn't, I'd like to add this property to the `User` class.

**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
