### PR TITLE
fix: syntaxhighlighter fill scrollbar width

### DIFF
--- a/apps/website/src/components/DocItem.tsx
+++ b/apps/website/src/components/DocItem.tsx
@@ -75,7 +75,7 @@ export async function DocItem({
 
 			<Scrollbars className="border-base-neutral-200 dark:border-base-neutral-600 bg-base-neutral-100 dark:bg-base-neutral-900 rounded-sm border">
 				<SyntaxHighlighter
-					className="bg-[#f3f3f4] py-4 text-sm dark:bg-[#121214]"
+					className="w-min bg-[#f3f3f4] py-4 text-sm dark:bg-[#121214]"
 					code={node.sourceExcerpt}
 					lang="typescript"
 				/>

--- a/apps/website/src/components/DocNode.tsx
+++ b/apps/website/src/components/DocNode.tsx
@@ -71,7 +71,11 @@ export async function DocNode({ node, version }: { readonly node?: any; readonly
 						defer
 						key={`${language}-${text}-${idx}`}
 					>
-						<SyntaxHighlighter className="bg-[#f3f3f4] py-4 text-sm dark:bg-[#121214]" code={text} lang={language} />
+						<SyntaxHighlighter
+							className="w-min bg-[#f3f3f4] py-4 text-sm dark:bg-[#121214]"
+							code={text}
+							lang={language}
+						/>
 					</Scrollbars>
 				);
 			}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This fixes SyntaxHighlighter background not properly expanding to fill Scrollbars horizontally.

Affects both mobile and PC.

https://discord.js.org/docs/packages/discord.js/14.19.3/ComponentBuilder:Class

https://discord.js.org/docs/packages/discord.js/14.19.3/ApplicationEmojiManager:Class
 
**Status and versioning classification:**


- Code changes have been tested against the Discord API, or there are no code changes

- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:


- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
