### PR TITLE
fix(website): show item name in docs page titles

### DIFF
--- a/apps/website/__tests__/util/parseDocsPathParams.test.ts
+++ b/apps/website/__tests__/util/parseDocsPathParams.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'vitest';
+import { parseDocsPathParams } from '../../src/util/parseDocsPathParams';
+
+describe('parseDocsPathParams', () => {
+	test('no item', () => {
+		expect(parseDocsPathParams(undefined)).toStrictEqual({ entryPoints: [], foundItem: undefined });
+	});
+
+	test('entry point without item', () => {
+		expect(parseDocsPathParams(['v10'])).toStrictEqual({ entryPoints: ['v10'], foundItem: undefined });
+	});
+
+	test('empty trailing segment falls back to the default entry point', () => {
+		expect(parseDocsPathParams([''])).toStrictEqual({ entryPoints: ['v10'], foundItem: undefined });
+	});
+
+	test('raw (non-decoded) item', () => {
+		expect(parseDocsPathParams(['bold%3AFunction'])).toStrictEqual({
+			entryPoints: [],
+			foundItem: 'bold%3AFunction',
+		});
+	});
+
+	test('raw (non-decoded) item with lowercase type marker', () => {
+		expect(parseDocsPathParams(['bold%3aFunction'])).toStrictEqual({
+			entryPoints: [],
+			foundItem: 'bold%3aFunction',
+		});
+	});
+
+	test('decoded item', () => {
+		expect(parseDocsPathParams(['bold:Function'])).toStrictEqual({
+			entryPoints: [],
+			foundItem: 'bold:Function',
+		});
+	});
+
+	test('entry point with raw (non-decoded) item', () => {
+		expect(parseDocsPathParams(['v10', 'ChannelType%3AEnum'])).toStrictEqual({
+			entryPoints: ['v10'],
+			foundItem: 'ChannelType%3AEnum',
+		});
+	});
+
+	test('entry point with decoded item', () => {
+		expect(parseDocsPathParams(['v10', 'ChannelType:Enum'])).toStrictEqual({
+			entryPoints: ['v10'],
+			foundItem: 'ChannelType:Enum',
+		});
+	});
+
+	test('multi-segment entry point without item', () => {
+		expect(parseDocsPathParams(['v10', 'payloads'])).toStrictEqual({
+			entryPoints: ['v10', 'payloads'],
+			foundItem: undefined,
+		});
+	});
+
+	test('multi-segment entry point with decoded item', () => {
+		expect(parseDocsPathParams(['v10', 'payloads', 'ChannelType:Enum'])).toStrictEqual({
+			entryPoints: ['v10', 'payloads'],
+			foundItem: 'ChannelType:Enum',
+		});
+	});
+});

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -18,14 +18,16 @@
 		"preview:cf": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"deploy:cf": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
 		"dev": "next dev --turbopack",
