### PR TITLE
refactor: Deprecate `ready` event in favor of `clientReady`

### DIFF
--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -387,7 +387,7 @@ class WebSocketManager extends EventEmitter {
       deprecationEmitted = true;
 
       process.emitWarning(
-        'The ready event has been renamed to clientReady. Please use that instead',
+        'The ready event has been renamed to clientReady to distinguish it from the gateway READY event and will only emit under that name in v15. Please use clientReady instead.',
         'DeprecationWarning',
       );
     }

--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -19,6 +19,7 @@ const Status = require('../../util/Status');
 const WebSocketShardEvents = require('../../util/WebSocketShardEvents');
 
 let zlib;
+let deprecationEmitted = false;
 
 try {
   zlib = require('zlib-sync');
@@ -379,6 +380,17 @@ class WebSocketManager extends EventEmitter {
     /**
      * Emitted when the client becomes ready to start working.
      * @event Client#ready
+     * @deprecated Use {@link Client#event:clientReady} instead.
+     * @param {Client} client The client
+     */
+    if (this.client.emit('ready', this.client) && !deprecationEmitted) {
+      deprecationEmitted = true;
+      process.emitWarning('The ready event is deprecated. Use clientReady instead.', 'DeprecationWarning');
+    }
+
+    /**
+     * Emitted when the client becomes ready to start working.
+     * @event Client#clientReady
      * @param {Client} client The client
      */
     this.client.emit(Events.ClientReady, this.client);

--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -385,7 +385,11 @@ class WebSocketManager extends EventEmitter {
      */
     if (this.client.emit('ready', this.client) && !deprecationEmitted) {
       deprecationEmitted = true;
-      process.emitWarning('The ready event is deprecated. Use clientReady instead.', 'DeprecationWarning');
+
+      process.emitWarning(
+        'The ready event has been renamed to clientReady. Please use that instead',
+        'DeprecationWarning',
+      );
     }
 
     /**

--- a/packages/discord.js/src/client/websocket/WebSocketManager.js
+++ b/packages/discord.js/src/client/websocket/WebSocketManager.js
@@ -387,6 +387,7 @@ class WebSocketManager extends EventEmitter {
       deprecationEmitted = true;
 
       process.emitWarning(
+        // eslint-disable-next-line max-len
         'The ready event has been renamed to clientReady to distinguish it from the gateway READY event and will only emit under that name in v15. Please use clientReady instead.',
         'DeprecationWarning',
       );

--- a/packages/discord.js/src/util/Events.js
+++ b/packages/discord.js/src/util/Events.js
@@ -12,7 +12,7 @@
  * @property {string} ChannelDelete channelDelete
  * @property {string} ChannelPinsUpdate channelPinsUpdate
  * @property {string} ChannelUpdate channelUpdate
- * @property {string} ClientReady ready
+ * @property {string} ClientReady clientReady
  * @property {string} Debug debug
  * @property {string} EntitlementCreate entitlementCreate
  * @property {string} EntitlementUpdate entitlementUpdate
@@ -108,7 +108,7 @@ module.exports = {
   ChannelDelete: 'channelDelete',
   ChannelPinsUpdate: 'channelPinsUpdate',
   ChannelUpdate: 'channelUpdate',
-  ClientReady: 'ready',
+  ClientReady: 'clientReady',
   Debug: 'debug',
   EntitlementCreate: 'entitlementCreate',
   EntitlementUpdate: 'entitlementUpdate',

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -5790,6 +5790,7 @@ export interface ClientEvents {
     oldChannel: DMChannel | NonThreadGuildBasedChannel,
     newChannel: DMChannel | NonThreadGuildBasedChannel,
   ];
+  clientReady: [client: Client<true>];
   debug: [message: string];
   warn: [message: string];
   emojiCreate: [emoji: GuildEmoji];
@@ -5850,6 +5851,7 @@ export interface ClientEvents {
     newMessage: OmitPartialGroupDMChannel<Message>,
   ];
   presenceUpdate: [oldPresence: Presence | null, newPresence: Presence];
+  /** @deprecated Use {@link ClientEvents.ClientReady} instead. */
   ready: [client: Client<true>];
   invalidated: [];
   roleCreate: [role: Role];
@@ -6035,7 +6037,7 @@ export enum Events {
   AutoModerationRuleCreate = 'autoModerationRuleCreate',
   AutoModerationRuleDelete = 'autoModerationRuleDelete',
   AutoModerationRuleUpdate = 'autoModerationRuleUpdate',
-  ClientReady = 'ready',
+  ClientReady = 'clientReady',
   EntitlementCreate = 'entitlementCreate',
   EntitlementDelete = 'entitlementDelete',
   EntitlementUpdate = 'entitlementUpdate',


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
`clientReady` is what should be used moving forward.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
