### PR TITLE
feat(ClientApplication)!: support `flags_new`

### DIFF
--- a/packages/discord.js/src/structures/ClientApplication.js
+++ b/packages/discord.js/src/structures/ClientApplication.js
@@ -150,13 +150,13 @@ class ClientApplication extends Application {
       this.customInstallURL = null;
     }
 
-    if ('flags' in data) {
+    if ('flags_new' in data) {
       /**
        * The flags this application has
        *
        * @type {ApplicationFlagsBitField}
        */
-      this.flags = new ApplicationFlagsBitField(data.flags).freeze();
+      this.flags = new ApplicationFlagsBitField(data.flags_new).freeze();
     }
 
     if ('approximate_guild_count' in data) {
@@ -369,7 +369,8 @@ class ClientApplication extends Application {
         description,
         role_connections_verification_url: roleConnectionsVerificationURL,
         install_params: installParams,
-        flags: flags === undefined ? undefined : ApplicationFlagsBitField.resolve(flags),
+        // `flags` is still documented to be a `number`.
+        flags: flags === undefined ? undefined : Number(ApplicationFlagsBitField.resolve(flags)),
         icon: icon && (await resolveImage(icon)),
         cover_image: coverImage && (await resolveImage(coverImage)),
         interactions_endpoint_url: interactionsEndpointURL,
@@ -457,6 +458,12 @@ class ClientApplication extends Application {
   async fetchActivityInstance(instanceId) {
     const data = await this.client.rest.get(Routes.applicationActivityInstance(this.id, instanceId));
     return new ActivityInstance(this.client, data);
+  }
+
+  toJSON() {
+    const application = super.toJSON();
+    if (this.flags) application.flags = this.flags.toJSON();
+    return application;
   }
 }
 

--- a/packages/discord.js/src/util/ApplicationFlagsBitField.js
+++ b/packages/discord.js/src/util/ApplicationFlagsBitField.js
@@ -15,8 +15,33 @@ class ApplicationFlagsBitField extends BitField {
    *
    * @type {ApplicationFlags}
    * @memberof ApplicationFlagsBitField
+   * @see {@link https://docs.discord.com/developers/resources/application#application-object-application-flags}
    */
   static Flags = ApplicationFlags;
+
+  /**
+   * @type {bigint}
+   * @memberof ApplicationFlagsBitField
+   * @private
+   */
+  static DefaultBit = 0n;
+
+  /**
+   * Resolves application flags to their bigint form.
+   *
+   * @param {ApplicationFlagsResolvable} [bit] Bit(s) to resolve
+   * @returns {bigint}
+   */
+  static resolve(bit) {
+    if (typeof bit === 'number' && Number.isSafeInteger(bit) && bit >= 0) return BigInt(bit);
+
+    if (typeof bit === 'string') {
+      const flag = this.Flags[bit];
+      if (typeof flag === 'number') return BigInt(flag);
+    }
+
+    return super.resolve(bit);
+  }
 }
 
 /**
@@ -29,7 +54,7 @@ class ApplicationFlagsBitField extends BitField {
 /**
  * Bitfield of the packed bits
  *
- * @type {number}
+ * @type {bigint}
  * @name ApplicationFlagsBitField#bitfield
  */
 
@@ -40,7 +65,7 @@ class ApplicationFlagsBitField extends BitField {
  * - An instance of ApplicationFlagsBitField
  * - An Array of ApplicationFlagsResolvable
  *
- * @typedef {string|number|ApplicationFlagsBitField|ApplicationFlagsResolvable[]} ApplicationFlagsResolvable
+ * @typedef {string|number|bigint|ApplicationFlagsBitField|ApplicationFlagsResolvable[]} ApplicationFlagsResolvable
  */
 
 exports.ApplicationFlagsBitField = ApplicationFlagsBitField;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -505,12 +505,12 @@ export class ApplicationRoleConnectionMetadata {
 
 export type ApplicationResolvable = Activity | Application | Snowflake;
 
-export class ApplicationFlagsBitField extends BitField<ApplicationFlagsString> {
+export class ApplicationFlagsBitField extends BitField<ApplicationFlagsString, bigint> {
   public static Flags: typeof ApplicationFlags;
-  public static resolve(bit?: BitFieldResolvable<ApplicationFlagsString, number>): number;
+  public static resolve(bit?: ApplicationFlagsResolvable): bigint;
 }
 
-export type ApplicationFlagsResolvable = BitFieldResolvable<ApplicationFlagsString, number>;
+export type ApplicationFlagsResolvable = BitFieldResolvable<ApplicationFlagsString, ApplicationFlags | bigint>;
 
 export type AutoModerationRuleResolvable = AutoModerationRule | Snowflake;
 

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -40,6 +40,7 @@ import {
   ApplicationCommandOptionType,
   ApplicationCommandPermissionType,
   ApplicationCommandType,
+  ApplicationFlags,
   ApplicationIntegrationType,
   AuditLogEvent,
   ButtonStyle,
@@ -222,6 +223,7 @@ import type {
   VoiceServerUpdateData,
 } from './index.js';
 import {
+  ApplicationFlagsBitField,
   Client,
   Collection,
   Events,
@@ -2870,6 +2872,15 @@ declare const application: ClientApplication;
 declare const entitlement: Entitlement;
 declare const sku: SKU;
 {
+  expectType<bigint>(application.flags.bitfield);
+  expectType<string>(application.flags.toJSON());
+  expectType<bigint>(ApplicationFlagsBitField.resolve(ApplicationFlags.GatewayPresenceLimited));
+  expectType<bigint>(ApplicationFlagsBitField.resolve('GatewayPresenceLimited'));
+  expectType<bigint>(ApplicationFlagsBitField.resolve(1n << 40n));
+
+  await application.edit({ flags: ApplicationFlags.GatewayPresenceLimited });
+  await application.edit({ flags: ['GatewayPresenceLimited', ApplicationFlags.GatewayGuildMembersLimited] });
+
   expectType<Collection<Snowflake, SKU>>(await application.fetchSKUs());
   expectType<Collection<Snowflake, Entitlement>>(await application.entitlements.fetch());
 


### PR DESCRIPTION
Implements the following:

- https://github.com/discord/discord-api-docs/pull/8345

`flags_new` is to be used this moment on. `flags` is still used for modifying the application and is still sent as a `number`.
