### PR TITLE
ci: fix docs workflow on v14 tag push

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,8 +1,6 @@
 name: Documentation
 on:
   push:
-    branches:
-      - 'main'
     paths:
       - 'packages/*/src/**'
       - '!packages/create-discord-bot/**'
@@ -13,14 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'The branch, tag or SHA to checkout'
-        required: true
-      ref_type:
-        type: choice
-        description: 'Branch or tag'
-        options:
-          - branch
-          - tag
+        description: 'The tag to checkout'
         required: true
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -32,7 +23,6 @@ jobs:
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-      REF_TYPE: ${{ inputs.ref_type || github.ref_type }}
     if: github.repository_owner == 'discordjs'
     steps:
       - name: Checkout repository
@@ -52,13 +42,11 @@ jobs:
         run: pnpm run build
 
       - name: Checkout main repository
-        if: ${{ inputs.ref && inputs.ref != 'main' }}
         uses: actions/checkout@v4
         with:
           path: 'main'
 
       - name: Build main
-        if: ${{ inputs.ref && inputs.ref != 'main' }}
         shell: bash
         run: |
           cd main
@@ -67,26 +55,20 @@ jobs:
           cd ..
 
       - name: Extract package and semver from tag
-        if: ${{ env.REF_TYPE == 'tag' }}
         id: extract-tag
         uses: ./packages/actions/src/formatTag
         with:
           tag: ${{ inputs.ref || github.ref_name }}
 
-      - name: Apply tag to api-extractor config
-        if: ${{ env.REF_TYPE == 'tag' && !inputs.ref }}
-        run: sed -i 's!https://github.com/discordjs/discord.js/tree/main!https://github.com/discordjs/discord.js/tree/${{ github.ref_name }}!' "packages/${{ steps.extract-tag.outputs.package}}/api-extractor.json"
-
       - name: Build docs
         run: pnpm run docs
 
       - name: Build docs with main api-extractor
-        if: ${{ inputs.ref && inputs.ref != 'main' }}
         run: |
           declare -a PACKAGES=("brokers" "builders" "collection" "core" "discord.js" "formatters" "next" "proxy" "rest" "util" "voice" "ws")
           for PACKAGE in "${PACKAGES[@]}"; do
             cd "packages/${PACKAGE}"
-            sed -i 's!https://github.com/discordjs/discord.js/tree/main!https://github.com/discordjs/discord.js/tree/${{ inputs.ref }}!' api-extractor.json
+            sed -i 's!https://github.com/discordjs/discord.js/tree/main!https://github.com/discordjs/discord.js/tree/${{ inputs.ref || github.ref_name }}!' api-extractor.json
             ../../main/packages/api-extractor/bin/api-extractor run --local --minify
             ../../main/packages/scripts/bin/generateSplitDocumentation.js
             cd ../..
@@ -100,25 +82,6 @@ jobs:
           path: 'out'
 
       - name: Upload documentation to database
-        if: ${{ env.REF_TYPE == 'tag' && (!inputs.ref || inputs.ref == 'main') }}
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          CF_D1_DOCS_API_KEY: ${{ secrets.CF_D1_DOCS_API_KEY }}
-          CF_D1_DOCS_ID: ${{ secrets.CF_D1_DOCS_ID }}
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-          CF_R2_DOCS_URL: ${{ secrets.CF_R2_DOCS_URL }}
-          CF_R2_DOCS_ACCESS_KEY_ID: ${{ secrets.CF_R2_DOCS_ACCESS_KEY_ID }}
-          CF_R2_DOCS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_DOCS_SECRET_ACCESS_KEY }}
-          CF_R2_DOCS_BUCKET: ${{ secrets.CF_R2_DOCS_BUCKET }}
-          CF_R2_DOCS_BUCKET_URL: ${{ secrets.CF_R2_DOCS_BUCKET_URL }}
-        uses: ./packages/actions/src/uploadDocumentation
-        with:
-          package: ${{ steps.extract-tag.outputs.package }}
-          version: ${{ steps.extract-tag.outputs.semver }}
-
-      - name: Upload documentation to database
-        if: ${{ env.REF_TYPE == 'tag' && inputs.ref && inputs.ref != 'main' }}
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           CF_D1_DOCS_API_KEY: ${{ secrets.CF_D1_DOCS_API_KEY }}
@@ -136,20 +99,6 @@ jobs:
           version: ${{ steps.extract-tag.outputs.semver }}
 
       - name: Upload split documentation to blob storage
-        if: ${{ env.REF_TYPE == 'tag' && (!inputs.ref || inputs.ref == 'main') }}
-        env:
-          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-          CF_R2_DOCS_URL: ${{ secrets.CF_R2_DOCS_URL }}
-          CF_R2_DOCS_ACCESS_KEY_ID: ${{ secrets.CF_R2_DOCS_ACCESS_KEY_ID }}
-          CF_R2_DOCS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_DOCS_SECRET_ACCESS_KEY }}
-          CF_R2_DOCS_BUCKET: ${{ secrets.CF_R2_DOCS_BUCKET }}
-        uses: ./packages/actions/src/uploadSplitDocumentation
-        with:
-          package: ${{ steps.extract-tag.outputs.package }}
-          version: ${{ steps.extract-tag.outputs.semver }}
-
-      - name: Upload split documentation to blob storage
-        if: ${{ env.REF_TYPE == 'tag' && inputs.ref && inputs.ref != 'main' }}
         env:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
           CF_R2_DOCS_URL: ${{ secrets.CF_R2_DOCS_URL }}
