### PR TITLE
fix: use in operator when resolving modal component

### DIFF
--- a/packages/discord.js/src/structures/ModalComponentResolver.js
+++ b/packages/discord.js/src/structures/ModalComponentResolver.js
@@ -104,11 +104,10 @@ class ModalComponentResolver {
    * Gets the value of a text input component
    *
    * @param {string} customId The custom id of the text input component
-   * @param {?boolean} required Whether to throw an error if the component value is not found or empty
    * @returns {?string}
    */
-  getTextInputValue(customId, required = false) {
-    return this._getTypedComponent(customId, [ComponentType.TextInput], ['value'], required).value ?? null;
+  getTextInputValue(customId) {
+    return this._getTypedComponent(customId, [ComponentType.TextInput]).value;
   }
 
   /**

--- a/packages/discord.js/src/structures/ModalSubmitInteraction.js
+++ b/packages/discord.js/src/structures/ModalSubmitInteraction.js
@@ -148,9 +148,9 @@ class ModalSubmitInteraction extends BaseInteraction {
     };
 
     // Text display components do not have custom ids.
-    if (rawComponent.custom_id) data.customId = rawComponent.custom_id;
+    if ('custom_id' in rawComponent) data.customId = rawComponent.custom_id;
 
-    if (rawComponent.value) data.value = rawComponent.value;
+    if ('value' in rawComponent) data.value = rawComponent.value;
 
     if (rawComponent.values) {
       data.values = rawComponent.values;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2609,8 +2609,7 @@ export class ModalComponentResolver<Cached extends CacheType = CacheType> {
     properties: string,
     required: boolean,
   ): ModalData;
-  public getTextInputValue(customId: string, required: true): string;
-  public getTextInputValue(customId: string, required?: boolean): string | null;
+  public getTextInputValue(customId: string): string;
   public getStringSelectValues(customId: string): readonly string[];
   public getSelectedUsers(customId: string, required: true): ReadonlyCollection<Snowflake, User>;
   public getSelectedUsers(customId: string, required?: boolean): ReadonlyCollection<Snowflake, User> | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
The current way of doing it will return false for empty strings (or any non-truthy value), instead explicitly check if a field is present or not

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
