### PR TITLE
fix(builders): text display component support for modals

### DIFF
--- a/packages/builders/src/interactions/modals/Assertions.ts
+++ b/packages/builders/src/interactions/modals/Assertions.ts
@@ -2,6 +2,7 @@ import { s } from '@sapphire/shapeshift';
 import { ActionRowBuilder, type ModalActionRowComponentBuilder } from '../../components/ActionRow.js';
 import { customIdValidator } from '../../components/Assertions.js';
 import { LabelBuilder } from '../../components/label/Label.js';
+import { TextDisplayBuilder } from '../../components/v2/TextDisplay.js';
 import { isValidationEnabled } from '../../util/validation.js';
 
 export const titleValidator = s
@@ -10,7 +11,7 @@ export const titleValidator = s
 	.lengthLessThanOrEqual(45)
 	.setValidationEnabled(isValidationEnabled);
 export const componentsValidator = s
-	.union([s.instance(ActionRowBuilder), s.instance(LabelBuilder)])
+	.union([s.instance(ActionRowBuilder), s.instance(LabelBuilder), s.instance(TextDisplayBuilder)])
 	.array()
 	.lengthGreaterThanOrEqual(1)
 	.setValidationEnabled(isValidationEnabled);
@@ -18,7 +19,7 @@ export const componentsValidator = s
 export function validateRequiredParameters(
 	customId?: string,
 	title?: string,
-	components?: (ActionRowBuilder<ModalActionRowComponentBuilder> | LabelBuilder)[],
+	components?: (ActionRowBuilder<ModalActionRowComponentBuilder> | LabelBuilder | TextDisplayBuilder)[],
 ) {
 	customIdValidator.parse(customId);
 	titleValidator.parse(title);


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

<img width="259" height="194" alt="image" src="https://github.com/user-attachments/assets/0e465d04-34b9-435a-b067-c87bffb28a56" />

Woopsy XD, forgot to add support for text displays in modal builder

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
