### PR TITLE
docs: don't generate all sub-package docs for /next

### DIFF
--- a/packages/next/api-extractor.json
+++ b/packages/next/api-extractor.json
@@ -2,25 +2,26 @@
 	"extends": "../../api-extractor.json",
 	"docModel": {
 		"projectFolderUrl": "https://github.com/discordjs/discord.js/tree/main/packages/next"
-	},
-	"additionalEntryPoints": [
-		{ "modulePath": "discord-api-types", "filePath": "<projectFolder>/dist-docs/exports/discord-api-types.d.ts" },
-		{ "modulePath": "builders", "filePath": "<projectFolder>/dist-docs/exports/builders.d.ts" },
-		{ "modulePath": "collection", "filePath": "<projectFolder>/dist-docs/exports/collection.d.ts" },
-		{ "modulePath": "core", "filePath": "<projectFolder>/dist-docs/exports/core.d.ts" },
-		{ "modulePath": "formatters", "filePath": "<projectFolder>/dist-docs/exports/formatters.d.ts" },
-		{ "modulePath": "rest", "filePath": "<projectFolder>/dist-docs/exports/rest.d.ts" },
-		{ "modulePath": "util", "filePath": "<projectFolder>/dist-docs/exports/util.d.ts" },
-		{ "modulePath": "ws", "filePath": "<projectFolder>/dist-docs/exports/ws.d.ts" }
-	],
-	"bundledPackages": [
-		"discord-api-types",
-		"@discordjs/builders",
-		"@discordjs/collection",
-		"@discordjs/core",
-		"@discordjs/formatters",
-		"@discordjs/rest",
-		"@discordjs/util",
-		"@discordjs/ws"
-	]
+	}
+	// We probably don't want to generate docs here for these and instead link to the other modules
+	// "additionalEntryPoints": [
+	// 	{ "modulePath": "discord-api-types", "filePath": "<projectFolder>/dist-docs/exports/discord-api-types.d.ts" },
+	// 	{ "modulePath": "builders", "filePath": "<projectFolder>/dist-docs/exports/builders.d.ts" },
+	// 	{ "modulePath": "collection", "filePath": "<projectFolder>/dist-docs/exports/collection.d.ts" },
+	// 	{ "modulePath": "core", "filePath": "<projectFolder>/dist-docs/exports/core.d.ts" },
+	// 	{ "modulePath": "formatters", "filePath": "<projectFolder>/dist-docs/exports/formatters.d.ts" },
+	// 	{ "modulePath": "rest", "filePath": "<projectFolder>/dist-docs/exports/rest.d.ts" },
+	// 	{ "modulePath": "util", "filePath": "<projectFolder>/dist-docs/exports/util.d.ts" },
+	// 	{ "modulePath": "ws", "filePath": "<projectFolder>/dist-docs/exports/ws.d.ts" }
+	// ],
+	// "bundledPackages": [
+	// 	"discord-api-types",
+	// 	"@discordjs/builders",
+	// 	"@discordjs/collection",
+	// 	"@discordjs/core",
+	// 	"@discordjs/formatters",
+	// 	"@discordjs/rest",
+	// 	"@discordjs/util",
+	// 	"@discordjs/ws"
+	// ]
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Currently we generate all sub-package docs another time in /next and upload them as entrypoints. This removes that.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
