### PR TITLE
fix(website): link to enum members in search index

### DIFF
--- a/packages/api-extractor-utils/src/parse.ts
+++ b/packages/api-extractor-utils/src/parse.ts
@@ -36,7 +36,6 @@ export function generatePath(items: readonly ApiItem[], version: string) {
 		switch (item.kind) {
 			case ApiItemKind.Model:
 			case ApiItemKind.EntryPoint:
-			case ApiItemKind.EnumMember:
 				break;
 			case ApiItemKind.Package:
 				path += `/${item.displayName}`;
@@ -55,6 +54,7 @@ export function generatePath(items: readonly ApiItem[], version: string) {
 			case ApiItemKind.Property:
 			case ApiItemKind.PropertySignature:
 			case ApiItemKind.Event:
+			case ApiItemKind.EnumMember:
 				path += `#${item.displayName}`;
 				break;
 			default:


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Previously searching for enum members like `DiscordJsError#InteractionAlreadyReplied` resulted in the URL https://discord.js.org/docs/packages/discord.js/14.19.2/DiscordjsErrorCodes:Enum instead of the correct https://discord.js.org/docs/packages/discord.js/14.19.2/DiscordjsErrorCodes:Enum#InteractionAlreadyReplied

Fixes #10874 

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
