### PR TITLE
feat(structures): add SoundboardSound structure

### DIFF
--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -6,6 +6,7 @@ export * from './interactions/index.js';
 export * from './invites/index.js';
 export * from './messages/index.js';
 export * from './polls/index.js';
+export * from './soundboards/index.js';
 export * from './stickers/index.js';
 export * from './users/index.js';
 export * from './Structure.js';

--- a/packages/structures/src/soundboards/SoundboardSound.ts
+++ b/packages/structures/src/soundboards/SoundboardSound.ts
@@ -20,7 +20,7 @@ export class SoundboardSound<Omitted extends keyof APISoundboardSound | '' = ''>
 	public static override readonly DataTemplate: Partial<APISoundboardSound> = {};
 
 	/**
-	 * @param data - The raw data received from the API for the emoji
+	 * @param data - The raw data received from the API for the soundboard sound
 	 */
 	public constructor(data: Partialize<APISoundboardSound, Omitted>) {
 		super(data);

--- a/packages/structures/src/soundboards/SoundboardSound.ts
+++ b/packages/structures/src/soundboards/SoundboardSound.ts
@@ -78,6 +78,8 @@ export class SoundboardSound<Omitted extends keyof APISoundboardSound | '' = ''>
 
 	/**
 	 * The timestamp this sound was created at
+	 *
+	 * @remarks only available for guild soundboard sounds
 	 */
 	public get createdTimestamp() {
 		return isIdSet(this[kData].sound_id) && isIdSet(this[kData].guild_id)
@@ -87,6 +89,8 @@ export class SoundboardSound<Omitted extends keyof APISoundboardSound | '' = ''>
 
 	/**
 	 * The time this sound was created at
+	 *
+	 * @remarks only available for guild soundboard sounds
 	 */
 	public get createdAt() {
 		const createdTimestamp = this.createdTimestamp;

--- a/packages/structures/src/soundboards/SoundboardSound.ts
+++ b/packages/structures/src/soundboards/SoundboardSound.ts
@@ -79,10 +79,9 @@ export class SoundboardSound<Omitted extends keyof APISoundboardSound | '' = ''>
 	 * The timestamp this sound was created at
 	 */
 	public get createdTimestamp() {
-		const id = this[kData].sound_id;
 		const inGuild = this[kData].guild_id && typeof this[kData].guild_id === 'string';
 
-		return inGuild ? DiscordSnowflake.timestampFrom(id as string) : null;
+		return inGuild ? DiscordSnowflake.timestampFrom(this[kData].sound_id as string) : null;
 	}
 
 	/**

--- a/packages/structures/src/soundboards/SoundboardSound.ts
+++ b/packages/structures/src/soundboards/SoundboardSound.ts
@@ -1,0 +1,96 @@
+import { DiscordSnowflake } from '@sapphire/snowflake';
+import type { APISoundboardSound } from 'discord-api-types/v10';
+import { Structure } from '../Structure';
+import { kData } from '../utils/symbols';
+import type { Partialize } from '../utils/types';
+
+/**
+ * Represents any soundboard sound on Discord.
+ *
+ * @typeParam Omitted - Specify the properties that will not be stored in the raw data field as a union, implement via `DataTemplate`
+ * @remarks has substructure `User` which needs to be instantiated and stored by an extending class using it
+ */
+export class SoundboardSound<Omitted extends keyof APISoundboardSound | '' = ''> extends Structure<
+	APISoundboardSound,
+	Omitted
+> {
+	/**
+	 * The template used for removing data from the raw data stored for each soundboard sound.
+	 */
+	public static override readonly DataTemplate: Partial<APISoundboardSound> = {};
+
+	/**
+	 * @param data - The raw data received from the API for the emoji
+	 */
+	public constructor(data: Partialize<APISoundboardSound, Omitted>) {
+		super(data);
+	}
+
+	/**
+	 * The name of this sound
+	 */
+	public get name() {
+		return this[kData].name;
+	}
+
+	/**
+	 * The id of this sound
+	 */
+	public get soundId() {
+		return this[kData].sound_id;
+	}
+
+	/**
+	 * The volume of this sound, from 0 to 1
+	 */
+	public get volume() {
+		return this[kData].volume;
+	}
+
+	/**
+	 * The id of this sound's custom emoji
+	 */
+	public get emojiId() {
+		return this[kData].emoji_id;
+	}
+
+	/**
+	 * The unicode character of this sound's standard emoji
+	 */
+	public get emojiName() {
+		return this[kData].emoji_name;
+	}
+
+	/**
+	 * The id of the guild this sound is in
+	 */
+	public get guildId() {
+		return this[kData].guild_id;
+	}
+
+	/**
+	 * Whether this sound can be used, may be false due to loss of server boosts
+	 */
+	public get available() {
+		return this[kData].available;
+	}
+
+	/**
+	 * The timestamp this sound was created at
+	 */
+	public get createdTimestamp() {
+		const id = this[kData].sound_id;
+		const inGuild = this[kData].guild_id && typeof this[kData].guild_id === 'string';
+
+		return inGuild ? DiscordSnowflake.timestampFrom(id as string) : null;
+	}
+
+	/**
+	 * The time this sound was created at
+	 */
+	public get createdAt() {
+		const timestamp = this.createdTimestamp;
+
+		return timestamp ? new Date(timestamp) : null;
+	}
+}

--- a/packages/structures/src/soundboards/SoundboardSound.ts
+++ b/packages/structures/src/soundboards/SoundboardSound.ts
@@ -2,6 +2,7 @@ import { DiscordSnowflake } from '@sapphire/snowflake';
 import type { APISoundboardSound } from 'discord-api-types/v10';
 import { Structure } from '../Structure';
 import { kData } from '../utils/symbols';
+import { isIdSet } from '../utils/type-guards';
 import type { Partialize } from '../utils/types';
 
 /**
@@ -79,17 +80,17 @@ export class SoundboardSound<Omitted extends keyof APISoundboardSound | '' = ''>
 	 * The timestamp this sound was created at
 	 */
 	public get createdTimestamp() {
-		const inGuild = this[kData].guild_id && typeof this[kData].guild_id === 'string';
-
-		return inGuild ? DiscordSnowflake.timestampFrom(this[kData].sound_id as string) : null;
+		return isIdSet(this[kData].sound_id) && isIdSet(this[kData].guild_id)
+			? DiscordSnowflake.timestampFrom(this[kData].sound_id)
+			: null;
 	}
 
 	/**
 	 * The time this sound was created at
 	 */
 	public get createdAt() {
-		const timestamp = this.createdTimestamp;
+		const createdTimestamp = this.createdTimestamp;
 
-		return timestamp ? new Date(timestamp) : null;
+		return createdTimestamp ? new Date(createdTimestamp) : null;
 	}
 }

--- a/packages/structures/src/soundboards/index.ts
+++ b/packages/structures/src/soundboards/index.ts
@@ -1,0 +1,1 @@
+export * from './SoundboardSound.js';


### PR DESCRIPTION
This PR will add the `SoundboardSound` API structure, as documented on the Discord API documentation [here](https://discord.com/developers/docs/resources/soundboard#soundboard-sound-object-soundboard-sound-structure).

This PR does not add tests for this structure.

Thanks to @edocsil47 for helping on how to determine if a guild id is present within the structure.

Mentioning #10981 for visibility.
