### PR TITLE
refactor(CDN)!: Use an object for the constructor

### DIFF
--- a/packages/rest/__tests__/CDN.test.ts
+++ b/packages/rest/__tests__/CDN.test.ts
@@ -8,7 +8,7 @@ const hash = 'abcdef';
 const animatedHash = 'a_bcdef';
 const defaultAvatar = 1_234 % 5;
 
-const cdn = new CDN(baseCDN, baseMedia);
+const cdn = new CDN({ cdn: baseCDN, mediaProxy: baseMedia });
 
 test('appAsset default', () => {
 	expect(cdn.appAsset(id, hash)).toEqual(`${baseCDN}/app-assets/${id}/${hash}.webp`);

--- a/packages/rest/src/lib/CDN.ts
+++ b/packages/rest/src/lib/CDN.ts
@@ -84,13 +84,35 @@ interface MakeURLOptions {
 }
 
 /**
+ * Options for initializing the {@link CDN} class.
+ */
+export interface CDNOptions {
+	/**
+	 * The base URL for the CDN.
+	 *
+	 * @defaultValue `DefaultRestOptions.cdn`
+	 */
+	cdn?: string | undefined;
+	/**
+	 * The base URL for the media proxy.
+	 *
+	 * @defaultValue `DefaultRestOptions.mediaProxy`
+	 */
+	mediaProxy?: string | undefined;
+}
+
+/**
  * The CDN link builder
  */
 export class CDN {
-	public constructor(
-		private readonly cdn: string = DefaultRestOptions.cdn,
-		private readonly mediaProxy: string = DefaultRestOptions.mediaProxy,
-	) {}
+	private readonly cdn: string;
+
+	private readonly mediaProxy: string;
+
+	public constructor({ cdn, mediaProxy }: CDNOptions = {}) {
+		this.cdn = cdn ?? DefaultRestOptions.cdn;
+		this.mediaProxy = mediaProxy ?? DefaultRestOptions.mediaProxy;
+	}
 
 	/**
 	 * Generates an app asset URL for a client's asset.

--- a/packages/rest/src/lib/REST.ts
+++ b/packages/rest/src/lib/REST.ts
@@ -78,7 +78,7 @@ export class REST extends AsyncEventEmitter<RestEvents> {
 
 	public constructor(options: Partial<RESTOptions> = {}) {
 		super();
-		this.cdn = new CDN(options.cdn ?? DefaultRestOptions.cdn, options.mediaProxy ?? DefaultRestOptions.mediaProxy);
+		this.cdn = new CDN(options);
 		this.options = { ...DefaultRestOptions, ...options };
 		this.globalRemaining = Math.max(1, this.options.globalRequestsPerSecond);
 		this.agent = options.agent ?? null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The constructor of `CDN` had two optional parameters with defaults, so it semantically makes sense to use an object.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
