### PR TITLE
chore(guide): consistent sidebar capitalization

### DIFF
--- a/apps/guide/content/docs/legacy/additional-features/meta.json
+++ b/apps/guide/content/docs/legacy/additional-features/meta.json
@@ -1,0 +1,3 @@
+{
+	"title": "Additional Features"
+}

--- a/apps/guide/content/docs/legacy/additional-info/meta.json
+++ b/apps/guide/content/docs/legacy/additional-info/meta.json
@@ -1,3 +1,4 @@
 {
+	"title": "Additional Info",
 	"pages": ["async-await", "collections", "es6-syntax", "notation", "rest-api", "proxy"]
 }

--- a/apps/guide/content/docs/legacy/additional-info/proxy.mdx
+++ b/apps/guide/content/docs/legacy/additional-info/proxy.mdx
@@ -1,5 +1,5 @@
 ---
-title: Using a proxy
+title: Using a Proxy
 ---
 
 This guide will show you how to set up a proxy with discord.js. This may be necessary if you are deploying your bot to a server with a firewall only allowing outside traffic through the proxy.

--- a/apps/guide/content/docs/legacy/app-creation/creating-commands.mdx
+++ b/apps/guide/content/docs/legacy/app-creation/creating-commands.mdx
@@ -1,8 +1,6 @@
 ---
-title: Creating slash commands
+title: Creating Slash Commands
 ---
-
-## Creating slash commands
 
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 import { File, Folder, Files } from 'fumadocs-ui/components/files';

--- a/apps/guide/content/docs/legacy/improving-dev-environment/meta.json
+++ b/apps/guide/content/docs/legacy/improving-dev-environment/meta.json
@@ -1,0 +1,3 @@
+{
+	"title": "Improving Your Dev Environment"
+}

--- a/apps/guide/content/docs/legacy/improving-dev-environment/package-json-scripts.mdx
+++ b/apps/guide/content/docs/legacy/improving-dev-environment/package-json-scripts.mdx
@@ -1,5 +1,5 @@
 ---
-title: Package scripts
+title: Package Scripts
 ---
 
 ## Setting up package.json scripts

--- a/apps/guide/content/docs/legacy/interactive-components/action-rows.mdx
+++ b/apps/guide/content/docs/legacy/interactive-components/action-rows.mdx
@@ -1,5 +1,5 @@
 ---
-title: Action rows
+title: Action Rows
 ---
 
 Action rows are a layout component with five "slots" that can be filled with other components. At the time of writing this guide, buttons take up one slot and select menus take up five "slots". Accordingly, each `ActionRow` can hold up to 5 buttons or a single select menu. A message can have up to five rows without providing the `IsComponentsV2` message flag. If you want to place buttons or action rows into the message body, they have to be wrapped inside rows.

--- a/apps/guide/content/docs/legacy/interactive-components/meta.json
+++ b/apps/guide/content/docs/legacy/interactive-components/meta.json
@@ -1,3 +1,4 @@
 {
+	"title": "Interactive Components",
 	"pages": ["action-rows", "buttons", "select-menus", "interactions"]
 }

--- a/apps/guide/content/docs/legacy/popular-topics/meta.json
+++ b/apps/guide/content/docs/legacy/popular-topics/meta.json
@@ -1,4 +1,5 @@
 {
+	"title": "Popular Topics",
 	"defaultOpen": true,
 	"pages": ["!faq", "...", "!display-components"]
 }

--- a/apps/guide/content/docs/legacy/preparations/adding-your-app.mdx
+++ b/apps/guide/content/docs/legacy/preparations/adding-your-app.mdx
@@ -1,5 +1,5 @@
 ---
-title: Adding your App
+title: Adding Your App
 ---
 
 After you set up a bot application, you'll notice that it's not in any servers yet. So how does that work?

--- a/apps/guide/content/docs/legacy/slash-commands/meta.json
+++ b/apps/guide/content/docs/legacy/slash-commands/meta.json
@@ -1,0 +1,3 @@
+{
+	"title": "Slash Commands"
+}


### PR DESCRIPTION
Consistently use `Title Case` for sidebar titles.