### PR TITLE
fix: broken link on sharding page

### DIFF
--- a/apps/guide/content/docs/legacy/sharding/index.mdx
+++ b/apps/guide/content/docs/legacy/sharding/index.mdx
@@ -50,7 +50,7 @@ The above code utilizes the discord.js sharding manager to spawn the recommended
 <Callout>
 	You can find the methods available for the ShardingManager class `ShardingManager`. Though, you may not be making much
 	use of this section, unlike the next feature we will explore, which you may learn about by clicking [this
-	link](./additional-information).
+	link](./sharding/additional-information).
 </Callout>
 
 ## Getting started


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Found a broken link on [this page](https://discordjs.guide/legacy/sharding).