### PR TITLE
fix: Mark external links as external

### DIFF
--- a/apps/guide/content/docs/legacy/meta.json
+++ b/apps/guide/content/docs/legacy/meta.json
@@ -2,7 +2,7 @@
 	"pages": [
 		"[MessageCircleQuestion][FAQ](/legacy/popular-topics/faq)",
 		"[ArrowDownToLine][Updating to v14](/legacy/additional-info/changes-in-v14)",
-		"[LibraryBig][Documentation](https://discord.js.org/docs)",
+		"external:[LibraryBig][Documentation](https://discord.js.org/docs)",
 		"[Info][Introduction](/legacy)",
 		"---Setup---",
 		"preparations",

--- a/apps/guide/content/docs/voice/meta.json
+++ b/apps/guide/content/docs/voice/meta.json
@@ -2,7 +2,7 @@
 	"title": "Voice",
 	"description": "Working with the voice library",
 	"pages": [
-		"[LibraryBig][Documentation](https://discord.js.org/docs/packages/voice/main)",
+		"external:[LibraryBig][Documentation](https://discord.js.org/docs/packages/voice/main)",
 		"---Working with Voice---",
 		"index",
 		"life-cycles",


### PR DESCRIPTION
This was preventing visiting voice documentation since it defaulted to the top, apparently. Marking external links as external per https://fumadocs.dev/docs/ui/page-conventions#pages seemed to fix this.