### PR TITLE
fix(voice): add trailing slash to voice WebSocket URL

### DIFF
--- a/packages/voice/src/networking/Networking.ts
+++ b/packages/voice/src/networking/Networking.ts
@@ -340,7 +340,7 @@ export class Networking extends EventEmitter {
 	 * @param lastSequence - The last sequence to set for this WebSocket
 	 */
 	private createWebSocket(endpoint: string, lastSequence?: number) {
-		const ws = new VoiceWebSocket(`wss://${endpoint}?v=8`, Boolean(this.debug));
+		const ws = new VoiceWebSocket(`wss://${endpoint}/?v=8`, Boolean(this.debug));
 
 		if (lastSequence !== undefined) {
 			ws.sequence = lastSequence;


### PR DESCRIPTION
Fixes #11439

Discord's voice gateway expects a path component in the WebSocket URL. Without the trailing slash, the connection drops after receiving OP 8 (Hello) and never reaches the Ready state.

This fix adds the missing trailing slash to the WebSocket URL, changing from:
`wss://${endpoint}?v=8` 

to:

`wss://${endpoint}/?v=8`

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one)*