### PR TITLE
ci(release): use main action always

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,13 +81,12 @@ jobs:
       - name: Install action deps (non-main ref only)
         if: ${{ inputs.ref && inputs.ref != 'main' }}
         shell: bash
+        working-directory: ./main
         env:
           COREPACK_ENABLE_STRICT: 0
         run: |
-          cd main
           pnpm self-update 10
           pnpm install --filter @discordjs/actions --frozen-lockfile --prefer-offline --loglevel error
-          cd ..
 
       - name: Release packages (non-main ref)
         if: ${{ inputs.ref && inputs.ref != 'main' }}
@@ -96,7 +95,7 @@ jobs:
           package: ${{ inputs.package }}
           exclude: ${{ inputs.exclude }}
           dry: ${{ inputs.dry_run }}
-          main: true
+          main: false
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -108,7 +107,7 @@ jobs:
           package: ${{ inputs.package }}
           exclude: ${{ inputs.exclude }}
           dry: ${{ inputs.dry_run }}
-          main: false
+          main: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,6 @@ jobs:
           package: ${{ inputs.package }}
           exclude: ${{ inputs.exclude }}
           dry: ${{ inputs.dry_run }}
-          main: false
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -107,7 +106,6 @@ jobs:
           package: ${{ inputs.package }}
           exclude: ${{ inputs.exclude }}
           dry: ${{ inputs.dry_run }}
-          main: true
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,12 +72,32 @@ jobs:
       - name: Build dependencies
         run: pnpm run build
 
+      - name: Checkout main repository
+        if: ${{ inputs.ref && inputs.ref != 'main' }}
+        uses: actions/checkout@v5
+        with:
+          path: 'main'
+
       - name: Release packages
+        if: ${{ inputs.ref && inputs.ref != 'main' }}
+        uses: ./main/packages/actions/src/releasePackages
+        with:
+          package: ${{ inputs.package }}
+          exclude: ${{ inputs.exclude }}
+          dry: ${{ inputs.dry_run }}
+          main: true
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Release packages
+        if: ${{ !inputs.ref || inputs.ref == 'main' }}
         uses: ./packages/actions/src/releasePackages
         with:
           package: ${{ inputs.package }}
           exclude: ${{ inputs.exclude }}
           dry: ${{ inputs.dry_run }}
+          main: false
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,18 @@ jobs:
         with:
           path: 'main'
 
-      - name: Release packages
+      - name: Install action deps (non-main ref only)
+        if: ${{ inputs.ref && inputs.ref != 'main' }}
+        shell: bash
+        env:
+          COREPACK_ENABLE_STRICT: 0
+        run: |
+          cd main
+          pnpm self-update 10
+          pnpm install --filter @discordjs/actions --frozen-lockfile --prefer-offline --loglevel error
+          cd ..
+
+      - name: Release packages (non-main ref)
         if: ${{ inputs.ref && inputs.ref != 'main' }}
         uses: ./main/packages/actions/src/releasePackages
         with:
@@ -90,7 +101,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-      - name: Release packages
+      - name: Release packages (main ref)
         if: ${{ !inputs.ref || inputs.ref == 'main' }}
         uses: ./packages/actions/src/releasePackages
         with:

--- a/packages/actions/src/releasePackages/action.yml
+++ b/packages/actions/src/releasePackages/action.yml
@@ -11,6 +11,9 @@ inputs:
     description: 'The published name of a single package to release'
   exclude:
     description: 'Comma separated list of packages to exclude from release (if not depended upon)'
+  main:
+    description: 'Is this running on the main branch?'
+    default: 'true'
 runs:
   using: composite
   steps:
@@ -22,3 +25,4 @@ runs:
         INPUT_DRY: ${{ inputs.dry }}
         INPUT_PACKAGE: ${{ inputs.package }}
         INPUT_EXCLUDE: ${{ inputs.exclude }}
+        INPUT_MAIN: ${{ inputs.main }}

