### PR TITLE
feat(formatters): add escapeHideLinkEmbed helper

### DIFF
--- a/packages/formatters/__tests__/escapers.test.ts
+++ b/packages/formatters/__tests__/escapers.test.ts
@@ -237,6 +237,19 @@ not a quote
 			expect(escapeHideLinkEmbed('<#123456>')).toEqual('<#123456>');
 		});
 
+		test('does not touch other discord angle-bracket syntaxes', () => {
+			// Timestamps
+			expect(escapeHideLinkEmbed('<t:1700000000>')).toEqual('<t:1700000000>');
+			expect(escapeHideLinkEmbed('<t:1700000000:R>')).toEqual('<t:1700000000:R>');
+			// Custom emoji
+			expect(escapeHideLinkEmbed('<:name:123>')).toEqual('<:name:123>');
+			expect(escapeHideLinkEmbed('<a:name:123>')).toEqual('<a:name:123>');
+			// Role mention
+			expect(escapeHideLinkEmbed('<@&123456>')).toEqual('<@&123456>');
+			// Slash-command mention
+			expect(escapeHideLinkEmbed('</cmd:123>')).toEqual('</cmd:123>');
+		});
+
 		test('multiple occurrences', () => {
 			expect(escapeHideLinkEmbed('see <https://a.example/> and <https://b.example/>')).toEqual(
 				'see \\<https://a.example/> and \\<https://b.example/>',
@@ -329,6 +342,26 @@ part of it
 			expect(escapeMarkdown(testString, { quote: false })).toEqual(
 				"> \\`\\_Behold!\\_\\`\n\\|\\|\\_\\_\\_\\~\\~\\*\\*\\*\\`\\`\\`js\n\\`use strict\\`;\nrequire('discord.js');\\`\\`\\`\\*\\*\\*\\~\\~\\_\\_\\_\\|\\|",
 			);
+		});
+
+		describe('hideLinkEmbed option', () => {
+			const input = 'prefix <https://example.com> suffix';
+
+			test('escapes the sequence by default', () => {
+				expect(escapeMarkdown(input)).toEqual('prefix \\<https://example.com> suffix');
+			});
+
+			test('leaves the sequence untouched when disabled', () => {
+				expect(escapeMarkdown(input, { hideLinkEmbed: false })).toEqual(input);
+			});
+
+			test('still applies inside the codeBlockContent recursion', () => {
+				const codeInput = '```\n<https://example.com>\n```\n<https://example.org>';
+				expect(escapeMarkdown(codeInput, { codeBlockContent: false })).toContain('\\<https://example.org>');
+				expect(escapeMarkdown(codeInput, { codeBlockContent: false, hideLinkEmbed: false })).toContain(
+					'<https://example.org>',
+				);
+			});
 		});
 
 		describe('block quotes', () => {

--- a/packages/formatters/__tests__/escapers.test.ts
+++ b/packages/formatters/__tests__/escapers.test.ts
@@ -14,6 +14,7 @@ import {
 	escapeMarkdown,
 	escapeQuote,
 	escapeBlockQuote,
+	escapeHideLinkEmbed,
 } from '../src/index.js';
 
 const testString = "> `_Behold!_`\n||___~~***```js\n`use strict`;\nrequire('discord.js');```***~~___||";
@@ -218,6 +219,28 @@ not a quote
  \\> another quote
 >> not a quote`;
 			expect(escapeQuote(input)).toEqual(expectedOutput);
+		});
+	});
+
+	describe('escapeHideLinkEmbed', () => {
+		test('basic', () => {
+			expect(escapeHideLinkEmbed('<https://discord.js.org/>')).toEqual('\\<https://discord.js.org/>');
+			expect(escapeHideLinkEmbed('<a:/b>')).toEqual('\\<a:/b>');
+			expect(escapeHideLinkEmbed('</:/:>')).toEqual('\\</:/:>');
+		});
+
+		test('does not affect unrelated text', () => {
+			expect(escapeHideLinkEmbed('no angle brackets here')).toEqual('no angle brackets here');
+			expect(escapeHideLinkEmbed('<https://example.com>')).toEqual('\\<https://example.com>');
+			expect(escapeHideLinkEmbed('plain https://example.com url')).toEqual('plain https://example.com url');
+			expect(escapeHideLinkEmbed('<@123456>')).toEqual('<@123456>');
+			expect(escapeHideLinkEmbed('<#123456>')).toEqual('<#123456>');
+		});
+
+		test('multiple occurrences', () => {
+			expect(escapeHideLinkEmbed('see <https://a.example/> and <https://b.example/>')).toEqual(
+				'see \\<https://a.example/> and \\<https://b.example/>',
+			);
 		});
 	});
 

--- a/packages/formatters/src/escapers.ts
+++ b/packages/formatters/src/escapers.ts
@@ -54,6 +54,13 @@ export interface EscapeMarkdownOptions {
 	heading?: boolean;
 
 	/**
+	 * Whether to escape "hide link embed" sequences (e.g. `<https://example.com>`).
+	 *
+	 * @defaultValue `true`
+	 */
+	hideLinkEmbed?: boolean;
+
+	/**
 	 * Whether to escape inline code.
 	 *
 	 * @defaultValue `true`
@@ -140,6 +147,7 @@ export function escapeMarkdown(text: string, options: EscapeMarkdownOptions = {}
 		maskedLink = true,
 		blockQuote = true,
 		quote = true,
+		hideLinkEmbed = true,
 	} = options;
 
 	if (!codeBlockContent) {
@@ -162,6 +170,7 @@ export function escapeMarkdown(text: string, options: EscapeMarkdownOptions = {}
 					maskedLink,
 					blockQuote,
 					quote,
+					hideLinkEmbed,
 				});
 			})
 			.join(codeBlock ? '\\`\\`\\`' : '```');
@@ -186,6 +195,7 @@ export function escapeMarkdown(text: string, options: EscapeMarkdownOptions = {}
 					maskedLink,
 					blockQuote,
 					quote,
+					hideLinkEmbed,
 				});
 			})
 			.join(inlineCode ? '\\`' : '`');
@@ -206,6 +216,7 @@ export function escapeMarkdown(text: string, options: EscapeMarkdownOptions = {}
 	if (maskedLink) res = escapeMaskedLink(res);
 	if (quote) res = escapeQuote(res);
 	if (blockQuote) res = escapeBlockQuote(res);
+	if (hideLinkEmbed) res = escapeHideLinkEmbed(res);
 	return res;
 }
 
@@ -356,4 +367,18 @@ export function escapeQuote(text: string): string {
  */
 export function escapeBlockQuote(text: string): string {
 	return text.replaceAll(/^(\s*)>>>(\s+)/gm, '$1\\>>>$2');
+}
+
+/**
+ * Escapes "hide link embed" markdown sequences in a string.
+ *
+ * @remarks
+ * Discord interprets a `<scheme:/path>` sequence (for example `<https://example.com>` or
+ * `<a:/b>`) as a directive to suppress embeds or otherwise consume the surrounding
+ * angle brackets. This escaper prepends a backslash to the leading `<`, so the sequence
+ * renders as literal text in the client.
+ * @param text - Content to escape
+ */
+export function escapeHideLinkEmbed(text: string): string {
+	return text.replaceAll(/<([^\s:<>]+:\/[^\s<>]+)>/g, '\\<$1>');
 }

--- a/packages/formatters/src/escapers.ts
+++ b/packages/formatters/src/escapers.ts
@@ -377,6 +377,11 @@ export function escapeBlockQuote(text: string): string {
  * `<a:/b>`) as a directive to suppress embeds or otherwise consume the surrounding
  * angle brackets. This escaper prepends a backslash to the leading `<`, so the sequence
  * renders as literal text in the client.
+ *
+ * Note that escaping the leading `<` drops the embed-suppression directive. To display
+ * literal angle brackets while still suppressing the embed, wrap the escaped output in
+ * another pair of angle brackets at the call site, e.g.
+ * `` `<${escapeHideLinkEmbed(text)}>` ``.
  * @param text - Content to escape
  */
 export function escapeHideLinkEmbed(text: string): string {


### PR DESCRIPTION
## Summary

- Adds `escapeHideLinkEmbed`, a new escaper that prepends `\` to the leading `<` of a `<scheme:/path>` sequence, so content like `<https://discord.js.org/>` or `<a:/b>` renders literally instead of being consumed by the client as a suppressed-embed / hide-link directive.
- `escapeMarkdown` now routes through the new helper via a matching `hideLinkEmbed` option (defaulting to `true`, in line with the other escapers).

## Why

Nicknames and other user-provided content can legitimately contain the angle-bracket shorthand (the original report mentions a nickname like `</:/:>` rendering as `/:/:` in bot output). The formatters package otherwise covers every Discord-flavored markdown sequence, this was the remaining gap called out in the linked issue.

## Test plan

- [x] `pnpm --filter=@discordjs/formatters test` (121/121 passing, new cases cover the URL form, the short scheme form, multiple matches, and no-op cases like plain text, bare URLs, and unrelated `<...>` mentions)
- [x] `pnpm --filter=@discordjs/formatters lint`

Closes #9852