### PR TITLE
fix: Add missing required flag for getTextInputValue (QoL)

### DIFF
--- a/packages/discord.js/src/structures/ModalComponentResolver.js
+++ b/packages/discord.js/src/structures/ModalComponentResolver.js
@@ -104,10 +104,11 @@ class ModalComponentResolver {
    * Gets the value of a text input component
    *
    * @param {string} customId The custom id of the text input component
+   * @param {boolean} [required=true] Whether to throw an error if the component value is not found or empty
    * @returns {string}
    */
-  getTextInputValue(customId) {
-    return this._getTypedComponent(customId, [ComponentType.TextInput]).value;
+  getTextInputValue(customId, required = true) {
+    return this._getTypedComponent(customId, [ComponentType.TextInput], ['value'], required).value;
   }
 
   /**

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2609,7 +2609,7 @@ export class ModalComponentResolver<Cached extends CacheType = CacheType> {
     properties: string,
     required: boolean,
   ): ModalData;
-  public getTextInputValue(customId: string): string;
+  public getTextInputValue(customId: string, required?: boolean): string | null;
   public getStringSelectValues(customId: string): readonly string[];
   public getSelectedUsers(customId: string, required: true): ReadonlyCollection<Snowflake, User>;
   public getSelectedUsers(customId: string, required?: boolean): ReadonlyCollection<Snowflake, User> | null;


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)


This adds (what I believe) is a missing flag from getTextInputValue, I noticed that other methods do have a required flag yet getTextInputValue does not which I believe would benefit from having it, also for consistency reasons.

Would love to hear if there are any comments or questions!