### PR TITLE
feat(voice): Add info about DAVE protocol dependencies and support

### DIFF
--- a/apps/guide/content/docs/voice/index.mdx
+++ b/apps/guide/content/docs/voice/index.mdx
@@ -64,10 +64,11 @@ After this, you'll be able to play Ogg and WebM Opus files without any other dep
 
 #### DAVE Protocol Support
 
- - [`@snazzah/davey`](https://www.npmjs.com/package/@snazzah/davey) - to enable end-to-end encryption with the DAVE protocol.
+- [`@snazzah/davey`](https://www.npmjs.com/package/@snazzah/davey) - to enable end-to-end encryption with the DAVE protocol.
 
 <Callout>
-	Some Discord clients already require the DAVE protocol for end-to-end encryption in voice chat. Ensure you have `@snazzah/davey` installed to avoid compatibility issues.
+	Some Discord clients already require the DAVE protocol for end-to-end encryption in voice chat. Ensure you have
+	`@snazzah/davey` installed to avoid compatibility issues.
 </Callout>
 
 <Callout>


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Changes remade from https://github.com/discordjs/guide/pull/1630 due to project moving from that repo to this one.

Seems that we might need a few updates here for the voice guides.

- There is support for the DAVE protocol, some users might be interested and it should show as an option.
- Same goes for `generateDependencyReport` output in the guide.
- Added warning about `@snazzah/davey` being a dev dependency, this could confuse some devs.
- We now support `node:crypto`, updated the section about the requirement to install encryption library and a tip to verify the system support.

Support for DAVE protocol was added here https://github.com/discordjs/discord.js/issues/10735
Please note that I discovered this while I got repeated crashes due to discord not downgrading my connection to a non e2ee connection!
Discord mention this in a past blog post [here](https://discord.com/developers/docs/change-log#voice-endtoend-encryption-dave-protocol) and it seems like this is about to be a requirement.

Created PR https://github.com/discordjs/discord.js/pull/11061 to update voice package readme as well.

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
<!--
Please move lines that apply to you out of the comment:


- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)

-->
