### PR TITLE
feat: bump builders in v14 (and fix runtime crashes)

### DIFF
--- a/packages/discord.js/package.json
+++ b/packages/discord.js/package.json
@@ -66,7 +66,7 @@
   "homepage": "https://discord.js.org",
   "funding": "https://github.com/discordjs/discord.js?sponsor",
   "dependencies": {
-    "@discordjs/builders": "^1.11.2",
+    "@discordjs/builders": "^1.12.0",
     "@discordjs/collection": "1.5.3",
     "@discordjs/formatters": "^0.6.1",
     "@discordjs/rest": "workspace:^",

--- a/packages/discord.js/src/index.js
+++ b/packages/discord.js/src/index.js
@@ -163,6 +163,7 @@ exports.Invite = require('./structures/Invite');
 exports.InviteStageInstance = require('./structures/InviteStageInstance');
 exports.InviteGuild = require('./structures/InviteGuild');
 exports.LabelComponent = require('./structures/LabelComponent');
+exports.LabelBuilder = require('./structures/LabelBuilder');
 exports.Message = require('./structures/Message').Message;
 exports.Attachment = require('./structures/Attachment');
 exports.AttachmentBuilder = require('./structures/AttachmentBuilder');

--- a/packages/discord.js/src/structures/LabelBuilder.js
+++ b/packages/discord.js/src/structures/LabelBuilder.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { LabelBuilder: BuildersLabel } = require('@discordjs/builders');
+const { isJSONEncodable } = require('@discordjs/util');
+const { toSnakeCase } = require('../util/Transformers');
+
+class LabelBuilder extends BuildersLabel {
+  constructor(data) {
+    super(toSnakeCase(data));
+  }
+
+  /**
+   * Creates a new label builder from JSON data
+   * @param {LabelBuilder|LabelComponent|APILabelComponent} other The other data
+   * @returns {LabelBuilder}
+   */
+  static from(other) {
+    return new this(isJSONEncodable(other) ? other.toJSON() : other);
+  }
+}
+
+module.exports = LabelBuilder;
+
+/**
+ * @external BuildersLabel
+ * @see {@link https://discord.js.org/docs/packages/builders/stable/LabelBuilder:Class}
+ */

--- a/packages/discord.js/src/structures/LabelComponent.js
+++ b/packages/discord.js/src/structures/LabelComponent.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const { Component } = require('./Component.js');
-const { createComponent } = require('../util/Components.js');
+const Component = require('./Component');
+const { createComponent } = require('../util/Components');
 
 /**
  * Represents a label component

--- a/packages/discord.js/src/util/InviteFlagsBitField.js
+++ b/packages/discord.js/src/util/InviteFlagsBitField.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { InviteFlags } = require('discord-api-types/v10');
-const { BitField } = require('./BitField.js');
+const BitField = require('./BitField');
 
 /**
  * Data structure that makes it easy to interact with a {@link GuildInvite#flags} bit field.

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -12,6 +12,7 @@ import {
   SelectMenuOptionBuilder as BuildersSelectMenuOption,
   ModalActionRowComponentBuilder,
   ModalBuilder as BuildersModal,
+  LabelBuilder as BuilderLabelComponent,
   AnyComponentBuilder,
   type RestOrArray,
   ApplicationCommandOptionAllowedChannelTypes,
@@ -361,7 +362,8 @@ export type ComponentInLabelData =
   | RoleSelectMenuComponentData
   | MentionableSelectMenuComponentData;
 
-export interface LabelData extends BaseComponentData {
+export interface LabelComponentData extends BaseComponentData {
+  type: ComponentType.Label;
   component: ComponentInLabelData;
   description?: string;
   label: string;
@@ -925,6 +927,11 @@ export class TextInputBuilder extends BuilderTextInputComponent {
 export class TextInputComponent extends Component<APITextInputComponent> {
   public get customId(): string;
   public get value(): string;
+}
+
+export class LabelBuilder extends BuilderLabelComponent {
+  public constructor(data?: Partial<LabelComponentData | APILabelComponent>);
+  public static from(other: JSONEncodable<APILabelComponent> | APILabelComponent): LabelBuilder;
 }
 
 export class LabelComponent extends Component<APILabelComponent> {
@@ -2780,7 +2787,7 @@ export interface ModalComponentData {
   components: readonly (
     | JSONEncodable<APIActionRowComponent<APIComponentInModalActionRow> | APILabelComponent>
     | ActionRowData<ModalActionRowComponentData>
-    | LabelData
+    | LabelComponentData
     | TextDisplayComponentData
   )[];
 }
@@ -4143,7 +4150,7 @@ export class Formatters extends null {
 export type ComponentData =
   | MessageActionRowComponentData
   | ModalActionRowComponentData
-  | LabelData
+  | LabelComponentData
   | ComponentInLabelData
   | ComponentInContainerData
   | ContainerComponentData

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -932,8 +932,8 @@ importers:
   packages/discord.js:
     dependencies:
       '@discordjs/builders':
-        specifier: ^1.11.2
-        version: 1.11.2
+        specifier: ^1.12.0
+        version: 1.12.0
       '@discordjs/collection':
         specifier: 1.5.3
         version: 1.5.3
@@ -2789,8 +2789,8 @@ packages:
     resolution: {integrity: sha512-4JINx4Rttha29f50PBsJo48xZXx/He5yaIWJRwVarhYAN947+S84YciHl+AIhQNRPAFkg8+5qFngEGtKxQDWXA==}
     engines: {node: '>=18.18.0'}
 
-  '@discordjs/builders@1.11.2':
-    resolution: {integrity: sha512-F1WTABdd8/R9D1icJzajC4IuLyyS8f3rTOz66JsSI3pKvpCAtsMBweu8cyNYsIyvcrKAVn9EPK+Psoymq+XC0A==}
+  '@discordjs/builders@1.12.0':
+    resolution: {integrity: sha512-jQ0m/fVOg6j3w2Rrzrg5VfqPpkslYNnpdTAyQzQXQ7S/5y0iScBnMlVZfu/AFLP9C34shQ4I+EpTGZV1VlN7RQ==}
     engines: {node: '>=16.11.0'}
 
   '@discordjs/collection@1.5.3':
@@ -8359,6 +8359,9 @@ packages:
 
   discord-api-types@0.38.24:
     resolution: {integrity: sha512-P7/DkcFIiIoaBogStnhhcGRX7KR+gIFp0SpmwsZUIM0bgDkYMEUx+8l+t3quYc/KSgg92wvE9w/4mabO57EMug==}
+
+  discord-api-types@0.38.29:
+    resolution: {integrity: sha512-+5BfrjLJN1hrrcK0MxDQli6NSv5lQH7Y3/qaOfk9+k7itex8RkA/UcevVMMLe8B4IKIawr4ITBTb2fBB2vDORg==}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -16318,12 +16321,12 @@ snapshots:
       tar-stream: 3.1.7
       which: 4.0.0
 
-  '@discordjs/builders@1.11.2':
+  '@discordjs/builders@1.12.0':
     dependencies:
       '@discordjs/formatters': 0.6.1
       '@discordjs/util': 1.1.1
       '@sapphire/shapeshift': 4.0.0
-      discord-api-types: 0.38.24
+      discord-api-types: 0.38.29
       fast-deep-equal: 3.1.3
       ts-mixer: 6.0.4
       tslib: 2.8.1
@@ -23712,6 +23715,8 @@ snapshots:
   discord-api-types@0.37.119: {}
 
   discord-api-types@0.38.24: {}
+
+  discord-api-types@0.38.29: {}
 
   dlv@1.1.3: {}
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Fixes a crash related to Label component and the Invite bitfield class
Bumps builders in v14 for new modal components

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
