### PR TITLE
feat(GuildMember): add 'clearTimeout' method

### DIFF
--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -530,7 +530,7 @@ class GuildMember extends Base {
    * Times this guild member out.
    *
    * @param {?number} timeout The duration in milliseconds
-   * for the member's communication to be disabled. Provide `null` to remove the timeout.
+   * for the member's communication to be disabled. Use clearTimeout or provide `null` to remove the timeout.
    * @param {string} [reason] The reason for this timeout.
    * @returns {Promise<GuildMember>}
    * @example
@@ -541,6 +541,21 @@ class GuildMember extends Base {
    */
   async timeout(timeout, reason) {
     return this.disableCommunicationUntil(timeout && Date.now() + timeout, reason);
+  }
+
+  /**
+   * Clear the timeout of this guild member.
+   *
+   * @param {string} [reason] The reason for clearing this timeout.
+   * @returns {Promise<GuildMember>}
+   * @example
+   * // Clear the timeout of a guild member
+   * guildMember.clearTimeout('I forgive you')
+   *   .then(console.log)
+   *   .catch(console.error);
+   */
+  async clearTimeout(reason) {
+    return this.disableCommunicationUntil(null, reason);
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1651,6 +1651,7 @@ export class GuildMember extends Base {
   public ban(options?: BanOptions): Promise<void>;
   public disableCommunicationUntil(timeout: DateResolvable | null, reason?: string): Promise<GuildMember>;
   public timeout(timeout: number | null, reason?: string): Promise<GuildMember>;
+  public clearTimeout(reason?: string): Promise<GuildMember>;
   public fetch(force?: boolean): Promise<GuildMember>;
   public createDM(force?: boolean): Promise<DMChannel>;
   public deleteDM(): Promise<DMChannel>;


### PR DESCRIPTION
This pull request add ``clearTimeout`` method to guildMember.

Actually, you have to set the duration on **null** to cancel the timeout of a guild member.
The clearTimeout method would make the code more easy to read.