### PR TITLE
fix(guild)!: Remove API related to guild ownership

### DIFF
--- a/packages/core/src/api/guild.ts
+++ b/packages/core/src/api/guild.ts
@@ -86,6 +86,8 @@ import {
 	type RESTPostAPIGuildScheduledEventResult,
 	type RESTPostAPIGuildStickerFormDataBody,
 	type RESTPostAPIGuildStickerResult,
+	type RESTPostAPIGuildTemplatesJSONBody,
+	type RESTPostAPIGuildTemplatesResult,
 	type RESTPutAPIGuildBanJSONBody,
 	type RESTPutAPIGuildMemberJSONBody,
 	type RESTPutAPIGuildMemberResult,
@@ -99,8 +101,6 @@ import {
 	type RESTPostAPIGuildSoundboardSoundJSONBody,
 	type RESTPostAPIGuildSoundboardSoundResult,
 	type Snowflake,
-	RESTPostAPIGuildTemplatesJSONBody,
-	RESTPostAPIGuildTemplatesResult,
 } from 'discord-api-types/v10';
 
 export interface CreateStickerOptions extends Omit<RESTPostAPIGuildStickerFormDataBody, 'file'> {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- https://github.com/discord/discord-api-docs/pull/7715
  - Guild creation was removed with #11012
- https://github.com/discord/discord-api-docs/pull/7720
- https://github.com/discord/discord-api-docs/pull/7722

> [!NOTE]  
> There was no method to create a guild from a template.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
