### PR TITLE
fix(voice): handle negative timeouts

### DIFF
--- a/packages/voice/src/DataStore.ts
+++ b/packages/voice/src/DataStore.ts
@@ -136,7 +136,7 @@ function prepareNextAudioFrame(players: AudioPlayer[]) {
 
 	if (!nextPlayer) {
 		if (nextTime !== -1) {
-			audioCycleInterval = setTimeout(() => audioCycleStep(), nextTime - Date.now());
+			audioCycleInterval = setTimeout(() => audioCycleStep(), Math.max(1, nextTime - Date.now()));
 		}
 
 		return;


### PR DESCRIPTION
I was getting random `TimeoutNegativeWarning` when running my bot with Node 24+ 
through `--trace-warnings` i was able to get the following stack trace

```
(node:38864) TimeoutNegativeWarning: -2 is a negative number.
Timeout duration was set to 1.
    at new Timeout (node:internal/timers:194:17)
    at setTimeout (node:timers:117:19)
    at prepareNextAudioFrame (/Users/amaterasu/projects/discord-soundbot/node_modules/@discordjs/voice/dist/index.js:137:28)
    at Immediate.<anonymous> (/Users/amaterasu/projects/discord-soundbot/node_modules/@discordjs/voice/dist/index.js:142:22)
    at process.processImmediate (node:internal/timers:504:21)
```

## scope

explicitly handle negative timeouts during `prepareNextAudioFrame`

if there is a different underlying issue, let me know so i can adjust as needed 🙏 