### PR TITLE
fix(builders): preserve empty attachment files

### DIFF
--- a/packages/builders/__tests__/messages/fileBody.test.ts
+++ b/packages/builders/__tests__/messages/fileBody.test.ts
@@ -35,6 +35,25 @@ test('AttachmentBuilder handles 0 as a valid id', () => {
 	});
 });
 
+test('AttachmentBuilder preserves zero-byte string files', () => {
+	const attachment = new AttachmentBuilder().setId(0).setFilename('empty.txt').setFileData('');
+
+	expect(attachment.getRawFile()).toStrictEqual({
+		data: '',
+		key: 'files[0]',
+		name: 'empty.txt',
+	});
+
+	const message = new MessageBuilder().setContent('empty attachment').addAttachments(attachment);
+	expect(message.toFileBody().files).toStrictEqual([
+		{
+			data: '',
+			key: 'files[0]',
+			name: 'empty.txt',
+		},
+	]);
+});
+
 test('MessageBuilder.toFileBody returns JSON body and files', () => {
 	const msg = new MessageBuilder().setContent('here is a file').addAttachments(
 		new AttachmentBuilder()

--- a/packages/builders/src/messages/Attachment.ts
+++ b/packages/builders/src/messages/Attachment.ts
@@ -146,7 +146,7 @@ export class AttachmentBuilder implements JSONEncodable<RESTAPIAttachment> {
 	 * @returns A {@link @discordjs/util#RawFile} object, or `undefined` if no file data is set
 	 */
 	public getRawFile(): Partial<RawFile> | undefined {
-		if (!this.fileData?.data) {
+		if (this.fileData.data === undefined) {
 			return;
 		}
 

--- a/packages/builders/src/messages/Message.ts
+++ b/packages/builders/src/messages/Message.ts
@@ -725,9 +725,7 @@ export class MessageBuilder
 		const files: RawFile[] = [];
 		for (const attachment of this.data.attachments) {
 			const rawFile = attachment.getRawFile();
-			// Only if data or content type are set, since that implies the intent is to send a new file.
-			// In case it's contentType but not data, a validation error will be thrown right after.
-			if (rawFile?.data || rawFile?.contentType) {
+			if (rawFile !== undefined) {
 				files.push(rawFile as RawFile);
 			}
 		}


### PR DESCRIPTION
## Summary

- Preserve empty string attachment data in `AttachmentBuilder`.
- Include the resulting zero-byte file in `MessageBuilder` multipart output.

## Root cause

Truthiness checks treated `''` as if no file data had been supplied. The REST layer accepts it and creates a valid zero-byte `Blob`, so builders silently dropped a requested attachment before the request was made.

## Validation

- `vitest run --config ../../vitest.config.ts` — 25 suites, 268 tests passed; type errors: none
- `prettier --check packages/builders`
- `eslint --format=pretty packages/builders/src packages/builders/__tests__`
- Built `@discordjs/util` and `@discordjs/builders` with Node 24
