### PR TITLE
fix(ThreadMemberFlagsBitField): use `ThreadMemberFlags` enum in `Flags`

### DIFF
--- a/packages/discord.js/src/util/APITypes.js
+++ b/packages/discord.js/src/util/APITypes.js
@@ -660,6 +660,11 @@
  */
 
 /**
+ * @external ThreadMemberFlags
+ * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/ThreadMemberFlags}
+ */
+
+/**
  * @external UserFlags
  * @see {@link https://discord-api-types.dev/api/discord-api-types-v10/enum/UserFlags}
  */

--- a/packages/discord.js/src/util/ThreadMemberFlagsBitField.js
+++ b/packages/discord.js/src/util/ThreadMemberFlagsBitField.js
@@ -1,6 +1,7 @@
 /* eslint-disable jsdoc/check-values */
 'use strict';
 
+const { ThreadMemberFlags } = require('discord-api-types/v10');
 const { BitField } = require('./BitField.js');
 
 /**
@@ -12,10 +13,10 @@ class ThreadMemberFlagsBitField extends BitField {
   /**
    * Numeric thread member flags. There are currently no bitflags relevant to bots for this.
    *
-   * @type {Object<string, number>}
+   * @type {ThreadMemberFlags}
    * @memberof ThreadMemberFlagsBitField
    */
-  static Flags = {};
+  static Flags = ThreadMemberFlags;
 }
 
 /**


### PR DESCRIPTION
The typings were already using the enum, but at runtime it was not being used.