### PR TITLE
feat: update `@types/node` to v22

### DIFF
--- a/packages/rest/__tests__/RequestHandler.test.ts
+++ b/packages/rest/__tests__/RequestHandler.test.ts
@@ -47,8 +47,8 @@ let serverOutage = true;
 let unexpected429 = true;
 let unexpected429cf = true;
 const sublimitIntervals: {
-	reset: NodeJS.Timer | null;
-	retry: NodeJS.Timer | null;
+	reset: NodeJS.Timeout | null;
+	retry: NodeJS.Timeout | null;
 } = {
 	reset: null,
 	retry: null,

--- a/packages/rest/package.json
+++ b/packages/rest/package.json
@@ -98,7 +98,7 @@
 		"@discordjs/api-extractor": "workspace:^",
 		"@discordjs/scripts": "workspace:^",
 		"@favware/cliff-jumper": "^4.1.0",
-		"@types/node": "18.17.9",
+		"@types/node": "^22.15.2",
 		"@vitest/coverage-v8": "^3.1.1",
 		"cross-env": "^7.0.3",
 		"esbuild-plugin-version-injector": "^1.2.1",

--- a/packages/rest/src/index.ts
+++ b/packages/rest/src/index.ts
@@ -1,13 +1,9 @@
-import { Blob } from 'node:buffer';
 import { shouldUseGlobalFetchAndWebSocket } from '@discordjs/util';
-import { FormData } from 'undici';
 import { setDefaultStrategy } from './environment.js';
 import { makeRequest } from './strategies/undiciRequest.js';
 
-// TODO(ckohen): remove once node engine req is bumped to > v18
-(globalThis as any).FormData ??= FormData;
-globalThis.Blob ??= Blob;
-
-setDefaultStrategy(shouldUseGlobalFetchAndWebSocket() ? fetch : makeRequest);
+// This cast is needed because of a mismatch between the version of undici-types provided by @types/node and undici
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+setDefaultStrategy(shouldUseGlobalFetchAndWebSocket() ? (fetch as typeof import('undici').fetch) : makeRequest);
 
 export * from './shared.js';

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -70,9 +70,9 @@ export class REST extends AsyncEventEmitter<RestEvents> {
 
 	#token: string | null = null;
 
-	private hashTimer!: NodeJS.Timer | number;
+	private hashTimer!: NodeJS.Timeout | number;
 
-	private handlerTimer!: NodeJS.Timer | number;
+	private handlerTimer!: NodeJS.Timeout | number;
 
 	public readonly options: RESTOptions;
 

--- a/packages/rest/src/lib/global/fetch.d.ts
+++ b/packages/rest/src/lib/global/fetch.d.ts
@@ -1,5 +1,0 @@
-import type * as undici from 'undici';
-
-declare global {
-	export const { fetch, FormData, Headers, Request, Response }: typeof undici;
-}

--- a/packages/rest/src/web.ts
+++ b/packages/rest/src/web.ts
@@ -1,5 +1,7 @@
 import { setDefaultStrategy } from './environment.js';
 
-setDefaultStrategy(fetch);
+// This cast is needed because of a mismatch between the version of undici-types provided by @types/node and undici
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+setDefaultStrategy(fetch as typeof import('undici').fetch);
 
 export * from './shared.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1435,11 +1435,11 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       '@types/node':
-        specifier: 18.17.9
-        version: 18.17.9
+        specifier: ^22.15.2
+        version: 22.15.26
       '@vitest/coverage-v8':
         specifier: ^3.1.1
-        version: 3.1.4(vitest@3.1.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@18.17.9)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0))
+        version: 3.1.4(vitest@3.1.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.15.26)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1463,7 +1463,7 @@ importers:
         version: 3.5.3
       tsup:
         specifier: ^8.4.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.3(@types/node@18.17.9))(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0)
+        version: 8.5.0(@microsoft/api-extractor@7.52.3(@types/node@22.15.26))(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0)
       turbo:
         specifier: ^2.5.2
         version: 2.5.3
@@ -1472,7 +1472,7 @@ importers:
         version: 5.5.4
       vitest:
         specifier: ^3.1.1
