### PR TITLE
docs(guide): add Guild Scheduled Events and Polls guide pages for v15

### DIFF
--- a/apps/guide/content/docs/v15/guild-scheduled-events.mdx
+++ b/apps/guide/content/docs/v15/guild-scheduled-events.mdx
@@ -1,0 +1,157 @@
+---
+title: Guild Scheduled Events
+---
+
+Scheduled events allow you to create, manage, and list events in a guild.
+
+## Creating a scheduled event
+
+You can create scheduled events using `GuildScheduledEventManager#create()`. There are three entity types you can use:
+
+- `GuildScheduledEventEntityType.StageInstance` — for stage channel events
+- `GuildScheduledEventEntityType.Voice` — for voice channel events
+- `GuildScheduledEventEntityType.External` — for external events (requires a location)
+
+```js
+const { GuildScheduledEventEntityType, GuildScheduledEventPrivacyLevel } = require('discord.js');
+
+// Create a voice channel event
+const voiceEvent = await guild.scheduledEvents.create({
+	name: 'Game Night',
+	scheduledStartTime: new Date('2026-06-01T20:00:00Z'),
+	scheduledEndTime: new Date('2026-06-01T23:00:00Z'),
+	privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+	entityType: GuildScheduledEventEntityType.Voice,
+	channel: '123456789012345678',
+	description: 'Come hang out and play games!',
+});
+
+// Create an external event
+const externalEvent = await guild.scheduledEvents.create({
+	name: 'Community Meetup',
+	scheduledStartTime: new Date('2026-06-15T14:00:00Z'),
+	scheduledEndTime: new Date('2026-06-15T17:00:00Z'),
+	privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+	entityType: GuildScheduledEventEntityType.External,
+	entityMetadata: { location: 'Central Park, NYC' },
+	description: 'Annual community meetup!',
+});
+```
+
+### Recurring events
+
+You can also create recurring events using the `recurrenceRule` option:
+
+```js
+const recurringEvent = await guild.scheduledEvents.create({
+	name: 'Weekly Standup',
+	scheduledStartTime: new Date('2026-06-01T09:00:00Z'),
+	scheduledEndTime: new Date('2026-06-01T10:00:00Z'),
+	privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+	entityType: GuildScheduledEventEntityType.Voice,
+	channel: '123456789012345678',
+	recurrenceRule: {
+		startAt: new Date('2026-06-01T09:00:00Z'),
+		frequency: GuildScheduledEventRecurrenceRuleFrequency.Weekly,
+		interval: 1,
+		byWeekday: [GuildScheduledEventRecurrenceRuleWeekday.Monday],
+		count: 10,
+	},
+});
+```
+
+## Fetching scheduled events
+
+Retrieve one or all scheduled events for a guild:
+
+```js
+// Fetch a single event
+const event = await guild.scheduledEvents.fetch('123456789012345678');
+
+// Fetch all events
+const allEvents = await guild.scheduledEvents.fetch();
+
+// Fetch with user count
+const eventsWithCounts = await guild.scheduledEvents.fetch({ withUserCount: true });
+```
+
+## Editing a scheduled event
+
+Modify an existing event's properties using `GuildScheduledEventManager#edit()`:
+
+```js
+const updatedEvent = await guild.scheduledEvents.edit('123456789012345678', {
+	name: 'Updated Event Name',
+	description: 'New description for the event',
+	scheduledStartTime: new Date('2026-07-01T18:00:00Z'),
+});
+```
+
+You can also use the helper methods on the `GuildScheduledEvent` instance directly:
+
+```js
+await event.setName('New Name');
+await event.setDescription('New Description');
+await event.setScheduledStartTime('2026-07-01T18:00:00Z');
+await event.setScheduledEndTime('2026-07-01T21:00:00Z');
+await event.setLocation('New Location');
+await event.setStatus(GuildScheduledEventStatus.Active);
+```
+
+## Deleting a scheduled event
+
+```js
+await guild.scheduledEvents.delete('123456789012345678');
+
+// Or on the event instance
+await event.delete();
+```
+
+## Event subscribers
+
+Fetch the list of users subscribed to an event:
+
+```js
+const subscribers = await event.fetchSubscribers({ limit: 100 });
+for (const [userId, subscriber] of subscribers) {
+	console.log(`${subscriber.user.tag} is attending`);
+}
+```
+
+## Cover images
+
+You can set or update the cover image of a scheduled event:
+
+```js
+const eventWithImage = await guild.scheduledEvents.create({
+	name: 'Big Event',
+	scheduledStartTime: new Date('2026-08-01T12:00:00Z'),
+	privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+	entityType: GuildScheduledEventEntityType.External,
+	entityMetadata: { location: 'Online' },
+	image: './path/to/banner.png',
+});
+```
+
+## Listening to events
+
+The client emits events when users subscribe or unsubscribe from scheduled events:
+
+```js
+client.on('guildScheduledEventUserAdd', (event, user) => {
+	console.log(`${user.tag} subscribed to ${event.name}`);
+});
+
+client.on('guildScheduledEventUserRemove', (event, user) => {
+	console.log(`${user.tag} unsubscribed from ${event.name}`);
+});
+```
+
+## Invite URLs
+
+Generate an invite URL for a scheduled event:
+
+```js
+const inviteURL = await event.createInviteURL();
+console.log(`Share this: ${inviteURL}`);
+```

