### PR TITLE
build: exclude type tests from pack

### DIFF
--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -36,7 +36,9 @@
   },
   "files": [
     "src",
-    "typings"
+    "typings/*.d.ts",
+    "typings/*.d.mts",
+    "typings/tsdoc-metadata.json"
   ],
   "contributors": [
     "Crawl <icrawltogo@gmail.com>",

--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -37,8 +37,7 @@
   "files": [
     "src",
     "typings/*.d.ts",
-    "typings/*.d.mts",
-    "typings/tsdoc-metadata.json"
+    "typings/*.d.mts"
   ],
   "contributors": [
     "Crawl <icrawltogo@gmail.com>",


### PR DESCRIPTION
Removed the `typings/index.d-test.ts` from the published package