### PR TITLE
fix(GuildMember): joinedAt possibly being NaN

### DIFF
--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -25,13 +25,6 @@ class GuildMember extends Base {
     this.guild = guild;
 
     /**
-     * The timestamp the member joined the guild at
-     *
-     * @type {?number}
-     */
-    this.joinedTimestamp = null;
-
-    /**
      * The last timestamp this member started boosting the guild
      *
      * @type {?number}
@@ -104,7 +97,17 @@ class GuildMember extends Base {
       this.banner ??= null;
     }
 
-    if ('joined_at' in data) this.joinedTimestamp = Date.parse(data.joined_at);
+    if ('joined_at' in data) {
+      /**
+       * The timestamp the member joined the guild at
+       *
+       * @type {?number}
+       */
+      this.joinedTimestamp = data.joined_at && Date.parse(data.joined_at);
+    } else {
+      this.joinedTimestamp ??= null;
+    }
+
     if ('premium_since' in data) {
       this.premiumSinceTimestamp = data.premium_since ? Date.parse(data.premium_since) : null;
     }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Fixes a case where if the API sends member data with `joined_at` being null, `Date.parse()` tries to parse that resulting in `joinedAt` and `joinedTimestsamp` being NaN.

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