--- a/apps/guide/content/docs/v15/guild-scheduled-events.mdx
+++ b/apps/guide/content/docs/v15/guild-scheduled-events.mdx
@@ -55,7 +55,6 @@ const recurringEvent = await guild.scheduledEvents.create({
 		frequency: GuildScheduledEventRecurrenceRuleFrequency.Weekly,
 		interval: 1,
 		byWeekday: [GuildScheduledEventRecurrenceRuleWeekday.Monday],
-		count: 10,
 	},
 });
 ```
@@ -123,13 +122,15 @@ for (const [userId, subscriber] of subscribers) {
 You can set or update the cover image of a scheduled event:
 
 ```js
+const fs = require('fs');
+
 const eventWithImage = await guild.scheduledEvents.create({
 	name: 'Big Event',
 	scheduledStartTime: new Date('2026-08-01T12:00:00Z'),
 	privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
 	entityType: GuildScheduledEventEntityType.External,
 	entityMetadata: { location: 'Online' },
-	image: './path/to/banner.png',
+	image: fs.readFileSync('./path/to/banner.png'),
 });
 ```
 

--- a/apps/guide/content/docs/v15/meta.json
+++ b/apps/guide/content/docs/v15/meta.json
@@ -1,7 +1,13 @@
 {
 	"title": "discord.js v15",
 	"description": "Work in progress...",
-	"pages": ["external:[LibraryBig][Documentation](https://discord.js.org/docs/packages/discord.js/main)", "index"],
+	"pages": [
+		"external:[LibraryBig][Documentation](https://discord.js.org/docs/packages/discord.js/main)",
+		"---Topics---",
+		"index",
+		"guild-scheduled-events",
+		"polls"
+	],
 	"icon": "FlaskConical",
 	"root": true
 }

--- a/apps/guide/content/docs/v15/polls.mdx
+++ b/apps/guide/content/docs/v15/polls.mdx
@@ -1,0 +1,132 @@
+---
+title: Polls
+---
+
+Polls let you collect feedback or opinions from members directly within a message.
+
+## Sending a poll
+
+Polls are sent as part of a message using the `poll` option. Each poll requires a question and at least one answer.
+
+```js
+const { PollLayoutType } = require('discord.js');
+
+const message = await channel.send({
+	content: 'Cast your vote!',
+	poll: {
+		question: { text: 'What is your favorite color?' },
+		answers: [
+			{ text: 'Red', emoji: { name: '🔴' } },
+			{ text: 'Blue', emoji: { name: '🔵' } },
+			{ text: 'Green', emoji: { name: '🟢' } },
+		],
+		layoutType: PollLayoutType.Default,
+	},
+});
+```
+
+## Multi-select polls
+
+Allow members to select multiple answers by setting `allowMultiselect` to `true`:
+
+```js
+const message = await channel.send({
+	poll: {
+		question: { text: 'Which languages do you know?' },
+		answers: [
+			{ text: 'JavaScript' },
+			{ text: 'Python' },
+			{ text: 'Rust' },
+			{ text: 'Go' },
+		],
+		allowMultiselect: true,
+		layoutType: PollLayoutType.Default,
+	},
+});
+```
+
+## Duration
+
+You can control how long a poll runs. If not specified, the default is 24 hours. The maximum duration is 7 days (168 hours).
+
+```js
+// Poll expires in 1 hour
+const message = await channel.send({
+	poll: {
+		question: { text: 'Quick poll!' },
+		answers: [{ text: 'Yes' }, { text: 'No' }],
+		duration: 1,
+	},
+});
+
+// Poll expires in 3 days
+const message = await channel.send({
+	poll: {
+		question: { text: 'Weekend plans?' },
+		answers: [{ text: 'Stay in' }, { text: 'Go out' }],
+		duration: 72,
+	},
+});
+```
+
+## Accessing poll data
+
+Once a poll is sent, you can access its data from the message:
+
+```js
+const poll = message.poll;
+
+console.log(`Question: ${poll.question.text}`);
+console.log(`Multi-select: ${poll.allowMultiselect}`);
+console.log(`Expires: ${poll.expiresAt}`);
+
+for (const [id, answer] of poll.answers) {
+	console.log(`Answer ${id}: ${answer.text} — ${answer.voteCount} votes`);
+}
+```
+
+## Ending a poll early
+
+You can end a poll before its natural expiry:
+
+```js
+await message.poll.end();
+```
+
+## Poll events
+
+Listen for vote events using the client:
+
+```js
+client.on('messagePollVoteAdd', (pollAnswer, userId) => {
+	console.log(`User ${userId} voted for ${pollAnswer.text}`);
+});
+
+client.on('messagePollVoteRemove', (pollAnswer, userId) => {
+	console.log(`User ${userId} removed their vote for ${pollAnswer.text}`);
+});
+```
+
+## Polls in other message types
+
+Polls can also be sent in interaction replies and webhook messages:
+
+```js
+// In an interaction reply
+await interaction.reply({
+	content: 'Vote now!',
+	poll: {
+		question: { text: 'Option A or B?' },
+		answers: [{ text: 'A' }, { text: 'B' }],
+	},
+});
+
+// In a webhook message
+await webhook.send({
+	content: 'Cast your vote!',
+	poll: {
+		question: { text: 'Choose wisely' },
+		answers: [{ text: 'Option 1' }, { text: 'Option 2' }],
+	},
+});
+```

--- a/apps/guide/content/docs/v15/polls.mdx
+++ b/apps/guide/content/docs/v15/polls.mdx
@@ -20,6 +20,8 @@ const message = await channel.send({
 			{ text: 'Blue', emoji: { name: '🔵' } },
 			{ text: 'Green', emoji: { name: '🟢' } },
 		],
+		duration: 24,
+		allowMultiselect: false,
 		layoutType: PollLayoutType.Default,
 	},
 });
@@ -39,6 +41,7 @@ const message = await channel.send({
 			{ text: 'Rust' },
 			{ text: 'Go' },
 		],
+		duration: 24,
 		allowMultiselect: true,
 		layoutType: PollLayoutType.Default,
 	},
@@ -47,7 +50,7 @@ const message = await channel.send({
 
 ## Duration
 
-You can control how long a poll runs. If not specified, the default is 24 hours. The maximum duration is 7 days (168 hours).
+You can control how long a poll runs. If not specified, the default is 24 hours. The maximum duration is 32 days (768 hours).
 
 ```js
 // Poll expires in 1 hour
@@ -118,6 +121,8 @@ await interaction.reply({
 	poll: {
 		question: { text: 'Option A or B?' },
 		answers: [{ text: 'A' }, { text: 'B' }],
+		duration: 24,
+		allowMultiselect: false,
 	},
 });
 
@@ -127,6 +132,8 @@ await webhook.send({
 	poll: {
 		question: { text: 'Choose wisely' },
 		answers: [{ text: 'Option 1' }, { text: 'Option 2' }],
+		duration: 24,
+		allowMultiselect: false,
 	},
 });
 ```


### PR DESCRIPTION
## Summary

Adds documentation pages for Guild Scheduled Events and Polls under the v15 guide section.

## Related Issue

Closes #10973

## Changes

- `apps/guide/content/docs/v15/guild-scheduled-events.mdx` — new guide page covering creation, fetching, editing, deleting, recurring events, subscribers, cover images, and event listeners
- `apps/guide/content/docs/v15/polls.mdx` — new guide page covering sending polls, multi-select, duration, poll data access, ending polls early, vote events, and polls in interactions/webhooks
- `apps/guide/content/docs/v15/meta.json` — updated sidebar to include both new pages