### PR TITLE
fix(GuildChannel): account for everyone base permissions

### DIFF
--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -263,10 +263,11 @@ class GuildChannel extends BaseChannel {
       return new PermissionsBitField(PermissionsBitField.All).freeze();
     }
 
+    const basePermissions = new PermissionsBitField([role.permissions, role.guild.roles.everyone.permissions]);
     const everyoneOverwrites = this.permissionOverwrites.cache.get(this.guild.id);
     const roleOverwrites = this.permissionOverwrites.cache.get(role.id);
 
-    return role.permissions
+    return basePermissions
       .remove(everyoneOverwrites?.deny ?? PermissionsBitField.DefaultBit)
       .add(everyoneOverwrites?.allow ?? PermissionsBitField.DefaultBit)
       .remove(roleOverwrites?.deny ?? PermissionsBitField.DefaultBit)


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

When calculating permissions after overwrites, the base permission of the at-everyone role need to be accounted for. Role#permissions is not sufficient, as it only describes base permissions of the role itself.

fixes #11052

**Status and versioning classification:**

- I know how to update typings and ~~have done so~~, or typings don't need updating
