### PR TITLE
feat(builders): add ColorResolvable support to ContainerBuilder and EmbedBuilder

### DIFF
--- a/packages/builders/__tests__/components/v2/container.test.ts
+++ b/packages/builders/__tests__/components/v2/container.test.ts
@@ -174,6 +174,27 @@ describe('Container Components', () => {
 			);
 		});
 
+		test('GIVEN ColorResolvable inputs THEN they are resolved correctly', () => {
+			const base = () => new ContainerBuilder().addSeparatorComponents(new SeparatorBuilder().setId(1).setSpacing(SeparatorSpacingSize.Small));
+
+			expect(base().setAccentColor(0x00ff00).toJSON().accent_color).toBe(0x00ff00);
+			expect(base().setAccentColor('#00ff00').toJSON().accent_color).toBe(0x00ff00);
+			expect(base().setAccentColor('00ff00').toJSON().accent_color).toBe(0x00ff00);
+			expect(base().setAccentColor([0, 255, 0] as const).toJSON().accent_color).toBe(0x00ff00);
+
+			const random = base().setAccentColor('Random').toJSON().accent_color;
+			expect(random).toBeGreaterThanOrEqual(0);
+			expect(random).toBeLessThanOrEqual(0xffffff);
+
+			expect(base().setAccentColor('Default').toJSON().accent_color).toBe(0);
+		});
+
+		test('GIVEN invalid color resolvable THEN throws', () => {
+			expect(() => new ContainerBuilder().addSeparatorComponents(new SeparatorBuilder()).setAccentColor('not-a-color' as any).toJSON()).toThrowError();
+			expect(() => new ContainerBuilder().addSeparatorComponents(new SeparatorBuilder()).setAccentColor(-1 as any).toJSON()).toThrowError();
+			expect(() => new ContainerBuilder().addSeparatorComponents(new SeparatorBuilder()).setAccentColor(0x1000000).toJSON()).toThrowError();
+		});
+
 		test('GIVEN valid method parameters THEN valid JSON is given', () => {
 			expect(
 				new ContainerBuilder()

--- a/packages/builders/__tests__/messages/embed.test.ts
+++ b/packages/builders/__tests__/messages/embed.test.ts
@@ -148,13 +148,23 @@ describe('Embed', () => {
 		test('GIVEN an embed with an invalid color THEN throws error', () => {
 			const embed = new EmbedBuilder();
 
-			// @ts-expect-error: Invalid color
 			embed.setColor('RED');
 			expect(() => embed.toJSON()).toThrowError();
 
-			// @ts-expect-error: Invalid color
+			// @ts-expect-error: Too few elements for RGB tuple
 			embed.setColor([42, 36]);
 			expect(() => embed.toJSON()).toThrowError();
+		});
+
+		test('GIVEN ColorResolvable inputs with setColor THEN they are resolved correctly', () => {
+			expect(new EmbedBuilder().setColor(0x00ff00).toJSON().color).toBe(0x00ff00);
+			expect(new EmbedBuilder().setColor('#00ff00').toJSON().color).toBe(0x00ff00);
+			expect(new EmbedBuilder().setColor('00ff00').toJSON().color).toBe(0x00ff00);
+			expect(new EmbedBuilder().setColor([0, 255, 0] as const).toJSON().color).toBe(0x00ff00);
+			expect(new EmbedBuilder().setColor('Default').toJSON().color).toBe(0);
+			const random = new EmbedBuilder().setColor('Random').toJSON().color;
+			expect(random).toBeGreaterThanOrEqual(0);
+			expect(random).toBeLessThanOrEqual(0xffffff);
 		});
 	});
 

--- a/packages/builders/src/components/v2/Container.ts
+++ b/packages/builders/src/components/v2/Container.ts
@@ -12,6 +12,7 @@ import {
 } from 'discord-api-types/v10';
 import { normalizeArray, type RestOrArray } from '../../util/normalizeArray';
 import { resolveBuilder } from '../../util/resolveBuilder';
+import { type ColorResolvable, resolveColor } from '../../util/colors';
 import { validate } from '../../util/validation';
 import { ActionRowBuilder } from '../ActionRow.js';
 import { ComponentBuilder } from '../Component.js';
@@ -73,8 +74,8 @@ export class ContainerBuilder extends ComponentBuilder<APIContainerComponent> {
 	 *
 	 * @param color - The color to use
 	 */
-	public setAccentColor(color: number) {
-		this.data.accent_color = color;
+	public setAccentColor(color: ColorResolvable) {
+		this.data.accent_color = resolveColor(color);
 		return this;
 	}
 

--- a/packages/builders/src/index.ts
+++ b/packages/builders/src/index.ts
@@ -90,6 +90,7 @@ export * from './messages/Message.js';
 export * from './messages/MessageReference.js';
 export * from './messages/SharedClientTheme.js';
 
+export * from './util/colors.js';
 export * from './util/normalizeArray.js';
 export * from './util/resolveBuilder.js';
 export { disableValidators, enableValidators, isValidationEnabled } from './util/validation.js';

--- a/packages/builders/src/messages/embed/Embed.ts
+++ b/packages/builders/src/messages/embed/Embed.ts
@@ -3,6 +3,7 @@ import type { APIEmbed, APIEmbedAuthor, APIEmbedField, APIEmbedFooter } from 'di
 import type { RestOrArray } from '../../util/normalizeArray.js';
 import { normalizeArray } from '../../util/normalizeArray.js';
 import { resolveBuilder } from '../../util/resolveBuilder.js';
+import { type ColorResolvable, resolveColor } from '../../util/colors';
 import { validate } from '../../util/validation.js';
 import { embedPredicate } from './Assertions.js';
 import { EmbedAuthorBuilder } from './EmbedAuthor.js';
@@ -176,8 +177,8 @@ export class EmbedBuilder implements JSONEncodable<APIEmbed> {
 	 *
 	 * @param color - The color to use
 	 */
-	public setColor(color: number): this {
-		this.data.color = color;
+	public setColor(color: ColorResolvable): this {
+		this.data.color = resolveColor(color);
 		return this;
 	}
 

--- a/packages/builders/src/util/colors.ts
+++ b/packages/builders/src/util/colors.ts
@@ -1,0 +1,27 @@
+export type ColorResolvable = number | string | readonly [number, number, number];
+
+const HEX_REGEX = /^#?[\da-f]{6}$/i;
+
+export function resolveColor(color: ColorResolvable): number {
+	if (typeof color === 'string') {
+		if (color === 'Random') return Math.floor(Math.random() * (0xffffff + 1));
+		if (color === 'Default') return 0;
+		if (HEX_REGEX.test(color)) return Number.parseInt(color.replace('#', ''), 16);
+
+		throw new RangeError(
+			`Expected a color resolvable, but got "${color}". Accepted values: 0-16777215, hex strings, or RGB arrays.`,
+		);
+	}
+
+	if (Array.isArray(color)) {
+		return (color[0] << 16) + (color[1] << 8) + color[2];
+	}
+
+	if (!Number.isInteger(color) || color < 0 || color > 0xffffff) {
+		throw new RangeError(
+			`Expected a color resolvable, but got "${String(color)}". Accepted values: 0-16777215, hex strings, or RGB arrays.`,
+		);
+	}
+
+	return color;
+}


### PR DESCRIPTION
## Summary

ContainerBuilder#setAccentColor and EmbedBuilder#setColor now accept `ColorResolvable` (number, hex string, RGB tuple, 'Random', 'Default') instead of only number, bringing consistency with the rest of the API.

## Related Issue

Closes #11496

## Changes

- `packages/builders/src/util/colors.ts` — new module exporting `ColorResolvable` type and `resolveColor()` utility
- `packages/builders/src/components/v2/Container.ts` — `setAccentColor` now accepts `ColorResolvable` and resolves internally
- `packages/builders/src/messages/embed/Embed.ts` — `setColor` now accepts `ColorResolvable` for consistency
- `packages/builders/src/index.ts` — exports new `colors` module
- Tests updated for both ContainerBuilder and EmbedBuilder with ColorResolvable inputs