### PR TITLE
fix(Action): restore DM recipient fallback for untyped channel payloads

### DIFF
--- a/packages/discord.js/src/client/actions/Action.js
+++ b/packages/discord.js/src/client/actions/Action.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { ChannelType } = require('discord-api-types/v10');
 const { Poll } = require('../../structures/Poll.js');
 const { PollAnswer } = require('../../structures/PollAnswer.js');
 const Partials = require('../../util/Partials.js');
@@ -40,10 +39,15 @@ class GenericAction {
       if (!data.recipients.some(existingRecipient => recipient.id === existingRecipient.id)) {
         payloadData.recipients = [...data.recipients, recipient];
       }
-    } else if (data.type === ChannelType.DM || data.type === ChannelType.GroupDM) {
-      // Try to resolve the recipient.
+    } else {
+      // Try to resolve the recipient, but do not add the client user.
+      // This branch fires for events where the channel type isn't carried
+      // in the payload (MESSAGE_CREATE, MESSAGE_UPDATE, etc. all strip
+      // `type` before reaching here). Without the recipient being injected
+      // the downstream createChannel() can't construct an uncached
+      // DMChannel, which silently drops the event — see #11486.
       const recipient = data.author ?? data.user ?? { id: data.user_id };
-      payloadData.recipients = [recipient];
+      if (recipient.id !== this.client.user.id) payloadData.recipients = [recipient];
     }
 
     if (id !== undefined) payloadData.id = id;


### PR DESCRIPTION
Please describe the changes this PR makes and why it should be merged:

Fixes #11486. Also closes #11497 (duplicate report).

## The bug

On `v14`, uncached DM channels never receive a `messageCreate` event. The first DM sent to a freshly-started bot is silently dropped; subsequent DMs from the same user hit the same path because the cache is never populated.

Reproducible with the minimal code sample from #11486 / #11497 against `discord.js@14.26.3`.

## Root cause

Introduced in #11479. That PR narrowed `Action.getChannel()`'s recipient-injection branch from an unconditional `else` to `else if (data.type === ChannelType.DM || data.type === ChannelType.GroupDM)`.

The problem: the callers that route through `getChannel()` don't all carry a channel `type`. In particular, `MessageCreateAction.handle()` (`src/client/actions/MessageCreate.js`) builds a stripped object:

```js
const channel = this.getChannel({
  id: data.channel_id,
  author: data.author,
  ...('guild_id' in data && { guild_id: data.guild_id }),
});
```

That object has no `type` field at all. `data.type` in `getChannel` is therefore `undefined`, neither the DM nor the GroupDM arm matches, and no `recipients` key is injected into `payloadData`.

Downstream, `createChannel()` (`src/util/Channels.js`) reaches the DM detection:

```js
if ((data.recipients && data.type !== ChannelType.GroupDM) || data.type === ChannelType.DM) {
  channel = new DMChannel(client, data);
}
```

Both conditions are false without `recipients` and without `type`, so `createChannel()` returns `undefined`, `ChannelManager._add` returns `null`, and `MessageCreateAction.handle`'s `if (channel)` guard silently short-circuits. The `messageCreate` event never fires.

The cache never gets populated, so every subsequent DM hits the same path.

## The fix

Restore the pre-#11462 fallback pattern that `main` already ships: when there's no existing `recipients` array on the payload, inject the derived recipient unconditionally, guarded by the client-user check so the bot doesn't add itself as a recipient for its own outbound events.

```js
if ('recipients' in data) {
  // existing dedupe logic, unchanged
} else {
  const recipient = data.author ?? data.user ?? { id: data.user_id };
  if (recipient.id !== this.client.user.id) payloadData.recipients = [recipient];
}
```

The `ChannelType` import is no longer needed.

## Why this is safe for guild channels (i.e. why #11479's concern doesn't regress)

Guild channels enter `createChannel()` via the `else` branch (`data.guild_id` is present), which ignores `recipients` entirely — it selects the channel constructor from `data.type` via the switch and passes the guild in. Nothing reads `payloadData.recipients` on that path. The `!data.guild_id && !guild` gate at the top of the DM arm in `createChannel()` already prevents any recipients-bearing guild payload from being misrouted to `new DMChannel()`.

The guard `recipient.id !== this.client.user.id` — already on `main` — additionally prevents self-recipient injection for cases where the event author is the bot itself.

## Equivalence with `main`

`main` already has this code. It landed as part of #11462's pre-image on `main` and was never touched by the subsequent `v14` PRs. The dev build `15.0.0-dev.1776125601-58c5ebdd0` has been reported working (see #11497). This PR effectively cherry-picks `main`'s `getChannel` implementation back into `v14`.

## Status

- [x] Documentation added (if applicable) — n/a, no API change
- [x] Tests added (if applicable) — the `discord.js` package currently ships only two integration-style tests (`test/reactionCollectorCreated.test.js`, `test/resolveGuildTemplateCode.test.js`) which require live Discord credentials. There is no vitest harness set up at the package level for pure unit tests of `Action.getChannel`. Manual reproduction is documented below and matches the original bug reports.
- [x] I have run `pnpm run lint` (passes, no new warnings) and `pnpm run test:typescript` (passes).

## Manual reproduction

1. Bot with `intents: [DirectMessages, MessageContent]` and `partials: [Partials.Channel]`.
2. Send the bot a DM from a user account, cold-started, with no prior DM history cached.
3. **Before this patch:** gateway delivers `MESSAGE_CREATE` (verifiable via a `raw` listener) but no `messageCreate` event fires. `client.on('debug', …)` shows `Failed to find guild, or unknown type for channel <id> undefined`.
4. **After this patch:** `messageCreate` fires with `channel.type === 1` (DM) and downstream handlers run normally.

This same pattern was validated independently in a working downstream workaround in https://github.com/esterne/simianclaw/commit/0265e35 — the workaround is no longer needed once this fix lands.