### PR TITLE
fix(Collector): resetTimer now updates options and handles null timers

### DIFF
--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -272,14 +272,25 @@ class Collector extends AsyncEventEmitter {
    * @param {CollectorResetTimerOptions} [options] Options for resetting
    */
   resetTimer({ time, idle } = {}) {
+    if (time !== undefined) this.options.time = time;
+    if (idle !== undefined) this.options.idle = idle;
+
     if (this._timeout) {
       clearTimeout(this._timeout);
-      this._timeout = setTimeout(() => this.stop('time'), time ?? this.options.time).unref();
+      this._timeout = null;
+    }
+
+    if (this.options.time) {
+      this._timeout = setTimeout(() => this.stop('time'), this.options.time).unref();
     }
 
     if (this._idletimeout) {
       clearTimeout(this._idletimeout);
-      this._idletimeout = setTimeout(() => this.stop('idle'), idle ?? this.options.idle).unref();
+      this._idletimeout = null;
+    }
+
+    if (this.options.idle) {
+      this._idletimeout = setTimeout(() => this.stop('idle'), this.options.idle).unref();
     }
   }
 


### PR DESCRIPTION
Closes #11286.

### Root cause

\`Collector#resetTimer\` rebuilt \`_timeout\` / \`_idletimeout\` from its arguments but never wrote the new values back onto \`this.options\`. Any later code path that reads \`this.options.idle\` or \`this.options.time\` (the one in \`handleCollect\` resetting the idle timer after each collect is the loud one) kept using the old values, so the reset only held until the next collect came in.

It also returned early when the collector was started without a \`time\` or \`idle\` option at all, because \`this._timeout\` / \`this._idletimeout\` were \`null\`. That made dynamically adding a timeout to an existing collector impossible, which was the secondary complaint in the issue.

### Change

\`resetTimer\` now:

1. Writes any provided \`time\` / \`idle\` to \`this.options\` first.
2. Clears the existing timer(s) unconditionally (harmless if they were \`null\`).
3. Creates new timers from \`this.options.time\` / \`this.options.idle\` when those are truthy.

Step 3 is driven by the (possibly just updated) option value, not by the presence of an old timer, so passing a new \`idle\` on a collector that had none now activates idle tracking from that point forward.

### Verification

Manual repro from the issue no longer triggers the stale-timer behaviour, and follow-up \`handleCollect\` calls use the new \`options.idle\`.