### PR TITLE
fix: update pinnable getter for permission split on 2026-01-12

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -803,7 +803,9 @@ class Message extends Base {
       !this.system &&
         (!this.guild ||
           (channel?.viewable &&
-            channel?.permissionsFor(this.client.user)?.has(PermissionFlagsBits.ManageMessages, false))),
+            channel
+              ?.permissionsFor(this.client.user)
+              ?.has([PermissionFlagsBits.ReadMessageHistory, PermissionFlagsBits.ManageChannelMessages], false))),
     );
   }
 


### PR DESCRIPTION
This PR updates the `pinnable` getter in the `Message` class to prepare for Discord's permission split scheduled for January 12, 2026.

### Changes Made:
- Replaced `ManageMessages` permission check with `ManageChannelMessages` and `ReadMessageHistory` permissions
- Updated the permission validation logic in the `pinnable` getter to align with Discord's upcoming API changes

### Why this change is needed:
On January 12, 2026, Discord will fully split the `ManageMessages` permission. After this date, `ManageMessages` will no longer grant the ability to pin messages. Only the specific `ManageChannelMessages` permission (along with `ReadMessageHistory`) will allow users to pin messages in channels.

### Related Issue:
Addresses #11197

### Modified Files:
- `packages/discord.js/src/structures/Message.js` - Updated `pinnable` getter

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)