### PR TITLE
feat(ws): add optional URL property to WebSocketManager options

### DIFF
--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -49,6 +49,7 @@ export const DefaultWebSocketManagerOptions = {
 		device: DefaultDeviceProperty,
 		os: process.platform,
 	},
+	url: null,
 	version: APIVersion,
 	encoding: Encoding.JSON,
 	compression: null,

--- a/packages/ws/src/ws/WebSocketManager.ts
+++ b/packages/ws/src/ws/WebSocketManager.ts
@@ -189,6 +189,10 @@ export interface OptionalWebSocketManagerOptions {
 	 */
 	updateSessionInfo(shardId: number, sessionInfo: SessionInfo | null): Awaitable<void>;
 	/**
+	 * The URL to use for the gateway
+	 */
+	url: string | null;
+	/**
 	 * Whether to use the `compress` option when identifying
 	 *
 	 * @defaultValue `false`
@@ -295,6 +299,10 @@ export class WebSocketManager extends AsyncEventEmitter<ManagerShardEventsMap> i
 		}
 
 		const data = await this.options.fetchGatewayInformation();
+
+		if (this.options.url) {
+			data.url = this.options.url;
+		}
 
 		// For single sharded bots session_start_limit.reset_after will be 0, use 5 seconds as a minimum expiration time
 		this.gatewayInformation = { data, expiresAt: Date.now() + (data.session_start_limit.reset_after || 5_000) };


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Added new optional `url` parameter in `OptionalWebSocketManagerOptions` (`WebSocketManagerOptions`).
When provided, this overrides the default gateway URL returned from `fetchGatewayInformation()`.

This is really needed in order to allow usage of projects such as gateway proxies, instead of requiring developers to hack around the HTTP client response for `/gateway/bot`.

**Status and versioning classification:**
- Code changes have been tested against the Discord API
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (new optional parameter added)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.