### PR TITLE
feat(ContainerBuilder): support ColorResolvable in setAccentColor

### DIFF
--- a/packages/builders/__tests__/components/v2/container.test.ts
+++ b/packages/builders/__tests__/components/v2/container.test.ts
@@ -174,6 +174,25 @@ describe('Container Components', () => {
 			);
 		});
 
+		test('GIVEN hex string or RGB tuple for accent color THEN resolves to integer', () => {
+			expect(new ContainerBuilder(containerWithTextDisplay).setAccentColor('#ff00ff').toJSON().accent_color).toBe(
+				0xff00ff,
+			);
+			expect(new ContainerBuilder(containerWithTextDisplay).setAccentColor('#000000').toJSON().accent_color).toBe(0);
+			expect(new ContainerBuilder(containerWithTextDisplay).setAccentColor([255, 0, 255]).toJSON().accent_color).toBe(
+				0xff00ff,
+			);
+			expect(new ContainerBuilder(containerWithTextDisplay).setAccentColor([0, 0, 0]).toJSON().accent_color).toBe(0);
+		});
+
+		test('GIVEN invalid accent color input THEN throws', () => {
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor('red' as any)).toThrowError();
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor('#fff' as any)).toThrowError();
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor([300, 0, 0] as any)).toThrowError();
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor(-1 as any)).toThrowError();
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor(0x1_00_00_00 as any)).toThrowError();
+		});
+
 		test('GIVEN valid method parameters THEN valid JSON is given', () => {
 			expect(
 				new ContainerBuilder()

--- a/packages/builders/__tests__/components/v2/container.test.ts
+++ b/packages/builders/__tests__/components/v2/container.test.ts
@@ -178,6 +178,9 @@ describe('Container Components', () => {
 			expect(new ContainerBuilder(containerWithTextDisplay).setAccentColor('#ff00ff').toJSON().accent_color).toBe(
 				0xff00ff,
 			);
+			expect(new ContainerBuilder(containerWithTextDisplay).setAccentColor('#FF00FF').toJSON().accent_color).toBe(
+				0xff00ff,
+			);
 			expect(new ContainerBuilder(containerWithTextDisplay).setAccentColor('#000000').toJSON().accent_color).toBe(0);
 			expect(new ContainerBuilder(containerWithTextDisplay).setAccentColor([255, 0, 255]).toJSON().accent_color).toBe(
 				0xff00ff,

--- a/packages/builders/__tests__/components/v2/container.test.ts
+++ b/packages/builders/__tests__/components/v2/container.test.ts
@@ -188,9 +188,30 @@ describe('Container Components', () => {
 		test('GIVEN invalid accent color input THEN throws', () => {
 			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor('red' as any)).toThrowError();
 			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor('#fff' as any)).toThrowError();
-			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor([300, 0, 0] as any)).toThrowError();
 			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor(-1 as any)).toThrowError();
 			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor(0x1_00_00_00 as any)).toThrowError();
+		});
+
+		test('GIVEN out-of-range RGB components THEN throws', () => {
+			// Each channel must be an integer within [0, 255].
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor([0, 0, 300] as any)).toThrowError(
+				RangeError,
+			);
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor([0, 256, 0] as any)).toThrowError(
+				RangeError,
+			);
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor([300, 0, 0] as any)).toThrowError(
+				RangeError,
+			);
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor([-1, 0, 0] as any)).toThrowError(
+				RangeError,
+			);
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor([1.9, 0, 0] as any)).toThrowError(
+				RangeError,
+			);
+			expect(() => new ContainerBuilder(containerWithTextDisplay).setAccentColor([0, 0] as any)).toThrowError(
+				TypeError,
+			);
 		});
 
 		test('GIVEN valid method parameters THEN valid JSON is given', () => {

--- a/packages/builders/src/components/v2/Container.ts
+++ b/packages/builders/src/components/v2/Container.ts
@@ -12,6 +12,7 @@ import {
 } from 'discord-api-types/v10';
 import { normalizeArray, type RestOrArray } from '../../util/normalizeArray';
 import { resolveBuilder } from '../../util/resolveBuilder';
+import { resolveColor, type ColorResolvable } from '../../util/resolveColor';
 import { validate } from '../../util/validation';
 import { ActionRowBuilder } from '../ActionRow.js';
 import { ComponentBuilder } from '../Component.js';
@@ -71,10 +72,12 @@ export class ContainerBuilder extends ComponentBuilder<APIContainerComponent> {
 	/**
 	 * Sets the accent color of this container.
 	 *
+	 * @remarks
+	 * Accepts either an integer, a `#rrggbb` hex string, or an `[r, g, b]` tuple.
 	 * @param color - The color to use
 	 */
-	public setAccentColor(color: number) {
-		this.data.accent_color = color;
+	public setAccentColor(color: ColorResolvable) {
+		this.data.accent_color = resolveColor(color);
 		return this;
 	}
 

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -91,6 +91,7 @@ export * from './messages/MessageReference.js';
 
 export * from './util/normalizeArray.js';
 export * from './util/resolveBuilder.js';
+export * from './util/resolveColor.js';
 export { disableValidators, enableValidators, isValidationEnabled } from './util/validation.js';
 export * from './util/ValidationError.js';
 

--- a/packages/builders/src/util/resolveColor.ts
+++ b/packages/builders/src/util/resolveColor.ts
@@ -17,7 +17,8 @@ export type ColorResolvable = HexColorString | RGBTuple | number;
  * Resolves a color input to an integer color value.
  *
  * @param color - The color to resolve
- * @throws {@link RangeError} If the resolved color is outside the range of 0 to `0xffffff`.
+ * @throws {@link RangeError} If the resolved color is outside the range of 0 to `0xffffff`,
+ * or if an RGB tuple contains a component outside 0-255.
  * @throws {@link TypeError} If the input is an invalid hex string or malformed RGB tuple.
  */
 export function resolveColor(color: ColorResolvable): number {
@@ -26,8 +27,14 @@ export function resolveColor(color: ColorResolvable): number {
 	if (typeof color === 'string' && /^#?[\da-f]{6}$/i.test(color)) {
 		resolved = Number.parseInt(color.replace('#', ''), 16);
 	} else if (Array.isArray(color)) {
-		if (color.length !== 3 || color.some((component) => typeof component !== 'number' || Number.isNaN(component))) {
+		if (color.length !== 3 || color.some((component) => typeof component !== 'number')) {
 			throw new TypeError('Invalid color tuple: expected [red, green, blue] with numeric components.');
+		}
+
+		for (const component of color) {
+			if (!Number.isInteger(component) || component < 0 || component > 0xff) {
+				throw new RangeError('RGB tuple components must be integers within the range 0 to 255.');
+			}
 		}
 
 		resolved = (color[0] << 16) + (color[1] << 8) + color[2];

--- a/packages/builders/src/util/resolveColor.ts
+++ b/packages/builders/src/util/resolveColor.ts
@@ -27,7 +27,7 @@ export function resolveColor(color: ColorResolvable): number {
 	if (typeof color === 'string' && /^#?[\da-f]{6}$/i.test(color)) {
 		resolved = Number.parseInt(color.replace('#', ''), 16);
 	} else if (Array.isArray(color)) {
-		if (color.length !== 3 || color.some((component) => typeof component !== 'number')) {
+		if (color.length !== 3) {
 			throw new TypeError('Invalid color tuple: expected [red, green, blue] with numeric components.');
 		}
 

--- a/packages/builders/src/util/resolveColor.ts
+++ b/packages/builders/src/util/resolveColor.ts
@@ -1,0 +1,45 @@
+/**
+ * A tuple representing a color as red, green, and blue components, each in the range 0-255.
+ */
+export type RGBTuple = readonly [red: number, green: number, blue: number];
+
+/**
+ * A hex color string, prefixed with `#`.
+ */
+export type HexColorString = `#${string}`;
+
+/**
+ * Data that can be resolved to a numeric color value.
+ */
+export type ColorResolvable = HexColorString | RGBTuple | number;
+
+/**
+ * Resolves a color input to an integer color value.
+ *
+ * @param color - The color to resolve
+ * @throws {@link RangeError} If the resolved color is outside the range of 0 to `0xffffff`.
+ * @throws {@link TypeError} If the input is an invalid hex string or malformed RGB tuple.
+ */
+export function resolveColor(color: ColorResolvable): number {
+	let resolved: number;
+
+	if (typeof color === 'string' && /^#?[\da-f]{6}$/i.test(color)) {
+		resolved = Number.parseInt(color.replace('#', ''), 16);
+	} else if (Array.isArray(color)) {
+		if (color.length !== 3 || color.some((component) => typeof component !== 'number' || Number.isNaN(component))) {
+			throw new TypeError('Invalid color tuple: expected [red, green, blue] with numeric components.');
+		}
+
+		resolved = (color[0] << 16) + (color[1] << 8) + color[2];
+	} else if (typeof color === 'number') {
+		resolved = color;
+	} else {
+		throw new TypeError('Invalid color: expected a number, RGB tuple, or "#rrggbb" hex string.');
+	}
+
+	if (!Number.isInteger(resolved) || resolved < 0 || resolved > 0xffffff) {
+		throw new RangeError('Color must be within the range 0 to 16777215 (0xFFFFFF).');
+	}
+
+	return resolved;
+}


### PR DESCRIPTION
## Summary

- Adds a small `resolveColor` helper to `@discordjs/builders` that accepts a raw integer, a `#rrggbb` hex string, or an `[r, g, b]` tuple. The semantics mirror `resolveColor` in the main `discord.js` package (both accept the same shapes and use the same range check).
- `ContainerBuilder#setAccentColor` now routes through it, so users can do `.setAccentColor('#00af89')` or `.setAccentColor([0, 175, 137])` in addition to raw integers.

## Why

`ContainerBuilder#setAccentColor` previously only accepted `number`, which is inconsistent with how color inputs are usually expressed in the ecosystem and with `resolveColor` exposed from `discord.js`. This closes the gap reported in #11496 without changing any existing behavior, since integers are still accepted unchanged.

## Test plan

- [x] `pnpm --filter=@discordjs/builders test` (255/255 passing, includes new cases for hex strings, RGB tuples, and invalid inputs)
- [x] `pnpm --filter=@discordjs/builders lint`

Closes #11496