### PR TITLE
fix: background on pages with little content

### DIFF
--- a/apps/website/src/app/docs/packages/layout.tsx
+++ b/apps/website/src/app/docs/packages/layout.tsx
@@ -29,7 +29,7 @@ export default async function Layout({ children }: PropsWithChildren) {
 						Preview environment
 					</div>
 				) : null}
-				<div className="bg-[#fbfbfb] pb-12 dark:bg-[#1a1a1e]">
+				<div className="flex-1 bg-[#fbfbfb] pb-12 dark:bg-[#1a1a1e]">
 					<div className="relative px-6 pt-6 md:hidden">
 						<div className="fixed top-5 left-6 z-20 md:hidden">
 							<SidebarTrigger aria-label="Navigation" size="icon" variant="filled" />


### PR DESCRIPTION
Fixes the background of the main content not occupying the entire screen on pages with little content

Before:
https://discord.js.org/docs/packages/discord.js/14.19.3/applicationDirectory:Function

After:
https://discord-js-git-fix-full-page-content-discordjs.vercel.app/docs/packages/discord.js/14.19.3/applicationDirectory:Function
