### PR TITLE
feat(api-extractor): emit warnings for missing jsdoc or typings

### DIFF
--- a/packages/api-extractor/src/analyzer/AstEntity.ts
+++ b/packages/api-extractor/src/analyzer/AstEntity.ts
@@ -13,6 +13,7 @@
  *   - AstSyntheticEntity
  *     - AstImport
  *     - AstNamespaceImport
+ *       - AstNamespaceExport
  * ```
  */
 export abstract class AstEntity {

--- a/packages/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/packages/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -9,7 +9,7 @@ import { AstModule, type IAstModuleExportInfo } from './AstModule.js';
 import { AstNamespaceExport } from './AstNamespaceExport.js';
 import { AstNamespaceImport } from './AstNamespaceImport.js';
 import { AstSymbol } from './AstSymbol.js';
-import type { IFetchAstSymbolOptions } from './AstSymbolTable.js';
+import type { AstSymbolTable, IFetchAstSymbolOptions } from './AstSymbolTable.js';
 import { SourceFileLocationFormatter } from './SourceFileLocationFormatter.js';
 import { SyntaxHelpers } from './SyntaxHelpers.js';
 import { TypeScriptHelpers } from './TypeScriptHelpers.js';
@@ -565,33 +565,6 @@ export class ExportAnalyzer {
 			// Ignore "export { A }" without a module specifier
 			if (exportDeclaration.moduleSpecifier) {
 				const externalModulePath: string | undefined = this._tryGetExternalModulePath(exportDeclaration);
-
-				// if (declaration.kind === ts.SyntaxKind.NamespaceExport) {
-				// 	if (externalModulePath === undefined) {
-				// 		const astModule: AstModule = this._fetchSpecifierAstModule(exportDeclaration, declarationSymbol);
-				// 		let namespaceImport: AstNamespaceImport | undefined = this._astNamespaceImportByModule.get(astModule);
-				// 		if (namespaceImport === undefined) {
-				// 			namespaceImport = new AstNamespaceImport({
-				// 				namespaceName: declarationSymbol.name,
-				// 				astModule,
-				// 				declaration,
-				// 				symbol: declarationSymbol,
-				// 			});
-				// 			this._astNamespaceImportByModule.set(astModule, namespaceImport);
-				// 		}
-
-				// 		return namespaceImport;
-				// 	}
-
-				// 	// Here importSymbol=undefined because {@inheritDoc} and such are not going to work correctly for
-				// 	// a package or source file.
-				// 	return this._fetchAstImport(undefined, {
-				// 		importKind: AstImportKind.StarImport,
-				// 		exportName,
-				// 		modulePath: externalModulePath,
-				// 		isTypeOnly: exportDeclaration.isTypeOnly,
-				// 	});
-				// }
 
 				if (externalModulePath !== undefined) {
 					return this._fetchAstImport(declarationSymbol, {

--- a/packages/api-extractor/src/analyzer/ExportAnalyzer.ts
+++ b/packages/api-extractor/src/analyzer/ExportAnalyzer.ts
@@ -9,7 +9,7 @@ import { AstModule, type IAstModuleExportInfo } from './AstModule.js';
 import { AstNamespaceExport } from './AstNamespaceExport.js';
 import { AstNamespaceImport } from './AstNamespaceImport.js';
 import { AstSymbol } from './AstSymbol.js';
-import type { IFetchAstSymbolOptions } from './AstSymbolTable.js';
+import type { AstSymbolTable, IFetchAstSymbolOptions } from './AstSymbolTable.js';
 import { SourceFileLocationFormatter } from './SourceFileLocationFormatter.js';
 import { SyntaxHelpers } from './SyntaxHelpers.js';
 import { TypeScriptHelpers } from './TypeScriptHelpers.js';
@@ -569,33 +569,6 @@ export class ExportAnalyzer {
 			// Ignore "export { A }" without a module specifier
 			if (exportDeclaration.moduleSpecifier) {
 				const externalModulePath: string | undefined = this._tryGetExternalModulePath(exportDeclaration);
-
-				// if (declaration.kind === ts.SyntaxKind.NamespaceExport) {
-				// 	if (externalModulePath === undefined) {
-				// 		const astModule: AstModule = this._fetchSpecifierAstModule(exportDeclaration, declarationSymbol);
-				// 		let namespaceImport: AstNamespaceImport | undefined = this._astNamespaceImportByModule.get(astModule);
-				// 		if (namespaceImport === undefined) {
-				// 			namespaceImport = new AstNamespaceImport({
-				// 				namespaceName: declarationSymbol.name,
-				// 				astModule,
-				// 				declaration,
-				// 				symbol: declarationSymbol,
-				// 			});
-				// 			this._astNamespaceImportByModule.set(astModule, namespaceImport);
-				// 		}
-
-				// 		return namespaceImport;
-				// 	}
-
-				// 	// Here importSymbol=undefined because {@inheritDoc} and such are not going to work correctly for
-				// 	// a package or source file.
-				// 	return this._fetchAstImport(undefined, {
-				// 		importKind: AstImportKind.StarImport,
-				// 		exportName,
-				// 		modulePath: externalModulePath,
-				// 		isTypeOnly: exportDeclaration.isTypeOnly,
-				// 	});
-				// }
 
 				if (externalModulePath !== undefined) {
 					return this._fetchAstImport(declarationSymbol, {

--- a/packages/api-extractor/src/api/ExtractorMessageId.ts
+++ b/packages/api-extractor/src/api/ExtractorMessageId.ts
@@ -22,6 +22,16 @@ export const enum ExtractorMessageId {
 	DifferentReleaseTags = 'ae-different-release-tags',
 
 	/**
+	 * "The symbol ___ has no matching jsdoc equivalent in the JavaScript source files."
+	 */
+	DjsMissingJSDoc = 'ae-djs-missing-jsdoc',
+
+	/**
+	 * "The JSDoc comment for___ has no matching type equivalent in the TypeScript declaration file."
+	 */
+	DjsMissingTypeScriptType = 'ae-djs-missing-types',
+
+	/**
 	 * "The doc comment should not contain more than one release tag."
 	 */
 	ExtraReleaseTag = 'ae-extra-release-tag',
@@ -127,6 +137,8 @@ export const allExtractorMessageIds: Set<string> = new Set<string>([
 	'ae-extra-release-tag',
 	'ae-undocumented',
 	'ae-different-release-tags',
+	'ae-djs-missing-jsdoc',
+	'ae-djs-missing-types',
 	'ae-incompatible-release-tags',
 	'ae-missing-release-tag',
 	'ae-misplaced-package-tag',

--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -627,7 +627,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${parentApiItem.displayName}#constrcutor() has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The constructor ${parentApiItem.displayName}() has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -726,7 +726,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The class ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -805,7 +805,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${parentApiItem.displayName}#constructor() has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The constructor signature ${parentApiItem.displayName}() has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -961,7 +961,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The function ${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -1092,7 +1092,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The interface ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -1182,7 +1182,7 @@ export class ApiModelGenerator {
 				if (!docComment && parent) {
 					this._collector.messageRouter.addAnalyzerIssue(
 						ExtractorMessageId.DjsMissingJSDoc,
-						`The symbol ${parentApiItem.displayName}#${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
+						`The method ${parentApiItem.displayName}#${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
 						astDeclaration,
 					);
 				}
@@ -1221,7 +1221,7 @@ export class ApiModelGenerator {
 
 				this._collector.messageRouter.addAnalyzerIssueForPosition(
 					ExtractorMessageId.DjsMissingTypeScriptType,
-					`The JSDoc comment for ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
+					`The JSDoc comment for method ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
 					this._mainSourceFile!,
 					0,
 				);
@@ -1294,7 +1294,7 @@ export class ApiModelGenerator {
 				if (!docComment && parent) {
 					this._collector.messageRouter.addAnalyzerIssue(
 						ExtractorMessageId.DjsMissingJSDoc,
-						`The symbol ${parentApiItem.displayName}#${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
+						`The method signature ${parentApiItem.displayName}#${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
 						astDeclaration,
 					);
 				}
@@ -1320,7 +1320,7 @@ export class ApiModelGenerator {
 			} else if (jsDoc) {
 				this._collector.messageRouter.addAnalyzerIssueForPosition(
 					ExtractorMessageId.DjsMissingTypeScriptType,
-					`The JSDoc comment for ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
+					`The JSDoc comment for method signature ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
 					this._mainSourceFile!,
 					0,
 				);
@@ -1366,7 +1366,8 @@ export class ApiModelGenerator {
 	private _processApiProperty(astDeclaration: AstDeclaration | null, context: IProcessAstEntityContext): void {
 		const { name, parentApiItem } = context;
 		const parent = context.parentDocgenJson as DocgenClassJson | DocgenInterfaceJson | DocgenTypedefJson | undefined;
-		const jsDoc = parent?.props?.find((prop) => prop.name === name);
+		const inherited = parent && 'extends' in parent ? this._isInherited(parent, name, parentApiItem.kind) : undefined;
+		const jsDoc = parent?.props?.find((prop) => prop.name === name) ?? inherited;
 		const isStatic: boolean = astDeclaration
 			? (astDeclaration.modifierFlags & ts.ModifierFlags.Static) !== 0
 			: parentApiItem.kind === ApiItemKind.Class || parentApiItem.kind === ApiItemKind.Interface
@@ -1376,11 +1377,7 @@ export class ApiModelGenerator {
 
 		let apiProperty: ApiProperty | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiProperty;
 
-		if (
-			apiProperty === undefined &&
-			(astDeclaration ||
-				!this._isInherited(parent as DocgenClassJson | DocgenInterfaceJson, jsDoc!, parentApiItem.kind))
-		) {
+		if (apiProperty === undefined && (astDeclaration || !inherited)) {
 			if (astDeclaration) {
 				const declaration: ts.Declaration = astDeclaration.declaration;
 				const nodesToCapture: IExcerptBuilderNodeToCapture[] = [];
@@ -1424,7 +1421,7 @@ export class ApiModelGenerator {
 				if (!docComment && parent) {
 					this._collector.messageRouter.addAnalyzerIssue(
 						ExtractorMessageId.DjsMissingJSDoc,
-						`The symbol ${parentApiItem.displayName}#${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+						`The property ${parentApiItem.displayName}#${name} has no matching jsdoc equivalent in the JavaScript source files.`,
 						astDeclaration,
 					);
 				}
