### PR TITLE
fix: Remove trailing `color` references

### DIFF
--- a/packages/discord.js/src/managers/RoleManager.js
+++ b/packages/discord.js/src/managers/RoleManager.js
@@ -61,7 +61,7 @@ class RoleManager extends CachedManager {
    * @example
    * // Fetch a single role
    * message.guild.roles.fetch('222078108977594368')
-   *   .then(role => console.log(`The role color is: ${role.color}`))
+   *   .then(role => console.log(`The role color is: ${role.colors.primaryColor}`))
    *   .catch(console.error);
    */
   async fetch(id, { cache = true, force = false } = {}) {

--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -293,7 +293,7 @@ class GuildMember extends Base {
    * @readonly
    */
   get displayColor() {
-    return this.roles.color?.color ?? 0;
+    return this.roles.color?.colors.primaryColor ?? 0;
   }
 
   /**

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -206,7 +206,7 @@ class Role extends Base {
    * @readonly
    */
   get hexColor() {
-    return `#${this.color.toString(16).padStart(6, '0')}`;
+    return `#${this.colors.primaryColor.toString(16).padStart(6, '0')}`;
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Updated the documentation of `RoleManager#fetch()` to use `colors`
- `GuildMember#displayColor` was always returning `0` as it referenced a non-existent property
- Getting the `hexColor` of a role will cause a crash as `this.color` does not exist

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
