### PR TITLE
types: fix `Client#pings` visibility and stale private declarations

### DIFF
--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -490,7 +490,6 @@ export class ApplicationCommand<PermissionsFetchType = {}> extends Base {
   ): boolean;
   private static transformOption(option: ApplicationCommandOptionData, received?: boolean): unknown;
   private static transformCommand(command: ApplicationCommandData): RESTPostAPIApplicationCommandsJSONBody;
-  private static isAPICommandData(command: object): command is RESTPostAPIApplicationCommandsJSONBody;
 }
 
 export class ApplicationRoleConnectionMetadata {
@@ -941,9 +940,8 @@ export class Client<Ready extends boolean = boolean>
   public constructor(options: ClientOptions);
   private readonly actions: unknown;
   private readonly expectedGuilds: Set<Snowflake>;
-  private readonly packetQueue: unknown[];
+  private readonly incomingPacketQueue: unknown[];
   private readonly presence: ClientPresence;
-  private readonly pings: Collection<number, number>;
   private readonly readyTimeout: NodeJS.Timeout | null;
   private _broadcast(packet: GatewaySendPayload): void;
   private _eval(script: string): unknown;
@@ -963,6 +961,7 @@ export class Client<Ready extends boolean = boolean>
   public lastPingTimestamps: ReadonlyCollection<number, number>;
   public options: ClientOptions & { intents: IntentsBitField };
   public get ping(): number | null;
+  public pings: ReadonlyCollection<number, number>;
   public get readyAt(): If<Ready, Date>;
   public readyTimestamp: If<Ready, number>;
   public rest: REST;


### PR DESCRIPTION
- `Client#pings` is documented as public in the JSDoc, shows up on the
  documentation site, but was typed as `private` for some reason
- rename `Client#packetQueue` to `incomingPacketQueue` since
  `packetQueue` doesn't exist
- remove `ApplicationCommand.isAPICommandData`, which seemingly never
  actually existed at runtime