### PR TITLE
fix(invite): Return `RESTDeleteAPIInviteResult` on delete

### DIFF
--- a/packages/core/src/api/invite.ts
+++ b/packages/core/src/api/invite.ts
@@ -1,7 +1,12 @@
 /* eslint-disable jsdoc/check-param-names */
 
 import { makeURLSearchParams, type RequestData, type REST } from '@discordjs/rest';
-import { Routes, type RESTGetAPIInviteQuery, type RESTGetAPIInviteResult } from 'discord-api-types/v10';
+import {
+	Routes,
+	type RESTDeleteAPIInviteResult,
+	type RESTGetAPIInviteQuery,
+	type RESTGetAPIInviteResult,
+} from 'discord-api-types/v10';
 
 export class InvitesAPI {
 	public constructor(private readonly rest: REST) {}
@@ -34,6 +39,6 @@ export class InvitesAPI {
 	 * @param options - The options for deleting the invite
 	 */
 	public async delete(code: string, { auth, reason, signal }: Pick<RequestData, 'auth' | 'reason' | 'signal'> = {}) {
-		await this.rest.delete(Routes.invite(code), { auth, reason, signal });
+		return this.rest.delete(Routes.invite(code), { auth, reason, signal }) as Promise<RESTDeleteAPIInviteResult>;
 	}
 }


### PR DESCRIPTION
Deleting an invite returns it.

Verified with testing and this is documented: https://docs.discord.com/developers/resources/invite#delete-invite