### PR TITLE
fix(GuildBanManager): remove ban from cache in remove method

### DIFF
--- a/packages/discord.js/src/managers/GuildBanManager.js
+++ b/packages/discord.js/src/managers/GuildBanManager.js
@@ -178,6 +178,7 @@ class GuildBanManager extends CachedManager {
     const id = this.client.users.resolveId(user);
     if (!id) throw new DiscordjsError(ErrorCodes.BanResolveId);
     await this.client.rest.delete(Routes.guildBan(this.guild.id, id), { reason });
+    this.cache.delete(id);
   }
 
   /**


### PR DESCRIPTION
When calling remove() or unban(), the ban is not removed from cache. Cache cleanup only happens via GUILD_BAN_REMOVE gateway event which requires GuildModeration intent, causing stale cache data.  This fix adds cache. delete() after the successful REST call, consistent with other managers like RoleManager.delete().