### PR TITLE
feat: add guildtag property to User class

### DIFF
--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -28,6 +28,8 @@ class User extends Base {
 
     this.flags = null;
 
+    this.guildtag = null;
+
     this._patch(data);
   }
 
@@ -150,6 +152,17 @@ class User extends Base {
       };
     } else {
       this.avatarDecorationData = null;
+    }
+
+    if (data.primary_guild?.tag) {
+      /**
+       * The guild tag name of this user
+       *
+       * @type {?string}
+       */
+      this.guildtag = data.primary_guild?.tag;
+    } else {
+      this.guildtag ??= null;
     }
   }
 
@@ -338,7 +351,8 @@ class User extends Base {
       this.banner === user.banner &&
       this.accentColor === user.accentColor &&
       this.avatarDecorationData?.asset === user.avatarDecorationData?.asset &&
-      this.avatarDecorationData?.skuId === user.avatarDecorationData?.skuId
+      this.avatarDecorationData?.skuId === user.avatarDecorationData?.skuId &&
+      this.guildtag === user.primary_guild?.tag
     );
   }
 
@@ -363,7 +377,8 @@ class User extends Base {
       ('avatar_decoration_data' in user
         ? this.avatarDecorationData?.asset === user.avatar_decoration_data?.asset &&
           this.avatarDecorationData?.skuId === user.avatar_decoration_data?.sku_id
-        : true)
+        : true) &&
+      this.guildtag === user.primary_guild?.tag
     );
   }
 
@@ -396,6 +411,7 @@ class User extends Base {
         defaultAvatarURL: true,
         hexAccentColor: true,
         tag: true,
+        guildtag: true,
       },
       ...props,
     );

--- a/packages/discord.js/src/structures/User.js
+++ b/packages/discord.js/src/structures/User.js
@@ -352,7 +352,7 @@ class User extends Base {
       this.accentColor === user.accentColor &&
       this.avatarDecorationData?.asset === user.avatarDecorationData?.asset &&
       this.avatarDecorationData?.skuId === user.avatarDecorationData?.skuId &&
-      this.guildtag === user.primary_guild?.tag
+      this.guildtag === user.guildtag
     );
   }
 

