### PR TITLE
fix: Adjust `reason` in methods options

### DIFF
--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -284,9 +284,14 @@ export class ChannelsAPI {
 	public async edit(
 		channelId: Snowflake,
 		body: RESTPatchAPIChannelJSONBody,
-		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+		{ auth, signal, reason }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
-		return this.rest.patch(Routes.channel(channelId), { auth, body, signal }) as Promise<RESTPatchAPIChannelResult>;
+		return this.rest.patch(Routes.channel(channelId), {
+			auth,
+			reason,
+			body,
+			signal,
+		}) as Promise<RESTPatchAPIChannelResult>;
 	}
 
 	/**

--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -519,7 +519,7 @@ export class ChannelsAPI {
 		channelId: Snowflake,
 		body: RESTPostAPIChannelThreadsJSONBody,
 		messageId?: Snowflake,
-		{ auth, signal, reason }: Pick<RequestData, 'auth' | 'signal' | 'reason'> = {},
+		{ auth, signal, reason }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		return this.rest.post(Routes.threads(channelId, messageId), {
 			auth,
@@ -540,7 +540,7 @@ export class ChannelsAPI {
 	public async createForumThread(
 		channelId: Snowflake,
 		{ message, ...optionsBody }: StartForumThreadOptions,
-		{ auth, signal, reason }: Pick<RequestData, 'auth' | 'signal' | 'reason'> = {},
+		{ auth, signal, reason }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
 	) {
 		const { files, ...messageBody } = message;
 

--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -519,12 +519,13 @@ export class ChannelsAPI {
 		channelId: Snowflake,
 		body: RESTPostAPIChannelThreadsJSONBody,
 		messageId?: Snowflake,
-		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+		{ auth, signal, reason }: Pick<RequestData, 'auth' | 'signal' | 'reason'> = {},
 	) {
 		return this.rest.post(Routes.threads(channelId, messageId), {
 			auth,
 			body,
 			signal,
+			reason,
 		}) as Promise<RESTPostAPIChannelThreadsResult>;
 	}
 
@@ -539,7 +540,7 @@ export class ChannelsAPI {
 	public async createForumThread(
 		channelId: Snowflake,
 		{ message, ...optionsBody }: StartForumThreadOptions,
-		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+		{ auth, signal, reason }: Pick<RequestData, 'auth' | 'signal' | 'reason'> = {},
 	) {
 		const { files, ...messageBody } = message;
 
@@ -548,7 +549,13 @@ export class ChannelsAPI {
 			message: messageBody,
 		};
 
-		return this.rest.post(Routes.threads(channelId), { auth, files, body, signal }) as Promise<APIThreadChannel>;
+		return this.rest.post(Routes.threads(channelId), {
+			auth,
+			files,
+			body,
+			reason,
+			signal,
+		}) as Promise<APIThreadChannel>;
 	}
 
 	/**

--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -301,8 +301,11 @@ export class ChannelsAPI {
 	 * @param channelId - The id of the channel to delete
 	 * @param options - The options for deleting the channel
 	 */
-	public async delete(channelId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
-		return this.rest.delete(Routes.channel(channelId), { auth, signal }) as Promise<RESTDeleteAPIChannelResult>;
+	public async delete(
+		channelId: Snowflake,
+		{ auth, signal, reason }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
+	) {
+		return this.rest.delete(Routes.channel(channelId), { auth, signal, reason }) as Promise<RESTDeleteAPIChannelResult>;
 	}
 
 	/**

--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -187,11 +187,8 @@ export class GuildsAPI {
 	 * @param guildId - The id of the guild to delete
 	 * @param options - The options for deleting this guild
 	 */
-	public async delete(
-		guildId: Snowflake,
-		{ auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {},
-	) {
-		await this.rest.delete(Routes.guild(guildId), { auth, reason, signal });
+	public async delete(guildId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+		await this.rest.delete(Routes.guild(guildId), { auth, signal });
 	}
 
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
These should allow `reason` per https://discord.com/developers/docs/resources/channel.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
