### PR TITLE
fix(Collector): persist time / idle on resetTimer

### DIFF
--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -272,14 +272,21 @@ class Collector extends AsyncEventEmitter {
    * @param {CollectorResetTimerOptions} [options] Options for resetting
    */
   resetTimer({ time, idle } = {}) {
+    // Persist new values on `this.options` so subsequent internal resets
+    // (e.g. the per-collect idle reset in `handleCollect`) and consumer
+    // reads of `collector.options.time` / `collector.options.idle` see the
+    // updated values, not the originals from construction.
+    if (time !== undefined) this.options.time = time;
+    if (idle !== undefined) this.options.idle = idle;
+
     if (this._timeout) {
       clearTimeout(this._timeout);
-      this._timeout = setTimeout(() => this.stop('time'), time ?? this.options.time).unref();
+      this._timeout = setTimeout(() => this.stop('time'), this.options.time).unref();
     }
 
     if (this._idletimeout) {
       clearTimeout(this._idletimeout);
-      this._idletimeout = setTimeout(() => this.stop('idle'), idle ?? this.options.idle).unref();
+      this._idletimeout = setTimeout(() => this.stop('idle'), this.options.idle).unref();
     }
   }
 


### PR DESCRIPTION
Closes #11286.

`resetTimer({ time, idle })` re-armed the underlying timeouts with the new values but never updated `this.options.time` / `this.options.idle`, so:

- A consumer reading `collector.options.time` / `.options.idle` after `resetTimer` still saw the original construction values.
- The per-collect idle reset in `handleCollect` reads `this.options.idle` to re-arm the timer after each item, which then silently reverted to the original idle on the very next collect.

## Fix

Assign new values to `this.options.time` / `.options.idle` first, then re-arm the timeouts off the now-updated options. No behaviour change when neither field is provided.

## Status

Please double check this works