### PR TITLE
fix(website): constructors show on too many items

### DIFF
--- a/apps/website/src/components/DocItem.tsx
+++ b/apps/website/src/components/DocItem.tsx
@@ -93,7 +93,7 @@ export async function DocItem({
 
 			<Outline node={node} />
 
-			{node.constructor ? <ConstructorNode node={node.constructor} version={version} /> : null}
+			{node.construct ? <ConstructorNode node={node.construct} version={version} /> : null}
 
 			{node.typeParameters?.length ? (
 				<div className="flex flex-col gap-4">

--- a/apps/website/src/components/SyntaxHighlighter.tsx
+++ b/apps/website/src/components/SyntaxHighlighter.tsx
@@ -20,7 +20,7 @@ export async function SyntaxHighlighter({
 	return (
 		<>
 			{/* eslint-disable-next-line react/no-danger */}
-			<div className={className} dangerouslySetInnerHTML={{ __html: codeHTML }} />
+			<span className={className} dangerouslySetInnerHTML={{ __html: codeHTML }} />
 		</>
 	);
 }

--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -889,7 +889,7 @@ function itemClass(item: ApiClass) {
 		extends: itemHierarchyText({ item, type: 'Extends' }),
 		implements: itemHierarchyText({ item, type: 'Implements' }),
 		typeParameters: itemTypeParameters(item),
-		constructor: constructor ? itemConstructor(constructor) : null,
+		construct: constructor ? itemConstructor(constructor) : null,
 		members: itemMembers(item),
 	};
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Because all instances in JS have a `.constructor` property the check in website was checking the wrong thing *and* the docs were overwriting that property.

This PR fixes that by renaming the property of the docs to document constructors.

Down side: all docs need to be regenerated after this merges or no constructors will show in docs.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
