### PR TITLE
ci(dev): pin associated dev versions

### DIFF
--- a/packages/actions/src/releasePackages/generateReleaseTree.ts
+++ b/packages/actions/src/releasePackages/generateReleaseTree.ts
@@ -58,6 +58,13 @@ async function getReleaseEntries(dry: boolean, devTag?: string) {
 		};
 
 		if (devTag) {
+			// Replace workspace dependencies with * to pin to associated dev versions
+			const pkgJsonString = await file(`${pkg.path}/package.json`).text();
+			pkgJsonString.replaceAll(/workspace:[\^~]/g, 'workspace:*');
+			if (!dry) {
+				await write(`${pkg.path}/package.json`, pkgJsonString);
+			}
+
 			const devVersion = await fetchDevVersion(pkg.name, devTag);
 			if (devVersion?.endsWith(commitHash)) {
 				// Write the currently released dev version so when pnpm publish runs on dependents they depend on the dev versions


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Semver is kinda annoying for non-pinned versions of prereleases....so we pin

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