-        version: 3.1.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@18.17.9)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0)
+        version: 3.1.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.15.26)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0)
 
   packages/scripts:
     dependencies:
@@ -6451,9 +6451,6 @@ packages:
 
   '@types/node@16.18.11':
     resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==}
-
-  '@types/node@18.17.9':
-    resolution: {integrity: sha512-fxaKquqYcPOGwE7tC1anJaPJ0GHyOVzfA2oUoXECjBjrtsIz4YJvtNYsq8LUcjEUehEF+jGpx8Z+lFrtT6z0tg==}
 
   '@types/node@18.19.107':
     resolution: {integrity: sha512-uvHN/vnsPj8hJWaqXUjT59LKYh0RlZXsdYa4CGz4R9aFGePPsUPN0xlHrDzOset937H2TunFJ8SwPCX69y9qhA==}
@@ -16215,15 +16212,6 @@ snapshots:
       '@types/react': 19.1.6
       react: 19.1.0
 
-  '@microsoft/api-extractor-model@7.30.5(@types/node@18.17.9)':
-    dependencies:
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1(patch_hash=3b647448c34391a3eb391ebdbe252924e783e3bb796def00b999a7cf147856f8)
-      '@rushstack/node-core-library': 5.13.0(@types/node@18.17.9)
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
-
   '@microsoft/api-extractor-model@7.30.5(@types/node@22.15.26)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
@@ -16231,25 +16219,6 @@ snapshots:
       '@rushstack/node-core-library': 5.13.0(@types/node@22.15.26)
     transitivePeerDependencies:
       - '@types/node'
-
-  '@microsoft/api-extractor@7.52.3(@types/node@18.17.9)':
-    dependencies:
-      '@microsoft/api-extractor-model': 7.30.5(@types/node@18.17.9)
-      '@microsoft/tsdoc': 0.15.1
-      '@microsoft/tsdoc-config': 0.17.1(patch_hash=3b647448c34391a3eb391ebdbe252924e783e3bb796def00b999a7cf147856f8)
-      '@rushstack/node-core-library': 5.13.0(@types/node@18.17.9)
-      '@rushstack/rig-package': 0.5.3
-      '@rushstack/terminal': 0.15.2(@types/node@18.17.9)
-      '@rushstack/ts-command-line': 4.23.7(@types/node@18.17.9)
-      lodash: 4.17.21
-      minimatch: 3.0.8
-      resolve: 1.22.10
-      semver: 7.5.4
-      source-map: 0.6.1
-      typescript: 5.8.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@microsoft/api-extractor@7.52.3(@types/node@22.15.26)':
     dependencies:
@@ -18412,20 +18381,6 @@ snapshots:
 
   '@rtsao/scc@1.1.0': {}
 
-  '@rushstack/node-core-library@5.13.0(@types/node@18.17.9)':
-    dependencies:
-      ajv: 8.13.0
-      ajv-draft-04: 1.0.0(ajv@8.13.0)
-      ajv-formats: 3.0.1
-      fs-extra: 11.3.0
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.10
-      semver: 7.5.4
-    optionalDependencies:
-      '@types/node': 18.17.9
-    optional: true
-
   '@rushstack/node-core-library@5.13.0(@types/node@22.15.26)':
     dependencies:
       ajv: 8.13.0
@@ -18457,14 +18412,6 @@ snapshots:
       resolve: 1.22.10
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.15.2(@types/node@18.17.9)':
-    dependencies:
-      '@rushstack/node-core-library': 5.13.0(@types/node@18.17.9)
-      supports-color: 8.1.1
-    optionalDependencies:
-      '@types/node': 18.17.9
-    optional: true
-
   '@rushstack/terminal@0.15.2(@types/node@22.15.26)':
     dependencies:
       '@rushstack/node-core-library': 5.13.0(@types/node@22.15.26)
@@ -18478,16 +18425,6 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 22.15.26
-
-  '@rushstack/ts-command-line@4.23.7(@types/node@18.17.9)':
-    dependencies:
-      '@rushstack/terminal': 0.15.2(@types/node@18.17.9)
-      '@types/argparse': 1.0.38
-      argparse: 1.0.10
-      string-argv: 0.3.2
-    transitivePeerDependencies:
-      - '@types/node'
-    optional: true
 
   '@rushstack/ts-command-line@4.23.7(@types/node@22.15.26)':
     dependencies:
