### PR TITLE
docs(Role): fix Role#tags docs

### DIFF
--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -141,15 +141,21 @@ class Role extends Base {
     }
 
     /**
-     * The tags this role has
+     * The tags a role has
      *
-     * @type {?Object}
+     * @typedef {Object} RoleTagData
      * @property {Snowflake} [botId] The id of the bot this role belongs to
      * @property {Snowflake|string} [integrationId] The id of the integration this role belongs to
      * @property {true} [premiumSubscriberRole] Whether this is the guild's premium subscription role
      * @property {Snowflake} [subscriptionListingId] The id of this role's subscription SKU and listing
      * @property {true} [availableForPurchase] Whether this role is available for purchase
      * @property {true} [guildConnections] Whether this role is a guild's linked role
+     */
+
+    /**
+     * The tags this role has
+     *
+     * @type {?RoleTagData}
      */
     this.tags = data.tags ? {} : null;
     if (data.tags) {


### PR DESCRIPTION
`Role#tags` are `RoleTagData` in documentation but the JSDoc defines the type directly on the property instead of as typedef. So the docs don't merge correctly: https://discord.js.org/docs/packages/discord.js/main/RoleTagData:Interface