-		"lint": "pnpm run build:check && prettier --check . && cross-env TIMING=1 eslint --format=pretty src ",
-		"format": "pnpm run build:check && prettier --write . && cross-env TIMING=1 eslint --fix --format=pretty src ",
+		"test": "vitest run --config ../../vitest.config.ts",
+		"lint": "pnpm run build:check && prettier --check . && cross-env TIMING=1 eslint --format=pretty src __tests__",
+		"format": "pnpm run build:check && prettier --write . && cross-env TIMING=1 eslint --fix --format=pretty src __tests__",
 		"fmt": "pnpm run format",
 		"postinstall": "next typegen"
 	},
 	"type": "module",
 	"directories": {
-		"lib": "src"
+		"lib": "src",
+		"test": "__tests__"
 	},
 	"contributors": [
 		"Crawl <icrawltogo@gmail.com>"
@@ -105,6 +107,7 @@
 		"turbo": "^2.8.21",
 		"typescript": "~5.9.3",
 		"vercel": "^50.37.3",
+		"vitest": "^4.1.2",
 		"wrangler": "^4.78.0"
 	},
 	"engines": {

--- a/apps/website/src/util/parseDocsPathParams.ts
+++ b/apps/website/src/util/parseDocsPathParams.ts
@@ -9,7 +9,9 @@ export function parseDocsPathParams(item: string[] | undefined): {
 	}
 
 	const lastElement = item.at(-1);
-	const hasTypeMarker = lastElement?.includes('%3A');
+	// Dynamic params reach `generateMetadata()` and `useParams()` decoded (`bold:Function`),
+	// while the page component receives them raw (`bold%3AFunction`), so check for both forms.
+	const hasTypeMarker = /:|%3a/i.test(lastElement ?? '');
 
 	return {
 		entryPoints: hasTypeMarker ? item.slice(0, -1) : lastElement?.length === 0 ? DEFAULT_ENTRY_POINT : item,

--- a/apps/website/tsconfig.test.json
+++ b/apps/website/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig.json",
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"skipLibCheck": true
+	},
+	"include": ["__tests__/**/*.ts"],
+	"exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,6 +424,9 @@ importers:
       vercel:
         specifier: ^50.37.3
         version: 50.37.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(encoding@0.1.13)(rollup@4.60.0)(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.2
+        version: 4.1.2(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
       wrangler:
         specifier: ^4.78.0
         version: 4.78.0(bufferutil@4.1.0)


### PR DESCRIPTION
Refs #11531

## What & why

Documentation item pages (e.g. <https://discord.js.org/docs/packages/discord.js/main/Client:Class>) render the layout's default title — `discord.js (main) | discord.js` — instead of an item-specific title, making tabs and browsing history indistinguishable.

**Root cause:** Next.js delivers route params **raw** to the page component (`['bold%3AFunction']`) but **decoded** to `generateMetadata()` (and `useParams()`) (`['bold:Function']`). `parseDocsPathParams` only recognized the literal `%3A` type marker, so `foundItem` was always `undefined` inside `generateMetadata()` and the item-specific title it builds (`${titlePart} (${packageName} - ${version})`) never took effect; the layout `default` title won. I verified this by instrumenting the route: `Page` logged `["bold%3AFunction"]` while `generateMetadata` logged `["bold:Function"]` for the same request.

**Fix:** accept both the decoded (`:`) and the raw (`%3A`, any case) type marker in `parseDocsPathParams`. One-line change plus comment. The existing title format is untouched — this restores the behavior the code already intended. (Whether the title should also include the item *kind*, e.g. `User:Class`, as suggested in the issue, is left as a maintainer decision.)

As a side effect, `Navigation`/`EntrypointSelect` (which read decoded params via `useParams()`) now also compute `entryPoints` correctly on item pages of packages with multiple entry points (e.g. discord-api-types), where the item segment previously leaked into the entry point list.

## Reproduction / verification

- Live site today: `curl -s https://discord.js.org/docs/packages/discord.js/main/Client:Class | grep -o '<title>[^<]*</title>'` → `<title>discord.js (main) | discord.js</title>` (item name missing).
- Local repro on `main` (Next dev, local split docs for `@discordjs/formatters`): both `/docs/packages/formatters/main/bold:Function` and `/docs/packages/formatters/main/bold%3AFunction` rendered `<title>formatters (main) | discord.js</title>` while the page body correctly showed the `bold` function docs.
- After the fix, both URL forms render `<title>bold (formatters - main) | discord.js</title>`; the package landing route (`/docs/packages/formatters/main`) keeps the layout default title as before.

## Checks run (apps/website, Node v24.15.0, pnpm 10.33.0)

- `pnpm run test` — 10/10 passing (new vitest suite `__tests__/util/parseDocsPathParams.test.ts` covering raw/decoded/lowercase markers, entry-point paths, and the `DEFAULT_ENTRY_POINT` fallback); typecheck via shared `vitest.config.ts` reports no errors. Adds a `test` script + `vitest` devDependency to `apps/website`, mirroring the setup of the tested packages.
- `pnpm run lint` (`tsc --noEmit` + `prettier --check` + `eslint`) — clean, with `lint`/`format` scripts extended to also cover `__tests__` like other packages do.
- Pre-commit hooks (`build:affected` + lint-staged) pass.
- Diff reviewed by an automated code review (kiro-cli); findings from round 1 (test location, config alignment, case-insensitive marker) were addressed, round 2 was clean apart from cosmetic nits.

## Honest limitations

- Verified locally against `@discordjs/formatters` docs only; multi-entry-point packages (discord-api-types) were covered by unit tests rather than a full local docs build.
- The repo declares `node >=24.17.0`; I ran everything on v24.15.0 (latest available here) — all checks pass, but I could not test on 24.17+.
- The dev server was used for verification; I did not run a production `next build` of the website.