### PR TITLE
fix(structures): use rawPosition instead of position in equals

### DIFF
--- a/packages/discord.js/src/structures/GuildChannel.js
+++ b/packages/discord.js/src/structures/GuildChannel.js
@@ -433,7 +433,7 @@ class GuildChannel extends BaseChannel {
       this.id === channel.id &&
       this.type === channel.type &&
       this.topic === channel.topic &&
-      this.position === channel.position &&
+      this.rawPosition === channel.rawPosition &&
       this.name === channel.name;
 
     if (equal) {

--- a/packages/discord.js/src/structures/Role.js
+++ b/packages/discord.js/src/structures/Role.js
@@ -507,7 +507,7 @@ class Role extends Base {
       this.colors.secondaryColor === role.colors.secondaryColor &&
       this.colors.tertiaryColor === role.colors.tertiaryColor &&
       this.hoist === role.hoist &&
-      this.position === role.position &&
+      this.rawPosition === role.rawPosition &&
       this.permissions.bitfield === role.permissions.bitfield &&
       this.managed === role.managed &&
       this.icon === role.icon &&


### PR DESCRIPTION
`Role#equals()` and `GuildChannel#equals()` both compared `this.position` which is a computed getter that iterates the entire cache. `rawPosition` is what the API sends and is the right field to compare for equality.