### PR TITLE
fix(GuildMember): add premiumSinceTimestamp to equals

### DIFF
--- a/packages/discord.js/src/structures/GuildMember.js
+++ b/packages/discord.js/src/structures/GuildMember.js
@@ -605,6 +605,7 @@ class GuildMember extends Base {
       this.avatar === member.avatar &&
       this.banner === member.banner &&
       this.pending === member.pending &&
+      this.premiumSinceTimestamp === member.premiumSinceTimestamp &&
       this.communicationDisabledUntilTimestamp === member.communicationDisabledUntilTimestamp &&
       this.flags.bitfield === member.flags.bitfield &&
       (this._roles === member._roles ||


### PR DESCRIPTION
`GuildMember#equals()` was missing `premiumSinceTimestamp`, meaning `guildMemberUpdate` never fired when a member started or stopped boosting.