### PR TITLE
refactor(PollAnswer)!: remove `fetchVoters`

### DIFF
--- a/packages/discord.js/src/managers/PollAnswerVoterManager.js
+++ b/packages/discord.js/src/managers/PollAnswerVoterManager.js
@@ -31,6 +31,14 @@ class PollAnswerVoterManager extends CachedManager {
    */
 
   /**
+   * Options used for fetching voters of a poll answer.
+   *
+   * @typedef {Object} BaseFetchPollAnswerVotersOptions
+   * @property {number} [limit] The maximum number of voters to fetch
+   * @property {Snowflake} [after] The user id to fetch voters after
+   */
+
+  /**
    * Fetches the users that voted on this poll answer. Resolves with a collection of users, mapped by their ids.
    *
    * @param {BaseFetchPollAnswerVotersOptions} [options={}] Options for fetching the users

--- a/packages/discord.js/src/structures/PollAnswer.js
+++ b/packages/discord.js/src/structures/PollAnswer.js
@@ -93,25 +93,6 @@ class PollAnswer extends Base {
   get partial() {
     return this.poll.partial || (this.text === null && this.emoji === null);
   }
-
-  /**
-   * Options used for fetching voters of a poll answer.
-   *
-   * @typedef {Object} BaseFetchPollAnswerVotersOptions
-   * @property {number} [limit] The maximum number of voters to fetch
-   * @property {Snowflake} [after] The user id to fetch voters after
-   */
-
-  /**
-   * Fetches the users that voted for this answer.
-   *
-   * @param {BaseFetchPollAnswerVotersOptions} [options={}] The options for fetching voters
-   * @returns {Promise<Collection<Snowflake, User>>}
-   * @deprecated Use {@link PollAnswerVoterManager#fetch} instead
-   */
-  async fetchVoters({ after, limit } = {}) {
-    return this.voters.fetch({ after, limit });
-  }
 }
 
 exports.PollAnswer = PollAnswer;

--- a/packages/discord.js/test/polls.js
+++ b/packages/discord.js/test/polls.js
@@ -16,7 +16,7 @@ client.on(Events.ClientReady, async () => {
   // console.dir(message.poll, { depth: Infinity });
 
   // const answer = message.poll.answers.first();
-  // const voters = await answer.fetchVoters();
+  // const voters = await answer.voters.fetch();
   // console.dir(voters);
 
   const message = await channel.send({

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2745,6 +2745,11 @@ export interface PollQuestionMedia {
   text: string | null;
 }
 
+export interface BaseFetchPollAnswerVotersOptions {
+  after?: Snowflake;
+  limit?: number;
+}
+
 export class PollAnswerVoterManager extends CachedManager<Snowflake, User, UserResolvable> {
   private constructor(answer: PollAnswer);
   public answer: PollAnswer;
@@ -2769,11 +2774,6 @@ export class Poll extends Base {
   public end(): Promise<Message>;
 }
 
-export interface BaseFetchPollAnswerVotersOptions {
-  after?: Snowflake;
-  limit?: number;
-}
-
 export class PollAnswer extends Base {
   private constructor(client: Client<true>, data: APIPollAnswer & { count?: number }, poll: Poll);
   private readonly _emoji: APIPartialEmoji | null;
@@ -2784,10 +2784,6 @@ export class PollAnswer extends Base {
   public voters: PollAnswerVoterManager;
   public get emoji(): Emoji | GuildEmoji | null;
   public get partial(): false;
-  /**
-   * @deprecated Use {@link PollAnswerVoterManager.fetch} instead
-   */
-  public fetchVoters(options?: BaseFetchPollAnswerVotersOptions): Promise<Collection<Snowflake, User>>;
 }
 
 export interface ReactionCollectorEventTypes extends CollectorEventTypes<Snowflake | string, MessageReaction, [User]> {


### PR DESCRIPTION
BREAKING CHANGE: The `PollAnswer#fetchVoters` method has been removed. Use `PollAnswer#voters#fetch` instead.
