### PR TITLE
fix: remove duplicate API version in fetchRecommendedShardCount URL

### DIFF
--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -83,7 +83,7 @@ async function fetchRecommendedShardCount(
   { guildsPerShard = 1_000, multipleOf = 1, api = RouteBases.api, version = APIVersion } = {},
 ) {
   if (!token) throw new DiscordjsError(ErrorCodes.TokenMissing);
-  const response = await fetch(`${api}/v${version}${Routes.gatewayBot()}`, {
+  const response = await fetch(`${api}${Routes.gatewayBot()}`, {
     method: 'GET',
     headers: { Authorization: `Bot ${token.replace(/^bot\s*/i, '')}` },
   });


### PR DESCRIPTION
Fixes #11541

RouteBases.api already includes the API version (e.g., https://discord.com/api/v10), so appending /v${version} was causing a double version in the URL. This fixes the URL construction in fetchRecommendedShardCount.