### PR TITLE
fix(voice): handle server update race condition

### DIFF
--- a/packages/voice/src/VoiceConnection.ts
+++ b/packages/voice/src/VoiceConnection.ts
@@ -384,7 +384,7 @@ export class VoiceConnection extends EventEmitter {
 			stuck in signalling state
 			gh issue #11553
 		*/
-		if (packet.channel_id && this.packets.server?.endpoint) {
+		if (packet.channel_id && this.state.status === VoiceConnectionStatus.Signalling) {
 			this.configureNetworking();
 		}
 	}

--- a/packages/voice/src/VoiceConnection.ts
+++ b/packages/voice/src/VoiceConnection.ts
@@ -384,7 +384,7 @@ export class VoiceConnection extends EventEmitter {
 			stuck in signalling state
 			gh issue #11553
 		*/
-		if (this.packets.server?.endpoint) {
+		if (packet.channel_id && this.packets.server?.endpoint) {
 			this.configureNetworking();
 		}
 	}

--- a/packages/voice/src/VoiceConnection.ts
+++ b/packages/voice/src/VoiceConnection.ts
@@ -378,6 +378,15 @@ export class VoiceConnection extends EventEmitter {
 			as it may have disconnected due to network failure. This will be gracefully handled once the voice websocket
 			dies, and then it is up to the user to decide how they wish to handle this.
 		*/
+
+		/*
+		  deals with race condition when VOICE_SERVER_UPDATE arrives before VOICE_STATE_UPDATE and connection stays
+			stuck in signalling state
+			gh issue #11553
+		*/
+		if (this.packets.server?.endpoint) {
+			this.configureNetworking();
+		}
 	}
 
 	/**


### PR DESCRIPTION
`VOICE_SERVER_UPDATE` can arrive before `VOICE_STATE_UPDATE` which causes the voice connection to stay stuck in signalling since `configureNetworking()` returns early without `this.packets.state` and is not called again after state is valid.

This pr fixes this by calling `configureNetowrking()` when `this.packets.server.endpoint` is set (implying that server update was received before state update)

Resolves #11553 