### PR TITLE
docs: duplicated "the". in the docs

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -343,7 +343,7 @@
 			 */
 			"default": {
 				/**
-				 * Specifies whether the message should be written to the the tool's output log.  Note that
+				 * Specifies whether the message should be written to the tool's output log.  Note that
 				 * the "addToApiReportFile" property may supersede this option.
 				 *
 				 * Possible values: "error", "warning", "none"

--- a/packages/api-extractor/src/schemas/api-extractor-template.json
+++ b/packages/api-extractor/src/schemas/api-extractor-template.json
@@ -376,7 +376,7 @@
 			 */
 			"default": {
 				/**
-				 * Specifies whether the message should be written to the the tool's output log.  Note that
+				 * Specifies whether the message should be written to the tool's output log.  Note that
 				 * the "addToApiReportFile" property may supersede this option.
 				 *
 				 * Possible values: "error", "warning", "none"

--- a/packages/api-extractor/src/schemas/api-extractor.schema.json
+++ b/packages/api-extractor/src/schemas/api-extractor.schema.json
@@ -252,7 +252,7 @@
 					"properties": {
 						"logLevel": {
 							"type": "string",
-							"description": "Specifies whether the message should be written to the the tool's output log. Note that the \"addToApiReportFile\" property may supersede this option.",
+							"description": "Specifies whether the message should be written to the tool's output log. Note that the \"addToApiReportFile\" property may supersede this option.",
 							"enum": ["error", "warning", "none"]
 						},
 						"addToApiReportFile": {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR removes the duplicated word **“the the”** from the comments in all three JSON config/schema files:

- `api-extractor.json`
- `packages/api-extractor/src/schemas/api-extractor-template.json`
- `packages/api-extractor/src/schemas/api-extractor.schema.json`

Fixing this typo keeps the documentation strings clean and consistent.  
No functionality, typings, or runtime behavior is affected.

---

**Status and versioning classification:**

- This PR **only** includes non‑code changes (documentation / schema comment updates).