@@ -19134,7 +19071,7 @@ snapshots:
       '@storybook/node-logger': 7.6.20
       '@storybook/types': 7.6.20
       '@types/find-cache-dir': 3.2.1
-      '@types/node': 18.17.9
+      '@types/node': 18.19.107
       '@types/node-fetch': 2.6.12
       '@types/pretty-hrtime': 1.0.3
       chalk: 4.1.2
@@ -19808,8 +19745,6 @@ snapshots:
       form-data: 4.0.2
 
   '@types/node@16.18.11': {}
-
-  '@types/node@18.17.9': {}
 
   '@types/node@18.19.107':
     dependencies:
@@ -20960,24 +20895,6 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
       vite: 6.3.5(@types/node@22.15.26)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@18.17.9)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0))':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@bcoe/v8-coverage': 1.0.2
-      debug: 4.4.1
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.17
-      magicast: 0.3.5
-      std-env: 3.9.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.1.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@18.17.9)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -28613,35 +28530,6 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(@microsoft/api-extractor@7.52.3(@types/node@18.17.9))(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.5)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.1
-      esbuild: 0.25.5
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.2)(yaml@2.8.0)
-      resolve-from: 5.0.0
-      rollup: 4.41.1
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tree-kill: 1.2.2
-    optionalDependencies:
-      '@microsoft/api-extractor': 7.52.3(@types/node@18.17.9)
-      postcss: 8.5.4
-      typescript: 5.5.4
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
-
   tsup@8.5.0(@microsoft/api-extractor@7.52.3(@types/node@22.15.26))(jiti@2.4.2)(postcss@8.5.4)(tsx@4.19.2)(typescript@5.5.4)(yaml@2.8.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.5)
@@ -29284,27 +29172,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@3.1.4(@types/node@18.17.9)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 6.3.5(@types/node@18.17.9)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@3.1.4(@types/node@22.15.26)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
@@ -29345,23 +29212,6 @@ snapshots:
       - rollup
       - supports-color
 
-  vite@6.3.5(@types/node@18.17.9)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0):
-    dependencies:
-      esbuild: 0.25.5
-      fdir: 6.4.5(picomatch@4.0.2)
-      picomatch: 4.0.2
-      postcss: 8.5.4
-      rollup: 4.41.1
-      tinyglobby: 0.2.14
-    optionalDependencies:
-      '@types/node': 18.17.9
-      fsevents: 2.3.3
-      jiti: 2.4.2
-      lightningcss: 1.30.1
-      terser: 5.39.0
-      tsx: 4.19.2
-      yaml: 2.8.0
-
   vite@6.3.5(@types/node@22.15.26)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
@@ -29384,47 +29234,6 @@ snapshots:
       '@vitest/utils': 3.1.1
       mock-socket: 9.3.1
       vitest: 3.1.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.15.26)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0)
-
-  vitest@3.1.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@18.17.9)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0):
-    dependencies:
-      '@vitest/expect': 3.1.4
-      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@22.15.26)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0))
-      '@vitest/pretty-format': 3.1.4
-      '@vitest/runner': 3.1.4
-      '@vitest/snapshot': 3.1.4
-      '@vitest/spy': 3.1.4
-      '@vitest/utils': 3.1.4
-      chai: 5.2.0
-      debug: 4.4.1
-      expect-type: 1.2.1
-      magic-string: 0.30.17
-      pathe: 2.0.3
-      std-env: 3.9.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.0.2
-      tinyrainbow: 2.0.0
-      vite: 6.3.5(@types/node@18.17.9)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0)
-      vite-node: 3.1.4(@types/node@18.17.9)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@edge-runtime/vm': 3.2.0
-      '@types/debug': 4.1.12
-      '@types/node': 18.17.9
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vitest@3.1.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.15.26)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.8.0):
     dependencies:


### PR DESCRIPTION
This brings the `@types/node` version in sync with the other packages.
The node engine version was already increased to v22.