### PR TITLE
fix: remove incorrect nullables from ApplicationEmoji and GuildEmoji, add ApplicationEmoji#managed

### DIFF
--- a/packages/discord.js/src/structures/ApplicationEmoji.js
+++ b/packages/discord.js/src/structures/ApplicationEmoji.js
@@ -18,7 +18,7 @@ class ApplicationEmoji extends Emoji {
 
     /**
      * The user who created this emoji
-     * @type {?User}
+     * @type {User}
      */
     this.author = null;
 
@@ -35,7 +35,8 @@ class ApplicationEmoji extends Emoji {
     if ('managed' in data) {
       /**
        * Whether this emoji is managed by an external service
-       * @type {?boolean}
+       * @remarks Always false for application emojis
+       * @type {false}
        */
       this.managed = data.managed;
     }
@@ -43,7 +44,8 @@ class ApplicationEmoji extends Emoji {
     if ('require_colons' in data) {
       /**
        * Whether or not this emoji requires colons surrounding it
-       * @type {?boolean}
+       * @remarks Always true for application emojis
+       * @type {true}
        */
       this.requiresColons = data.require_colons;
     }
@@ -114,5 +116,60 @@ class ApplicationEmoji extends Emoji {
     return other.id === this.id && other.name === this.name;
   }
 }
+
+/**
+ * The emoji's name
+ * @name name
+ * @memberof ApplicationEmoji
+ * @instance
+ * @type {string}
+ * @readonly
+ */
+
+/**
+ * Whether or not the emoji is animated
+ * @name animated
+ * @memberof ApplicationEmoji
+ * @instance
+ * @type {boolean}
+ * @readonly
+ */
+
+/**
+ * Returns a URL for the emoji.
+ * @method imageURL
+ * @memberof ApplicationEmoji
+ * @instance
+ * @param {BaseImageURLOptions} [options] Options for the image URL
+ * @returns {string}
+ */
+
+/**
+ * Returns a URL for the emoji.
+ * @name url
+ * @memberof ApplicationEmoji
+ * @instance
+ * @type {string}
+ * @readonly
+ * @deprecated Use {@link ApplicationEmoji#imageURL} instead.
+ */
+
+/**
+ * The time the emoji was created at
+ * @name createdAt
+ * @memberof ApplicationEmoji
+ * @instance
+ * @type {Date}
+ * @readonly
+ */
+
+/**
+ * The timestamp the emoji was created at
+ * @name createdTimestamp
+ * @memberof ApplicationEmoji
+ * @instance
+ * @type {number}
+ * @readonly
+ */
 
 module.exports = ApplicationEmoji;

--- a/packages/discord.js/src/structures/ApplicationEmoji.js
+++ b/packages/discord.js/src/structures/ApplicationEmoji.js
@@ -24,6 +24,7 @@ class ApplicationEmoji extends Emoji {
 
     this.managed = null;
     this.requiresColons = null;
+    this.available = null;
 
     this._patch(data);
   }
@@ -48,6 +49,15 @@ class ApplicationEmoji extends Emoji {
        * @type {true}
        */
       this.requiresColons = data.require_colons;
+    }
+
+    if ('available' in data) {
+      /**
+       * Whether this emoji is available
+       * @remarks Always true for application emojis
+       * @type {true}
+       */
+      this.available = data.available;
     }
   }
 
@@ -109,7 +119,8 @@ class ApplicationEmoji extends Emoji {
         other.id === this.id &&
         other.name === this.name &&
         other.managed === this.managed &&
-        other.requiresColons === this.requiresColons
+        other.requiresColons === this.requiresColons &&
+        other.available === this.available
       );
     }
 