--- a/packages/actions/src/releasePackages/action.yml
+++ b/packages/actions/src/releasePackages/action.yml
@@ -11,18 +11,14 @@ inputs:
     description: 'The published name of a single package to release'
   exclude:
     description: 'Comma separated list of packages to exclude from release (if not depended upon)'
-  main:
-    description: 'Is this running on the main branch?'
-    default: 'true'
 runs:
   using: composite
   steps:
     - uses: oven-sh/setup-bun@v2
-    - run: bun packages/actions/src/releasePackages/index.ts
+    - run: bun $GITHUB_ACTION_PATH/index.ts
       shell: bash
       env:
         INPUT_DEV: ${{ inputs.dev }}
         INPUT_DRY: ${{ inputs.dry }}
         INPUT_PACKAGE: ${{ inputs.package }}
         INPUT_EXCLUDE: ${{ inputs.exclude }}
-        INPUT_MAIN: ${{ inputs.main }}

--- a/packages/actions/src/releasePackages/index.ts
+++ b/packages/actions/src/releasePackages/index.ts
@@ -1,5 +1,4 @@
 import { getInput, startGroup, endGroup, getBooleanInput, info } from '@actions/core';
-import { $ } from 'bun';
 import { program } from 'commander';
 import { generateReleaseTree } from './generateReleaseTree.js';
 import { releasePackage } from './releasePackage.js';
@@ -7,7 +6,6 @@ import { releasePackage } from './releasePackage.js';
 const excludeInput = getInput('exclude');
 let dryInput = false;
 let devInput = false;
-let mainInput = true;
 
 try {
 	devInput = getBooleanInput('dev');
@@ -19,12 +17,6 @@ try {
 	dryInput = getBooleanInput('dry');
 } catch {
 	// We're not running in actions or the input isn't set (cron)
-}
-
-try {
-	mainInput = getBooleanInput('main');
-} catch {
-	// We're not running in actions
 }
 
 program
@@ -42,10 +34,6 @@ program
 
 const { exclude, dry, dev } = program.opts<{ dev: boolean; dry: boolean; exclude: string[] }>();
 const [packageName] = program.processedArgs as [string];
-
-if (!mainInput) {
-	$.cwd('../');
-}
 
 const tree = await generateReleaseTree(dev, dry, packageName, exclude);
 for (const branch of tree) {

--- a/packages/actions/src/releasePackages/index.ts
+++ b/packages/actions/src/releasePackages/index.ts
@@ -1,4 +1,5 @@
 import { getInput, startGroup, endGroup, getBooleanInput, info } from '@actions/core';
+import { $ } from 'bun';
 import { program } from 'commander';
 import { generateReleaseTree } from './generateReleaseTree.js';
 import { releasePackage } from './releasePackage.js';
@@ -6,6 +7,7 @@ import { releasePackage } from './releasePackage.js';
 const excludeInput = getInput('exclude');
 let dryInput = false;
 let devInput = false;
+let mainInput = true;
 
 try {
 	devInput = getBooleanInput('dev');
@@ -17,6 +19,12 @@ try {
 	dryInput = getBooleanInput('dry');
 } catch {
 	// We're not running in actions or the input isn't set (cron)
+}
+
+try {
+	mainInput = getBooleanInput('main');
+} catch {
+	// We're not running in actions
 }
 
 program
@@ -34,6 +42,10 @@ program
 
 const { exclude, dry, dev } = program.opts<{ dev: boolean; dry: boolean; exclude: string[] }>();
 const [packageName] = program.processedArgs as [string];
+
+if (!mainInput) {
+	$.cwd('../');
+}
 
 const tree = await generateReleaseTree(dev, dry, packageName, exclude);
 for (const branch of tree) {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Makes the Release CI always use the main workflow which allows us to release from branches that don't have the workflow. Doing this in the dev workflow adds an extra layer of security, that will be done in or after #11120

(yes, no build step for the action is correct, bun negates that)

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
