### PR TITLE
fix: detect spoiler attachments with flag (v14)

### DIFF
--- a/packages/discord.js/src/structures/Attachment.js
+++ b/packages/discord.js/src/structures/Attachment.js
@@ -1,7 +1,8 @@
 'use strict';
 
+const { AttachmentFlags } = require('discord-api-types/v10');
 const AttachmentFlagsBitField = require('../util/AttachmentFlagsBitField.js');
-const { basename, flatten } = require('../util/Util');
+const { flatten } = require('../util/Util');
 
 /**
  * @typedef {Object} AttachmentPayload
@@ -152,7 +153,7 @@ class Attachment {
    * @readonly
    */
   get spoiler() {
-    return basename(this.url ?? this.name).startsWith('SPOILER_');
+    return this.flags.has(AttachmentFlags.IsSpoiler);
   }
 
   toJSON() {


### PR DESCRIPTION
backporting #11560 to v14. did not update AttachmentBuilder because it is ok to keep using the prefix for sending - the important change is for reading.
