### PR TITLE
Fix/v14 dm recipients regression

### DIFF
--- a/packages/discord.js/src/client/actions/MessageCreate.js
+++ b/packages/discord.js/src/client/actions/MessageCreate.js
@@ -10,6 +10,7 @@ class MessageCreateAction extends Action {
       id: data.channel_id,
       author: data.author,
       ...('guild_id' in data && { guild_id: data.guild_id }),
+      ...('channel_type' in data && { type: data.channel_type }),
     });
     if (channel) {
       if (!channel.isTextBased()) return {};


### PR DESCRIPTION
So this is basically a backport to fix a DM bug that showed up in v14.26.2 after a previous PR.

that earlier change (#11479) tweaked how `getChannel` decides whether something is a DM, mainly to stop guild channels from accidentally being treated like DMs on the wrong shard. It did that by checking `data.type` and only treating it as a DM if the type explicitly matched DM or Group DM.

The problem is that assumption doesn’t hold in this case.

`MessageCreateAction` calls `getChannel` with just `{ id, author }`, and the actual gateway event for `MESSAGE_CREATE` doesn’t even include `channel type`. So `data.type` is always `undefined` here. That means the new condition never passes, `recipients` never gets set, and without `recipients` the code can’t create a `DMChannel`. Result: DM messages just silently disappear.

the fix is to go back to the approach used on `main`: don’t rely on `data.type` at all. Instead, it checks whether `recipients` already exists. If it doesn’t, it tries to infer the recipient from `author`, `user`, or `user_id` but importantly, it filters out the client user so it doesn’t confuse bot/self messages.

so the behavior becomes:

* If `recipients` is already there (like real DM interactions), leave it alone
* If it’s missing and the user is *not* the bot, set `recipients` so the DM channel can be created
* If it’s missing and it *is* the bot itself, don’t set anything, so we don’t accidentally misclassify shards or ephemeral bot messages as DMs

that restores DM handling without reintroducing the original cross-shard bug.

and since `ChannelType` is no longer used in this path, the import from `discord-api-types/v10` gets removed too.

Fixes #11486