### PR TITLE
fix(SoundboardSound): wrong emoji comparison in `equals`

### DIFF
--- a/packages/discord.js/src/structures/GuildAuditLogsEntry.js
+++ b/packages/discord.js/src/structures/GuildAuditLogsEntry.js
@@ -487,7 +487,6 @@ class GuildAuditLogsEntry {
         AuditLogEvent.ThreadUpdate,
         AuditLogEvent.SoundboardSoundUpdate,
         AuditLogEvent.ApplicationCommandPermissionUpdate,
-        AuditLogEvent.SoundboardSoundUpdate,
         AuditLogEvent.AutoModerationRuleUpdate,
         AuditLogEvent.AutoModerationBlockMessage,
         AuditLogEvent.AutoModerationFlagToChannel,

--- a/packages/discord.js/src/structures/SoundboardSound.js
+++ b/packages/discord.js/src/structures/SoundboardSound.js
@@ -181,8 +181,8 @@ class SoundboardSound extends Base {
         this.available === other.available &&
         this.name === other.name &&
         this.volume === other.volume &&
-        this.emojiId === other.emojiId &&
-        this.emojiName === other.emojiName &&
+        this._emoji?.id === other._emoji?.id &&
+        this._emoji?.name === other._emoji?.name &&
         this.guildId === other.guildId &&
         this.user?.id === other.user?.id
       );
@@ -193,8 +193,8 @@ class SoundboardSound extends Base {
       this.available === other.available &&
       this.name === other.name &&
       this.volume === other.volume &&
-      this.emojiId === other.emoji_id &&
-      this.emojiName === other.emoji_name &&
+      (this._emoji?.id ?? null) === other.emoji_id &&
+      (this._emoji?.name ?? null) === other.emoji_name &&
       this.guildId === other.guild_id &&
       this.user?.id === other.user?.id
     );


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes `emojiId` and `emojiName` still being used in `equals` even when they don't exist anymore (changed in [`7b3cfe4` (#10590)](https://github.com/discordjs/discord.js/pull/10590/commits/7b3cfe4c19ab7b84406379fb0ed11c5a17d98237))

Also removes the duplicate `AuditLogEvent.SoundboardSoundUpdate` in GuildAuditLogsEntry

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
