### PR TITLE
docs(builders): edited docs to correctly link to splice

### DIFF
--- a/packages/builders/src/components/selectMenu/StringSelectMenu.ts
+++ b/packages/builders/src/components/selectMenu/StringSelectMenu.ts
@@ -108,7 +108,7 @@ export class StringSelectMenuBuilder extends BaseSelectMenuBuilder<APIStringSele
 	 *
 	 * @remarks
 	 * This method behaves similarly
-	 * to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/slice | Array.prototype.splice()}.
+	 * to {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/splice | Array.prototype.splice()}.
 	 * It's useful for modifying and adjusting the order of existing options.
 	 * @example
 	 * Remove the first option:


### PR DESCRIPTION
StringSelectMenuBuilder.splice()'s docs incorrectly linked to slice instead of splice in MDN docs, fixed that