--- a/packages/discord.js/src/structures/BaseGuildEmoji.js
+++ b/packages/discord.js/src/structures/BaseGuildEmoji.js
@@ -77,7 +77,7 @@ class BaseGuildEmoji extends Emoji {
  * @name name
  * @memberof BaseGuildEmoji
  * @instance
- * @type {Snowflake}
+ * @type {string}
  * @readonly
  */
 

--- a/packages/discord.js/src/structures/BaseGuildEmoji.js
+++ b/packages/discord.js/src/structures/BaseGuildEmoji.js
@@ -72,4 +72,40 @@ class BaseGuildEmoji extends Emoji {
  * @deprecated Use {@link BaseGuildEmoji#imageURL} instead.
  */
 
+/**
+ * The emoji's name
+ * @name name
+ * @memberof BaseGuildEmoji
+ * @instance
+ * @type {Snowflake}
+ * @readonly
+ */
+
+/**
+ * Whether or not the emoji is animated
+ * @name animated
+ * @memberof BaseGuildEmoji
+ * @instance
+ * @type {boolean}
+ * @readonly
+ */
+
+/**
+ * The time the emoji was created at.
+ * @name createdAt
+ * @memberof BaseGuildEmoji
+ * @instance
+ * @type {Date}
+ * @readonly
+ */
+
+/**
+ * The timestamp the emoji was created at.
+ * @name createdTimestamp
+ * @memberof BaseGuildEmoji
+ * @instance
+ * @type {number}
+ * @readonly
+ */
+
 module.exports = BaseGuildEmoji;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -704,7 +704,7 @@ export abstract class BaseGuild extends Base {
 export class BaseGuildEmoji extends Emoji {
   protected constructor(client: Client<true>, data: RawGuildEmojiData, guild: Guild | GuildPreview);
   public imageURL(options?: BaseImageURLOptions): string;
-  /** @deprecated Use {@link BaseGuildEmoji#imageURL} instead */
+  /** @deprecated Use {@link BaseGuildEmoji.imageURL} instead */
   public get url(): string;
   public available: boolean | null;
   public get createdAt(): Date;
@@ -1502,7 +1502,7 @@ export class ApplicationEmoji extends Emoji {
   public available: true;
   public get createdAt(): Date;
   public get createdTimestamp(): number;
-  /** @deprecated Use {@link ApplicationEmoji#imageURL} instead */
+  /** @deprecated Use {@link ApplicationEmoji.imageURL} instead */
   public get url(): string;
   public imageURL(options?: BaseImageURLOptions): string;
   public delete(): Promise<ApplicationEmoji>;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -704,13 +704,16 @@ export abstract class BaseGuild extends Base {
 export class BaseGuildEmoji extends Emoji {
   protected constructor(client: Client<true>, data: RawGuildEmojiData, guild: Guild | GuildPreview);
   public imageURL(options?: BaseImageURLOptions): string;
+  /** @deprecated Use {@link BaseGuildEmoji#imageURL} instead */
   public get url(): string;
   public available: boolean | null;
   public get createdAt(): Date;
   public get createdTimestamp(): number;
   public guild: Guild | GuildPreview;
   public id: Snowflake;
-  public managed: boolean | null;
+  public name: string;
+  public animated: boolean;
+  public managed: boolean;
   public requiresColons: boolean | null;
 }
 
@@ -1490,10 +1493,17 @@ export class ApplicationEmoji extends Emoji {
   private constructor(client: Client<true>, data: RawApplicationEmojiData, application: ClientApplication);
 
   public application: ClientApplication;
-  public author: User | null;
+  public author: User;
   public id: Snowflake;
-  public managed: boolean | null;
-  public requiresColons: boolean | null;
+  public managed: false;
+  public requiresColons: true;
+  public name: string;
+  public animated: boolean;
+  public get createdAt(): Date;
+  public get createdTimestamp(): number;
+  /** @deprecated Use {@link ApplicationEmoji#imageURL} instead */
+  public get url(): string;
+  public imageURL(options?: BaseImageURLOptions): string;
   public delete(): Promise<ApplicationEmoji>;
   public edit(options: ApplicationEmojiEditOptions): Promise<ApplicationEmoji>;
   public equals(other: ApplicationEmoji | unknown): boolean;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1499,6 +1499,7 @@ export class ApplicationEmoji extends Emoji {
   public requiresColons: true;
   public name: string;
   public animated: boolean;
+  public available: true;
   public get createdAt(): Date;
   public get createdTimestamp(): number;
   /** @deprecated Use {@link ApplicationEmoji#imageURL} instead */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

ApplicationEmoji and BaseGuildEmoji inherit some incorrect nullables from Emoji (since they are never null for their case). Also BaseGuildEmoji#url wasn't marked as deprecated in the index.d.ts and ApplicationEmoji#available was missing (though always true, added for consistency with the rest). Internal discussion at https://discord.com/channels/222078108977594368/1366526457064591440/1366526457064591440

This also addresses the pending changes at https://github.com/discordjs/discord.js/pull/10905

Fixes #10858 

## Specific (attempted) changes
### Typings
- Remove `| null` from `ApplicationEmoji#author`, `managed`, and `requiresColons`
- Change `ApplicationEmoji#managed`'s type to `false` and `requiresColons` to `true`
- Add `ApplicationEmoji#available: true`
- Type override `ApplicationEmoji#name`, `animated`, `imageURL`, `url`, `createdAt` and `createdTimestamp` to make them non nullable
- Add `@deprecated` tag for `BaseGuildEmoji#url`
- Type override `BaseGuildEmoji#name`, `animated`, and `managed` to make them non nullable (the other properties were already non nullable)
### JS
- Add jsdoc comments overriding `ApplicationEmoji#name`, `animated`, `imageURL`, `url`, `createdAt` and `createdTimestamp`'s to remove the "or null if unicode" mentions
- Add jsdoc comments overriding `BaseGuildEmoji#name`, `animated`, `createdAt` and `createdTimestamp`'s to remove the "or null if unicode" mentions (`url` and `imageURL` already have them)
- Add `available` on `ApplicationEmoji`:
  - Set to `null` in constructor
  - Set in `_patch()`
  - Add check to `equals()`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- - I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
