### PR TITLE
feat(core)!: rename getAllMembers to getMembers with query support

### DIFF
--- a/packages/core/src/api/thread.ts
+++ b/packages/core/src/api/thread.ts
@@ -5,6 +5,7 @@ import {
 	Routes,
 	type RESTGetAPIChannelThreadMemberQuery,
 	type RESTGetAPIChannelThreadMemberResult,
+	type RESTGetAPIChannelThreadMembersQuery,
 	type RESTGetAPIChannelThreadMembersResult,
 	type Snowflake,
 } from 'discord-api-types/v10';
@@ -112,16 +113,22 @@ export class ThreadsAPI {
 	}
 
 	/**
-	 * Fetches all members of a thread
+	 * Fetches members of a thread
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/channel#list-thread-members}
 	 * @param threadId - The id of the thread to fetch the members from
+	 * @param query - The query for fetching the members
 	 * @param options - The options for fetching the members
 	 */
-	public async getAllMembers(threadId: Snowflake, { auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {}) {
+	public async getMembers(
+		threadId: Snowflake,
+		query: RESTGetAPIChannelThreadMembersQuery = {},
+		{ auth, signal }: Pick<RequestData, 'auth' | 'signal'> = {},
+	) {
 		return this.rest.get(Routes.threadMembers(threadId), {
 			auth,
 			signal,
+			query: makeURLSearchParams(query),
 		}) as Promise<RESTGetAPIChannelThreadMembersResult>;
 	}
 }


### PR DESCRIPTION
BREAKING CHANGE: getAllMembers has been removed. Use getMembers instead, which accepts an optional query parameter.


Internal discussion: https://discord.com/channels/222078108977594368/1209960895141388389/1490469080464097312
Changelog: https://docs.discord.com/developers/change-log#thread-member-details-and-pagination