### PR TITLE
fix: only return DMChannel that have the user as known recipient

### DIFF
--- a/packages/discord.js/src/managers/UserManager.js
+++ b/packages/discord.js/src/managers/UserManager.js
@@ -45,7 +45,9 @@ class UserManager extends CachedManager {
     return (
       this.client.channels.cache.find(
         channel =>
-          channel.type === ChannelType.DM && channel.recipientIds.every(id => expectedRecipientIds.includes(id)),
+          channel.type === ChannelType.DM &&
+          channel.recipientId === userId &&
+          channel.recipientIds.every(id => expectedRecipientIds.includes(id)),
       ) ?? null
     );
   }


### PR DESCRIPTION
Fixes an issue that happens when another shard than shard 0 sent a DM to a new user.

This causes a DMChannel with only the ClientUser as known recpient to get cached on shard 0. The current logic introduced by #11462 returned this channel as valid DMChannel for **all** users then.