### PR TITLE
fix(structures): add missing `toJSON` method on Subscription structure

### DIFF
--- a/packages/structures/src/subscriptions/Subscription.ts
+++ b/packages/structures/src/subscriptions/Subscription.ts
@@ -1,6 +1,7 @@
 import { DiscordSnowflake } from '@sapphire/snowflake';
 import type { APISubscription, SubscriptionStatus } from 'discord-api-types/v10';
 import { Structure } from '../Structure.js';
+import { dateToDiscordISOTimestamp } from '../utils/optimization.js';
 import {
 	kData,
 	kCurrentPeriodStartTimestamp,
@@ -173,5 +174,30 @@ export class Subscription<
 	public get createdAt() {
 		const createdTimestamp = this.createdTimestamp;
 		return createdTimestamp ? new Date(createdTimestamp) : null;
+	}
+
+	/**
+	 * {@inheritDoc Structure.toJSON}
+	 */
+	public override toJSON() {
+		const clone = super.toJSON();
+
+		const currentPeriodStartTimestamp = this[kCurrentPeriodStartTimestamp];
+		const currentPeriodEndTimestamp = this[kCurrentPeriodEndTimestamp];
+		const canceledTimestamp = this[kCanceledTimestamp];
+
+		if (currentPeriodEndTimestamp) {
+			clone.current_period_end = dateToDiscordISOTimestamp(new Date(currentPeriodEndTimestamp));
+		}
+
+		if (currentPeriodStartTimestamp) {
+			clone.current_period_start = dateToDiscordISOTimestamp(new Date(currentPeriodStartTimestamp));
+		}
+
+		if (canceledTimestamp) {
+			clone.canceled_at = dateToDiscordISOTimestamp(new Date(canceledTimestamp));
+		}
+
+		return clone;
 	}
 }


### PR DESCRIPTION
When writing tests for #11407, it became apparent that I had forgotten to add the `toJSON` method for this structure when I initially wrote the structure. I have now added this method and it passes when running the tests that I have written for this (which will be merged in a following PR).

Apologies for having missed this the first time. 