### PR TITLE
chore: move pnpm settings to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,0 @@
-auto-install-peers=false
-resolution-mode=highest
-public-hoist-pattern[]=*eslint*
-public-hoist-pattern[]=*prettier*
-public-hoist-pattern[]=*@rushstack/node-core-library*
-public-hoist-pattern[]=*jju*

--- a/apps/website/.gitignore
+++ b/apps/website/.gitignore
@@ -16,7 +16,6 @@ pids
 .env*.local
 
 # Dist
-.contentlayer
 .next
 public/searchIndex
 src/assets/readme

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,6 @@
 		"ignore": [
 			".turbo",
 			".vercel",
-			".contentlayer",
 			".next",
 			"coverage",
 			"dist",

--- a/package.json
+++ b/package.json
@@ -75,42 +75,8 @@
 		"vercel": "^41.4.1",
 		"vitest": "^3.1.1"
 	},
-	"pnpm": {
-		"peerDependencyRules": {
-			"ignoreMissing": [
-				"*"
-			],
-			"allowAny": [
-				"*"
-			]
-		},
-		"overrides": {
-			"@contentlayer/utils>@opentelemetry/core": "^1.15.1",
-			"@contentlayer/utils>@opentelemetry/exporter-trace-otlp-grpc": "^0.41.1",
-			"@contentlayer/utils>@opentelemetry/resources": "^1.15.1",
-			"@contentlayer/utils>@opentelemetry/sdk-trace-base": "^1.15.1",
-			"@contentlayer/utils>@opentelemetry/sdk-trace-node": "^1.15.1",
-			"@contentlayer/utils>@opentelemetry/semantic-conventions": "^1.15.1"
-		},
-		"patchedDependencies": {
-			"@microsoft/tsdoc-config": "patches/@microsoft__tsdoc-config.patch"
-		},
-		"ignoredBuiltDependencies": [
-			"core-js-pure"
-		],
-		"onlyBuiltDependencies": [
-			"@discordjs/opus",
-			"bufferutil",
-			"contentlayer",
-			"esbuild",
-			"protobufjs",
-			"sharp",
-			"utf-8-validate",
-			"zlib-sync"
-		]
-	},
 	"engines": {
 		"node": ">=22.12.0"
 	},
-	"packageManager": "pnpm@10.7.1"
+	"packageManager": "pnpm@10.8.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,14 +4,6 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-overrides:
-  '@contentlayer/utils>@opentelemetry/core': ^1.15.1
-  '@contentlayer/utils>@opentelemetry/exporter-trace-otlp-grpc': ^0.41.1
-  '@contentlayer/utils>@opentelemetry/resources': ^1.15.1
-  '@contentlayer/utils>@opentelemetry/sdk-trace-base': ^1.15.1
-  '@contentlayer/utils>@opentelemetry/sdk-trace-node': ^1.15.1
-  '@contentlayer/utils>@opentelemetry/semantic-conventions': ^1.15.1
-
 patchedDependencies:
   '@microsoft/tsdoc-config':
     hash: 96d7f4c962bda3b7fefb9be332eb6b1de236ee66cf4d00de1441904355148331

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,41 @@
+autoInstallPeers: false
+
+ignoredBuiltDependencies:
+  - core-js-pure
+
+onlyBuiltDependencies:
+  - '@discordjs/opus'
+  - bufferutil
+  - contentlayer
+  - esbuild
+  - protobufjs
+  - sharp
+  - utf-8-validate
+  - zlib-sync
+
+overrides:
+  '@contentlayer/utils>@opentelemetry/core': ^1.15.1
+  '@contentlayer/utils>@opentelemetry/exporter-trace-otlp-grpc': ^0.41.1
+  '@contentlayer/utils>@opentelemetry/resources': ^1.15.1
+  '@contentlayer/utils>@opentelemetry/sdk-trace-base': ^1.15.1
+  '@contentlayer/utils>@opentelemetry/sdk-trace-node': ^1.15.1
+  '@contentlayer/utils>@opentelemetry/semantic-conventions': ^1.15.1
+
 packages:
