### PR TITLE
fix(MessageCreateAction): receive DMs in uncached DMChannels again

### DIFF
--- a/packages/discord.js/src/client/actions/MessageCreate.js
+++ b/packages/discord.js/src/client/actions/MessageCreate.js
@@ -10,6 +10,7 @@ class MessageCreateAction extends Action {
       id: data.channel_id,
       author: data.author,
       ...('guild_id' in data && { guild_id: data.guild_id }),
+      ...('channel_type' in data && { type: data.channel_type }),
     });
     if (channel) {
       if (!channel.isTextBased()) return {};


### PR DESCRIPTION
While fixing #11429 with the combination of #11462 and #11479 I accidentally broke receiving of messages sent to the bot in uncached DMChannels, because they aren't recognized as such anymore.

Fixes #11486
Depends on
- https://github.com/discord/discord-api-docs/pull/8311
- https://github.com/discordjs/discord-api-types/pull/1638

Needs further testing if there still is a fixable issue for reactions being added/removed on a message in such an uncached DMChannel.