### PR TITLE
feat: add table formatting function for markdown tables

### DIFF
--- a/packages/formatters/__tests__/formatters.test.ts
+++ b/packages/formatters/__tests__/formatters.test.ts
@@ -31,6 +31,7 @@ import {
 	userMention,
 	email,
 	phoneNumber,
+	table,
 } from '../src/index.js';
 
 describe('Message formatters', () => {
@@ -397,6 +398,25 @@ describe('Message formatters', () => {
 
 		test('GIVEN Faces.Unflip THEN returns "┬─┬ノ( º _ ºノ)"', () => {
 			expect<'┬─┬ノ( º _ ºノ)'>(Faces.Unflip).toEqual('┬─┬ノ( º _ ºノ)');
+		});
+	});
+	describe('table', () => {
+		test('GIVEN a 2D array THEN returns a markdown table', () => {
+			const data = [
+				['Name', 'Age', 'City'],
+				['Alice', '30', 'New York'],
+				['Bob', '25', 'Los Angeles'],
+				['Charlie', '35', 'Chicago'],
+			];
+
+			const expectedTable =
+				'| Name    | Age | City        |\n' +
+				'|---------|-----|-------------|\n' +
+				'| Alice   | 30  | New York    |\n' +
+				'| Bob     | 25  | Los Angeles |\n' +
+				'| Charlie | 35  | Chicago     |';
+
+			expect(table(data)).toEqual(expectedTable);
 		});
 	});
 });

--- a/packages/formatters/src/formatters.ts
+++ b/packages/formatters/src/formatters.ts
@@ -569,6 +569,63 @@ export function unorderedList(list: RecursiveArray<string>): string {
 }
 
 /**
+ * Options for formatting a table.
+ */
+export interface TableOptions {
+	/**
+	 * The columns to include in the table
+	 */
+	columns?: readonly string[];
+	/**
+	 * Whether to include a header row
+	 */
+	header?: boolean;
+}
+
+/**
+ * Formats an array of objects into a markdown table.
+ *
+ * @param data - The array of objects to format into a table
+ * @param options - The options for formatting the table
+ */
+export function table(data: readonly (readonly string[])[], options?: TableOptions): string {
+	if (data.length === 0) {
+		return '';
+	}
+
+	const { header = true, columns } = options ?? {};
+	const headers = columns ?? (data.length > 0 ? data[0] : undefined);
+
+	if (!headers || headers.length === 0) {
+		return '';
+	}
+
+	const rows = header && columns ? data : data.slice(header ? 1 : 0);
+
+	const widths = Array.from(headers).map((headerCell, columnIndex) => {
+		let maxWidth = headerCell.length;
+		for (const row of rows) {
+			const cell = row[columnIndex];
+			if (cell) {
+				maxWidth = Math.max(maxWidth, cell.length);
+			}
+		}
+
+		return maxWidth;
+	});
+
+	const headerRow = `| ${Array.from(headers)
+		.map((headerCell, columnIndex) => headerCell.padEnd(widths[columnIndex] ?? 0))
+		.join(' | ')} |`;
+	const separatorRow = `|${widths.map((width) => '-'.repeat(width + 2)).join('|')}|`;
+	const dataRows = rows.map(
+		(row) => `| ${row.map((cell, columnIndex) => (cell ?? '').padEnd(widths[columnIndex] ?? 0)).join(' | ')} |`,
+	);
+
+	return [headerRow, separatorRow, ...dataRows].join('\n');
+}
+
+/**
  * Formats the content into a subtext.
  *
  * @typeParam Content - This is inferred by the supplied content


### PR DESCRIPTION
## Description
I've added a new formatter function called `table` in the @discordjs/formatter package for easily generating markdown tables compatible with Discord messages.

## Changes

 - Added `table()` function to format 2D arrays into properly aligned markdown tables
 - Added `TableOptions` interface with configuration options:
  - `columns`: Optional array to specify custom column headers
  - `header`: Optional boolean to control header row display (defaults to true)
- Function automatically calculates column widths for optimal alignment
- Handles empty cells gracefully with nullish coalescing

## Testing
- Unit tests added covering basic table generation
- No Typescript errors

## Usage Example
```typescript
const data = [
  ['Name', 'Age', 'City'],
  ['Alice', '25', 'NYC'],
  ['Bob', '30', 'LA'],
];

console.log(table(data));
// | Name  | Age | City |
// |-------|-----|------|
// | Alice | 25  | NYC  |
// | Bob   | 30  | LA   |


