### PR TITLE
Also import clearInterval

### DIFF
--- a/src/client/websocket/WebSocketShard.js
+++ b/src/client/websocket/WebSocketShard.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const EventEmitter = require('node:events');
-const { setTimeout, setInterval, clearTimeout } = require('node:timers');
+const { setTimeout, setInterval, clearTimeout, clearInterval } = require('node:timers');
 const WebSocket = require('../../WebSocket');
 const { Status, Events, ShardEvents, Opcodes, WSEvents, WSCodes } = require('../../util/Constants');
 const Intents = require('../../util/Intents');


### PR DESCRIPTION
This simple change fixes issues when running in environments that re-define node's timers, such as FiveM, where node timers [are tied to the game ticks](https://github.com/citizenfx/fivem/blob/2414af3f803cdf7ff9349d3d4bb223022ceb10ef/data/shared/citizen/scripting/v8/timer.js#L244).

The issue is that `clearInterval` is used in the web socket files, namely when clearing the heartbeat interval, but as it's not imported from `node:timers`, in the case of a FiveM resource, it tries to use the overriden `clearInterval` function, which has no idea what to to with the timer ID/cookie coming from the `node:timer`'s `setInterval` function (which was already imported). Consequences of this are heartbeat timers not being properly cleared, which, when running for a long time (i.e., lots of reconnections to discord's servers) will cause excessive heartbeats to be sent, not respecting the heartbeat interval.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
