### PR TITLE
fix(formatters): don't escape * in links

### DIFF
--- a/packages/formatters/src/escapers.ts
+++ b/packages/formatters/src/escapers.ts
@@ -212,7 +212,7 @@ export function escapeInlineCode(text: string): string {
  */
 export function escapeItalic(text: string): string {
 	let idx = 0;
-	const newText = text.replaceAll(/(?<=^|[^*])\*([^*]|\*\*|$)/g, (_, match) => {
+	const newText = text.replaceAll(/(?<=^|[^*])(?<!https?:\/\/\S+)\*([^*]|\*\*|$)/g, (_, match) => {
 		if (match === '**') return ++idx % 2 ? `\\*${match}` : `${match}\\*`;
 		return `\\*${match}`;
 	});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The underscore matcher already has `(?<!<a?:.+|https?:\/\/\S+)`, which prevents escaping underscores in emojis, animated emojis, and links (from the https to the first whitespace character).
This PR makes sure asterisks aren't escaped in links either, fixing #11603.

**Status and versioning classification:**

- Code changes but no Discord API related changes
- Typings don't need updating
<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
