### PR TITLE
chore(guide): Update name of legacy path

### DIFF
--- a/apps/guide/content/docs/legacy/meta.json
+++ b/apps/guide/content/docs/legacy/meta.json
@@ -25,8 +25,8 @@
 		"...oauth2",
 		"sharding"
 	],
-	"title": "Legacy Guide",
-	"description": "The legacy discord.js guide",
+	"title": "discord.js",
+	"description": "The discord.js guide",
 	"icon": "Book",
 	"root": true
 }


### PR DESCRIPTION
As discussed[^1], we will change the name to "discord.js" without changing the "legacy" path.

[^1]: https://canary.discord.com/channels/222078108977594368/1078692758153351278/1424895025703157760