### PR TITLE
types: broadcastEval overload order

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -3199,17 +3199,17 @@ export class ShardClientUtil {
   public mode: ShardingManagerMode;
   public parentPort: MessagePort | null;
   public broadcastEval<Result>(fn: (client: Client) => Awaitable<Result>): Promise<Serialized<Result>[]>;
-  public broadcastEval<Result>(
-    fn: (client: Client) => Awaitable<Result>,
-    options: { shard: number },
+  public broadcastEval<Result, Context>(
+    fn: (client: Client<true>, context: Serialized<Context>) => Awaitable<Result>,
+    options: { context: Context; shard: number },
   ): Promise<Serialized<Result>>;
   public broadcastEval<Result, Context>(
     fn: (client: Client<true>, context: Serialized<Context>) => Awaitable<Result>,
     options: { context: Context },
   ): Promise<Serialized<Result>[]>;
-  public broadcastEval<Result, Context>(
-    fn: (client: Client<true>, context: Serialized<Context>) => Awaitable<Result>,
-    options: { context: Context; shard: number },
+  public broadcastEval<Result>(
+    fn: (client: Client) => Awaitable<Result>,
+    options: { shard: number },
   ): Promise<Serialized<Result>>;
   public fetchClientValues(prop: string): Promise<unknown[]>;
   public fetchClientValues(prop: string, shard: number): Promise<unknown>;


### PR DESCRIPTION
The overloads of `ShardingManager#broadcastEval()` and `ShardClientUtil#broadcastEval()` were in the wrong order, causing usages of the form that passes `context` and `shard` being matched by the general version for no passed context causing `any` argument types of the passed function and return type.

https://www.typescriptlang.org/play/?ts=5.5.4#code/JYWwDg9gTgLgBAbzgYQDbAKYDsYBo4DKAFgIZQAmwWA5gLIlYnUZT4wCeYGcAggO4lgMEgCNUGNp24ApAgHkAcgFEsAYwjlR4yV0ItgJdAC8M5OAF84AMygQQcAOSUAzuooA6AFbOHAbgBQ-uQYqqhk3KEkzs4o0FAhMMRklDT0jMxQiP5wcGAArmLAqnAitiTkqlEwSgBuhgA8AEoYznmoMAB8ABRWWABccF2hmDgDaCMwAJRwALwdvAJCWhhNLW2dkwMACrYgwM4rBPqGwCbkq63tHQDaALodATn5hcWlEOWVztV1qBfr+MgIDgMAAPTpdbI5az9QbDbAwMboeH1GBQPIYDr4dTAsEDI5QAzGUz1QE4jazeb8QTCMQrZqXTq4SE5CBgGDAIHOAZIbEwUEI2Jk3xwZykCgDLB5EAiFgWJk5TZwHZ2faHY5E8709YdB6Q57oV5lCpVWoNLXtAFAvlg7rM6EDIZI0YoJ0wFFojFYq38vHq07E0nW8lzBbU5Z-K7yqGs9mc7lwXk+wVBuWQxXKvYHer4wn+zVrK53XVPAoGkpGz7fM0F8F23oOuHO8bw6YhqlLWkRxl2mMcrBcxAisXkCVSmWZcxR9O7VXZv1nLs6gLmQLBSLxBOc+AgBhMFh44dUOi7jIBNdhDfYr4JtJ7qBjOIJJIUI+30-+K-wEGzOAARgCH5bgmP47ukLDuG8Hwmj8XSOhM+AIGQ1DmK28yNjA7gYDU8IKCQIAtF0kwIaKyQDAADF6ZLckhAwguYKEBAA9IxUJwAAegA-IEn5wGYMw3ie4GQcaXymqgsHoQhSEoRSCauph2E4Lh+HOIRxHDuRlFBtRUDULR9GTExLFQpx3FAaov4gYJUAQRW0GGBJrpSbpMkhuhCk4XhBFEYgia4ogNFwHRDH+MxrGmYB-bwOQln8aob5CXZokwXB8LOchqFyRMHlKV5qk+QgfkCohun6SFYUmVxkXXqoABMVlgTZwmVmJjkTJl7lYZ5KlqYgJHinAZHlcZOQRTx5D1XFCVNUlVbialOAdfJXW5T1BX9SOg3DeFVU8aoADMDV3rZ7wiXNbUtrJnWKTAyneYZoUjexu1AeQh1TdZJ1QclDkLVMV3LTdd35Q9FWjVVQA