### PR TITLE
feat!: make voice receivers return AudioPacket classes instead of just Audio

### DIFF
--- a/packages/voice/__mocks__/rtp.ts
+++ b/packages/voice/__mocks__/rtp.ts
@@ -1,8 +1,8 @@
 import { Buffer } from 'node:buffer';
 
 // The following constants are silence packets collected from various platforms because Discord did not previously send header extensions
-// The header extension (extra data in decrypted vs opusFrame) can be detected in the position of {encrypted.subarray(12,14)} if it is equal to 0xbe,0xde
-// The header extension length will then follow as an integer and can be removed from the decrypted data (see ../src/receive/VoiceReceiver.ts:parsePacket)
+// The header extension (extra data in decrypted vs opusFrame) is indicated by the X bit (4th bit of byte 0) in the RTP header
+// The header extension length follows the CSRC identifiers and can be removed from the decrypted data (see ../src/receive/VoiceReceiver.ts:parsePacket)
 
 export const RTP_PACKET_DESKTOP = {
 	ssrc: 341_124,
@@ -48,6 +48,7 @@ export const XCHACHA20_SAMPLE = {
 		133, 174, 108, 144, 251, 110,
 	]),
 
+	// First 8 bytes are Header Extension payload
 	decrypted: Buffer.from([
 		0x32, 0x64, 0xe6, 0x62, 0x10, 0xe3, 0x90, 0x02, 0x78, 0x07, 0xd6, 0x2f, 0x52, 0x23, 0x20, 0x9a, 0xab, 0x2c, 0xcc,
 		0x1c, 0x88, 0x8e, 0xcb, 0xd9, 0x4d, 0xe5, 0x33, 0x7a, 0x4b, 0x2b, 0xed, 0xa7, 0xaf, 0x5f, 0x8d, 0xb2, 0x59, 0x99,

--- a/packages/voice/src/receive/AudioReceiveStream.ts
+++ b/packages/voice/src/receive/AudioReceiveStream.ts
@@ -37,16 +37,21 @@ export interface AudioReceiveStreamOptions extends ReadableOptions {
 }
 
 /**
- * A Buffer containing encoded Opus packet data and key RTP Header metadata.
+ * An audio packet containing encoded Opus payload data and key RTP Header metadata.
  */
-export interface AudioPacket extends Buffer {
+export interface AudioPacket {
+	/**
+	 * The encoded Opus payload data.
+	 */
+	readonly payload: Buffer;
+
 	/**
 	 * The RTP sequence number of this packet (16-bit, wraps at 65535).
 	 */
 	readonly sequence: number;
 
 	/**
-	 * The synchronization source identifier for this packet (32-bit).
+	 * The RTP synchronization source identifier for this packet (32-bit).
 	 * A change in SSRC indicates a new RTP stream, so any associated
 	 * decoder should be reset.
 	 */
@@ -89,22 +94,22 @@ export class AudioReceiveStream extends Readable {
 		this.end = end;
 	}
 
-	public override push(buffer: Buffer | null) {
+	public override push(packet: AudioPacket | null) {
 		if (
-			buffer &&
+			packet &&
 			(this.end.behavior === EndBehaviorType.AfterInactivity ||
 				(this.end.behavior === EndBehaviorType.AfterSilence &&
-					(buffer.compare(SILENCE_FRAME) !== 0 || this.endTimeout === undefined)))
+					(packet.payload.compare(SILENCE_FRAME) !== 0 || this.endTimeout === undefined)))
 		) {
 			this.renewEndTimeout(this.end);
 		}
 
-		if (buffer === null) {
+		if (packet === null) {
 			// null marks EOF for stream
 			process.nextTick(() => this.destroy());
 		}
 
-		return super.push(buffer);
+		return super.push(packet);
 	}
 
 	private renewEndTimeout(end: EndBehavior & { duration: number }) {

--- a/packages/voice/src/receive/AudioReceiveStream.ts
+++ b/packages/voice/src/receive/AudioReceiveStream.ts
@@ -37,7 +37,7 @@ export interface AudioReceiveStreamOptions extends ReadableOptions {
 }
 
 /**
- * A Buffer containing a decoded Opus packet with RTP header metadata.
+ * A Buffer containing encoded Opus packet data and key RTP Header metadata.
  */
 export interface AudioPacket extends Buffer {
 	/**
@@ -46,16 +46,16 @@ export interface AudioPacket extends Buffer {
 	readonly sequence: number;
 
 	/**
+	 * The synchronization source identifier for this packet (32-bit).
+	 * A change in SSRC indicates a new RTP stream, so any associated
+	 * decoder should be reset.
+	 */
+	readonly ssrc: number;
+
+	/**
 	 * The RTP timestamp of this packet (32-bit, wraps at 2^32 - 1).
 	 */
 	readonly timestamp: number;
-
-	/**
-	 * The synchronization source identifier for this packet (32-bit).
-	 * A change in SSRC indicates a new RTP stream, and any stateful
-	 * codec (e.g. Opus) decoder should be reset.
-	 */
-	readonly ssrc: number;
 }
 
 export function createDefaultAudioReceiveStreamOptions(): AudioReceiveStreamOptions {

--- a/packages/voice/src/receive/AudioReceiveStream.ts
+++ b/packages/voice/src/receive/AudioReceiveStream.ts
@@ -36,6 +36,28 @@ export interface AudioReceiveStreamOptions extends ReadableOptions {
 	end: EndBehavior;
 }
 
+/**
+ * A Buffer containing a decoded Opus packet with RTP header metadata.
+ */
+export interface AudioPacket extends Buffer {
+	/**
+	 * The RTP sequence number of this packet (16-bit, wraps at 65535).
+	 */
+	readonly sequence: number;
+
+	/**
+	 * The RTP timestamp of this packet (32-bit, wraps at 2^32 - 1).
+	 */
+	readonly timestamp: number;
+
+	/**
+	 * The synchronization source identifier for this packet (32-bit).
+	 * A change in SSRC indicates a new RTP stream, and any stateful
+	 * codec (e.g. Opus) decoder should be reset.
+	 */
+	readonly ssrc: number;
+}
+
 export function createDefaultAudioReceiveStreamOptions(): AudioReceiveStreamOptions {
 	return {
 		end: {

--- a/packages/voice/src/receive/AudioReceiveStream.ts
+++ b/packages/voice/src/receive/AudioReceiveStream.ts
@@ -39,28 +39,44 @@ export interface AudioReceiveStreamOptions extends ReadableOptions {
 /**
  * An audio packet containing encoded Opus payload data and key RTP Header metadata.
  */
-export interface AudioPacket {
+export class AudioPacket {
 	/**
-	 * The encoded Opus payload data.
+	 * Encoded Opus payload data.
 	 */
-	readonly payload: Buffer;
+	public readonly payload: Buffer;
 
 	/**
-	 * The RTP sequence number of this packet (16-bit, wraps at 65535).
+	 * RTP sequence number of this packet (16-bit, wraps at 65535).
 	 */
-	readonly sequence: number;
+	public readonly sequence: number;
 
 	/**
-	 * The RTP synchronization source identifier for this packet (32-bit).
+	 * RTP synchronization source identifier for this packet (32-bit).
 	 * A change in SSRC indicates a new RTP stream, so any associated
 	 * decoder should be reset.
 	 */
-	readonly ssrc: number;
+	public readonly ssrc: number;
 
 	/**
-	 * The RTP timestamp of this packet (32-bit, wraps at 2^32 - 1).
+	 * RTP timestamp of this packet (32-bit, wraps at 2^32 - 1, 48kHz clock).
 	 */
-	readonly timestamp: number;
+	public readonly timestamp: number;
+
+	/**
+	 * Construct a new AudioPacket.
+	 * **This is not a stable public API.**
+	 *
+	 * @param payload - Opus payload
+	 * @param sequence - RTP Sequence Number
+	 * @param timestamp - RTP Timestamp
+	 * @param ssrc - RTP Synchronization Source Identifier
+	 */
+	public constructor(payload: Buffer, sequence: number, timestamp: number, ssrc: number) {
+		this.payload = payload;
+		this.sequence = sequence;
+		this.timestamp = timestamp;
+		this.ssrc = ssrc;
+	}
 }
 
 export function createDefaultAudioReceiveStreamOptions(): AudioReceiveStreamOptions {

--- a/packages/voice/src/receive/AudioReceiveStream.ts
+++ b/packages/voice/src/receive/AudioReceiveStream.ts
@@ -64,7 +64,6 @@ export class AudioPacket {
 
 	/**
 	 * Construct a new AudioPacket.
-	 * **This is not a stable public API.**
 	 *
 	 * @param payload - Opus payload
 	 * @param sequence - RTP Sequence Number

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -169,28 +169,10 @@ export class VoiceReceiver {
 
 		// Extend packet with RTP header information
 		if (packet) {
-			return VoiceReceiver.addPacketHeaders(packet, sequence, timestamp, ssrc);
+			return addPacketHeaders(packet, sequence, timestamp, ssrc);
 		} else {
 			return null;
 		}
-	}
-
-	/**
-	 * Extends the Buffer for Opus audio data with RTP Header information
-	 *
-	 * @param buffer - the opus packet data to extend
-	 * @param sequence - the sequence number of the packet
-	 * @param timestamp see definition in
-	 * @param ssrc x
-	 * @returns the input buffer, with RTP header information added
-	 */
-	private static addPacketHeaders(buffer: Buffer, sequence: number, timestamp: number, ssrc: number): AudioPacket {
-		Object.defineProperties(buffer, {
-			sequence: { value: sequence, writable: false, enumerable: false, configurable: false },
-			timestamp: { value: timestamp, writable: false, enumerable: false, configurable: false },
-			ssrc: { value: ssrc, writable: false, enumerable: false, configurable: false },
-		});
-		return buffer as AudioPacket;
 	}
 
 	/**
@@ -247,4 +229,22 @@ export class VoiceReceiver {
 		this.subscriptions.set(userId, stream);
 		return stream;
 	}
+}
+
+/**
+ * Extends the Buffer for Opus audio data with RTP Header information
+ *
+ * @param buffer - the opus packet data to extend
+ * @param sequence - NTP Header sequence value for the packet
+ * @param timestamp - NTP Header timestamp value for the packet
+ * @param ssrc - NTP Header synchronization source identifier (SSRC) for the packet
+ * @returns the input buffer, with RTP header information added
+ */
+function addPacketHeaders(buffer: Buffer, sequence: number, timestamp: number, ssrc: number): AudioPacket {
+	Object.defineProperties(buffer, {
+		sequence: { value: sequence, writable: false, enumerable: false, configurable: false },
+		timestamp: { value: timestamp, writable: false, enumerable: false, configurable: false },
+		ssrc: { value: ssrc, writable: false, enumerable: false, configurable: false },
+	});
+	return buffer as AudioPacket;
 }

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -135,7 +135,14 @@ export class VoiceReceiver {
 	 * @param ssrc - already-parsed SSRC (Synchronization Source Identifier) from the RTP Header
 	 * @returns The parsed Opus packet
 	 */
-	private parsePacket(buffer: Buffer, mode: string, nonce: Buffer, secretKey: Uint8Array, userId: string, ssrc: number) {
+	private parsePacket(
+		buffer: Buffer,
+		mode: string,
+		nonce: Buffer,
+		secretKey: Uint8Array,
+		userId: string,
+		ssrc: number,
+	) {
 		// Parse key RTP Header fields
 		const sequence = buffer.readUInt16BE(2);
 		const timestamp = buffer.readUInt32BE(4);
@@ -208,8 +215,8 @@ export class VoiceReceiver {
 					this.connectionData.nonceBuffer,
 					this.connectionData.secretKey,
 					userData.userId,
-					ssrc
-			);
+					ssrc,
+				);
 				if (packet) stream.push(packet);
 			} catch (error) {
 				stream.destroy(error as Error);

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -168,7 +168,11 @@ export class VoiceReceiver {
 		}
 
 		// Extend packet with RTP header information
-		return VoiceReceiver.addPacketHeaders(packet, sequence, timestamp, ssrc);
+		if (packet) {
+			return VoiceReceiver.addPacketHeaders(packet, sequence, timestamp, ssrc);
+		} else {
+			return null;
+		}
 	}
 
 	/**

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -178,8 +178,8 @@ export class VoiceReceiver {
 	/**
 	 * Extends the Buffer for Opus audio data with RTP Header information
 	 *
-	 * @param buffer the opus packet data to extend
-	 * @param sequence the sequence number of the packet
+	 * @param buffer - the opus packet data to extend
+	 * @param sequence - the sequence number of the packet
 	 * @param timestamp see definition in
 	 * @param ssrc x
 	 * @returns the input buffer, with RTP header information added

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -10,7 +10,7 @@ import { methods } from '../util/Secretbox';
 import {
 	AudioReceiveStream,
 	createDefaultAudioReceiveStreamOptions,
-	type AudioPacket,
+	AudioPacket,
 	type AudioReceiveStreamOptions,
 } from './AudioReceiveStream';
 import { SSRCMap } from './SSRCMap';
@@ -186,7 +186,7 @@ export class VoiceReceiver {
 		}
 
 		// Construct AudioPacket with Opus payload and RTP header information
-		return { payload, sequence, timestamp, ssrc };
+		return new AudioPacket(payload, sequence, timestamp, ssrc);
 	}
 
 	/**

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -11,6 +11,7 @@ import { RTP_OPUS_PAYLOAD_TYPE } from '../util/constants';
 import {
 	AudioReceiveStream,
 	createDefaultAudioReceiveStreamOptions,
+	type AudioPacket,
 	type AudioReceiveStreamOptions,
 } from './AudioReceiveStream';
 import { SSRCMap } from './SSRCMap';
@@ -19,6 +20,15 @@ import { SpeakingMap } from './SpeakingMap';
 const HEADER_EXTENSION_BYTE = Buffer.from([0xbe, 0xde]);
 const UNPADDED_NONCE_LENGTH = 4;
 const AUTH_TAG_LENGTH = 16;
+
+function createAudioPacket(buffer: Buffer, sequence: number, timestamp: number, ssrc: number): AudioPacket {
+	Object.defineProperties(buffer, {
+		sequence: { value: sequence, writable: false, enumerable: false, configurable: false },
+		timestamp: { value: timestamp, writable: false, enumerable: false, configurable: false },
+		ssrc: { value: ssrc, writable: false, enumerable: false, configurable: false },
+	});
+	return buffer as AudioPacket;
+}
 
 /**
  * Attaches to a VoiceConnection, allowing you to receive audio packets from other
@@ -175,6 +185,8 @@ export class VoiceReceiver {
 	 */
 	public onUdpMessage(msg: Buffer) {
 		if (msg.length <= 8) return;
+		const sequence = msg.readUInt16BE(2);
+		const timestamp = msg.readUInt32BE(4);
 		const ssrc = msg.readUInt32BE(8);
 
 		const userData = this.ssrcMap.get(ssrc);
@@ -201,7 +213,7 @@ export class VoiceReceiver {
 					this.connectionData.secretKey,
 					userData.userId,
 				);
-				if (packet) stream.push(packet);
+				if (packet) stream.push(createAudioPacket(packet, sequence, timestamp, ssrc));
 			} catch (error) {
 				stream.destroy(error as Error);
 			}

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -136,7 +136,14 @@ export class VoiceReceiver {
 	 * @param ssrc - already-parsed SSRC (Synchronization Source Identifier) from the RTP Header
 	 * @returns The parsed Opus packet
 	 */
-	private parsePacket(buffer: Buffer, mode: string, nonce: Buffer, secretKey: Uint8Array, userId: string, ssrc: number) {
+	private parsePacket(
+		buffer: Buffer,
+		mode: string,
+		nonce: Buffer,
+		secretKey: Uint8Array,
+		userId: string,
+		ssrc: number,
+	) {
 		// Parse key RTP Header fields
 		const sequence = buffer.readUInt16BE(2);
 		const timestamp = buffer.readUInt32BE(4);
@@ -225,8 +232,8 @@ export class VoiceReceiver {
 					this.connectionData.nonceBuffer,
 					this.connectionData.secretKey,
 					userData.userId,
-					ssrc
-			);
+					ssrc,
+				);
 				if (packet) stream.push(packet);
 			} catch (error) {
 				stream.destroy(error as Error);

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -139,9 +139,16 @@ export class VoiceReceiver {
 	 * @param secretKey - The secret key used by the connection for encryption
 	 * @param userId - The user id that sent the packet
 	 * @param ssrc - already-parsed SSRC (Synchronization Source Identifier) from the RTP Header
-	 * @returns The parsed Opus packet
+	 * @returns Decrypted Opus payload and RTP header information, or null if DAVE decrypt failed in a way that should be ignored
 	 */
-	private parsePacket(rtp: Buffer, mode: string, nonce: Buffer, secretKey: Uint8Array, userId: string, ssrc: number) {
+	private parsePacket(
+		rtp: Buffer,
+		mode: string,
+		nonce: Buffer,
+		secretKey: Uint8Array,
+		userId: string,
+		ssrc: number,
+	): AudioPacket | null {
 		// Parse key RTP Header fields
 		const first = rtp.readUint8();
 		const hasHeaderExtension = Boolean((first >> 4) & 0x01); // X field
@@ -181,15 +188,15 @@ export class VoiceReceiver {
 				this.voiceConnection.state.networking.state.code === NetworkingStatusCode.Resuming)
 		) {
 			const daveSession = this.voiceConnection.state.networking.state.dave;
-			if (daveSession) payload = daveSession.decrypt(payload, userId)!;
+			if (daveSession) {
+				payload = daveSession.decrypt(payload, userId)!;
+
+				if (!payload) return null; // decryption failed but should be ignored
+			}
 		}
 
-		// Return Opus packet data Buffer, enriched with RTP header information
-		if (payload) {
-			return addPacketHeaders(payload, sequence, timestamp, ssrc);
-		} else {
-			return null;
-		}
+		// Construct AudioPacket with Opus payload and RTP header information
+		return { payload, sequence, timestamp, ssrc };
 	}
 
 	/**
@@ -253,22 +260,4 @@ export class VoiceReceiver {
 		this.subscriptions.set(userId, stream);
 		return stream;
 	}
-}
-
-/**
- * Extends the Buffer for Opus audio data with RTP Header information
- *
- * @param buffer - the opus packet data to extend
- * @param sequence - RTP Header sequence value for the packet
- * @param timestamp - RTP Header timestamp value for the packet
- * @param ssrc - RTP Header synchronization source identifier (SSRC) for the packet
- * @returns the input buffer, with RTP header information added
- */
-function addPacketHeaders(buffer: Buffer, sequence: number, timestamp: number, ssrc: number): AudioPacket {
-	Object.defineProperties(buffer, {
-		sequence: { value: sequence, writable: false, enumerable: false, configurable: false },
-		timestamp: { value: timestamp, writable: false, enumerable: false, configurable: false },
-		ssrc: { value: ssrc, writable: false, enumerable: false, configurable: false },
-	});
-	return buffer as AudioPacket;
 }

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -188,8 +188,8 @@ export class VoiceReceiver {
 	/**
 	 * Extends the Buffer for Opus audio data with RTP Header information
 	 *
-	 * @param buffer the opus packet data to extend
-	 * @param sequence the sequence number of the packet
+	 * @param buffer - the opus packet data to extend
+	 * @param sequence - the sequence number of the packet
 	 * @param timestamp see definition in
 	 * @param ssrc x
 	 * @returns the input buffer, with RTP header information added

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -21,15 +21,6 @@ const HEADER_EXTENSION_BYTE = Buffer.from([0xbe, 0xde]);
 const UNPADDED_NONCE_LENGTH = 4;
 const AUTH_TAG_LENGTH = 16;
 
-function createAudioPacket(buffer: Buffer, sequence: number, timestamp: number, ssrc: number): AudioPacket {
-	Object.defineProperties(buffer, {
-		sequence: { value: sequence, writable: false, enumerable: false, configurable: false },
-		timestamp: { value: timestamp, writable: false, enumerable: false, configurable: false },
-		ssrc: { value: ssrc, writable: false, enumerable: false, configurable: false },
-	});
-	return buffer as AudioPacket;
-}
-
 /**
  * Attaches to a VoiceConnection, allowing you to receive audio packets from other
  * users that are speaking.
@@ -142,9 +133,14 @@ export class VoiceReceiver {
 	 * @param nonce - The nonce buffer used by the connection for encryption
 	 * @param secretKey - The secret key used by the connection for encryption
 	 * @param userId - The user id that sent the packet
+	 * @param ssrc - already-parsed SSRC (Synchronization Source Identifier) from the RTP Header
 	 * @returns The parsed Opus packet
 	 */
-	private parsePacket(buffer: Buffer, mode: string, nonce: Buffer, secretKey: Uint8Array, userId: string) {
+	private parsePacket(buffer: Buffer, mode: string, nonce: Buffer, secretKey: Uint8Array, userId: string, ssrc: number) {
+		// Parse key RTP Header fields
+		const sequence = buffer.readUInt16BE(2);
+		const timestamp = buffer.readUInt32BE(4);
+
 		let packet: Buffer = this.decrypt(buffer, mode, nonce, secretKey);
 		if (!packet) throw new Error('Failed to parse packet');
 
@@ -174,7 +170,26 @@ export class VoiceReceiver {
 			if (daveSession) packet = daveSession.decrypt(packet, userId)!;
 		}
 
-		return packet;
+		// Extend packet with RTP header information
+		return VoiceReceiver.addPacketHeaders(packet, sequence, timestamp, ssrc);
+	}
+
+	/**
+	 * Extends the Buffer for Opus audio data with RTP Header information
+	 *
+	 * @param buffer the opus packet data to extend
+	 * @param sequence the sequence number of the packet
+	 * @param timestamp see definition in
+	 * @param ssrc x
+	 * @returns the input buffer, with RTP header information added
+	 */
+	private static addPacketHeaders(buffer: Buffer, sequence: number, timestamp: number, ssrc: number): AudioPacket {
+		Object.defineProperties(buffer, {
+			sequence: { value: sequence, writable: false, enumerable: false, configurable: false },
+			timestamp: { value: timestamp, writable: false, enumerable: false, configurable: false },
+			ssrc: { value: ssrc, writable: false, enumerable: false, configurable: false },
+		});
+		return buffer as AudioPacket;
 	}
 
 	/**
@@ -184,9 +199,7 @@ export class VoiceReceiver {
 	 * @internal
 	 */
 	public onUdpMessage(msg: Buffer) {
-		if (msg.length <= 8) return;
-		const sequence = msg.readUInt16BE(2);
-		const timestamp = msg.readUInt32BE(4);
+		if (msg.length <= 12) return;
 		const ssrc = msg.readUInt32BE(8);
 
 		const userData = this.ssrcMap.get(ssrc);
@@ -212,8 +225,9 @@ export class VoiceReceiver {
 					this.connectionData.nonceBuffer,
 					this.connectionData.secretKey,
 					userData.userId,
-				);
-				if (packet) stream.push(createAudioPacket(packet, sequence, timestamp, ssrc));
+					ssrc
+			);
+				if (packet) stream.push(packet);
 			} catch (error) {
 				stream.destroy(error as Error);
 			}

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -17,7 +17,6 @@ import {
 import { SSRCMap } from './SSRCMap';
 import { SpeakingMap } from './SpeakingMap';
 
-const HEADER_EXTENSION_BYTE = Buffer.from([0xbe, 0xde]);
 const UNPADDED_NONCE_LENGTH = 4;
 const AUTH_TAG_LENGTH = 16;
 
@@ -80,18 +79,24 @@ export class VoiceReceiver {
 		}
 	}
 
-	private decrypt(buffer: Buffer, mode: string, nonce: Buffer, secretKey: Uint8Array) {
+	/**
+	 * Decrypt RTP packet payload
+	 *
+	 * @param buffer - RTP packet buffer
+	 * @param mode - cipher mode
+	 * @param nonce - encryption nonce
+	 * @param secretKey - encryption key
+	 * @param headerSize - size of the unencrypted RTP header (fixed header + CSRC + extension header)
+	 * @returns decrypted packet payload
+	 */
+	private decrypt(buffer: Buffer, mode: string, nonce: Buffer, secretKey: Uint8Array, headerSize: number) {
 		// Copy the last 4 bytes of unpadded nonce to the padding of (12 - 4) or (24 - 4) bytes
 		buffer.copy(nonce, 0, buffer.length - UNPADDED_NONCE_LENGTH);
 
-		let headerSize = 12;
-		const first = buffer.readUint8();
-		if ((first >> 4) & 0x01) headerSize += 4;
-
-		// The unencrypted RTP header contains 12 bytes, HEADER_EXTENSION and the extension size
+		// The unencrypted RTP header is used as AAD (authenticated but not encrypted)
 		const header = buffer.subarray(0, headerSize);
 
-		// Encrypted contains the extension, if any, the opus packet, and the auth tag
+		// Encrypted contains the extension data, if any, the opus packet, and the auth tag
 		const encrypted = buffer.subarray(headerSize, buffer.length - AUTH_TAG_LENGTH - UNPADDED_NONCE_LENGTH);
 		const authTag = buffer.subarray(
 			buffer.length - AUTH_TAG_LENGTH - UNPADDED_NONCE_LENGTH,
@@ -128,7 +133,7 @@ export class VoiceReceiver {
 	/**
 	 * Parses an audio packet, decrypting it to yield an Opus packet.
 	 *
-	 * @param buffer - The buffer to parse
+	 * @param rtp - The incoming RTP packet buffer to be parsed
 	 * @param mode - The encryption mode
 	 * @param nonce - The nonce buffer used by the connection for encryption
 	 * @param secretKey - The secret key used by the connection for encryption
@@ -136,50 +141,52 @@ export class VoiceReceiver {
 	 * @param ssrc - already-parsed SSRC (Synchronization Source Identifier) from the RTP Header
 	 * @returns The parsed Opus packet
 	 */
-	private parsePacket(
-		buffer: Buffer,
-		mode: string,
-		nonce: Buffer,
-		secretKey: Uint8Array,
-		userId: string,
-		ssrc: number,
-	) {
+	private parsePacket(rtp: Buffer, mode: string, nonce: Buffer, secretKey: Uint8Array, userId: string, ssrc: number) {
 		// Parse key RTP Header fields
-		const sequence = buffer.readUInt16BE(2);
-		const timestamp = buffer.readUInt32BE(4);
+		const first = rtp.readUint8();
+		const hasHeaderExtension = Boolean((first >> 4) & 0x01); // X field
+		const cc = first & 0x0f; // CSRC Count field
+		const sequence = rtp.readUInt16BE(2);
+		const timestamp = rtp.readUInt32BE(4);
 
-		let packet: Buffer = this.decrypt(buffer, mode, nonce, secretKey);
-		if (!packet) throw new Error('Failed to parse packet');
+		// Compute unencrypted header size: fixed header + CSRC Identifiers + extension header if present
+		let headerSize = 12 + 4 * cc;
+		const extensionHeaderOffset = headerSize; // where the extension header starts, if present
+		if (hasHeaderExtension) headerSize += 4; // extension header (profile ID + length)
+
+		// Decrypt the RTP Payload
+		let payload: Buffer = this.decrypt(rtp, mode, nonce, secretKey, headerSize);
+		if (!payload) throw new Error('Failed to parse packet');
 
 		// Strip padding (RFC3550 5.1)
-		const hasPadding = buffer[0] && Boolean(buffer[0] & 0b100000);
+		const hasPadding = rtp[0] && Boolean(rtp[0] & 0b100000);
 		if (hasPadding) {
-			const paddingAmount = packet[packet.length - 1]!;
-			if (paddingAmount < packet.length) {
-				packet = packet.subarray(0, packet.length - paddingAmount);
+			const paddingAmount = payload[payload.length - 1]!;
+			if (paddingAmount < payload.length) {
+				payload = payload.subarray(0, payload.length - paddingAmount);
 			}
 		}
 
-		// Strip decrypted RTP Header Extension if present
-		// The header is only indicated in the original data, so compare with buffer first
-		if (buffer.subarray(12, 14).compare(HEADER_EXTENSION_BYTE) === 0) {
-			const headerExtensionLength = buffer.subarray(14).readUInt16BE();
-			packet = packet.subarray(4 * headerExtensionLength);
+		// Skip the decrypted RTP Header Extension data if present
+		if (hasHeaderExtension) {
+			// Extension Header Length field
+			const headerExtensionLength = rtp.readUInt16BE(extensionHeaderOffset + 2);
+			payload = payload.subarray(4 * headerExtensionLength);
 		}
 
-		// Decrypt packet if in a DAVE session.
+		// Decrypt payload if in a DAVE session.
 		if (
 			this.voiceConnection.state.status === VoiceConnectionStatus.Ready &&
 			(this.voiceConnection.state.networking.state.code === NetworkingStatusCode.Ready ||
 				this.voiceConnection.state.networking.state.code === NetworkingStatusCode.Resuming)
 		) {
 			const daveSession = this.voiceConnection.state.networking.state.dave;
-			if (daveSession) packet = daveSession.decrypt(packet, userId)!;
+			if (daveSession) payload = daveSession.decrypt(payload, userId)!;
 		}
 
-		// Extend packet with RTP header information
-		if (packet) {
-			return addPacketHeaders(packet, sequence, timestamp, ssrc);
+		// Return Opus packet data Buffer, enriched with RTP header information
+		if (payload) {
+			return addPacketHeaders(payload, sequence, timestamp, ssrc);
 		} else {
 			return null;
 		}
@@ -252,9 +259,9 @@ export class VoiceReceiver {
  * Extends the Buffer for Opus audio data with RTP Header information
  *
  * @param buffer - the opus packet data to extend
- * @param sequence - NTP Header sequence value for the packet
- * @param timestamp - NTP Header timestamp value for the packet
- * @param ssrc - NTP Header synchronization source identifier (SSRC) for the packet
+ * @param sequence - RTP Header sequence value for the packet
+ * @param timestamp - RTP Header timestamp value for the packet
+ * @param ssrc - RTP Header synchronization source identifier (SSRC) for the packet
  * @returns the input buffer, with RTP header information added
  */
 function addPacketHeaders(buffer: Buffer, sequence: number, timestamp: number, ssrc: number): AudioPacket {

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -11,7 +11,7 @@ import { RTP_OPUS_PAYLOAD_TYPE } from '../util/constants';
 import {
 	AudioReceiveStream,
 	createDefaultAudioReceiveStreamOptions,
-	type AudioPacket,
+	AudioPacket,
 	type AudioReceiveStreamOptions,
 } from './AudioReceiveStream';
 import { SSRCMap } from './SSRCMap';
@@ -196,7 +196,7 @@ export class VoiceReceiver {
 		}
 
 		// Construct AudioPacket with Opus payload and RTP header information
-		return { payload, sequence, timestamp, ssrc };
+		return new AudioPacket(payload, sequence, timestamp, ssrc);
 	}
 
 	/**

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -178,7 +178,11 @@ export class VoiceReceiver {
 		}
 
 		// Extend packet with RTP header information
-		return VoiceReceiver.addPacketHeaders(packet, sequence, timestamp, ssrc);
+		if (packet) {
+			return VoiceReceiver.addPacketHeaders(packet, sequence, timestamp, ssrc);
+		} else {
+			return null;
+		}
 	}
 
 	/**

--- a/packages/voice/src/receive/VoiceReceiver.ts
+++ b/packages/voice/src/receive/VoiceReceiver.ts
@@ -179,28 +179,10 @@ export class VoiceReceiver {
 
 		// Extend packet with RTP header information
 		if (packet) {
-			return VoiceReceiver.addPacketHeaders(packet, sequence, timestamp, ssrc);
+			return addPacketHeaders(packet, sequence, timestamp, ssrc);
 		} else {
 			return null;
 		}
-	}
-
-	/**
-	 * Extends the Buffer for Opus audio data with RTP Header information
-	 *
-	 * @param buffer - the opus packet data to extend
-	 * @param sequence - the sequence number of the packet
-	 * @param timestamp see definition in
-	 * @param ssrc x
-	 * @returns the input buffer, with RTP header information added
-	 */
-	private static addPacketHeaders(buffer: Buffer, sequence: number, timestamp: number, ssrc: number): AudioPacket {
-		Object.defineProperties(buffer, {
-			sequence: { value: sequence, writable: false, enumerable: false, configurable: false },
-			timestamp: { value: timestamp, writable: false, enumerable: false, configurable: false },
-			ssrc: { value: ssrc, writable: false, enumerable: false, configurable: false },
-		});
-		return buffer as AudioPacket;
 	}
 
 	/**
@@ -264,4 +246,22 @@ export class VoiceReceiver {
 		this.subscriptions.set(userId, stream);
 		return stream;
 	}
+}
+
+/**
+ * Extends the Buffer for Opus audio data with RTP Header information
+ *
+ * @param buffer - the opus packet data to extend
+ * @param sequence - NTP Header sequence value for the packet
+ * @param timestamp - NTP Header timestamp value for the packet
+ * @param ssrc - NTP Header synchronization source identifier (SSRC) for the packet
+ * @returns the input buffer, with RTP header information added
+ */
+function addPacketHeaders(buffer: Buffer, sequence: number, timestamp: number, ssrc: number): AudioPacket {
+	Object.defineProperties(buffer, {
+		sequence: { value: sequence, writable: false, enumerable: false, configurable: false },
+		timestamp: { value: timestamp, writable: false, enumerable: false, configurable: false },
+		ssrc: { value: ssrc, writable: false, enumerable: false, configurable: false },
+	});
+	return buffer as AudioPacket;
 }


### PR DESCRIPTION
Currently, RTP packet headers are stripped and clients are only delivered Opus frames as `Buffer`s. The lack of timestamp makes jitter/drift hard to combat for clients, who must compute wall-clock delivery time.

This change introduces an `AudioPacket` interface which extends `Buffer` with the following read-only fields:
- `sequence` (16-bit uint monotonically increasing counter to allow for identifying out-of-order RTP packets)
- `timestamp` (32-bit uint that counts encoder-side timestamps; [RFC 7587, Opus in RTP](https://datatracker.ietf.org/doc/html/rfc7587) requires this be expressed at 48kHz no matter the audio sample rate)
- `ssrc` (to allow consumers to detect a change and reset their Opus decoder state; updates on this value can already be received via SSRCMap events, however I think it also belongs on AudioPacket because there's a risk of delayed SSRCMap event delivery, and the client needs to know as soon as they receive a packet that changes it so they can reset their decoder state to correctly parse the packet)

This change deliberately does not attempt to provide a generalised parser for all the fields in the RTP Header to keep this PR small and focused just on the essential fields.