### PR TITLE
fix(api-extractor): include entrypoint in links

### DIFF
--- a/packages/api-extractor/src/generators/DeclarationReferenceGenerator.ts
+++ b/packages/api-extractor/src/generators/DeclarationReferenceGenerator.ts
@@ -350,14 +350,14 @@ export class DeclarationReferenceGenerator {
 
 			if (packageJson?.name) {
 				if (packageJson?.exports && !Array.isArray(packageJson.exports) && typeof packageJson.exports !== 'string') {
-						const entryPoint = Object.keys(packageJson.exports).find((path) =>
-							dirname(sourceFile.fileName).endsWith(path.slice(1)),
-						);
+					const entryPoint = Object.keys(packageJson.exports).find((path) =>
+						dirname(sourceFile.fileName).endsWith(path.slice(1)),
+					);
 
-						if (entryPoint && packageJson.exports[entryPoint]) {
-							return `${packageJson.name}${entryPoint.slice(1)}`;
-						}
+					if (entryPoint && packageJson.exports[entryPoint]) {
+						return `${packageJson.name}${entryPoint.slice(1)}`;
 					}
+				}
 
 				return packageJson.name;
 			}

--- a/packages/api-extractor/src/generators/DeclarationReferenceGenerator.ts
+++ b/packages/api-extractor/src/generators/DeclarationReferenceGenerator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { dirname } from 'node:path';
 import { Navigation, Meaning } from '@discordjs/api-extractor-model';
 import {
 	DeclarationReference,
@@ -348,6 +349,16 @@ export class DeclarationReferenceGenerator {
 			);
 
 			if (packageJson?.name) {
+				if (packageJson?.exports && !Array.isArray(packageJson.exports) && typeof packageJson.exports !== 'string') {
+						const entryPoint = Object.keys(packageJson.exports).find((path) =>
+							dirname(sourceFile.fileName).endsWith(path.slice(1)),
+						);
+
+						if (entryPoint && packageJson.exports[entryPoint]) {
+							return `${packageJson.name}${entryPoint.slice(1)}`;
+						}
+					}
+
 				return packageJson.name;
 			}
 

--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -46,7 +46,7 @@ import type {
 	DocFencedCode,
 	DocComment,
 } from '@microsoft/tsdoc';
-import type { DeclarationReference } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference.js';
+import type { DeclarationReference, ModuleSource } from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference.js';
 import { BuiltinDocumentationLinks } from './builtinDocumentationLinks.js';
 import { PACKAGES, fetchVersionDocs, fetchVersions } from './shared.js';
 
@@ -147,6 +147,9 @@ function resolveCanonicalReference(
 				containerKey: `|${
 					canonicalReference.symbol.meaning
 				}|${canonicalReference.symbol.componentPath.component.toString()}`,
+				getAssociatedEntryPoint() {
+					return canonicalReference.source as ModuleSource;
+				},
 			},
 			// eslint-disable-next-line unicorn/better-regex
 			version: apiPackage?.dependencies?.[canonicalReference.source.packageName]?.replace(/[~^]/, ''),
@@ -167,6 +170,9 @@ function resolveCanonicalReference(
 				members: canonicalReference.memberReferences
 					.slice(1)
 					.map((member) => ({ kind: member.kind, displayName: member.memberIdentifier!.identifier! })),
+				getAssociatedEntryPoint() {
+					return canonicalReference;
+				},
 			},
 			// eslint-disable-next-line unicorn/better-regex
 			version: apiPackage?.dependencies?.[canonicalReference.packageName ?? '']?.replace(/[~^]/, ''),
@@ -204,10 +210,14 @@ export function hasEvents(item: ApiItemContainerMixin) {
 	return resolveMembers(item, memberPredicate).some(({ item: member }) => member.kind === ApiItemKind.Event);
 }
 
+interface ApiEntryPointLike {
+	importPath: string | undefined;
+}
+
 interface ApiItemLike {
 	containerKey?: string;
 	displayName: string;
-	getAssociatedEntryPoint?(): ApiEntryPoint | undefined;
+	getAssociatedEntryPoint?(): ApiEntryPointLike | undefined;
 	kind: string;
 	members?: readonly ApiItemLike[];
 	parent?: ApiItemLike | undefined;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Links in docs for discord-api-types didn't include the /v10 part for the entrypoint. Now they do

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
