### PR TITLE
types(ApplicationEmoji): fix animated, author and name props

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1295,9 +1295,11 @@ export class ApplicationEmoji extends Emoji {
   private constructor(client: Client<true>, data: RawApplicationEmojiData, application: ClientApplication);
 
   public application: ClientApplication;
-  public author: User | null;
+  public animated: boolean;
+  public author: User;
   public id: Snowflake;
   public managed: boolean | null;
+  public name: string;
   public requiresColons: boolean | null;
   public delete(): Promise<ApplicationEmoji>;
   public edit(options: ApplicationEmojiEditOptions): Promise<ApplicationEmoji>;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes: https://github.com/discordjs/discord.js/issues/10858

The properties `animated`, `author` and `name` shouldn't accept null for `ApplicationEmoji` as described in the issue.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
