### PR TITLE
fix(PartialGroupDMChannel): Prevent `undefined` values

### DIFF
--- a/packages/discord.js/src/structures/PartialGroupDMChannel.js
+++ b/packages/discord.js/src/structures/PartialGroupDMChannel.js
@@ -27,7 +27,7 @@ class PartialGroupDMChannel extends BaseChannel {
      * The hash of the channel icon
      * @type {?string}
      */
-    this.icon = data.icon;
+    this.icon = data.icon ?? null;
 
     /**
      * Recipient data received in a {@link PartialGroupDMChannel}.
@@ -39,7 +39,7 @@ class PartialGroupDMChannel extends BaseChannel {
      * The recipients of this Group DM Channel.
      * @type {PartialRecipient[]}
      */
-    this.recipients = data.recipients;
+    this.recipients = data.recipients ?? [];
 
     /**
      * A manager of the messages belonging to this channel


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
When fetching a group direct message invite, I encountered this:

![image](https://github.com/user-attachments/assets/a00e24e4-3c0a-421f-b1eb-298ed7c73c00)

`icon` and `recipients` were `undefined`. Looking at the specification, only `id` and `type` are definitely sent:

https://github.com/discord/discord-api-spec/blob/507909d1ea5a921064d599e1f3b57163af2037d6/specs/openapi.json#L23049-L23052

This pull request puts sensible defaults into place.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
