### PR TITLE
Voice readme dave protocol

### DIFF
--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -61,10 +61,11 @@ try installing another.
 - `@noble/ciphers`: ^1.0.0
 - `libsodium-wrappers`: ^0.7.9
 
+**DAVE Protocol Libraries (e2ee)**
+
 > [!NOTE]
 > Some Discord clients may require the DAVE protocol for end-to-end encryption in voice chat and refuse to downgrade the connection in the future. Ensure you have `@snazzah/davey` installed to avoid compatibility issues, as `@snazzah/davey` is only set as a dev-dependency for `@discordjs/voice` and may not install in production environments without explicit installation.
 
-**DAVE Protocol Libraries (e2ee)**
 - `@snazzah/davey`: ^0.1.6
 
 **Opus Libraries (npm install):**

--- a/packages/voice/README.md
+++ b/packages/voice/README.md
@@ -61,6 +61,12 @@ try installing another.
 - `@noble/ciphers`: ^1.0.0
 - `libsodium-wrappers`: ^0.7.9
 
+> [!NOTE]
+> Some Discord clients may require the DAVE protocol for end-to-end encryption in voice chat and refuse to downgrade the connection in the future. Ensure you have `@snazzah/davey` installed to avoid compatibility issues, as `@snazzah/davey` is only set as a dev-dependency for `@discordjs/voice` and may not install in production environments without explicit installation.
+
+**DAVE Protocol Libraries (e2ee)**
+- `@snazzah/davey`: ^0.1.6
+
 **Opus Libraries (npm install):**
 
 - `@discordjs/opus`: ^0.4.0


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Support for DAVE protocol was added at https://github.com/discordjs/discord.js/issues/10735
Discord mention this in a past blog post [here](https://discord.com/developers/docs/change-log#voice-endtoend-encryption-dave-protocol) and it seems like this is about to be a requirement.
As I discovered while I got repeated crashes due to discord not downgrading my connection to a non e2ee connection!
It could be very useful if i known about this dependency while searching for a solution.
It could be also a good idea to inform users in the release notes/changelog so they know it's a good idea to add this dependency.

Made another PR for the guide as well https://github.com/discordjs/guide/pull/1630

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
-->
