### PR TITLE
fix(Collector): persist time and idle in resetTimer

### DIFF
--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -268,19 +268,27 @@ class Collector extends AsyncEventEmitter {
 
   /**
    * Resets the collector's timeout and idle timer.
+   * <info>If `time` or `idle` is provided, the corresponding option is updated and used
+   * for subsequent automatic resets (such as the idle timer being reset on each collected element).</info>
    *
    * @param {CollectorResetTimerOptions} [options] Options for resetting
    */
   resetTimer({ time, idle } = {}) {
+    if (time !== undefined) this.options.time = time;
+    if (idle !== undefined) this.options.idle = idle;
+
     if (this._timeout) {
       clearTimeout(this._timeout);
-      this._timeout = setTimeout(() => this.stop('time'), time ?? this.options.time).unref();
+      this._timeout = null;
     }
 
     if (this._idletimeout) {
       clearTimeout(this._idletimeout);
-      this._idletimeout = setTimeout(() => this.stop('idle'), idle ?? this.options.idle).unref();
+      this._idletimeout = null;
     }
+
+    if (this.options.time) this._timeout = setTimeout(() => this.stop('time'), this.options.time).unref();
+    if (this.options.idle) this._idletimeout = setTimeout(() => this.stop('idle'), this.options.idle).unref();
   }
 
   /**


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

`Collector#resetTimer` previously created new timers using the values
passed in but never wrote them back to `this.options`. As a result:

1. The next automatic idle reset inside `handleCollect` (`Collector.js:153`) read the *stale* `this.options.idle` and re-armed the timer with the original construction-time value, so `resetTimer` was effectively undone on the next collected element.
2. If a collector was constructed without `time` (or `idle`) and the user later called `resetTimer({ time })`, the corresponding `if (this._timeout)` branch was false and the call silently did nothing.

This change writes the new values to `this.options`, clears any existing timers, and (re)creates timers from the now-current options. `resetTimer({ time, idle })` can therefore add, replace, or implicitly remove a timer in one call.

**Status and versioning classification:**

- [x] Code change (e.g. fix or feature)

**Semantic versioning classification:**

- [x] This PR changes the library's interface (methods or parameters added)
- [x] This PR **fixes a bug** (and does not change the interface)

Closes #11286