-  - 'apps/*'
-  - 'packages/*'
+  - apps/*
+  - packages/*
+
+patchedDependencies:
+  '@microsoft/tsdoc-config': patches/@microsoft__tsdoc-config.patch
+
+peerDependencyRules:
+  ignoreMissing:
+    - '*'
+  allowAny:
+    - '*'
+
+publicHoistPattern:
+  - '*eslint*'
+  - '*prettier*'
+  - '*@rushstack/node-core-library*'
+  - '*jju*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,20 +6,11 @@ ignoredBuiltDependencies:
 onlyBuiltDependencies:
   - '@discordjs/opus'
   - bufferutil
-  - contentlayer
   - esbuild
   - protobufjs
   - sharp
   - utf-8-validate
   - zlib-sync
-
-overrides:
-  '@contentlayer/utils>@opentelemetry/core': ^1.15.1
-  '@contentlayer/utils>@opentelemetry/exporter-trace-otlp-grpc': ^0.41.1
-  '@contentlayer/utils>@opentelemetry/resources': ^1.15.1
-  '@contentlayer/utils>@opentelemetry/sdk-trace-base': ^1.15.1
-  '@contentlayer/utils>@opentelemetry/sdk-trace-node': ^1.15.1
-  '@contentlayer/utils>@opentelemetry/semantic-conventions': ^1.15.1
 
 packages:
   - apps/*

--- a/turbo.json
+++ b/turbo.json
@@ -23,12 +23,11 @@
 				"public/**",
 				"src/**",
 				"!src/styles/unocss.css",
-				"contentlayer.config.ts",
 				"next.config.js",
 				"package.json",
 				"tsconfig.json"
 			],
-			"outputs": [".next/**", ".next/cache/**", ".contentlayer/**"],
+			"outputs": [".next/**", ".next/cache/**"],
 			"outputLogs": "full"
 		},
 		"@discordjs/guide#build:prod": {
@@ -37,12 +36,11 @@
 				"public/**",
 				"src/**",
 				"!src/styles/unocss.css",
-				"contentlayer.config.ts",
 				"next.config.js",
 				"package.json",
 				"tsconfig.json"
 			],
-			"outputs": [".next/**", ".next/cache/**", ".contentlayer/**"],
+			"outputs": [".next/**", ".next/cache/**"],
 			"outputLogs": "full"
 		},
 		"@discordjs/website#build:local": {
@@ -79,11 +77,6 @@
 			"outputs": [".next/**", ".next/cache/**", "src/assets/readme/**"],
 			"outputLogs": "full"
 		},
-		"@discordjs/guide#generate:contentlayer": {
-			"inputs": ["src/**/*.mdx"],
-			"outputs": [".contentlayer/**"],
-			"outputLogs": "errors-only"
-		},
 		"test": {
 			"dependsOn": ["^build"],
 			"inputs": ["__mocks__/**", "__tests__/**", "src/**", "jest.config.js", "package.json", "tsconfig.json"],
@@ -107,7 +100,7 @@
 			"outputLogs": "errors-only"
 		},
 		"@discordjs/guide#lint": {
-			"dependsOn": ["^build", "build:local", "generate:contentlayer"],
+			"dependsOn": ["^build", "build:local"],
 			"inputs": [
 				"../../eslint.config.js",
 				"../../.prettierrc.json",
@@ -151,7 +144,7 @@
 			"outputLogs": "errors-only"
 		},
 		"@discordjs/guide#format": {
-			"dependsOn": ["^build", "generate:contentlayer"],
+			"dependsOn": ["^build"],
 			"inputs": [
 				"../../eslint.config.js",
 				"../../.prettierrc.json",

--- a/unocss.config.ts
+++ b/unocss.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, presetTypography, presetUno } from 'unocss';
 
 export default defineConfig({
 	content: {
-		filesystem: ['src/**/*.tsx', 'contentlayer.config.ts', '../../packages/ui/src/lib/components/**/*.tsx'],
+		filesystem: ['src/**/*.tsx', '../../packages/ui/src/lib/components/**/*.tsx'],
 	},
 	theme: {
 		colors: {


### PR DESCRIPTION
Since pnpm [10.5](<https://github.com/pnpm/pnpm/releases/tag/v10.5.0>) and [10.6](<https://github.com/pnpm/pnpm/releases/tag/v10.6.0>), the `pnpm-workspace.yaml` file can hold settings from `package.json`'s `pnpm` key and `.npmrc` files.

Upgrade pnpm to 10.8

Removed the `resolution-mode=highest` setting as that is the default value