### PR TITLE
ci(documentation): Ignore tag pushes for create-discord-bot

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,6 +10,8 @@ on:
       - '!packages/ui/**'
     tags:
       - '**'
+      - '!create-discord-app@*'
+      - '!create-discord-bot@*'
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore:
> Path filters are not evaluated for pushes of tags.