### PR TITLE
chore: bump discord.js across create-discord-x templates

### DIFF
--- a/packages/create-discord-bot/template/Bun/JavaScript/package.json
+++ b/packages/create-discord-bot/template/Bun/JavaScript/package.json
@@ -11,8 +11,8 @@
 		"start": "bun run src/index.[REPLACE_IMPORT_EXT]"
 	},
 	"dependencies": {
-		"@discordjs/core": "^2.1.0",
-		"discord.js": "^14.19.3"
+		"@discordjs/core": "^2.1.1",
+		"discord.js": "^14.20.0"
 	},
 	"devDependencies": {
 		"eslint": "^9.24.0",

--- a/packages/create-discord-bot/template/Bun/TypeScript/package.json
+++ b/packages/create-discord-bot/template/Bun/TypeScript/package.json
@@ -11,8 +11,8 @@
 		"start": "bun run src/index.[REPLACE_IMPORT_EXT]"
 	},
 	"dependencies": {
-		"@discordjs/core": "^2.1.0",
-		"discord.js": "^14.19.3"
+		"@discordjs/core": "^2.1.1",
+		"discord.js": "^14.20.0"
 	},
 	"devDependencies": {
 		"@sapphire/ts-config": "^5.0.1",

--- a/packages/create-discord-bot/template/Deno/src/commands/index.ts
+++ b/packages/create-discord-bot/template/Deno/src/commands/index.ts
@@ -1,4 +1,4 @@
-import type { RESTPostAPIApplicationCommandsJSONBody, CommandInteraction } from 'npm:discord.js@^14.19.3';
+import type { RESTPostAPIApplicationCommandsJSONBody, CommandInteraction } from 'npm:discord.js@^14.20.0';
 import { z } from 'npm:zod@^3.24.1';
 import type { StructurePredicate } from '../util/loaders.ts';
 

--- a/packages/create-discord-bot/template/Deno/src/events/index.ts
+++ b/packages/create-discord-bot/template/Deno/src/events/index.ts
@@ -1,4 +1,4 @@
-import type { ClientEvents } from 'npm:discord.js@^14.19.3';
+import type { ClientEvents } from 'npm:discord.js@^14.20.0';
 import { z } from 'npm:zod@^3.24.1';
 import type { StructurePredicate } from '../util/loaders.ts';
 

--- a/packages/create-discord-bot/template/Deno/src/events/interactionCreate.ts
+++ b/packages/create-discord-bot/template/Deno/src/events/interactionCreate.ts
@@ -1,4 +1,4 @@
-import { Events } from 'npm:discord.js@^14.19.3';
+import { Events } from 'npm:discord.js@^14.20.0';
 import type { Event } from './index.ts';
 import { loadCommands } from '../util/loaders.ts';
 

--- a/packages/create-discord-bot/template/Deno/src/events/ready.ts
+++ b/packages/create-discord-bot/template/Deno/src/events/ready.ts
@@ -1,4 +1,4 @@
-import { Events } from 'npm:discord.js@^14.19.3';
+import { Events } from 'npm:discord.js@^14.20.0';
 import type { Event } from './index.ts';
 
 export default {

--- a/packages/create-discord-bot/template/Deno/src/index.ts
+++ b/packages/create-discord-bot/template/Deno/src/index.ts
@@ -1,6 +1,6 @@
 import 'https://deno.land/std@0.223.0/dotenv/load.ts';
 import { URL } from 'node:url';
-import { Client, GatewayIntentBits } from 'npm:discord.js@^14.19.3';
+import { Client, GatewayIntentBits } from 'npm:discord.js@^14.20.0';
 import { loadEvents } from './util/loaders.ts';
 
 // Initialize the client

--- a/packages/create-discord-bot/template/Deno/src/util/deploy.ts
+++ b/packages/create-discord-bot/template/Deno/src/util/deploy.ts
@@ -1,7 +1,7 @@
 import 'https://deno.land/std@0.223.0/dotenv/load.ts';
 import { URL } from 'node:url';
-import { API } from 'npm:@discordjs/core@^2.1.0/http-only';
-import { REST } from 'npm:discord.js@^14.19.3';
+import { API } from 'npm:@discordjs/core@^2.1.1/http-only';
+import { REST } from 'npm:discord.js@^14.20.0';
 import { loadCommands } from './loaders.ts';
 
 const commands = await loadCommands(new URL('../commands/', import.meta.url));

--- a/packages/create-discord-bot/template/JavaScript/package.json
+++ b/packages/create-discord-bot/template/JavaScript/package.json
@@ -11,8 +11,8 @@
 		"deploy": "node --require dotenv/config src/util/deploy.js"
 	},
 	"dependencies": {
-		"@discordjs/core": "^2.1.0",
-		"discord.js": "^14.19.3",
+		"@discordjs/core": "^2.1.1",
+		"discord.js": "^14.20.0",
 		"dotenv": "^16.4.5"
 	},
 	"devDependencies": {

--- a/packages/create-discord-bot/template/TypeScript/package.json
+++ b/packages/create-discord-bot/template/TypeScript/package.json
@@ -12,8 +12,8 @@
 		"start": "node --require dotenv/config dist/index.js"
 	},
 	"dependencies": {
-		"@discordjs/core": "^2.1.0",
-		"discord.js": "^14.19.3",
+		"@discordjs/core": "^2.1.1",
+		"discord.js": "^14.20.0",
 		"dotenv": "^16.4.7"
 	},
 	"devDependencies": {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

New release, new template bumps

One of these days we should really make these replacers that happen when the template gets dropped in the file system (and move deno to import mappings >.>)

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
