### PR TITLE
docs: Replace Discord API with Discord Developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This repository contains multiple packages with separate [releases][github-relea
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -68,7 +68,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/discord.js
 [npm]: https://www.npmjs.com/package/discord.js
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/apps/website/README.md
+++ b/apps/website/README.md
@@ -21,7 +21,7 @@
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [Related libraries][related-libs]
 
@@ -42,7 +42,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/apps/website
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries
 [contributing]: https://github.com/discordjs/discord.js/blob/main/.github/CONTRIBUTING.md

--- a/packages/actions/README.md
+++ b/packages/actions/README.md
@@ -20,7 +20,7 @@
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [Related libraries][related-libs]
 
@@ -39,7 +39,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/actions
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries
 [contributing]: https://github.com/discordjs/discord.js/blob/main/.github/CONTRIBUTING.md

--- a/packages/api-extractor-utils/README.md
+++ b/packages/api-extractor-utils/README.md
@@ -20,7 +20,7 @@
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [Related libraries][related-libs]
 
@@ -39,7 +39,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/api-extractor-utils
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries
 [contributing]: https://github.com/discordjs/discord.js/blob/main/.github/CONTRIBUTING.md

--- a/packages/brokers/README.md
+++ b/packages/brokers/README.md
@@ -94,7 +94,7 @@ await broker.subscribe('responders', ['testcall']);
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -116,7 +116,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/brokers
 [npm]: https://www.npmjs.com/package/@discordjs/brokers
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/builders/README.md
+++ b/packages/builders/README.md
@@ -43,7 +43,7 @@ You can find examples of how to use the builders in the [Slash Command Builders]
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -66,7 +66,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/builders
 [npm]: https://www.npmjs.com/package/@discordjs/builders
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/collection/README.md
+++ b/packages/collection/README.md
@@ -39,7 +39,7 @@ pnpm add @discordjs/collection
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -61,7 +61,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/collection
 [npm]: https://www.npmjs.com/package/@discordjs/collection
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -93,7 +93,7 @@ const guild = await api.guilds.get('1234567891011');
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -115,7 +115,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/core
 [npm]: https://www.npmjs.com/package/@discordjs/core
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/create-discord-bot/README.md
+++ b/packages/create-discord-bot/README.md
@@ -31,7 +31,7 @@ bun create discord-bot ./your/chosen/directory
 - [Guide] ([source][guide-source])
   - Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 
 ## Contributing
@@ -47,6 +47,6 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/create-discord-bot
 [contributing]: https://github.com/discordjs/discord.js/blob/main/.github/CONTRIBUTING.md

--- a/packages/discord.js/README.md
+++ b/packages/discord.js/README.md
@@ -112,7 +112,7 @@ client.login(TOKEN);
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -138,7 +138,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/discord.js
 [npm]: https://www.npmjs.com/package/discord.js
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/docgen/README.md
+++ b/packages/docgen/README.md
@@ -20,7 +20,7 @@
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -40,7 +40,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/docgen
 [npm]: https://www.npmjs.com/package/@discordjs/docgen
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/formatters/README.md
+++ b/packages/formatters/README.md
@@ -56,7 +56,7 @@ console.log(formattedCode);
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -78,7 +78,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/formatters
 [npm]: https://www.npmjs.com/package/@discordjs/formatters
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -32,7 +32,7 @@ bun add @discordjs/next
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -54,7 +54,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/next
 [npm]: https://www.npmjs.com/package/@discordjs/next
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/proxy-container/README.md
+++ b/packages/proxy-container/README.md
@@ -58,7 +58,7 @@ Webhooks with tokens or other requests that don't include the Authorization head
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [Related libraries][related-libs]
 
@@ -77,7 +77,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/proxy-container
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries
 [contributing]: https://github.com/discordjs/discord.js/blob/main/.github/CONTRIBUTING.md

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -40,7 +40,7 @@ bun add @discordjs/proxy
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -62,7 +62,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/proxy
 [npm]: https://www.npmjs.com/package/@discordjs/proxy
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/rest/README.md
+++ b/packages/rest/README.md
@@ -109,7 +109,7 @@ try {
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -131,7 +131,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/rest
 [npm]: https://www.npmjs.com/package/@discordjs/rest
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -20,7 +20,7 @@
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [Related libraries][related-libs]
 
@@ -39,7 +39,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/scripts
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries
 [contributing]: https://github.com/discordjs/discord.js/blob/main/.github/CONTRIBUTING.md

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -20,7 +20,7 @@
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [Related libraries][related-libs]
 
@@ -39,7 +39,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/ui
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries
 [contributing]: https://github.com/discordjs/discord.js/blob/main/.github/CONTRIBUTING.md

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -37,7 +37,7 @@ bun add @discordjs/util
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -59,7 +59,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/util
 [npm]: https://www.npmjs.com/package/@discordjs/util
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -82,7 +82,7 @@ The [voice-examples][voice-examples] repository contains examples on how to use 
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -104,7 +104,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/voice
 [npm]: https://www.npmjs.com/package/@discordjs/voice
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries

--- a/packages/ws/README.md
+++ b/packages/ws/README.md
@@ -194,7 +194,7 @@ parentPort!.postMessage({ custom: 'data' });
 - [Guide][guide] ([source][guide-source])
   Also see the v13 to v14 [Update Guide][guide-update], which includes updated and removed items from the library.
 - [discord.js Discord server][discord]
-- [Discord API Discord server][discord-api]
+- [Discord Developers Discord server][discord-developers]
 - [GitHub][source]
 - [npm][npm]
 - [Related libraries][related-libs]
@@ -216,7 +216,7 @@ If you don't understand something in the documentation, you are experiencing pro
 [guide-source]: https://github.com/discordjs/guide
 [guide-update]: https://discordjs.guide/additional-info/changes-in-v14.html
 [discord]: https://discord.gg/djs
-[discord-api]: https://discord.gg/discord-api
+[discord-developers]: https://discord.gg/discord-developers
 [source]: https://github.com/discordjs/discord.js/tree/main/packages/ws
 [npm]: https://www.npmjs.com/package/@discordjs/ws
 [related-libs]: https://discord.com/developers/docs/topics/community-resources#libraries


### PR DESCRIPTION
This used to serve a purpose and as such will be replaced with Discord Developers as it is an official resource.