### PR TITLE
fix(ModalSubmitInteraction): resolve each component by its own type

### DIFF
--- a/packages/discord.js/src/structures/ModalComponentResolver.js
+++ b/packages/discord.js/src/structures/ModalComponentResolver.js
@@ -13,8 +13,18 @@ const { DiscordjsTypeError, ErrorCodes } = require('../errors/index.js');
  */
 function isEmpty(value) {
   if (value instanceof Collection) return value.size === 0;
-  if (Array.isArray(value)) return value.length === 0;
   return value === null || value === undefined;
+}
+
+/**
+ * Narrows an empty component property to null.
+ *
+ * @param {*} value The property to narrow
+ * @returns {*}
+ * @ignore
+ */
+function nullIfEmpty(value) {
+  return isEmpty(value) ? null : value;
 }
 
 /**
@@ -147,7 +157,7 @@ class ModalComponentResolver {
       ['users'],
       required,
     );
-    return component.users ?? null;
+    return nullIfEmpty(component.users);
   }
 
   /**
@@ -164,7 +174,7 @@ class ModalComponentResolver {
       ['roles'],
       required,
     );
-    return component.roles ?? null;
+    return nullIfEmpty(component.roles);
   }
 
   /**
@@ -191,7 +201,7 @@ class ModalComponentResolver {
       }
     }
 
-    return channels ?? null;
+    return nullIfEmpty(channels);
   }
 
   /**
@@ -207,7 +217,7 @@ class ModalComponentResolver {
       ['members'],
       false,
     );
-    return component.members ?? null;
+    return nullIfEmpty(component.members);
   }
 
   /**
@@ -225,15 +235,9 @@ class ModalComponentResolver {
       required,
     );
 
-    if (component.users || component.members || component.roles) {
-      return {
-        users: component.users ?? new Collection(),
-        members: component.members ?? new Collection(),
-        roles: component.roles ?? new Collection(),
-      };
-    }
+    if (isEmpty(component.users) && isEmpty(component.members) && isEmpty(component.roles)) return null;
 
-    return null;
+    return { users: component.users, members: component.members, roles: component.roles };
   }
 
   /**
@@ -244,7 +248,9 @@ class ModalComponentResolver {
    * @returns {?Collection<Snowflake, Attachment>} The uploaded files, or null if none were uploaded and not required
    */
   getUploadedFiles(customId, required = false) {
-    return this._getTypedComponent(customId, [ComponentType.FileUpload], ['attachments'], required).attachments ?? null;
+    return nullIfEmpty(
+      this._getTypedComponent(customId, [ComponentType.FileUpload], ['attachments'], required).attachments,
+    );
   }
 
   /**

--- a/packages/discord.js/src/structures/ModalComponentResolver.js
+++ b/packages/discord.js/src/structures/ModalComponentResolver.js
@@ -3,18 +3,7 @@
 const { Collection } = require('@discordjs/collection');
 const { ComponentType } = require('discord-api-types/v10');
 const { DiscordjsTypeError, ErrorCodes } = require('../errors/index.js');
-
-/**
- * Checks whether a component property is absent or holds an empty collection.
- *
- * @param {*} value The property to check
- * @returns {boolean}
- * @ignore
- */
-function isEmpty(value) {
-  if (value instanceof Collection) return value.size === 0;
-  return value === null || value === undefined;
-}
+const { isEmptyComponentValue } = require('../util/Util.js');
 
 /**
  * Narrows an empty component property to null.
@@ -24,7 +13,7 @@ function isEmpty(value) {
  * @ignore
  */
 function nullIfEmpty(value) {
-  return isEmpty(value) ? null : value;
+  return isEmptyComponentValue(value) ? null : value;
 }
 
 /**
@@ -116,7 +105,7 @@ class ModalComponentResolver {
         component.type,
         allowedTypes.join(', '),
       );
-    } else if (required && properties.every(prop => isEmpty(component[prop]))) {
+    } else if (required && properties.every(prop => isEmptyComponentValue(component[prop]))) {
       throw new DiscordjsTypeError(ErrorCodes.ModalSubmitInteractionComponentEmpty, customId, component.type);
     }
 
@@ -235,7 +224,13 @@ class ModalComponentResolver {
       required,
     );
 
-    if (isEmpty(component.users) && isEmpty(component.members) && isEmpty(component.roles)) return null;
+    if (
+      isEmptyComponentValue(component.users) &&
+      isEmptyComponentValue(component.members) &&
+      isEmptyComponentValue(component.roles)
+    ) {
+      return null;
+    }
 
     return { users: component.users, members: component.members, roles: component.roles };
   }

--- a/packages/discord.js/src/structures/ModalComponentResolver.js
+++ b/packages/discord.js/src/structures/ModalComponentResolver.js
@@ -5,6 +5,19 @@ const { ComponentType } = require('discord-api-types/v10');
 const { DiscordjsTypeError, ErrorCodes } = require('../errors/index.js');
 
 /**
+ * Checks whether a component property is absent or holds an empty collection.
+ *
+ * @param {*} value The property to check
+ * @returns {boolean}
+ * @ignore
+ */
+function isEmpty(value) {
+  if (value instanceof Collection) return value.size === 0;
+
+  return value === null || value === undefined;
+}
+
+/**
  * @typedef {Object} ModalSelectedMentionables
  * @property {Collection<Snowflake, User>} users The selected users
  * @property {Collection<Snowflake, GuildMember | APIGuildMember>} members The selected members
@@ -93,7 +106,7 @@ class ModalComponentResolver {
         component.type,
         allowedTypes.join(', '),
       );
-    } else if (required && properties.every(prop => component[prop] === null || component[prop] === undefined)) {
+    } else if (required && properties.every(prop => isEmpty(component[prop]))) {
       throw new DiscordjsTypeError(ErrorCodes.ModalSubmitInteractionComponentEmpty, customId, component.type);
     }
 

--- a/packages/discord.js/src/structures/ModalComponentResolver.js
+++ b/packages/discord.js/src/structures/ModalComponentResolver.js
@@ -13,7 +13,7 @@ const { DiscordjsTypeError, ErrorCodes } = require('../errors/index.js');
  */
 function isEmpty(value) {
   if (value instanceof Collection) return value.size === 0;
-
+  if (Array.isArray(value)) return value.length === 0;
   return value === null || value === undefined;
 }
 

