### PR TITLE
fix(Collector): persist time and idle options on resetTimer

### DIFF
--- a/packages/discord.js/src/structures/interfaces/Collector.js
+++ b/packages/discord.js/src/structures/interfaces/Collector.js
@@ -272,14 +272,17 @@ class Collector extends AsyncEventEmitter {
    * @param {CollectorResetTimerOptions} [options] Options for resetting
    */
   resetTimer({ time, idle } = {}) {
+    if (time !== undefined) this.options.time = time;
+    if (idle !== undefined) this.options.idle = idle;
+
     if (this._timeout) {
       clearTimeout(this._timeout);
-      this._timeout = setTimeout(() => this.stop('time'), time ?? this.options.time).unref();
+      this._timeout = setTimeout(() => this.stop('time'), this.options.time).unref();
     }
 
     if (this._idletimeout) {
       clearTimeout(this._idletimeout);
-      this._idletimeout = setTimeout(() => this.stop('idle'), idle ?? this.options.idle).unref();
+      this._idletimeout = setTimeout(() => this.stop('idle'), this.options.idle).unref();
     }
   }
 


### PR DESCRIPTION
This PR fixes issue #11553.

Previously, `resetTimer` would use the provided `time` or `idle` to reset the active timeout, but it failed to persist the new values to `this.options`. As a result, the next time the collector fired a `collect` event and automatically reset its idle timer, it would revert back to the originally configured `options.idle`, ignoring the user's manual timer extension.

This patch updates `this.options` if new `time` or `idle` options are explicitly passed to `resetTimer()`.