### PR TITLE
docs: fix typos and duplicated words in comments and guide

### DIFF
--- a/apps/guide/content/docs/legacy/miscellaneous/useful-packages.mdx
+++ b/apps/guide/content/docs/legacy/miscellaneous/useful-packages.mdx
@@ -110,7 +110,7 @@ interaction.reply(oneLineCommaListsOr`
 `);
 ```
 
-Check the the documentation to find more useful functions.
+Check the documentation to find more useful functions.
 
 ## chalk
 

--- a/packages/brokers/src/brokers/redis/RedisGateway.ts
+++ b/packages/brokers/src/brokers/redis/RedisGateway.ts
@@ -35,8 +35,8 @@ export type RedisBrokerDiscordEvents = {
  * events as the receiving service expects, and also that you handle GatewaySend events.
  * - One drawback to using this directly with `@discordjs/core` is that you lose granular control over when to `ack`
  * events. This implementation `ack`s as soon as the event is emitted to listeners. In practice, this means that if your
- * service crashes while handling an event, it's pretty arbitrary wether that event gets re-processed on restart or not.
- * (Mostly dependant on if your handler is async or not, and also if the `ack` call has time to go through).
+ * service crashes while handling an event, it's pretty arbitrary whether that event gets re-processed on restart or not.
+ * (Mostly dependent on if your handler is async or not, and also if the `ack` call has time to go through).
  *
  * @example
  * ```ts

--- a/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
+++ b/packages/discord.js/src/structures/CommandInteractionOptionResolver.js
@@ -97,7 +97,7 @@ class CommandInteractionOptionResolver {
    *
    * @param {string} name The name of the option.
    * @param {ApplicationCommandOptionType[]} allowedTypes The allowed types of the option.
-   * @param {string[]} properties The properties to check for for `required`.
+   * @param {string[]} properties The properties to check for `required`.
    * @param {boolean} required Whether to throw an error if the option is not found.
    * @returns {?CommandInteractionOption} The option, if found.
    * @private

--- a/packages/discord.js/src/structures/ModalComponentResolver.js
+++ b/packages/discord.js/src/structures/ModalComponentResolver.js
@@ -79,7 +79,7 @@ class ModalComponentResolver {
    *
    * @param {string} customId The custom id of the component.
    * @param {ComponentType[]} allowedTypes The allowed types of the component.
-   * @param {string[]} properties The properties to check for for `required`.
+   * @param {string[]} properties The properties to check for `required`.
    * @param {boolean} required Whether to throw an error if the component value(s) are not found.
    * @returns {ModalData} The option, if found.
    * @private


### PR DESCRIPTION
## Summary

Small, documentation-only fixes across a few packages and the guide. No code behavior is changed.

## Please describe the changes this PR makes and why it should be merged:

- **`packages/brokers/src/brokers/redis/RedisGateway.ts`** — fix `wether` → `whether` and `dependant` → `dependent` in the `RedisGateway` class JSDoc.
- **`apps/guide/content/docs/legacy/miscellaneous/useful-packages.mdx`** — remove duplicated word: "Check the the documentation" → "Check the documentation".
- **`packages/discord.js/src/structures/CommandInteractionOptionResolver.js`** and **`packages/discord.js/src/structures/ModalComponentResolver.js`** — remove duplicated word in the `@param` description for `properties`: "check for for \`required\`" → "check for \`required\`".

## Status and versioning classification:

<!-- Please move lines that apply to you out of the comment: -->
<!-- - Code changes have been tested against the Discord API, or there are no code changes -->
<!-- - I know how to set up a development environment, and have done so -->

- This PR changes the library's interface (methods or parameters added)
- This PR **includes breaking changes** (methods removed or renamed, parameters moved or removed)
- This PR is a breaking change that users should opt into (e.g. a new plugin)

---

All changes are documentation/comment only. Lint (`prettier --check` + `eslint`) and `docs:test` (`docgen`) pass locally for the touched packages.