### PR TITLE
build: use the same timestamp for release versions

### DIFF
--- a/packages/actions/src/releasePackages/generateReleaseTree.ts
+++ b/packages/actions/src/releasePackages/generateReleaseTree.ts
@@ -43,6 +43,7 @@ async function getReleaseEntries(dev: boolean, dry: boolean) {
 		await $`pnpm list --recursive --only-projects --filter {packages/\*} --prod --json`.json();
 
 	const commitHash = (await $`git rev-parse --short HEAD`.text()).trim();
+	const timestamp = Math.round(Date.now() / 1_000);
 
 	for (const pkg of packageList) {
 		// Don't release private packages ever (npm will error anyways)
@@ -71,9 +72,9 @@ async function getReleaseEntries(dev: boolean, dry: boolean) {
 				release.version = devVersion;
 			} else if (dry) {
 				info(`[DRY] Bumping ${pkg.name} via git-cliff.`);
-				release.version = `${pkg.version}.DRY-dev.${Math.round(Date.now() / 1_000)}-${commitHash}`;
+				release.version = `${pkg.version}.DRY-dev.${timestamp}-${commitHash}`;
 			} else {
-				await $`pnpm --filter=${pkg.name} run release --preid "dev.${Math.round(Date.now() / 1_000)}-${commitHash}" --skip-changelog`;
+				await $`pnpm --filter=${pkg.name} run release --preid "dev.${timestamp}-${commitHash}" --skip-changelog`;
 				// Read again instead of parsing the output to be sure we're matching when checking against npm
 				const pkgJson = (await file(`${pkg.path}/package.json`).json()) as PackageJSON;
 				release.version = pkgJson.version;


### PR DESCRIPTION
Moved the creation of the timestamp part of release versions outside of the loop, so all the versions released in each run will have the same timestamp. This is mostly a QoL change for people (me) when upgrading packages.

e.g., this is the way the versions are currently: 
```json
{
	"dependencies": {
		"@discordjs/core": "3.0.0-dev.1756512122-cc43dadca",
		"@discordjs/rest": "3.0.0-dev.1756512128-cc43dadca",
		"@discordjs/ws": "3.0.0-dev.1756512132-cc43dadca"
	}
}
```

Everything matches but the timestamp, which is off by a few seconds... Upgrading this manually would entail opening the npm page (or whatever else) for each of those to get the correct timestamp for the version. Now all the versions will have the same timestamp, simplifying the upgrade