### PR TITLE
types: add missing BaseMessageCreateOptions

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6241,11 +6241,10 @@ export interface BaseMessageOptionsWithPoll extends BaseMessageOptions {
   poll?: JSONEncodable<RESTAPIPoll> | PollData;
 }
 
-export interface MessageCreateOptions extends BaseMessageOptionsWithPoll {
+export interface BaseMessageCreateOptions extends BaseMessageOptionsWithPoll {
   tts?: boolean;
   nonce?: string | number;
   enforceNonce?: boolean;
-  messageReference?: MessageReferenceOptions;
   stickers?: readonly StickerResolvable[];
   flags?:
     | BitFieldResolvable<
@@ -6255,9 +6254,13 @@ export interface MessageCreateOptions extends BaseMessageOptionsWithPoll {
     | undefined;
 }
 
+export interface MessageCreateOptions extends BaseMessageCreateOptions {
+  messageReference?: MessageReferenceOptions;
+}
+
 export interface GuildForumThreadMessageCreateOptions
   extends BaseMessageOptions,
-    Pick<MessageCreateOptions, 'flags' | 'stickers'> {}
+    Pick<BaseMessageCreateOptions, 'flags' | 'stickers'> {}
 
 export interface MessageEditAttachmentData {
   id: Snowflake;
@@ -6525,7 +6528,7 @@ export interface ReactionCollectorOptions extends CollectorOptions<[MessageReact
   maxUsers?: number;
 }
 
-export interface MessageReplyOptions extends Omit<MessageCreateOptions, 'messageReference'> {
+export interface MessageReplyOptions extends BaseMessageCreateOptions {
   failIfNotExists?: boolean;
 }
 
@@ -6805,8 +6808,7 @@ export interface WebhookFetchMessageOptions {
   threadId?: Snowflake;
 }
 
-export interface WebhookMessageCreateOptions
-  extends Omit<MessageCreateOptions, 'nonce' | 'messageReference' | 'stickers'> {
+export interface WebhookMessageCreateOptions extends Omit<BaseMessageCreateOptions, 'nonce' | 'stickers'> {
   username?: string;
   avatarURL?: string;
   threadId?: Snowflake;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

#9283 introduced `BaseMessageCreateOptions` in JSDoc but didn't update typings to reflect that. So documentation was missing the description of some of its fields.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
