### PR TITLE
types(CommandInteractionOptionResolver): getChannels type fix

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1190,7 +1190,9 @@ export class CommandInteractionOptionResolver<Cached extends CacheType = CacheTy
    * The `type` property of the {@link PublicThreadChannel} interface is typed as `ChannelType.PublicThread | ChannelType.AnnouncementThread`.
    * If the user were to pass only one of those channel types, the `Extract<>` would resolve to `never`.
    */
-  public getChannel<const Type extends ChannelType = ChannelType>(
+  public getChannel<
+    const Type extends ApplicationCommandOptionAllowedChannelType = ApplicationCommandOptionAllowedChannelType,
+  >(
     name: string,
     required: true,
     channelTypes?: readonly Type[],
@@ -1208,7 +1210,9 @@ export class CommandInteractionOptionResolver<Cached extends CacheType = CacheTy
    * The `type` property of the {@link PublicThreadChannel} interface is typed as `ChannelType.PublicThread | ChannelType.AnnouncementThread`.
    * If the user were to pass only one of those channel types, the `Extract<>` would resolve to `never`.
    */
-  public getChannel<const Type extends ChannelType = ChannelType>(
+  public getChannel<
+    const Type extends ApplicationCommandOptionAllowedChannelType = ApplicationCommandOptionAllowedChannelType,
+  >(
     name: string,
     required?: boolean,
     channelTypes?: readonly Type[],


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
getChannels can't return channel types that not in allowed

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->

<sub>Why no description template?..</sub>