### PR TITLE
fix(discord.js): resolve MessagePayload crash on edit

### DIFF
--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -190,13 +190,14 @@ class MessagePayload {
       }
     }
 
-    const attachments = this.options.files?.map((file, index) => ({
-      id: index.toString(),
-      description: file.description,
-      title: file.title,
-      waveform: file.waveform,
-      duration_secs: file.duration,
-    }));
+    const attachments =
+      this.options.files?.map((file, index) => ({
+        id: index.toString(),
+        description: file.description,
+        title: file.title,
+        waveform: file.waveform,
+        duration_secs: file.duration,
+      })) ?? [];
 
     // Only passable during edits
     if (Array.isArray(this.options.attachments)) {


### PR DESCRIPTION
`MessagePayload.resolveBody()` crashes with `TypeError: Cannot read properties of undefined (reading 'push')` when `options.attachments` is provided without `options.files`, because `files?.map()` returns `undefined` and `.push()` is then called on it.

This affects any `message.edit({ attachments: [...] })` call that keeps existing attachments without uploading new files.

Fix: default the `files?.map()` result to `[]` with `?? []`.