### PR TITLE
build: fix package name argument parsing

### DIFF
--- a/packages/actions/src/releasePackages/index.ts
+++ b/packages/actions/src/releasePackages/index.ts
@@ -33,7 +33,7 @@ program
 	.parse();
 
 const { exclude, dry, dev } = program.opts<{ dev: boolean; dry: boolean; exclude: string[] }>();
-const packageName = program.args[0]!;
+const [packageName] = program.processedArgs as [string];
 
 const tree = await generateReleaseTree(dev, dry, packageName, exclude);
 for (const branch of tree) {


### PR DESCRIPTION
`program.args` is empty if no arguments are passed via CLI, despite us passing a default value.
`program.processedArgs` seems to work as we expect.