### PR TITLE
feat(structures): add Team structure

### DIFF
--- a/packages/structures/src/index.ts
+++ b/packages/structures/src/index.ts
@@ -7,6 +7,7 @@ export * from './invites/index.js';
 export * from './messages/index.js';
 export * from './polls/index.js';
 export * from './stickers/index.js';
+export * from './teams/index.js';
 export * from './users/index.js';
 export * from './Structure.js';
 export * from './Mixin.js';

--- a/packages/structures/src/teams/Team.ts
+++ b/packages/structures/src/teams/Team.ts
@@ -10,7 +10,6 @@ import type { Partialize } from '../utils/types.js';
  *
  * @typeParam Omitted - Specify the properties that will not be stored in the raw data field as a union, implement via `DataTemplate`
  * @remarks has substructure `TeamMember` which needs to be instantiated and stored by an extending class using it
- * @remarks intentionally does not export `ownerUserId` so that extending classes can resolve `Snowflake` to `User`
  */
 export class Team<Omitted extends keyof APITeam | '' = ''> extends Structure<APITeam, Omitted> {
 	/**
@@ -44,6 +43,13 @@ export class Team<Omitted extends keyof APITeam | '' = ''> extends Structure<API
 	 */
 	public get name() {
 		return this[kData].name;
+	}
+
+	/**
+	 * User ID of the current team owner
+	 */
+	public get ownerUserId() {
+		return this[kData].owner_user_id;
 	}
 
 	/**

--- a/packages/structures/src/teams/Team.ts
+++ b/packages/structures/src/teams/Team.ts
@@ -1,0 +1,63 @@
+import { DiscordSnowflake } from '@sapphire/snowflake';
+import type { APITeam } from 'discord-api-types/v10';
+import { Structure } from '../Structure.js';
+import { kData } from '../utils/symbols.js';
+import { isIdSet } from '../utils/type-guards.js';
+import type { Partialize } from '../utils/types.js';
+
+/**
+ * Represents any team on Discord.
+ *
+ * @typeParam Omitted - Specify the properties that will not be stored in the raw data field as a union, implement via `DataTemplate`
+ * @remarks has substructure `TeamMember` which needs to be instantiated and stored by an extending class using it
+ * @remarks intentionally does not export `ownerUserId` so that extending classes can resolve `Snowflake` to `User`
+ */
+export class Team<Omitted extends keyof APITeam | '' = ''> extends Structure<APITeam, Omitted> {
+	/**
+	 * The template used for removing data from the raw data stored for each team.
+	 */
+	public static override readonly DataTemplate: Partial<APITeam> = {};
+
+	/**
+	 * @param data - The raw data received from the API for the team.
+	 */
+	public constructor(data: Partialize<APITeam, Omitted>) {
+		super(data);
+	}
+
+	/**
+	 * Hash of the image of the team's icon
+	 */
+	public get icon() {
+		return this[kData].icon;
+	}
+
+	/**
+	 * The unique id of the team
+	 */
+	public get id() {
+		return this[kData].id;
+	}
+
+	/**
+	 * Name of the team
+	 */
+	public get name() {
+		return this[kData].name;
+	}
+
+	/**
+	 * The timestamp the team was created at
+	 */
+	public get createdTimestamp() {
+		return isIdSet(this.id) ? DiscordSnowflake.timestampFrom(this.id) : null;
+	}
+
+	/**
+	 * The time the team was created at
+	 */
+	public get createdAt() {
+		const createdTimestamp = this.createdTimestamp;
+		return createdTimestamp ? new Date(createdTimestamp) : null;
+	}
+}

--- a/packages/structures/src/teams/TeamMember.ts
+++ b/packages/structures/src/teams/TeamMember.ts
@@ -1,0 +1,43 @@
+import type { APITeamMember, TeamMemberMembershipState, TeamMemberRole } from 'discord-api-types/v10';
+import { Structure } from '../Structure.js';
+import { kData } from '../utils/symbols.js';
+import type { Partialize } from '../utils/types.js';
+
+/**
+ * Represents any team member on Discord.
+ *
+ * @typeParam Omitted - Specify the properties that will not be stored in the raw data field as a union, implement via `DataTemplate`
+ * @remarks has substructure `User` which needs to be instantiated and stored by an extending class using it
+ * @remarks intentionally does not export `teamId` so that extending classes can resolve `Snowflake` to `Team`
+ */
+export class TeamMember<Omitted extends keyof APITeamMember | '' = ''> extends Structure<APITeamMember, Omitted> {
+	/**
+	 * The template used for removing data from the raw data stored for each team member
+	 */
+	public static override readonly DataTemplate: Partial<APITeamMember> = {};
+
+	/**
+	 * @param data - The raw data received from the API for the team member
+	 */
+	public constructor(data: Partialize<APITeamMember, Omitted>) {
+		super(data);
+	}
+
+	/**
+	 * User's {@link https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum | membership state} on the team
+	 *
+	 * @see {@link TeamMemberMembershipState}
+	 */
+	public get membershipState() {
+		return this[kData].membership_state;
+	}
+
+	/**
+	 * {@link https://discord.com/developers/docs/topics/teams#team-member-roles-team-member-role-types | Role} of the team member
+	 *
+	 * @see {@link TeamMemberRole}
+	 */
+	public get role() {
+		return this[kData].role;
+	}
+}

--- a/packages/structures/src/teams/TeamMember.ts
+++ b/packages/structures/src/teams/TeamMember.ts
@@ -8,7 +8,6 @@ import type { Partialize } from '../utils/types.js';
  *
  * @typeParam Omitted - Specify the properties that will not be stored in the raw data field as a union, implement via `DataTemplate`
  * @remarks has substructure `User` which needs to be instantiated and stored by an extending class using it
- * @remarks intentionally does not export `teamId` so that extending classes can resolve `Snowflake` to `Team`
  */
 export class TeamMember<Omitted extends keyof APITeamMember | '' = ''> extends Structure<APITeamMember, Omitted> {
 	/**
@@ -30,6 +29,13 @@ export class TeamMember<Omitted extends keyof APITeamMember | '' = ''> extends S
 	 */
 	public get membershipState() {
 		return this[kData].membership_state;
+	}
+
+	/**
+	 * Id of the parent team of which they are a member
+	 */
+	public get teamId() {
+		return this[kData].team_id;
 	}
 
 	/**

--- a/packages/structures/src/teams/TeamMember.ts
+++ b/packages/structures/src/teams/TeamMember.ts
@@ -1,4 +1,4 @@
-import type { APITeamMember, TeamMemberMembershipState, TeamMemberRole } from 'discord-api-types/v10';
+import type { APITeamMember } from 'discord-api-types/v10';
 import { Structure } from '../Structure.js';
 import { kData } from '../utils/symbols.js';
 import type { Partialize } from '../utils/types.js';
@@ -23,9 +23,9 @@ export class TeamMember<Omitted extends keyof APITeamMember | '' = ''> extends S
 	}
 
 	/**
-	 * User's {@link https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum | membership state} on the team
+	 * User's membership state on the team
 	 *
-	 * @see {@link TeamMemberMembershipState}
+	 * @see {@link https://discord.com/developers/docs/topics/teams#data-models-membership-state-enum}
 	 */
 	public get membershipState() {
 		return this[kData].membership_state;
@@ -39,9 +39,9 @@ export class TeamMember<Omitted extends keyof APITeamMember | '' = ''> extends S
 	}
 
 	/**
-	 * {@link https://discord.com/developers/docs/topics/teams#team-member-roles-team-member-role-types | Role} of the team member
+	 * Role of the team member
 	 *
-	 * @see {@link TeamMemberRole}
+	 * @see {@link https://discord.com/developers/docs/topics/teams#team-member-roles-team-member-role-types}
 	 */
 	public get role() {
 		return this[kData].role;

--- a/packages/structures/src/teams/index.ts
+++ b/packages/structures/src/teams/index.ts
@@ -1,0 +1,2 @@
+export * from './Team.js';
+export * from './TeamMember.js';


### PR DESCRIPTION
This PR will add the `Team`s structure and `TeamMember`s substructure.

Mentioning #10981 for visibility.

Note: if #11393 is merged first, then the TODO comment re. Teams structure should be removed.



