### PR TITLE
fix(ModalSubmitFields): respect `required` option value (v14)

### DIFF
--- a/packages/discord.js/src/structures/ModalSubmitFields.js
+++ b/packages/discord.js/src/structures/ModalSubmitFields.js
@@ -54,11 +54,17 @@ class ModalSubmitFields {
    * Gets a field given a custom id from a component
    * @param {string} customId The custom id of the component
    * @param {ComponentType} [type] The type of the component
-   * @returns {ModalData}
+   * @param {boolean} [required=false] Whether to throw an error if the field is not found.
+   * @returns {?ModalData} The field, if found.
    */
-  getField(customId, type) {
+  getField(customId, type, required = false) {
     const field = this.fields.get(customId);
-    if (!field) throw new DiscordjsTypeError(ErrorCodes.ModalSubmitInteractionFieldNotFound, customId);
+    if (!field) {
+      if (required) {
+        throw new DiscordjsTypeError(ErrorCodes.ModalSubmitInteractionFieldNotFound, customId);
+      }
+      return null;
+    }
 
     if (type !== undefined && type !== field.type) {
       throw new DiscordjsTypeError(ErrorCodes.ModalSubmitInteractionFieldType, customId, field.type, type);
@@ -79,7 +85,9 @@ class ModalSubmitFields {
    */
   _getTypedComponent(customId, allowedTypes, properties, required) {
     const component = this.getField(customId);
-    if (!allowedTypes.includes(component.type)) {
+    if (!component) {
+      return null;
+    } else if (!allowedTypes.includes(component.type)) {
       throw new DiscordjsTypeError(
         ErrorCodes.ModalSubmitInteractionFieldNotFound,
         customId,

--- a/packages/discord.js/src/structures/ModalSubmitFields.js
+++ b/packages/discord.js/src/structures/ModalSubmitFields.js
@@ -54,10 +54,10 @@ class ModalSubmitFields {
    * Gets a field given a custom id from a component
    * @param {string} customId The custom id of the component
    * @param {ComponentType} [type] The type of the component
-   * @param {boolean} [required=false] Whether to throw an error if the field is not found.
+   * @param {boolean} [required=true] Whether to throw an error if the field is not found.
    * @returns {?ModalData} The field, if found.
    */
-  getField(customId, type, required = false) {
+  getField(customId, type, required = true) {
     const field = this.fields.get(customId);
     if (!field) {
       if (required) {

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2888,7 +2888,11 @@ export class ModalSubmitFields<Cached extends CacheType = CacheType> {
     type: Type,
     required?: boolean,
   ): Extract<ModalData, { type: Type }>;
-  public getField(customId: string, type?: ComponentType, required?: boolean): ModalData | null;
+  public getField<Required extends boolean = true>(
+    customId: string,
+    type?: ComponentType,
+    required?: Required,
+  ): Required extends true ? ModalData : ModalData | null;
   private _getTypedComponent(
     customId: string,
     allowedTypes: readonly ComponentType[],

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2878,8 +2878,17 @@ export class ModalSubmitFields<Cached extends CacheType = CacheType> {
   public components: (ActionRowModalData | LabelModalData | TextDisplayModalData)[];
   public resolved: Readonly<BaseInteractionResolvedData<Cached>> | null;
   public fields: Collection<string, ModalData>;
-  public getField<Type extends ComponentType>(customId: string, type: Type): Extract<ModalData, { type: Type }>;
-  public getField(customId: string, type?: ComponentType): ModalData;
+  public getField<Type extends ComponentType>(
+    customId: string,
+    type: Type,
+    required: true,
+  ): Extract<ModalData, { type: Type }>;
+  public getField<Type extends ComponentType>(
+    customId: string,
+    type: Type,
+    required?: boolean,
+  ): Extract<ModalData, { type: Type }> | null;
+  public getField(customId: string, type?: ComponentType, required?: boolean): ModalData | null;
   private _getTypedComponent(
     customId: string,
     allowedTypes: readonly ComponentType[],

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2881,13 +2881,13 @@ export class ModalSubmitFields<Cached extends CacheType = CacheType> {
   public getField<Type extends ComponentType>(
     customId: string,
     type: Type,
-    required: true,
-  ): Extract<ModalData, { type: Type }>;
+    required: false,
+  ): Extract<ModalData, { type: Type }> | null;
   public getField<Type extends ComponentType>(
     customId: string,
     type: Type,
     required?: boolean,
-  ): Extract<ModalData, { type: Type }> | null;
+  ): Extract<ModalData, { type: Type }>;
   public getField(customId: string, type?: ComponentType, required?: boolean): ModalData | null;
   private _getTypedComponent(
     customId: string,


### PR DESCRIPTION
Fixes modal fields unconditionally throwing when required is false/undefined. 

>    `   * @param {boolean} [required=false] Whether to throw an error if the component value is not found or empty`

An example jsdoc on most of the getters where it explicitly mentions the throwing on "not found", this implies that it shouldn't throw unconditionally.


This brings it inline with the command interaction options:

https://github.com/discordjs/discord.js/blob/40ce0791a8ed348189d9aefe0669cee29bf59920/packages/discord.js/src/structures/CommandInteractionOptionResolver.js#L75-L116

---

**Note:** To try and minimize breaking changes, the public `getField` function defaults to required but the individual getters still fulfill their jsdoc promise (should prob fix properly in v15)