### PR TITLE
fix: ending uncached polls

### DIFF
--- a/packages/discord.js/src/structures/Poll.js
+++ b/packages/discord.js/src/structures/Poll.js
@@ -179,7 +179,7 @@ class Poll extends Base {
    * @returns {Promise<Message>}
    */
   async end() {
-    if (Date.now() > this.expiresTimestamp) {
+    if (this.expiresTimestamp !== null && Date.now() > this.expiresTimestamp) {
       throw new DiscordjsError(ErrorCodes.PollAlreadyExpired);
     }
 


### PR DESCRIPTION
`expiresTimestamp` is nullable, and `Date.now() > null` would be true.