### PR TITLE
fix(ApplicationCommand): normalize undefined in _optionEquals

### DIFF
--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -504,7 +504,7 @@ class ApplicationCommand extends Base {
       option.name !== existing.name ||
       option.type !== existing.type ||
       option.description !== existing.description ||
-      option.autocomplete !== existing.autocomplete ||
+      (option.autocomplete ?? false) !== (existing.autocomplete ?? false) ||
       (option.required ??
         ([ApplicationCommandOptionType.Subcommand, ApplicationCommandOptionType.SubcommandGroup].includes(option.type)
           ? undefined
@@ -513,10 +513,10 @@ class ApplicationCommand extends Base {
       option.options?.length !== existing.options?.length ||
       (option.channelTypes ?? option.channel_types)?.length !== existing.channelTypes?.length ||
       (option.fileTypes ?? option.file_types)?.length !== existing.fileTypes?.length ||
-      (option.minValue ?? option.min_value) !== existing.minValue ||
-      (option.maxValue ?? option.max_value) !== existing.maxValue ||
-      (option.minLength ?? option.min_length) !== existing.minLength ||
-      (option.maxLength ?? option.max_length) !== existing.maxLength ||
+      (option.minValue ?? option.min_value ?? null) !== (existing.minValue ?? null) ||
+      (option.maxValue ?? option.max_value ?? null) !== (existing.maxValue ?? null) ||
+      (option.minLength ?? option.min_length ?? null) !== (existing.minLength ?? null) ||
+      (option.maxLength ?? option.max_length ?? null) !== (existing.maxLength ?? null) ||
       !isEqual(option.nameLocalizations ?? option.name_localizations ?? {}, existing.nameLocalizations ?? {}) ||
       !isEqual(
         option.descriptionLocalizations ?? option.description_localizations ?? {},

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -438,7 +438,7 @@ class ApplicationCommand extends Base {
       ('description' in command && command.description !== this.description) ||
       ('version' in command && command.version !== this.version) ||
       (command.type && command.type !== this.type) ||
-      ('nsfw' in command && command.nsfw !== this.nsfw) ||
+      (command.nsfw ?? false) !== (this.nsfw ?? false) ||
       command.options?.length !== this.options?.length ||
       defaultMemberPermissions !== (this.defaultMemberPermissions?.bitfield ?? null) ||
       !isEqual(command.nameLocalizations ?? command.name_localizations ?? {}, this.nameLocalizations ?? {}) ||

--- a/packages/discord.js/src/structures/ApplicationCommand.js
+++ b/packages/discord.js/src/structures/ApplicationCommand.js
@@ -504,7 +504,7 @@ class ApplicationCommand extends Base {
       option.name !== existing.name ||
       option.type !== existing.type ||
       option.description !== existing.description ||
-      (option.autocomplete ?? false) !== (existing.autocomplete ?? false) ||
+      option.autocomplete !== existing.autocomplete ||
       (option.required ??
         ([ApplicationCommandOptionType.Subcommand, ApplicationCommandOptionType.SubcommandGroup].includes(option.type)
           ? undefined
@@ -513,10 +513,10 @@ class ApplicationCommand extends Base {
       option.options?.length !== existing.options?.length ||
       (option.channelTypes ?? option.channel_types)?.length !== existing.channelTypes?.length ||
       (option.fileTypes ?? option.file_types)?.length !== existing.fileTypes?.length ||
-      (option.minValue ?? option.min_value ?? null) !== (existing.minValue ?? null) ||
-      (option.maxValue ?? option.max_value ?? null) !== (existing.maxValue ?? null) ||
-      (option.minLength ?? option.min_length ?? null) !== (existing.minLength ?? null) ||
-      (option.maxLength ?? option.max_length ?? null) !== (existing.maxLength ?? null) ||
+      (option.minValue ?? option.min_value) !== existing.minValue ||
+      (option.maxValue ?? option.max_value) !== existing.maxValue ||
+      (option.minLength ?? option.min_length) !== existing.minLength ||
+      (option.maxLength ?? option.max_length) !== existing.maxLength ||
       !isEqual(option.nameLocalizations ?? option.name_localizations ?? {}, existing.nameLocalizations ?? {}) ||
       !isEqual(
         option.descriptionLocalizations ?? option.description_localizations ?? {},
@@ -647,7 +647,7 @@ class ApplicationCommand extends Base {
         option.type === ApplicationCommandOptionType.SubcommandGroup
           ? undefined
           : false),
-      autocomplete: option.autocomplete,
+      ...(option.autocomplete !== undefined && { autocomplete: option.autocomplete }),
       choices: option.choices?.map(choice => ({
         name: choice.name,
         [nameLocalizedKey]: choice.nameLocalized ?? choice.name_localized,
@@ -657,10 +657,10 @@ class ApplicationCommand extends Base {
       options: option.options?.map(opt => this.transformOption(opt, received)),
       [channelTypesKey]: option.channelTypes ?? option.channel_types,
       [fileTypesKey]: option.fileTypes ?? option.file_types,
-      [minValueKey]: option.minValue ?? option.min_value,
-      [maxValueKey]: option.maxValue ?? option.max_value,
-      [minLengthKey]: option.minLength ?? option.min_length,
-      [maxLengthKey]: option.maxLength ?? option.max_length,
+      ...((option.minValue ?? option.min_value) !== undefined && { [minValueKey]: option.minValue ?? option.min_value }),
+      ...((option.maxValue ?? option.max_value) !== undefined && { [maxValueKey]: option.maxValue ?? option.max_value }),
+      ...((option.minLength ?? option.min_length) !== undefined && { [minLengthKey]: option.minLength ?? option.min_length }),
+      ...((option.maxLength ?? option.max_length) !== undefined && { [maxLengthKey]: option.maxLength ?? option.max_length }),
     };
   }
 }


### PR DESCRIPTION
fixes #10920

fields like `autocomplete`, `minValue`, `maxValue`, `minLength`, and `maxLength` are omitted from the api response when unset but stored as `null`/`undefined` locally. the strict comparison treats them as different so `equals()` returns false and commands get re-registered on every startup even when nothing changed.

normalize both sides before comparing.