### PR TITLE
ci(pr-triage): Make validate title run always

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -19,7 +19,6 @@ jobs:
           sync-labels: true
   validate-title:
     name: Validate title
-    if: github.event.action != 'synchronize'
     runs-on: ubuntu-latest
     steps:
       - name: Validate pull request title


### PR DESCRIPTION
Imagine this scenario:

1. A user opens a pull request that is out of date with main. The pull request title does not match the regular expression
2. The user updates their branch 

When the user updates their branch, synchronisation occurs. This means validation will be skipped, and the error will go away. This means a bad actor could merge a pull request with any name they like if the pull request was in an approved state.

This pull request makes validation always run.