### PR TITLE
types(GuildSoundboardSoundEditOptions): add missing `reason`

### DIFF
--- a/packages/discord.js/src/managers/GuildSoundboardSoundManager.js
+++ b/packages/discord.js/src/managers/GuildSoundboardSoundManager.js
@@ -105,7 +105,7 @@ class GuildSoundboardSoundManager extends CachedManager {
    * Data for editing a soundboard sound.
    * @typedef {Object} GuildSoundboardSoundEditOptions
    * @property {string} [name] The name of the soundboard sound
-   * @property {?number} [volume] The volume of the soundboard sound, from 0 to 1
+   * @property {?number} [volume] The volume (a double) of the soundboard sound, from 0 (inclusive) to 1
    * @property {?Snowflake} [emojiId] The emoji id of the soundboard sound
    * @property {?string} [emojiName] The emoji name of the soundboard sound
    * @property {string} [reason] The reason for editing the soundboard sound

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -4857,6 +4857,7 @@ export interface GuildSoundboardSoundEditOptions {
   volume?: number | null;
   emojiId?: Snowflake | null;
   emojiName?: string | null;
+  reason?: string;
 }
 
 export interface FetchGuildSoundboardSoundOptions extends BaseFetchOptions {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`reason` property was missing in `GuildSoundboardSoundEditOptions`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
