### PR TITLE
fix(ClientUser): Remove token assignment

### DIFF
--- a/packages/discord.js/src/structures/ClientUser.js
+++ b/packages/discord.js/src/structures/ClientUser.js
@@ -70,8 +70,6 @@ class ClientUser extends User {
       },
     });
 
-    this.client.token = data.token;
-    this.client.rest.setToken(data.token);
     const { updated } = this.client.actions.UserUpdate.handle(data);
     return updated ?? this;
   }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
A recent change has made `token` no longer available from the received data. This is also not present in the [API specification](https://github.com/discord/discord-api-spec/blob/ca2a01996e1eca3843d53edc581d8be543854659/specs/openapi.json#L32372), so it will be removed.

#djs-questions post: https://discord.com/channels/222078108977594368/1387344520814792746

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
