### PR TITLE
fix: clean up mixin error text and switch Next middleware to proxy

### DIFF
--- a/apps/guide/src/proxy.ts
+++ b/apps/guide/src/proxy.ts
@@ -1,6 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
 	// TODO: Remove this eventually
 	if (request.nextUrl.pathname.startsWith('/guide/')) {
 		const newUrl = request.nextUrl.clone();

--- a/apps/website/src/proxy.ts
+++ b/apps/website/src/proxy.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { PACKAGES } from '@/util/constants';
 import { fetchLatestVersion } from '@/util/fetchLatestVersion';
 
-export default async function middleware(request: NextRequest) {
+export default async function proxy(request: NextRequest) {
 	if (request.nextUrl.pathname === '/docs') {
 		const latestVersion = await fetchLatestVersion('discord.js');
 		return NextResponse.redirect(new URL(`/docs/packages/discord.js/${latestVersion}`, request.url));

--- a/packages/api-extractor-model/src/mixins/ApiParameterListMixin.ts
+++ b/packages/api-extractor-model/src/mixins/ApiParameterListMixin.ts
@@ -132,7 +132,7 @@ export function ApiParameterListMixin<TBaseClass extends IApiItemConstructor>(
 					}
 				}
 			} else {
-				throw new InternalError('ApiReturnTypeMixin expects a base class that inherits from ApiDeclaredItem');
+				throw new InternalError('ApiParameterListMixin expects a base class that inherits from ApiDeclaredItem');
 			}
 		}
 


### PR DESCRIPTION
corrected the copied error message in ApiParameterListMixin so it points to the right mixin & renamed the guide and website Nextjs middleware entrypoints to proxy to match the current convention and remove the deprecation warning