### PR TITLE
fix(website): remove several obsolete special handling of dtypes

### DIFF
--- a/apps/website/src/components/EntrypointSelect.tsx
+++ b/apps/website/src/components/EntrypointSelect.tsx
@@ -17,24 +17,21 @@ export function EntryPointSelect({
 	const { entryPoints: parsedEntrypoints } = parseDocsPathParams(params.item as string[] | undefined);
 
 	return (
-		<Select
-			aria-label="Select an entrypoint"
-			defaultSelectedKey={parsedEntrypoints.length ? parsedEntrypoints.join('/') : 'global'}
-		>
+		<Select aria-label="Select an entrypoint" defaultSelectedKey={parsedEntrypoints.join('/')}>
 			<SelectTrigger className="bg-[#f3f3f4] dark:bg-[#121214]" />
 			<SelectList classNames={{ popover: 'bg-[#f3f3f4] dark:bg-[#28282d]' }} items={entryPoints}>
 				{(item) => (
 					<SelectOption
 						className="dark:pressed:bg-[#313135] bg-[#f3f3f4] dark:bg-[#28282d] dark:hover:bg-[#313135]"
 						href={`/docs/packages/${params.packageName}/${params.version}/${item.entryPoint}`}
-						id={item.entryPoint || 'global'}
-						key={item.entryPoint || 'global'}
+						id={item.entryPoint}
+						key={item.entryPoint}
 						onHoverStart={() =>
 							router.prefetch(`/docs/packages/${params.packageName}/${params.version}/${item.entryPoint}`)
 						}
-						textValue={item.entryPoint || 'global'}
+						textValue={item.entryPoint}
 					>
-						{item.entryPoint || 'global'}
+						{item.entryPoint}
 					</SelectOption>
 				)}
 			</SelectList>

--- a/apps/website/src/middleware.ts
+++ b/apps/website/src/middleware.ts
@@ -1,6 +1,6 @@
 import Cloudflare from 'cloudflare';
 import { NextResponse, type NextRequest } from 'next/server';
-import { PACKAGES } from './util/constants';
+import { PACKAGES, PACKAGES_WITH_ENTRY_POINTS } from './util/constants';
 import { ENV } from './util/env';
 
 const client = new Cloudflare({
@@ -8,7 +8,12 @@ const client = new Cloudflare({
 });
 
 async function fetchLatestVersion(packageName: string): Promise<string> {
+	const hasEntryPoints = PACKAGES_WITH_ENTRY_POINTS.includes(packageName);
 	if (ENV.IS_LOCAL_DEV) {
+		if (hasEntryPoints) {
+			return 'main/v10';
+		}
+
 		return 'main';
 	}
 
@@ -19,7 +24,7 @@ async function fetchLatestVersion(packageName: string): Promise<string> {
 			params: [packageName],
 		});
 
-		return (result[0]?.results as { version: string }[] | undefined)?.[0]?.version ?? 'main';
+		return `${(result[0]?.results as { version: string }[] | undefined)?.[0]?.version ?? 'main'}${hasEntryPoints ? '/v10' : ''}`;
 	} catch {
 		return '';
 	}

--- a/apps/website/src/middleware.ts
+++ b/apps/website/src/middleware.ts
@@ -1,6 +1,6 @@
 import Cloudflare from 'cloudflare';
 import { NextResponse, type NextRequest } from 'next/server';
-import { PACKAGES, PACKAGES_WITH_ENTRY_POINTS } from './util/constants';
+import { DEFAULT_ENTRY_POINT, PACKAGES, PACKAGES_WITH_ENTRY_POINTS } from './util/constants';
 import { ENV } from './util/env';
 
 const client = new Cloudflare({
@@ -11,7 +11,7 @@ async function fetchLatestVersion(packageName: string): Promise<string> {
 	const hasEntryPoints = PACKAGES_WITH_ENTRY_POINTS.includes(packageName);
 	if (ENV.IS_LOCAL_DEV) {
 		if (hasEntryPoints) {
-			return 'main/v10';
+			return ['main', ...DEFAULT_ENTRY_POINT].join('/');
 		}
 
 		return 'main';
@@ -24,7 +24,7 @@ async function fetchLatestVersion(packageName: string): Promise<string> {
 			params: [packageName],
 		});
 
-		return `${(result[0]?.results as { version: string }[] | undefined)?.[0]?.version ?? 'main'}${hasEntryPoints ? '/v10' : ''}`;
+		return `${(result[0]?.results as { version: string }[] | undefined)?.[0]?.version ?? 'main'}${hasEntryPoints ? ['', ...DEFAULT_ENTRY_POINT].join('/') : ''}`;
 	} catch {
 		return '';
 	}

--- a/apps/website/src/util/constants.ts
+++ b/apps/website/src/util/constants.ts
@@ -16,5 +16,7 @@ export const PACKAGES = [
 
 export const PACKAGES_WITH_ENTRY_POINTS = ['discord-api-types'];
 
+export const DEFAULT_ENTRY_POINT = ['v10'];
+
 export const DESCRIPTION =
 	"discord.js is a powerful Node.js module that allows you to interact with the Discord API very easily. It takes a much more object-oriented approach than most other JS Discord libraries, making your bot's code significantly tidier and easier to comprehend.";

--- a/apps/website/src/util/parseDocsPathParams.ts
+++ b/apps/website/src/util/parseDocsPathParams.ts
@@ -10,7 +10,7 @@ export function parseDocsPathParams(item: string[] | undefined): {
 	const hasTypeMarker = lastElement?.includes('%3A');
 
 	return {
-		entryPoints: hasTypeMarker ? item.slice(0, -1) : item,
+		entryPoints: hasTypeMarker ? item.slice(0, -1) : lastElement?.length === 0 ? ['v10'] : item,
 		foundItem: hasTypeMarker ? lastElement : undefined,
 	};
 }

--- a/apps/website/src/util/parseDocsPathParams.ts
+++ b/apps/website/src/util/parseDocsPathParams.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_ENTRY_POINT } from './constants';
+
 export function parseDocsPathParams(item: string[] | undefined): {
 	entryPoints: string[];
 	foundItem: string | undefined;
@@ -10,7 +12,7 @@ export function parseDocsPathParams(item: string[] | undefined): {
 	const hasTypeMarker = lastElement?.includes('%3A');
 
 	return {
-		entryPoints: hasTypeMarker ? item.slice(0, -1) : lastElement?.length === 0 ? ['v10'] : item,
+		entryPoints: hasTypeMarker ? item.slice(0, -1) : lastElement?.length === 0 ? DEFAULT_ENTRY_POINT : item,
 		foundItem: hasTypeMarker ? lastElement : undefined,
 	};
 }

--- a/packages/api-extractor-model/src/model/ApiEntryPoint.ts
+++ b/packages/api-extractor-model/src/model/ApiEntryPoint.ts
@@ -15,16 +15,14 @@ import { ApiPackage } from './ApiPackage.js';
 export interface IApiEntryPointOptions extends IApiItemContainerMixinOptions, IApiNameMixinOptions {}
 
 /**
- * Represents the entry point for an NPM package.
+ * Represents an entry point for an NPM package.
  *
  * @remarks
  *
  * This is part of the {@link ApiModel} hierarchy of classes, which are serializable representations of
  * API declarations.
  *
- * `ApiEntryPoint` represents the entry point to an NPM package.  API Extractor does not currently support
- * analysis of multiple entry points, but the `ApiEntryPoint` object is included to support a future feature.
- * In the current implementation, `ApiEntryPoint.importPath` is always the empty string.
+ * `ApiEntryPoint` represents an entry point to an NPM package.
  *
  * For example, suppose the package.json file looks like this:
  *
@@ -37,7 +35,7 @@ export interface IApiEntryPointOptions extends IApiItemContainerMixinOptions, IA
  * }
  * ```
  *
- * In this example, the `ApiEntryPoint` would represent the TypeScript module for `./lib/index.js`.
+ * In this example, the main `ApiEntryPoint` would represent the TypeScript module for `./lib/index.js`.
  * @public
  */
 export class ApiEntryPoint extends ApiItemContainerMixin(ApiNameMixin(ApiItem)) {
@@ -62,12 +60,7 @@ export class ApiEntryPoint extends ApiItemContainerMixin(ApiNameMixin(ApiItem)) 
 
 	/**
 	 * The module path for this entry point, relative to the parent `ApiPackage`.  In the current implementation,
-	 * this is always the empty string, indicating the default entry point.
-	 *
-	 * @remarks
-	 *
-	 * API Extractor does not currently support analysis of multiple entry points.  If that feature is implemented
-	 * in the future, then the `ApiEntryPoint.importPath` will be used to distinguish different entry points,
+	 * this is used to distinguish different entry points,
 	 * for example: `controls/Button` in `import { Button } from "example-package/controls/Button";`.
 	 *
 	 * The `ApiEntryPoint.name` property stores the same value as `ApiEntryPoint.importPath`.

--- a/packages/api-extractor/src/api/ExtractorConfig.ts
+++ b/packages/api-extractor/src/api/ExtractorConfig.ts
@@ -209,6 +209,7 @@ interface IExtractorConfigParameters {
 	docModelIncludeForgottenExports: boolean;
 	enumMemberOrder: EnumMemberOrder;
 	mainEntryPointFilePath: string;
+	mainEntryPointName: string;
 	messages: IExtractorMessagesConfig;
 	newlineKind: NewlineKind;
 	omitTrimmingComments: boolean;
@@ -474,6 +475,7 @@ export class ExtractorConfig {
 		projectFolder,
 		packageJson,
 		packageFolder,
+		mainEntryPointName,
 		mainEntryPointFilePath,
 		additionalEntryPoints,
 		bundledPackages,
@@ -509,7 +511,7 @@ export class ExtractorConfig {
 		this.packageJson = packageJson;
 		this.packageFolder = packageFolder;
 		this.mainEntryPointFilePath = {
-			modulePath: '',
+			modulePath: mainEntryPointName,
 			filePath: mainEntryPointFilePath,
 		};
 		this.additionalEntryPoints = additionalEntryPoints;
@@ -1003,6 +1005,8 @@ export class ExtractorConfig {
 				tokenContext,
 			);
 
+			const mainEntryPointName = configObject.mainEntryPointName ?? '';
+
 			if (!ExtractorConfig.hasDtsFileExtension(mainEntryPointFilePath)) {
 				throw new Error('The "mainEntryPointFilePath" value is not a declaration file: ' + mainEntryPointFilePath);
 			}
@@ -1289,6 +1293,7 @@ export class ExtractorConfig {
 				packageJson,
 				packageFolder,
 				mainEntryPointFilePath,
+				mainEntryPointName,
 				additionalEntryPoints,
 				bundledPackages,
 				tsconfigFilePath,

--- a/packages/api-extractor/src/api/IConfigFile.ts
+++ b/packages/api-extractor/src/api/IConfigFile.ts
@@ -492,6 +492,11 @@ export interface IConfigFile {
 	mainEntryPointFilePath: string;
 
 	/**
+	 * Specifies the import path of the entrypoint used as the starting point for analysis.
+	 */
+	mainEntryPointName: string;
+
+	/**
 	 * {@inheritDoc IExtractorMessagesConfig}
 	 */
 	messages?: IExtractorMessagesConfig;

--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -291,6 +291,7 @@ export class ApiModelGenerator {
 			docComment: packageDocComment,
 			tsdocConfiguration: this._collector.extractorConfig.tsdocConfiguration,
 			projectFolderUrl: this._collector.extractorConfig.projectFolderUrl,
+			preserveMemberOrder: true,
 		});
 		this._apiModel.addMember(apiPackage);
 

--- a/packages/api-extractor/src/schemas/api-extractor-defaults.json
+++ b/packages/api-extractor/src/schemas/api-extractor-defaults.json
@@ -3,6 +3,8 @@
 
 	// ("mainEntryPointFilePath" is required)
 
+	"mainEntryPointName": "",
+
 	"bundledPackages": [],
 
 	"newlineKind": "crlf",

--- a/packages/api-extractor/src/schemas/api-extractor-template.json
+++ b/packages/api-extractor/src/schemas/api-extractor-template.json
@@ -48,6 +48,11 @@
 	"mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
 
 	/**
+	 * Specifies the import path of the entrypoint used as the starting point for analysis.
+	 */
+	// "mainEntryPointName": "",
+
+	/**
 	 * A list of NPM package names whose exports should be treated as part of this package.
 	 *
 	 * For example, suppose that Webpack is used to generate a distributed bundle for the project "library1",

--- a/packages/api-extractor/src/schemas/api-extractor.schema.json
+++ b/packages/api-extractor/src/schemas/api-extractor.schema.json
@@ -23,6 +23,11 @@
 			"type": "string"
 		},
 
+		"mainEntryPointName": {
+			"description": "Specifies the import path of the entrypoint used as the starting point for analysis.",
+			"type": "string"
+		},
+
 		"additionalEntryPoints": {
 			"description": "Specifies the .d.ts files to be used as the starting points for analysis.",
 			"type": "array",

--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -517,7 +517,7 @@ function resolveFileUrl(item: ApiDeclaredItem) {
 				currentItem = currentItem.parent as ApiDeclaredItem;
 
 			return {
-				sourceURL: `/docs/packages/${pkgName}/${version}/${extractImportPath(pkgName, currentItem.parent as ApiEntryPoint)}/${currentItem.displayName}:${currentItem.kind}`,
+				sourceURL: `/docs/packages/${pkgName}/${version}/${(currentItem.parent as ApiEntryPoint).importPath}/${currentItem.displayName}:${currentItem.kind}`,
 			};
 		}
 	} else if (fileUrl?.includes('/dist/') && fileUrl.includes('/main/packages/')) {
@@ -968,14 +968,6 @@ function memberKind(member: ApiItem | null) {
 	}
 }
 
-function extractImportPath(pkgName: string, entryPoint: ApiEntryPoint) {
-	if (pkgName === 'discord-api-types' && entryPoint.importPath === '') {
-		return 'v10';
-	}
-
-	return entryPoint.importPath;
-}
-
 async function writeSplitDocsToFileSystem({
 	entry,
 	member,
@@ -1036,7 +1028,7 @@ export async function generateSplitDocumentation({
 
 			await writeSplitDocsToFileSystem({
 				member: entries.map((entry) => ({
-					entryPoint: extractImportPath(pkgName, entry),
+					entryPoint: entry.importPath,
 				})),
 				packageName: pkgName,
 				tag: version,
@@ -1062,7 +1054,7 @@ export async function generateSplitDocumentation({
 						kind: item.kind,
 						name: item.displayName,
 						href: resolveItemURI(item),
-						entry: extractImportPath(pkgName, entry),
+						entry: entry.importPath,
 					}));
 
 				await writeSplitDocsToFileSystem({
@@ -1070,7 +1062,7 @@ export async function generateSplitDocumentation({
 					packageName: pkgName,
 					tag: version,
 					overrideName: 'sitemap',
-					entry: extractImportPath(pkgName, entry),
+					entry: entry.importPath,
 				});
 
 				for (const member of members) {
@@ -1095,7 +1087,7 @@ export async function generateSplitDocumentation({
 						member: returnValue,
 						packageName: pkgName,
 						tag: version,
-						entry: extractImportPath(pkgName, entry),
+						entry: entry.importPath,
 					});
 				}
 			}

--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -517,7 +517,7 @@ function resolveFileUrl(item: ApiDeclaredItem) {
 				currentItem = currentItem.parent as ApiDeclaredItem;
 
 			return {
-				sourceURL: `/docs/packages/${pkgName}/${version}/${(currentItem.parent as ApiEntryPoint).importPath || 'v10'}/${currentItem.displayName}:${currentItem.kind}`,
+				sourceURL: `/docs/packages/${pkgName}/${version}/${extractImportPath(pkgName, currentItem.parent as ApiEntryPoint)}/${currentItem.displayName}:${currentItem.kind}`,
 			};
 		}
 	} else if (fileUrl?.includes('/dist/') && fileUrl.includes('/main/packages/')) {

--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -223,39 +223,8 @@ function resolveItemURI(item: ApiItemLike, entryPoint?: ApiEntryPoint): string {
 }
 
 function itemExcerptText(excerpt: Excerpt, apiPackage: ApiPackage, parent?: ApiTypeParameterListMixin) {
-	const DISCORD_API_TYPES_VERSION = 'v10';
-	const DISCORD_API_TYPES_DOCS_URL = `https://discord-api-types.dev/api/discord-api-types-${DISCORD_API_TYPES_VERSION}`;
-
 	return excerpt.spannedTokens.map((token) => {
 		if (token.kind === ExcerptTokenKind.Reference) {
-			const source = token.canonicalReference?.source;
-			const symbol = token.canonicalReference?.symbol;
-
-			if (source && 'packageName' in source && source.packageName === 'discord-api-types' && symbol) {
-				const { meaning, componentPath: path } = symbol;
-				let href = DISCORD_API_TYPES_DOCS_URL;
-
-				// dapi-types doesn't have routes for class members
-				// so we can assume this member is for an enum
-				if (meaning === 'member' && path && 'parent' in path) {
-					// unless it's a variable like FormattingPatterns.Role
-					if (path.parent.toString() === '__type') {
-						href += `#${token.text.split('.')[0]}`;
-					} else {
-						href += `/enum/${path.parent}#${path.component}`;
-					}
-				} else if (meaning === 'type' || meaning === 'var') {
-					href += `#${token.text}`;
-				} else {
-					href += `/${meaning}/${token.text}`;
-				}
-
-				return {
-					text: token.text,
-					href,
-				};
-			}
-
 			if (token.canonicalReference) {
 				const resolved = resolveCanonicalReference(token.canonicalReference, apiPackage);
 
@@ -316,9 +285,6 @@ function itemExcerptText(excerpt: Excerpt, apiPackage: ApiPackage, parent?: ApiT
 }
 
 function itemTsDoc(item: DocNode, apiItem: ApiItem) {
-	const DISCORD_API_TYPES_VERSION = 'v10';
-	const DISCORD_API_TYPES_DOCS_URL = `https://discord-api-types.dev/api/discord-api-types-${DISCORD_API_TYPES_VERSION}`;
-
 	const createNode = (node: DocNode): any => {
 		switch (node.kind) {
 			case DocNodeKind.PlainText:
@@ -377,29 +343,6 @@ function itemTsDoc(item: DocNode, apiItem: ApiItem) {
 						return {
 							kind: DocNodeKind.LinkTag,
 							text: itemName ?? null,
-						};
-					}
-
-					if (resolved && resolved.package === 'discord-api-types') {
-						const { displayName, kind, members, containerKey } = resolved.item;
-						let href = DISCORD_API_TYPES_DOCS_URL;
-
-						// dapi-types doesn't have routes for class members
-						// so we can assume this member is for an enum
-						if (kind === 'enum' && members?.[0]) {
-							href += `/enum/${displayName}#${members[0].displayName}`;
-						} else if (kind === 'type' || kind === 'var') {
-							href += `#${displayName}`;
-						} else {
-							href += `/${kind}/${displayName}`;
-						}
-
-						return {
-							kind: DocNodeKind.LinkTag,
-							text: displayName,
-							containerKey,
-							uri: href,
-							members: members?.map((member) => `.${member.displayName}`).join('') ?? '',
 						};
 					}
 
@@ -545,8 +488,6 @@ function itemInfo(item: ApiDeclaredItem) {
 
 function resolveFileUrl(item: ApiDeclaredItem) {
 	const {
-		displayName,
-		kind,
 		sourceLocation: { fileUrl, fileLine },
 	} = item;
 	if (fileUrl?.includes('/node_modules/')) {
@@ -571,20 +512,12 @@ function resolveFileUrl(item: ApiDeclaredItem) {
 
 		// https://github.com/discordjs/discord.js/tree/main/node_modules/.pnpm/discord-api-types@0.37.97/node_modules/discord-api-types/payloads/v10/gateway.d.ts#L240
 		if (pkgName === 'discord-api-types') {
-			const DISCORD_API_TYPES_VERSION = 'v10';
-			const DISCORD_API_TYPES_DOCS_URL = `https://discord-api-types.dev/api/discord-api-types-${DISCORD_API_TYPES_VERSION}`;
-			let href = DISCORD_API_TYPES_DOCS_URL;
-
-			if (kind === ApiItemKind.EnumMember) {
-				href += `/enum/${item.parent!.displayName}#${displayName}`;
-			} else if (kind === ApiItemKind.TypeAlias || kind === ApiItemKind.Variable) {
-				href += `#${displayName}`;
-			} else {
-				href += `/${kindToMeaning.get(kind)}/${displayName}`;
-			}
+			let currentItem = item;
+			while (currentItem.parent && currentItem.parent.kind !== ApiItemKind.EntryPoint)
+				currentItem = currentItem.parent as ApiDeclaredItem;
 
 			return {
-				sourceURL: href,
+				sourceURL: `/docs/packages/${pkgName}/${version}/${(currentItem.parent as ApiEntryPoint).importPath || 'v10'}/${currentItem.displayName}:${currentItem.kind}`,
 			};
 		}
 	} else if (fileUrl?.includes('/dist/') && fileUrl.includes('/main/packages/')) {
@@ -1035,6 +968,14 @@ function memberKind(member: ApiItem | null) {
 	}
 }
 
+function extractImportPath(pkgName: string, entryPoint: ApiEntryPoint) {
+	if (pkgName === 'discord-api-types' && entryPoint.importPath === '') {
+		return 'v10';
+	}
+
+	return entryPoint.importPath;
+}
+
 async function writeSplitDocsToFileSystem({
 	entry,
 	member,
@@ -1095,7 +1036,7 @@ export async function generateSplitDocumentation({
 
 			await writeSplitDocsToFileSystem({
 				member: entries.map((entry) => ({
-					entryPoint: entry.importPath,
+					entryPoint: extractImportPath(pkgName, entry),
 				})),
 				packageName: pkgName,
 				tag: version,
@@ -1121,7 +1062,7 @@ export async function generateSplitDocumentation({
 						kind: item.kind,
 						name: item.displayName,
 						href: resolveItemURI(item),
-						entry: entry.importPath,
+						entry: extractImportPath(pkgName, entry),
 					}));
 
 				await writeSplitDocsToFileSystem({
@@ -1129,7 +1070,7 @@ export async function generateSplitDocumentation({
 					packageName: pkgName,
 					tag: version,
 					overrideName: 'sitemap',
-					entry: entry.importPath,
+					entry: extractImportPath(pkgName, entry),
 				});
 
 				for (const member of members) {
@@ -1154,7 +1095,7 @@ export async function generateSplitDocumentation({
 						member: returnValue,
 						packageName: pkgName,
 						tag: version,
-						entry: entry.importPath,
+						entry: extractImportPath(pkgName, entry),
 					});
 				}
 			}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Removes several special treatments for the `discord-api-types` package in docs pipeline that are obsolete now that they are on the same website.

Also moves the special treatment of `v10` as default entryPoint for `discord-api-types` to the generateSplitDocumentation` script instead of website.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
