### PR TITLE
Fix/invite handlers null guild

### DIFF
--- a/packages/discord.js/src/client/websocket/handlers/INVITE_CREATE.js
+++ b/packages/discord.js/src/client/websocket/handlers/INVITE_CREATE.js
@@ -5,7 +5,7 @@ const { Events } = require('../../../util/Events.js');
 module.exports = (client, { d: data }) => {
   const channel = client.channels.cache.get(data.channel_id);
   const guild = client.guilds.cache.get(data.guild_id);
-  if (!channel) return;
+  if (!channel || !guild) return;
 
   const inviteData = Object.assign(data, { channel, guild });
   const invite = guild.invites._add(inviteData);

--- a/packages/discord.js/src/client/websocket/handlers/INVITE_DELETE.js
+++ b/packages/discord.js/src/client/websocket/handlers/INVITE_DELETE.js
@@ -6,7 +6,7 @@ const { Events } = require('../../../util/Events.js');
 module.exports = (client, { d: data }) => {
   const channel = client.channels.cache.get(data.channel_id);
   const guild = client.guilds.cache.get(data.guild_id);
-  if (!channel) return;
+  if (!channel || !guild) return;
 
   const inviteData = Object.assign(data, { channel, guild });
   const invite = new GuildInvite(client, inviteData);

--- a/packages/discord.js/src/structures/MessagePayload.js
+++ b/packages/discord.js/src/structures/MessagePayload.js
@@ -190,13 +190,14 @@ class MessagePayload {
       }
     }
 
-    const attachments = this.options.files?.map((file, index) => ({
-      id: index.toString(),
-      description: file.description,
-      title: file.title,
-      waveform: file.waveform,
-      duration_secs: file.duration,
-    }));
+    const attachments =
+      this.options.files?.map((file, index) => ({
+        id: index.toString(),
+        description: file.description,
+        title: file.title,
+        waveform: file.waveform,
+        duration_secs: file.duration,
+      })) ?? [];
 
     // Only passable during edits
     if (Array.isArray(this.options.attachments)) {


### PR DESCRIPTION
`INVITE_CREATE` and `INVITE_DELETE` gateway handlers crash with `TypeError: Cannot read properties of undefined (reading 'invites')` when the guild is not in cache.

Other handlers like `GUILD_BAN_ADD` correctly guard with `if (!guild) return;`.
