### PR TITLE
feat(Message): add context menu targets to interaction metadata

### DIFF
--- a/packages/discord.js/src/structures/Message.js
+++ b/packages/discord.js/src/structures/Message.js
@@ -421,6 +421,10 @@ class Message extends Base {
        * @property {?Snowflake} interactedMessageId
        * Id of the message that contained interactive component.
        * Present only on messages created from component interactions
+       * @property {?User} targetUser
+       * The user the command was run on. Present only on user context menu command interactions
+       * @property {?Snowflake} targetMessageId
+       * Id of the message the command was run on. Present only on message context menu command interactions
        * @property {?MessageInteractionMetadata} triggeringInteractionMetadata
        * Metadata for the interaction that was used to open the modal. Present only on modal submit interactions
        */

--- a/packages/discord.js/src/util/Transformers.js
+++ b/packages/discord.js/src/util/Transformers.js
@@ -55,6 +55,10 @@ function _transformAPIMessageInteractionMetadata(client, messageInteractionMetad
     ),
     originalResponseMessageId: messageInteractionMetadata.original_response_message_id ?? null,
     interactedMessageId: messageInteractionMetadata.interacted_message_id ?? null,
+    targetUser: messageInteractionMetadata.target_user
+      ? client.users._add(messageInteractionMetadata.target_user)
+      : null,
+    targetMessageId: messageInteractionMetadata.target_message_id ?? null,
     triggeringInteractionMetadata: messageInteractionMetadata.triggering_interaction_metadata
       ? _transformAPIMessageInteractionMetadata(client, messageInteractionMetadata.triggering_interaction_metadata)
       : null,

--- a/packages/discord.js/typings/index.d.ts
+++ b/packages/discord.js/typings/index.d.ts
@@ -6759,6 +6759,8 @@ export interface MessageInteractionMetadata {
   id: Snowflake;
   interactedMessageId: Snowflake | null;
   originalResponseMessageId: Snowflake | null;
+  targetMessageId: Snowflake | null;
+  targetUser: User | null;
   triggeringInteractionMetadata: MessageInteractionMetadata | null;
   type: InteractionType;
   user: User;

--- a/packages/discord.js/typings/index.test-d.ts
+++ b/packages/discord.js/typings/index.test-d.ts
@@ -1796,6 +1796,11 @@ declare const guildChannelManager: GuildChannelManager;
     expectType<Guild>(message.guild);
     expectType<Snowflake>(message.guildId);
     expectType<GuildTextBasedChannel>(message.channel.messages.channel);
+
+    if (message.interactionMetadata) {
+      expectType<User | null>(message.interactionMetadata.targetUser);
+      expectType<Snowflake | null>(message.interactionMetadata.targetMessageId);
+    }
   }
 }
 


### PR DESCRIPTION
Adds `targetMessageId` and `targetUser` sent in a context menu command's response message when used on a message or user