### PR TITLE
chore: remove container limit

### DIFF
--- a/packages/builders/src/components/v2/Assertions.ts
+++ b/packages/builders/src/components/v2/Assertions.ts
@@ -57,7 +57,7 @@ export function assertReturnOfBuilder<ReturnType extends MediaGalleryItemBuilder
 	input: unknown,
 	ExpectedInstanceOf: new () => ReturnType,
 ): asserts input is ReturnType {
-	s.instance(ExpectedInstanceOf).parse(input);
+	s.instance(ExpectedInstanceOf).setValidationEnabled(isValidationEnabled).parse(input);
 }
 
 export function validateComponentArray<
@@ -67,5 +67,6 @@ export function validateComponentArray<
 		.array()
 		.lengthGreaterThanOrEqual(min)
 		.lengthLessThanOrEqual(max)
+		.setValidationEnabled(isValidationEnabled)
 		.parse(input);
 }

--- a/packages/builders/src/components/v2/Container.ts
+++ b/packages/builders/src/components/v2/Container.ts
@@ -19,7 +19,7 @@ import type { AnyComponentBuilder, MessageActionRowComponentBuilder } from '../A
 import { ActionRowBuilder } from '../ActionRow.js';
 import { ComponentBuilder } from '../Component.js';
 import { createComponentBuilder, resolveBuilder } from '../Components.js';
-import { containerColorPredicate, spoilerPredicate, validateComponentArray } from './Assertions.js';
+import { containerColorPredicate, spoilerPredicate } from './Assertions.js';
 import { FileBuilder } from './File.js';
 import { SeparatorBuilder } from './Separator.js';
 import { TextDisplayBuilder } from './TextDisplay.js';
@@ -231,7 +231,6 @@ export class ContainerBuilder extends ComponentBuilder<APIContainerComponent> {
 	 * {@inheritDoc ComponentBuilder.toJSON}
 	 */
 	public toJSON(): APIContainerComponent {
-		validateComponentArray(this.components, 1, 10);
 		return {
 			...this.data,
 			components: this.components.map((component) => component.toJSON()),

--- a/packages/builders/src/components/v2/Thumbnail.ts
+++ b/packages/builders/src/components/v2/Thumbnail.ts
@@ -11,7 +11,7 @@ export class ThumbnailBuilder extends ComponentBuilder<APIThumbnailComponent> {
 	 * @example
 	 * Creating a thumbnail from an API data object:
 	 * ```ts
-	 * const thumbnaik = new ThumbnailBuilder({
+	 * const thumbnail = new ThumbnailBuilder({
 	 * 	description: 'some text',
 	 *  media: {
 	 *      url: 'https://cdn.discordapp.com/embed/avatars/4.png',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removes the assertion limiting amount of components in a container
- https://github.com/discord/discord-api-docs/pull/7534

Also adds `.setValidationEnabled(isValidationEnabled)` to two shapes that were missing it.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
