### PR TITLE
types(Invite): Approximate fields should be nullable

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2255,8 +2255,8 @@ export class Invite extends Base {
   public inviterId: Snowflake | null;
   public maxAge: number | null;
   public maxUses: number | null;
-  public memberCount: number;
-  public presenceCount: number;
+  public memberCount: number | null;
+  public presenceCount: number | null;
   public targetApplication: IntegrationApplication | null;
   public targetUser: User | null;
   public targetType: InviteTargetType | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

https://github.com/discordjs/discord.js/blob/84c4cb7cd11947b547d997cff864d2197ec343d5/packages/discord.js/src/structures/Invite.js#L54-L74

May be reproduced by creating an invite.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