@@ -1455,7 +1452,7 @@ export class ApiModelGenerator {
 			} else if (parentApiItem.kind === ApiItemKind.Class || parentApiItem.kind === ApiItemKind.Interface) {
 				this._collector.messageRouter.addAnalyzerIssueForPosition(
 					ExtractorMessageId.DjsMissingTypeScriptType,
-					`The JSDoc comment for ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
+					`The JSDoc comment for property ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
 					this._mainSourceFile!,
 					0,
 				);
@@ -1484,11 +1481,13 @@ export class ApiModelGenerator {
 			containerKey,
 		) as ApiPropertySignature;
 		const parent = context.parentDocgenJson as DocgenInterfaceJson | DocgenPropertyJson | DocgenTypedefJson | undefined;
-		const jsDoc = parent?.props?.find((prop) => prop.name === name);
+		const inherited = parent && 'extends' in parent ? this._isInherited(parent, name, parentApiItem.kind) : undefined;
+		const jsDoc = parent?.props?.find((prop) => prop.name === name) ?? inherited;
 
 		if (
 			apiPropertySignature === undefined &&
-			(astDeclaration || !this._isInherited(parent as DocgenInterfaceJson, jsDoc!, parentApiItem.kind))
+			(astDeclaration || !inherited) &&
+			parentApiItem.kind !== ApiItemKind.Class
 		) {
 			if (astDeclaration) {
 				const propertySignature: ts.PropertySignature = astDeclaration.declaration as ts.PropertySignature;
@@ -1517,7 +1516,7 @@ export class ApiModelGenerator {
 				if (!docComment && parent) {
 					this._collector.messageRouter.addAnalyzerIssue(
 						ExtractorMessageId.DjsMissingJSDoc,
-						`The symbol ${parentApiItem.displayName}#${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+						`The property signature ${parentApiItem.displayName}#${name} has no matching jsdoc equivalent in the JavaScript source files.`,
 						astDeclaration,
 					);
 				}
@@ -1539,10 +1538,10 @@ export class ApiModelGenerator {
 					fileLine: jsDoc && 'meta' in jsDoc ? jsDoc.meta.line : sourceLocation.sourceFileLine,
 					fileColumn: sourceLocation.sourceFileColumn,
 				});
-			} else if (parentApiItem.kind === ApiItemKind.Class || parentApiItem.kind === ApiItemKind.Interface) {
+			} else if (parentApiItem.kind === ApiItemKind.Interface) {
 				this._collector.messageRouter.addAnalyzerIssueForPosition(
 					ExtractorMessageId.DjsMissingTypeScriptType,
-					`The JSDoc comment for ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
+					`The JSDoc comment for property signature ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
 					this._mainSourceFile!,
 					0,
 				);
@@ -1610,7 +1609,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The type alias ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -1848,20 +1847,19 @@ export class ApiModelGenerator {
 
 	private _isInherited(
 		container: DocgenClassJson | DocgenInterfaceJson,
-		jsDoc: DocgenParamJson | DocgenPropertyJson,
+		propertyName: string,
 		containerKind: ApiItemKind,
-	): boolean {
+	): DocgenPropertyJson | undefined {
 		switch (containerKind) {
 			case ApiItemKind.Class: {
 				const token = (container as DocgenClassJson).extends;
 				const parentName = Array.isArray(token) ? token[0]?.[0]?.[0] : token?.types?.[0]?.[0]?.[0];
 				const parentJson = this._jsDocJson?.classes.find((clas) => clas.name === parentName);
 				if (parentJson) {
-					if (parentJson.props?.find((prop) => prop.name === jsDoc.name)) {
-						return true;
-					} else {
-						return this._isInherited(parentJson, jsDoc, containerKind);
-					}
+					return (
+						parentJson.props?.find((prop) => prop.name === propertyName) ??
+						this._isInherited(parentJson, propertyName, containerKind)
+					);
 				}
 
 				break;
@@ -1873,13 +1871,15 @@ export class ApiModelGenerator {
 				const parentJsons = parentNames?.map((name) =>
 					this._jsDocJson?.interfaces.find((inter) => inter.name === name),
 				);
+				if (propertyName === 'content') console.log(container.name, parentNames, parentJsons);
 				if (parentJsons?.length) {
 					for (const parentJson of parentJsons) {
-						if (
-							parentJson?.props?.find((prop) => prop.name === jsDoc.name) ||
-							this._isInherited(parentJson as DocgenInterfaceJson, jsDoc, containerKind)
-						) {
-							return true;
+						const result =
+							parentJson?.props?.find((prop) => prop.name === propertyName) ??
+							this._isInherited(parentJson as DocgenInterfaceJson, propertyName, containerKind);
+
+						if (result) {
+							return result;
 						}
 					}
 				}
@@ -1888,10 +1888,10 @@ export class ApiModelGenerator {
 			}
 
 			default:
-				console.log(`Unexpected parent of type ${containerKind} (${container.name}) of ${jsDoc?.name} `);
+				console.log(`Unexpected parent of type ${containerKind} (${container.name}) of ${propertyName} `);
 		}
 
-		return false;
+		return undefined;
 	}
 
 	private _isReadonly(astDeclaration: AstDeclaration): boolean {

--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -1049,7 +1049,9 @@ export class ApiModelGenerator {
 		let apiInterface: ApiInterface | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiInterface;
 		const parent = context.parentDocgenJson as DocgenJson | undefined;
 		const jsDoc =
-			parent?.interfaces.find((int) => int.name === name) ?? parent?.typedefs.find((int) => int.name === name);
+			parent?.interfaces.find((int) => int.name === name) ??
+			parent?.typedefs.find((int) => int.name === name) ??
+			parent?.classes.find((int) => int.name === name); // this case is needed for class interface merging
 
 		if (apiInterface === undefined) {
 			const interfaceDeclaration: ts.InterfaceDeclaration = astDeclaration.declaration as ts.InterfaceDeclaration;
@@ -1232,17 +1234,17 @@ export class ApiModelGenerator {
 					return;
 				}
 
+				const methodOptions = this._mapMethod(jsDoc, parentApiItem.getAssociatedPackage()!.name);
+				if (methodOptions.releaseTag === ReleaseTag.Internal || methodOptions.releaseTag === ReleaseTag.Alpha) {
+					return; // trim out items marked as "@internal" or "@alpha"
+				}
+
 				this._collector.messageRouter.addAnalyzerIssueForPosition(
 					ExtractorMessageId.DjsMissingTypeScriptType,
 					`The JSDoc comment for method ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
 					this._mainSourceFile!,
 					0,
 				);
-
-				const methodOptions = this._mapMethod(jsDoc, parentApiItem.getAssociatedPackage()!.name);
-				if (methodOptions.releaseTag === ReleaseTag.Internal || methodOptions.releaseTag === ReleaseTag.Alpha) {
-					return; // trim out items marked as "@internal" or "@alpha"
-				}
 
 				apiMethod = new ApiMethod(methodOptions);
 			}
@@ -1467,16 +1469,17 @@ export class ApiModelGenerator {
 					fileColumn: sourceLocation.sourceFileColumn,
 				});
 			} else if (parentApiItem.kind === ApiItemKind.Class || parentApiItem.kind === ApiItemKind.Interface) {
+				const propertyOptions = this._mapProp(jsDoc as DocgenPropertyJson, parentApiItem.getAssociatedPackage()!.name);
+				if (propertyOptions.releaseTag === ReleaseTag.Internal || propertyOptions.releaseTag === ReleaseTag.Alpha) {
+					return; // trim out items marked as "@internal" or "@alpha"
+				}
+
 				this._collector.messageRouter.addAnalyzerIssueForPosition(
 					ExtractorMessageId.DjsMissingTypeScriptType,
 					`The JSDoc comment for property ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
 					this._mainSourceFile!,
 					0,
 				);
-				const propertyOptions = this._mapProp(jsDoc as DocgenPropertyJson, parentApiItem.getAssociatedPackage()!.name);
-				if (propertyOptions.releaseTag === ReleaseTag.Internal || propertyOptions.releaseTag === ReleaseTag.Alpha) {
-					return; // trim out items marked as "@internal" or "@alpha"
-				}
 
 				apiProperty = new ApiProperty(propertyOptions);
 			} else {
@@ -1911,8 +1914,10 @@ export class ApiModelGenerator {
 			case ApiItemKind.Interface: {
 				const token = (container as DocgenInterfaceJson).extends;
 				const parentNames = Array.isArray(token) ? token.map((parent) => parent[0]?.[0]) : undefined;
-				const parentJsons = parentNames?.map((name) =>
-					this._jsDocJson?.interfaces.find((inter) => inter.name === name),
+				const parentJsons = parentNames?.map(
+					(name) =>
+						this._jsDocJson?.interfaces.find((inter) => inter.name === name) ??
+						this._jsDocJson?.classes.find((clas) => clas.name === name),
 				);
 				if (propertyName === 'content') console.log(container.name, parentNames, parentJsons);
 				if (parentJsons?.length) {

--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -634,7 +634,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${parentApiItem.displayName}#constrcutor() has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The constructor ${parentApiItem.displayName}() has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -733,7 +733,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The class ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -814,7 +814,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${parentApiItem.displayName}#constructor() has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The constructor signature ${parentApiItem.displayName}() has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -972,7 +972,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The function ${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -1103,7 +1103,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The interface ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -1195,7 +1195,7 @@ export class ApiModelGenerator {
 				if (!docComment && parent) {
 					this._collector.messageRouter.addAnalyzerIssue(
 						ExtractorMessageId.DjsMissingJSDoc,
-						`The symbol ${parentApiItem.displayName}#${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
+						`The method ${parentApiItem.displayName}#${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
 						astDeclaration,
 					);
 				}
@@ -1234,7 +1234,7 @@ export class ApiModelGenerator {
 
 				this._collector.messageRouter.addAnalyzerIssueForPosition(
 					ExtractorMessageId.DjsMissingTypeScriptType,
-					`The JSDoc comment for ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
+					`The JSDoc comment for method ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
 					this._mainSourceFile!,
 					0,
 				);
@@ -1309,7 +1309,7 @@ export class ApiModelGenerator {
 				if (!docComment && parent) {
 					this._collector.messageRouter.addAnalyzerIssue(
 						ExtractorMessageId.DjsMissingJSDoc,
-						`The symbol ${parentApiItem.displayName}#${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
+						`The method signature ${parentApiItem.displayName}#${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
 						astDeclaration,
 					);
 				}
@@ -1335,7 +1335,7 @@ export class ApiModelGenerator {
 			} else if (jsDoc) {
 				this._collector.messageRouter.addAnalyzerIssueForPosition(
 					ExtractorMessageId.DjsMissingTypeScriptType,
-					`The JSDoc comment for ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
+					`The JSDoc comment for method signature ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
 					this._mainSourceFile!,
 					0,
 				);
@@ -1381,7 +1381,8 @@ export class ApiModelGenerator {
 	private _processApiProperty(astDeclaration: AstDeclaration | null, context: IProcessAstEntityContext): void {
 		const { entryPoint, name, parentApiItem } = context;
 		const parent = context.parentDocgenJson as DocgenClassJson | DocgenInterfaceJson | DocgenTypedefJson | undefined;
-		const jsDoc = parent?.props?.find((prop) => prop.name === name);
+		const inherited = parent && 'extends' in parent ? this._isInherited(parent, name, parentApiItem.kind) : undefined;
+		const jsDoc = parent?.props?.find((prop) => prop.name === name) ?? inherited;
 		const isStatic: boolean = astDeclaration
 			? (astDeclaration.modifierFlags & ts.ModifierFlags.Static) !== 0
 			: parentApiItem.kind === ApiItemKind.Class || parentApiItem.kind === ApiItemKind.Interface
@@ -1391,11 +1392,7 @@ export class ApiModelGenerator {
 
 		let apiProperty: ApiProperty | undefined = parentApiItem.tryGetMemberByKey(containerKey) as ApiProperty;
 
-		if (
-			apiProperty === undefined &&
-			(astDeclaration ||
-				!this._isInherited(parent as DocgenClassJson | DocgenInterfaceJson, jsDoc!, parentApiItem.kind))
-		) {
+		if (apiProperty === undefined && (astDeclaration || !inherited)) {
 			if (astDeclaration) {
 				const declaration: ts.Declaration = astDeclaration.declaration;
 				const nodeTransforms: IExcerptBuilderNodeTransform[] = [];
@@ -1441,7 +1438,7 @@ export class ApiModelGenerator {
 				if (!docComment && parent) {
 					this._collector.messageRouter.addAnalyzerIssue(
 						ExtractorMessageId.DjsMissingJSDoc,
-						`The symbol ${parentApiItem.displayName}#${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+						`The property ${parentApiItem.displayName}#${name} has no matching jsdoc equivalent in the JavaScript source files.`,
 						astDeclaration,
 					);
 				}
@@ -1472,7 +1469,7 @@ export class ApiModelGenerator {
 			} else if (parentApiItem.kind === ApiItemKind.Class || parentApiItem.kind === ApiItemKind.Interface) {
 				this._collector.messageRouter.addAnalyzerIssueForPosition(
 					ExtractorMessageId.DjsMissingTypeScriptType,
-					`The JSDoc comment for ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
+					`The JSDoc comment for property ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
 					this._mainSourceFile!,
 					0,
 				);
@@ -1501,11 +1498,13 @@ export class ApiModelGenerator {
 			containerKey,
 		) as ApiPropertySignature;
 		const parent = context.parentDocgenJson as DocgenInterfaceJson | DocgenPropertyJson | DocgenTypedefJson | undefined;
-		const jsDoc = parent?.props?.find((prop) => prop.name === name);
+		const inherited = parent && 'extends' in parent ? this._isInherited(parent, name, parentApiItem.kind) : undefined;
+		const jsDoc = parent?.props?.find((prop) => prop.name === name) ?? inherited;
 
 		if (
 			apiPropertySignature === undefined &&
-			(astDeclaration || !this._isInherited(parent as DocgenInterfaceJson, jsDoc!, parentApiItem.kind))
+			(astDeclaration || !inherited) &&
+			parentApiItem.kind !== ApiItemKind.Class
 		) {
 			if (astDeclaration) {
 				const propertySignature: ts.PropertySignature = astDeclaration.declaration as ts.PropertySignature;
@@ -1536,7 +1535,7 @@ export class ApiModelGenerator {
 				if (!docComment && parent) {
 					this._collector.messageRouter.addAnalyzerIssue(
 						ExtractorMessageId.DjsMissingJSDoc,
-						`The symbol ${parentApiItem.displayName}#${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+						`The property signature ${parentApiItem.displayName}#${name} has no matching jsdoc equivalent in the JavaScript source files.`,
 						astDeclaration,
 					);
 				}
@@ -1558,10 +1557,10 @@ export class ApiModelGenerator {
 					fileLine: jsDoc && 'meta' in jsDoc ? jsDoc.meta.line : sourceLocation.sourceFileLine,
 					fileColumn: sourceLocation.sourceFileColumn,
 				});
-			} else if (parentApiItem.kind === ApiItemKind.Class || parentApiItem.kind === ApiItemKind.Interface) {
+			} else if (parentApiItem.kind === ApiItemKind.Interface) {
 				this._collector.messageRouter.addAnalyzerIssueForPosition(
 					ExtractorMessageId.DjsMissingTypeScriptType,
-					`The JSDoc comment for ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
+					`The JSDoc comment for property signature ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
 					this._mainSourceFile!,
 					0,
 				);
@@ -1629,7 +1628,7 @@ export class ApiModelGenerator {
 			if (!docComment && parent) {
 				this._collector.messageRouter.addAnalyzerIssue(
 					ExtractorMessageId.DjsMissingJSDoc,
-					`The symbol ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+					`The type alias ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
 					astDeclaration,
 				);
 			}
@@ -1891,20 +1890,19 @@ export class ApiModelGenerator {
 
 	private _isInherited(
 		container: DocgenClassJson | DocgenInterfaceJson,
-		jsDoc: DocgenParamJson | DocgenPropertyJson,
+		propertyName: string,
 		containerKind: ApiItemKind,
-	): boolean {
+	): DocgenPropertyJson | undefined {
 		switch (containerKind) {
 			case ApiItemKind.Class: {
 				const token = (container as DocgenClassJson).extends;
 				const parentName = Array.isArray(token) ? token[0]?.[0]?.[0] : token?.types?.[0]?.[0]?.[0];
 				const parentJson = this._jsDocJson?.classes.find((clas) => clas.name === parentName);
 				if (parentJson) {
-					if (parentJson.props?.find((prop) => prop.name === jsDoc.name)) {
-						return true;
-					} else {
-						return this._isInherited(parentJson, jsDoc, containerKind);
-					}
+					return (
+						parentJson.props?.find((prop) => prop.name === propertyName) ??
+						this._isInherited(parentJson, propertyName, containerKind)
+					);
 				}
 
 				break;
@@ -1916,13 +1914,15 @@ export class ApiModelGenerator {
 				const parentJsons = parentNames?.map((name) =>
 					this._jsDocJson?.interfaces.find((inter) => inter.name === name),
 				);
+				if (propertyName === 'content') console.log(container.name, parentNames, parentJsons);
 				if (parentJsons?.length) {
 					for (const parentJson of parentJsons) {
-						if (
-							parentJson?.props?.find((prop) => prop.name === jsDoc.name) ||
-							this._isInherited(parentJson as DocgenInterfaceJson, jsDoc, containerKind)
-						) {
-							return true;
+						const result =
+							parentJson?.props?.find((prop) => prop.name === propertyName) ??
+							this._isInherited(parentJson as DocgenInterfaceJson, propertyName, containerKind);
+
+						if (result) {
+							return result;
 						}
 					}
 				}
@@ -1931,10 +1931,10 @@ export class ApiModelGenerator {
 			}
 
 			default:
-				console.log(`Unexpected parent of type ${containerKind} (${container.name}) of ${jsDoc?.name} `);
+				console.log(`Unexpected parent of type ${containerKind} (${container.name}) of ${propertyName} `);
 		}
 
-		return false;
+		return undefined;
 	}
 
 	private _isReadonly(astDeclaration: AstDeclaration): boolean {

--- a/packages/api-extractor/src/generators/ApiModelGenerator.ts
+++ b/packages/api-extractor/src/generators/ApiModelGenerator.ts
@@ -52,6 +52,7 @@ import { AstNamespaceImport } from '../analyzer/AstNamespaceImport.js';
 import { AstSymbol } from '../analyzer/AstSymbol.js';
 import { TypeScriptInternals } from '../analyzer/TypeScriptInternals.js';
 import type { ExtractorConfig } from '../api/ExtractorConfig';
+import { ExtractorMessageId } from '../api/ExtractorMessageId.js';
 import type { ApiItemMetadata } from '../collector/ApiItemMetadata.js';
 import type { Collector } from '../collector/Collector.js';
 import type { DeclarationMetadata } from '../collector/DeclarationMetadata.js';
@@ -259,6 +260,8 @@ export class ApiModelGenerator {
 
 	private readonly _jsDocJson: DocgenJson | undefined;
 
+	private readonly _mainSourceFile: ts.SourceFile | undefined;
+
 	public constructor(collector: Collector, extractorConfig: ExtractorConfig) {
 		this._collector = collector;
 		this._apiModel = new ApiModel();
@@ -274,6 +277,9 @@ export class ApiModelGenerator {
 
 		// @ts-expect-error we reuse the private tsdocParser from collector here
 		this._tsDocParser = collector._tsdocParser;
+		this._mainSourceFile = this._collector.workingPackage.entryPoints.find((entry) =>
+			this._collector.workingPackage.isDefaultEntryPoint(entry),
+		)?.sourceFile;
 	}
 
 	public get apiModel(): ApiModel {
@@ -323,6 +329,15 @@ export class ApiModelGenerator {
 
 	private _processAstEntity(astEntity: AstEntity, context: IProcessAstEntityContext): void {
 		if (astEntity instanceof AstSymbol) {
+			if (
+				context.parentDocgenJson &&
+				astEntity.followedSymbol.declarations?.some(
+					(declaration) => declaration.getSourceFile() !== this._mainSourceFile,
+				)
+			) {
+				context.parentDocgenJson = undefined;
+			}
+
 			// Skip ancillary declarations; we will process them with the main declaration
 			for (const astDeclaration of this._collector.getNonAncillaryDeclarations(astEntity)) {
 				this._processDeclaration(astDeclaration, context);
@@ -615,6 +630,15 @@ export class ApiModelGenerator {
 						} */`,
 					).docComment
 				: apiItemMetadata.tsdocComment;
+
+			if (!docComment && parent) {
+				this._collector.messageRouter.addAnalyzerIssue(
+					ExtractorMessageId.DjsMissingJSDoc,
+					`The symbol ${parentApiItem.displayName}#constrcutor() has no matching jsdoc equivalent in the JavaScript source files.`,
+					astDeclaration,
+				);
+			}
+
 			const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
 			const isProtected: boolean = (astDeclaration.modifierFlags & ts.ModifierFlags.Protected) !== 0;
 			const sourceLocation: ISourceLocation = this._getSourceLocation(constructorDeclaration);
@@ -705,6 +729,15 @@ export class ApiModelGenerator {
 						} */`,
 					).docComment
 				: apiItemMetadata.tsdocComment;
+
+			if (!docComment && parent) {
+				this._collector.messageRouter.addAnalyzerIssue(
+					ExtractorMessageId.DjsMissingJSDoc,
+					`The symbol ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+					astDeclaration,
+				);
+			}
+
 			const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
 			const isAbstract: boolean = (ts.getCombinedModifierFlags(classDeclaration) & ts.ModifierFlags.Abstract) !== 0;
 			const sourceLocation: ISourceLocation = this._getSourceLocation(classDeclaration);
@@ -777,6 +810,15 @@ export class ApiModelGenerator {
 						} */`,
 					).docComment
 				: apiItemMetadata.tsdocComment;
+
+			if (!docComment && parent) {
+				this._collector.messageRouter.addAnalyzerIssue(
+					ExtractorMessageId.DjsMissingJSDoc,
+					`The symbol ${parentApiItem.displayName}#constructor() has no matching jsdoc equivalent in the JavaScript source files.`,
+					astDeclaration,
+				);
+			}
+
 			const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
 			const sourceLocation: ISourceLocation = this._getSourceLocation(constructSignature);
 
@@ -926,6 +968,15 @@ export class ApiModelGenerator {
 						} */`,
 					).docComment
 				: apiItemMetadata.tsdocComment;
+
+			if (!docComment && parent) {
+				this._collector.messageRouter.addAnalyzerIssue(
+					ExtractorMessageId.DjsMissingJSDoc,
+					`The symbol ${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
+					astDeclaration,
+				);
+			}
+
 			const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
 			const sourceLocation: ISourceLocation = this._getSourceLocation(functionDeclaration);
 
@@ -1048,6 +1099,15 @@ export class ApiModelGenerator {
 						} */`,
 					).docComment
 				: apiItemMetadata.tsdocComment;
+
+			if (!docComment && parent) {
+				this._collector.messageRouter.addAnalyzerIssue(
+					ExtractorMessageId.DjsMissingJSDoc,
+					`The symbol ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+					astDeclaration,
+				);
+			}
+
 			const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
 			const sourceLocation: ISourceLocation = this._getSourceLocation(interfaceDeclaration);
 
@@ -1131,6 +1191,15 @@ export class ApiModelGenerator {
 							} */`,
 						).docComment
 					: apiItemMetadata.tsdocComment;
+
+				if (!docComment && parent) {
+					this._collector.messageRouter.addAnalyzerIssue(
+						ExtractorMessageId.DjsMissingJSDoc,
+						`The symbol ${parentApiItem.displayName}#${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
+						astDeclaration,
+					);
+				}
+
 				const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
 				if (releaseTag === ReleaseTag.Internal || releaseTag === ReleaseTag.Alpha) {
 					return; // trim out items marked as "@internal" or "@alpha"
@@ -1162,6 +1231,13 @@ export class ApiModelGenerator {
 				if (jsDoc.inherited) {
 					return;
 				}
+
+				this._collector.messageRouter.addAnalyzerIssueForPosition(
+					ExtractorMessageId.DjsMissingTypeScriptType,
+					`The JSDoc comment for ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
+					this._mainSourceFile!,
+					0,
+				);
 
 				const methodOptions = this._mapMethod(jsDoc, parentApiItem.getAssociatedPackage()!.name);
 				if (methodOptions.releaseTag === ReleaseTag.Internal || methodOptions.releaseTag === ReleaseTag.Alpha) {
@@ -1229,6 +1305,15 @@ export class ApiModelGenerator {
 							} */`,
 						).docComment
 					: apiItemMetadata.tsdocComment;
+
+				if (!docComment && parent) {
+					this._collector.messageRouter.addAnalyzerIssue(
+						ExtractorMessageId.DjsMissingJSDoc,
+						`The symbol ${parentApiItem.displayName}#${name}() has no matching jsdoc equivalent in the JavaScript source files.`,
+						astDeclaration,
+					);
+				}
+
 				const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
 				const isOptional: boolean = (astDeclaration.astSymbol.followedSymbol.flags & ts.SymbolFlags.Optional) !== 0;
 				const sourceLocation: ISourceLocation = this._getSourceLocation(methodSignature);
@@ -1248,6 +1333,12 @@ export class ApiModelGenerator {
 					fileColumn: sourceLocation.sourceFileColumn,
 				});
 			} else if (jsDoc) {
+				this._collector.messageRouter.addAnalyzerIssueForPosition(
+					ExtractorMessageId.DjsMissingTypeScriptType,
+					`The JSDoc comment for ${parentApiItem.displayName}#${name}() has no matching type equivalent in the TypeScript declaration file.`,
+					this._mainSourceFile!,
+					0,
+				);
 				apiMethodSignature = new ApiMethodSignature(this._mapMethod(jsDoc, parentApiItem.getAssociatedPackage()!.name));
 			}
 
@@ -1346,6 +1437,15 @@ export class ApiModelGenerator {
 							} */`,
 						).docComment
 					: apiItemMetadata.tsdocComment;
+
+				if (!docComment && parent) {
+					this._collector.messageRouter.addAnalyzerIssue(
+						ExtractorMessageId.DjsMissingJSDoc,
+						`The symbol ${parentApiItem.displayName}#${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+						astDeclaration,
+					);
+				}
+
 				const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
 				const isOptional: boolean = (astDeclaration.astSymbol.followedSymbol.flags & ts.SymbolFlags.Optional) !== 0;
 				const isProtected: boolean = (astDeclaration.modifierFlags & ts.ModifierFlags.Protected) !== 0;
@@ -1370,6 +1470,12 @@ export class ApiModelGenerator {
 					fileColumn: sourceLocation.sourceFileColumn,
 				});
 			} else if (parentApiItem.kind === ApiItemKind.Class || parentApiItem.kind === ApiItemKind.Interface) {
+				this._collector.messageRouter.addAnalyzerIssueForPosition(
+					ExtractorMessageId.DjsMissingTypeScriptType,
+					`The JSDoc comment for ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
+					this._mainSourceFile!,
+					0,
+				);
 				const propertyOptions = this._mapProp(jsDoc as DocgenPropertyJson, parentApiItem.getAssociatedPackage()!.name);
 				if (propertyOptions.releaseTag === ReleaseTag.Internal || propertyOptions.releaseTag === ReleaseTag.Alpha) {
 					return; // trim out items marked as "@internal" or "@alpha"
@@ -1426,6 +1532,15 @@ export class ApiModelGenerator {
 							} */`,
 						).docComment
 					: apiItemMetadata.tsdocComment;
+
+				if (!docComment && parent) {
+					this._collector.messageRouter.addAnalyzerIssue(
+						ExtractorMessageId.DjsMissingJSDoc,
+						`The symbol ${parentApiItem.displayName}#${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+						astDeclaration,
+					);
+				}
+
 				const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
 				const isOptional: boolean = (astDeclaration.astSymbol.followedSymbol.flags & ts.SymbolFlags.Optional) !== 0;
 				const isReadonly: boolean = this._isReadonly(astDeclaration);
@@ -1444,6 +1559,12 @@ export class ApiModelGenerator {
 					fileColumn: sourceLocation.sourceFileColumn,
 				});
 			} else if (parentApiItem.kind === ApiItemKind.Class || parentApiItem.kind === ApiItemKind.Interface) {
+				this._collector.messageRouter.addAnalyzerIssueForPosition(
+					ExtractorMessageId.DjsMissingTypeScriptType,
+					`The JSDoc comment for ${parentApiItem.displayName}#${name} has no matching type equivalent in the TypeScript declaration file.`,
+					this._mainSourceFile!,
+					0,
+				);
 				apiPropertySignature = new ApiPropertySignature(
 					this._mapProp(jsDoc as DocgenPropertyJson, parentApiItem.getAssociatedPackage()!.name),
 				);
@@ -1504,6 +1625,15 @@ export class ApiModelGenerator {
 						} */`,
 					).docComment
 				: apiItemMetadata.tsdocComment;
+
+			if (!docComment && parent) {
+				this._collector.messageRouter.addAnalyzerIssue(
+					ExtractorMessageId.DjsMissingJSDoc,
+					`The symbol ${name} has no matching jsdoc equivalent in the JavaScript source files.`,
+					astDeclaration,
+				);
+			}
+
 			const releaseTag: ReleaseTag = apiItemMetadata.effectiveReleaseTag;
 			const sourceLocation: ISourceLocation = this._getSourceLocation(typeAliasDeclaration);
 

--- a/packages/api-extractor/src/generators/DtsRollupGenerator.ts
+++ b/packages/api-extractor/src/generators/DtsRollupGenerator.ts
@@ -108,18 +108,12 @@ export class DtsRollupGenerator {
 		// Emit the imports
 		for (const entity of [...collector.entities.values()][0]!) {
 			if (entity.astEntity instanceof AstImport) {
+				// Note: it isn't valid to trim imports based on their release tags.
+				// E.g. class Foo (`@public`) extends interface Bar (`@beta`) from some external library.
+				// API-Extractor cannot trim `import { Bar } from "external-library"` when generating its public rollup,
+				// or the export of `Foo` would include a broken reference to `Bar`.
 				const astImport: AstImport = entity.astEntity;
-
-				// For example, if the imported API comes from an external package that supports AEDoc,
-				// and it was marked as `@internal`, then don't emit it.
-				const symbolMetadata: SymbolMetadata | undefined = collector.tryFetchMetadataForAstEntity(astImport);
-				const maxEffectiveReleaseTag: ReleaseTag = symbolMetadata
-					? symbolMetadata.maxEffectiveReleaseTag
-					: ReleaseTag.None;
-
-				if (this._shouldIncludeReleaseTag(maxEffectiveReleaseTag, dtsKind)) {
-					DtsEmitHelpers.emitImport(writer, entity, astImport);
-				}
+				DtsEmitHelpers.emitImport(writer, entity, astImport);
 			}
 		}
 
@@ -209,6 +203,17 @@ export class DtsRollupGenerator {
 						throw new InternalError(
 							`Cannot find collector entity for ${entity.nameForEmit}.${exportedEntity.localName}`,
 						);
+					}
+
+					// If the entity's declaration won't be included, then neither should the namespace export it
+					// This fixes the issue encountered here: https://github.com/microsoft/rushstack/issues/2791
+					const exportedSymbolMetadata: SymbolMetadata | undefined =
+						collector.tryFetchMetadataForAstEntity(exportedEntity);
+					const exportedMaxEffectiveReleaseTag: ReleaseTag = exportedSymbolMetadata
+						? exportedSymbolMetadata.maxEffectiveReleaseTag
+						: ReleaseTag.None;
+					if (!this._shouldIncludeReleaseTag(exportedMaxEffectiveReleaseTag, dtsKind)) {
+						continue;
 					}
 
 					if (collectorEntity.nameForEmit === exportedName) {

--- a/packages/discord.js/src/structures/ClientUser.js
+++ b/packages/discord.js/src/structures/ClientUser.js
@@ -181,11 +181,7 @@ class ClientUser extends User {
   /**
    * Options for setting an activity.
    *
-   * @typedef {Object} ActivityOptions
-   * @property {string} name Name of the activity
-   * @property {string} [state] State of the activity
-   * @property {string} [url] Twitch / YouTube stream URL
-   * @property {ActivityType} [type] Type of the activity
+   * @typedef {ActivitiesOptions} ActivityOptions
    * @property {number|number[]} [shardId] Shard Id(s) to have the activity set on
    */
 

--- a/packages/discord.js/tsdoc.json
+++ b/packages/discord.js/tsdoc.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["@discordjs/api-extractor/extends/tsdoc-base.json"],
+
+  "tagDefinitions": [
+    {
+      "tagName": "@unstable",
+      "syntaxKind": "modifier"
+    }
+  ],
+  "supportForTags": { "@unstable": true }
+}

--- a/packages/discord.js/tsdoc.json
+++ b/packages/discord.js/tsdoc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
   "extends": ["@discordjs/api-extractor/extends/tsdoc-base.json"],
+
   "tagDefinitions": [
     {
       "tagName": "@unstable",

--- a/packages/rpc/.gitignore
+++ b/packages/rpc/.gitignore
@@ -1,0 +1,28 @@
+# Packages
+node_modules
+
+# Log files
+logs
+*.log
+npm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+
+# Env
+.env
+
+# Dist
+dist
+dist-docs
+
+# Docs
+docs/**/*
+!docs/README.md
+
+# Miscellaneous
+.turbo
+.tmp
+coverage


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

API Extractor will emit warnings for any typings that have no JSDoc equivalent in the JavaScript files.

Similarly will emit warnings for JSDoc comments that have no matching typing.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
