### PR TITLE
fix(ChannelManager): Remove threads from cache upon deletion

### DIFF
--- a/packages/discord.js/src/managers/ChannelManager.js
+++ b/packages/discord.js/src/managers/ChannelManager.js
@@ -73,6 +73,15 @@ class ChannelManager extends CachedManager {
 
     channel?.parent?.threads?.cache.delete(id);
     this.cache.delete(id);
+
+    if (channel?.threads) {
+      for (const cacheChannelId of this.cache.keys()) {
+        if (channel.threads.cache.has(cacheChannelId)) {
+          this.cache.delete(cacheChannelId);
+          channel.guild?.channels.cache.delete(cacheChannelId);
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
If a channel with threads is deleted, the threads are still accessible in the channel manager and the guild manager. This clears them.

Resolves #10871.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
