### PR TITLE
fix(scripts): correctly mark external docs on non-main tags

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,7 @@ const nodeRuleset = merge(...node, {
 		'n/prefer-global/text-encoder': [2, 'always'],
 		'n/prefer-global/url-search-params': [2, 'always'],
 		'n/prefer-global/url': [2, 'always'],
+		'unicorn/better-regex': 1,
 	},
 });
 

--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -540,10 +540,12 @@ function resolveFileUrl(item: ApiDeclaredItem) {
 	} else if (fileUrl?.includes('/dist/') && fileUrl.includes('/packages/')) {
 		const [dir, pkg] = fileUrl.split('/packages/');
 		const pkgName = pkg!.split('/')[0];
+		const prefix = pkgName === 'discord.js' ? '' : '@discordjs/';
 		const version =
 			dir?.split('/').at(-1) === 'main'
 				? 'main'
-				: item.getAssociatedPackage()?.dependencies?.[pkgName!]?.replace(/[~^]/, '');
+				: // eslint-disable-next-line unicorn/better-regex
+					item.getAssociatedPackage()?.dependencies?.[`${prefix}${pkgName}`]?.replace(/[~^]/, '');
 
 		// https://github.com/discordjs/discord.js/tree/main/packages/builders/dist/index.d.ts
 		let currentItem = item;

--- a/packages/scripts/src/generateSplitDocumentation.ts
+++ b/packages/scripts/src/generateSplitDocumentation.ts
@@ -537,10 +537,13 @@ function resolveFileUrl(item: ApiDeclaredItem) {
 				sourceURL: `/docs/packages/${pkgName}/${version}/${(currentItem.parent as ApiEntryPoint).importPath}/${currentItem.displayName}:${currentItem.kind}`,
 			};
 		}
-	} else if (fileUrl?.includes('/dist/') && fileUrl.includes('/main/packages/')) {
-		const [, pkg] = fileUrl.split('/main/packages/');
+	} else if (fileUrl?.includes('/dist/') && fileUrl.includes('/packages/')) {
+		const [dir, pkg] = fileUrl.split('/packages/');
 		const pkgName = pkg!.split('/')[0];
-		const version = 'main';
+		const version =
+			dir?.split('/').at(-1) === 'main'
+				? 'main'
+				: item.getAssociatedPackage()?.dependencies?.[pkgName!]?.replace(/[~^]/, '');
 
 		// https://github.com/discordjs/discord.js/tree/main/packages/builders/dist/index.d.ts
 		let currentItem = item;


### PR DESCRIPTION
This should fix the issue where the source of re-exported external members links to a `/dist/index.d.ts` file instead of the documentation of the external package.

Example: https://discord.js.org/docs/packages/discord.js/14.25.0/SlashCommandBuilder:Class