--- a/packages/discord.js/src/structures/ModalSubmitInteraction.js
+++ b/packages/discord.js/src/structures/ModalSubmitInteraction.js
@@ -2,6 +2,7 @@
 
 const { Collection } = require('@discordjs/collection');
 const { lazy } = require('@discordjs/util');
+const { ComponentType } = require('discord-api-types/v10');
 const { transformResolved } = require('../util/Util.js');
 const { BaseInteraction } = require('./BaseInteraction.js');
 const { InteractionWebhook } = require('./InteractionWebhook.js');
@@ -9,7 +10,6 @@ const { ModalComponentResolver } = require('./ModalComponentResolver.js');
 const { InteractionResponses } = require('./interfaces/InteractionResponses.js');
 
 const getMessage = lazy(() => require('./Message.js').Message);
-const getAttachment = lazy(() => require('./Attachment.js').Attachment);
 
 /**
  * @typedef {Object} BaseModalData
@@ -103,6 +103,11 @@ class ModalSubmitInteraction extends BaseInteraction {
       this.message = null;
     }
 
+    const resolved = transformResolved(
+      { client: this.client, guild: this.guild, channel: this.channel },
+      data.data.resolved,
+    );
+
     /**
      * The components within the modal
      *
@@ -110,8 +115,8 @@ class ModalSubmitInteraction extends BaseInteraction {
      */
     this.components = new ModalComponentResolver(
       this.client,
-      data.data.components?.map(component => this.transformComponent(component, data.data.resolved)),
-      transformResolved({ client: this.client, guild: this.guild, channel: this.channel }, data.data.resolved),
+      data.data.components?.map(component => this.transformComponent(component, resolved)),
+      resolved,
     );
 
     /**
@@ -147,7 +152,7 @@ class ModalSubmitInteraction extends BaseInteraction {
    * Transforms component data to discord.js-compatible data
    *
    * @param {*} rawComponent The data to transform
-   * @param {APIInteractionDataResolved} resolved The resolved data for the interaction
+   * @param {BaseInteractionResolvedData} resolved The transformed resolved data for the interaction
    * @returns {ModalData[]}
    * @private
    */
