### PR TITLE
fix(ShardingManager): default api url

### DIFF
--- a/packages/discord.js/src/sharding/ShardingManager.js
+++ b/packages/discord.js/src/sharding/ShardingManager.js
@@ -7,7 +7,7 @@ const { setTimeout: sleep } = require('node:timers/promises');
 const { Collection } = require('@discordjs/collection');
 const { range } = require('@discordjs/util');
 const { AsyncEventEmitter } = require('@vladfrangu/async_event_emitter');
-const { APIVersion, RouteBases } = require('discord-api-types/v10');
+const { APIVersion } = require('discord-api-types/v10');
 const { DiscordjsError, DiscordjsTypeError, DiscordjsRangeError, ErrorCodes } = require('../errors/index.js');
 const { fetchRecommendedShardCount } = require('../util/Util.js');
 const { Shard } = require('./Shard.js');
@@ -172,7 +172,7 @@ class ShardingManager extends AsyncEventEmitter {
      *
      * @type {string}
      */
-    this.api = _options.api ?? RouteBases.api;
+    this.api = _options.api ?? 'https://discord.com/api';
 
     /**
      * The API version to use

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -3,7 +3,7 @@
 const { parse } = require('node:path');
 const { Collection } = require('@discordjs/collection');
 const { lazy } = require('@discordjs/util');
-const { APIVersion, ChannelType, Routes, RouteBases } = require('discord-api-types/v10');
+const { APIVersion, ChannelType, Routes } = require('discord-api-types/v10');
 const { fetch } = require('undici');
 const { Colors } = require('./Colors.js');
 // eslint-disable-next-line import-x/order
@@ -80,7 +80,7 @@ function flatten(obj, ...props) {
  */
 async function fetchRecommendedShardCount(
   token,
-  { guildsPerShard = 1_000, multipleOf = 1, api = RouteBases.api, version = APIVersion } = {},
+  { guildsPerShard = 1_000, multipleOf = 1, api = 'https://discord.com/api', version = APIVersion } = {},
 ) {
   if (!token) throw new DiscordjsError(ErrorCodes.TokenMissing);
   const response = await fetch(`${api}/v${version}${Routes.gatewayBot()}`, {


### PR DESCRIPTION
`RouteBases.api` already includes the API version in the URL, which was resulting in `https://discord.com/api/v10/v10`

Regression from #11471