### PR TITLE
fix(GuildMemberManager): handle potential null user ID in member resolution

### DIFF
--- a/packages/discord.js/src/managers/GuildMemberManager.js
+++ b/packages/discord.js/src/managers/GuildMemberManager.js
@@ -402,7 +402,7 @@ class GuildMemberManager extends CachedManager {
 
     let endpoint;
 
-    if (id === this.client.user.id) {
+    if (id === this.client.user?.id) {
       const keys = Object.keys(options);
 
       if (keys.length === 1 && keys[0] === 'nick') {


### PR DESCRIPTION
I encountered an error when trying to add multiple roles to a guild member. The issue comes from `client.user` being null. The code runs smoothly after adding a null check for the user object.

I’ve reported the issue here: #11382