### PR TITLE
fix(discord.js): make FileUploadModalData.attachments optional

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2562,7 +2562,7 @@ export interface SelectMenuModalData<Cached extends CacheType = CacheType> exten
 }
 
 export interface FileUploadModalData extends BaseModalData<ComponentType.FileUpload> {
-  attachments: ReadonlyCollection<Snowflake, Attachment>;
+  attachments?: ReadonlyCollection<Snowflake, Attachment>;
   customId: string;
   values: readonly Snowflake[];
 }

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -100,6 +100,7 @@ import type {
   FetchedThreadsMore,
   FetchPinnedMessagesResponse,
   FileComponentData,
+  FileUploadModalData,
   ForumChannel,
   Guild,
   GuildApplicationCommandManager,
@@ -3044,3 +3045,7 @@ await textChannel.send({
   ],
   flags: MessageFlags.IsVoiceMessage,
 });
+
+// FileUploadModalData.attachments should be optional (issue #11359)
+declare const fileUploadModalData: FileUploadModalData;
+expectType<ReadonlyCollection<Snowflake, Attachment> | undefined>(fileUploadModalData.attachments);


### PR DESCRIPTION
## Summary

- Makes the `attachments` property optional in `FileUploadModalData` interface
- Aligns TypeScript types with runtime behavior where attachments may be undefined
- Adds type test to verify the optional property behavior

## Issue

Fixes #11359

## Test Plan

- [x] Added type test in `typings/index.test-d.ts` to verify `attachments` can be undefined
- [x] All existing tests pass (`pnpm run test --filter=discord.js`)
- [x] Type definitions are valid (tsd passes)

## Changes

- `packages/discord.js/typings/index.d.ts`: Changed `attachments` from required to optional in `FileUploadModalData`
- `packages/discord.js/typings/index.test-d.ts`: Added type assertion test for optional attachments