### PR TITLE
perf(collection): avoid duplicated population of new collections

### DIFF
--- a/packages/collection/src/collection.ts
+++ b/packages/collection/src/collection.ts
@@ -1023,7 +1023,10 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	 * but returns a Collection instead of an Array.
 	 */
 	public toReversed() {
-		return new this.constructor[Symbol.species](this).reverse();
+		const entries = [...this.entries()];
+		entries.reverse();
+
+		return new this.constructor[Symbol.species](entries);
 	}
 
 	/**
@@ -1039,7 +1042,10 @@ export class Collection<Key, Value> extends Map<Key, Value> {
 	 * ```
 	 */
 	public toSorted(compareFunction: Comparator<Key, Value> = Collection.defaultSort): Collection<Key, Value> {
-		return new this.constructor[Symbol.species](this).sort(compareFunction);
+		const entries = [...this.entries()];
+		entries.sort((a, b): number => compareFunction(a[1], b[1], a[0], b[0]));
+
+		return new this.constructor[Symbol.species](entries);
 	}
 
 	public toJSON() {


### PR DESCRIPTION
There are a couple of Collection methods where a new Collection is fully populated, only to be fully re-populated moments later.

- `toReversed()`, `toSorted()`:
  - Current:
    - Iterate over `coll1` to populate a new Collection `coll2`
    - Iterate over `coll2` to populate an array
    - Reverse/sort the array
    - Clear `coll2`
    - Iterate over the array to re-populate `coll2`
  - PR:
    - Iterate over entries in `coll1` to populate an array
    - Reverse/sort the array
    - Iterate over the array to populate a new Collection `coll2`

<details>
<summary>toReversed benchmarks</summary>

<pre>
Running "[size=10] toReversed()" suite...
Progress: 100%

  [baseline] copy collection then reverse entries:
    189 956 ops/s, ±4.01%   | slowest, 28.93% slower

  [candidate] pass reversed array to constructor:
    267 266 ops/s, ±4.04%   | fastest

Finished 2 cases!
  Fastest: [candidate] pass reversed array to constructor
  Slowest: [baseline] copy collection then reverse entries

Running "[size=100] toReversed()" suite...
Progress: 100%

  [baseline] copy collection then reverse entries:
    23 912 ops/s, ±3.35%   | slowest, 35.06% slower

  [candidate] pass reversed array to constructor:
    36 821 ops/s, ±2.73%   | fastest

Finished 2 cases!
  Fastest: [candidate] pass reversed array to constructor
  Slowest: [baseline] copy collection then reverse entries

Running "[size=1,000] toReversed()" suite...
Progress: 100%

  [baseline] copy collection then reverse entries:
    2 399 ops/s, ±3.76%   | slowest, 35.16% slower

  [candidate] pass reversed array to constructor:
    3 700 ops/s, ±2.95%   | fastest

Finished 2 cases!
  Fastest: [candidate] pass reversed array to constructor
  Slowest: [baseline] copy collection then reverse entries

Running "[size=10,000] toReversed()" suite...
Progress: 100%

  [baseline] copy collection then reverse entries:
    135 ops/s, ±5.54%   | slowest, 44.21% slower

  [candidate] pass reversed array to constructor:
    242 ops/s, ±3.43%   | fastest

Finished 2 cases!
  Fastest: [candidate] pass reversed array to constructor
  Slowest: [baseline] copy collection then reverse entries

</pre>
</details>
<details>
<summary>toSorted benchmarks</summary>

<pre>
Running "[size=10] toSorted()" suite...
Progress: 100%

  [baseline] copy collection then sort entries:
    151 567 ops/s, ±3.33%   | slowest, 18.61% slower

  [candidate] pass sorted array to constructor:
    186 224 ops/s, ±5.65%   | fastest

Finished 2 cases!
  Fastest: [candidate] pass sorted array to constructor
  Slowest: [baseline] copy collection then sort entries

Running "[size=100] toSorted()" suite...
Progress: 100%

  [baseline] copy collection then sort entries:
    15 080 ops/s, ±2.81%   | slowest, 15.08% slower

  [candidate] pass sorted array to constructor:
    17 757 ops/s, ±3.33%   | fastest

Finished 2 cases!
  Fastest: [candidate] pass sorted array to constructor
  Slowest: [baseline] copy collection then sort entries

Running "[size=1,000] toSorted()" suite...
Progress: 100%

  [baseline] copy collection then sort entries:
    1 121 ops/s, ±2.77%   | slowest, 9.74% slower

  [candidate] pass sorted array to constructor:
    1 242 ops/s, ±4.25%   | fastest

Finished 2 cases!
  Fastest: [candidate] pass sorted array to constructor
  Slowest: [baseline] copy collection then sort entries

Running "[size=10,000] toSorted()" suite...
Progress: 100%

  [baseline] copy collection then sort entries:
    67 ops/s, ±1.89%   | slowest, 5.63% slower

  [candidate] pass sorted array to constructor:
    71 ops/s, ±5.29%   | fastest

Finished 2 cases!
  Fastest: [candidate] pass sorted array to constructor
  Slowest: [baseline] copy collection then sort entries

</pre>
</details>