### PR TITLE
fix(actions): guard emojiUpdate and stickerUpdate with equals check

### DIFF
--- a/packages/discord.js/src/client/actions/GuildEmojiUpdate.js
+++ b/packages/discord.js/src/client/actions/GuildEmojiUpdate.js
@@ -13,7 +13,7 @@ class GuildEmojiUpdateAction extends Action {
      * @param {GuildEmoji} oldEmoji The old emoji
      * @param {GuildEmoji} newEmoji The new emoji
      */
-    this.client.emit(Events.GuildEmojiUpdate, old, current);
+    if (!current.equals(old)) this.client.emit(Events.GuildEmojiUpdate, old, current);
     return { emoji: current };
   }
 }

--- a/packages/discord.js/src/client/actions/GuildStickerUpdate.js
+++ b/packages/discord.js/src/client/actions/GuildStickerUpdate.js
@@ -13,7 +13,7 @@ class GuildStickerUpdateAction extends Action {
      * @param {Sticker} oldSticker The old sticker
      * @param {Sticker} newSticker The new sticker
      */
-    this.client.emit(Events.GuildStickerUpdate, old, current);
+    if (!current.equals(old)) this.client.emit(Events.GuildStickerUpdate, old, current);
     return { sticker: current };
   }
 }


### PR DESCRIPTION
`emojiUpdate` and `stickerUpdate` fire on every dispatch even when nothing changed. both structs already have `equals()` — just missing the guard that `guildMemberUpdate` already has.