### PR TITLE
chore: make docgen package private

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
           - '@discordjs/collection'
           - '@discordjs/core'
           - 'create-discord-bot'
-          - '@discordjs/docgen'
+          # - '@discordjs/docgen'
           - '@discordjs/formatters'
           - '@discordjs/next'
           - '@discordjs/proxy'

--- a/packages/docgen/package.json
+++ b/packages/docgen/package.json
@@ -3,6 +3,7 @@
 	"name": "@discordjs/docgen",
 	"version": "0.12.1",
 	"description": "The docs.json generator for discord.js and its related projects",
+	"private": true,
 	"scripts": {
 		"build": "tsup",
 		"lint": "prettier --check . && cross-env TIMING=1 eslint --format=pretty src",


### PR DESCRIPTION
Fixes https://github.com/discordjs/discord.js/actions/runs/22256430186/job/64387918343#step:9:181

This package has not had any releases on the last 4 years anyways, and the only package which uses it is `discord.js`, which uses the `workspace:` protocol, not an npm-hosted version