### PR TITLE
docs: fix missing type

### DIFF
--- a/packages/brokers/src/brokers/redis/BaseRedis.ts
+++ b/packages/brokers/src/brokers/redis/BaseRedis.ts
@@ -67,7 +67,7 @@ export abstract class BaseRedisBroker<
 	/**
 	 * Used for Redis queues, see the 3rd argument taken by {@link https://redis.io/commands/xadd | xadd}
 	 */
-	public static readonly STREAM_DATA_KEY = 'data';
+	public static readonly STREAM_DATA_KEY = 'data' as const;
 
 	/**
 	 * Options this broker is using


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/242621a9-3e2e-42ca-b373-b4d675d99473)

<https://discord.js.org/docs/packages/brokers/main/BaseRedisBroker:Class#STREAM_DATA_KEY>