### PR TITLE
fix: Channel Name ratelimit make channel.edit functions freeze

### DIFF
--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -158,9 +158,10 @@ export class SequentialHandler implements IHandler {
 				const wait = queue.wait();
 				this.#asyncQueue.shift();
 				await wait;
+			} else if (this.#sublimitPromise) {
+				// Stall requests while the sublimit queue gets processed
+				await this.#sublimitPromise.promise;
 			}
-			// Note: Removed the "else if (this.#sublimitPromise)" block to allow non-sublimited requests
-			// to proceed independently of the sublimit queue
 		}
 
 		try {

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -158,10 +158,9 @@ export class SequentialHandler implements IHandler {
 				const wait = queue.wait();
 				this.#asyncQueue.shift();
 				await wait;
-			} else if (this.#sublimitPromise) {
-				// Stall requests while the sublimit queue gets processed
-				await this.#sublimitPromise.promise;
 			}
+			// Note: Removed the "else if (this.#sublimitPromise)" block to allow non-sublimited requests
+			// to proceed independently of the sublimit queue
 		}
 
 		try {

--- a/packages/rest/src/lib/handlers/SequentialHandler.ts
+++ b/packages/rest/src/lib/handlers/SequentialHandler.ts
@@ -158,7 +158,7 @@ export class SequentialHandler implements IHandler {
 				const wait = queue.wait();
 				this.#asyncQueue.shift();
 				await wait;
-			} else if (this.#sublimitPromise) {
+			} else if (this.#sublimitPromise && hasSublimit(routeId.bucketRoute, requestData.body, options.method)) {
 				// Stall requests while the sublimit queue gets processed
 				await this.#sublimitPromise.promise;
 			}

--- a/packages/rest/src/lib/utils/utils.ts
+++ b/packages/rest/src/lib/utils/utils.ts
@@ -79,8 +79,8 @@ export function hasSublimit(bucketRoute: string, body?: unknown, method?: string
 		return ['name', 'topic'].some((key) => Reflect.has(castedBody, key));
 	}
 
-	// Only return true for explicitly known sublimited routes to avoid unnecessarily sublimiting requests
-	return false;
+	// If we are checking if a request has a sublimit on a route not checked above, sublimit all requests to avoid a flood of 429s
+	return true;
 }
 
 /**

--- a/packages/rest/src/lib/utils/utils.ts
+++ b/packages/rest/src/lib/utils/utils.ts
@@ -79,8 +79,8 @@ export function hasSublimit(bucketRoute: string, body?: unknown, method?: string
 		return ['name', 'topic'].some((key) => Reflect.has(castedBody, key));
 	}
 
-	// If we are checking if a request has a sublimit on a route not checked above, sublimit all requests to avoid a flood of 429s
-	return true;
+	// Only return true for explicitly known sublimited routes to avoid unnecessarily sublimiting requests
+	return false;
 }
 
 /**


### PR DESCRIPTION
**Description of Changes and Justification:**

This PR adjusts the request handler to avoid unnecessary sublimit blocking when editing a channel. Currently, editing a channel name three times triggers a sublimit rate limit. Following that, all subsequent `channel.edit()` calls (even ones *not* modifying the name) are queued behind the rate limit, which is incorrect.

This PR ensures that `channel.edit()` requests which do *not* modify the `name` field are not blocked by the name change sublimit. This improves compliance with Discord's rate-limiting behavior and prevents unrelated modifications (e.g., permissions, user limits, etc.) from being delayed.

**Status and versioning classification:**

* Code changes have been tested against the Discord API
* Typings don't need updating
* This PR changes the library's interface: **No**
* This PR includes breaking changes: **No**
* This PR only includes non-code changes: **No**