### PR TITLE
fix: allowedMentions, container, media item `toJSON()` for components v2

### DIFF
--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -249,12 +249,7 @@ class MessagePayload {
       username,
       avatar_url: avatarURL,
       allowed_mentions:
-        content === undefined &&
-        message_reference === undefined &&
-        // Components V2 can mention, so need to check for them too
-        (!components?.length || flags & (MessageFlags.IsComponentsV2 === 0))
-          ? undefined
-          : allowedMentions,
+        this.isMessage() && this.target.author.id !== this.target.client.user.id ? undefined : allowedMentions,
       flags,
       message_reference,
       attachments: this.options.attachments,

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -249,7 +249,7 @@ class MessagePayload {
       username,
       avatar_url: avatarURL,
       allowed_mentions:
-        this.isMessage() && this.target.author.id !== this.target.client.user.id ? undefined : allowedMentions,
+        this.isMessage && this.target.author.id !== this.target.client.user.id ? undefined : allowedMentions,
       flags,
       message_reference,
       attachments: this.options.attachments,

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -248,7 +248,13 @@ class MessagePayload {
       components,
       username,
       avatar_url: avatarURL,
-      allowed_mentions: content === undefined && message_reference === undefined ? undefined : allowedMentions,
+      allowed_mentions:
+        content === undefined &&
+        message_reference === undefined &&
+        // Components V2 can mention, so need to check for them too
+        (!components?.length || flags & (MessageFlags.IsComponentsV2 === 0))
+          ? undefined
+          : allowedMentions,
       flags,
       message_reference,
       attachments: this.options.attachments,

--- a/packages/discord.js/src/structures/UnfurledMediaItem.js
+++ b/packages/discord.js/src/structures/UnfurledMediaItem.js
@@ -20,6 +20,14 @@ class UnfurledMediaItem {
   get url() {
     return this.data.url;
   }
+
+  /**
+   * Returns the API-compatible JSON for this media item
+   * @returns {APIUnfurledMediaItem}
+   */
+  toJSON() {
+    return { ...this.data };
+  }
 }
 
 module.exports = UnfurledMediaItem;

--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -215,24 +215,30 @@ function createComponentBuilder(data) {
 }
 
 /**
+ * Extracts all interactive components from the component tree
+ * @param {Component|APIMessageComponent} component The component to find all interactive components in
+ * @returns {Array<Component|APIMessageComponent>}
+ */
+function extractInteractiveComponents(component) {
+  switch (component.type) {
+    case ComponentType.ActionRow:
+      return component.components;
+    case ComponentType.Section:
+      return [...component.components, component.accessory];
+    case ComponentType.Container:
+      return component.components.flatMap(extractInteractiveComponents);
+    default:
+      return [component];
+  }
+}
+
+/**
  * Finds a component by customId in nested components
  * @param {Array<Component|APIMessageComponent>} components The components to search in
  * @param {string} customId The customId to search for
  * @returns {Component|APIMessageComponent}
  */
 function findComponentByCustomId(components, customId) {
-  const extractInteractiveComponents = component => {
-    switch (component.type) {
-      case ComponentType.ActionRow:
-        return component.components;
-      case ComponentType.Section:
-        return [...component.components, component.accessory];
-      case ComponentType.Container:
-        return component.components.flatMap(extractInteractiveComponents);
-      default:
-        return [component];
-    }
-  };
   return (
     components
       .flatMap(extractInteractiveComponents)

--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -229,6 +229,8 @@ function findComponentByCustomId(components, customId) {
             return component.components;
           case ComponentType.Section:
             return [...component.components, component.accessory];
+          case ComponentType.Container:
+            return [findComponentByCustomId(component.components, customId)];
           default:
             return [component];
         }

--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -218,6 +218,7 @@ function createComponentBuilder(data) {
  * Extracts all interactive components from the component tree
  * @param {Component|APIMessageComponent} component The component to find all interactive components in
  * @returns {Array<Component|APIMessageComponent>}
+ * @ignore
  */
 function extractInteractiveComponents(component) {
   switch (component.type) {

--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -221,22 +221,21 @@ function createComponentBuilder(data) {
  * @returns {Component|APIMessageComponent}
  */
 function findComponentByCustomId(components, customId) {
-  return (
-    components
-      .flatMap(component => {
-        switch (component.type) {
-          case ComponentType.ActionRow:
-            return component.components;
-          case ComponentType.Section:
-            return [...component.components, component.accessory];
-          case ComponentType.Container:
-            return [findComponentByCustomId(component.components, customId)];
-          default:
-            return [component];
-        }
-      })
-      .find(component => (component.customId ?? component.custom_id) === customId) ?? null
-  );
+  const extractInteractiveComponents = component => {
+    switch (component.type) {
+      case ComponentType.ActionRow:
+        return component.components;
+      case ComponentType.Section:
+        return [...component.components, component.accessory];
+      case ComponentType.Container:
+        return component.components.flatMap(extractInteractiveComponents);
+      default:
+        return [component];
+    }
+  };
+  return components
+    .flatMap(extractInteractiveComponents)
+    .find(component => (component.customId ?? component.custom_id) === customId) ?? null;
 }
 
 module.exports = { createComponent, createComponentBuilder, findComponentByCustomId };

--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -238,6 +238,7 @@ function extractInteractiveComponents(component) {
  * @param {Array<Component|APIMessageComponent>} components The components to search in
  * @param {string} customId The customId to search for
  * @returns {Component|APIMessageComponent}
+ * @ignore
  */
 function findComponentByCustomId(components, customId) {
   return (

--- a/packages/discord.js/src/util/Components.js
+++ b/packages/discord.js/src/util/Components.js
@@ -233,9 +233,11 @@ function findComponentByCustomId(components, customId) {
         return [component];
     }
   };
-  return components
-    .flatMap(extractInteractiveComponents)
-    .find(component => (component.customId ?? component.custom_id) === customId) ?? null;
+  return (
+    components
+      .flatMap(extractInteractiveComponents)
+      .find(component => (component.customId ?? component.custom_id) === customId) ?? null
+  );
 }
 
 module.exports = { createComponent, createComponentBuilder, findComponentByCustomId };

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -7043,7 +7043,12 @@ export interface MessageEditAttachmentData {
 export interface MessageEditOptions extends Omit<BaseMessageOptions, 'content'> {
   content?: string | null;
   attachments?: readonly (Attachment | MessageEditAttachmentData)[];
-  flags?: BitFieldResolvable<Extract<MessageFlagsString, 'SuppressEmbeds'>, MessageFlags.SuppressEmbeds> | undefined;
+  flags?:
+    | BitFieldResolvable<
+        Extract<MessageFlagsString, 'SuppressEmbeds' | 'IsComponentsV2'>,
+        MessageFlags.SuppressEmbeds | MessageFlags.IsComponentsV2
+      >
+    | undefined;
 }
 
 export type MessageReactionResolvable = MessageReaction | Snowflake | string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes an issue where allowedMentions don't get used in MessagePayload if `IsComponentsV2`.

Fixes #10855

Adds the missing `UnfurledMediaItem#toJSON()`.

Fixes `MessageComponentInteraction#component` not working for components in an ActionRow inside a Container.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
