### PR TITLE
fix(website): link to external constructors

### DIFF
--- a/apps/website/src/components/ConstructorNode.tsx
+++ b/apps/website/src/components/ConstructorNode.tsx
@@ -2,6 +2,7 @@ import { VscSymbolMethod } from '@react-icons/all-files/vsc/VscSymbolMethod';
 import { Code2, LinkIcon } from 'lucide-react';
 import Link from 'next/link';
 import { ENV } from '@/util/env';
+import { Badges } from './Badges';
 import { ExampleNode } from './ExampleNode';
 import { ParameterNode } from './ParameterNode';
 import { SeeNode } from './SeeNode';
@@ -20,11 +21,14 @@ export async function ConstructorNode({ node, version }: { readonly node: any; r
 					className={`${ENV.IS_LOCAL_DEV || ENV.IS_PREVIEW ? 'scroll-mt-16' : 'scroll-mt-8'} group px-2 font-mono font-semibold break-all`}
 					id="constructor"
 				>
-					{/* constructor({parsedContent.constructor.parametersString}) */}
-					<Link className="float-left -ml-6 hidden pr-2 pb-2 group-hover:block" href="#constructor">
-						<LinkIcon aria-hidden size={16} />
-					</Link>
-					constructor({node.parameters?.length ? <ParameterNode node={node.parameters} version={version} /> : null})
+					<Badges node={node} />
+					<span>
+						{/* constructor({parsedContent.constructor.parametersString}) */}
+						<Link className="float-left -ml-6 hidden pr-2 pb-2 group-hover:block" href="#constructor">
+							<LinkIcon aria-hidden size={16} />
+						</Link>
+						constructor({node.parameters?.length ? <ParameterNode node={node.parameters} version={version} /> : null})
+					</span>
 				</h3>
 
 				<a

--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -690,12 +690,8 @@ function itemParameters(item: ApiDocumentedItem & ApiParameterListMixin) {
 
 function itemConstructor(item: ApiConstructor) {
 	return {
-		kind: item.kind,
-		name: item.displayName,
-		sourceURL: item.sourceLocation.fileUrl,
-		sourceLine: item.sourceLocation.fileLine,
+		...itemInfo(item),
 		parametersString: parametersString(item),
-		summary: item.tsdocComment ? itemTsDoc(item.tsdocComment, item) : null,
 		parameters: itemParameters(item),
 	};
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Mark constructors as external too on external classes to fix their source code link

example: https://discord.js.org/docs/packages/discord.js/14.19.2/ContainerBuilder:Class#constructor

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
