### PR TITLE
types(GuildScheduledEvent): allow scheduledEndTime to be null

### DIFF
--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -193,7 +193,7 @@ class GuildScheduledEventManager extends CachedManager {
    * @typedef {Object} GuildScheduledEventEditOptions
    * @property {string} [name] The name of the guild scheduled event
    * @property {DateResolvable} [scheduledStartTime] The time to schedule the event at
-   * @property {DateResolvable} [scheduledEndTime] The time to end the event at
+   * @property {DateResolvable|null} [scheduledEndTime] The time to end the event at
    * @property {GuildScheduledEventPrivacyLevel} [privacyLevel] The privacy level of the guild scheduled event
    * @property {GuildScheduledEventEntityType} [entityType] The scheduled entity type of the event
    * @property {string} [description] The description of the guild scheduled event

--- a/packages/discord.js/src/managers/GuildScheduledEventManager.js
+++ b/packages/discord.js/src/managers/GuildScheduledEventManager.js
@@ -193,7 +193,8 @@ class GuildScheduledEventManager extends CachedManager {
    * @typedef {Object} GuildScheduledEventEditOptions
    * @property {string} [name] The name of the guild scheduled event
    * @property {DateResolvable} [scheduledStartTime] The time to schedule the event at
-   * @property {DateResolvable|null} [scheduledEndTime] The time to end the event at
+   * @property {?DateResolvable} [scheduledEndTime] The time to end the event at
+   * <info>This cannot be `null` if `entityType` is {@link GuildScheduledEventEntityType.External}</info>
    * @property {GuildScheduledEventPrivacyLevel} [privacyLevel] The privacy level of the guild scheduled event
    * @property {GuildScheduledEventEntityType} [entityType] The scheduled entity type of the event
    * @property {string} [description] The description of the guild scheduled event

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -450,11 +450,10 @@ class GuildScheduledEvent extends Base {
     return this.edit({ scheduledStartTime, reason });
   }
 
-  // TODO: scheduledEndTime gets reset on passing null but it hasn't been documented
   /**
    * Sets a new time to end the event at.
    *
-   * @param {DateResolvable} scheduledEndTime The time to end the event at
+   * @param {DateResolvable|null} scheduledEndTime The time to end the event at, or null to reset/remove the end time
    * @param {string} [reason] The reason for changing the scheduled end time
    * @returns {Promise<GuildScheduledEvent>}
    * @example

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -453,7 +453,7 @@ class GuildScheduledEvent extends Base {
   /**
    * Sets a new time to end the event at.
    *
-   * @param {DateResolvable|null} scheduledEndTime The time to end the event at, or null to reset/remove the end time
+   * @param {DateResolvable|null} scheduledEndTime The time to end the event at, or null to reset/remove the end time (only for non-external events)
    * @param {string} [reason] The reason for changing the scheduled end time
    * @returns {Promise<GuildScheduledEvent>}
    * @example

--- a/packages/discord.js/src/structures/GuildScheduledEvent.js
+++ b/packages/discord.js/src/structures/GuildScheduledEvent.js
@@ -453,7 +453,8 @@ class GuildScheduledEvent extends Base {
   /**
    * Sets a new time to end the event at.
    *
-   * @param {DateResolvable|null} scheduledEndTime The time to end the event at, or null to reset/remove the end time (only for non-external events)
+   * @param {?DateResolvable} scheduledEndTime The time to end the event at, or `null` to remove the end time
+   * <info>This cannot be `null` if this event's `entityType` is {@link GuildScheduledEventEntityType.External}</info>
    * @param {string} [reason] The reason for changing the scheduled end time
    * @returns {Promise<GuildScheduledEvent>}
    * @example

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -1817,7 +1817,10 @@ export class GuildScheduledEvent<Status extends GuildScheduledEventStatus = Guil
     scheduledStartTime: DateResolvable,
     reason?: string,
   ): Promise<GuildScheduledEvent<Status>>;
-  public setScheduledEndTime(scheduledEndTime: DateResolvable, reason?: string): Promise<GuildScheduledEvent<Status>>;
+  public setScheduledEndTime(
+    scheduledEndTime: DateResolvable | null,
+    reason?: string,
+  ): Promise<GuildScheduledEvent<Status>>;
   public setDescription(description: string, reason?: string): Promise<GuildScheduledEvent<Status>>;
   public setStatus<AcceptableStatus extends GuildScheduledEventSetStatusArg<Status>>(
     status: AcceptableStatus,
@@ -6462,7 +6465,7 @@ export interface BaseGuildScheduledEventOptions {
   privacyLevel?: GuildScheduledEventPrivacyLevel;
   reason?: string;
   recurrenceRule?: GuildScheduledEventRecurrenceRuleOptions | null;
-  scheduledEndTime?: DateResolvable;
+  scheduledEndTime?: DateResolvable | null;
   scheduledStartTime?: DateResolvable;
 }
 
@@ -7512,3 +7515,4 @@ export * from '@discordjs/rest';
 export * from '@discordjs/util';
 export * from '@discordjs/ws';
 export * from 'discord-api-types/v10';
+

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6476,6 +6476,7 @@ export interface GuildScheduledEventCreateOptions extends BaseGuildScheduledEven
   name: string;
   privacyLevel: GuildScheduledEventPrivacyLevel;
   recurrenceRule?: GuildScheduledEventRecurrenceRuleOptions;
+  scheduledEndTime?: DateResolvable;
   scheduledStartTime: DateResolvable;
 }
 
@@ -7515,4 +7516,3 @@ export * from '@discordjs/rest';
 export * from '@discordjs/util';
 export * from '@discordjs/ws';
 export * from 'discord-api-types/v10';
-


### PR DESCRIPTION
Allow `scheduledEndTime` to accept `null` in both `setScheduledEndTime()` and `BaseGuildScheduledEventOptions` to support resetting/removing the end time of a scheduled event. 

Also updates JSDocs to document this behavior.
