### PR TITLE
fix: github icon size

### DIFF
--- a/apps/guide/src/components/GitHubIcon.tsx
+++ b/apps/guide/src/components/GitHubIcon.tsx
@@ -5,9 +5,9 @@ export function GitHubIcon(props: ComponentProps<'svg'>) {
 		<svg
 			aria-hidden
 			fill="none"
-			height={96}
+			height="1em"
 			viewBox="0 0 98 96"
-			width={98}
+			width="1em"
 			xmlns="http://www.w3.org/2000/svg"
 			{...props}
 		>


### PR DESCRIPTION
<img width="461" height="218" alt="image" src="https://github.com/user-attachments/assets/87fb36b9-56c2-420f-aa29-98f6e9af9ca9" />
