### PR TITLE
fix(DJSError): Differentiate error type

### DIFF
--- a/packages/discord.js/src/errors/DJSError.js
+++ b/packages/discord.js/src/errors/DJSError.js
@@ -20,7 +20,7 @@ function makeDiscordjsError(Base) {
     constructor(code, ...args) {
       super(message(code, args));
       this.code = code;
-      Error.captureStackTrace?.(this, this.constructor);
+      Error.captureStackTrace(this, this.constructor);
     }
 
     get name() {


### PR DESCRIPTION
Following from #11294, error types are differentiated (they all became `DiscordjsError`):

`throw new DiscordjsError(ErrorCodes.InvalidType, 'options', 'object', true);`:
```
DiscordjsError [InvalidType]: Supplied options is not an object.
    at Object.<anonymous> (/Users/jiralite/Documents/GitHub/discord.js/discord.js/packages/discord.js/src/managers/GuildBanManager.js:226:7)
    at Module._compile (node:internal/modules/cjs/loader:1760:14)
    at Object..js (node:internal/modules/cjs/loader:1893:10)
    at Module.load (node:internal/modules/cjs/loader:1480:32)
    at Module._load (node:internal/modules/cjs/loader:1299:12)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:244:24)
    at Module.require (node:internal/modules/cjs/loader:1503:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/Users/jiralite/Documents/GitHub/discord.js/discord.js/packages/discord.js/src/structures/Guild.js:10:29) {
  code: 'InvalidType'
}
```

`throw new DiscordjsTypeError(ErrorCodes.InvalidType, 'options', 'object', true);`:
```
DiscordjsTypeError [InvalidType]: Supplied options is not an object.
    at Object.<anonymous> (/Users/jiralite/Documents/GitHub/discord.js/discord.js/packages/discord.js/src/managers/GuildBanManager.js:226:7)
    at Module._compile (node:internal/modules/cjs/loader:1760:14)
    at Object..js (node:internal/modules/cjs/loader:1893:10)
    at Module.load (node:internal/modules/cjs/loader:1480:32)
    at Module._load (node:internal/modules/cjs/loader:1299:12)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:244:24)
    at Module.require (node:internal/modules/cjs/loader:1503:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/Users/jiralite/Documents/GitHub/discord.js/discord.js/packages/discord.js/src/structures/Guild.js:10:29) {
  code: 'InvalidType'
}
```