### PR TITLE
fix(Action): don't add recipients to guild channels

### DIFF
--- a/packages/discord.js/src/client/actions/Action.js
+++ b/packages/discord.js/src/client/actions/Action.js
@@ -40,7 +40,7 @@ class GenericAction {
       if (!data.recipients.some(existingRecipient => recipient.id === existingRecipient.id)) {
         payloadData.recipients = [...data.recipients, recipient];
       }
-    } else if ([ChannelType.DM, ChannelType.GroupDM].includes(data.type)) {
+    } else if (data.type === ChannelType.DM || data.type === ChannelType.GroupDM) {
       // Try to resolve the recipient.
       const recipient = data.author ?? data.user ?? { id: data.user_id };
       payloadData.recipients = [recipient];

--- a/packages/discord.js/src/client/actions/Action.js
+++ b/packages/discord.js/src/client/actions/Action.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { ChannelType } = require('discord-api-types/v10');
 const { Poll } = require('../../structures/Poll.js');
 const { PollAnswer } = require('../../structures/PollAnswer.js');
 const Partials = require('../../util/Partials.js');
@@ -39,7 +40,7 @@ class GenericAction {
       if (!data.recipients.some(existingRecipient => recipient.id === existingRecipient.id)) {
         payloadData.recipients = [...data.recipients, recipient];
       }
-    } else {
+    } else if ([ChannelType.DM, ChannelType.GroupDM].includes(data.type)) {
       // Try to resolve the recipient.
       const recipient = data.author ?? data.user ?? { id: data.user_id };
       payloadData.recipients = [recipient];


### PR DESCRIPTION
Fixes GuildChannels from another shard being cached as DMChannel on shard 0 when sending ephemeral interaaction replies with Channel partial enabled.

What happened before this fix:
- Interaction with an ephemeral reply is sent in a guild channel on shard != 0
- messageCreate emits on shard 0 because of the ephemeral message
- the Channel partial causes the guild channel to be cached as DMChannel because data.guild_id is null in the messageCreate and recipients gets added by the getChannel() call (and the channel doesn't belong to shard 0, so isn't in cache yet)