### PR TITLE
fix: export all used types

### DIFF
--- a/packages/brokers/src/brokers/redis/RPCRedis.ts
+++ b/packages/brokers/src/brokers/redis/RPCRedis.ts
@@ -4,7 +4,7 @@ import type { IRPCBroker } from '../Broker.js';
 import type { RedisBrokerOptions } from './BaseRedis.js';
 import { BaseRedisBroker, DefaultRedisBrokerOptions } from './BaseRedis.js';
 
-interface InternalPromise {
+export interface InternalPromise {
 	reject(error: any): void;
 	resolve(data: any): void;
 	timeout: NodeJS.Timeout;

--- a/packages/brokers/src/brokers/redis/RedisGateway.ts
+++ b/packages/brokers/src/brokers/redis/RedisGateway.ts
@@ -9,12 +9,12 @@ export type DiscordEvents = {
 	};
 };
 
-interface BrokerProps<Payload> {
+export interface BrokerProps<Payload> {
 	payload: Payload;
 	shardId: number;
 }
 
-interface Events extends DiscordEvents {
+export interface Events extends DiscordEvents {
 	// eslint-disable-next-line @typescript-eslint/no-use-before-define
 	[RedisGateway.GatewaySendEvent]: GatewaySendPayload;
 }

--- a/packages/builders/src/messages/Attachment.ts
+++ b/packages/builders/src/messages/Attachment.ts
@@ -16,7 +16,7 @@ export class AttachmentBuilder implements JSONEncodable<RESTAPIAttachment> {
 	/**
 	 * This data is not included in the output of `toJSON()`. For this class specifically, this refers to binary data
 	 * that will wind up being included in the multipart/form-data request, if used with the `MessageBuilder`.
-	 * To retrieve this data, use {@link getRawFile}.
+	 * To retrieve this data, use {@link AttachmentBuilder.getRawFile}.
 	 *
 	 * @remarks This cannot be set via the constructor, primarily because of the behavior described
 	 * {@link https://discord.com/developers/docs/reference#editing-message-attachments | here}.
@@ -107,7 +107,7 @@ export class AttachmentBuilder implements JSONEncodable<RESTAPIAttachment> {
 	 * Sets the file data to upload with this attachment.
 	 *
 	 * @param data - The file data
-	 * @remarks Note that this data is NOT included in the {@link toJSON} output. To retrieve it, use {@link getRawFile}.
+	 * @remarks Note that this data is NOT included in the {@link AttachmentBuilder.toJSON} output. To retrieve it, use {@link AttachmentBuilder.getRawFile}.
 	 */
 	public setFileData(data: Buffer | Uint8Array | string): this {
 		this.fileData.data = data;
@@ -125,7 +125,7 @@ export class AttachmentBuilder implements JSONEncodable<RESTAPIAttachment> {
 	/**
 	 * Sets the content type of the file data to upload with this attachment.
 	 *
-	 * @remarks Note that this data is NOT included in the {@link toJSON} output. To retrieve it, use {@link getRawFile}.
+	 * @remarks Note that this data is NOT included in the {@link AttachmentBuilder.toJSON} output. To retrieve it, use {@link AttachmentBuilder.getRawFile}.
 	 */
 	public setFileContentType(contentType: string): this {
 		this.fileData.contentType = contentType;
@@ -141,9 +141,9 @@ export class AttachmentBuilder implements JSONEncodable<RESTAPIAttachment> {
 	}
 
 	/**
-	 * Converts this attachment to a {@link RawFile} for uploading.
+	 * Converts this attachment to a {@link @discordjs/util#RawFile} for uploading.
 	 *
-	 * @returns A {@link RawFile} object, or `undefined` if no file data is set
+	 * @returns A {@link @discordjs/util#RawFile} object, or `undefined` if no file data is set
 	 */
 	public getRawFile(): Partial<RawFile> | undefined {
 		if (!this.fileData?.data) {

--- a/packages/core/tsdoc.json
+++ b/packages/core/tsdoc.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+	"extends": ["@discordjs/api-extractor/extends/tsdoc-base.json"],
+	"tagDefinitions": [
+		{
+			"tagName": "@unstable",
+			"syntaxKind": "modifier"
+		}
+	],
+	"supportForTags": {
+		"@unstable": true
+	}
+}

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1083,7 +1083,7 @@ export class ContainerComponent extends Component<APIContainerComponent> {
   public readonly components: ComponentInContainer[];
 }
 
-export { Collection, type ReadonlyCollection } from '@discordjs/collection';
+export { Collection, type ReadonlyCollection, type Comparator, type Keep } from '@discordjs/collection';
 
 export interface CollectorEventTypes<Key, Value, Extras extends unknown[] = []> {
   collect: [Value, ...Extras];

--- a/packages/structures/src/automoderation/AutoModerationRuleTriggerMetadata.ts
+++ b/packages/structures/src/automoderation/AutoModerationRuleTriggerMetadata.ts
@@ -1,4 +1,4 @@
-import type { APIAutoModerationRuleTriggerMetadata, AutoModerationRuleTriggerType } from 'discord-api-types/v10';
+import type { APIAutoModerationRuleTriggerMetadata } from 'discord-api-types/v10';
 import { Structure } from '../Structure.js';
 import { kData } from '../utils/symbols.js';
 import type { Partialize } from '../utils/types.js';
@@ -32,7 +32,7 @@ export class AutoModerationRuleTriggerMetadata<
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies | Keyword matching strategies}
 	 *
-	 * Associated trigger types: {@link AutoModerationRuleTriggerType.Keyword}, {@link AutoModerationRuleTriggerType.MemberProfile}
+	 * Associated trigger types: {@link discord-api-types/v10#AutoModerationRuleTriggerType.Keyword}, {@link discord-api-types/v10#AutoModerationRuleTriggerType.MemberProfile}
 	 */
 	public get keywordFilter() {
 		return this[kData].keyword_filter;
@@ -45,7 +45,7 @@ export class AutoModerationRuleTriggerMetadata<
 	 *
 	 * Each regex pattern must be 260 characters or less.
 	 *
-	 * Associated trigger types: {@link AutoModerationRuleTriggerType.Keyword}, {@link AutoModerationRuleTriggerType.MemberProfile}
+	 * Associated trigger types: {@link discord-api-types/v10#AutoModerationRuleTriggerType.Keyword}, {@link discord-api-types/v10#AutoModerationRuleTriggerType.MemberProfile}
 	 */
 	public get regexPatterns() {
 		return this[kData].regex_patterns;
@@ -56,7 +56,7 @@ export class AutoModerationRuleTriggerMetadata<
 	 *
 	 * @see {@link https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-preset-types | Keyword preset types}
 	 *
-	 * Associated trigger types: {@link AutoModerationRuleTriggerType.KeywordPreset}
+	 * Associated trigger types: {@link discord-api-types/v10#AutoModerationRuleTriggerType.KeywordPreset}
 	 */
 	public get presets() {
 		return this[kData].presets;
@@ -76,7 +76,7 @@ export class AutoModerationRuleTriggerMetadata<
 	 * @see {@link https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-trigger-types | triggerType}
 	 * @see {@link https://discord.com/developers/docs/resources/auto-moderation#auto-moderation-rule-object-keyword-matching-strategies | Keyword matching strategies}
 	 *
-	 * Associated trigger types: {@link AutoModerationRuleTriggerType.Keyword}, {@link AutoModerationRuleTriggerType.KeywordPreset}, {@link AutoModerationRuleTriggerType.MemberProfile}
+	 * Associated trigger types: {@link discord-api-types/v10#AutoModerationRuleTriggerType.Keyword}, {@link discord-api-types/v10#AutoModerationRuleTriggerType.KeywordPreset}, {@link discord-api-types/v10#AutoModerationRuleTriggerType.MemberProfile}
 	 */
 	public get allowList() {
 		return this[kData].allow_list;
@@ -85,7 +85,7 @@ export class AutoModerationRuleTriggerMetadata<
 	/**
 	 * Total number of unique role and user mentions allowed per message (Maximum of 50)
 	 *
-	 * Associated trigger types: {@link AutoModerationRuleTriggerType.MentionSpam}
+	 * Associated trigger types: {@link discord-api-types/v10#AutoModerationRuleTriggerType.MentionSpam}
 	 */
 	public get mentionTotalLimit() {
 		return this[kData].mention_total_limit;
@@ -94,7 +94,7 @@ export class AutoModerationRuleTriggerMetadata<
 	/**
 	 * Whether to automatically detect mention raids
 	 *
-	 * Associated trigger types: {@link AutoModerationRuleTriggerType.MentionSpam}
+	 * Associated trigger types: {@link discord-api-types/v10#AutoModerationRuleTriggerType.MentionSpam}
 	 */
 	public get mentionRaidProtectionEnabled() {
 		return this[kData].mention_raid_protection_enabled;

--- a/packages/structures/src/automoderation/actions/AutoModerationActionMetadata.ts
+++ b/packages/structures/src/automoderation/actions/AutoModerationActionMetadata.ts
@@ -1,8 +1,4 @@
-import type {
-	APIAutoModerationActionMetadata,
-	AutoModerationActionType,
-	AutoModerationRuleTriggerType,
-} from 'discord-api-types/v10';
+import type { APIAutoModerationActionMetadata } from 'discord-api-types/v10';
 import { Structure } from '../../Structure.js';
 import { kData } from '../../utils/symbols.js';
 import type { Partialize } from '../../utils/types.js';
@@ -30,7 +26,7 @@ export class AutoModerationActionMetadata<
 	/**
 	 * Channel to which user content should be logged. This must be an existing channel
 	 *
-	 * Associated action types: {@link AutoModerationActionType.SendAlertMessage}
+	 * Associated action types: {@link discord-api-types/v10#AutoModerationActionType.SendAlertMessage}
 	 */
 	public get channelId() {
 		return this[kData].channel_id;
@@ -39,11 +35,11 @@ export class AutoModerationActionMetadata<
 	/**
 	 * Timeout duration in seconds. Maximum of 2419200 seconds (4 weeks).
 	 *
-	 * A `TIMEOUT` action can only be set up for {@link AutoModerationRuleTriggerType.Keyword} and {@link AutoModerationRuleTriggerType.MentionSpam}.
+	 * A `TIMEOUT` action can only be set up for {@link discord-api-types/v10#AutoModerationRuleTriggerType.Keyword} and {@link discord-api-types/v10#AutoModerationRuleTriggerType.MentionSpam}.
 	 *
-	 * The `MODERATE_MEMBERS` permission is required to use {@link AutoModerationActionType.Timeout} actions.
+	 * The `MODERATE_MEMBERS` permission is required to use {@link discord-api-types/v10#AutoModerationActionType.Timeout} actions.
 	 *
-	 * Associated action types: {@link AutoModerationActionType.Timeout}
+	 * Associated action types: {@link discord-api-types/v10#AutoModerationActionType.Timeout}
 	 */
 	public get durationSeconds() {
 		return this[kData].duration_seconds;
@@ -52,7 +48,7 @@ export class AutoModerationActionMetadata<
 	/**
 	 * Additional explanation that will be shown to members whenever their message is blocked. Maximum of 150 characters
 	 *
-	 * Associated action types: {@link AutoModerationActionType.BlockMessage}
+	 * Associated action types: {@link discord-api-types/v10#AutoModerationActionType.BlockMessage}
 	 */
 	public get customMessage() {
 		return this[kData].custom_message;

--- a/packages/structures/src/bitfields/SKUFlagsBitField.ts
+++ b/packages/structures/src/bitfields/SKUFlagsBitField.ts
@@ -2,7 +2,7 @@ import { SKUFlags } from 'discord-api-types/v10';
 import { BitField } from './BitField.js';
 
 /**
- * Data structure that makes it easy to interact with an {@link SKUFlags} bitfield.
+ * Data structure that makes it easy to interact with an {@link discord-api-types/v10#SKUFlags} bitfield.
  */
 export class SKUFlagsBitField extends BitField<keyof typeof SKUFlags> {
 	/**

--- a/packages/structures/src/subscriptions/Subscription.ts
+++ b/packages/structures/src/subscriptions/Subscription.ts
@@ -1,5 +1,5 @@
 import { DiscordSnowflake } from '@sapphire/snowflake';
-import type { APISubscription, SubscriptionStatus } from 'discord-api-types/v10';
+import type { APISubscription } from 'discord-api-types/v10';
 import { Structure } from '../Structure.js';
 import { dateToDiscordISOTimestamp } from '../utils/optimization.js';
 import {
@@ -131,7 +131,7 @@ export class Subscription<
 	}
 
 	/**
-	 * The {@link SubscriptionStatus} of the current subscription
+	 * The {@link discord-api-types/v10#SubscriptionStatus} of the current subscription
 	 */
 	public get status() {
 		return this[kData].status;
@@ -147,7 +147,7 @@ export class Subscription<
 	/**
 	 * The time when the subscription was canceled
 	 *
-	 * @remarks This is populated when the {@link Subscription#status} transitions to {@link SubscriptionStatus.Ending}.
+	 * @remarks This is populated when the {@link Subscription.status} transitions to {@link discord-api-types/v10#SubscriptionStatus.Ending}.
 	 */
 	public get canceledAt() {
 		const canceledTimestamp = this.canceledTimestamp;

--- a/packages/structures/src/utils/optimization.ts
+++ b/packages/structures/src/utils/optimization.ts
@@ -13,8 +13,7 @@ export function extendTemplate<SuperTemplate extends Record<string, unknown>>(
  * Turns a JavaScript Date object into the timestamp format used by Discord in payloads.
  * E.g. `2025-11-16T14:09:25.239000+00:00`
  *
- * @private
- * @param date a Date instance
+ * @param date - a Date instance
  * @returns an ISO8601 timestamp with microseconds precision and explicit +00:00 timezone
  */
 export function dateToDiscordISOTimestamp(date: Date) {

--- a/packages/voice/src/VoiceConnection.ts
+++ b/packages/voice/src/VoiceConnection.ts
@@ -233,6 +233,8 @@ export class VoiceConnection extends EventEmitter {
 	/**
 	 * The receiver of this voice connection. You should join the voice channel with `selfDeaf` set
 	 * to false for this feature to work properly.
+	 *
+	 * @beta
 	 */
 	public readonly receiver: VoiceReceiver;
 

--- a/packages/voice/src/index.ts
+++ b/packages/voice/src/index.ts
@@ -7,6 +7,7 @@ export {
 	Networking,
 	type ConnectionData,
 	type ConnectionOptions,
+	type NetworkingOptions,
 	type NetworkingState,
 	type NetworkingResumingState,
 	type NetworkingSelectingProtocolState,
@@ -19,7 +20,12 @@ export {
 	VoiceUDPSocket,
 	VoiceWebSocket,
 	type SocketConfig,
+	type BinaryWebSocketMessage,
 	DAVESession,
+	type SessionMethods,
+	type DAVESessionOptions,
+	type TransitionResult,
+	type ProposalsResult,
 } from './networking/index.js';
 
 export {

--- a/packages/voice/src/networking/DAVESession.ts
+++ b/packages/voice/src/networking/DAVESession.ts
@@ -4,7 +4,7 @@ import Davey from '@snazzah/davey';
 import type { VoiceDavePrepareEpochData, VoiceDavePrepareTransitionData } from 'discord-api-types/voice/v8';
 import { SILENCE_FRAME } from '../audio/AudioPlayer';
 
-interface SessionMethods {
+export interface SessionMethods {
 	canPassthrough(userId: string): boolean;
 	decrypt(userId: string, mediaType: 0 | 1, packet: Buffer): Buffer;
 	encryptOpus(packet: Buffer): Buffer;
@@ -21,7 +21,7 @@ interface SessionMethods {
 	voicePrivacyCode: string;
 }
 
-interface ProposalsResult {
+export interface ProposalsResult {
 	commit?: Buffer;
 	welcome?: Buffer;
 }
@@ -44,7 +44,7 @@ const TRANSITION_EXPIRY_PENDING_DOWNGRADE = 24;
  */
 export const DEFAULT_DECRYPTION_FAILURE_TOLERANCE = 36;
 
-interface TransitionResult {
+export interface TransitionResult {
 	success: boolean;
 	transitionId: number;
 }


### PR DESCRIPTION
Fixes several issues reported by api-extractor.

- some types that are used as parameters need to be exported by the d.ts file
- some link tags used malformed syntax