### PR TITLE
fix(structures): zero-pad ms in `dateToDiscordISOTimestamp`

### DIFF
--- a/packages/structures/__tests__/optimization.test.ts
+++ b/packages/structures/__tests__/optimization.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+import { dateToDiscordISOTimestamp } from '../src/utils/optimization.js';
+
+describe('dateToDiscordISOTimestamp', () => {
+	test('zero-pads milliseconds below 100', () => {
+		// 5ms is .005000, not .500000
+		expect(dateToDiscordISOTimestamp(new Date(Date.UTC(2_024, 0, 1, 0, 0, 0, 5)))).toBe(
+			'2024-01-01T00:00:00.005000+00:00',
+		);
+		expect(dateToDiscordISOTimestamp(new Date(Date.UTC(2_024, 0, 1, 0, 0, 0, 42)))).toBe(
+			'2024-01-01T00:00:00.042000+00:00',
+		);
+		expect(dateToDiscordISOTimestamp(new Date(Date.UTC(2_024, 0, 1, 0, 0, 0, 0)))).toBe(
+			'2024-01-01T00:00:00.000000+00:00',
+		);
+	});
+
+	test('round-trips every millisecond value', () => {
+		for (const ms of [0, 1, 9, 10, 50, 99, 100, 500, 999]) {
+			const date = new Date(Date.UTC(2_024, 5, 15, 12, 30, 45, ms));
+			expect(new Date(dateToDiscordISOTimestamp(date)).getTime()).toBe(date.getTime());
+		}
+	});
+});

--- a/packages/structures/src/utils/optimization.ts
+++ b/packages/structures/src/utils/optimization.ts
@@ -17,5 +17,5 @@ export function extendTemplate<SuperTemplate extends Record<string, unknown>>(
  * @returns an ISO8601 timestamp with microseconds precision and explicit +00:00 timezone
  */
 export function dateToDiscordISOTimestamp(date: Date) {
-	return `${date.getUTCFullYear()}-${(date.getUTCMonth() + 1).toString().padStart(2, '0')}-${date.getUTCDate().toString().padStart(2, '0')}T${date.getUTCHours().toString().padStart(2, '0')}:${date.getUTCMinutes().toString().padStart(2, '0')}:${date.getUTCSeconds().toString().padStart(2, '0')}.${date.getUTCMilliseconds().toString().padEnd(6, '0')}+00:00`;
+	return `${date.getUTCFullYear()}-${(date.getUTCMonth() + 1).toString().padStart(2, '0')}-${date.getUTCDate().toString().padStart(2, '0')}T${date.getUTCHours().toString().padStart(2, '0')}:${date.getUTCMinutes().toString().padStart(2, '0')}:${date.getUTCSeconds().toString().padStart(2, '0')}.${date.getUTCMilliseconds().toString().padStart(3, '0').padEnd(6, '0')}+00:00`;
 }


### PR DESCRIPTION
`dateToDiscordISOTimestamp` pads milliseconds with `padEnd(6, '0')` instead of `padStart`, so sub-100ms
values serialize wrong, e.g. `5ms` becomes `.500000`. This hits the `toJSON` of every structure that
re-emits a timestamp (`Message`, `Subscription`, `Entitlement`, `Invite`, `Poll`, `Embed`, `MessageCall`).

Padding to 3 digits first (like the rest of the line) fixes it and it's no-op for `>= 100ms`. `message.test.ts`
already round-trips this helper but only with `>= 100ms` values so it missed this.