### PR TITLE
refactor(DJSError): Prefer `this.constructor.name`

### DIFF
--- a/packages/discord.js/src/errors/DJSError.js
+++ b/packages/discord.js/src/errors/DJSError.js
@@ -20,7 +20,7 @@ function makeDiscordjsError(Base) {
     }
 
     get name() {
-      return `${super.name} [${this.code}]`;
+      return `${this.constructor.name} [${this.code}]`;
     }
   };
 }


### PR DESCRIPTION
Errors look like this currently:

```
TypeError [InvalidType]: Supplied options is not an object.
    at Object.<anonymous>
// Stack...
```

Using `this.constructor.name` will result in this:

```
DiscordjsError [InvalidType]: Supplied options is not an object.
    at Object.<anonymous>
// Stack...
```

Seems more favourable!