### PR TITLE
feat(Message): add threadable getter

### DIFF
--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { PermissionFlagsBits } = require('discord-api-types/v10');
 const { GuildMessageManager } = require('../managers/GuildMessageManager.js');
 const { GuildTextThreadManager } = require('../managers/GuildTextThreadManager.js');
 const { GuildChannel } = require('./GuildChannel.js');
@@ -97,18 +96,6 @@ class BaseGuildTextChannel extends GuildChannel {
     if ('messages' in data) {
       for (const message of data.messages) this.messages._add(message);
     }
-  }
-
-  /**
-   * Whether the client user can start a new thread in this channel.
-   *
-   * @type {boolean}
-   * @readonly
-   */
-  get threadable() {
-    if (!this.viewable) return false;
-    const permissions = this.permissionsFor(this.client.user);
-    return permissions?.has(PermissionFlagsBits.CreatePublicThreads, false) ?? false;
   }
 
   /**

--- a/packages/discord.js/src/structures/BaseGuildTextChannel.js
+++ b/packages/discord.js/src/structures/BaseGuildTextChannel.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { PermissionFlagsBits } = require('discord-api-types/v10');
 const { GuildMessageManager } = require('../managers/GuildMessageManager.js');
 const { GuildTextThreadManager } = require('../managers/GuildTextThreadManager.js');
 const { GuildChannel } = require('./GuildChannel.js');
@@ -96,6 +97,18 @@ class BaseGuildTextChannel extends GuildChannel {
     if ('messages' in data) {
       for (const message of data.messages) this.messages._add(message);
     }
+  }
+
+  /**
+   * Whether the client user can start a new thread in this channel.
+   *
+   * @type {boolean}
+   * @readonly
+   */
+  get threadable() {
+    if (!this.viewable) return false;
+    const permissions = this.permissionsFor(this.client.user);
+    return permissions?.has(PermissionFlagsBits.CreatePublicThreads, false) ?? false;
   }
 
   /**

--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -811,6 +811,23 @@ class Message extends Base {
   }
 
   /**
+   * Whether a thread can be started from this message by the client user.
+   *
+   * @type {boolean}
+   * @readonly
+   */
+  get threadable() {
+    const { channel } = this;
+    if (!channel) return false;
+    if (![ChannelType.GuildText, ChannelType.GuildAnnouncement].includes(channel.type)) return false;
+    if (this.hasThread) return false;
+    if (!channel.viewable) return false;
+
+    const permissions = channel.permissionsFor(this.client.user);
+    return permissions?.has(PermissionFlagsBits.CreatePublicThreads, false) ?? false;
+  }
+
+  /**
    * Fetches the Message this crosspost/reply/pin-add references, if available to the client
    *
    * @returns {Promise<Message>}

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -622,6 +622,7 @@ export class BaseGuildTextChannel extends GuildChannel {
   public rateLimitPerUser: number | null;
   public nsfw: boolean;
   public threads: GuildTextThreadManager<AllowedThreadTypeForAnnouncementChannel | AllowedThreadTypeForTextChannel>;
+  public get threadable(): boolean;
   public topic: string | null;
   public createInvite(options?: InviteCreateOptions): Promise<GuildInvite>;
   public fetchInvites(cache?: boolean): Promise<Collection<string, GuildInvite>>;
@@ -2220,6 +2221,7 @@ export class Message<InGuild extends boolean = boolean> extends Base {
   public resolved: CommandInteractionResolvedData | null;
   public system: boolean;
   public get thread(): AnyThreadChannel | null;
+  public get threadable(): boolean;
   public tts: boolean;
   public poll: Poll | null;
   public call: MessageCall | null;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -622,7 +622,6 @@ export class BaseGuildTextChannel extends GuildChannel {
   public rateLimitPerUser: number | null;
   public nsfw: boolean;
   public threads: GuildTextThreadManager<AllowedThreadTypeForAnnouncementChannel | AllowedThreadTypeForTextChannel>;
-  public get threadable(): boolean;
   public topic: string | null;
   public createInvite(options?: InviteCreateOptions): Promise<GuildInvite>;
   public fetchInvites(cache?: boolean): Promise<Collection<string, GuildInvite>>;


### PR DESCRIPTION
## Summary

- Adds `Message#threadable`, mirroring the existing `deletable` / `editable` / `crosspostable` / `pinnable` getters. It returns whether the client user can start a thread from the message (parent channel type supports threads, no pre-existing thread, channel viewable, `CreatePublicThreads` permission).
- Updates the TypeScript typings accordingly.

## Why

Bots frequently filter messages to decide whether to offer a "start thread" affordance, and the library already ships the same sort of `-able` helpers for deleting, editing, and pinning. This closes the gap reported in the linked issue without introducing new intents or requests, since every check is based on already-cached state.

The channel-level variant that was in an earlier push of this PR was dropped per review: `TextChannel` supports both public and private threads behind separate permissions (`CreatePublicThreads` / `CreatePrivateThreads`), so a single boolean would have been misleading.

## Test plan

- [x] `pnpm --filter=discord.js test`
- [x] `pnpm --filter=discord.js lint`

Closes #11264