### PR TITLE
chore(guide): manually sort popular topics

### DIFF
--- a/apps/guide/content/docs/legacy/popular-topics/meta.json
+++ b/apps/guide/content/docs/legacy/popular-topics/meta.json
@@ -1,5 +1,21 @@
 {
 	"title": "Popular Topics",
 	"defaultOpen": true,
-	"pages": ["!faq", "...", "!display-components"]
+	"pages": [
+		"!faq",
+		"!display-components",
+		"audit-logs",
+		"canvas",
+		"collectors",
+		"errors",
+		"formatters",
+		"intents",
+		"embeds",
+		"partials",
+		"permissions",
+		"permissions-extended",
+		"reactions",
+		"threads",
+		"webhooks"
+	]
 }


### PR DESCRIPTION
The [`...` syntax](https://fumadocs.dev/docs/ui/page-conventions#pages) resolves pages by their file name, resulting in a semi-alphabetical sorting (e.g. `embeds.md` is called Message Embeds). Additionally, the advanced concepts in "Permissions (extended)" should be covered after the base permission concepts.

Caveat: If new pages are added, they have to be manually added to `meta.json`

### Alternative Approach
Renaming the files to have a sort order consistent with their sidebar title
Caveat: breaks some additional forwards re: #11170

<img width="281" height="530" alt="image" src="https://github.com/user-attachments/assets/c1ef524b-553d-4266-9790-8cc1b514774d" />
