### PR TITLE
chore: allow dev version publishing with pnpm 11

### DIFF
--- a/packages/actions/src/releasePackages/generateReleaseTree.ts
+++ b/packages/actions/src/releasePackages/generateReleaseTree.ts
@@ -1,3 +1,4 @@
+import process from 'node:process';
 import { info, warning } from '@actions/core';
 import type { PackageJSON, PackumentVersion } from '@npm/types';
 import { $, file, write } from 'bun';
@@ -42,6 +43,10 @@ async function getReleaseEntries(dry: boolean, devTag?: string) {
 
 	const commitHash = (await $`git rev-parse --short HEAD`.text()).trim();
 	const timestamp = Math.round(Date.now() / 1_000);
+
+	// We intentionally pin workspace dependencies in package.json for dev releases below,
+	// which causes pnpm's dependency validations to fail since the lockfile gets out of sync
+	if (devTag && !dry) process.env.pnpm_config_verify_deps_before_run = 'false';
 
 	for (const pkg of packageList) {
 		// Don't release private packages ever (npm will error anyways)

--- a/packages/actions/src/releasePackages/releasePackage.ts
+++ b/packages/actions/src/releasePackages/releasePackage.ts
@@ -4,6 +4,8 @@ import { getOctokit, context } from '@actions/github';
 import { $ } from 'bun';
 import type { ReleaseEntry } from './generateReleaseTree.js';
 
+const REGISTRY_CHECK_TIMEOUT_MS = 15 * 60 * 1_000;
+
 let octokit: ReturnType<typeof getOctokit> | undefined;
 
 if (process.env.GITHUB_TOKEN) {
@@ -69,7 +71,7 @@ export async function releasePackage(release: ReleaseEntry, dry: boolean, devTag
 				return;
 			}
 
-			if (performance.now() > before + 5 * 60 * 1_000) {
+			if (performance.now() > before + REGISTRY_CHECK_TIMEOUT_MS) {
 				clearInterval(interval);
 				reject(new Error(`Release for ${release.name} failed.`));
 			}


### PR DESCRIPTION
pnpm 11 now validates dependencies when running commands, which fails while creating dev releases since we intentionally modify the range for workspace dependencies, which leaves the lockfile out of sync

https://github.com/discordjs/discord.js/blob/183ade24249f78e48fccdca08167bd3a02862184/packages/actions/src/releasePackages/generateReleaseTree.ts#L58-L62

works: https://github.com/discordjs/discord.js/actions/runs/33894085676