### PR TITLE
refactor(create-discord-bot): replace deps with built-in apis

### DIFF
--- a/packages/create-discord-bot/bin/index.ts
+++ b/packages/create-discord-bot/bin/index.ts
@@ -2,8 +2,8 @@
 
 // eslint-disable-next-line n/shebang
 import process from 'node:process';
+import { styleText } from 'node:util';
 import { Option, program } from 'commander';
-import picocolors from 'picocolors';
 import prompts from 'prompts';
 import validateProjectName from 'validate-npm-package-name';
 import packageJSON from '../package.json' assert { type: 'json' };
@@ -34,7 +34,7 @@ program
 	.version(packageJSON.version)
 	.description('Create a basic discord.js bot.')
 	.argument('[directory]', 'What is the name of the directory you want to create this project in?')
-	.usage(`${picocolors.green('<directory>')}`)
+	.usage(`${styleText('green', '<directory>')}`)
 	.action((directory) => {
 		projectDirectory = directory;
 	})
@@ -68,13 +68,16 @@ if (!projectDirectory) {
 					const errors = [];
 
 					for (const error of [...(validationResult.errors ?? []), ...(validationResult.warnings ?? [])]) {
-						errors.push(picocolors.red(`- ${error}`));
+						errors.push(styleText('red', `- ${error}`));
 					}
 
-					return picocolors.red(
-						`Cannot create a project named ${picocolors.yellow(
+					return styleText(
+						'red',
+						`Cannot create a project named ${styleText(
+							'yellow',
 							`"${directory}"`,
-						)} due to npm naming restrictions.\n\nErrors:\n${errors.join('\n')}\n\n${picocolors.red(
+						)} due to npm naming restrictions.\n\nErrors:\n${errors.join('\n')}\n\n${styleText(
+							'red',
 							'\nSee https://docs.npmjs.com/cli/configuring-npm/package-json for more details.',
 						)}}`,
 					);

--- a/packages/create-discord-bot/package.json
+++ b/packages/create-discord-bot/package.json
@@ -51,8 +51,6 @@
 	"funding": "https://github.com/discordjs/discord.js?sponsor",
 	"dependencies": {
 		"commander": "^13.1.0",
-		"fast-glob": "^3.3.3",
-		"picocolors": "^1.1.1",
 		"prompts": "^2.4.2",
 		"validate-npm-package-name": "^6.0.0"
 	},

--- a/packages/create-discord-bot/src/create-discord-bot.ts
+++ b/packages/create-discord-bot/src/create-discord-bot.ts
@@ -1,10 +1,9 @@
 import type { ExecException } from 'node:child_process';
-import { cp, stat, mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { cp, glob, mkdir, stat, readdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
 import { URL } from 'node:url';
-import glob from 'fast-glob';
-import picocolors from 'picocolors';
+import { styleText } from 'node:util';
 import type { PackageManager } from './helpers/packageManager.js';
 import { install, isNodePackageManager } from './helpers/packageManager.js';
 import { GUIDE_URL } from './util/constants.js';
@@ -35,15 +34,16 @@ export async function createDiscordBot({ directory, installPackages, typescript,
 	// If the directory is actually a file or if it's not empty, throw an error.
 	if (!directoryStats.isDirectory() || (await readdir(root)).length > 0) {
 		console.error(
-			picocolors.red(
-				`The directory ${picocolors.yellow(`"${directoryName}"`)} is either not a directory or is not empty.`,
+			styleText(
+				'red',
+				`The directory ${styleText('yellow', `"${directoryName}"`)} is either not a directory or is not empty.`,
 			),
 		);
-		console.error(picocolors.red(`Please specify an empty directory.`));
+		console.error(styleText('red', `Please specify an empty directory.`));
 		process.exit(1);
 	}
 
-	console.log(`Creating ${directoryName} in ${picocolors.green(root)}.`);
+	console.log(`Creating ${directoryName} in ${styleText('green', root)}.`);
 	const deno = packageManager === 'deno';
 	await cp(new URL(`../template/${deno ? 'Deno' : typescript ? 'TypeScript' : 'JavaScript'}`, import.meta.url), root, {
 		recursive: true,
@@ -80,8 +80,8 @@ export async function createDiscordBot({ directory, installPackages, typescript,
 	});
 	await writeFile('./.vscode/settings.json', newVSCodeSettings);
 
-	const globStream = glob.stream('./src/**/*.ts');
-	for await (const file of globStream) {
+	const globIterator = glob('./src/**/*.ts');
+	for await (const file of globIterator) {
 		const newData = await readFile(file, { encoding: 'utf8' }).then((str) =>
 			str.replaceAll('[REPLACE_IMPORT_EXT]', typescript && !isNodePackageManager(packageManager) ? 'ts' : 'js'),
 		);
@@ -109,15 +109,15 @@ export async function createDiscordBot({ directory, installPackages, typescript,
 			console.log();
 			const err = error as ExecException;
 			if (err.signal === 'SIGINT') {
-				console.log(picocolors.red('Installation aborted.'));
+				console.log(styleText('red', 'Installation aborted.'));
 			} else {
-				console.error(picocolors.red('Installation failed.'));
+				console.error(styleText('red', 'Installation failed.'));
 				process.exit(1);
 			}
 		}
 	}
 
 	console.log();
-	console.log(picocolors.green('All done! Be sure to read through the discord.js guide for help on your journey.'));
-	console.log(`Link: ${picocolors.cyan(GUIDE_URL)}`);
+	console.log(styleText('green', 'All done! Be sure to read through the discord.js guide for help on your journey.'));
+	console.log(`Link: ${styleText('cyan', GUIDE_URL)}`);
 }

--- a/packages/create-discord-bot/src/helpers/packageManager.ts
+++ b/packages/create-discord-bot/src/helpers/packageManager.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import process from 'node:process';
-import picocolors from 'picocolors';
+import { styleText } from 'node:util';
 import { DEFAULT_PACKAGE_MANAGER, NODE_PACKAGE_MANAGERS } from '../util/constants.js';
 
 /**
@@ -36,7 +36,8 @@ export function resolvePackageManager(): PackageManager {
 	}
 
 	console.error(
-		picocolors.yellow(
+		styleText(
+			'yellow',
 			`Detected an unsupported package manager (${npmConfigUserAgent}). Falling back to ${DEFAULT_PACKAGE_MANAGER}.`,
 		),
 	);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -937,12 +937,6 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
-      fast-glob:
-        specifier: ^3.3.3
-        version: 3.3.3
-      picocolors:
-        specifier: ^1.1.1
-        version: 1.1.1
       prompts:
         specifier: ^2.4.2
         version: 2.4.2


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The target node version being set to `22.12.0` allows `create-discord-bot` to become a lot smaller in terms of dependency count:

- `node:fs/promises`' [`glob`](https://nodejs.org/api/fs.html#fspromisesglobpattern-options) was added in node 22.0.0. we can use it instead of `fast-glob` since we don't need any fast-glob exclusive functionality.
- `node:util`'s [`styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text-options) was added in node 20.17.0. we can use it instead of `picocolors`.

I was going to remove `dotenv` and replace it with [`--env-file`](https://nodejs.org/api/cli.html#--env-fileconfig), but it looks like that was already done in #10967

This makes `create-discord-bot` lose most of its subdependencies, going from [24](https://npmgraph.js.org/?q=create-discord-bot@4.0.0) to just [5](https://npmgraph.js.org/?q=https://raw.githubusercontent.com/SuperchupuDev/discord.js/e015c2b/packages/create-discord-bot/package.json). This should significantly speed up installation times and decrease bundle size by a wide margin.

![image](https://github.com/user-attachments/assets/b8c45cce-8284-46bb-aa7d-21e2eb2979c7)

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
