### PR TITLE
fix(builders): allow DM and GroupDM channel option types

### DIFF
--- a/packages/builders/__tests__/interactions/ChatInputCommands/Options.test.ts
+++ b/packages/builders/__tests__/interactions/ChatInputCommands/Options.test.ts
@@ -86,6 +86,18 @@ describe('Application Command toJSON() results', () => {
 		});
 	});
 
+	test('GIVEN a channel option with DM and group DM channel types THEN calling toJSON should return a valid JSON', () => {
+		expect(
+			getChannelOption().setChannelTypes(ChannelType.DM, ChannelType.GroupDM).toJSON(),
+		).toEqual<APIApplicationCommandChannelOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Channel,
+			required: true,
+			channel_types: [ChannelType.DM, ChannelType.GroupDM],
+		});
+	});
+
 	test('GIVEN a integer option THEN calling toJSON should return a valid JSON', () => {
 		expect(getIntegerOption().toJSON()).toEqual<APIApplicationCommandIntegerOption>({
 			name: 'owo',

--- a/packages/builders/src/interactions/commands/chatInput/mixins/ApplicationCommandOptionChannelTypesMixin.ts
+++ b/packages/builders/src/interactions/commands/chatInput/mixins/ApplicationCommandOptionChannelTypesMixin.ts
@@ -16,6 +16,8 @@ export const ApplicationCommandOptionAllowedChannelTypes = [
 	ChannelType.GuildStageVoice,
 	ChannelType.GuildForum,
 	ChannelType.GuildMedia,
+	ChannelType.DM,
+	ChannelType.GroupDM,
 ] as const satisfies readonly ApplicationCommandOptionAllowedChannelType[];
 
 export interface ApplicationCommandOptionChannelTypesData extends Pick<


### PR DESCRIPTION
## Please describe the changes this PR makes and why it should be merged

`ApplicationCommandOptionAllowedChannelType` from `discord-api-types` excludes only `ChannelType.GuildDirectory` (it already permits `DM`/`GroupDM`), but `@discordjs/builders`' own `ApplicationCommandOptionAllowedChannelTypes` list in `ApplicationCommandOptionChannelTypesMixin.ts` was still missing `ChannelType.DM` and `ChannelType.GroupDM`.

Since this list is used by the Zod predicate in `Assertions.ts` (`z.literal(ApplicationCommandOptionAllowedChannelTypes).array()`), calling `.addChannelTypes(ChannelType.DM)` and then `.toJSON()` throws a runtime validation error even though the public `addChannelTypes`/`setChannelTypes` method signatures already accept it. So on `main` this reproduces as a runtime-only bug (TypeScript itself already permits it, since those methods are typed against the raw `ApplicationCommandOptionAllowedChannelType` union directly).

Fix: add `ChannelType.DM` and `ChannelType.GroupDM` to the local list so runtime validation matches what the type already allows.

Not a breaking change.

close #11622

**Testing:** Added a test case in `packages/builders/__tests__/interactions/ChatInputCommands/Options.test.ts` covering `channel_types: [DM, GroupDM]`. `tsc --noEmit`, the full `builders` vitest suite (269/269), and `eslint`/`prettier` all pass for the changed package.

Note: I wasn't able to run the monorepo-wide `build:affected` pre-commit hook locally — it cascades into rebuilding sibling packages that pull in native voice codec bindings (`@discordjs/opus`, `zlib-sync`), which need a C++ toolchain not available in my environment. Happy to address anything CI surfaces that I couldn't catch locally.

---
*This PR description was drafted with the help of Claude.*