### PR TITLE
types(ReadonlyCollection): derivation logic

### DIFF
--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -5,7 +5,7 @@
  */
 export type ReadonlyCollection<Key, Value> = Omit<
 	Collection<Key, Value>,
-	'clear' | 'delete' | 'ensure' | 'forEach' | 'get' | 'reverse' | 'set' | 'sort' | 'sweep'
+	keyof Map<Key, Value> | 'ensure' | 'reverse' | 'sort' | 'sweep'
 > &
 	ReadonlyMap<Key, Value>;
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This small change to the derivation for `ReadonlyCollection` future-protects the definition against the addition of mutating methods to the Map prototype, as will soon occur with [proposal-upsert](https://github.com/tc39/proposal-upsert) reaching stage 3.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
