### PR TITLE
refactor(builders): validate section accessories in the parent

### DIFF
--- a/packages/builders/__tests__/components/v2/section.test.ts
+++ b/packages/builders/__tests__/components/v2/section.test.ts
@@ -1,5 +1,5 @@
 import { ButtonStyle, ComponentType } from 'discord-api-types/v10';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 import { PrimaryButtonBuilder } from '../../../src/components/button/CustomIdButton';
 import { SectionBuilder } from '../../../src/components/v2/Section';
 import { TextDisplayBuilder } from '../../../src/components/v2/TextDisplay';
@@ -7,6 +7,34 @@ import { ThumbnailBuilder } from '../../../src/components/v2/Thumbnail';
 
 describe('Section', () => {
 	describe('Validation', () => {
+		test('GIVEN a section accessory THEN serializes it without nested validation', () => {
+			const thumbnail = new ThumbnailBuilder().setURL('https://example.com/image.png');
+			const toJSON = vi.spyOn(thumbnail, 'toJSON');
+			const section = new SectionBuilder()
+				.addTextDisplayComponents(new TextDisplayBuilder().setContent('Hello world'))
+				.setThumbnailAccessory(thumbnail);
+
+			section.toJSON();
+
+			expect(toJSON).toHaveBeenCalledWith(false);
+		});
+
+		test('GIVEN an invalid thumbnail accessory THEN the section rejects it', () => {
+			const section = new SectionBuilder()
+				.addTextDisplayComponents(new TextDisplayBuilder().setContent('Hello world'))
+				.setThumbnailAccessory(new ThumbnailBuilder());
+
+			expect(() => section.toJSON()).toThrowError();
+		});
+
+		test('GIVEN an invalid button accessory THEN the section rejects it', () => {
+			const section = new SectionBuilder()
+				.addTextDisplayComponents(new TextDisplayBuilder().setContent('Hello world'))
+				.setPrimaryButtonAccessory(new PrimaryButtonBuilder().setCustomId('click_me'));
+
+			expect(() => section.toJSON()).toThrowError();
+		});
+
 		test('GIVEN empty section builder THEN throws error on toJSON', () => {
 			const section = new SectionBuilder();
 			expect(() => section.toJSON()).toThrowError();

--- a/packages/builders/src/components/v2/Assertions.ts
+++ b/packages/builders/src/components/v2/Assertions.ts
@@ -1,7 +1,7 @@
 import { ComponentType, SeparatorSpacingSize } from 'discord-api-types/v10';
 import { z } from 'zod';
 import { idPredicate } from '../../Assertions.js';
-import { actionRowPredicate } from '../Assertions.js';
+import { actionRowPredicate, buttonPredicate } from '../Assertions.js';
 
 const unfurledMediaItemPredicate = z.object({
 	url: z.url({ protocol: /^(?:https?|attachment)$/ }),
@@ -56,10 +56,7 @@ export const sectionPredicate = z.object({
 	type: z.literal(ComponentType.Section),
 	id: idPredicate,
 	components: z.array(textDisplayPredicate).min(1).max(3),
-	accessory: z.union([
-		z.object({ type: z.literal(ComponentType.Button) }),
-		z.object({ type: z.literal(ComponentType.Thumbnail) }),
-	]),
+	accessory: z.union([buttonPredicate, thumbnailPredicate]),
 });
 
 export const containerPredicate = z.object({

--- a/packages/builders/src/components/v2/Section.ts
+++ b/packages/builders/src/components/v2/Section.ts
@@ -256,7 +256,7 @@ export class SectionBuilder extends ComponentBuilder<APISectionComponent> {
 		const data = {
 			...structuredClone(rest),
 			components: components.map((component) => component.toJSON(false)),
-			accessory: accessory?.toJSON(validationOverride),
+			accessory: accessory?.toJSON(false),
 		};
 
 		validate(sectionPredicate, data, validationOverride);


### PR DESCRIPTION
## Summary

- Serialize section accessories without running their builder validation separately.
- Validate the complete button or thumbnail data in `sectionPredicate`.
- Add regression tests for skipped child validation and invalid accessories.

## Why

`SectionBuilder` already serializes text display components with validation disabled and validates their output as part of `sectionPredicate`. Accessories took a different path: the accessory builder validated itself, while the section predicate only checked its component type.

This change makes the section predicate responsible for validating the complete accessory output. Invalid button and thumbnail accessories are still rejected by the parent validation.

## Validation

- `pnpm exec vitest run --config ../../vitest.config.ts __tests__/components/v2/section.test.ts`: 14 tests passed, with no type errors.
- `pnpm test` in `packages/builders`: 25 test files and 271 tests passed, with no type errors.
- `pnpm run build`: 25 Turbo tasks succeeded.
- `pnpm test`: 27 Turbo tasks succeeded.
- `pnpm lint`: 44 Turbo tasks succeeded.

Closes #11307
