### PR TITLE
docs: fix incorrect casing in the ready event deprecation

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6111,7 +6111,7 @@ export interface ClientEvents {
     newMessage: OmitPartialGroupDMChannel<Message>,
   ];
   presenceUpdate: [oldPresence: Presence | null, newPresence: Presence];
-  /** @deprecated Use {@link ClientEvents.ClientReady} instead. */
+  /** @deprecated Use {@link ClientEvents.clientReady} instead. */
   ready: [client: Client<true>];
   invalidated: [];
   roleCreate: [role: Role];


### PR DESCRIPTION
Found the bug in `packages/discord.js/typings/index.d.ts`. The deprecation comment on the `ready` event links to `ClientEvents.ClientReady` but the actual property is `clientReady` (lowercase c). Since that link target doesn't exist, the docs site's `{@link}` fails to resolve and just falls back to showing "ClientEvents" instead of the real message, which is the bug reported in #11571
