### PR TITLE
docs(ModalComponentResolver): correct getTextInputValue return type

### DIFF
--- a/packages/discord.js/src/structures/ModalComponentResolver.js
+++ b/packages/discord.js/src/structures/ModalComponentResolver.js
@@ -104,7 +104,7 @@ class ModalComponentResolver {
    * Gets the value of a text input component
    *
    * @param {string} customId The custom id of the text input component
-   * @returns {?string}
+   * @returns {string}
    */
   getTextInputValue(customId) {
     return this._getTypedComponent(customId, [ComponentType.TextInput]).value;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This should not return `null`

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
