### PR TITLE
fix(rest): emit warning on HTTP 401 with non-zero code

### DIFF
--- a/packages/rest/src/lib/handlers/Shared.ts
+++ b/packages/rest/src/lib/handlers/Shared.ts
@@ -7,6 +7,8 @@ import { RESTEvents } from '../utils/constants.js';
 import type { ResponseLike, HandlerRequestData, RouteData } from '../utils/types.js';
 import { parseResponse, shouldRetry } from '../utils/utils.js';
 
+let authFalseWarningEmitted = false;
+
 /**
  * Invalid request limiting is done on a per-IP basis, not a per-token basis.
  * The best we can do is track invalid counts process-wide (on the theory that
@@ -137,15 +139,29 @@ export async function handleErrors(
 	} else {
 		// Handle possible malformed requests
 		if (status >= 400 && status < 500) {
+			// The request will not succeed for some reason, parse the error returned from the api
+			const data = (await parseResponse(res)) as DiscordErrorData | OAuthErrorData;
+			const isDiscordError = 'code' in data;
+
 			// If we receive this status code, it means the token we had is no longer valid.
 			if (status === 401 && requestData.auth === true) {
+				if (isDiscordError && data.code !== 0 && !authFalseWarningEmitted) {
+					const errorText = `Encountered HTTP 401 with error ${data.code}: ${data.message}. Your token will be removed from this REST instance. If you are using @discordjs/rest directly, consider adding 'auth: false' to the request. Open an issue with your library if not.`;
+					// Use emitWarning if possible, probably not available in edge / web
+					if (typeof process?.emitWarning === 'function') {
+						process.emitWarning(errorText);
+					} else {
+						console.warn(errorText);
+					}
+
+					authFalseWarningEmitted = true;
+				}
+
 				manager.setToken(null!);
 			}
 
-			// The request will not succeed for some reason, parse the error returned from the api
-			const data = (await parseResponse(res)) as DiscordErrorData | OAuthErrorData;
 			// throw the API error
-			throw new DiscordAPIError(data, 'code' in data ? data.code : data.error, status, method, url, requestData);
+			throw new DiscordAPIError(data, isDiscordError ? data.code : data.error, status, method, url, requestData);
 		}
 
 		return res;

--- a/packages/rest/src/lib/utils/types.ts
+++ b/packages/rest/src/lib/utils/types.ts
@@ -292,7 +292,9 @@ export interface RequestData {
 	 */
 	appendToFormData?: boolean;
 	/**
-	 * Alternate authorization data to use for this request only, or `false` to disable the Authorization header
+	 * Alternate authorization data to use for this request only, or `false` to disable the Authorization header.
+	 * When making a request to a ropute that includes a token (such as interactions or webhooks), set to `false`
+	 * to avoid accidentally unsetting the instance token if a 401 is encountered.
 	 *
 	 * @defaultValue `true`
 	 */


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The risk of actually handling these errors differently is not worth it when the fix is to use the opt-out options we already provide.
All djs libraries already handle this properly and thus it's only direct users and external lib users that encounter this.

This should hopefully be enough information, with both the docs update and the warning, to get these users across the line with an easy fix to their code.

Supersedes #10798 and #11041 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
