### PR TITLE
fix(proxyRequests): pass on ratelimit information

### DIFF
--- a/packages/proxy/src/util/responseHelpers.ts
+++ b/packages/proxy/src/util/responseHelpers.ts
@@ -50,6 +50,12 @@ export function populateGeneralErrorResponse(res: ServerResponse, error: Discord
 export function populateRatelimitErrorResponse(res: ServerResponse, error: RateLimitError): void {
 	res.statusCode = 429;
 	res.setHeader('Retry-After', error.timeToReset / 1_000);
+
+	if (error.global) {
+		res.setHeader('X-RateLimit-Global', 'true');
+	}
+
+	res.setHeader('X-RateLimit-Scope', error.scope);
 }
 
 /**


### PR DESCRIPTION
In setups where the proxy 429s and the downstream client decides what to do with that, missing the `global` information was quite problematic.