@@ -180,59 +185,26 @@ class ModalSubmitInteraction extends BaseInteraction {
 
     if (rawComponent.values) {
       data.values = rawComponent.values;
-      if (resolved) {
-        const { members, users, channels, roles, attachments } = resolved;
-        const valueSet = new Set(rawComponent.values);
 
-        if (users) {
-          data.users = new Collection();
+      // Discord sends one resolved object for the whole modal.
+      const selectedIds = new Set(rawComponent.values);
+      const selected = collection => collection?.filter((_, id) => selectedIds.has(id)) ?? new Collection();
 
-          for (const [id, user] of Object.entries(users)) {
-            if (valueSet.has(id)) {
-              data.users.set(id, this.client.users._add(user));
-            }
-          }
-        }
+      if (rawComponent.type === ComponentType.UserSelect || rawComponent.type === ComponentType.MentionableSelect) {
+        data.users = selected(resolved.users);
+        data.members = selected(resolved.members);
+      }
 
-        if (channels) {
-          data.channels = new Collection();
+      if (rawComponent.type === ComponentType.RoleSelect || rawComponent.type === ComponentType.MentionableSelect) {
+        data.roles = selected(resolved.roles);
+      }
 
-          for (const [id, apiChannel] of Object.entries(channels)) {
-            if (valueSet.has(id)) {
-              data.channels.set(id, this.client.channels._add(apiChannel, this.guild) ?? apiChannel);
-            }
-          }
-        }
+      if (rawComponent.type === ComponentType.ChannelSelect) {
+        data.channels = selected(resolved.channels);
+      }
 
-        if (members) {
-          data.members = new Collection();
-
-          for (const [id, member] of Object.entries(members)) {
-            if (valueSet.has(id)) {
-              const user = users?.[id];
-              data.members.set(id, this.guild?.members._add({ user, ...member }) ?? member);
-            }
-          }
-        }
-
-        if (roles) {
-          data.roles = new Collection();
-
-          for (const [id, role] of Object.entries(roles)) {
-            if (valueSet.has(id)) {
-              data.roles.set(id, this.guild?.roles._add(role) ?? role);
-            }
-          }
-        }
-
-        if (attachments) {
-          data.attachments = new Collection();
-          for (const [id, attachment] of Object.entries(attachments)) {
-            if (valueSet.has(id)) {
-              data.attachments.set(id, new (getAttachment())(attachment));
-            }
-          }
-        }
+      if (rawComponent.type === ComponentType.FileUpload) {
+        data.attachments = selected(resolved.attachments);
       }
     }
 

--- a/packages/discord.js/src/structures/ModalSubmitInteraction.js
+++ b/packages/discord.js/src/structures/ModalSubmitInteraction.js
@@ -221,12 +221,12 @@ class ModalSubmitInteraction extends BaseInteraction {
       const selectedIds = new Set(rawComponent.values);
       const selected = collection => collection?.filter((_, id) => selectedIds.has(id)) ?? new Collection();
 
-      if (rawComponent.type === ComponentType.UserSelect || rawComponent.type === ComponentType.MentionableSelect) {
+      if ([ComponentType.UserSelect, ComponentType.MentionableSelect].includes(rawComponent.type)) {
         data.users = selected(resolved.users);
         data.members = selected(resolved.members);
       }
 
-      if (rawComponent.type === ComponentType.RoleSelect || rawComponent.type === ComponentType.MentionableSelect) {
+      if ([ComponentType.RoleSelect, ComponentType.MentionableSelect].includes(rawComponent.type)) {
         data.roles = selected(resolved.roles);
       }
 

--- a/packages/discord.js/src/structures/ModalSubmitInteraction.js
+++ b/packages/discord.js/src/structures/ModalSubmitInteraction.js
@@ -18,39 +18,35 @@ const getMessage = lazy(() => require('./Message.js').Message);
  */
 
 /**
- * @typedef {BaseModalData} StringSelectModalData
+ * @typedef {BaseModalData} BaseSelectMenuModalData
  * @property {string} customId The custom id of the component
  * @property {string[]} values The values of the component
  */
 
 /**
- * @typedef {BaseModalData} UserSelectModalData
- * @property {string} customId The custom id of the component
- * @property {string[]} values The values of the component
+ * @typedef {BaseSelectMenuModalData} StringSelectModalData
+ */
+
+/**
+ * @typedef {BaseSelectMenuModalData} UserSelectModalData
  * @property {Collection<Snowflake, User|APIUser>} users The resolved users
  * @property {Collection<Snowflake, GuildMember|APIGuildMember>} members The resolved members
  */
 
 /**
- * @typedef {BaseModalData} RoleSelectModalData
- * @property {string} customId The custom id of the component
- * @property {string[]} values The values of the component
+ * @typedef {BaseSelectMenuModalData} RoleSelectModalData
  * @property {Collection<Snowflake, Role|APIRole>} roles The resolved roles
  */
 
 /**
- * @typedef {BaseModalData} MentionableSelectModalData
- * @property {string} customId The custom id of the component
- * @property {string[]} values The values of the component
+ * @typedef {BaseSelectMenuModalData} MentionableSelectModalData
  * @property {Collection<Snowflake, User|APIUser>} users The resolved users
  * @property {Collection<Snowflake, GuildMember|APIGuildMember>} members The resolved members
  * @property {Collection<Snowflake, Role|APIRole>} roles The resolved roles
  */
 
 /**
- * @typedef {BaseModalData} ChannelSelectModalData
- * @property {string} customId The custom id of the component
- * @property {string[]} values The values of the component
+ * @typedef {BaseSelectMenuModalData} ChannelSelectModalData
  * @property {Collection<Snowflake, BaseChannel|APIChannel>} channels The resolved channels
  */
 

--- a/packages/discord.js/src/structures/ModalSubmitInteraction.js
+++ b/packages/discord.js/src/structures/ModalSubmitInteraction.js
@@ -18,13 +18,44 @@ const getMessage = lazy(() => require('./Message.js').Message);
  */
 
 /**
- * @typedef {BaseModalData} SelectMenuModalData
+ * @typedef {BaseModalData} StringSelectModalData
  * @property {string} customId The custom id of the component
  * @property {string[]} values The values of the component
- * @property {Collection<Snowflake, GuildMember|APIGuildMember>} [members] The resolved members
- * @property {Collection<Snowflake, User|APIUser>} [users] The resolved users
- * @property {Collection<Snowflake, Role|APIRole>} [roles] The resolved roles
- * @property {Collection<Snowflake, BaseChannel|APIChannel>} [channels] The resolved channels
+ */
+
+/**
+ * @typedef {BaseModalData} UserSelectModalData
+ * @property {string} customId The custom id of the component
+ * @property {string[]} values The values of the component
+ * @property {Collection<Snowflake, User|APIUser>} users The resolved users
+ * @property {Collection<Snowflake, GuildMember|APIGuildMember>} members The resolved members
+ */
+
+/**
+ * @typedef {BaseModalData} RoleSelectModalData
+ * @property {string} customId The custom id of the component
+ * @property {string[]} values The values of the component
+ * @property {Collection<Snowflake, Role|APIRole>} roles The resolved roles
+ */
+
+/**
+ * @typedef {BaseModalData} MentionableSelectModalData
+ * @property {string} customId The custom id of the component
+ * @property {string[]} values The values of the component
+ * @property {Collection<Snowflake, User|APIUser>} users The resolved users
+ * @property {Collection<Snowflake, GuildMember|APIGuildMember>} members The resolved members
+ * @property {Collection<Snowflake, Role|APIRole>} roles The resolved roles
+ */
+
+/**
+ * @typedef {BaseModalData} ChannelSelectModalData
+ * @property {string} customId The custom id of the component
+ * @property {string[]} values The values of the component
+ * @property {Collection<Snowflake, BaseChannel|APIChannel>} channels The resolved channels
+ */
+
+/**
+ * @typedef {ChannelSelectModalData|MentionableSelectModalData|RoleSelectModalData|StringSelectModalData|UserSelectModalData} SelectMenuModalData
  */
 
 /**

--- a/packages/discord.js/src/util/Util.js
+++ b/packages/discord.js/src/util/Util.js
@@ -573,6 +573,18 @@ function transformResolved(
 }
 
 /**
+ * Checks whether a resolved component property is absent or holds an empty collection.
+ *
+ * @param {*} value The property to check
+ * @returns {boolean}
+ * @private
+ */
+function isEmptyComponentValue(value) {
+  if (value instanceof Collection) return value.size === 0;
+  return value === null || value === undefined;
+}
+
+/**
  * Resolves a SKU id from a SKU resolvable.
  *
  * @param {SKUResolvable} resolvable The SKU resolvable to resolve
@@ -607,3 +619,4 @@ exports.setPosition = setPosition;
 exports.basename = basename;
 exports.findName = findName;
 exports.transformResolved = transformResolved;
+exports.isEmptyComponentValue = isEmptyComponentValue;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2599,48 +2599,42 @@ export interface TextInputModalData extends BaseModalData<ComponentType.TextInpu
   value: string;
 }
 
+export interface BaseSelectMenuModalData<Type extends ComponentType> extends BaseModalData<Type> {
+  customId: string;
+  values: readonly string[];
+}
+
+export interface ModalSelectedUsers<Cached extends CacheType = CacheType> {
+  members: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, GuildMember, APIInteractionDataResolvedGuildMember>>;
+  users: ReadonlyCollection<Snowflake, User>;
+}
+
+export interface ModalSelectedRoles<Cached extends CacheType = CacheType> {
+  roles: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, Role, APIRole>>;
+}
+
 export interface ChannelSelectModalData<
   Cached extends CacheType = CacheType,
-> extends BaseModalData<ComponentType.ChannelSelect> {
+> extends BaseSelectMenuModalData<ComponentType.ChannelSelect> {
   channels: ReadonlyCollection<
     Snowflake,
     CacheTypeReducer<Cached, GuildBasedChannel, APIInteractionDataResolvedChannel>
   >;
-  customId: string;
-  values: readonly string[];
 }
 
-export interface MentionableSelectModalData<
-  Cached extends CacheType = CacheType,
-> extends BaseModalData<ComponentType.MentionableSelect> {
-  customId: string;
-  members: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, GuildMember, APIInteractionDataResolvedGuildMember>>;
-  roles: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, Role, APIRole>>;
-  users: ReadonlyCollection<Snowflake, User>;
-  values: readonly string[];
-}
+export interface MentionableSelectModalData<Cached extends CacheType = CacheType>
+  extends
+    BaseSelectMenuModalData<ComponentType.MentionableSelect>,
+    ModalSelectedRoles<Cached>,
+    ModalSelectedUsers<Cached> {}
 
-export interface RoleSelectModalData<
-  Cached extends CacheType = CacheType,
-> extends BaseModalData<ComponentType.RoleSelect> {
-  customId: string;
-  roles: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, Role, APIRole>>;
-  values: readonly string[];
-}
+export interface RoleSelectModalData<Cached extends CacheType = CacheType>
+  extends BaseSelectMenuModalData<ComponentType.RoleSelect>, ModalSelectedRoles<Cached> {}
 
-export interface StringSelectModalData extends BaseModalData<ComponentType.StringSelect> {
-  customId: string;
-  values: readonly string[];
-}
+export interface StringSelectModalData extends BaseSelectMenuModalData<ComponentType.StringSelect> {}
 
-export interface UserSelectModalData<
-  Cached extends CacheType = CacheType,
-> extends BaseModalData<ComponentType.UserSelect> {
-  customId: string;
-  members: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, GuildMember, APIInteractionDataResolvedGuildMember>>;
-  users: ReadonlyCollection<Snowflake, User>;
-  values: readonly string[];
-}
+export interface UserSelectModalData<Cached extends CacheType = CacheType>
+  extends BaseSelectMenuModalData<ComponentType.UserSelect>, ModalSelectedUsers<Cached> {}
 
 export type SelectMenuModalData<Cached extends CacheType = CacheType> =
   | ChannelSelectModalData<Cached>
@@ -2687,11 +2681,8 @@ export interface ActionRowModalData extends BaseModalData<ComponentType.ActionRo
 
 export interface TextDisplayModalData extends BaseModalData<ComponentType.TextDisplay> {}
 
-export interface ModalSelectedMentionables<Cached extends CacheType = CacheType> {
-  members: MentionableSelectModalData<Cached>['members'];
-  roles: MentionableSelectModalData<Cached>['roles'];
-  users: MentionableSelectModalData<Cached>['users'];
-}
+export interface ModalSelectedMentionables<Cached extends CacheType = CacheType>
+  extends ModalSelectedRoles<Cached>, ModalSelectedUsers<Cached> {}
 export class ModalComponentResolver<Cached extends CacheType = CacheType> {
   private constructor(client: Client<true>, components: readonly ModalData[], resolved: BaseInteractionResolvedData);
   public readonly client: Client<true>;
@@ -2709,9 +2700,7 @@ export class ModalComponentResolver<Cached extends CacheType = CacheType> {
   public getStringSelectValues(customId: string): readonly string[];
   public getSelectedUsers(customId: string, required: true): ReadonlyCollection<Snowflake, User>;
   public getSelectedUsers(customId: string, required?: boolean): ReadonlyCollection<Snowflake, User> | null;
-  public getSelectedMembers(
-    customId: string,
-  ): (MentionableSelectModalData<Cached> | UserSelectModalData<Cached>)['members'] | null;
+  public getSelectedMembers(customId: string): ModalSelectedUsers<Cached>['members'] | null;
   public getSelectedChannels<const Type extends ChannelType = ChannelType>(
     customId: string,
     required: true,
@@ -2743,14 +2732,8 @@ export class ModalComponentResolver<Cached extends CacheType = CacheType> {
     >
   > | null;
 
-  public getSelectedRoles(
-    customId: string,
-    required: true,
-  ): (MentionableSelectModalData<Cached> | RoleSelectModalData<Cached>)['roles'];
-  public getSelectedRoles(
-    customId: string,
-    required?: boolean,
-  ): (MentionableSelectModalData<Cached> | RoleSelectModalData<Cached>)['roles'] | null;
+  public getSelectedRoles(customId: string, required: true): ModalSelectedRoles<Cached>['roles'];
+  public getSelectedRoles(customId: string, required?: boolean): ModalSelectedRoles<Cached>['roles'] | null;
 
   public getSelectedMentionables(customId: string, required: true): ModalSelectedMentionables<Cached>;
   public getSelectedMentionables(customId: string, required?: boolean): ModalSelectedMentionables<Cached> | null;

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -2599,23 +2599,55 @@ export interface TextInputModalData extends BaseModalData<ComponentType.TextInpu
   value: string;
 }
 
-export interface SelectMenuModalData<Cached extends CacheType = CacheType> extends BaseModalData<
-  | ComponentType.ChannelSelect
-  | ComponentType.MentionableSelect
-  | ComponentType.RoleSelect
-  | ComponentType.StringSelect
-  | ComponentType.UserSelect
-> {
-  channels?: ReadonlyCollection<
+export interface ChannelSelectModalData<
+  Cached extends CacheType = CacheType,
+> extends BaseModalData<ComponentType.ChannelSelect> {
+  channels: ReadonlyCollection<
     Snowflake,
     CacheTypeReducer<Cached, GuildBasedChannel, APIInteractionDataResolvedChannel>
   >;
   customId: string;
-  members?: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, GuildMember, APIInteractionDataResolvedGuildMember>>;
-  roles?: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, Role, APIRole>>;
-  users?: ReadonlyCollection<Snowflake, User>;
   values: readonly string[];
 }
+
+export interface MentionableSelectModalData<
+  Cached extends CacheType = CacheType,
+> extends BaseModalData<ComponentType.MentionableSelect> {
+  customId: string;
+  members: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, GuildMember, APIInteractionDataResolvedGuildMember>>;
+  roles: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, Role, APIRole>>;
+  users: ReadonlyCollection<Snowflake, User>;
+  values: readonly string[];
+}
+
+export interface RoleSelectModalData<
+  Cached extends CacheType = CacheType,
+> extends BaseModalData<ComponentType.RoleSelect> {
+  customId: string;
+  roles: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, Role, APIRole>>;
+  values: readonly string[];
+}
+
+export interface StringSelectModalData extends BaseModalData<ComponentType.StringSelect> {
+  customId: string;
+  values: readonly string[];
+}
+
+export interface UserSelectModalData<
+  Cached extends CacheType = CacheType,
+> extends BaseModalData<ComponentType.UserSelect> {
+  customId: string;
+  members: ReadonlyCollection<Snowflake, CacheTypeReducer<Cached, GuildMember, APIInteractionDataResolvedGuildMember>>;
+  users: ReadonlyCollection<Snowflake, User>;
+  values: readonly string[];
+}
+
+export type SelectMenuModalData<Cached extends CacheType = CacheType> =
+  | ChannelSelectModalData<Cached>
+  | MentionableSelectModalData<Cached>
+  | RoleSelectModalData<Cached>
+  | StringSelectModalData
+  | UserSelectModalData<Cached>;
 
 export interface FileUploadModalData extends BaseModalData<ComponentType.FileUpload> {
   attachments: ReadonlyCollection<Snowflake, Attachment>;
@@ -2656,9 +2688,9 @@ export interface ActionRowModalData extends BaseModalData<ComponentType.ActionRo
 export interface TextDisplayModalData extends BaseModalData<ComponentType.TextDisplay> {}
 
 export interface ModalSelectedMentionables<Cached extends CacheType = CacheType> {
-  members: NonNullable<SelectMenuModalData<Cached>['members']>;
-  roles: NonNullable<SelectMenuModalData<Cached>['roles']>;
-  users: NonNullable<SelectMenuModalData<Cached>['users']>;
+  members: MentionableSelectModalData<Cached>['members'];
+  roles: MentionableSelectModalData<Cached>['roles'];
+  users: MentionableSelectModalData<Cached>['users'];
 }
 export class ModalComponentResolver<Cached extends CacheType = CacheType> {
   private constructor(client: Client<true>, components: readonly ModalData[], resolved: BaseInteractionResolvedData);
@@ -2677,7 +2709,9 @@ export class ModalComponentResolver<Cached extends CacheType = CacheType> {
   public getStringSelectValues(customId: string): readonly string[];
   public getSelectedUsers(customId: string, required: true): ReadonlyCollection<Snowflake, User>;
   public getSelectedUsers(customId: string, required?: boolean): ReadonlyCollection<Snowflake, User> | null;
-  public getSelectedMembers(customId: string): NonNullable<SelectMenuModalData<Cached>['members']> | null;
+  public getSelectedMembers(
+    customId: string,
+  ): (MentionableSelectModalData<Cached> | UserSelectModalData<Cached>)['members'] | null;
   public getSelectedChannels<const Type extends ChannelType = ChannelType>(
     customId: string,
     required: true,
@@ -2709,11 +2743,14 @@ export class ModalComponentResolver<Cached extends CacheType = CacheType> {
     >
   > | null;
 
-  public getSelectedRoles(customId: string, required: true): NonNullable<SelectMenuModalData<Cached>['roles']>;
+  public getSelectedRoles(
+    customId: string,
+    required: true,
+  ): (MentionableSelectModalData<Cached> | RoleSelectModalData<Cached>)['roles'];
   public getSelectedRoles(
     customId: string,
     required?: boolean,
-  ): NonNullable<SelectMenuModalData<Cached>['roles']> | null;
+  ): (MentionableSelectModalData<Cached> | RoleSelectModalData<Cached>)['roles'] | null;
 
   public getSelectedMentionables(customId: string, required: true): ModalSelectedMentionables<Cached>;
   public getSelectedMentionables(customId: string, required?: boolean): ModalSelectedMentionables<Cached> | null;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -96,6 +96,7 @@ import type {
   ChannelMention,
   ChannelSelectMenuComponent,
   ChannelSelectMenuInteraction,
+  ChannelSelectModalData,
   ChatInputApplicationCommandData,
   ChatInputCommandInteraction,
   ClientApplication,
@@ -152,6 +153,7 @@ import type {
   MediaGalleryItemData,
   MentionableSelectMenuComponent,
   MentionableSelectMenuInteraction,
+  MentionableSelectModalData,
   Message,
   MessageActionRowComponent,
   MessageActionRowComponentData,
@@ -161,6 +163,7 @@ import type {
   MessageManager,
   MessageMentions,
   MessageReaction,
+  ModalData,
   ModalSubmitInteraction,
   NonThreadGuildBasedChannel,
   PartialDMChannel,
@@ -185,6 +188,7 @@ import type {
   RoleManager,
   RoleSelectMenuComponent,
   RoleSelectMenuInteraction,
+  RoleSelectModalData,
   SectionComponentData,
   SelectMenuInteraction,
   SendableChannels,
@@ -202,6 +206,7 @@ import type {
   StringSelectMenuComponent,
   StringSelectMenuComponentData,
   StringSelectMenuInteraction,
+  StringSelectModalData,
   TextBasedChannel,
   TextBasedChannelTypes,
   ThreadManager,
@@ -214,6 +219,7 @@ import type {
   ThreadOnlyChannel,
   Typing,
   User,
+  UserSelectModalData,
   VoiceBasedChannel,
   VoiceChannel,
   Invite,
@@ -2756,7 +2762,7 @@ declare const threadOnlyChannel: ThreadOnlyChannel;
 // Threads have messages.
 expectType<GuildMessageManager>(threadChannel.messages);
 
-// Thread-only channels have threads—not messages.
+// Thread-only channels do not have messages.
 notPropertyOf(threadOnlyChannel, 'messages');
 notPropertyOf(forumChannel, 'messages');
 notPropertyOf(mediaChannel, 'messages');
@@ -3110,4 +3116,47 @@ declare const authorizingIntegrationOwners: AuthorizingIntegrationOwners;
   expectType<Snowflake | null>(authorizingIntegrationOwners.userId);
   expectType<User | null>(authorizingIntegrationOwners.user);
   expectType<Snowflake | undefined>(authorizingIntegrationOwners[ApplicationIntegrationType.GuildInstall]);
+}
+
+declare const modalComponent: ModalData;
+{
+  if (modalComponent.type === ComponentType.UserSelect) {
+    expectType<ReadonlyCollection<Snowflake, User>>(modalComponent.users);
+    notPropertyOf(modalComponent, 'roles');
+    notPropertyOf(modalComponent, 'channels');
+  }
+
+  if (modalComponent.type === ComponentType.RoleSelect) {
+    notPropertyOf(modalComponent, 'users');
+    notPropertyOf(modalComponent, 'members');
+  }
+
+  if (modalComponent.type === ComponentType.ChannelSelect) {
+    notPropertyOf(modalComponent, 'users');
+  }
+
+  if (modalComponent.type === ComponentType.MentionableSelect) {
+    expectType<ReadonlyCollection<Snowflake, User>>(modalComponent.users);
+    notPropertyOf(modalComponent, 'channels');
+  }
+
+  if (modalComponent.type === ComponentType.StringSelect) {
+    expectType<readonly string[]>(modalComponent.values);
+    notPropertyOf(modalComponent, 'users');
+    notPropertyOf(modalComponent, 'channels');
+  }
+}
+
+declare const cachedUserSelect: UserSelectModalData<'cached'>;
+declare const cachedRoleSelect: RoleSelectModalData<'cached'>;
+declare const cachedChannelSelect: ChannelSelectModalData<'cached'>;
+declare const cachedMentionableSelect: MentionableSelectModalData<'cached'>;
+declare const stringSelect: StringSelectModalData;
+{
+  expectType<ReadonlyCollection<Snowflake, User>>(cachedUserSelect.users);
+  expectType<ReadonlyCollection<Snowflake, GuildMember>>(cachedUserSelect.members);
+  expectType<ReadonlyCollection<Snowflake, Role>>(cachedRoleSelect.roles);
+  expectType<ReadonlyCollection<Snowflake, GuildBasedChannel>>(cachedChannelSelect.channels);
+  expectType<ReadonlyCollection<Snowflake, Role>>(cachedMentionableSelect.roles);
+  expectType<readonly string[]>(stringSelect.values);
 }

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -164,6 +164,7 @@ import type {
   MessageMentions,
   MessageReaction,
   ModalData,
+  ModalSelectedMentionables,
   ModalSubmitInteraction,
   NonThreadGuildBasedChannel,
   PartialDMChannel,
@@ -3152,11 +3153,18 @@ declare const cachedRoleSelect: RoleSelectModalData<'cached'>;
 declare const cachedChannelSelect: ChannelSelectModalData<'cached'>;
 declare const cachedMentionableSelect: MentionableSelectModalData<'cached'>;
 declare const stringSelect: StringSelectModalData;
+declare const cachedMentionables: ModalSelectedMentionables<'cached'>;
 {
   expectType<ReadonlyCollection<Snowflake, User>>(cachedUserSelect.users);
   expectType<ReadonlyCollection<Snowflake, GuildMember>>(cachedUserSelect.members);
   expectType<ReadonlyCollection<Snowflake, Role>>(cachedRoleSelect.roles);
   expectType<ReadonlyCollection<Snowflake, GuildBasedChannel>>(cachedChannelSelect.channels);
+  expectType<ReadonlyCollection<Snowflake, User>>(cachedMentionableSelect.users);
+  expectType<ReadonlyCollection<Snowflake, GuildMember>>(cachedMentionableSelect.members);
   expectType<ReadonlyCollection<Snowflake, Role>>(cachedMentionableSelect.roles);
   expectType<readonly string[]>(stringSelect.values);
+
+  expectType<ReadonlyCollection<Snowflake, User>>(cachedMentionables.users);
+  expectType<ReadonlyCollection<Snowflake, GuildMember>>(cachedMentionables.members);
+  expectType<ReadonlyCollection<Snowflake, Role>>(cachedMentionables.roles);
 }


### PR DESCRIPTION
Since a modal can hold select menus, when someone submits, Discord sends back 2 separate things. Each component tells you which ids it picked, for eg
```json
{ "type": 5, "custom_id": "reviewer", "values": ["8035111"] }
```

Then once for the entire modal, it sends the actual objects those ids point at
```json
"resolved": {
  "users": { "8035111": { "id": "8035111", "username": "gwen" } }
}
```

Check `resolved`'s location. It is one object for the whole modal. It carries every user, role, channel and attachment that any component in that modal picked in one place. We need to match them to each other. For each component, take the ids in its own values, find them in resolved, and then make a `Collection` off it so you can write smth like `component.users`.

It's currently broken. (well, not after the PR merges). The old code looked at `resolved` and just checked which keys it had.

```js
if (resolved) {
  const { members, users, channels, roles, attachments } = resolved;

  if (users) {
    data.users = new Collection();
    for (const [id, user] of Object.entries(users)) {
      if (valueSet.has(id)) data.users.set(id, this.client.users._add(user));
    }
  }

  if (channels) { /* same shape */ }
  // ...and so on for members, roles, attachments
}
```

Look at that block. All it does is check "did the modal wide `resolved` come with a users key?". But doesn't check what kind of component this is. So the answer ended up depending on what someone picked in a _different_ menu 💀.

Now, my my repro from before hopefully written better this time.

Put two user selects in a modal, `first` and `second`. Pick someone in the `first`. Leave `second` empty.

Discord sends `resolved.users` because `first` picked somebody. The loop runs for every component, so `second` gets a users Collection too, and the filter finds nothing to put it in. You get `Collection(0)`. Fine.

Now delete `first` from the modal. Nobody picked a user anywhere, so `resolved` has no `users` key at all. So if `if (users)` is false, and `second` never gets the property, that `Collection` is now `undefined`. Same submission from the user's perspective, but two different results in the code decided by a menu that has nothing to do with the one you're trying to get the results of.

Now a third menu. Keep `first` and `second`, and add a channel select called `where`. Three menus in the modal now. Someone picks a user in `first` and touches nothing else. Look at the channel select (the type issue from the message I posted in the server)
```js
const where = interaction.components.getComponent('where');

where.type // ComponentType.ChannelSelect
where.users // Collection(0)
where.channels // undefined
```

A channel select menu with a `users` property on it, that IS defined, and a `channels` property that's undefined. Nothing about `where` produced that. Nobody picked a user in it (it can't hold users in the first place). It got a `users` property because `first`, a different menu, put a user in the modal's shared `resolved`. And no `channels` because nobody picked a channel anywhere, so `resolved` came up with no channel key making the loop ignore it all together.

This bug made the `required` flag stop working. Now that's also fixed.

Closes #11535

Supersedes #11569 