### PR TITLE
fix: Remove outdated documentation logic

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -101,13 +101,6 @@ jobs:
             cd ../..
           done
 
-      - name: Checkout docs repository
-        uses: actions/checkout@v5
-        with:
-          repository: 'discordjs/docs'
-          token: ${{ secrets.DJS_DOCS }}
-          path: 'out'
-
       - name: Upload documentation to database
         if: ${{ env.REF_TYPE == 'tag' && (!inputs.ref || inputs.ref == 'main') }}
         env:
@@ -164,20 +157,6 @@ jobs:
           package: ${{ steps.extract-tag.outputs.package }}
           version: ${{ steps.extract-tag.outputs.semver }}
 
-      - name: Move docs to correct directory
-        if: ${{ env.REF_TYPE == 'tag' }}
-        env:
-          PACKAGE: ${{ steps.extract-tag.outputs.package }}
-          SEMVER: ${{ steps.extract-tag.outputs.semver }}
-        run: |
-          mkdir -p "out/${PACKAGE}"
-          if [[ "${PACKAGE}" == "discord.js" ]]; then
-            mv "packages/${PACKAGE}/docs/docs.json" "out/${PACKAGE}/${SEMVER}.json"
-            mv "packages/${PACKAGE}/docs/docs.api.json" "out/${PACKAGE}/${SEMVER}.api.json"
-          else
-            mv "packages/${PACKAGE}/docs/docs.api.json" "out/${PACKAGE}/${SEMVER}.api.json"
-          fi
-
       - name: Upload documentation to database
         if: ${{ env.REF_TYPE == 'branch' && (!inputs.ref || inputs.ref == 'main') }}
         env:
@@ -221,35 +200,6 @@ jobs:
           CF_R2_DOCS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_DOCS_SECRET_ACCESS_KEY }}
           CF_R2_DOCS_BUCKET: ${{ secrets.CF_R2_DOCS_BUCKET }}
         uses: ./main/packages/actions/src/uploadSplitDocumentation
-
-      - name: Move docs to correct directory
-        if: ${{ env.REF_TYPE == 'branch' }}
-        run: |
-          declare -a PACKAGES=("brokers" "builders" "collection" "core" "discord.js" "formatters" "next" "proxy" "rest" "structures" "util" "voice" "ws")
-          for PACKAGE in "${PACKAGES[@]}"; do
-            if [ ! -d "packages/${PACKAGE}" ]; then
-              echo "::notice::${PACKAGE} does not exist on this ref. Skipping..."
-              continue
-            fi
-
-            if [[ "${PACKAGE}" == "discord.js" ]]; then
-              mkdir -p "out/${PACKAGE}"
-              mv "packages/${PACKAGE}/docs/docs.json" "out/${PACKAGE}/${GITHUB_REF_NAME}.json"
-              mv "packages/${PACKAGE}/docs/docs.api.json" "out/${PACKAGE}/${GITHUB_REF_NAME}.api.json"
-            else
-              mkdir -p "out/${PACKAGE}"
-              mv "packages/${PACKAGE}/docs/docs.api.json" "out/${PACKAGE}/${GITHUB_REF_NAME}.api.json"
-            fi
-          done
-
-      - name: Commit and push
-        run: |
-          cd out
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git add .
-          git commit -m "Docs build for ${GITHUB_REF_TYPE} ${GITHUB_REF_NAME}: ${GITHUB_SHA}" || true
-          git push
 
   build-indices:
     needs: build-docs

--- a/apps/website/scripts/generateAllIndices.js
+++ b/apps/website/scripts/generateAllIndices.js
@@ -1,14 +1,14 @@
 import { readFile } from 'node:fs/promises';
 import { generateAllIndices } from '@discordjs/scripts';
 
-console.log('Generating all indices...');
+console.info('Generating all indices...');
+
 await generateAllIndices({
-	fetchPackageVersions: async (pkg) => {
-		return ['main'];
-	},
+	fetchPackageVersions: () => ['main'],
 	fetchPackageVersionDocs: async (pkg, version) => {
 		console.log(`Fetching data for ${pkg} ${version}...`);
 		return JSON.parse(await readFile(`${process.cwd()}/../../../docs/${pkg}/${version}.api.json`, 'utf8'));
 	},
 });
-console.log('Generated all indices.');
+
+console.info('Generated all indices.');

--- a/packages/scripts/src/shared.ts
+++ b/packages/scripts/src/shared.ts
@@ -18,11 +18,11 @@ export const PACKAGES = [
 ];
 
 export async function fetchVersions(pkg: string) {
-	const response = await request(`https://docs.discordjs.dev/api/info?package=${pkg}`);
+	const response = await request(`https://discord.js.org/api/docs/versions?packageName=${pkg}`);
 	return response.body.json() as Promise<string[]>;
 }
 
 export async function fetchVersionDocs(pkg: string, version: string) {
-	const response = await request(`https://docs.discordjs.dev/docs/${pkg}/${version}.api.json`);
+	const response = await request(`https://r2-docs.discordjs.dev/${pkg}/${version}.json`);
 	return response.body.json();
 }


### PR DESCRIPTION
Nothing is utilising https://github.com/discordjs/docs any more. That repository is redundant. We can probably remove old.discordjs.dev too whilst we're at it.

Alongside this, I've removed the relevant code paths that committed to that repository and updated relevant code elsewhere.