### PR TITLE
fix: clear existing idle timeout in Collector.resetTimer

### DIFF
--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -279,10 +279,12 @@ class Collector extends AsyncEventEmitter {
 
     if (this._idletimeout) {
       clearTimeout(this._idletimeout);
+      this._idletimeout = null;
     }
 
-    if (idle ?? this.options.idle) {
-      this._idletimeout = setTimeout(() => this.stop('idle'), idle ?? this.options.idle).unref();
+    const idleValue = idle ?? this.options.idle;
+    if (idleValue) {
+      this._idletimeout = setTimeout(() => this.stop('idle'), idleValue).unref();
     }
   }
 

--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -279,6 +279,9 @@ class Collector extends AsyncEventEmitter {
 
     if (this._idletimeout) {
       clearTimeout(this._idletimeout);
+    }
+
+    if (idle ?? this.options.idle) {
       this._idletimeout = setTimeout(() => this.stop('idle'), idle ?? this.options.idle).unref();
     }
   }

--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -274,7 +274,12 @@ class Collector extends AsyncEventEmitter {
   resetTimer({ time, idle } = {}) {
     if (this._timeout) {
       clearTimeout(this._timeout);
-      this._timeout = setTimeout(() => this.stop('time'), time ?? this.options.time).unref();
+      this._timeout = null;
+    }
+
+    const timeValue = time ?? this.options.time;
+    if (timeValue) {
+      this._timeout = setTimeout(() => this.stop('time'), timeValue).unref();
     }
 
     if (this._idletimeout) {


### PR DESCRIPTION
## Summary
- Fix `Collector.resetTimer({ idle: newValue })` not properly resetting the idle timer
- The old code only reset the idle timeout when `this._idletimeout` already existed, and kept the clear and set coupled inside the same conditional
- Now the existing idle timeout is always cleared first, then a new one is created if an idle value is provided (either via the argument or from the original options)

## Test plan
- [ ] Call `resetTimer({ idle: 5000 })` on a collector that was created with a different idle value and verify the new idle duration takes effect
- [ ] Call `resetTimer({ idle: 5000 })` on a collector that was created without an idle option and verify an idle timeout is now active
- [ ] Call `resetTimer()` with no arguments on a collector with an existing idle timeout and verify it resets to the original idle value