### PR TITLE
fix(Container): Use the same discord-api-types version

### DIFF
--- a/packages/builders/src/components/v2/Container.ts
+++ b/packages/builders/src/components/v2/Container.ts
@@ -1,14 +1,15 @@
-import type {
-	APIActionRowComponent,
-	APIFileComponent,
-	APITextDisplayComponent,
-	APIContainerComponent,
-	APIComponentInContainer,
-	APIMediaGalleryComponent,
-	APISectionComponent,
+import {
+	type APIComponentInMessageActionRow,
+	type APISeparatorComponent,
+	type APIActionRowComponent,
+	type APIFileComponent,
+	type APITextDisplayComponent,
+	type APIContainerComponent,
+	type APIComponentInContainer,
+	type APIMediaGalleryComponent,
+	type APISectionComponent,
+	ComponentType,
 } from 'discord-api-types/v10';
-import { ComponentType } from 'discord-api-types/v10';
-import type { APIComponentInMessageActionRow, APISeparatorComponent } from 'discord-api-types/v9';
 import { normalizeArray, type RestOrArray } from '../../util/normalizeArray';
 import { resolveBuilder } from '../../util/resolveBuilder';
 import { validate } from '../../util/validation';


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Using discord-api-types v10 for imports instead of being mixed.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
