### PR TITLE
types(core): use result types instead of direct types

### DIFF
--- a/packages/core/scripts/find-returns-not-return-type.mts
+++ b/packages/core/scripts/find-returns-not-return-type.mts
@@ -1,0 +1,28 @@
+import { glob, readFile } from 'node:fs/promises';
+
+const cwd = new URL('../src/api/', import.meta.url);
+const results: string[] = [];
+
+for await (const file of glob('**/*.ts', { cwd })) {
+	const content = await readFile(new URL(file, cwd), { encoding: 'utf-8' });
+
+	const matches = content.matchAll(/as Promise<(?<returnType>\w+)>/g);
+
+	for (const match of matches) {
+		const returnType = match.groups!.returnType!;
+
+		if (!returnType.startsWith('REST')) {
+			results.push(`in file core/src/api/${file}: ${returnType}`);
+		}
+	}
+}
+
+if (results.length > 0) {
+	console.warn('Found return types that are not REST return types:');
+
+	for (const result of results) {
+		console.warn(`  - ${result}`);
+	}
+} else {
+	console.log('No return types that are not REST return types found');
+}

--- a/packages/core/src/api/channel.ts
+++ b/packages/core/src/api/channel.ts
@@ -32,7 +32,6 @@ import {
 	type Snowflake,
 	type RESTPostAPIChannelThreadsJSONBody,
 	type RESTPostAPIChannelThreadsResult,
-	type APIThreadChannel,
 	type RESTPostAPIGuildForumThreadsJSONBody,
 	type RESTPostAPISoundboardSendSoundJSONBody,
 	type RESTPostAPISendSoundboardSoundResult,
@@ -565,7 +564,7 @@ export class ChannelsAPI {
 			body,
 			reason,
 			signal,
-		}) as Promise<APIThreadChannel>;
+		}) as Promise<RESTPostAPIChannelThreadsResult>;
 	}
 
 	/**

--- a/packages/core/src/api/thread.ts
+++ b/packages/core/src/api/thread.ts
@@ -1,12 +1,11 @@
 /* eslint-disable jsdoc/check-param-names */
 
 import type { RequestData, REST } from '@discordjs/rest';
-import {
+import type {
+	RESTGetAPIChannelThreadMemberResult,
 	Routes,
-	type APIThreadMember,
 	type RESTGetAPIChannelThreadMembersResult,
-	type Snowflake,
-} from 'discord-api-types/v10';
+	type Snowflake} from 'discord-api-types/v10';
 
 export class ThreadsAPI {
 	public constructor(private readonly rest: REST) {}
@@ -78,7 +77,10 @@ export class ThreadsAPI {
 		userId: Snowflake,
 		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
 	) {
-		return this.rest.get(Routes.threadMembers(threadId, userId), { auth, signal }) as Promise<APIThreadMember>;
+		return this.rest.get(Routes.threadMembers(threadId, userId), {
+			auth,
+			signal,
+		}) as Promise<RESTGetAPIChannelThreadMemberResult>;
 	}
 
 	/**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Just fixes some type references. WIll PR to DTypes to fix the thread return type being a generic channel instead of a specific type

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
