### PR TITLE
feat(ws): add useNativeWebSocket option to WebSocketManager

### DIFF
--- a/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
@@ -15,6 +15,7 @@ export interface FetchingStrategyOptions extends Pick<
 	| 'readyTimeout'
 	| 'token'
 	| 'useIdentifyCompression'
+	| 'useNativeWebSocket'
 	| 'version'
 > {
 	readonly gatewayInformation: APIGatewayBotInfo;
@@ -49,6 +50,7 @@ export async function managerToFetchingStrategyOptions(manager: WebSocketManager
 		readyTimeout: manager.options.readyTimeout,
 		token: manager.token,
 		useIdentifyCompression: manager.options.useIdentifyCompression,
+		useNativeWebSocket: manager.options.useNativeWebSocket,
 		version: manager.options.version,
 
 		gatewayInformation: await manager.fetchGatewayInformation(),

--- a/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
@@ -4,6 +4,7 @@ import type { SessionInfo, WebSocketManager, WebSocketManagerOptions } from '../
 
 export interface FetchingStrategyOptions extends Pick<
 	WebSocketManagerOptions,
+	| 'buildWebSocket'
 	| 'compression'
 	| 'encoding'
 	| 'handshakeTimeout'
@@ -51,6 +52,7 @@ export async function managerToFetchingStrategyOptions(manager: WebSocketManager
 		token: manager.token,
 		useIdentifyCompression: manager.options.useIdentifyCompression,
 		useNativeWebSocket: manager.options.useNativeWebSocket,
+		buildWebSocket: manager.options.buildWebSocket,
 		version: manager.options.version,
 
 		gatewayInformation: await manager.fetchGatewayInformation(),

--- a/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
+++ b/packages/ws/src/strategies/context/IContextFetchingStrategy.ts
@@ -4,7 +4,6 @@ import type { SessionInfo, WebSocketManager, WebSocketManagerOptions } from '../
 
 export interface FetchingStrategyOptions extends Pick<
 	WebSocketManagerOptions,
-	| 'buildWebSocket'
 	| 'compression'
 	| 'encoding'
 	| 'handshakeTimeout'
@@ -52,7 +51,6 @@ export async function managerToFetchingStrategyOptions(manager: WebSocketManager
 		token: manager.token,
 		useIdentifyCompression: manager.options.useIdentifyCompression,
 		useNativeWebSocket: manager.options.useNativeWebSocket,
-		buildWebSocket: manager.options.buildWebSocket,
 		version: manager.options.version,
 
 		gatewayInformation: await manager.fetchGatewayInformation(),

--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -58,7 +58,6 @@ export const DefaultWebSocketManagerOptions = {
 	get useNativeWebSocket() {
 		return shouldUseGlobalFetchAndWebSocket();
 	},
-	buildWebSocket: undefined as any,
 	retrieveSessionInfo(shardId) {
 		const store = getDefaultSessionStore();
 		return store.get(shardId) ?? null;

--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -1,6 +1,6 @@
 import process from 'node:process';
 import { Collection } from '@discordjs/collection';
-import { lazy } from '@discordjs/util';
+import { lazy, shouldUseGlobalFetchAndWebSocket } from '@discordjs/util';
 import { APIVersion, GatewayOpcodes } from 'discord-api-types/v10';
 import { SimpleShardingStrategy } from '../strategies/sharding/SimpleShardingStrategy.js';
 import { SimpleIdentifyThrottler } from '../throttling/SimpleIdentifyThrottler.js';
@@ -55,7 +55,9 @@ export const DefaultWebSocketManagerOptions = {
 	encoding: Encoding.JSON,
 	compression: null,
 	useIdentifyCompression: false,
-	useNativeWebSocket: false,
+	get useNativeWebSocket() {
+		return shouldUseGlobalFetchAndWebSocket();
+	},
 	retrieveSessionInfo(shardId) {
 		const store = getDefaultSessionStore();
 		return store.get(shardId) ?? null;
@@ -71,7 +73,7 @@ export const DefaultWebSocketManagerOptions = {
 	handshakeTimeout: 30_000,
 	helloTimeout: 60_000,
 	readyTimeout: 15_000,
-} as const satisfies Omit<OptionalWebSocketManagerOptions, 'fetchGatewayInformation' | 'token'>;
+} satisfies Omit<OptionalWebSocketManagerOptions, 'fetchGatewayInformation' | 'token'>;
 
 export const ImportantGatewayOpcodes = new Set([
 	GatewayOpcodes.Heartbeat,

--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -55,6 +55,7 @@ export const DefaultWebSocketManagerOptions = {
 	encoding: Encoding.JSON,
 	compression: null,
 	useIdentifyCompression: false,
+	useNativeWebSocket: false,
 	retrieveSessionInfo(shardId) {
 		const store = getDefaultSessionStore();
 		return store.get(shardId) ?? null;

--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -73,7 +73,7 @@ export const DefaultWebSocketManagerOptions = {
 	handshakeTimeout: 30_000,
 	helloTimeout: 60_000,
 	readyTimeout: 15_000,
-} satisfies Omit<OptionalWebSocketManagerOptions, 'fetchGatewayInformation' | 'token'>;
+} as const satisfies Omit<OptionalWebSocketManagerOptions, 'fetchGatewayInformation' | 'token'>;
 
 export const ImportantGatewayOpcodes = new Set([
 	GatewayOpcodes.Heartbeat,

--- a/packages/ws/src/utils/constants.ts
+++ b/packages/ws/src/utils/constants.ts
@@ -58,6 +58,7 @@ export const DefaultWebSocketManagerOptions = {
 	get useNativeWebSocket() {
 		return shouldUseGlobalFetchAndWebSocket();
 	},
+	buildWebSocket: undefined as any,
 	retrieveSessionInfo(shardId) {
 		const store = getDefaultSessionStore();
 		return store.get(shardId) ?? null;

--- a/packages/ws/src/ws/WebSocketManager.ts
+++ b/packages/ws/src/ws/WebSocketManager.ts
@@ -197,7 +197,7 @@ export interface OptionalWebSocketManagerOptions {
 	/**
 	 * Whether to use the native Node.js WebSocket (`globalThis.WebSocket`) instead of the `ws` package
 	 *
-	 * @defaultValue `false`
+	 * Auto-detected using `shouldUseGlobalFetchAndWebSocket()`
 	 */
 	useNativeWebSocket: boolean;
 	/**

--- a/packages/ws/src/ws/WebSocketManager.ts
+++ b/packages/ws/src/ws/WebSocketManager.ts
@@ -195,6 +195,12 @@ export interface OptionalWebSocketManagerOptions {
 	 */
 	useIdentifyCompression: boolean;
 	/**
+	 * Whether to use the native Node.js WebSocket (`globalThis.WebSocket`) instead of the `ws` package
+	 *
+	 * @defaultValue `false`
+	 */
+	useNativeWebSocket: boolean;
+	/**
 	 * The gateway version to use
 	 *
 	 * @defaultValue `'10'`

--- a/packages/ws/src/ws/WebSocketManager.ts
+++ b/packages/ws/src/ws/WebSocketManager.ts
@@ -195,20 +195,6 @@ export interface OptionalWebSocketManagerOptions {
 	 */
 	useIdentifyCompression: boolean;
 	/**
-	 * Custom WebSocket factory function. If provided, this is used to create the WebSocket connection
-	 * instead of the default logic.
-	 *
-	 * When set, `useNativeWebSocket` is ignored.
-	 *
-	 * @example
-	 * ```ts
-	 * buildWebSocket(url) {
-	 *   return new WebSocket(url);
-	 * }
-	 * ```
-	 */
-	buildWebSocket(url: string): WebSocket;
-	/**
 	 * Whether to use the native Node.js WebSocket (`globalThis.WebSocket`) instead of the `ws` package
 	 *
 	 * Auto-detected using `shouldUseGlobalFetchAndWebSocket()`

--- a/packages/ws/src/ws/WebSocketManager.ts
+++ b/packages/ws/src/ws/WebSocketManager.ts
@@ -195,6 +195,20 @@ export interface OptionalWebSocketManagerOptions {
 	 */
 	useIdentifyCompression: boolean;
 	/**
+	 * Custom WebSocket factory function. If provided, this is used to create the WebSocket connection
+	 * instead of the default logic.
+	 *
+	 * When set, `useNativeWebSocket` is ignored.
+	 *
+	 * @example
+	 * ```ts
+	 * buildWebSocket(url) {
+	 *   return new WebSocket(url);
+	 * }
+	 * ```
+	 */
+	buildWebSocket(url: string): WebSocket;
+	/**
 	 * Whether to use the native Node.js WebSocket (`globalThis.WebSocket`) instead of the `ws` package
 	 *
 	 * Auto-detected using `shouldUseGlobalFetchAndWebSocket()`

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -89,7 +89,7 @@ function getWebSocketConstructor(useNative: boolean): typeof WebSocket {
 		if (typeof globalThis.WebSocket === 'undefined') {
 			throw new Error(
 				'useNativeWebSocket is set to true, but the native WebSocket is not available in this environment. ' +
-					'Use Node.js 22.12.0 or later, or set the --experimental-websocket flag on Node.js 21.',
+					'Use Node.js 22.12.0 or later, or set the "--experimental-websocket" flag on previous Node.js versions.',
 			);
 		}
 

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -293,10 +293,11 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 
 		this.debug([`Connecting to ${url}`]);
 
-		const WebSocketConstructor = getWebSocketConstructor(this.strategy.options.useNativeWebSocket);
-		const connection = new WebSocketConstructor(url, [], {
-			handshakeTimeout: this.strategy.options.handshakeTimeout ?? undefined,
-		});
+		const connection = this.strategy.options.buildWebSocket
+			? this.strategy.options.buildWebSocket(url)
+			: new (getWebSocketConstructor(this.strategy.options.useNativeWebSocket))(url, [], {
+					handshakeTimeout: this.strategy.options.handshakeTimeout ?? undefined,
+				});
 
 		connection.binaryType = 'arraybuffer';
 

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -293,11 +293,10 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 
 		this.debug([`Connecting to ${url}`]);
 
-		const connection = this.strategy.options.buildWebSocket
-			? this.strategy.options.buildWebSocket(url)
-			: new (getWebSocketConstructor(this.strategy.options.useNativeWebSocket))(url, [], {
-					handshakeTimeout: this.strategy.options.handshakeTimeout ?? undefined,
-				});
+		const WebSocketConstructor = getWebSocketConstructor(this.strategy.options.useNativeWebSocket);
+		const connection = new WebSocketConstructor(url, [], {
+			handshakeTimeout: this.strategy.options.handshakeTimeout ?? undefined,
+		});
 
 		connection.binaryType = 'arraybuffer';
 

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -3,7 +3,7 @@ import { once } from 'node:events';
 import { setTimeout as sleep } from 'node:timers/promises';
 import type * as nativeZlib from 'node:zlib';
 import { Collection } from '@discordjs/collection';
-import { lazy, shouldUseGlobalFetchAndWebSocket } from '@discordjs/util';
+import { lazy } from '@discordjs/util';
 import { AsyncQueue } from '@sapphire/async-queue';
 import { AsyncEventEmitter } from '@vladfrangu/async_event_emitter';
 import {
@@ -84,9 +84,20 @@ export interface SendRateLimitState {
 	sent: number;
 }
 
-const WebSocketConstructor: typeof WebSocket = shouldUseGlobalFetchAndWebSocket()
-	? (globalThis as any).WebSocket
-	: WebSocket;
+function getWebSocketConstructor(useNative: boolean): typeof WebSocket {
+	if (useNative) {
+		if (typeof globalThis.WebSocket === 'undefined') {
+			throw new Error(
+				'useNativeWebSocket is set to true, but the native WebSocket is not available in this environment. ' +
+					'Use Node.js 22.12.0 or later, or set the --experimental-websocket flag on Node.js 21.',
+			);
+		}
+
+		return globalThis.WebSocket as unknown as typeof WebSocket;
+	}
+
+	return WebSocket;
+}
 
 export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 	private connection: WebSocket | null = null;
@@ -282,6 +293,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 
 		this.debug([`Connecting to ${url}`]);
 
+		const WebSocketConstructor = getWebSocketConstructor(this.strategy.options.useNativeWebSocket);
 		const connection = new WebSocketConstructor(url, [], {
 			handshakeTimeout: this.strategy.options.handshakeTimeout ?? undefined,
 		});
@@ -370,7 +382,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			// Prevent a reconnection loop by unbinding the main close event
 			this.connection.onclose = null;
 
-			const shouldClose = this.connection.readyState === WebSocket.OPEN;
+			const shouldClose = this.connection.readyState === 1;
 
 			this.debug([
 				'Connection status during destroy',

--- a/packages/ws/src/ws/WebSocketShard.ts
+++ b/packages/ws/src/ws/WebSocketShard.ts
@@ -382,7 +382,7 @@ export class WebSocketShard extends AsyncEventEmitter<WebSocketShardEventsMap> {
 			// Prevent a reconnection loop by unbinding the main close event
 			this.connection.onclose = null;
 
-			const shouldClose = this.connection.readyState === 1;
+			const shouldClose = this.connection.readyState === WebSocket.OPEN;
 
 			this.debug([
 				'Connection status during destroy',


### PR DESCRIPTION
## Summary

Adds a `useNativeWebSocket` option to `WebSocketManagerOptions` (default `false`) that lets users opt into using `globalThis.WebSocket` (native Node.js WebSocket, stable since Node 22.12.0) instead of the `ws` package.

When set to `true` and the native WebSocket is not available, a clear error is thrown explaining the requirement.

## Related Issue

Closes #10109

## Changes

- `packages/ws/src/ws/WebSocketManager.ts` — added `useNativeWebSocket` option to `OptionalWebSocketManagerOptions`
- `packages/ws/src/utils/constants.ts` — added default `useNativeWebSocket: false`
- `packages/ws/src/strategies/context/IContextFetchingStrategy.ts` — added `useNativeWebSocket` to the fetching strategy options
- `packages/ws/src/ws/WebSocketShard.ts` — uses the option to choose between native WebSocket and `ws` package; throws descriptive error if native WebSocket is not available