### PR TITLE
fix: adjust types for typescript upgrade

### DIFF
--- a/packages/voice/package.json
+++ b/packages/voice/package.json
@@ -87,7 +87,7 @@
 		"prettier": "^3.6.2",
 		"tsup": "^8.5.0",
 		"turbo": "^2.5.6",
-		"typescript": "~5.5.4",
+		"typescript": "~5.9.2",
 		"vitest": "^3.2.4",
 		"vitest-websocket-mock": "^0.5.0"
 	},

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -134,7 +134,7 @@ export class VoiceReceiver {
 	 * @returns The parsed Opus packet
 	 */
 	private parsePacket(buffer: Buffer, mode: string, nonce: Buffer, secretKey: Uint8Array, userId: string) {
-		let packet = this.decrypt(buffer, mode, nonce, secretKey);
+		let packet: Buffer = this.decrypt(buffer, mode, nonce, secretKey);
 		if (!packet) throw new Error('Failed to parse packet');
 
 		// Strip decrypted RTP Header Extension if present

--- a/packages/voice/src/util/Secretbox.ts
+++ b/packages/voice/src/util/Secretbox.ts
@@ -5,13 +5,13 @@ interface Methods {
 		cipherText: Buffer,
 		additionalData: Buffer,
 		nonce: Buffer,
-		key: ArrayBufferLike,
+		key: Uint8Array,
 	): Buffer;
 	crypto_aead_xchacha20poly1305_ietf_encrypt(
 		plaintext: Buffer,
 		additionalData: Buffer,
 		nonce: Buffer,
-		key: ArrayBufferLike,
+		key: Uint8Array,
 	): Buffer;
 }
 
@@ -21,7 +21,7 @@ const libs = {
 			cipherText: Buffer,
 			additionalData: Buffer,
 			nonce: Buffer,
-			key: ArrayBufferLike,
+			key: Uint8Array,
 		) => {
 			const message = Buffer.alloc(cipherText.length - sodium.crypto_aead_xchacha20poly1305_ietf_ABYTES);
 			sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(message, null, cipherText, additionalData, nonce, key);
@@ -31,7 +31,7 @@ const libs = {
 			plaintext: Buffer,
 			additionalData: Buffer,
 			nonce: Buffer,
-			key: ArrayBufferLike,
+			key: Uint8Array,
 		) => {
 			const cipherText = Buffer.alloc(plaintext.length + sodium.crypto_aead_xchacha20poly1305_ietf_ABYTES);
 			sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(cipherText, plaintext, additionalData, null, nonce, key);
@@ -43,13 +43,13 @@ const libs = {
 			cipherText: Buffer,
 			additionalData: Buffer,
 			nonce: Buffer,
-			key: ArrayBufferLike,
+			key: Uint8Array,
 		) => sodium.api.crypto_aead_xchacha20poly1305_ietf_decrypt(cipherText, additionalData, null, nonce, key),
 		crypto_aead_xchacha20poly1305_ietf_encrypt: (
 			plaintext: Buffer,
 			additionalData: Buffer,
 			nonce: Buffer,
-			key: ArrayBufferLike,
+			key: Uint8Array,
 		) => sodium.api.crypto_aead_xchacha20poly1305_ietf_encrypt(plaintext, additionalData, null, nonce, key),
 	}),
 	'libsodium-wrappers': (sodium: any): Methods => ({
@@ -57,13 +57,13 @@ const libs = {
 			cipherText: Buffer,
 			additionalData: Buffer,
 			nonce: Buffer,
-			key: ArrayBufferLike,
+			key: Uint8Array,
 		) => sodium.crypto_aead_xchacha20poly1305_ietf_decrypt(null, cipherText, additionalData, nonce, key),
 		crypto_aead_xchacha20poly1305_ietf_encrypt: (
 			plaintext: Buffer,
 			additionalData: Buffer,
 			nonce: Buffer,
-			key: ArrayBufferLike,
+			key: Uint8Array,
 		) => sodium.crypto_aead_xchacha20poly1305_ietf_encrypt(plaintext, additionalData, null, nonce, key),
 	}),
 	'@stablelib/xchacha20poly1305': (stablelib: any): Methods => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1830,7 +1830,7 @@ importers:
         version: 9.33.0(jiti@2.5.1)
       eslint-config-neon:
         specifier: ^0.2.7
-        version: 0.2.7(@typescript-eslint/types@8.40.0)(@typescript-eslint/utils@8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.33.0(jiti@2.5.1)))(eslint@9.33.0(jiti@2.5.1))(typescript@5.5.4)
+        version: 0.2.7(@typescript-eslint/types@8.40.0)(@typescript-eslint/utils@8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)
       eslint-formatter-compact:
         specifier: ^8.40.0
         version: 8.40.0
@@ -1842,13 +1842,13 @@ importers:
         version: 3.6.2
       tsup:
         specifier: ^8.5.0
-        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@22.17.2))(jiti@2.5.1)(postcss@8.5.6)(typescript@5.5.4)(yaml@2.8.1)
+        version: 8.5.0(@microsoft/api-extractor@7.52.11(@types/node@22.17.2))(jiti@2.5.1)(postcss@8.5.6)(typescript@5.9.2)(yaml@2.8.1)
       turbo:
         specifier: ^2.5.6
         version: 2.5.6
       typescript:
-        specifier: ~5.5.4
-        version: 5.5.4
+        specifier: ~5.9.2
+        version: 5.9.2
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.17.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.1)


### PR DESCRIPTION
Changed the type of `key` in the Secretbox methods to `Uint8Array` to match what is actually being passed, as in the newer TypeScript versions `Uint8Array` doesn't satisfy the `ArrayBufferLike` constraint.

https://github.com/discordjs/discord.js/blob/cf89260c9862d5101d6583bfe7a55ad9238631db/packages/voice/src/networking/Networking.ts#L158

For the VoiceReceiver changes, the direct assignment in the declaration was narrowing `packet` to `Buffer<ArrayBuffer>` while further down it's being widened to `Buffer<ArrayBufferLike>`. Added a type annotation to keep the type wide from the start, which the consumers of this method can handle.

***

There is a newer version of TypeScript, but I kept it the same as the other versions from the workspace. Dependency bump pull request will come later.