--- a/packages/discord.js/test/user-guildtag.test.js
+++ b/packages/discord.js/test/user-guildtag.test.js
@@ -96,9 +96,22 @@ describe('User guildtag property tests', () => {
     const apiUserData = {
       id: '1234567890123456789',
       username: 'testuser',
+      avatar: null,
       discriminator: '0',
-      avatar: 'test_avatar_hash',
       public_flags: 128,
+      flags: 128,
+      banner: null,
+      accent_color: null,
+      global_name: 'Test User',
+      avatar_decoration_data: null,
+      collectibles: null,
+      banner_color: null,
+      clan: {
+        identity_guild_id: '9876543210987654321',
+        identity_enabled: true,
+        tag: 'TEST',
+        badge: 'abcdef1234567890abcdef1234567890',
+      },
       primary_guild: {
         identity_guild_id: '9876543210987654321',
         identity_enabled: true,

--- a/packages/discord.js/test/user-guildtag.test.js
+++ b/packages/discord.js/test/user-guildtag.test.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const { Client, GatewayIntentBits } = require('../src/index.js');
+
+// Mock data based on actual API response (personal information anonymized)
+const mockUserDataWithGuildtag = {
+  id: '1234567890123456789',
+  username: 'testuser',
+  avatar: null,
+  discriminator: '0',
+  public_flags: 128,
+  flags: 128,
+  banner: null,
+  accent_color: null,
+  global_name: 'Test User',
+  avatar_decoration_data: null,
+  collectibles: null,
+  banner_color: null,
+  clan: {
+    identity_guild_id: '9876543210987654321',
+    identity_enabled: true,
+    tag: 'TEST',
+    badge: 'abcdef1234567890abcdef1234567890',
+  },
+  primary_guild: {
+    identity_guild_id: '9876543210987654321',
+    identity_enabled: true,
+    tag: 'TEST',
+    badge: 'abcdef1234567890abcdef1234567890',
+  },
+};
+
+const mockUserDataWithoutGuildtag = {
+  id: '123456789012345678',
+  username: 'testuser',
+  discriminator: '1234',
+  avatar: 'test_avatar_hash',
+  bot: false,
+  system: false,
+  public_flags: 0,
+  // primary_guild is not present
+};
+
+describe('User guildtag property tests', () => {
+  let client;
+  let user;
+
+  beforeEach(() => {
+    client = new Client({
+      intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages, GatewayIntentBits.DirectMessages],
+    });
+
+    const { User } = require('../src/structures/User.js');
+    user = new User(client, mockUserDataWithGuildtag);
+  });
+
+  afterEach(() => {
+    if (client) {
+      client.destroy();
+    }
+  });
+
+  test('should have guildtag property when provided in data', () => {
+    expect(user.guildtag).toBe('TEST');
+  });
+
+  test('should set guildtag to null when not provided in data', () => {
+    const userWithoutGuildtag = new (require('../src/structures/User.js').User)(client, mockUserDataWithoutGuildtag);
+    expect(userWithoutGuildtag.guildtag).toBeNull();
+  });
+
+  test('should update guildtag when _patch is called with new data', () => {
+    const newData = {
+      ...mockUserDataWithGuildtag,
+      primary_guild: { ...mockUserDataWithGuildtag.primary_guild, tag: 'NewGuildTag' },
+    };
+    user._patch(newData);
+    expect(user.guildtag).toBe('NewGuildTag');
+  });
+
+  test('should handle guildtag in equals method', () => {
+    const { User } = require('../src/structures/User.js');
+    const user1 = new User(client, mockUserDataWithGuildtag);
+    const user2 = new User(client, {
+      ...mockUserDataWithGuildtag,
+      primary_guild: { ...mockUserDataWithGuildtag.primary_guild, tag: 'DifferentGuildTag' },
+    });
+
+    expect(user1.equals(user2)).toBe(false);
+
+    const user3 = new User(client, mockUserDataWithGuildtag);
+    expect(user1.equals(user3)).toBe(true);
+  });
+
+  test('should handle guildtag in _equals method', () => {
+    const apiUserData = {
+      id: '1234567890123456789',
+      username: 'testuser',
+      discriminator: '0',
+      avatar: 'test_avatar_hash',
+      public_flags: 128,
+      primary_guild: {
+        identity_guild_id: '9876543210987654321',
+        identity_enabled: true,
+        tag: 'TEST',
+        badge: 'abcdef1234567890abcdef1234567890',
+      },
+    };
+
+    expect(user._equals(apiUserData)).toBe(true);
+
+    const differentApiData = {
+      ...apiUserData,
+      primary_guild: { ...apiUserData.primary_guild, tag: 'DifferentGuildTag' },
+    };
+    expect(user._equals(differentApiData)).toBe(false);
+  });
+
+  test('should include guildtag in toJSON output', () => {
+    const json = user.toJSON();
+    expect(json.guildtag).toBe('TEST');
+  });
+
+  test('should handle guildtag in cache operations', () => {
+    client.users.cache.set(user.id, user);
+    const cachedUser = client.users.cache.get(user.id);
+    expect(cachedUser.guildtag).toBe('TEST');
+  });
+
+  test('should handle partial user data', () => {
+    const partialData = { id: '123456789012345678' };
+    const partialUser = new (require('../src/structures/User.js').User)(client, partialData);
+
+    expect(partialUser.partial).toBe(true);
+    expect(partialUser.guildtag).toBeNull();
+  });
+});

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3519,6 +3519,7 @@ export class User extends Base {
   public avatarDecorationData: AvatarDecorationData | null;
   public banner: string | null | undefined;
   public bot: boolean;
+  public guildtag: string | null;
   public get createdAt(): Date;
   public get createdTimestamp(): number;
   public discriminator: string;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds a `guildtag` property to the User class to provide access to a user's primary guild tag from the Discord API. The guildtag represents the tag associated with a user's primary guild identity, which is useful for displaying guild affiliations and implementing guild-based features.

### Changes Made:
- Added `guildtag` property to User class that reads from `primary_guild.tag` in API(v10/users) response
- Updated `equals` method to include guildtag comparison between User instances  
- Updated `_equals` method to include guildtag comparison with API user objects
- Added TypeScript type definition for the guildtag property (`string | null`)
- Updated `toJSON` method to include guildtag in serialized output

### Why this should be merged:
- Provides access to guild tag information that's already available in Discord's API
- Enables developers to display guild affiliations in their applications
- Maintains consistency with other User properties
- No breaking changes - purely additive feature
- Includes comprehensive test coverage

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)

