### PR TITLE
fix(GuildChannel): correctly handle empty permission overwrites

### DIFF
--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -131,12 +131,15 @@ class GuildChannel extends BaseChannel {
 
       // Handle empty overwrite
       if (
-        (!channelVal &&
+        ((!channelVal &&
           parentVal.deny.bitfield === PermissionsBitField.DefaultBit &&
-          parentVal.allow.bitfield === PermissionsBitField.DefaultBit) ||
-        (!parentVal &&
-          channelVal.deny.bitfield === PermissionsBitField.DefaultBit &&
-          channelVal.allow.bitfield === PermissionsBitField.DefaultBit)
+          parentVal.allow.bitfield === PermissionsBitField.DefaultBit &&
+          parentVal.id === this.guild.id) ||
+
+          (!parentVal &&
+            channelVal.deny.bitfield === PermissionsBitField.DefaultBit &&
+            channelVal.allow.bitfield === PermissionsBitField.DefaultBit &&
+            channelVal.id === this.guild.id))
       ) {
         return true;
       }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Previously, permissionsLocked returned true for any empty overwrite, causing
channels with empty user or role overwrites to appear locked. This change limits
the "locked" behavior to only the @everyone overwrite (id === guild.id), which
matches Discord's expected permission inheritance behavior.

Link to Issue: https://github.com/discordjs/discord.js/issues/11190

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
