### PR TITLE
ci(deprecateVersion): Fix empty `message`

### DIFF
--- a/packages/actions/src/deprecateVersion/action.yml
+++ b/packages/actions/src/deprecateVersion/action.yml
@@ -10,7 +10,7 @@ inputs:
   message:
     description: Deprecation message
     required: false
-    default: This version is deprecated. Please use a newer version.
+    # Default message lives in the command to handle empty strings.
   node-auth-token:
     description: npm authentication token
     required: true
@@ -19,7 +19,8 @@ runs:
   steps:
     - name: Deprecate version
       shell: bash
-      run: |
-        pnpm exec npm-deprecate --name "${{ inputs.version }}" --message "${{ inputs.message }}" --package "${{ inputs.package }}"
       env:
+        MESSAGE: ${{ inputs.message }}
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
+      run: |
+        pnpm exec npm-deprecate --name "${{ inputs.version }}" --message "${MESSAGE:-This version is deprecated. Please use a newer version.}" --package "${{ inputs.package }}"

--- a/packages/actions/src/deprecateVersion/action.yml
+++ b/packages/actions/src/deprecateVersion/action.yml
@@ -20,7 +20,7 @@ runs:
     - name: Deprecate version
       shell: bash
       env:
-        MESSAGE: ${{ inputs.message }}
+        MESSAGE: ${{ inputs.message || 'This version is deprecated. Please use a newer version.' }}
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
       run: |
-        pnpm exec npm-deprecate --name "${{ inputs.version }}" --message "${MESSAGE:-This version is deprecated. Please use a newer version.}" --package "${{ inputs.package }}"
+        pnpm exec npm-deprecate --name "${{ inputs.version }}" --message "$MESSAGE" --package "${{ inputs.package }}"

--- a/packages/actions/src/deprecateVersion/action.yml
+++ b/packages/actions/src/deprecateVersion/action.yml
@@ -20,7 +20,9 @@ runs:
     - name: Deprecate version
       shell: bash
       env:
+        VERSION: ${{ inputs.version }}
         MESSAGE: ${{ inputs.message || 'This version is deprecated. Please use a newer version.' }}
+        PACKAGE: ${{ inputs.package }}
         NODE_AUTH_TOKEN: ${{ inputs.node-auth-token }}
       run: |
-        pnpm exec npm-deprecate --name "${{ inputs.version }}" --message "$MESSAGE" --package "${{ inputs.package }}"
+        pnpm exec npm-deprecate --name "$VERSION" --message "$MESSAGE" --package "$PACKAGE"


### PR DESCRIPTION
Since moving to packages/actions, calls always pass `message`:

https://github.com/discordjs/discord.js/blob/a39fb54c78fb4617c12b334216fa6245a5f12f83/.github/workflows/deprecate-version.yml#L50-L56

https://github.com/discordjs/discord.js/blob/a39fb54c78fb4617c12b334216fa6245a5f12f83/.github/workflows/remove-tag.yml#L54-L60

This means the default message will not be used as a value is present. Moved the handling of the default to the command instead.

Also moved other variables to `env`.