### PR TITLE
docs(readme): add import statement for pure REST usage to align with other examples

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -71,6 +71,9 @@ gateway.connect();
 ## Independent REST API Usage
 
 ```ts
+import { REST } from "@discordjs/rest";
+import { API } from "@discordjs/core/http-only";
+
 // Create REST instance
 const rest = new REST({ version: '10' }).setToken(token);
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -71,8 +71,8 @@ gateway.connect();
 ## Independent REST API Usage
 
 ```ts
-import { REST } from '@discordjs/rest';
 import { API } from '@discordjs/core/http-only';
+import { REST } from '@discordjs/rest';
 
 // Create REST instance
 const rest = new REST({ version: '10' }).setToken(token);

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -71,8 +71,8 @@ gateway.connect();
 ## Independent REST API Usage
 
 ```ts
-import { REST } from "@discordjs/rest";
-import { API } from "@discordjs/core/http-only";
+import { REST } from '@discordjs/rest';
+import { API } from '@discordjs/core/http-only';
 
 // Create REST instance
 const rest = new REST({ version: '10' }).setToken(token);


### PR DESCRIPTION
This PR updates the "Independent REST API Usage" section in the README to include the appropriate import statements, ensuring consistency with the structure and format of other examples in the documentation. This makes the usage clearer and aligns with the overall style of the README.
