### PR TITLE
ci: bump actions/setup-node to v5

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -17,9 +17,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/.github/workflows/deprecate-version.yml
+++ b/.github/workflows/deprecate-version.yml
@@ -38,9 +38,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -41,9 +41,10 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       - name: Install Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache
@@ -253,9 +254,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/.github/workflows/publish-dev-docker.yml
+++ b/.github/workflows/publish-dev-docker.yml
@@ -13,9 +13,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -25,9 +25,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -10,9 +10,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -17,9 +17,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,10 @@ jobs:
           ref: ${{ inputs.ref || '' }}
 
       - name: Install Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,10 @@ jobs:
           fetch-depth: 0
 
       - name: Install Node.js v22
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install dependencies
         uses: ./packages/actions/src/pnpmCache


### PR DESCRIPTION
This version has automatic package manager dependencies cache enabled by default, but we have our own implementation of it, so added `package-manager-cache: false` to disable it.