@@ -162,7 +111,6 @@ jobs:
           version: ${{ steps.extract-tag.outputs.semver }}
 
       - name: Move docs to correct directory
-        if: ${{ env.REF_TYPE == 'tag' }}
         env:
           PACKAGE: ${{ steps.extract-tag.outputs.package }}
           SEMVER: ${{ steps.extract-tag.outputs.semver }}
@@ -174,71 +122,6 @@ jobs:
           else
             mv "packages/${PACKAGE}/docs/docs.api.json" "out/${PACKAGE}/${SEMVER}.api.json"
           fi
-
-      - name: Upload documentation to database
-        if: ${{ env.REF_TYPE == 'branch' && (!inputs.ref || inputs.ref == 'main') }}
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          CF_D1_DOCS_API_KEY: ${{ secrets.CF_D1_DOCS_API_KEY }}
-          CF_D1_DOCS_ID: ${{ secrets.CF_D1_DOCS_ID }}
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-          CF_R2_DOCS_URL: ${{ secrets.CF_R2_DOCS_URL }}
-          CF_R2_DOCS_ACCESS_KEY_ID: ${{ secrets.CF_R2_DOCS_ACCESS_KEY_ID }}
-          CF_R2_DOCS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_DOCS_SECRET_ACCESS_KEY }}
-          CF_R2_DOCS_BUCKET: ${{ secrets.CF_R2_DOCS_BUCKET }}
-          CF_R2_DOCS_BUCKET_URL: ${{ secrets.CF_R2_DOCS_BUCKET_URL }}
-        uses: ./packages/actions/src/uploadDocumentation
-
-      - name: Upload documentation to database
-        if: ${{ env.REF_TYPE == 'branch' && inputs.ref && inputs.ref != 'main' }}
-        env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          CF_D1_DOCS_API_KEY: ${{ secrets.CF_D1_DOCS_API_KEY }}
-          CF_D1_DOCS_ID: ${{ secrets.CF_D1_DOCS_ID }}
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-          CF_R2_DOCS_URL: ${{ secrets.CF_R2_DOCS_URL }}
-          CF_R2_DOCS_ACCESS_KEY_ID: ${{ secrets.CF_R2_DOCS_ACCESS_KEY_ID }}
-          CF_R2_DOCS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_DOCS_SECRET_ACCESS_KEY }}
-          CF_R2_DOCS_BUCKET: ${{ secrets.CF_R2_DOCS_BUCKET }}
-          CF_R2_DOCS_BUCKET_URL: ${{ secrets.CF_R2_DOCS_BUCKET_URL }}
-        uses: ./main/packages/actions/src/uploadDocumentation
-
-      - name: Upload split documentation to blob storage
-        if: ${{ env.REF_TYPE == 'branch' && (!inputs.ref || inputs.ref == 'main') }}
-        env:
-          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-          CF_R2_DOCS_URL: ${{ secrets.CF_R2_DOCS_URL }}
-          CF_R2_DOCS_ACCESS_KEY_ID: ${{ secrets.CF_R2_DOCS_ACCESS_KEY_ID }}
-          CF_R2_DOCS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_DOCS_SECRET_ACCESS_KEY }}
-          CF_R2_DOCS_BUCKET: ${{ secrets.CF_R2_DOCS_BUCKET }}
-        uses: ./packages/actions/src/uploadSplitDocumentation
-
-      - name: Upload split documentation to blob storage
-        if: ${{ env.REF_TYPE == 'branch' && inputs.ref && inputs.ref != 'main' }}
-        env:
-          BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
-          CF_R2_DOCS_URL: ${{ secrets.CF_R2_DOCS_URL }}
-          CF_R2_DOCS_ACCESS_KEY_ID: ${{ secrets.CF_R2_DOCS_ACCESS_KEY_ID }}
-          CF_R2_DOCS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_DOCS_SECRET_ACCESS_KEY }}
-          CF_R2_DOCS_BUCKET: ${{ secrets.CF_R2_DOCS_BUCKET }}
-        uses: ./main/packages/actions/src/uploadSplitDocumentation
-
-      - name: Move docs to correct directory
-        if: ${{ env.REF_TYPE == 'branch' }}
-        run: |
-          declare -a PACKAGES=("brokers" "builders" "collection" "core" "discord.js" "formatters" "next" "proxy" "rest" "util" "voice" "ws")
-          for PACKAGE in "${PACKAGES[@]}"; do
-            if [[ "${PACKAGE}" == "discord.js" ]]; then
-              mkdir -p "out/${PACKAGE}"
-              mv "packages/${PACKAGE}/docs/docs.json" "out/${PACKAGE}/${GITHUB_REF_NAME}.json"
-              mv "packages/${PACKAGE}/docs/docs.api.json" "out/${PACKAGE}/${GITHUB_REF_NAME}.api.json"
-            else
-              mkdir -p "out/${PACKAGE}"
-              mv "packages/${PACKAGE}/docs/docs.api.json" "out/${PACKAGE}/${GITHUB_REF_NAME}.api.json"
-            fi
-          done
 
       - name: Commit and push
         run: |


### PR DESCRIPTION
This changes the documentation workflow on v14 branch to only work on tags (which it already did anyway, since the only branch it runs on is `main`) and make sure it runs the main workflow where necessary.

This should fix the docs regression where linking to the source code of re-exported members incorrectly linked to generated `dist/*.d.ts` files of the imported subpackages instead of the actual source.