### PR TITLE
fix(discord.js): add missing GuildUncachedMe checks

### DIFF
--- a/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildVoiceChannel.js
@@ -2,6 +2,7 @@
 
 const { Collection } = require('@discordjs/collection');
 const { PermissionFlagsBits } = require('discord-api-types/v10');
+const { DiscordjsError, ErrorCodes } = require('../errors/index.js');
 const { GuildMessageManager } = require('../managers/GuildMessageManager.js');
 const { GuildChannel } = require('./GuildChannel.js');
 const { TextBasedChannel } = require('./interfaces/TextBasedChannel.js');
@@ -141,6 +142,7 @@ class BaseGuildVoiceChannel extends GuildChannel {
     // This flag allows joining even if timed out
     if (permissions.has(PermissionFlagsBits.Administrator, false)) return true;
 
+    if (!this.guild.members.me) throw new DiscordjsError(ErrorCodes.GuildUncachedMe);
     return (
       this.guild.members.me.communicationDisabledUntilTimestamp < Date.now() &&
       permissions.has(PermissionFlagsBits.Connect, false)

--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -469,6 +469,7 @@ class GuildChannel extends BaseChannel {
 
     // This flag allows managing even if timed out
     if (permissions.has(PermissionFlagsBits.Administrator, false)) return true;
+    if (!this.guild.members.me) throw new DiscordjsError(ErrorCodes.GuildUncachedMe);
     if (this.guild.members.me.communicationDisabledUntilTimestamp > Date.now()) return false;
 
     const baseBitfield = PermissionFlagsBits.ViewChannel | PermissionFlagsBits.ManageChannels;

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -766,10 +766,10 @@ class Message extends Base {
     if (permissions.has(PermissionFlagsBits.Administrator, false)) return true;
 
     // The auto moderation action message author is the reference message author
-    return (
-      (this.type !== MessageType.AutoModerationAction && this.author.id === this.client.user.id) ||
-      (permissions.has(PermissionFlagsBits.ManageMessages, false) && !this.guild.members.me.isCommunicationDisabled())
-    );
+    if (this.type !== MessageType.AutoModerationAction && this.author.id === this.client.user.id) return true;
+    if (!permissions.has(PermissionFlagsBits.ManageMessages, false)) return false;
+    if (!this.guild.members.me) throw new DiscordjsError(ErrorCodes.GuildUncachedMe);
+    return !this.guild.members.me.isCommunicationDisabled();
   }
 
   /**

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -230,6 +230,7 @@ class Role extends Base {
   get editable() {
     if (this.managed) return false;
     const clientMember = this.guild.members.resolve(this.client.user);
+    if (!clientMember) throw new DiscordjsError(ErrorCodes.GuildUncachedMe);
     if (!clientMember.permissions.has(PermissionFlagsBits.ManageRoles)) return false;
     return clientMember.roles.highest.comparePositionTo(this) > 0;
   }

--- a/packages/discord.js/src/structures/ThreadChannel.js
+++ b/packages/discord.js/src/structures/ThreadChannel.js
@@ -2,7 +2,7 @@
 
 const { lazy } = require('@discordjs/util');
 const { ChannelFlags, ChannelType, PermissionFlagsBits, Routes } = require('discord-api-types/v10');
-const { DiscordjsRangeError, ErrorCodes } = require('../errors/index.js');
+const { DiscordjsError, DiscordjsRangeError, ErrorCodes } = require('../errors/index.js');
 const { GuildMessageManager } = require('../managers/GuildMessageManager.js');
 const { ThreadMemberManager } = require('../managers/ThreadMemberManager.js');
 const { ChannelFlagsBitField } = require('../util/ChannelFlagsBitField.js');
@@ -569,6 +569,7 @@ class ThreadChannel extends BaseChannel {
     // This flag allows managing even if timed out
     if (permissions.has(PermissionFlagsBits.Administrator, false)) return true;
 
+    if (!this.guild.members.me) throw new DiscordjsError(ErrorCodes.GuildUncachedMe);
     return (
       this.guild.members.me.communicationDisabledUntilTimestamp < Date.now() &&
       permissions.has(PermissionFlagsBits.ManageThreads, false)
@@ -599,6 +600,7 @@ class ThreadChannel extends BaseChannel {
     // This flag allows sending even if timed out
     if (permissions.has(PermissionFlagsBits.Administrator, false)) return true;
 
+    if (!this.guild.members.me) throw new DiscordjsError(ErrorCodes.GuildUncachedMe);
     return (
       !(this.archived && this.locked && !this.manageable) &&
       (this.type !== ChannelType.PrivateThread || this.joined || this.manageable) &&

--- a/packages/discord.js/src/structures/VoiceChannel.js
+++ b/packages/discord.js/src/structures/VoiceChannel.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { PermissionFlagsBits, Routes } = require('discord-api-types/v10');
+const { DiscordjsError, ErrorCodes } = require('../errors/index.js');
 const { BaseGuildVoiceChannel } = require('./BaseGuildVoiceChannel.js');
 
 /**
@@ -32,6 +33,7 @@ class VoiceChannel extends BaseGuildVoiceChannel {
     // This flag allows speaking even if timed out
     if (permissions.has(PermissionFlagsBits.Administrator, false)) return true;
 
+    if (!this.guild.members.me) throw new DiscordjsError(ErrorCodes.GuildUncachedMe);
     return (
       this.guild.members.me.communicationDisabledUntilTimestamp < Date.now() &&
       permissions.has(PermissionFlagsBits.Speak, false)


### PR DESCRIPTION
Several getters access `guild.members.me` or `guild.members.resolve()` without guarding against null, causing `TypeError` when the bot's own member is not cached (e.g. without GuildMembers intent).

Add `GuildUncachedMe` checks consistent with the existing pattern in `GuildMember.manageable`, `GuildEmoji.deletable`, and `GuildInvite.deletable`.

Affected getters:
- `Role.editable`
- `GuildChannel.manageable`
- `Message.deletable`
- `VoiceChannel.speakable`
- `BaseGuildVoiceChannel.joinable`
- `ThreadChannel.manageable`
- `ThreadChannel.sendable`