### PR TITLE
chore: bump dependencies

### DIFF
--- a/apps/guide/next.config.ts
+++ b/apps/guide/next.config.ts
@@ -4,7 +4,6 @@ import type { NextConfig } from 'next';
 const withMDX = createMDX();
 
 export default withMDX({
-	reactStrictMode: true,
 	serverExternalPackages: ['typescript', 'twoslash'],
 	images: {
 		dangerouslyAllowSVG: true,

--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from 'next';
 
 export default {
-	reactStrictMode: true,
 	images: {
 		dangerouslyAllowSVG: true,
 		contentDispositionType: 'attachment',


### PR DESCRIPTION
- eslint-config-neon patch no longer needed
- `tseslint.config()` -> `defineConfig()`: https://typescript-eslint.io/packages/typescript-eslint/#config-deprecated