### PR TITLE
fix: overflow on package home

### DIFF
--- a/apps/website/src/app/docs/packages/[packageName]/[version]/[[...item]]/page.tsx
+++ b/apps/website/src/app/docs/packages/[packageName]/[version]/[[...item]]/page.tsx
@@ -61,7 +61,7 @@ export default async function Page({
 		const fileContent = await readFile(join(process.cwd(), `src/assets/readme/${packageName}/home-README.md`), 'utf8');
 
 		return (
-			<div className="prose prose-neutral dark:prose-invert prose-a:[&>img]:inline-block prose-a:[&>img]:m-0 prose-a:[&>img[height='44']]:h-11 prose-p:my-2 prose-pre:py-3 prose-pre:rounded-sm prose-pre:px-0 prose-pre:border prose-pre:border-[#d4d4d4] dark:prose-pre:border-[#404040] prose-code:font-normal prose-a:text-[#5865F2] prose-a:no-underline prose-a:hover:text-[#3d48c3] dark:prose-a:hover:text-[#7782fa] mx-auto max-w-screen-xl px-6 py-6 [&_code_span:last-of-type:empty]:hidden [&_div[align='center']_p_a+a]:ml-2">
+			<div className="prose prose-neutral dark:prose-invert prose-a:[&>img]:inline-block prose-a:[&>img]:m-0 prose-a:[&>img[height='44']]:h-11 prose-p:my-2 prose-pre:py-3 prose-pre:rounded-sm prose-pre:px-0 prose-pre:border prose-pre:border-[#d4d4d4] dark:prose-pre:border-[#404040] prose-code:font-normal prose-a:text-[#5865F2] prose-a:no-underline prose-a:hover:text-[#3d48c3] dark:prose-a:hover:text-[#7782fa] mx-auto max-w-screen-xl px-6 py-6 break-words [&_code_span:last-of-type:empty]:hidden [&_div[align='center']_p_a+a]:ml-2">
 				<MDXRemote
 					options={{
 						mdxOptions: {


### PR DESCRIPTION
| [Before](https://discord.js.org/docs/packages/voice/0.19.0) | [After](https://discord-js-git-fix-overflow-package-home-discordjs.vercel.app/docs/packages/voice/0.19.0) | 
| - | - |
| <img width="225" height="376" alt="image" src="https://github.com/user-attachments/assets/118fe7d4-44d8-4baa-95e9-3c0af49aad63" /> | <img width="225" height="376" alt="image" src="https://github.com/user-attachments/assets/e2e3f41d-025e-4666-803e-363a80e39e13" /> | 
