### PR TITLE
chore(rpc): gitignore generated docs files

### DIFF
--- a/packages/rpc/.gitignore
+++ b/packages/rpc/.gitignore
@@ -1,0 +1,28 @@
+# Packages
+node_modules
+
+# Log files
+logs
+*.log
+npm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+
+# Env
+.env
+
+# Dist
+dist
+dist-docs
+
+# Docs
+docs/**/*
+!docs/README.md
+
+# Miscellaneous
+.turbo
+.tmp
+coverage


### PR DESCRIPTION
The `rpc` package was missing a `.gitignore` file. 